### PR TITLE
fix: Metrics poller should start even if inital fetch fails.

### DIFF
--- a/lib/db/client-metrics-store.js
+++ b/lib/db/client-metrics-store.js
@@ -12,13 +12,18 @@ class ClientMetricsStore extends EventEmitter {
         this.metricsDb = metricsDb;
         this.highestIdSeen = 0;
 
-        // Build internal state
-        metricsDb
-            .getMetricsLastHour()
-            .then(metrics => this._emitMetrics(metrics))
-            .then(() => this._startPoller(pollInterval))
-            .then(() => this.emit('ready'))
-            .catch(err => logger.error(err));
+        this._init(pollInterval);
+    }
+
+    async _init(pollInterval) {
+        try {
+            const metrics = await this.metricsDb.getMetricsLastHour();
+            this._emitMetrics(metrics);
+        } catch (err) {
+            logger.error('Error fetching metrics last hour', err);
+        }
+        this._startPoller(pollInterval);
+        this.emit('ready');
     }
 
     _startPoller(pollInterval) {

--- a/lib/db/client-metrics-store.test.js
+++ b/lib/db/client-metrics-store.test.js
@@ -37,6 +37,28 @@ test.cb('should call database on startup', t => {
     });
 });
 
+test.cb('should start poller even if inital database fetch fails', t => {
+    const clock = lolex.install();
+    const mock = getMockDb();
+    mock.getMetricsLastHour = () => Promise.reject('oops');
+
+    const store = new ClientMetricStore(mock, 100);
+
+    const metrics = [];
+    store.on('metrics', m => metrics.push(m));
+
+    store.on('ready', () => {
+        t.true(metrics.length === 0);
+        clock.tick(300);
+        process.nextTick(() => {
+            t.true(metrics.length === 3);
+            t.true(store.highestIdSeen === 4);
+            store.destroy();
+            t.end();
+        });
+    });
+});
+
 test.cb('should poll for updates', t => {
     const clock = lolex.install();
 
@@ -55,7 +77,6 @@ test.cb('should poll for updates', t => {
             t.true(metrics.length === 4);
             t.true(store.highestIdSeen === 4);
             store.destroy();
-            clock.uninstall();
             t.end();
         });
     });


### PR DESCRIPTION
Currently if the initial metrics-fetch fails unleash will not setup a metrics-poller. This fix ensures that the metrics-poller will start regardless of whether the initial fetch fails or succeeds.

closes #396