### PR TITLE
fix: add logger.js to package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bin",
     "migrations",
     "server.js",
+    "logger.js",
     "migrator.js"
   ],
   "repository": {


### PR DESCRIPTION
**Problem:**
Setting a log provider is not possible using the [official getting started docs](https://github.com/Unleash/unleash/blob/master/docs/getting-started.md#how-do-i-set-a-logger-provider).

**Cause:**
The `logger.js` file is not being shipped with the npm package.

**Workaround:**
using `require('unleash-server/lib/logger.js')` directly instead.

This PR should fixe the root cause by including the `logger.js` file in the package. Tho, i'm uncertain if this really fixes the issue. It would mean the `custom-logger-provider` feature has never worked as documented :fearful: 