### PR TITLE
chore: Added unleash-client-core as official sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Official client SDK's:
 - [unleash/unleash-client-go](https://github.com/unleash/unleash-client-go)
 - [unleash/unleash-client-ruby](https://github.com/unleash/unleash-client-ruby)
 - [unleash/unleash-client-python](https://github.com/Unleash/unleash-client-python)
+- [unleash/unleash-client-core](https://github.com/Unleash/unleash-client-core) (.Net Core)
 
 Clients written by awesome enthusiasts: :fire:
 
-- [stiano/unleash-client-dotnet](https://github.com/stiano/unleash-client-dotnet) (.Net Core)
-- [onybo/unleash-client-core](https://github.com/onybo/unleash-client-core) (.Net Core)
 - [rarruda/unleash-client-python](https://github.com/rarruda/unleash-client-python) (Python 3)
 - [afontaine/unleash_ex](https://gitlab.com/afontaine/unleash_ex) (Elixir)
 


### PR DESCRIPTION
Added in readme unleash-client-core as official sdk and removed unofficial ones