### PR TITLE
Add query param support for /api/client/features #251

### DIFF
--- a/docs/api/client/feature-toggles-api.md
+++ b/docs/api/client/feature-toggles-api.md
@@ -65,6 +65,18 @@ has the latest response locally.
 }
 ```
 
+### Query Parameters
+The api has support for querying. You may specify the following query paramters:
+- **name** - A regex to match on feature toggle name. Eg.g: `^test-.*`
+- **enabled** - Specify whether toggles should be `true` or `false`. 
+
+Example usage with query params:
+
+`GET: http://unleash.host.com/api/client/features?enabled=true&name=^test`
+
+
+## Fetch Specific Toggle
+
 `GET: http://unleash.host.com/api/client/features/:featureName`
 
 Used to fetch details about a specific featureToggle. This is mostly provded to make it easy to 

--- a/docs/api/client/feature-toggles-api.md
+++ b/docs/api/client/feature-toggles-api.md
@@ -67,7 +67,7 @@ has the latest response locally.
 
 ### Query Parameters
 The api has support for querying. You may specify the following query paramters:
-- **name** - A regex to match on feature toggle name. Eg.g: `^test-.*`
+- **name** - Query a toggle with a name that starts with a specified prefix. 
 - **enabled** - Specify whether toggles should be `true` or `false`. 
 
 Example usage with query params:

--- a/lib/routes/client-api/feature-filter.js
+++ b/lib/routes/client-api/feature-filter.js
@@ -14,11 +14,7 @@ function enabledFilter(query) {
 function nameFilter(query) {
     return toggle => {
         if (query.name) {
-            try {
-                return new RegExp(query.name).test(toggle.name);
-            } catch (error) {
-                return false;
-            }
+            return toggle.name.startsWith(query.name);
         } else {
             return true;
         }

--- a/lib/routes/client-api/feature-filter.js
+++ b/lib/routes/client-api/feature-filter.js
@@ -1,0 +1,36 @@
+'use strict';
+
+function enabledFilter(query) {
+    return toggle => {
+        if (query.enabled) {
+            const enabled = query.enabled === 'true';
+            return toggle.enabled === enabled;
+        } else {
+            return true;
+        }
+    };
+}
+
+function nameFilter(query) {
+    return toggle => {
+        if (query.name) {
+            try {
+                return new RegExp(query.name).test(toggle.name);
+            } catch (error) {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    };
+}
+
+function makeQueryFilter(query) {
+    return function(featureToggles) {
+        return featureToggles
+            .filter(enabledFilter(query))
+            .filter(nameFilter(query));
+    };
+}
+
+module.exports.makeQueryFilter = makeQueryFilter;

--- a/lib/routes/client-api/feature-filter.test.js
+++ b/lib/routes/client-api/feature-filter.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const { test } = require('ava');
+const { makeQueryFilter } = require('./feature-filter');
+
+test('should handle empty list', t => {
+    const query = {};
+    const queryFilter = makeQueryFilter(query);
+    const input = [];
+
+    const output = queryFilter(input);
+    t.is(output.length, 0);
+});
+
+test('should not filter without query', t => {
+    const query = {};
+    const queryFilter = makeQueryFilter(query);
+    const input = [
+        {
+            name: 'test1',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: true,
+        },
+        {
+            name: 'test3',
+            enabled: false,
+        },
+    ];
+
+    const output = queryFilter(input);
+    t.is(output.length, 3);
+});
+
+test('should filter enabled=false', t => {
+    const query = {
+        enabled: 'false',
+    };
+    const queryFilter = makeQueryFilter(query);
+    const input = [
+        {
+            name: 'test1',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: true,
+        },
+        {
+            name: 'test3',
+            enabled: false,
+        },
+    ];
+
+    const output = queryFilter(input);
+    t.is(output.length, 1);
+});
+
+test('should filter based on name', t => {
+    const query = {
+        name: '^test[1,2]$',
+    };
+    const queryFilter = makeQueryFilter(query);
+    const input = [
+        {
+            name: 'test1',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: true,
+        },
+        {
+            name: 'test3',
+            enabled: false,
+        },
+    ];
+
+    const output = queryFilter(input);
+    t.is(output.length, 2);
+});
+
+test('should filter based on name and enabled', t => {
+    const query = {
+        name: '^test[1,2]$',
+        enabled: 'true',
+    };
+    const queryFilter = makeQueryFilter(query);
+    const input = [
+        {
+            name: 'test1',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: false,
+        },
+        {
+            name: 'test3',
+            enabled: false,
+        },
+    ];
+
+    const output = queryFilter(input);
+    t.is(output.length, 1);
+    t.is(output[0].name, 'test1');
+});
+
+test('should handle invalid regex', t => {
+    const query = {
+        name: '*.',
+        enabled: 'true',
+    };
+    const queryFilter = makeQueryFilter(query);
+    const input = [
+        {
+            name: 'test1',
+            enabled: true,
+        },
+        {
+            name: 'test2',
+            enabled: false,
+        },
+        {
+            name: 'test3',
+            enabled: false,
+        },
+    ];
+
+    const output = queryFilter(input);
+    t.is(output.length, 0);
+});

--- a/lib/routes/client-api/feature-filter.test.js
+++ b/lib/routes/client-api/feature-filter.test.js
@@ -60,7 +60,7 @@ test('should filter enabled=false', t => {
 
 test('should filter based on name', t => {
     const query = {
-        name: '^test[1,2]$',
+        name: 'test',
     };
     const queryFilter = makeQueryFilter(query);
     const input = [
@@ -73,7 +73,7 @@ test('should filter based on name', t => {
             enabled: true,
         },
         {
-            name: 'test3',
+            name: 'somethingelse.test',
             enabled: false,
         },
     ];
@@ -84,7 +84,7 @@ test('should filter based on name', t => {
 
 test('should filter based on name and enabled', t => {
     const query = {
-        name: '^test[1,2]$',
+        name: 'test',
         enabled: 'true',
     };
     const queryFilter = makeQueryFilter(query);
@@ -98,7 +98,7 @@ test('should filter based on name and enabled', t => {
             enabled: false,
         },
         {
-            name: 'test3',
+            name: 'some',
             enabled: false,
         },
     ];
@@ -108,9 +108,9 @@ test('should filter based on name and enabled', t => {
     t.is(output[0].name, 'test1');
 });
 
-test('should handle invalid regex', t => {
+test('should not match on name', t => {
     const query = {
-        name: '*.',
+        name: 'rubbish',
         enabled: 'true',
     };
     const queryFilter = makeQueryFilter(query);

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Router } = require('express');
+const { makeQueryFilter } = require('./feature-filter');
 
 const version = 1;
 
@@ -11,6 +12,7 @@ exports.router = config => {
     router.get('/', (req, res) => {
         featureToggleStore
             .getFeatures()
+            .then(makeQueryFilter(req.query))
             .then(features => res.json({ version, features }));
     });
 

--- a/lib/routes/client-api/feature.test.js
+++ b/lib/routes/client-api/feature.test.js
@@ -57,3 +57,53 @@ test('fetch single feature', t => {
             t.true(res.body.name === 'test_');
         });
 });
+
+test('fetch enabled features', t => {
+    t.plan(2);
+    const { request, featureToggleStore, base } = getSetup();
+    featureToggleStore.addFeature({
+        name: 'test_enabled',
+        enabled: true,
+        strategies: [{ name: 'default' }],
+    });
+
+    featureToggleStore.addFeature({
+        name: 'test_disabled',
+        enabled: false,
+        strategies: [{ name: 'default' }],
+    });
+
+    return request
+        .get(`${base}/api/client/features?enabled=true`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.features.length === 1);
+            t.is(res.body.features[0].name, 'test_enabled');
+        });
+});
+
+test('fetch features with specific name', t => {
+    t.plan(2);
+    const { request, featureToggleStore, base } = getSetup();
+    featureToggleStore.addFeature({
+        name: 'test-one',
+        enabled: true,
+        strategies: [{ name: 'default' }],
+    });
+
+    featureToggleStore.addFeature({
+        name: 'test-two',
+        enabled: false,
+        strategies: [{ name: 'default' }],
+    });
+
+    return request
+        .get(`${base}/api/client/features?name=^test-two`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.features.length === 1);
+            t.is(res.body.features[0].name, 'test-two');
+        });
+});

--- a/lib/routes/client-api/feature.test.js
+++ b/lib/routes/client-api/feature.test.js
@@ -99,7 +99,7 @@ test('fetch features with specific name', t => {
     });
 
     return request
-        .get(`${base}/api/client/features?name=^test-two`)
+        .get(`${base}/api/client/features?name=test-two`)
         .expect('Content-Type', /json/)
         .expect(200)
         .expect(res => {


### PR DESCRIPTION
Added support for the following fields:
- **name** - must start with specified string
- **enabled** - must be true or false

Example usage with query params:
 
`GET: http://unleash.host.com/api/client/features?enabled=true&name=test