### PR TITLE
Technical cleanups

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,7 +4,7 @@ const express = require('express');
 const compression = require('compression');
 const favicon = require('serve-favicon');
 const cookieParser = require('cookie-parser');
-const routes = require('./routes');
+const IndexRouter = require('./routes');
 const path = require('path');
 const errorHandler = require('errorhandler');
 const unleashSession = require('./middleware/session');
@@ -49,11 +49,11 @@ module.exports = function(config) {
     }
 
     // Setup API routes
-    const middleware = routes.router(config);
+    const middleware = new IndexRouter(config);
     if (!middleware) {
         throw new Error('Routes invalid');
     }
-    app.use(`${baseUriPath}/`, middleware);
+    app.use(`${baseUriPath}/`, middleware.router());
 
     if (process.env.NODE_ENV !== 'production') {
         app.use(errorHandler());

--- a/lib/app.test.js
+++ b/lib/app.test.js
@@ -4,8 +4,10 @@ const { test } = require('ava');
 const express = require('express');
 const proxyquire = require('proxyquire');
 const getApp = proxyquire('./app', {
-    './routes': {
-        router: () => express.Router(),
+    './routes': class Index {
+        router() {
+            return express.Router();
+        }
     },
 });
 

--- a/lib/routes/backstage.js
+++ b/lib/routes/backstage.js
@@ -3,15 +3,23 @@
 const { Router } = require('express');
 const { register: prometheusRegister } = require('prom-client');
 
-exports.router = config => {
-    const router = Router();
+class BackstageController {
+    constructor(config) {
+        const router = Router();
 
-    if (config.serverMetrics) {
-        router.get('/prometheus', (req, res) => {
-            res.set('Content-Type', prometheusRegister.contentType);
-            res.end(prometheusRegister.metrics());
-        });
+        if (config.serverMetrics) {
+            router.get('/prometheus', (req, res) => {
+                res.set('Content-Type', prometheusRegister.contentType);
+                res.end(prometheusRegister.metrics());
+            });
+        }
+
+        this.app = router;
     }
 
-    return router;
-};
+    router() {
+        return this.app;
+    }
+}
+
+module.exports = BackstageController;

--- a/lib/routes/client-api/client-api.json
+++ b/lib/routes/client-api/client-api.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "links": {
+    "feature-toggles": {
+      "uri": "/api/client/features"
+    },
+    "register": {
+      "uri": "/api/client/register"
+    },
+    "metrics": {
+      "uri": "/api/client/metrics"
+    }
+  }
+}

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -1,13 +1,9 @@
 'use strict';
 
 const { Router } = require('express');
+const { filter } = require('./util');
 
 const version = 1;
-
-const filter = (key, value) => {
-    if (!key || !value) return array => array;
-    return array => array.filter(item => item[key].startsWith(value));
-};
 
 class FeatureController {
     constructor(config) {

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -9,26 +9,38 @@ const filter = (key, value) => {
     return array => array.filter(item => item[key].startsWith(value));
 };
 
-exports.router = config => {
-    const router = Router();
-    const { featureToggleStore } = config.stores;
+class FeatureController {
+    constructor(config) {
+        const router = Router();
+        this._router = router;
+        this.store = config.stores.featureToggleStore;
 
-    router.get('/', (req, res) => {
+        router.get('/', (req, res) => this.getAll(req, res));
+        router.get('/:featureName', this.getFeatureToggle.bind(this));
+    }
+
+    async getAll(req, res) {
         const nameFilter = filter('name', req.query.namePrefix);
-        featureToggleStore
-            .getFeatures()
-            .then(nameFilter)
-            .then(features => res.json({ version, features }));
-    });
 
-    router.get('/:featureName', (req, res) => {
-        featureToggleStore
-            .getFeature(req.params.featureName)
-            .then(feature => res.json(feature).end())
-            .catch(() =>
-                res.status(404).json({ error: 'Could not find feature' })
-            );
-    });
+        const allFeatureToggles = await this.store.getFeatures();
+        const features = nameFilter(allFeatureToggles);
 
-    return router;
-};
+        res.json({ version, features });
+    }
+
+    async getFeatureToggle(req, res) {
+        try {
+            const name = req.params.featureName;
+            const featureToggle = await this.store.getFeature(name);
+            res.json(featureToggle).end();
+        } catch (err) {
+            res.status(404).json({ error: 'Could not find feature' });
+        }
+    }
+
+    router() {
+        return this._router;
+    }
+}
+
+module.exports = FeatureController;

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -6,10 +6,10 @@ const { filter } = require('./util');
 const version = 1;
 
 class FeatureController {
-    constructor(config) {
+    constructor({ featureToggleStore }) {
         const router = Router();
         this._router = router;
-        this.store = config.stores.featureToggleStore;
+        this.toggleStore = featureToggleStore;
 
         router.get('/', (req, res) => this.getAll(req, res));
         router.get('/:featureName', this.getFeatureToggle.bind(this));
@@ -18,7 +18,7 @@ class FeatureController {
     async getAll(req, res) {
         const nameFilter = filter('name', req.query.namePrefix);
 
-        const allFeatureToggles = await this.store.getFeatures();
+        const allFeatureToggles = await this.toggleStore.getFeatures();
         const features = nameFilter(allFeatureToggles);
 
         res.json({ version, features });
@@ -27,7 +27,7 @@ class FeatureController {
     async getFeatureToggle(req, res) {
         try {
             const name = req.params.featureName;
-            const featureToggle = await this.store.getFeature(name);
+            const featureToggle = await this.toggleStore.getFeature(name);
             res.json(featureToggle).end();
         } catch (err) {
             res.status(404).json({ error: 'Could not find feature' });

--- a/lib/routes/client-api/index.js
+++ b/lib/routes/client-api/index.js
@@ -2,7 +2,7 @@
 
 const { Router } = require('express');
 const FeatureController = require('./feature.js');
-const metrics = require('./metrics.js');
+const ClientMetricsController = require('./metrics.js');
 const register = require('./register.js');
 const clientApi = require('./client-api.json');
 
@@ -13,7 +13,7 @@ class ClientApi {
 
         router.get('/', this.index);
         router.use('/features', new FeatureController(config).router());
-        router.use('/metrics', metrics.router(config));
+        router.use('/metrics', new ClientMetricsController(config).router());
         router.use('/register', register.router(config));
     }
 

--- a/lib/routes/client-api/index.js
+++ b/lib/routes/client-api/index.js
@@ -11,10 +11,12 @@ class ClientApi {
         const router = Router();
         this._router = router;
 
+        const stores = config.stores;
+
         router.get('/', this.index);
-        router.use('/features', new FeatureController(config).router());
-        router.use('/metrics', new MetricsController(config).router());
-        router.use('/register', new RegisterController(config).router());
+        router.use('/features', new FeatureController(stores).router());
+        router.use('/metrics', new MetricsController(stores).router());
+        router.use('/register', new RegisterController(stores).router());
     }
 
     index(req, res) {

--- a/lib/routes/client-api/index.js
+++ b/lib/routes/client-api/index.js
@@ -4,27 +4,28 @@ const { Router } = require('express');
 const FeatureController = require('./feature.js');
 const metrics = require('./metrics.js');
 const register = require('./register.js');
+const clientApi = require('./client-api.json');
 
-const apiDef = {
-    version: 2,
-    links: {
-        'feature-toggles': { uri: '/api/client/features' },
-        register: { uri: '/api/client/register' },
-        metrics: { uri: '/api/client/metrics' },
-    },
-};
+class ClientApi {
+    constructor(config) {
+        const router = Router();
+        this._router = router;
 
-exports.apiDef = apiDef;
+        router.get('/', this.index);
+        router.use('/features', new FeatureController(config).router());
+        router.use('/metrics', metrics.router(config));
+        router.use('/register', register.router(config));
+    }
 
-exports.router = config => {
-    const router = Router();
-    router.get('/', (req, res) => {
-        res.json(apiDef);
-    });
+    index(req, res) {
+        res.json(clientApi);
+    }
 
-    router.use('/features', new FeatureController(config).router());
-    router.use('/metrics', metrics.router(config));
-    router.use('/register', register.router(config));
+    router() {
+        return this._router;
+    }
+}
 
-    return router;
-};
+ClientApi.api = clientApi;
+
+module.exports = ClientApi;

--- a/lib/routes/client-api/index.js
+++ b/lib/routes/client-api/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Router } = require('express');
-const features = require('./feature.js');
+const FeatureController = require('./feature.js');
 const metrics = require('./metrics.js');
 const register = require('./register.js');
 
@@ -22,7 +22,7 @@ exports.router = config => {
         res.json(apiDef);
     });
 
-    router.use('/features', features.router(config));
+    router.use('/features', new FeatureController(config).router());
     router.use('/metrics', metrics.router(config));
     router.use('/register', register.router(config));
 

--- a/lib/routes/client-api/index.js
+++ b/lib/routes/client-api/index.js
@@ -2,9 +2,9 @@
 
 const { Router } = require('express');
 const FeatureController = require('./feature.js');
-const ClientMetricsController = require('./metrics.js');
-const register = require('./register.js');
-const clientApi = require('./client-api.json');
+const MetricsController = require('./metrics.js');
+const RegisterController = require('./register.js');
+const clientApiSpec = require('./client-api.json');
 
 class ClientApi {
     constructor(config) {
@@ -13,12 +13,12 @@ class ClientApi {
 
         router.get('/', this.index);
         router.use('/features', new FeatureController(config).router());
-        router.use('/metrics', new ClientMetricsController(config).router());
-        router.use('/register', register.router(config));
+        router.use('/metrics', new MetricsController(config).router());
+        router.use('/register', new RegisterController(config).router());
     }
 
     index(req, res) {
-        res.json(clientApi);
+        res.json(clientApiSpec);
     }
 
     router() {
@@ -26,6 +26,6 @@ class ClientApi {
     }
 }
 
-ClientApi.api = clientApi;
+ClientApi.api = clientApiSpec;
 
 module.exports = ClientApi;

--- a/lib/routes/client-api/metrics.js
+++ b/lib/routes/client-api/metrics.js
@@ -6,34 +6,44 @@ const logger = require('../../logger')('client-api/metrics.js');
 
 const { clientMetricsSchema } = require('./metrics-schema');
 
-exports.router = config => {
-    const { clientMetricsStore, clientInstanceStore } = config.stores;
-    const router = Router();
+class ClientMetricsController {
+    constructor({ stores: { clientMetricsStore, clientInstanceStore } }) {
+        const router = Router();
+        this.clientMetricsStore = clientMetricsStore;
+        this.clientInstanceStore = clientInstanceStore;
+        this._router = router;
 
-    router.post('/', (req, res) => {
+        router.post('/', (req, res) => this.registerMetrics(req, res));
+    }
+
+    async registerMetrics(req, res) {
         const data = req.body;
         const clientIp = req.ip;
 
-        joi.validate(data, clientMetricsSchema, (err, cleaned) => {
-            if (err) {
-                logger.warn('Invalid metrics posted', err);
-                return res.status(400).json(err);
-            }
+        const { error, value } = joi.validate(data, clientMetricsSchema);
 
-            clientMetricsStore
-                .insert(cleaned)
-                .then(() =>
-                    clientInstanceStore.insert({
-                        appName: cleaned.appName,
-                        instanceId: cleaned.instanceId,
-                        clientIp,
-                    })
-                )
-                .catch(err => logger.error('failed to store metrics', err));
+        if (error) {
+            logger.warn('Invalid metrics posted', error);
+            return res.status(400).json(error);
+        }
 
+        try {
+            await this.clientMetricsStore.insert(value);
+            await this.clientInstanceStore.insert({
+                appName: value.appName,
+                instanceId: value.instanceId,
+                clientIp,
+            });
             res.status(202).end();
-        });
-    });
+        } catch (e) {
+            logger.error('failed to store metrics', e);
+            res.status(500).end();
+        }
+    }
 
-    return router;
-};
+    router() {
+        return this._router;
+    }
+}
+
+module.exports = ClientMetricsController;

--- a/lib/routes/client-api/metrics.js
+++ b/lib/routes/client-api/metrics.js
@@ -7,7 +7,7 @@ const logger = require('../../logger')('client-api/metrics.js');
 const { clientMetricsSchema } = require('./metrics-schema');
 
 class ClientMetricsController {
-    constructor({ stores: { clientMetricsStore, clientInstanceStore } }) {
+    constructor({ clientMetricsStore, clientInstanceStore }) {
         const router = Router();
         this.clientMetricsStore = clientMetricsStore;
         this.clientInstanceStore = clientInstanceStore;

--- a/lib/routes/client-api/register.js
+++ b/lib/routes/client-api/register.js
@@ -7,7 +7,7 @@ const logger = require('../../logger')('/client-api/register.js');
 const { clientRegisterSchema: schema } = require('./register-schema');
 
 class RegisterController {
-    constructor({ stores: { clientInstanceStore, clientApplicationsStore } }) {
+    constructor({ clientInstanceStore, clientApplicationsStore }) {
         const router = Router();
         this._router = router;
         this.clientInstanceStore = clientInstanceStore;

--- a/lib/routes/client-api/register.js
+++ b/lib/routes/client-api/register.js
@@ -4,37 +4,47 @@ const { Router } = require('express');
 const joi = require('joi');
 const logger = require('../../logger')('/client-api/register.js');
 
-const { clientRegisterSchema } = require('./register-schema');
+const { clientRegisterSchema: schema } = require('./register-schema');
 
-exports.router = config => {
-    const { clientInstanceStore, clientApplicationsStore } = config.stores;
-    const router = Router();
+class RegisterController {
+    constructor({ stores: { clientInstanceStore, clientApplicationsStore } }) {
+        const router = Router();
+        this._router = router;
+        this.clientInstanceStore = clientInstanceStore;
+        this.clientApplicationsStore = clientApplicationsStore;
 
-    router.post('/', (req, res) => {
+        router.post('/', (req, res) => this.handleRegister(req, res));
+    }
+
+    async handleRegister(req, res) {
         const data = req.body;
+        const { value: clientRegistration, error } = joi.validate(data, schema);
 
-        joi.validate(data, clientRegisterSchema, (err, clientRegistration) => {
-            if (err) {
-                logger.warn('Invalid client data posted', err);
-                return res.status(400).json(err);
-            }
+        if (error) {
+            logger.warn('Invalid client data posted', error);
+            return res.status(400).json(error);
+        }
 
-            clientRegistration.clientIp = req.ip;
+        clientRegistration.clientIp = req.ip;
 
-            clientApplicationsStore
-                .upsert(clientRegistration)
-                .then(() => clientInstanceStore.insert(clientRegistration))
-                .then(() =>
-                    logger.info(`New client registered with
-                        appName=${clientRegistration.appName} and instanceId=${
-                        clientRegistration.instanceId
-                    }`)
-                )
-                .catch(err => logger.error('failed to register client', err));
+        try {
+            await this.clientApplicationsStore.upsert(clientRegistration);
+            await this.clientInstanceStore.insert(clientRegistration);
+            logger.info(
+                `New client registered with appName=${
+                    clientRegistration.appName
+                } and instanceId=${clientRegistration.instanceId}`
+            );
+            return res.status(202).end();
+        } catch (err) {
+            logger.error('failed to register client', err);
+            return res.status(500).end();
+        }
+    }
 
-            res.status(202).end();
-        });
-    });
+    router() {
+        return this._router;
+    }
+}
 
-    return router;
-};
+module.exports = RegisterController;

--- a/lib/routes/client-api/register.test.js
+++ b/lib/routes/client-api/register.test.js
@@ -73,3 +73,35 @@ test('should require strategies field', t => {
         })
         .expect(400);
 });
+
+test('should fail if store fails', t => {
+    t.plan(0);
+
+    // --- start custom config
+    const stores = store.createStores();
+    stores.clientApplicationsStore = {
+        upsert: () => {
+            throw new Error('opps');
+        },
+    };
+
+    const app = getApp({
+        baseUriPath: '',
+        stores,
+        eventBus,
+    });
+    // --- end custom config
+
+    const request = supertest(app);
+
+    return request
+        .post('/api/client/register')
+        .send({
+            appName: 'demo',
+            instanceId: 'test',
+            strategies: ['default'],
+            started: Date.now(),
+            interval: 10,
+        })
+        .expect(500);
+});

--- a/lib/routes/client-api/util.js
+++ b/lib/routes/client-api/util.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const filter = (key, value) => {
+    if (!key || !value) return array => array;
+    return array => array.filter(item => item[key].startsWith(value));
+};
+
+module.exports = {
+    filter,
+};

--- a/lib/routes/health-check.js
+++ b/lib/routes/health-check.js
@@ -1,24 +1,31 @@
 'use strict';
 
-const logger = require('../logger')('health-check.js');
 const { Router } = require('express');
+const logger = require('../logger')('health-check.js');
 
-exports.router = function(config) {
-    const router = Router();
+class HealthCheckController {
+    constructor(config) {
+        const app = Router();
 
-    router.get('/', (req, res) => {
-        config.stores.db
-            .select(1)
-            .from('features')
-            .then(() => res.json({ health: 'GOOD' }))
-            .catch(err => {
-                logger.error(
-                    'Could not select from features, error was: ',
-                    err
-                );
-                res.status(500).json({ health: 'BAD' });
-            });
-    });
+        this.app = app;
+        this.db = config.stores.db;
 
-    return router;
-};
+        app.get('/', (req, res) => this.index(req, res));
+    }
+
+    async index(req, res) {
+        try {
+            await this.db.select(1).from('features');
+            res.json({ health: 'GOOD' });
+        } catch (e) {
+            logger.error('Could not select from features, error was: ', e);
+            res.status(500).json({ health: 'BAD' });
+        }
+    }
+
+    router() {
+        return this.app;
+    }
+}
+
+module.exports = HealthCheckController;

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -7,7 +7,7 @@ require('pkginfo')(module, 'version');
 const version = module.exports.version;
 
 const adminApi = require('./admin-api');
-const clientApi = require('./client-api');
+const ClientApi = require('./client-api');
 const FeatureController = require('./client-api/feature.js');
 
 const HealthCheckController = require('./health-check');
@@ -25,7 +25,7 @@ class IndexRouter {
         );
         router.get('/api', (req, res) => this.api(req, res));
         router.use('/api/admin', adminApi.router(config));
-        router.use('/api/client', clientApi.router(config));
+        router.use('/api/client', new ClientApi(config).router());
 
         // legacy support (remove in 4.x)
         if (config.enableLegacyRoutes) {
@@ -44,7 +44,7 @@ class IndexRouter {
                 },
                 client: {
                     uri: '/api/client',
-                    links: clientApi.apiDef.links,
+                    links: ClientApi.api.links,
                 },
             },
         });

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -29,7 +29,10 @@ class IndexRouter {
 
         // legacy support (remove in 4.x)
         if (config.enableLegacyRoutes) {
-            router.use('/api/features', new FeatureController(config).router());
+            router.use(
+                '/api/features',
+                new FeatureController(config.stores).router()
+            );
         }
     }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -11,13 +11,13 @@ const clientApi = require('./client-api');
 const clientFeatures = require('./client-api/feature.js');
 
 const HealthCheckController = require('./health-check');
-const backstage = require('./backstage.js');
+const BackstageController = require('./backstage.js');
 
 exports.router = function(config) {
     const router = Router();
 
     router.use('/health', new HealthCheckController(config).router());
-    router.use('/internal-backstage', backstage.router(config));
+    router.use('/internal-backstage', new BackstageController(config).router());
 
     router.get('/api', (req, res) => {
         res.json({

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -8,7 +8,7 @@ const version = module.exports.version;
 
 const adminApi = require('./admin-api');
 const clientApi = require('./client-api');
-const clientFeatures = require('./client-api/feature.js');
+const FeatureController = require('./client-api/feature.js');
 
 const HealthCheckController = require('./health-check');
 const BackstageController = require('./backstage.js');
@@ -29,7 +29,7 @@ class IndexRouter {
 
         // legacy support (remove in 4.x)
         if (config.enableLegacyRoutes) {
-            router.use('/api/features', clientFeatures.router(config));
+            router.use('/api/features', new FeatureController(config).router());
         }
     }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -13,13 +13,27 @@ const clientFeatures = require('./client-api/feature.js');
 const HealthCheckController = require('./health-check');
 const BackstageController = require('./backstage.js');
 
-exports.router = function(config) {
-    const router = Router();
+class IndexRouter {
+    constructor(config) {
+        const router = Router();
+        this._router = router;
 
-    router.use('/health', new HealthCheckController(config).router());
-    router.use('/internal-backstage', new BackstageController(config).router());
+        router.use('/health', new HealthCheckController(config).router());
+        router.use(
+            '/internal-backstage',
+            new BackstageController(config).router()
+        );
+        router.get('/api', (req, res) => this.api(req, res));
+        router.use('/api/admin', adminApi.router(config));
+        router.use('/api/client', clientApi.router(config));
 
-    router.get('/api', (req, res) => {
+        // legacy support (remove in 4.x)
+        if (config.enableLegacyRoutes) {
+            router.use('/api/features', clientFeatures.router(config));
+        }
+    }
+
+    api(req, res) {
         res.json({
             name: 'unleash-server',
             version,
@@ -34,18 +48,11 @@ exports.router = function(config) {
                 },
             },
         });
-    });
-
-    router.use('/api/admin', adminApi.router(config));
-    router.use('/api/client', clientApi.router(config));
-
-    // legacy support
-    // $root/features
-    // $root/client/register
-    // $root/client/metrics
-    if (config.enableLegacyRoutes) {
-        router.use('/api/features', clientFeatures.router(config));
     }
 
-    return router;
-};
+    router() {
+        return this._router;
+    }
+}
+
+module.exports = IndexRouter;

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -10,13 +10,13 @@ const adminApi = require('./admin-api');
 const clientApi = require('./client-api');
 const clientFeatures = require('./client-api/feature.js');
 
-const health = require('./health-check');
+const HealthCheckController = require('./health-check');
 const backstage = require('./backstage.js');
 
 exports.router = function(config) {
     const router = Router();
 
-    router.use('/health', health.router(config));
+    router.use('/health', new HealthCheckController(config).router());
     router.use('/internal-backstage', backstage.router(config));
 
     router.get('/api', (req, res) => {

--- a/lib/server-impl.js
+++ b/lib/server-impl.js
@@ -24,14 +24,14 @@ function createApp(options) {
             eventBus,
             logFactory,
         },
-        options,
+        options
     );
 
     const app = getApp(config);
     startMonitoring(options.serverMetrics, eventBus, stores.eventStore);
 
     const server = app.listen({ port: options.port, host: options.host }, () =>
-        logger.info(`Unleash started on port ${server.address().port}`),
+        logger.info(`Unleash started on port ${server.address().port}`)
     );
 
     return new Promise((resolve, reject) => {

--- a/lib/server-impl.js
+++ b/lib/server-impl.js
@@ -2,6 +2,7 @@
 
 const { EventEmitter } = require('events');
 
+const logFactory = require('./logger');
 const logger = require('./logger')('server-impl.js');
 const migrator = require('../migrator');
 const getApp = require('./app');
@@ -21,15 +22,16 @@ function createApp(options) {
         {
             stores,
             eventBus,
+            logFactory,
         },
-        options
+        options,
     );
 
     const app = getApp(config);
     startMonitoring(options.serverMetrics, eventBus, stores.eventStore);
 
     const server = app.listen({ port: options.port, host: options.host }, () =>
-        logger.info(`Unleash started on port ${server.address().port}`)
+        logger.info(`Unleash started on port ${server.address().port}`),
     );
 
     return new Promise((resolve, reject) => {

--- a/lib/server-impl.test.js
+++ b/lib/server-impl.test.js
@@ -5,8 +5,10 @@ const proxyquire = require('proxyquire');
 const express = require('express');
 
 const getApp = proxyquire('./app', {
-    './routes': {
-        router: () => express.Router(),
+    './routes': class Index {
+        router() {
+            return express.Router();
+        }
     },
 });
 


### PR DESCRIPTION
This PR resolves #298. 

- [ ] Use `Class` as implementation for all express routers. 
  - [x] Client Api
  - [ ] Admin Api
- [ ] Use `async` and `await` instead of promise chains
  - [x] Client Api
  - [ ] Admin Api
- [ ] Use [Joi](https://github.com/hapijs/joi) for all validations in routes in stead of express-validator
  - [x] Client Api
  - [ ] Admin Api