### PR TITLE
Added finn-specific prepare as a db-migration

### DIFF
--- a/unleash-server/migrations/sql/001-initial-schema.up.sql
+++ b/unleash-server/migrations/sql/001-initial-schema.up.sql
@@ -19,8 +19,3 @@ CREATE TABLE events (
   created_by varchar(255) NOT NULL,
   data json
 );
-
-GRANT ALL ON TABLE events TO unleash_user;
-GRANT ALL ON TABLE features TO unleash_user;
-GRANT ALL ON TABLE strategies TO unleash_user;
-GRANT USAGE, SELECT ON SEQUENCE events_id_seq TO unleash_user;

--- a/unleash-server/scripts/generate-liquibase-artifact.js
+++ b/unleash-server/scripts/generate-liquibase-artifact.js
@@ -24,6 +24,8 @@ fs.readdir(sqlRoot, function (err, files) {
 
     var changes = {};
 
+    initialInit(changes);
+
     files.forEach(function (sqlFile) {
         var match = sqlFile.match(/(.+?)\.(up|down)\.sql/);
 
@@ -48,4 +50,10 @@ fs.readdir(sqlRoot, function (err, files) {
 
     util.puts(changeLog.end({pretty: true}));
 });
+
+function initialInit(changes) {
+    changes["init-prepare"] = {};
+    changes["init-prepare"]["up"] = fs.readFileSync(path.resolve(__dirname, './init.up.sql'), {encoding: encoding});
+    changes["init-prepare"]["down"] = fs.readFileSync(path.resolve(__dirname, './init.down.sql'), {encoding: encoding});
+}
 

--- a/unleash-server/scripts/init.down.sql
+++ b/unleash-server/scripts/init.down.sql
@@ -1,0 +1,2 @@
+alter default privileges for user unleash_admin revoke select,insert,update,delete on tables TO unleash_user;
+alter default privileges for user unleash_admin revoke select,update on sequences TO unleash_user;

--- a/unleash-server/scripts/init.up.sql
+++ b/unleash-server/scripts/init.up.sql
@@ -1,0 +1,2 @@
+alter default privileges for user unleash_admin grant select,insert,update,delete on tables TO unleash_user;
+alter default privileges for user unleash_admin grant select,update on sequences TO unleash_user;


### PR DESCRIPTION
A simple but not too elegant way to have a "finn-specific" initial migration to prepare the database. This sets up a trigger to automatically give unleash_user access to all tables created by unleash_admin. 

Before we merge this we have to reset all our databases.

@jarib @gardleopard do you have some time to look more on this tomorrow?
