### PR TITLE
chore: Add baseUriPath support to docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,6 +60,7 @@ Available unleash options include:
 - **ui** (object) - Set of UI specific overrides. You may set the following keys: `headerBackground`, `environment`, `slogan`.
 - **getLogger** (function) - Used to register a [custom log provider](#How do I configure the log output).
 - **eventHook** (`function(event, data)`) - If provided, this function will be invoked whenever a feature is mutated. The possible values for `event` are `'feature-created'`, `'feature-updated'`, `'feature-archived'`, `'feature-revived'`. The `data` argument contains information about the mutation. Its fields are `type` (string) - the event type (same as `event`); `createdBy` (string) - the user who performed the mutation; `data` - the contents of the change. The contents in `data` differs based on the event type; For `'feature-archived'` and `'feature-revived'`, the only field will be `name` - the name of the feature. For `'feature-created'` and `'feature-updated'` the data follows a schema defined in the code [here](https://github.com/Unleash/unleash/blob/master/lib/routes/admin-api/feature-schema.js#L38-L59). See an example [here](./guides/feautre-updates-to-slack.md).
+- **baseUriPath** (string) - use to register a base path for all routes on the application. For example `my/unleash/base`. Defaults to `/`.
 
 ### 3. Docker
 


### PR DESCRIPTION
I thought it would be nice to let developers know of the useful `baseUriPath` option, as I found this very useful.