### PR TITLE
fix: Add explicit endpoints for toggle on/off

### DIFF
--- a/lib/routes/admin-api/feature.js
+++ b/lib/routes/admin-api/feature.js
@@ -32,6 +32,8 @@ class FeatureController extends Controller {
         this.delete('/:featureName', this.deleteToggle, DELETE_FEATURE);
         this.post('/validate', this.validate);
         this.post('/:featureName/toggle', this.toggle, UPDATE_FEATURE);
+        this.post('/:featureName/toggle/on', this.toggleOn, UPDATE_FEATURE);
+        this.post('/:featureName/toggle/off', this.toggleOff, UPDATE_FEATURE);
     }
 
     async getAllToggles(req, res) {
@@ -117,7 +119,27 @@ class FeatureController extends Controller {
         }
     }
 
+    // Kept to keep backward compatability
     async toggle(req, res) {
+        try {
+            const name = req.params.featureName;
+            const feature = await this.featureToggleStore.getFeature(name);
+            const enabled = !feature.enabled;
+            this._toggle(enabled, req, res);
+        } catch (error) {
+            handleErrors(res, error);
+        }
+    }
+
+    async toggleOn(req, res) {
+        this._toggle(true, req, res);
+    }
+
+    async toggleOff(req, res) {
+        this._toggle(false, req, res);
+    }
+
+    async _toggle(enabled, req, res) {
         const featureName = req.params.featureName;
         const userName = extractUser(req);
 
@@ -126,13 +148,13 @@ class FeatureController extends Controller {
                 featureName
             );
 
-            feature.enabled = !feature.enabled;
+            feature.enabled = enabled;
             await this.eventStore.store({
                 type: FEATURE_UPDATED,
                 createdBy: userName,
                 data: feature,
             });
-            res.status(200).end();
+            res.json(feature).end();
         } catch (error) {
             handleErrors(res, error);
         }

--- a/lib/routes/admin-api/feature.test.js
+++ b/lib/routes/admin-api/feature.test.js
@@ -296,3 +296,63 @@ test('should not allow variants with same name when updating feature flag', t =>
         .set('Content-Type', 'application/json')
         .expect(400);
 });
+
+test('should toggle on', t => {
+    t.plan(1);
+    const { request, featureToggleStore, base, perms } = getSetup();
+    perms.withPermissions(UPDATE_FEATURE);
+
+    featureToggleStore.addFeature({
+        name: 'toggle.disabled',
+        enabled: false,
+        strategies: [{ name: 'default' }],
+    });
+
+    return request
+        .post(`${base}/api/admin/features/toggle.disabled/toggle/on`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.enabled === true);
+        });
+});
+
+test('should toggle off', t => {
+    t.plan(1);
+    const { request, featureToggleStore, base, perms } = getSetup();
+    perms.withPermissions(UPDATE_FEATURE);
+
+    featureToggleStore.addFeature({
+        name: 'toggle.enabled',
+        enabled: true,
+        strategies: [{ name: 'default' }],
+    });
+
+    return request
+        .post(`${base}/api/admin/features/toggle.enabled/toggle/off`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.enabled === false);
+        });
+});
+
+test('should toggle', t => {
+    t.plan(1);
+    const { request, featureToggleStore, base, perms } = getSetup();
+    perms.withPermissions(UPDATE_FEATURE);
+
+    featureToggleStore.addFeature({
+        name: 'toggle.disabled',
+        enabled: false,
+        strategies: [{ name: 'default' }],
+    });
+
+    return request
+        .post(`${base}/api/admin/features/toggle.disabled/toggle`)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.true(res.body.enabled === true);
+        });
+});


### PR DESCRIPTION
This PR makes the Admin API expose two new endpoints:

`/api/admin/features/:featureName/toggle/on` - Enable the toggle, regardless of current state. 
`/api/admin/features/:featureName/toggle/off` - Disable the toggle, regardless of current state. 

Both endpoints will in addition return the current state of the feature toggle.

We also need to update unleash-frontend to take advantage of these two new endpoints, see:
https://github.com/Unleash/unleash-frontend/pull/169
 

closes #394 

cc @Catuna