### PR TITLE
feat: Update "enableLegacyRoutes" to false

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -16,7 +16,7 @@ function defaultOptions() {
         pipe: undefined,
         baseUriPath: process.env.BASE_URI_PATH || '',
         serverMetrics: true,
-        enableLegacyRoutes: true,
+        enableLegacyRoutes: false,
         extendedPermissions: false,
         publicFolder,
         enableRequestLogger: isDev(),


### PR DESCRIPTION
Defining "enableLegacyRoutes" as "true" is less secure than setting it to "false" by default, according to the documentation in "Securing Unleash" (https://unleash.github.io/docs/securing_unleash).

Happy to hear criticisms/explanations of current state! <3