### PR TITLE
Introduces the /api path.

### DIFF
--- a/packages/unleash-api/app.js
+++ b/packages/unleash-api/app.js
@@ -12,7 +12,7 @@ const path = require('path');
 
 module.exports = function (config) {
     const app = express();
-    const router = express.Router(); // eslint-disable-line new-cap
+
     const baseUriPath  = config.baseUriPath || '';
     const publicFolder = config.publicFolder;
 
@@ -37,7 +37,13 @@ module.exports = function (config) {
     }));
 
     // Setup API routes
-    routes.create(router, config);
+    const apiRouter = express.Router(); // eslint-disable-line new-cap
+    routes.createAPI(apiRouter, config);
+    app.use(`${baseUriPath}/api/`, apiRouter);
+
+    // Setup deprecated routes
+    const router = express.Router(); // eslint-disable-line new-cap
+    routes.createLegacy(router, config);
     app.use(baseUriPath, router);
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/unleash-api/lib/routes/index.js
+++ b/packages/unleash-api/lib/routes/index.js
@@ -1,10 +1,16 @@
 'use strict';
 
-exports.create = function (app, config) {
-    require('./event')(app, config);
-    require('./feature')(app, config);
-    require('./feature-archive')(app, config);
-    require('./strategy')(app, config);
-    require('./health-check')(app, config);
-    require('./metrics')(app, config);
+
+exports.createAPI = function (router, config) {
+    require('./event')(router, config);
+    require('./feature')(router, config);
+    require('./feature-archive')(router, config);
+    require('./strategy')(router, config);
+    require('./health-check')(router, config);
+    require('./metrics')(router, config);
+};
+
+exports.createLegacy = function (router, config) {
+    require('./feature')(router, config);
+    require('./health-check')(router, config);
 };

--- a/packages/unleash-api/migrations/sql/009-create-client-strategies.up.sql
+++ b/packages/unleash-api/migrations/sql/009-create-client-strategies.up.sql
@@ -1,6 +1,6 @@
 --create new client_strategies table
 CREATE TABLE client_strategies (
   app_name varchar(255) PRIMARY KEY NOT NULL,
-  updated_at timestamp default now(),
+  r timestamp default now(),
   strategies json
 );

--- a/packages/unleash-api/migrations/sql/009-create-client-strategies.up.sql
+++ b/packages/unleash-api/migrations/sql/009-create-client-strategies.up.sql
@@ -1,6 +1,6 @@
 --create new client_strategies table
 CREATE TABLE client_strategies (
   app_name varchar(255) PRIMARY KEY NOT NULL,
-  r timestamp default now(),
+  updated_at timestamp default now(),
   strategies json
 );

--- a/packages/unleash-api/test/e2e/event-api.test.js
+++ b/packages/unleash-api/test/e2e/event-api.test.js
@@ -5,14 +5,14 @@ const request = require('./test-helper').request;
 describe('The event api', () => {
     it('returns events', done => {
         request
-            .get('/events')
+            .get('/api/events')
             .expect('Content-Type', /json/)
             .expect(200, done);
     });
 
     it('returns events given a name', done => {
         request
-            .get('/events/myname')
+            .get('/api/events/myname')
             .expect('Content-Type', /json/)
             .expect(200, done);
     });

--- a/packages/unleash-api/test/e2e/feature-api.test.js
+++ b/packages/unleash-api/test/e2e/feature-api.test.js
@@ -58,7 +58,7 @@ describe('The features api', () => {
             .set('Content-Type', 'application/json')
             .end(() => {
                 request
-                    .get('/events')
+                    .get('/api/events')
                     .end((err, res) => {
                         assert.equal(res.body.events[0].createdBy, 'ivaosthu');
                         done();

--- a/packages/unleash-api/test/e2e/feature-archive-api.test.js
+++ b/packages/unleash-api/test/e2e/feature-archive-api.test.js
@@ -16,7 +16,7 @@ describe('The archive features api', () => {
 
     it('returns three archived toggles', done => {
         request
-            .get('/archive/features')
+            .get('/api/archive/features')
             .expect('Content-Type', /json/)
             .expect(200)
             .end((err, res) => {
@@ -27,7 +27,7 @@ describe('The archive features api', () => {
 
     it('revives a feature by name', done => {
         request
-            .post('/archive/revive')
+            .post('/api/archive/revive')
             .send({ name: 'featureArchivedX' })
             .set('Content-Type', 'application/json')
             .expect(200, done);
@@ -35,7 +35,7 @@ describe('The archive features api', () => {
 
     it('must set name when reviving toggle', done => {
         request
-            .post('/archive/revive')
+            .post('/api/archive/revive')
             .send({ name: '' })
             .expect(400, done);
     });

--- a/packages/unleash-api/test/e2e/strategy-api.test.js
+++ b/packages/unleash-api/test/e2e/strategy-api.test.js
@@ -12,28 +12,28 @@ describe('The strategy api', () => {
 
     it('gets all strategies', done => {
         request
-            .get('/strategies')
+            .get('/api/strategies')
             .expect('Content-Type', /json/)
             .expect(200, done);
     });
 
     it('gets a strategy by name', done => {
         request
-            .get('/strategies/default')
+            .get('/api/strategies/default')
             .expect('Content-Type', /json/)
             .expect(200, done);
     });
 
     it('cant get a strategy by name that dose not exist', done => {
         request
-            .get('/strategies/mystrategy')
+            .get('/api/strategies/mystrategy')
             .expect('Content-Type', /json/)
             .expect(404, done);
     });
 
     it('creates a new strategy', done => {
         request
-            .post('/strategies')
+            .post('/api/strategies')
             .send({ name: 'myCustomStrategy', description: 'Best strategy ever.' })
             .set('Content-Type', 'application/json')
             .expect(201, done);
@@ -41,7 +41,7 @@ describe('The strategy api', () => {
 
     it('requires new strategies to have a name', done => {
         request
-            .post('/strategies')
+            .post('/api/strategies')
             .send({ name: '' })
             .set('Content-Type', 'application/json')
             .expect(400, done);
@@ -49,7 +49,7 @@ describe('The strategy api', () => {
 
     it('refuses to create a strategy with an existing name', done => {
         request
-            .post('/strategies')
+            .post('/api/strategies')
             .send({ name: 'default' })
             .set('Content-Type', 'application/json')
             .expect(403, done);
@@ -57,13 +57,13 @@ describe('The strategy api', () => {
 
     it('deletes a new strategy', done => {
         request
-            .delete('/strategies/usersWithEmail')
+            .delete('/api/strategies/usersWithEmail')
             .expect(200, done);
     });
 
     it('can\'t delete a strategy that dose not exist', done => {
         request
-            .delete('/strategies/unknown')
+            .delete('/api/strategies/unknown')
             .expect(404, done);
     });
 });

--- a/packages/unleash-api/test/unit/routes/strategies.test.js
+++ b/packages/unleash-api/test/unit/routes/strategies.test.js
@@ -33,7 +33,7 @@ describe('Unit: The strategies api', () => {
 
     it('should add version numbers for /stategies', (done) => {
         request
-            .get('/strategies')
+            .get('/api/strategies')
             .expect('Content-Type', /json/)
             .expect(200)
             .end((err, res) => {


### PR DESCRIPTION
Some endpoints are provided on both `/` and `/api` to support older clients.

What do you think @sveisvei ?