### PR TITLE
fix: Heroku Postgres add-on version change

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "9.5"
+        "version": "9.6"
       }
     }
   ]

--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "9.6"
+        "version": "10"
       }
     }
   ]


### PR DESCRIPTION
Heroku Postgres doesn't support version 9.5 anymore. Available versions are 9.6, 10, 11, 12