### PR TITLE
Should not allow creation of archived toggle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - DATABASE_URL=postgres://postgres@localhost:5432/unleash_test TEST_DATABASE_URL=postgres://postgres@localhost:5432/unleash_test
   global:
     secure: HyWYh1dbUfe2yPF9ZdcdA/IVGyNWmJmpuaRvRGnnpO63/5Y0KT6/hyL6nZ4YJ7Wr/KEt4eMJBJsnzaCFtiqNA3cWyyprzXJButw0o8C6dfd/9jOleisuvdqndu92RqDKIIq2EjHVq3sd6B8uGyiOlkMsyFH57O/V+xHW8MYLnaQ=
-before_install: yarn global add greenkeeper-lockfile@1
+before_install: npm install -g greenkeeper-lockfile@1
 before_script:
 - psql -c 'create database unleash_test;' -U postgres
 - greenkeeper-lockfile-update

--- a/lib/db/feature-toggle-store.js
+++ b/lib/db/feature-toggle-store.js
@@ -51,6 +51,14 @@ class FeatureToggleStore {
             .then(this.rowToFeature);
     }
 
+    hasFeatureName(name) {
+        return this.db
+            .first('name')
+            .from(TABLE)
+            .where({ name })
+            .then(n => !!n);
+    }
+
     getArchivedFeatures() {
         return this.db
             .select(FEATURE_COLUMNS)

--- a/lib/routes/admin-api/feature.js
+++ b/lib/routes/admin-api/feature.js
@@ -97,12 +97,13 @@ module.exports.router = function(config) {
 
     function validateUniqueName(req) {
         return new Promise((resolve, reject) => {
-            featureToggleStore
-                .getFeature(req.body.name)
-                .then(() =>
-                    reject(new NameExistsError('Feature name already exist'))
-                )
-                .catch(() => resolve(req));
+            featureToggleStore.hasFeatureName(req.body.name).then(hasName => {
+                if (hasName) {
+                    reject(new NameExistsError('Feature name already exist'));
+                } else {
+                    resolve(req);
+                }
+            });
         });
     }
 

--- a/test/e2e/api/admin/feature.e2e.test.js
+++ b/test/e2e/api/admin/feature.e2e.test.js
@@ -193,3 +193,18 @@ test.serial(
             .then(destroy);
     }
 );
+
+test.serial('should not be possible to create archived toggle', async t => {
+    t.plan(0);
+    const { request, destroy } = await setupApp('feature_api_serial');
+    return request
+        .post('/api/admin/features')
+        .send({
+            name: 'featureArchivedX',
+            enabled: false,
+            strategies: [{ name: 'default' }],
+        })
+        .set('Content-Type', 'application/json')
+        .expect(403)
+        .then(destroy);
+});

--- a/test/fixtures/fake-feature-toggle-store.js
+++ b/test/fixtures/fake-feature-toggle-store.js
@@ -12,6 +12,7 @@ module.exports = () => {
             }
         },
         getFeatures: () => Promise.resolve(_features),
+        hasFeatureName: () => Promise.resolve(false),
         addFeature: feature => _features.push(feature),
     };
 };


### PR DESCRIPTION
Fixed name-validation to also check archived feature toggle names.

Inline validation works again:
![image](https://user-images.githubusercontent.com/158948/34095853-557f4e82-e3d3-11e7-9020-e4d7e990617d.png)

API error message shown again:
![image](https://user-images.githubusercontent.com/158948/34095893-8764fa3c-e3d3-11e7-81d0-bd90f6d3a6c6.png)



closes #284 
