### PR TITLE
fix: none authentication should have a mock user

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -11,6 +11,7 @@ const unleashSession = require('./middleware/session');
 const responseTime = require('./middleware/response-time');
 const requestLogger = require('./middleware/request-logger');
 const simpleAuthentication = require('./middleware/simple-authentication');
+const noAuthentication = require('./middleware/no-authentication');
 
 module.exports = function(config) {
     const app = express();
@@ -40,6 +41,10 @@ module.exports = function(config) {
 
     if (config.adminAuthentication === 'unsecure') {
         simpleAuthentication(baseUriPath, app);
+    }
+
+    if (config.adminAuthentication === 'none') {
+        noAuthentication(baseUriPath, app);
     }
 
     if (typeof config.preRouterHook === 'function') {

--- a/lib/middleware/no-authentication.js
+++ b/lib/middleware/no-authentication.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const User = require('../user');
+
+function noneAuthentication(basePath = '', app) {
+    app.use(`${basePath}/api/admin/`, (req, res, next) => {
+        req.user = new User({ email: 'none@unknown.com' });
+        next();
+    });
+}
+
+module.exports = noneAuthentication;

--- a/lib/middleware/no-authentication.test.js
+++ b/lib/middleware/no-authentication.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const test = require('ava');
+const supertest = require('supertest');
+const express = require('express');
+const noAuthentication = require('./no-authentication');
+
+test('should add dummy user object to all requests', t => {
+    t.plan(1);
+
+    const app = express();
+    noAuthentication('', app);
+    app.get('/api/admin/test', (req, res) => {
+        const user = Object.assign({}, req.user);
+
+        return res
+            .status(200)
+            .json(user)
+            .end();
+    });
+    const request = supertest(app);
+
+    return request
+        .get('/api/admin/test')
+        .expect(200)
+        .expect(res => {
+            console.log(res.body);
+            t.true(res.body.email === 'none@unknown.com');
+        });
+});

--- a/test/e2e/api/admin/feature.e2e.test.js
+++ b/test/e2e/api/admin/feature.e2e.test.js
@@ -91,7 +91,7 @@ test.serial('creates new feature toggle with createdBy unknown', async t => {
     await request
         .get('/api/admin/events')
         .expect(res => {
-            t.true(res.body.events[0].createdBy === 'unknown');
+            t.true(res.body.events[0].createdBy === 'none@unknown.com');
         })
         .then(destroy);
 });


### PR DESCRIPTION
I believe Unleash should provide a dummy user with admin permissions in the `adminAuthentication=none` scenario. 

fixes #453