### PR TITLE
Add support for sdkVersion in client registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Add sdkVersion in client registration
 
 ## 3.0.0-alpha.1
 - upgrade unleash-frontend to 3.0.0-alpha.1

--- a/docs/api/client/metrics-api.md
+++ b/docs/api/client/metrics-api.md
@@ -1,30 +1,5 @@
 # This document describes the client metrics endpoints
 
-### Client registration
-
-`POST: http://unleash.host.com/api/client/register`
-
-Register a client instance with the unleash server. The client should send all fields specified. 
-
-```json
-{
-    "appName": "appName",
-    "instanceId": "instanceId",
-    "strategies": ["default", "some-strategy-1"],
-    "started": "2016-11-03T07:16:43.572Z",
-    "interval": 10000,
-}
-```
-
-
-**Fields:**
-
-* **appName** - Name of the application seen by unleash-server
-* **instanceId** - Instance id for this application (typically hostname, podId or similar)
-* **strategies** - List of strategies implemented by this application
-* **started** - When this client started. Should be reported as UTC time.
-* **interval** - At wich interval will this client be expected to send metrics? 
-
 ### Send metrics
 
 `POST http://unleash.host.com/api/client/metrics`

--- a/docs/api/client/register-api.md
+++ b/docs/api/client/register-api.md
@@ -1,0 +1,28 @@
+# This document describes the client registration endpoints
+
+### Client registration
+
+`POST: http://unleash.host.com/api/client/register`
+
+Register a client instance with the unleash server. The client should send all fields specified. 
+
+```json
+{
+    "appName": "appName",
+    "instanceId": "instanceId",
+    "sdkVersion": "unleash-client-java:2.2.0",
+    "strategies": ["default", "some-strategy-1"],
+    "started": "2016-11-03T07:16:43.572Z",
+    "interval": 10000
+}
+```
+
+
+**Fields:**
+
+* **appName** - Name of the application seen by unleash-server
+* **instanceId** - Instance id for this application (typically hostname, podId or similar)
+* **sdkVersion** - Optional field that describes the sdk version (name:version)
+* **strategies** - List of strategies implemented by this application
+* **started** - When this client started. Should be reported as UTC time.
+* **interval** - At wich interval will this client be expected to send metrics? 

--- a/lib/db/client-instance-store.js
+++ b/lib/db/client-instance-store.js
@@ -5,6 +5,7 @@ const logger = require('../logger');
 const COLUMNS = [
     'app_name',
     'instance_id',
+    'sdk_version',
     'client_ip',
     'last_seen',
     'created_at',
@@ -14,6 +15,7 @@ const TABLE = 'client_instances';
 const mapRow = row => ({
     appName: row.app_name,
     instanceId: row.instance_id,
+    sdkVersion: row.sdk_version,
     clientIp: row.client_ip,
     lastSeen: row.last_seen,
     createdAt: row.created_at,
@@ -48,6 +50,7 @@ class ClientInstanceStore {
             .update({
                 last_seen: 'now()',
                 client_ip: details.clientIp,
+                sdk_version: details.sdkVersion,
             });
     }
 
@@ -55,6 +58,7 @@ class ClientInstanceStore {
         return this.db(TABLE).insert({
             app_name: details.appName,
             instance_id: details.instanceId,
+            sdk_version: details.sdkVersion,
             client_ip: details.clientIp,
         });
     }

--- a/lib/routes/client-api/metrics-schema.js
+++ b/lib/routes/client-api/metrics-schema.js
@@ -12,12 +12,4 @@ const clientMetricsSchema = joi.object().keys({
     }),
 });
 
-const clientRegisterSchema = joi.object().keys({
-    appName: joi.string().required(),
-    instanceId: joi.string().required(),
-    strategies: joi.array().required().items(joi.string(), joi.any().strip()),
-    started: joi.date().required(),
-    interval: joi.number().required(),
-});
-
-module.exports = { clientMetricsSchema, clientRegisterSchema };
+module.exports = { clientMetricsSchema };

--- a/lib/routes/client-api/register-schema.js
+++ b/lib/routes/client-api/register-schema.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const joi = require('joi');
+
+const clientRegisterSchema = joi.object().keys({
+    appName: joi.string().required(),
+    instanceId: joi.string().required(),
+    sdkVersion: joi.string().optional(),
+    strategies: joi.array().required().items(joi.string(), joi.any().strip()),
+    started: joi.date().required(),
+    interval: joi.number().required(),
+});
+
+module.exports = { clientRegisterSchema };

--- a/lib/routes/client-api/register.js
+++ b/lib/routes/client-api/register.js
@@ -4,7 +4,7 @@ const { Router } = require('express');
 const joi = require('joi');
 const logger = require('../../logger');
 
-const { clientRegisterSchema } = require('./metrics-schema');
+const { clientRegisterSchema } = require('./register-schema');
 
 exports.router = config => {
     const { clientInstanceStore, clientApplicationsStore } = config.stores;

--- a/lib/routes/client-api/register.test.js
+++ b/lib/routes/client-api/register.test.js
@@ -36,6 +36,22 @@ test('should register client', t => {
             appName: 'demo',
             instanceId: 'test',
             strategies: ['default'],
+            sdkVersion: 'unleash-client-test:1.2',
+            started: Date.now(),
+            interval: 10,
+        })
+        .expect(202);
+});
+
+test('should register client without sdkVersin', t => {
+    t.plan(0);
+    const { request } = getSetup();
+    return request
+        .post('/api/client/register')
+        .send({
+            appName: 'demo',
+            instanceId: 'test',
+            strategies: ['default'],
             started: Date.now(),
             interval: 10,
         })

--- a/migrations/20170628205541-add-sdk-version-to-client-instances.js
+++ b/migrations/20170628205541-add-sdk-version-to-client-instances.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function(db, callback) {
+    db.runSql(
+        'ALTER TABLE client_instances ADD "sdk_version" varchar(255);',
+        callback
+    );
+};
+
+exports.down = function(db, callback) {
+    db.runSql(
+        'ALTER TABLE client_instances DROP COLUMN "sdk_version";',
+        callback
+    );
+};


### PR DESCRIPTION
This PR adds support for a sdkVersion field to the client registration. This should be sent by official clients in future version to ease debugging. 

Format: `"sdkVersion" : "unleash-client-java:2.2.0"`


closes #221