### PR TITLE
A prototype on app details

### DIFF
--- a/lib/client-metrics/application-toggle-service.js
+++ b/lib/client-metrics/application-toggle-service.js
@@ -1,0 +1,54 @@
+/*
+ * TODO:
+ * After some time it should also remove toggles from application.
+ *
+ * A simple way to do this is to have a current and prev variable and swtich
+ * these once in a while. There is no harm in having unleash lagging some minutes
+ * before a new toggle is detected.
+ *
+ */
+
+module.exports = class ApplicationToggleService {
+    constructor (stores, metricService) {
+        this.clientInstanceStore = stores.clientInstanceStore;
+        this.clientStrategyStore = stores.clientStrategyStore;
+        metricService.on('metrics', (metrics) => this.addMetrics(metrics));
+        this.applicationToggles = {};
+    }
+
+    addMetrics (metrics) {
+        metrics.forEach(m => {
+            const item = m.metrics;
+            const toggles = Object.keys(item.bucket.toggles);
+            this.applicationToggles[item.appName] =  this.applicationToggles[item.appName] || {};
+            this.applicationToggles[item.appName].toggles = this.applicationToggles[item.appName].toggles || [];
+            toggles.forEach((toggle) => {
+                if(!this.applicationToggles[item.appName].toggles.includes(toggle)) {
+                    this.applicationToggles[item.appName].toggles.push(toggle);
+                }
+            });
+
+        });
+    }
+
+    getAppToggles () {
+        return Promise.all([this.clientInstanceStore.getAll(), this.clientStrategyStore.getAll()])
+            .then(values => {
+                const apps = Object.assign({}, this.applicationToggles);
+                console.log(apps);
+                values[1].forEach(item => {
+                    apps[item.appName] = apps[item.appName] || {};
+                    apps[item.appName].strategies = item.strategies;
+                });
+
+                values[0].forEach(item => {
+                    apps[item.appName] = apps[item.appName] || {};
+                    apps[item.appName].instances = apps[item.appName].instances || [];
+                    apps[item.appName].instances.push(item.instanceId);
+                });
+
+                return apps;
+            });
+        return this.apps;
+    }
+}

--- a/lib/routes/metrics.js
+++ b/lib/routes/metrics.js
@@ -3,6 +3,7 @@
 const logger = require('../logger');
 const ClientMetrics = require('../client-metrics');
 const ClientMetricsService = require('../client-metrics/service');
+const ApplicationToggleService = require('../client-metrics/application-toggle-service');
 const joi = require('joi');
 const { clientMetricsSchema, clientRegisterSchema } = require('./metrics-schema');
 
@@ -12,9 +13,10 @@ module.exports = function (app, config) {
         clientStrategyStore,
         clientInstanceStore,
     } = config.stores;
-    
+
     const metrics = new ClientMetrics();
     const service = new ClientMetricsService(clientMetricsStore);
+    const applicationService = new ApplicationToggleService(config.stores, service);
 
     service.on('metrics', (entries) => {
         entries.forEach((m) => {
@@ -38,7 +40,7 @@ module.exports = function (app, config) {
             }
             service.insert(cleaned)
                 .catch(e => logger.error('Error inserting metrics data', e));
-            
+
             res.status(202).end();
         });
     });
@@ -72,6 +74,12 @@ module.exports = function (app, config) {
     app.get('/client/instances', (req, res) => {
         clientInstanceStore.getAll()
             .then(data => res.json(data))
+            .catch(err => logger.error(err));
+    });
+
+    app.get('/client/applications', (req, res) => {
+        applicationService.getAppToggles()
+            .then(apps => res.json(apps))
             .catch(err => logger.error(err));
     });
 };


### PR DESCRIPTION
This small examples illustrates how we can use exiting data to build a more UI friendly format for showing details about registered clients. 

Format produced:
```json
{
	"demo-app": {
		"strategies": ["default", "test"]
	},
	"demo-app-3": {
		"strategies": ["default", "extra"],
		"instances": ["index-593", "index-603"],
		"toggles": ["myApp.awesomeToggle", "Demo", "Test.123", "Test"]
	},
	"demo-app-0": {
		"strategies": ["default", "extra"],
		"instances": ["index-620", "index-595", "index-600", "index-605", "index-615", "index-610", "index-630"],
		"toggles": ["Test", "Test.123", "myApp.awesomeToggle", "Demo"]
	},
	"demo-app-1": {
		"strategies": ["default", "extra"],
		"instances": ["index-591", "index-596", "index-626"],
		"toggles": ["Demo", "Test.123", "myApp.awesomeToggle", "Test"]
	},
	"demo-app-4": {
		"strategies": ["default", "extra"],
		"instances": ["index-594", "index-599", "index-604", "index-609", "index-614"],
		"toggles": ["Demo", "myApp.awesomeToggle", "Test", "Test.123"]
	},
	"demo-app-2": {
		"strategies": ["default", "extra"],
		"instances": ["index-597", "index-592", "index-627"],
		"toggles": ["myApp.awesomeToggle", "Test.123", "Test", "Demo"]
	}
}
```

Still missing:
- we need to remove toggles clients stops reporting on. Find a easy way to do this...
- missing meta such as when application was first created and when an instance was last seen. 

/cc @sveisvei 