### PR TITLE
Allow underscores in name validation

### DIFF
--- a/lib/routes/admin-api/feature.js
+++ b/lib/routes/admin-api/feature.js
@@ -103,8 +103,8 @@ module.exports.router = function(config) {
     router.post('/validate', (req, res) => {
         req.checkBody('name', 'Name is required').notEmpty();
         req
-            .checkBody('name', 'Name must match format ^[0-9a-zA-Z\\.\\-]+$')
-            .matches(/^[0-9a-zA-Z\\.\\-]+$/i);
+            .checkBody('name', 'Name must match format ^[0-9a-zA-Z\\.\\-\\_]+$')
+            .matches(/^[0-9a-zA-Z\\.\\-\\_]+$/i);
 
         validateRequest(req)
             .then(validateUniqueName)
@@ -115,8 +115,8 @@ module.exports.router = function(config) {
     router.post('/', (req, res) => {
         req.checkBody('name', 'Name is required').notEmpty();
         req
-            .checkBody('name', 'Name must match format ^[0-9a-zA-Z\\.\\-]+$')
-            .matches(/^[0-9a-zA-Z\\.\\-]+$/i);
+            .checkBody('name', 'Name must match format ^[0-9a-zA-Z\\.\\-\\_]+$')
+            .matches(/^[0-9a-zA-Z\\.\\-\\_]+$/i);
         const userName = extractUser(req);
 
         validateRequest(req)


### PR DESCRIPTION
This PR adds support for underscores in strategy names, allowing for const style naming conventions (`FOO_BAR`).

See related PR in `Unleash/unleash-frontend` - https://github.com/Unleash/unleash-frontend/pull/93

<img width="1121" alt="create feature toggle with underscores" src="https://user-images.githubusercontent.com/1551632/30576322-6eeb6f2e-9d4a-11e7-80ef-d65de69d7f85.png">
