### PR TITLE
fix: Support SSL settings

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,10 @@ function defaultOptions() {
             host: process.env.DATABASE_HOST,
             port: process.env.DATABASE_PORT || 5432,
             database: process.env.DATABASE_NAME || 'unleash',
-            ssl: process.env.DATABASE_SSL,
+            ssl:
+                process.env.DATABASE_SSL != null
+                    ? JSON.parse(process.env.DATABASE_SSL)
+                    : false,
             driver: 'postgres',
         },
         port: process.env.HTTP_PORT || process.env.PORT || 4242,


### PR DESCRIPTION
As described in https://node-postgres.com/features/ssl , `ssl` is an object which will be passed to Node TLS socket.
Also:

```
(node:1) DeprecationWarning: Implicit disabling of certificate verification is deprecated and will be removed in pg 8. Specify `rejectUnauthorized: true` to require a valid CA or `rejectUnauthorized: false` to explicitly opt out of MITM protection.
```

This change makes it possible to configure accepted SSL CA certificate, or to accept self-signed certificate.