### PR TITLE
feat: Separate DATABASE_URL to multiple DATABASE_* variable

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -32,11 +32,12 @@ const DEFAULT_OPTIONS = {
 
 function defaultDatabaseUrl() {
     const dbUsername = process.env.DATABASE_USERNAME || 'unleash_user';
-    const dbPassword = process.env.DATABASE_PASSWORD || 'password';
+    const dbPassword = process.env.DATABASE_PASSWORD || 'passord';
     const dbHost = process.env.DATABASE_HOST || 'localhost';
     const dbPort = process.env.DATABASE_PORT || 5432;
     const dbName = process.env.DATABASE_NAME || 'unleash';
-    return `postgres://${dbUsername}:${dbPassword}@${dbHost}:${dbPort}/${dbName}`;
+    const sslSupport = process.env.DATABASE_SSL || 'false';
+    return `postgres://${dbUsername}:${dbPassword}@${dbHost}:${dbPort}/${dbName}?ssl=${sslSupport}`;
 }
 
 module.exports = {

--- a/lib/options.js
+++ b/lib/options.js
@@ -36,7 +36,7 @@ function defaultDatabaseUrl() {
     const dbHost = process.env.DATABASE_HOST || 'localhost';
     const dbPort = process.env.DATABASE_PORT || 5432;
     const dbName = process.env.DATABASE_NAME || 'unleash';
-    const sslSupport = process.env.DATABASE_SSL || 'false';
+    const sslSupport = process.env.DATABASE_SSL || 'true';
     return `postgres://${dbUsername}:${dbPassword}@${dbHost}:${dbPort}/${dbName}?ssl=${sslSupport}`;
 }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,10 @@ const isDev = () => process.env.NODE_ENV === 'development';
 const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
 
 const DEFAULT_OPTIONS = {
-    databaseUrl: process.env.DATABASE_URL,
+    databaseUrl:
+        process.env.DATABASE_URL || process.env.DATABASE_HOST
+            ? defaultDatabaseUrl()
+            : null,
     databaseSchema: 'public',
     port: process.env.HTTP_PORT || process.env.PORT || 4242,
     host: process.env.HTTP_HOST,
@@ -27,19 +30,27 @@ const DEFAULT_OPTIONS = {
     getLogger: defaultLogProvider,
 };
 
+function defaultDatabaseUrl() {
+    const dbUsername = process.env.DATABASE_USERNAME || 'unleash_user';
+    const dbPassword = process.env.DATABASE_PASSWORD || 'password';
+    const dbHost = process.env.DATABASE_HOST || 'localhost';
+    const dbPort = process.env.DATABASE_PORT || 5432;
+    const dbName = process.env.DATABASE_NAME || 'unleash';
+    return `postgres://${dbUsername}:${dbPassword}@${dbHost}:${dbPort}/${dbName}`;
+}
+
 module.exports = {
     createOptions: opts => {
         const options = Object.assign({}, DEFAULT_OPTIONS, opts);
 
         // If we are running in development we should assume local db
         if (isDev() && !options.databaseUrl) {
-            options.databaseUrl =
-                'postgres://unleash_user:passord@localhost:5432/unleash';
+            options.databaseUrl = defaultDatabaseUrl();
         }
 
         if (!options.databaseUrl) {
             throw new Error(
-                'You must either pass databaseUrl option or set environemnt variable DATABASE_URL'
+                'You must either pass databaseUrl option or set environemnt variable DATABASE_URL || (DATABASE_HOST, DATABASE_PORT, DATABASE_USERNAME, DATABASE_PASSWORD, DATABASE_NAME)'
             );
         }
 

--- a/lib/options.test.js
+++ b/lib/options.test.js
@@ -20,7 +20,7 @@ test('should set default databaseUrl for develpment', t => {
 
     t.true(
         options.databaseUrl ===
-            'postgres://unleash_user:passord@localhost:5432/unleash'
+            'postgres://unleash_user:password@localhost:5432/unleash'
     );
 });
 

--- a/lib/options.test.js
+++ b/lib/options.test.js
@@ -20,7 +20,7 @@ test('should set default databaseUrl for develpment', t => {
 
     t.true(
         options.databaseUrl ===
-            'postgres://unleash_user:password@localhost:5432/unleash'
+            'postgres://unleash_user:passord@localhost:5432/unleash'
     );
 });
 

--- a/lib/options.test.js
+++ b/lib/options.test.js
@@ -20,7 +20,7 @@ test('should set default databaseUrl for develpment', t => {
 
     t.true(
         options.databaseUrl ===
-            'postgres://unleash_user:passord@localhost:5432/unleash'
+            'postgres://unleash_user:passord@localhost:5432/unleash?ssl=false'
     );
 });
 

--- a/lib/options.test.js
+++ b/lib/options.test.js
@@ -20,7 +20,7 @@ test('should set default databaseUrl for develpment', t => {
 
     t.true(
         options.databaseUrl ===
-            'postgres://unleash_user:passord@localhost:5432/unleash?ssl=false'
+            'postgres://unleash_user:passord@localhost:5432/unleash?ssl=true'
     );
 });
 


### PR DESCRIPTION
Due to deploy unleash to kubernetes cluster, I would like separate DATABASE_URL to use multiple DATABASE_*, which help us to reuse current configmap, and protect DATABASE_PASSWORD by using vault secret.
Setting DATABASE_URL still available due to backward compatible