### PR TITLE
Remove uncaught exception logging

### DIFF
--- a/lib/server-impl.js
+++ b/lib/server-impl.js
@@ -44,11 +44,6 @@ function start (opts) {
         .catch(err => logger.error('failed creating app', err));
 }
 
-process.on('uncaughtException', err => {
-    logger.error('Uncaught Exception:', err.message);
-    logger.error(err.stack);
-});
-
 module.exports = {
     start,
 };


### PR DESCRIPTION
This is the responsibility of the app

For us, this is really annoying in fiaas, as it doesn't produce JSON.