### PR TITLE
fix(clientApi): Add namePrefix paramter to /api/client/features

### DIFF
--- a/docs/api/client/feature-toggles-api.md
+++ b/docs/api/client/feature-toggles-api.md
@@ -65,6 +65,9 @@ has the latest response locally.
 }
 ```
 
+You may limit the response by sending a `namePrefix` query-parameter. 
+
+
 `GET: http://unleash.host.com/api/client/features/:featureName`
 
 Used to fetch details about a specific feature toggle. This is mainly provided to make it easy to 

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -4,13 +4,20 @@ const { Router } = require('express');
 
 const version = 1;
 
+const filter = (key, value) => {
+    if (!key || !value) return array => array;
+    return array => array.filter(item => item[key].startsWith(value));
+};
+
 exports.router = config => {
     const router = Router();
     const { featureToggleStore } = config.stores;
 
     router.get('/', (req, res) => {
+        const nameFilter = filter('name', req.query.namePrefix);
         featureToggleStore
             .getFeatures()
+            .then(nameFilter)
             .then(features => res.json({ version, features }));
     });
 

--- a/lib/routes/client-api/feature.test.js
+++ b/lib/routes/client-api/feature.test.js
@@ -52,3 +52,23 @@ test('fetch single feature', t => {
             t.true(res.body.name === 'test_');
         });
 });
+
+test('support name prefix', t => {
+    t.plan(2);
+    const { request, featureToggleStore, base } = getSetup();
+    featureToggleStore.addFeature({ name: 'a_test1' });
+    featureToggleStore.addFeature({ name: 'a_test2' });
+    featureToggleStore.addFeature({ name: 'b_test1' });
+    featureToggleStore.addFeature({ name: 'b_test2' });
+
+    const namePrefix = 'b_';
+
+    return request
+        .get(`${base}/api/client/features?namePrefix=${namePrefix}`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.features.length === 2);
+            t.true(res.body.features[1].name === 'b_test2');
+        });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4174,7 +4174,8 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
   version "0.4.0"
-  resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
+  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"
@@ -4182,7 +4183,7 @@ listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/l
     figures "^1.7.0"
     indent-string "^3.0.0"
     log-symbols "^1.0.2"
-    log-update "^2.3.0"
+    log-update "^1.0.2"
     strip-ansi "^3.0.1"
 
 listr-verbose-renderer@^0.4.0:


### PR DESCRIPTION
Allows the client to limit the response to name with the given prefix.

Closes #251 