### PR TITLE
Open API specification (OAS)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,19 +5,16 @@
 # Enable and Update a Feature toggle have same bodies as much of the response 200 (can we use $ref to simplify the OAS?)
 # TEST
 # Is colon before a query parameter in the documentation a literal colon or is it used to denote the type of parameter?
-# Are features, toggles and feature toggles all the same thing?
-# EXTEND
-# 
 # DOCUMENTATION STYLE NOTES
 # Use 'and' instead of &
 # Headings: use newspaper-style headings 'This is a heading' or movie-style 'This is a Heading'?
 # American English or British English?
-# Proper nouns for Unleash: Unleash, Feature, Toggle (not that plurals are lower-case: toggles and features)
+# Proper nouns for Unleash: Unleash, Feature Toggle (note that the plural is lower-case: feature toggles)
 # Parameter names: use JS-style (aParameter) or Open API style (aparameter)?
-# TERMINOLOGY QUERIES
-# What does 'globally unique' mean - what is 'global'?
+# QUESTIONS
+# In http://unleash.host.com/api/admin/features/:toggleName` isn't the toggleName superfluous since toggleName nust be part of the body query anyway?
 # NOTE SOMEWHERE (client API docs?)
-# Feature (toggle?) names cannot have spaces. List of legal characters?
+# Feature Toggle names cannot have spaces. List of legal characters?
 # 
 openapi: 3.0.0
 servers:
@@ -48,7 +45,7 @@ paths:
         - A feature toggle will have *at least* one configured strategy.
         - A strategy will have a `name` and `parameters` map.
 
-        **Note:** To only return one feature, add the feature name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Sepcification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
+        **Note:** To only return one Feature Toggle, add the Feature Toggle name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Sepcification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
       externalDocs:
         description: Activation strategies
         url: https://unleash.github.io/docs/activation_strategy
@@ -87,21 +84,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/200'
         '409':
-          description: '*name* is not unique'
+          description: 'Feature Toggle name is not unique'
           content:
-            text/plain:
+            application/json:
               schema:
-                title: '*name* is not unique'
-                type: string
+                $ref: '#/components/schemas/409'
       summary: Create a Feature Toggle
+  '/admin/features/{featureName}':
     put:
       summary: Update a Feature Toggle
-      description: Used by the admin dashboard to update a Feature Toggle.
-      operationId: updateFeatureToggle
+      description: Update a Feature Toggle.
+      operationId: featureName
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/toggleNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       requestBody:
         required: true
         content:
@@ -120,12 +117,12 @@ paths:
       description: |
         Feature toggles can only be archived - they cannot be deleted.
 
-        If an old Feature Toggle *re-appears*, this is because someone else has created a Feature Toggle with the same name.
+        If an old Feature Toggle *re-appears*, this is because someone else has created a new one with the same name.
       operationId: archiveFeatureToggle
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/toggleNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -141,7 +138,7 @@ paths:
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/featureNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -157,7 +154,7 @@ paths:
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/featureNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -176,7 +173,7 @@ paths:
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/featureNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -195,7 +192,7 @@ paths:
       tags:
         - Admin - Feature toggles
       parameters:
-        - $ref: '#/components/parameters/featureNameRequired'
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -211,8 +208,8 @@ paths:
                 $ref: '#/components/schemas/409'
   /admin/archive/features:
     get:
-      summary: List all the archived Feature Toggles on the Unleash server'
-      description: Archived Features are those that have been previously deleted
+      summary: List all the archived feature toggles on the Unleash server'
+      description: Archived feature toggles are those that have been previously deleted
       operationId: fetchArchivedToggles
       tags:
         - Admin - archive
@@ -244,17 +241,11 @@ paths:
                 $ref: '#/components/schemas/200'
 components:
   parameters:
-    featureNameRequired:
+    featureNamePath:
       name: featureName
       required: true
       in: path
       description: Must match an existing Feature Toggle.
-      schema:
-        type: string
-    toggleNameRequired:
-      name: toggleName
-      required: true
-      in: query
       schema:
         type: string
   schemas:
@@ -343,7 +334,7 @@ components:
         name:
           type: string
           minLength: 1
-          description: '*name* must be **unique**; otherwise, you will get a *403-response*.'
+          description: 'Feature Toggle name must be unique.'
           example: FeatureA
         description:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,101 +1,75 @@
-# IMPLEMENT
-# Check code for toggle type strings
-# REVIEW
-# Is putting 'Required' in the description adding any value? If so, colour-code it (not italics, not code block)
-# Make sure all operation IDs are unique and in JS-style
-# Are features, toggles and feature toggles all the same thing?
-# Rationalise component parameters. No point in having several iterations of the same schema
-# Enable and Update a Feature toggle have same bodies as much of the response 200 (can we use $ref to simplify the OAS?)
-# Can feature names have spaces. mit a full-stop be used instead? Feature C vs Feature.C
-# TEST
-# Is colon before a query parameter in the documentation a literal colon or is it used to denote the type of parameter?
-# EXTEND
-# 
-# DOCUMENTATION STYLE NOTES
-# Use 'and' instead of &
-# Use newspaper-style headings 'This is a heading' instead of movie-style 'This is a Heading'
-# Proper nouns for Unleash: Unleash, Feature, Toggle
-# TERMINOLOGY QUERIES
-# What does 'globally unique' mean - what is 'global'?
-#
-# #################
-# OpenAPI object
-# #################
-openapi: "3.0.0"
+openapi: 3.0.0
+tags:
+  - name: "Admin - Feature Toggles"
+    description: Funny nosed pig-head racoon.
+  - name: "Admin - archive"
+    description: Angry short-legged omnivores.
 servers:
-- description: "Local host."
-  url: https://localhost:4242/api
-- description: "Online demo. Add your own server details to the Open API specification, too (in the *servers* section)."
-  url: https://unleash.herokuapp.com/api
-- description: Secure online demo.
-  url: https://secure-unleash.herokuapp.com/api
-  # Added by API Auto Mocking Plugin
-- description: SwaggerHub API mocking
-  url: https://unleash.github.io/docs/getting_started
+  - description: Local host.
+    url: 'http://localhost:4242/api'
 info:
-  title: "Unleash API"
-  description: "Unleash is a open source feature flag and toggle system. It gives you a great overview over all feature toggles across all your applications and services."
-  version: "3.5.6"
-security:
-  - auth:
-      - read
-      - write
+  title: Unleash API
+  description: Unleash is a open source feature flag and toggle system. It gives you a great overview over all feature toggles across all your applications and services.
+  version: 3.5.6
+  contact:
+    name: "The Unleash team"
+    url: "https://unleash.github.io/"
+    email: "some_email@gmail.com"
 externalDocs:
   description: Documentation
-  url: https://openweathermap.org/api
+  url: 'https://openweathermap.org/api'
 paths:
   /admin/features:
     get:
-      summary: "Fetches all available feature toggles from the *Unleash server*."
+      summary: Fetches all feature toggles from the *Unleash server*.
       description: |
-         The response returns all active feature toggles and their current strategy configuration.
-         - A feature toggle will have *at least* one configured strategy.
-         - A strategy will have a `name` and `parameters` map.
+        The response returns all active feature toggles and their current strategy configuration.
+        - A feature toggle will have *at least* one configured strategy.
+        - A strategy will have a `name` and `parameters` map.
       operationId: getFeatures
       tags:
-        - Admin - Feature Toggles
+        - "Admin - Feature Toggles"
       parameters:
-        - $ref: "#/components/parameters/featureNameOptional"
+        - $ref: '#/components/parameters/featureNameOptional'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-        "401":
+                $ref: '#/components/schemas/200'
+        '401':
           description: Not authorised
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/401"
-
+                $ref: '#/components/schemas/401'
     post:
       description: Create a new Feature Toggle
       tags:
-       - Admin - Feature Toggles
+        - Admin - Feature Toggles
       operationId: createFeatureToggle
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/newFeatureToggle"
+              $ref: '#/components/schemas/newFeatureToggle'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-        "403":
-          description: "*name* is not globally unique"
+                $ref: '#/components/schemas/200'
+        '403':
+          description: '*name* is not globally unique'
           content:
             text/plain:
               schema:
-                title: "*name* is not globally unique"
-              
+                title: '*name* is not globally unique'
                 type: string
+      summary: Create a Feature Toggle
     put:
       summary: Update a Feature Toggle
       description: Used by the admin dashboard to update a Feature Toggle.
@@ -103,120 +77,113 @@ paths:
       tags:
         - Admin - Feature Toggles
       parameters:
-        - $ref: "#/components/parameters/toggleNameRequired"
+        - $ref: '#/components/parameters/toggleNameRequired'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/updateFeatureToggle"
+              $ref: '#/components/schemas/updateFeatureToggle'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-
+                $ref: '#/components/schemas/200'
     delete:
       summary: Archive a Feature Toggle.
-      description: "Feature toggles can only be archived - they cannot be deleted.<br><br>If an old Feature Toggle 're-appears', this is because someone else has created a Feature Toggle with the same name."
+      description: 'Feature toggles can only be archived - they cannot be deleted.<br><br>If an old Feature Toggle ''re-appears'', this is because someone else has created a Feature Toggle with the same name.'
       operationId: archiveFeatureToggle
       tags:
         - Admin - Feature Toggles
       parameters:
-      - $ref: "#/components/parameters/toggleNameRequired"
+        - $ref: '#/components/parameters/toggleNameRequired'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-
-  /admin/features/{featureNameRequired}/toggle/on:
+                $ref: '#/components/schemas/200'
+  '/admin/features/{featureNameRequired}/toggle/on':
     post:
       summary: Enable a Feature Toggle.
-      description: "*featureName* must match an existing Feature Toggle."
+      description: '*featureName* must match an existing Feature Toggle.'
       operationId: enableFeatureToggle
       tags:
         - Admin - Feature Toggles
       parameters:
-        - $ref: "#/components/parameters/featureNameRequired"
+        - $ref: '#/components/parameters/featureNameRequired'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-
-  /admin/features/{featureNameRequired}/toggle/off:
+                $ref: '#/components/schemas/200'
+  '/admin/features/{featureNameRequired}/toggle/off':
     post:
       summary: Disable a Feature Toggle.
-      description: "*featureName* must match an existing Feature Toggle."
+      description: '*featureName* must match an existing Feature Toggle.'
       operationId: disableFeatureToggle
       tags:
         - Admin - Feature Toggles
       parameters:
-        - $ref: "#/components/parameters/featureNameRequired"
+        - $ref: '#/components/parameters/featureNameRequired'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"    
-
-  /admin/features/{featureNameRequired}/stale/on:
+                $ref: '#/components/schemas/200'
+  '/admin/features/{featureNameRequired}/stale/on':
     post:
       summary: Mark a Feature Toggle as 'stale' (deprecated).
-      description: "*featureName* must match an existing Feature Toggle."
+      description: '*featureName* must match an existing Feature Toggle.'
       operationId: markFeatureToggleStale
       tags:
         - Admin - Feature Toggles
       parameters:
-        - $ref: "#/components/parameters/featureNameRequired"
+        - $ref: '#/components/parameters/featureNameRequired'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"    
-
-  /admin/features/{featureNameRequired}/stale/off:
+                $ref: '#/components/schemas/200'
+  '/admin/features/{featureNameRequired}/stale/off':
     post:
       summary: Mark a Feature Toggle as active.
-      description: "*featureName* must match an existing Feature Toggle."
+      description: '*featureName* must match an existing Feature Toggle.'
       operationId: markFeatureToggleActive
       tags:
         - Admin - Feature Toggles
       parameters:
-        - $ref: "#/components/parameters/featureNameRequired"
+        - $ref: '#/components/parameters/featureNameRequired'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-
+                $ref: '#/components/schemas/200'
   /admin/archive/features:
     get:
       summary: List all the archived Feature Toggles on the Unleash server'
-      description: "Archived Features are those that have been previously deleted"
+      description: Archived Features are those that have been previously deleted
       operationId: fetchArchivedToggles
       tags:
-        - Admin - archive
+        - "Admin - archive"
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
-
+                $ref: '#/components/schemas/200'
     post:
       summary: Un-archive a Feature Toggle
       description: The Feature Toggle had been previously deleted
@@ -228,222 +195,211 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/reviveFeature"
+              $ref: '#/components/schemas/reviveFeature'
       responses:
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/200"
+                $ref: '#/components/schemas/200'
 components:
   parameters:
     featureNameOptional:
       name: featureName
       in: query
-      description: "Used to fetch details about a specific Feature Toggle. This is mostly provided to make it easy to debug the API and should not be used by the client implementations."
+      description: Used to fetch details about a specific Feature Toggle. This is mostly provided to make it easy to debug the API and should not be used by the client implementations.
       schema:
         type: string
     featureNameRequired:
       name: featureNameRequired
       required: true
       in: path
-      description: "Must match an existing Feature Toggle."
+      description: Must match an existing Feature Toggle.
       schema:
-        type: string     
+        type: string
     toggleNameRequired:
       name: toggleName
       required: true
       in: query
       schema:
         type: string
-# Schemas
   schemas:
-      reviveFeature:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-            example: Feature.C
-        required:
-          - name
-
-      newFeatureToggle:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-            description: "*name* must be **globally unique**; otherwise, you will get a *403-response*."
-            example: Feature A
-          description:
-            type: string
-            minLength: 1
-            example: Toggles Feature A on and off
-          type:
-            type: string
-            enum: [release,experiment,ops,killswitch,permission]
-            minLength: 1
-            description: "*type* is optional. If not defined, it defaults to `release`"
-            example: release
-          enabled:
-            type: boolean
-            example: false
-          stale:
-            type: boolean
-            example: false
-          strategies:
-            type: array
-            uniqueItems: true
-            minItems: 1
-            items:
-              required:
-                - name
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  example: default
-                parameters:
-                  type: object
-                  properties: {}
-        required:
-          - name
-          - description
-          - enabled
-          - stale
-          - strategies
-
-      updateFeatureToggle:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-            description: "*name* must match an existing Feature Toggle."
-            example: Feature B
-          description:
-            type: string
-            minLength: 1
-            example: Toggles Feature B on and off
-          type:
-            type: string
-            minLength: 1
-            description: "*type* is optional. If not defined, it defaults to `release`"
-            example: release
-          enabled:
-            type: boolean
-            example: false
-          stale:
-            type: boolean
-            example: false
-          strategies:
-            type: array
-            uniqueItems: true
-            minItems: 1
-            items:
-              required:
-                - name
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  example: default
-                parameters:
-                  type: object
-                  properties: {}
-          variants:
-            type: array
-            items:
-              properties: {}
-        required:
-          - name
-          - description
-          - enabled
-          - stale
-          - strategies
-          - variants
-
-# http responses
-      "401":
-        description: "Not authorised"
-        type: object
-        properties:
-          type:
-            type: string
-            minLength: 1
-          path:
-            type: string
-            minLength: 1
-          message:
-            type: string
-            minLength: 1
-        required:
-          - type
-          - path
-          - message
-      "200":
-        title: Successful response
-        type: object
-        properties:
-          version:
-            type: number
-          features:
-            type: array
-            uniqueItems: true
-            minItems: 1
-            items:
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                description:
-                  type: string
-                  minLength: 1
-                type:
-                  type: string
-                  minLength: 1
-                enabled:
-                  type: boolean
-                stale:
-                  type: boolean
-                strategies:
-                  type: array
-                  uniqueItems: true
-                  minItems: 1
-                  items:
-                    required:
-                      - name
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                      parameters:
-                        type: object
-                        properties: {}
-                variants:
-                  type: array
-                  uniqueItems: true
-                  minItems: 1
-                  items:
-                    required:
-                      - name
-                      - weight
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                      weight:
-                        type: number
-  securitySchemes:
-    auth:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: https://accounts.google.com/o/oauth2/auth
-          tokenUrl: https://oauth2.googleapis.com/token
-          refreshUrl: http://localhost:4242/api/auth/callback
-          scopes:
-            write: allows modifying resources
-            read: allows reading resources
+    '200':
+      title: Successful response
+      type: object
+      properties:
+        version:
+          type: number
+        features:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            properties:
+              name:
+                type: string
+                minLength: 1
+              description:
+                type: string
+                minLength: 1
+              type:
+                type: string
+                minLength: 1
+              enabled:
+                type: boolean
+              stale:
+                type: boolean
+              strategies:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    parameters:
+                      type: object
+                      properties: {}
+              variants:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  required:
+                    - name
+                    - weight
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    weight:
+                      type: number
+    '401':
+      description: Not authorised
+      type: object
+      properties:
+        type:
+          type: string
+          minLength: 1
+        path:
+          type: string
+          minLength: 1
+        message:
+          type: string
+          minLength: 1
+      required:
+        - type
+        - path
+        - message
+    reviveFeature:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          example: Feature.C
+      required:
+        - name
+    newFeatureToggle:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: '*name* must be **globally unique**; otherwise, you will get a *403-response*.'
+          example: Feature A
+        description:
+          type: string
+          minLength: 1
+          example: Toggles Feature A on and off
+        type:
+          type: string
+          enum:
+            - release
+            - experiment
+            - ops
+            - killswitch
+            - permission
+          minLength: 1
+          description: '*type* is optional. If not defined, it defaults to `release`'
+          example: release
+        enabled:
+          type: boolean
+          example: false
+        stale:
+          type: boolean
+          example: false
+        strategies:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+            properties:
+              name:
+                type: string
+                minLength: 1
+                example: default
+              parameters:
+                type: object
+                properties: {}
+      required:
+        - name
+        - description
+        - enabled
+        - stale
+        - strategies
+    updateFeatureToggle:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: '*name* must match an existing Feature Toggle.'
+          example: Feature B
+        description:
+          type: string
+          minLength: 1
+          example: Toggles Feature B on and off
+        type:
+          type: string
+          minLength: 1
+          description: '*type* is optional. If not defined, it defaults to `release`'
+          example: release
+        enabled:
+          type: boolean
+          example: false
+        stale:
+          type: boolean
+          example: false
+        strategies:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+            properties:
+              name:
+                type: string
+                minLength: 1
+                example: default
+              parameters:
+                type: object
+                properties: {}
+        variants:
+          type: array
+          items:
+            properties: {}
+      required:
+        - name
+        - description
+        - enabled
+        - stale
+        - strategies
+        - variants

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,3 +1,8 @@
+# simpleStrategySchema works (and may be correct for some responses)
+# strategySchema can't render in Swagger UI. use simple for now
+# Add questions list
+# Check for $ref substitutions - see the 'required' items
+# Need to define variants schema
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -9,6 +14,8 @@ tags:
     description: Idientifying events on the Unleash server
   - name: Feature toggles
     description: Accessing feature toggles
+  - name: Feature types
+    description: Details of the five Unleash Feature Toggle types
   - name: Import and export
     description: Importing and exporting feature toggles and strategies
   - name: Metrics
@@ -446,7 +453,8 @@ paths:
   /admin/feature-types:
     get:
       summary: Fetch the list of Unleash feature types
-      tags: []
+      tags:
+        - Feature types
       responses:
         '200':
           description: OK
@@ -805,6 +813,7 @@ components:
               icon:
                 description: The icon to use for something. Link?
                 type: string
+
     200appdetails:
       type: object
       required:
@@ -836,7 +845,7 @@ components:
           description: The icon to use for something. Link?
           type: string
         strategies:
-          $ref: '#/components/schemas/strategySchema'
+          $ref: '#/components/schemas/simpleStrategySchema'
         instances:
           type: object
           required:
@@ -1223,11 +1232,12 @@ components:
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
     200featuretype:
-      description: ''
       type: object
       properties:
         version:
+          description: A version number of something?
           type: number
+          example: 1
         types:
           type: array
           uniqueItems: true
@@ -1240,16 +1250,39 @@ components:
               - lifetimeDays
             properties:
               id:
+                description: The *id* string for the Feature Toggle type
+                externalDocs:
+                  description: Feature Toggle types
+                  url: 'https://unleash.github.io/docs/feature_toggle_types'
                 type: string
                 minLength: 1
+                example: release
               name:
+                description: The title of the Feature Toggle type
                 type: string
+                enum:
+                  - Release
+                  - Experiment
+                  - Operational
+                  - Kill switch
+                  - Permission
                 minLength: 1
+                example: Release
               description:
+                description: A description of what this Feature Toggle type could be used for
                 type: string
+                enum:
+                  - Enables trunk-based development for teams practicing continuous delivery
+                  - Performs multivariate or A/B testing
+                  - Controls operational aspects of the system behaviour # US English?
+                  - Gracefully degrades system functionality
+                  - Changez the features or product experiences that certain users receive
                 minLength: 1
               lifetimeDays:
+                description: What's this?
                 type: number
+                example: 40
       required:
         - version
         - types
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,11 +1,14 @@
+
 openapi: 3.0.0
 servers:
   - description: Local host.
     url: 'http://localhost:4242/api'
 tags:
-  - name: Admin - Feature toggles
+  - name: Admin - feature toggles
     description: Accessing feature toggles on the Unleash admin server
   - name: Admin - archive
+    description: Handling Feature Toggle archiving and un-archiving on the Unleash admin server
+  - name: Admin - strategies
     description: Handling Feature Toggle archiving and un-archiving on the Unleash admin server
 info:
   title: Unleash API
@@ -33,7 +36,7 @@ paths:
         url: 'https://unleash.github.io/docs/activation_strategy'
       operationId: getFeatures
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       responses:
         '200':
           description: Successful response
@@ -50,7 +53,7 @@ paths:
     post:
       description: Create a new Feature Toggle
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       operationId: createFeatureToggle
       requestBody:
         required: true
@@ -78,7 +81,7 @@ paths:
       description: Update a Feature Toggle.
       operationId: featureName
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       requestBody:
@@ -102,7 +105,7 @@ paths:
         If an old Feature Toggle *re-appears*, this is because someone else has created a new one with the same name.
       operationId: archiveFeatureToggle
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -118,7 +121,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: enableFeatureToggle
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -134,7 +137,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: disableFeatureToggle
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -153,7 +156,7 @@ paths:
         url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleStale
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -172,7 +175,7 @@ paths:
         url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleActive
       tags:
-        - Admin - Feature toggles
+        - Admin - feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -211,6 +214,39 @@ paths:
         - Admin - archive
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200'
+  /admin/strategies:
+    get:
+      summary: Fetch all strategies and their parameters.
+      description: Fetch all strategies and their parameters.
+      operationId: getStrategies
+      tags:
+        - Admin - strategies
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200strategy'
+    post:
+      summary: Create Strategy
+      description: Create Strategy
+      operationId: createStrategy
+      tags:
+        - Admin - strategies
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createStrategy'
       responses:
         '200':
           description: Successful response
@@ -281,6 +317,56 @@ components:
                       minLength: 1
                     weight:
                       type: number
+    '200strategy':
+      description: 'Successful.'
+      type: object
+      properties:
+        version:
+          type: number
+          example: 1
+        strategies:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+              - editable
+              - description
+            properties:
+              name:
+                type: string
+                minLength: 1
+              editable:
+                type: boolean
+              description:
+                type: string
+                minLength: 1
+              parameters:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  required:
+                    - name
+                    - type
+                    - description
+                    - required
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    type:
+                      type: string
+                      minLength: 1
+                    description:
+                      type: string
+                      minLength: 1
+                    required:
+                      type: boolean
+      required:
+        - version
+        - strategies
     '401':
       description: Not authorised
       type: object
@@ -430,3 +516,43 @@ components:
         - stale
         - strategies
         - variants
+    createStrategy:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          example: gradualRollout
+        description:
+          type: string
+          minLength: 1
+          example: Gradual rollout to logged in users
+        parameters:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+              - type
+              - description
+              - required
+            properties:
+              name:
+                type: string
+                minLength: 1
+                example: percentage
+              type:
+                type: string
+                minLength: 1
+                example: percentage
+              description:
+                type: string
+                minLength: 1
+                example: How many percent of users should the new Feature Toggle be active for.
+              required:
+                type: boolean
+      required:
+        - name
+        - description
+        - parameters

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -202,19 +202,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  /admin/archive/revive:
+  /admin/archive/revive/{featureName}:
     post:
       summary: Un-archive a Feature Toggle
       description: The Feature Toggle had been previously deleted
       operationId: reviveFeatureToggle
       tags:
         - Admin - archive
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/reviveFeature'
+      parameters:
+        - $ref: '#/components/parameters/featureNamePath'
       responses:
         '200':
           description: Successful response
@@ -325,15 +321,6 @@ components:
         - isJoi
         - name
         - details
-    reviveFeature:
-      type: object
-      properties:
-        name:
-          type: string
-          minLength: 1
-          example: Feature.C
-      required:
-        - name
     newFeatureToggle:
       type: object
       properties:
@@ -443,4 +430,3 @@ components:
         - stale
         - strategies
         - variants
-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -304,8 +304,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200feature'
+  /admin/metrics/applications:
+    get:
+      summary: A list of known applications ('seen' by unleash ib the last two days) and a link for more details.
+      description: |
+        - **Yes** is the number of times a given feature toggle was enabled in a client application
+        - **No** is the number of times it was disabled.
+      operationId: getApplications
+      tags:
+        - Admin - metrics
+      parameters:
+        - $ref: '#/components/parameters/strategyQuery'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200application'
 components:
   parameters:
+    strategyQuery:
+      name: strategyName
+      in: query
+      description: Return all applications implementing the specified Strategy. Must match an existing Strategy name.
+      schema:
+        type: string
     featureNamePath:
       name: featureName
       required: true
@@ -636,7 +660,9 @@ components:
           metricsCount:
             type: number
     200feature:
-      description: ''
+      description: |
+        - **lastHour** - 'hour projection collected' metrics for all feature toggles.
+        - **lastMinute** - 'minute projection collected' metrics for all feature toggles.
       type: object
       properties:
         lastHour:
@@ -716,3 +742,37 @@ components:
       required:
         - lastHour
         - lastMinute
+    200application:
+      description: ''
+      type: object
+      properties:
+        applications:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - appName
+              - createdAt
+            properties:
+              appName:
+                type: string
+                minLength: 1
+              strategies:
+                type: array
+                items:
+                  required: []
+                  properties: {}
+              createdAt:
+                type: string
+                minLength: 1
+              links:
+                type: object
+                properties:
+                  appDetails:
+                    type: string
+                    minLength: 1
+                required:
+                  - appDetails
+      required:
+        - applications

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,21 +1,3 @@
-# IMPLEMENT
-# Check code for toggle type strings
-# REVIEW
-# Rationalise component parameters. No point in having several iterations of the same schema. UpdateFeatureToggle vs NewFeatureToggle
-# Enable and Update a Feature toggle have same bodies as much of the response 200 (can we use $ref to simplify the OAS?)
-# TEST
-# Is colon before a query parameter in the documentation a literal colon or is it used to denote the type of parameter?
-# DOCUMENTATION STYLE NOTES
-# Use 'and' instead of &
-# Headings: use newspaper-style headings 'This is a heading' or movie-style 'This is a Heading'?
-# American English or British English?
-# Proper nouns for Unleash: Unleash, Feature Toggle (note that the plural is lower-case: feature toggles)
-# Parameter names: use JS-style (aParameter) or Open API style (aparameter)?
-# QUESTIONS
-# In http://unleash.host.com/api/admin/features/:toggleName` isn't the toggleName superfluous since toggleName nust be part of the body query anyway?
-# NOTE SOMEWHERE (client API docs?)
-# Feature Toggle names cannot have spaces. List of legal characters?
-# 
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -37,7 +19,7 @@ externalDocs:
   description: Unleash documentation
   url: 'https://unleash.github.io/docs/getting_started'
 paths:
-  '/admin/features':
+  /admin/features:
     get:
       summary: Fetches all feature toggles from the Unleash server.
       description: |
@@ -48,7 +30,7 @@ paths:
         **Note:** To only return one Feature Toggle, add the Feature Toggle name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Sepcification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
       externalDocs:
         description: Activation strategies
-        url: https://unleash.github.io/docs/activation_strategy
+        url: 'https://unleash.github.io/docs/activation_strategy'
       operationId: getFeatures
       tags:
         - Admin - Feature toggles
@@ -84,7 +66,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/200'
         '409':
-          description: 'Feature Toggle name is not unique'
+          description: Feature Toggle name is not unique
           content:
             application/json:
               schema:
@@ -168,7 +150,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       externalDocs:
         description: Feature Toggle types
-        url: https://unleash.github.io/docs/feature_toggle_types
+        url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleStale
       tags:
         - Admin - Feature toggles
@@ -187,7 +169,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       externalDocs:
         description: Feature Toggle types
-        url: https://unleash.github.io/docs/feature_toggle_types
+        url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleActive
       tags:
         - Admin - Feature toggles
@@ -208,7 +190,7 @@ paths:
                 $ref: '#/components/schemas/409'
   /admin/archive/features:
     get:
-      summary: List all the archived feature toggles on the Unleash server'
+      summary: List all the archived feature toggles on the Unleash server
       description: Archived feature toggles are those that have been previously deleted
       operationId: fetchArchivedToggles
       tags:
@@ -220,6 +202,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+  /admin/archive/revive:
     post:
       summary: Un-archive a Feature Toggle
       description: The Feature Toggle had been previously deleted
@@ -319,6 +302,29 @@ components:
         - type
         - path
         - message
+    '409':
+      type: object
+      properties:
+        isJoi:
+          type: boolean
+        name:
+          type: string
+          minLength: 1
+        details:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - message
+            properties:
+              message:
+                type: string
+                minLength: 1
+      required:
+        - isJoi
+        - name
+        - details
     reviveFeature:
       type: object
       properties:
@@ -334,7 +340,7 @@ components:
         name:
           type: string
           minLength: 1
-          description: 'Feature Toggle name must be unique.'
+          description: Feature Toggle name must be unique.
           example: FeatureA
         description:
           type: string
@@ -352,7 +358,7 @@ components:
           description: '*type* is optional. If not defined, it defaults to `release`'
           externalDocs:
             description: Feature Toggle types
-            url: https://unleash.github.io/docs/feature_toggle_types
+            url: 'https://unleash.github.io/docs/feature_toggle_types'
           example: release
         enabled:
           type: boolean
@@ -381,37 +387,9 @@ components:
         - enabled
         - stale
         - strategies
-    '409':
-      type: object
-      properties:
-        isJoi:
-          type: boolean
-        name:
-          type: string
-          minLength: 1
-        details:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - message
-            properties:
-              message:
-                type: string
-                minLength: 1
-      required:
-        - isJoi
-        - name
-        - details
     updateFeatureToggle:
       type: object
       properties:
-        name:
-          type: string
-          minLength: 1
-          description: '*name* must match an existing Feature Toggle.'
-          example: FeatureB
         description:
           type: string
           minLength: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,12 +1,12 @@
-# Continue from components/schemas/200seenapps (schema needs work and isn't displaying in Swagger UI).
+# Continue from components/schemas/200seenapps and 200appdetails (schemas needs work and aren't displaying in Swagger UI). 200appdetails schema appears simpler from the markdown
 # Run tests against prevous items (I've done a global strategies $ref replacement)
 # Add examples to everything (inclusing response schemas)
 # Verify response schemas match object structure
 # Check question marks with unleash team
-# $ref any duplicate aspects
+# $ref any duplicate aspects - check the require elements for things you can replace
 # British English or American English?
 # {} in a definition means 'I don't know' - fix
-# Need a variants schema
+# Need a variants schema?
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -338,7 +338,6 @@ paths:
         - Metrics
       parameters:
         - $ref: '#/components/parameters/appNamePath'
-
       responses:
         '200':
           description: Successful response
@@ -696,7 +695,7 @@ components:
       required:
         - applications
 
-    200appdetails:
+    '200appdetails':
       type: object
       required:
         - appName
@@ -728,8 +727,7 @@ components:
           description: The icon to use for something. Link?
           type: string
         strategies:
-          $ref: '#/components/schemas/strategySchema'
-
+          $ref: '#/components/schemas/appStrategySchema'
         instances:
           type: object
           required:
@@ -864,8 +862,11 @@ components:
                 type: string
                 minLength: 1
                 example: https://medium.com/keptn
-              color: {}
+              color:
+                description: The colour (American English?) of something. Hex code?
+                type: string
               icon:
+                description: The icon to use for something. Link?
                 type: string
                 minLength: 1
 
@@ -911,3 +912,25 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
+    appStrategySchema:
+      title: appStrategySchema
+      type: object
+      required:
+        - appName
+        - strategies
+      properties:
+        appName:
+          description: Application name
+          type: string
+          minLength: 1
+          example: demo-app
+        strategies:
+          type: array
+          items:
+            required:
+              - strategyName
+            properties:
+              strategyName:
+                description: Name of Strategy
+                type: string
+                example: extra

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -322,7 +322,7 @@ paths:
                 $ref: '#/components/schemas/200application'
   '/admin/metrics/applications/{appName}':
     get:
-      summary: 'Details about a client application.'
+      summary: Details about a client application.
       description: 'Details include things such as instances, strategies implemented and seen feature toggles.'
       operationId: getApplicationDetails
       tags:
@@ -336,6 +336,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200appdetails'
+  /admin/metrics/seen-apps:
+    get:
+      summary: Details about application seen per Feature Toggle.
+      description: Details about application seen per Feature Toggle.
+      operationId: seenApps
+      tags:
+        - Admin - metrics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200seenapps'
 components:
   parameters:
     strategyQuery:
@@ -853,3 +867,46 @@ components:
         - instances
         - strategies
         - seenToggles
+    200seenapps:
+      description: ''
+      type: object
+      properties:
+        my-toggle:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - appName
+              - createdAt
+              - updatedAt
+              - description
+              - url
+              - icon
+            properties:
+              appName:
+                type: string
+                minLength: 1
+              createdAt:
+                type: string
+                minLength: 1
+              updatedAt:
+                type: string
+                minLength: 1
+              description:
+                type: string
+                minLength: 1
+              strategies:
+                type: array
+                items:
+                  required: []
+                  properties: {}
+              url:
+                type: string
+                minLength: 1
+              color: {}
+              icon:
+                type: string
+                minLength: 1
+      required:
+        - my-toggle

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,3 +1,5 @@
+# simpleStrategySchema works (and may be correct for some responses)
+# strategySchema can't render in Swagger UI. use simple for now
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -9,6 +11,8 @@ tags:
     description: Idientifying events on the Unleash server
   - name: Feature toggles
     description: Accessing feature toggles
+  - name: Import and export
+    description: Importing and exporting feature toggles and strategies
   - name: Metrics
     description: Determining usage of feature toggles and applications
   - name: Strategies
@@ -352,7 +356,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seenapps'
-
   /admin/events:
     get:
       summary: Fetch all changes in the Unleash system
@@ -367,8 +370,7 @@ paths:
                 $ref: '#/components/schemas/200-events'
       operationId: get-admin-events
       description: |-
-        |
-          It returns one of the five event types:
+          Returns one of the five event types:
           - feature-created
           - feature-updated
           - feature-archived
@@ -376,6 +378,42 @@ paths:
           - strategy-created
           - strategy-deleted
 
+  /admin/state/export:
+    get:
+      summary: Export feature toggles and strategies
+      tags:
+        - Import and export
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200export'
+      operationId: get-admin-state-export
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: format
+          description: |
+            Choose export format, either json or yaml. json is the default
+        - schema:
+            type: boolean
+          in: query
+          name: download
+          description: Export the data as a file? Default is false
+        - schema:
+            type: boolean
+          in: query
+          name: featureToggles
+          description: Include feature toggles in the export? Default is true
+        - schema:
+            type: boolean
+          in: query
+          name: strategies
+          description: Include strategies in the export? Default is true
+      description: Exports a list of feature toggles and/or strategies in either JSON or YAML format.
 components:
   parameters:
     strategyQuery:
@@ -509,7 +547,6 @@ components:
           example: 1
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
-
     newFeatureToggle:
       type: object
       required:
@@ -893,7 +930,6 @@ components:
                 description: The icon to use for something. Link?
                 type: string
                 minLength: 1
-
     strategySchema:
       type: array
       properties:
@@ -935,7 +971,6 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
-
     simpleStrategySchema:
       type: object
       required:
@@ -957,7 +992,7 @@ components:
                 description: Name of Strategy's parameter
                 type: string
                 example: extra
-    
+                
     200-events:
       type: object
       properties:
@@ -968,10 +1003,10 @@ components:
         events:
           type: array
           required:
-          - id
-          - type
-          - createdBy
-          - createdAt
+            - id
+            - type
+            - createdBy
+            - createdAt
           uniqueItems: true
           minItems: 1
           items:
@@ -1003,16 +1038,16 @@ components:
               data:
                 type: object
                 required:
-                - name
-                - description
-                - type
-                - enabled
-                - stale
-                - strategies
-                - createdAt
+                  - name
+                  - description
+                  - type
+                  - enabled
+                  - stale
+                  - strategies
+                  - createdAt
                 properties:
                   name:
-                    description: Feature Toggle name must be unique.
+                    description: Feature Toggle name .
                     type: string
                     minLength: 1
                     example: FeatureA
@@ -1043,7 +1078,7 @@ components:
                     type: boolean
                     example: false
                   strategies:
-                    $ref: '#/components/schemas/strategySchema'
+                    $ref: '#/components/schemas/simpleStrategySchema'
                   variants: {}
                   createdAt:
                     description: Date and time when the Feature Toggle was created?
@@ -1078,3 +1113,67 @@ components:
                     rhs:
                       description: Left-hand side of something?
                       type: boolean
+    200export:
+      type: object
+      required:
+        - version
+        - features
+        - strategies
+      properties:
+        version:
+          description: Version number of what?
+          type: number
+          example: 1
+        features:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+              - description
+              - type
+              - enabled
+              - stale
+              - createdAt
+            properties:
+              name:
+                description: Feature Toggle name .
+                type: string
+                minLength: 1
+                example: FeatureA
+              description:
+                description: What the Feature Toggle does
+                type: string
+                minLength: 1
+                example: Toggles FeatureA on and off
+              type:
+                type: string
+                description: '*type* is optional. If not defined, it defaults to `release`'
+                externalDocs:
+                  description: Feature Toggle types
+                  url: 'https://unleash.github.io/docs/feature_toggle_types'
+                enum:
+                  - release
+                  - experiment
+                  - ops
+                  - killswitch
+                  - permission
+                minLength: 1
+                example: release
+              enabled:
+                type: boolean
+                example: false
+              stale:
+                description: Is the Feature Toggle deprecated (stale)?
+                type: boolean
+                example: false
+              strategies:
+                $ref: '#/components/schemas/simpleStrategySchema'
+              variants: {}
+              createdAt:
+                type: string
+                minLength: 1
+        strategies:
+          $ref: '#/components/schemas/simpleStrategySchema' # Strategies twice? How does this vary to the other strategies schema in the response?
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -352,10 +352,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seenapps'
+
   /admin/events:
     get:
       summary: Fetch all changes in the Unleash system
-      tags: []
+      tags:
+        - Events
       responses:
         '200':
           description: OK
@@ -373,6 +375,7 @@ paths:
           - feature-revived
           - strategy-created
           - strategy-deleted
+
 components:
   parameters:
     strategyQuery:
@@ -506,6 +509,7 @@ components:
           example: 1
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
+
     newFeatureToggle:
       type: object
       required:
@@ -516,16 +520,21 @@ components:
         - strategies
       properties:
         name:
+          description: Feature Toggle name must be unique.
           type: string
           minLength: 1
-          description: Feature Toggle name must be unique.
           example: FeatureA
         description:
+          description: What the Feature Toggle does
           type: string
           minLength: 1
           example: Toggles FeatureA on and off
         type:
           type: string
+          description: '*type* is optional. If not defined, it defaults to `release`'
+          externalDocs:
+            description: Feature Toggle types
+            url: 'https://unleash.github.io/docs/feature_toggle_types'
           enum:
             - release
             - experiment
@@ -533,10 +542,6 @@ components:
             - killswitch
             - permission
           minLength: 1
-          description: '*type* is optional. If not defined, it defaults to `release`'
-          externalDocs:
-            description: Feature Toggle types
-            url: 'https://unleash.github.io/docs/feature_toggle_types'
           example: release
         enabled:
           type: boolean
@@ -888,6 +893,7 @@ components:
                 description: The icon to use for something. Link?
                 type: string
                 minLength: 1
+
     strategySchema:
       type: array
       properties:
@@ -929,6 +935,7 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
+
     simpleStrategySchema:
       type: object
       required:
@@ -950,61 +957,102 @@ components:
                 description: Name of Strategy's parameter
                 type: string
                 example: extra
+    
     200-events:
-      description: ''
       type: object
       properties:
         version:
+          description: Version number of what?
           type: number
+          example: 1
         events:
           type: array
+          required:
+          - id
+          - type
+          - createdBy
+          - createdAt
           uniqueItems: true
           minItems: 1
           items:
-            required:
-              - id
-              - type
-              - createdBy
-              - createdAt
             properties:
               id:
+                description: The event number. Starts at 1? On first run of application version?
                 type: number
+                example: 55
               type:
+                description: One of the five event types
                 type: string
+                enum:
+                  - feature-created
+                  - feature-updated
+                  - feature-archived
+                  - feature-revived
+                  - strategy-created
+                  - strategy-deleted
                 minLength: 1
+                example: feature-updated
               createdBy:
+                description: Creator of the application? Where is this taken from?
                 type: string
                 minLength: 1
               createdAt:
+                description: Date and time when the application was initially created
                 type: string
-                minLength: 1
+                example: '2016-12-09T14:56:36.730Z'
               data:
                 type: object
+                required:
+                - name
+                - description
+                - type
+                - enabled
+                - stale
+                - strategies
+                - createdAt
                 properties:
                   name:
+                    description: Feature Toggle name must be unique.
                     type: string
                     minLength: 1
+                    example: FeatureA
                   description:
-                    type: string
-                  strategy:
+                    description: What the Feature Toggle does
                     type: string
                     minLength: 1
+                    example: Toggles FeatureA on and off
+                  type:
+                    type: string
+                    description: '*type* is optional. If not defined, it defaults to `release`'
+                    externalDocs:
+                      description: Feature Toggle types
+                      url: 'https://unleash.github.io/docs/feature_toggle_types'
+                    enum:
+                      - release
+                      - experiment
+                      - ops
+                      - killswitch
+                      - permission
+                    minLength: 1
+                    example: release
                   enabled:
                     type: boolean
-                  parameters:
-                    type: object
-                    properties: {}
-
-                required:
-                  - name
-                  - description
-                  - strategy
-                  - enabled
-                  - parameters
+                    example: false
+                  stale:
+                    description: Is the Feature Toggle deprecated (stale)?
+                    type: boolean
+                    example: false
+                  strategies:
+                    $ref: '#/components/schemas/strategySchema'
+                  variants: {}
+                  createdAt:
+                    description: Date and time when the Feature Toggle was created?
+                    type: string
+                    minLength: 1
+                    example: '2020-11-09T13:51:08.949Z'
               diffs:
+                description: What are diffs? I don't think this part of the schema is correct
                 type: array
-                uniqueItems: true
-                minItems: 1
                 items:
                   required:
                     - kind
@@ -1013,15 +1061,20 @@ components:
                   properties:
                     kind:
                       type: string
-                      minLength: 1
+                      example: E
                     path:
                       type: array
                       items:
-                        properties: {}
+                        required:
+                          - pathItem
+                      properties:
+                        pathItem:
+                          description: What's this?
+                          type: string
+                          example: enabled
                     lhs:
+                      description: Left-hand side of something?
                       type: boolean
                     rhs:
+                      description: Left-hand side of something?
                       type: boolean
-      required:
-        - version
-        - events

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -338,7 +338,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200appdetails'
-
   /admin/metrics/seen-apps:
     get:
       summary: Details about application seen per Feature Toggle.
@@ -353,29 +352,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seenapps'
-
   /admin/events:
     get:
       summary: Fetch all changes in the Unleash system
-      description: |
-        It returns one of the five event types:
-        - feature-created
-        - feature-updated
-        - feature-archived
-        - feature-revived
-        - strategy-created
-        - strategy-deleted
-      operationId: getEvents
-      tags:
-        - Events
+      tags: []
       responses:
-      '200':
-        description: Successful response
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/200seenapps'
-
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200-events'
+      operationId: get-admin-events
+      description: |-
+        |
+          It returns one of the five event types:
+          - feature-created
+          - feature-updated
+          - feature-archived
+          - feature-revived
+          - strategy-created
+          - strategy-deleted
 components:
   parameters:
     strategyQuery:
@@ -997,7 +994,7 @@ components:
                   parameters:
                     type: object
                     properties: {}
-                    required: []
+
                 required:
                   - name
                   - description
@@ -1020,7 +1017,6 @@ components:
                     path:
                       type: array
                       items:
-                        required: []
                         properties: {}
                     lhs:
                       type: boolean

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,12 +1,3 @@
-# Continue from components/schemas/200appdetails (schema needs work and isn't displaying in Swagger UI)
-# Run tests against prevous items (I've done a global strategies $ref replacement)
-# Add examples to everything (inclusing response schemas)
-# Verify response schemas match object structure
-# Check question marks with unleash team
-# $ref any duplicate aspects - check the require elements for things you can replace
-# British English or American English?
-# {} in a definition means 'I don't know' - fix
-# Need a variants schema?
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -14,6 +5,8 @@ servers:
 tags:
   - name: Archive
     description: Handling Feature Toggle archiving and un-archiving
+  - name: Events
+    description: Idientifying events on the Unleash server
   - name: Feature toggles
     description: Accessing feature toggles
   - name: Metrics
@@ -231,7 +224,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  '/admin/strategies':
+  /admin/strategies:
     get:
       summary: Fetch all strategies and their parameters.
       description: Fetch all strategies and their parameters.
@@ -299,7 +292,7 @@ paths:
                 $ref: '#/components/schemas/200seen'
   /admin/metrics/feature-toggles:
     get:
-      summary: 'Gives ''last minute'' and ''last hour'' metrics for all active toggles (based on what was reported by the client applications).'
+      summary: Gives 'last minute' and 'last hour' metrics for all active toggles (based on what was reported by the client applications).
       description: |
         - **Yes** is the number of times a given feature toggle was enabled in a client applcation
         - **No** is the number of times it was disabled.
@@ -329,7 +322,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200application'
-
   '/admin/metrics/applications/{appName}':
     get:
       summary: Details about a client application.
@@ -347,7 +339,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/200appdetails'
 
-  '/admin/metrics/seen-apps':
+  /admin/metrics/seen-apps:
     get:
       summary: Details about application seen per Feature Toggle.
       description: Details about application seen per Feature Toggle.
@@ -361,12 +353,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seenapps'
+
+  /admin/events:
+    get:
+      summary: Fetch all changes in the Unleash system
+      description: |
+        It returns one of the five event types:
+        - feature-created
+        - feature-updated
+        - feature-archived
+        - feature-revived
+        - strategy-created
+        - strategy-deleted
+      operationId: getEvents
+      tags:
+        - Events
+      responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/200seenapps'
+
 components:
   parameters:
     strategyQuery:
       name: strategyName
       in: query
-      description: '(Optional). Return all applications implementing the specified Strategy. Must match an existing Strategy name.'
+      description: (Optional). Return all applications implementing the specified Strategy. Must match an existing Strategy name.
       schema:
         type: string
     featureNamePath:
@@ -392,56 +407,56 @@ components:
         type: string
   schemas:
     '200':
-        title: Successful response
-        type: object
-        properties:
-          version:
-            type: number
-          features:
-            type: array
-            uniqueItems: true
-            minItems: 1
-            items:
-              properties:
-                name:
-                  description: Feature Toggle name
-                  type: string
-                  minLength: 1
-                  example: featureX
-                description:
-                  description: What the Feature Toggle does
-                  type: string
-                  minLength: 1
-                type:
-                  description: One of the five types of Feature Toggle
-                  externalDocs:
-                    description: Feature Toggle types
-                    url: 'https://unleash.github.io/docs/feature_toggle_types'
-                  type: string
-                  minLength: 1
-                  example: release
-                enabled:
-                  description: Is the Feature Toggle enabled?
-                  type: boolean
-                stale:
-                  description: Is the Feature Toggle 'stale' (deprecated)?
-                  type: boolean
-                strategies:
-                  $ref: '#/components/schemas/simpleStrategySchema'
-                variants:
-                  type: array
-                  uniqueItems: true
-                  minItems: 1
-                  items:
-                    required:
-                      - name
-                      - weight
-                    properties:
-                      name:
-                        type: string
-                        minLength: 1
-                      weight:
-                        type: number
+      title: Successful response
+      type: object
+      properties:
+        version:
+          type: number
+        features:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            properties:
+              name:
+                description: Feature Toggle name
+                type: string
+                minLength: 1
+                example: featureX
+              description:
+                description: What the Feature Toggle does
+                type: string
+                minLength: 1
+              type:
+                description: One of the five types of Feature Toggle
+                externalDocs:
+                  description: Feature Toggle types
+                  url: 'https://unleash.github.io/docs/feature_toggle_types'
+                type: string
+                minLength: 1
+                example: release
+              enabled:
+                description: Is the Feature Toggle enabled?
+                type: boolean
+              stale:
+                description: Is the Feature Toggle 'stale' (deprecated)?
+                type: boolean
+              strategies:
+                $ref: '#/components/schemas/simpleStrategySchema'
+              variants:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  required:
+                    - name
+                    - weight
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                    weight:
+                      type: number
     '401':
       description: Not authorised
       type: object
@@ -482,7 +497,6 @@ components:
         - isJoi
         - name
         - details
-
     200strategy:
       description: Successful.
       type: object
@@ -495,7 +509,6 @@ components:
           example: 1
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
-
     newFeatureToggle:
       type: object
       required:
@@ -537,7 +550,6 @@ components:
           example: false
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
-
     updateFeatureToggle:
       type: object
       properties:
@@ -569,7 +581,6 @@ components:
         - stale
         - strategies
         - variants
-
     createStrategy:
       type: object
       properties:
@@ -610,8 +621,6 @@ components:
         - name
         - description
         - parameters
-
-  
     200seen:
       type: array
       description: ''
@@ -648,22 +657,25 @@ components:
         properties:
           appName:
             type: string
-            enum: [lastHour, lastMinute]
+            enum:
+              - lastHour
+              - lastMinute
             minLength: 1
             example: lastHour
           seenToggles:
             type: object
             required:
-            - yesno
-            - metricsCount
+              - yesno
+              - metricsCount
             properties:
               yesno:
                 type: string
-                enum: [yes, no]
+                enum:
+                  - 'yes'
+                  - 'no'
               metricsCount:
                 type: number
-
-    '200application':
+    200application:
       type: object
       required:
         - applications
@@ -697,19 +709,17 @@ components:
               strategies:
                 description: A description of what the application does
                 type: string
- #               $ref: '#/components/schemas/simpleStrategySchema'
               url:
                 description: Link to more information about the application? Relative only?
                 type: string
-                example: https://medium.com/keptn
+                example: 'https://medium.com/keptn'
               color:
                 description: The colour (American English?) of something. Hex code?
                 type: string
               icon:
                 description: The icon to use for something. Link?
                 type: string
-
-    '200appdetails':
+    200appdetails:
       type: object
       required:
         - appName
@@ -732,7 +742,7 @@ components:
         url:
           description: Link to more information about the application? Relative only?
           type: string
-          example: https://medium.com/keptn
+          example: 'https://medium.com/keptn'
         color:
           description: The colour (American English?) of something. Hex code?
           type: string
@@ -765,12 +775,12 @@ components:
               description: The version of the Unleash client SDK running the application
               type: string
               minLength: 1
-              example: unleash-client-node:3.4.0
+              example: 'unleash-client-node:3.4.0'
             clientIp:
               description: The IP address of the system running this instance of the application. What is the prefix on the string?
               type: string
               minLength: 1
-              example: ::ffff:127.0.0.1
+              example: '::ffff:127.0.0.1'
             lastSeen:
               description: The last time the application accessed Unleash?
               type: string
@@ -813,7 +823,7 @@ components:
                 description: Is the Feature Toggle enabled?
                 type: boolean
               stale:
-                description: Is the Feature Toggle 
+                description: Is the Feature Toggle
                 type: boolean
               strategies:
                 $ref: '#/components/schemas/strategySchema'
@@ -834,8 +844,7 @@ components:
               minLength: 1
           required:
             - self
-
-    '200seenapps':
+    200seenapps:
       type: object
       properties:
         my-toggle:
@@ -874,7 +883,7 @@ components:
                 description: Link to more information about the application? Relative only?
                 type: string
                 minLength: 1
-                example: https://medium.com/keptn
+                example: 'https://medium.com/keptn'
               color:
                 description: The colour (American English?) of something. Hex code?
                 type: string
@@ -882,8 +891,7 @@ components:
                 description: The icon to use for something. Link?
                 type: string
                 minLength: 1
-
-    'strategySchema':
+    strategySchema:
       type: array
       properties:
         name:
@@ -924,8 +932,7 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
-
-    'simpleStrategySchema':
+    simpleStrategySchema:
       type: object
       required:
         - appName
@@ -946,3 +953,79 @@ components:
                 description: Name of Strategy's parameter
                 type: string
                 example: extra
+    200-events:
+      description: ''
+      type: object
+      properties:
+        version:
+          type: number
+        events:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - id
+              - type
+              - createdBy
+              - createdAt
+            properties:
+              id:
+                type: number
+              type:
+                type: string
+                minLength: 1
+              createdBy:
+                type: string
+                minLength: 1
+              createdAt:
+                type: string
+                minLength: 1
+              data:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  description:
+                    type: string
+                  strategy:
+                    type: string
+                    minLength: 1
+                  enabled:
+                    type: boolean
+                  parameters:
+                    type: object
+                    properties: {}
+                    required: []
+                required:
+                  - name
+                  - description
+                  - strategy
+                  - enabled
+                  - parameters
+              diffs:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  required:
+                    - kind
+                    - lhs
+                    - rhs
+                  properties:
+                    kind:
+                      type: string
+                      minLength: 1
+                    path:
+                      type: array
+                      items:
+                        required: []
+                        properties: {}
+                    lhs:
+                      type: boolean
+                    rhs:
+                      type: boolean
+      required:
+        - version
+        - events

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,5 @@
-# Continue from events
+# Continue from components/schemas/200seenapps (schema needs work and isn't displaying in Swagger UI).
+# Run tests against prevous items (I've done a global strategies $ref replacement)
 # Add examples to everything (inclusing response schemas)
 # Verify response schemas match object structure
 # Check question marks with unleash team
@@ -337,6 +338,7 @@ paths:
         - Metrics
       parameters:
         - $ref: '#/components/parameters/appNamePath'
+
       responses:
         '200':
           description: Successful response
@@ -344,7 +346,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200appdetails'
-  /admin/metrics/seen-apps:
+  '/admin/metrics/seen-apps':
     get:
       summary: Details about application seen per Feature Toggle.
       description: Details about application seen per Feature Toggle.
@@ -727,6 +729,7 @@ components:
           type: string
         strategies:
           $ref: '#/components/schemas/strategySchema'
+
         instances:
           type: object
           required:
@@ -785,7 +788,7 @@ components:
                 minLength: 1
                 example: FeatureX
               description:
-                description: What the Feture Toggle does
+                description: What the Feature Toggle does
                 type: string
               type:
                 description: One of the five types of Feature Toggle
@@ -826,8 +829,6 @@ components:
       properties:
         my-toggle:
           type: array
-          uniqueItems: true
-          minItems: 1
           items:
             required:
               - appName
@@ -838,26 +839,36 @@ components:
               - icon
             properties:
               appName:
+                description: Appplication name
                 type: string
                 minLength: 1
+                example: my-application
               createdAt:
+                description: Date and time when the application was initially created
                 type: string
                 minLength: 1
+                example: '2016-12-09T14:56:36.730Z'
               updatedAt:
+                description: Date and time when the application was last updated
                 type: string
                 minLength: 1
+                example: '2020-11-14T09:55:23.653Z'
               description:
+                description: A description of what the application does
                 type: string
                 minLength: 1
               strategies:
                 $ref: '#/components/schemas/strategySchema'
               url:
+                description: Link to more information about the application? Relative only?
                 type: string
                 minLength: 1
+                example: https://medium.com/keptn
               color: {}
               icon:
                 type: string
                 minLength: 1
+
 
     strategySchema:
       type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,11 +5,13 @@ servers:
     url: 'http://localhost:4242/api'
 tags:
   - name: Admin - feature toggles
-    description: Accessing feature toggles on the Unleash admin server
+    description: Accessing feature toggles
   - name: Admin - archive
-    description: Handling Feature Toggle archiving and un-archiving on the Unleash admin server
+    description: Handling Feature Toggle archiving and un-archiving
   - name: Admin - strategies
-    description: Handling Feature Toggle archiving and un-archiving on the Unleash admin server
+    description: Accessing and updating strategies
+  - name: Admin - metrics
+    description: Determining usage of feature toggles and applications   
 info:
   title: Unleash API
   description: Unleash is a open source feature flag and toggle system for all your applications and services.
@@ -248,12 +250,41 @@ paths:
             schema:
               $ref: '#/components/schemas/createStrategy'
       responses:
+        '201':
+          description: Strategy successfully added
+  /admin/strategies/{strategyName}:
+    put:
+      summary: Update Strategy
+      description: |
+        Use to update a Strategy definition.
+
+        *name* and *strategyName* must match and must also match an existing Strategy name.
+
+        **Caution:** It can be dangerous to change a Strategy (as the implementation also might need to be changed).
+      operationId: updateStrategy
+      tags:
+        - Admin - strategies
+      parameters:
+        - $ref: '#/components/parameters/strategyNamePath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createStrategy'
+      responses:
         '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/200'
+          description: Strategy successfully updated.
+  /admin/seen-toggles:
+    get:
+      summary: Returns a list of applications and the feature toggles that unleash has 'seen' for each application.
+      description:  It is only guaranteed that feature toggles reported by client applications within the last hour will be returned. However, in most cases, earlier reported feature toggles will also be returned.
+      operationId: seenToggles
+      tags:
+        - Admin - metrics
+      responses:
+        '200':
+          description: Gotcha!
 components:
   parameters:
     featureNamePath:
@@ -261,6 +292,13 @@ components:
       required: true
       in: path
       description: Must match an existing Feature Toggle.
+      schema:
+        type: string
+    strategyNamePath:
+      name: strategyName
+      required: true
+      in: path
+      description: Must match an existing Strategy name.
       schema:
         type: string
   schemas:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,10 +1,10 @@
 # Add questions list
 # Add style guide MD. UK/US, Newspaper/Movie, JS/OAS. Nouns: UBleash, Feature Toggle. Strategy. Plurals. &. Glossary
+# Only use backticks for code samples and API paths. Use bold for schema items and italic for schema item settings
 # Move responses to root responses section in components (from schema section)
-# Issues with rendering as externaldocs from Swagger UI
-# Only use backticks for code samples (there is just one). Use bold for schema items and italic for schema item settings
-# Add descriptions and examples to everything in components. (Almost) every description needs an example
-# Up to updateFeatureToggle. Fix Feature Toggle $ref first
+# Issues with rendering as nested externaldocs from Swagger UI. See GET /admin​/feature-types
+# Make sure everthing from the Unleash admin documentation is incorporated or referenced
+# List questions
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -26,7 +26,7 @@ tags:
     description: Accessing and updating strategies
 info:
   title: Unleash API
-  description: Unleash is a open source feature flag and toggle system for all your applications and services.
+  description: Unleash is an open source feature flag and toggle system for all your applications and services.
   version: 3.5.6
   contact:
     name: The Unleash team
@@ -428,7 +428,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/200application'
+                $ref: '#/components/schemas/applicationArray'
         '401':
           description: Not authorised
           content:
@@ -476,7 +476,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/200seenapps'
+                $ref: '#/components/schemas/applicationArray'
         '401':
           description: Not authorised
           content:
@@ -535,18 +535,18 @@ paths:
           in: query
           name: download
           example: false
-          description: Export the data as a file? Default is false
+          description: Do you want to export the data as a file? Default is false
         - schema:
             type: boolean
           in: query
           name: featureToggles
-          description: Include feature toggles in the export? Default is true
+          description: Do you want to include feature toggles in the export? Default is true
           example: true
         - schema:
             type: boolean
           in: query
           name: strategies
-          description: Include strategies in the export? Default is true
+          description: Do you want to include strategies in the export? Default is true
           example: true
       responses:
         '200':
@@ -679,9 +679,8 @@ components:
       type: object
       properties:
         version:
-          type: number
+          $ref: '#/components/schemas/versionSchema'
         features:
-          type: array
           $ref: '#/components/schemas/featureToggleSchema'
 
     '401':
@@ -709,9 +708,7 @@ components:
         - strategies
       properties:
         version:
-          type: number
-          description: What is this?
-          example: 1
+          $ref: '#/components/schemas/versionSchema'
         strategies:
           $ref: '#/components/schemas/strategySchema'
 
@@ -811,8 +808,13 @@ components:
                   - 'no'
               metricsCount:
                 type: number
+                
+    applicationArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/application'
 
-    200application:
+    application:
       type: object
       required:
         - applications
@@ -847,46 +849,26 @@ components:
                 description: A description of what the application does
                 type: string
               url:
-                description: Link to more information about the application? Relative only?
+                description: Link to more information about the application? Relative only? # Question?
                 type: string
                 example: 'https://medium.com/keptn'
               color:
-                description: The colour (American English?) of something. Hex code?
+                description: The colour (American English?) of something. Hex code? # Question?
                 type: string
               icon:
-                description: The icon to use for something. Link?
+                description: The icon to use for something. Link? # Question?
                 type: string
 
     200appdetails:
       type: object
       required:
-        - appName
+        - application
         - instances
         - strategies
         - seenToggles
       properties:
-        appName:
-          description: Application name
-          type: string
-          minLength: 1
-          example: my-application
-        createdAt:
-          description: Date and time when the application was initially created
-          type: string
-          example: '2016-12-09T14:56:36.730Z'
-        description:
-          description: A description of what the application does
-          type: string
-        url:
-          description: Link to more information about the application? Relative only?
-          type: string
-          example: 'https://medium.com/keptn'
-        color:
-          description: The colour (American English?) of something. Hex code?
-          type: string
-        icon:
-          description: The icon to use for something. Link?
-          type: string
+        application:
+          $ref: '#/components/schemas/application'
         strategies:
           $ref: '#/components/schemas/strategySchema'
         instances:
@@ -915,122 +897,31 @@ components:
               minLength: 1
               example: 'unleash-client-node:3.4.0'
             clientIp:
-              description: The IP address of the system running this instance of the application. What is the prefix on the string?
+              description: The IP address of the system running this instance of the application. What is the prefix on the string? # Question?
               type: string
               minLength: 1
               example: '::ffff:127.0.0.1'
             lastSeen:
-              description: The last time the application accessed Unleash?
+              description: The last time the application accessed Unleash? # Question?
               type: string
               minLength: 1
               example: '2020-11-14T11:17:24.482Z'
             createdAt:
-              description: When the application was created?
+              description: When the application was created? # Question?
               type: string
               minLength: 1
               example: '2020-11-13T16:56:29.279Z'
         seenToggles:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - name
-              - type
-              - enabled
-              - stale
-              - createdAt
-            properties:
-              name:
-                description: Name of the Feature Toggle
-                type: string
-                minLength: 1
-                example: FeatureX
-              description:
-                description: What the Feature Toggle does
-                type: string
-              type:
-                description: One of the five types of Feature Toggle
-                type: string
-                externalDocs:
-                  description: Feature Toggle types
-                  url: 'https://unleash.github.io/docs/feature_toggle_types'
-                minLength: 1
-                example: release
-              enabled:
-                description: Is the Feature Toggle enabled?
-                type: boolean
-                example: true
-              stale:
-                description: Is the Feature Toggle deprecated (stale)?
-                type: boolean
-                example: false
-              strategies:
-                $ref: '#/components/schemas/strategySchema'
-              variants:
-                $ref: '#/components/schemas/variantsSchema'
-              createdAt:
-                description: Date and time when the application was initially created
-                type: string
-                minLength: 1
-                example: '2020-11-09T15:25:59.517Z'
+          $ref: '#/components/schemas/featureToggleSchema'
         links:
           type: object
           properties:
             self:
-              description: What is this?
+              description: What is this? # Question?
               type: string
               minLength: 1
           required:
             - self
-
-    200seenapps:
-      type: object
-      properties:
-        my-toggle:
-          type: array
-          items:
-            required:
-              - appName
-              - createdAt
-              - updatedAt
-              - description
-              - url
-              - icon
-            properties:
-              appName:
-                description: Appplication name
-                type: string
-                minLength: 1
-                example: my-application
-              createdAt:
-                description: Date and time when the application was initially created
-                type: string
-                minLength: 1
-                example: '2016-12-09T14:56:36.730Z'
-              updatedAt:
-                description: Date and time when the application was last updated
-                type: string
-                minLength: 1
-                example: '2020-11-14T09:55:23.653Z'
-              description:
-                description: A description of what the application does
-                type: string
-                minLength: 1
-              strategies:
-                $ref: '#/components/schemas/simpleStrategySchema'
-              url:
-                description: Link to more information about the application? Relative only?
-                type: string
-                minLength: 1
-                example: 'https://medium.com/keptn'
-              color:
-                description: The colour (American English?) of something. Hex code?
-                type: string
-              icon:
-                description: The icon to use for something. Link?
-                type: string
-                minLength: 1
 
     featureToggleTypeSchema:
       type: string
@@ -1040,50 +931,60 @@ components:
         - ops
         - killswitch
         - permission
-      description: '**type** is optional. If not defined, it defaults to *release*'
+      description: |-
+        'One of the five Unleash Feature Toggle types.
+        
+        **type** is optional. If not defined, it defaults to *release*'
       default: 'release'
       externalDocs:
         description: Feature Toggle types
         url: 'https://unleash.github.io/docs/feature_toggle_types'
       minLength: 1
       example: release
+    
+    versionSchema:
+      type: number
+      description: What is this? # Question?
+      example: 1
 
     featureToggleSchema:
-      type: object
-      required:
-      - name
-      - description
-      - type
-      - enabled
-      - stale
-      - strategies
-      properties:
-        name:
-          description: Feature Toggle name must be unique.
-          type: string
-          minLength: 1
-          example: featureX
-        description:
-          type: string
-          minLength: 1
-          example: Toggles featureX on and off
-        type:
-          $ref: '#/components/schemas/featureToggleTypeSchema'
-        enabled:
-          description: Is the Feature Toggle enabled?
-          type: boolean
-          example: true
-        stale:
-          description: Is the Feature Toggle 'stale' (deprecated)?
-          type: boolean
-          example: false
-        strategies:
-          $ref: '#/components/schemas/strategySchema'
-        variants:
-          $ref: '#/components/schemas/variantsSchema'
-        createdAt:
-          type: string
-          minLength: 1
+      type: array
+      items:
+        type: object
+        required:
+        - name
+        - description
+        - type
+        - enabled
+        - stale
+        - strategies
+        properties:
+          name:
+            description: Feature Toggle name must be unique.
+            type: string
+            minLength: 1
+            example: featureX
+          description:
+            type: string
+            minLength: 1
+            example: Toggles featureX on and off
+          type:
+            $ref: '#/components/schemas/featureToggleTypeSchema'
+          enabled:
+            description: Is the Feature Toggle enabled?
+            type: boolean
+            example: true
+          stale:
+            description: Is the Feature Toggle 'stale' (deprecated)?
+            type: boolean
+            example: false
+          strategies:
+            $ref: '#/components/schemas/strategySchema'
+          variants:
+            $ref: '#/components/schemas/variantsSchema'
+          createdAt:
+            type: string
+            minLength: 1
 
     strategySchema:
       type: array
@@ -1129,6 +1030,9 @@ components:
                     example: false
 
     variantsSchema:
+      externalDocs:
+        description: How to use Feature Toggle variants
+        url: https://unleash.github.io/docs/toggle_variants
       type: array
       items:
         required:
@@ -1136,40 +1040,20 @@ components:
           - weight
         properties:
           name:
+            description: The name of the Feature Toggle variant
             type: string
             minLength: 1
+            example: yellow
           weight:
+            description: The 'weighting' for the variant. How does Unleash use weighting to determine which variant to use? What is the range? # Question?
             type: number
-
-    simpleStrategySchema:
-      type: object
-      required:
-        - appName
-        - parameterName
-      properties:
-        appName:
-          description: Application name
-          type: string
-          minLength: 1
-          example: demo-app
-        strategies:
-          type: array
-          items:
-            required:
-              - strategyName
-            properties:
-              parameterName:
-                description: Name of Strategy's parameter
-                type: string
-                example: extra
+            example: 20
 
     200-events:
       type: object
       properties:
         version:
-          description: Version number of what?
-          type: number
-          example: 1
+          $ref: '#/components/schemas/versionSchema'
         events:
           type: array
           required:
@@ -1182,11 +1066,11 @@ components:
           items:
             properties:
               id:
-                description: The event number. Starts at 1? On first run of application version?
+                description: The event number. Starts at 1? On first run of application version? # Question?
                 type: number
                 example: 55
               type:
-                description: One of the five event types
+                description: One of the six event types
                 type: string
                 enum:
                   - feature-created
@@ -1198,7 +1082,7 @@ components:
                 minLength: 1
                 example: feature-updated
               createdBy:
-                description: Creator of the application? Where is this taken from?
+                description: Creator of the application? Where is this taken from? # Question?
                 type: string
                 minLength: 1
               createdAt:
@@ -1208,7 +1092,7 @@ components:
               data:
                 $ref: '#/components/schemas/featureToggleSchema'
               diffs:
-                description: What are diffs? I don't think this part of the schema is correct
+                description: What are diffs?  # Question?
                 type: array
                 items:
                   required:
@@ -1217,6 +1101,7 @@ components:
                     - rhs
                   properties:
                     kind:
+                      description: What do these letters signify? What's the full list? # Question? 
                       type: string
                       example: E
                     path:
@@ -1226,15 +1111,15 @@ components:
                           - pathItem
                       properties:
                         pathItem:
-                          description: What's this?
+                          description: What's this? # Question?
                           type: string
                           example: enabled
                     lhs:
-                      description: Left-hand side of something?
+                      description: Left-hand side of something? Sometimes boolean, sometimes an object, sometimes null. What is it? # Question?
                       type: boolean
                       example: true
                     rhs:
-                      description: Left-hand side of something?
+                      description: Left-hand side of something? Sometimes boolean, sometimes an object, sometimes null. What is it? # Question?
                       type: boolean
                       example: false
 
@@ -1246,71 +1131,20 @@ components:
         - strategies
       properties:
         version:
-          description: Version number of what?
-          type: number
-          example: 1
+          $ref: '#/components/schemas/versionSchema'
         features:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - name
-              - description
-              - type
-              - enabled
-              - stale
-              - createdAt
-            properties:
-              name:
-                description: Feature Toggle name.
-                type: string
-                minLength: 1
-                example: FeatureA
-              description:
-                description: What the Feature Toggle does
-                type: string
-                minLength: 1
-                example: Toggles FeatureA on and off
-              type:
-                type: string
-                description: '*type* is optional. If not defined, it defaults to `release`'
-                externalDocs:
-                  description: Feature Toggle types
-                  url: 'https://unleash.github.io/docs/feature_toggle_types'
-                enum:
-                  - release
-                  - experiment
-                  - ops
-                  - killswitch
-                  - permission
-                minLength: 1
-                example: release
-                default: 'release'
-              enabled:
-                type: boolean
-                example: false
-              stale:
-                description: Is the Feature Toggle deprecated (stale)?
-                type: boolean
-                example: false
-              strategies:
-                $ref: '#/components/schemas/strategySchema'
-              variants:
-                $ref: '#/components/schemas/variantsSchema'
-              createdAt:
-                type: string
-                minLength: 1
+          $ref: '#/components/schemas/featureToggleSchema'
         strategies:
-          $ref: '#/components/schemas/strategySchema'
+          $ref: '#/components/schemas/strategySchema' # Difference between this and the strategies in the Feature Toggle schema?
 
     200featuretype:
       type: object
+      required:
+        - version
+        - types
       properties:
         version:
-          description: A version number of something?
-          type: number
-          example: 1
+          $ref: '#/components/schemas/versionSchema'
         types:
           type: array
           uniqueItems: true
@@ -1343,13 +1177,11 @@ components:
                   - Performs multivariate or A/B testing
                   - Controls operational aspects of the system behaviour # US English?
                   - Gracefully degrades system functionality
-                  - Changez the features or product experiences that certain users receive
+                  - Changes the features or product experiences that certain users receive
                 minLength: 1
               lifetimeDays:
-                description: What's this?
+                description: What's this? # Question?
                 type: number
                 example: 40
-      required:
-        - version
-        - types
+
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,36 +1,60 @@
+# IMPLEMENT
+# Check code for toggle type strings
+# REVIEW
+# Rationalise component parameters. No point in having several iterations of the same schema. UpdateFeatureToggle vs NewFeatureToggle
+# Enable and Update a Feature toggle have same bodies as much of the response 200 (can we use $ref to simplify the OAS?)
+# TEST
+# Is colon before a query parameter in the documentation a literal colon or is it used to denote the type of parameter?
+# Are features, toggles and feature toggles all the same thing?
+# EXTEND
+# 
+# DOCUMENTATION STYLE NOTES
+# Use 'and' instead of &
+# Headings: use newspaper-style headings 'This is a heading' or movie-style 'This is a Heading'?
+# American English or British English?
+# Proper nouns for Unleash: Unleash, Feature, Toggle (not that plurals are lower-case: toggles and features)
+# Parameter names: use JS-style (aParameter) or Open API style (aparameter)?
+# TERMINOLOGY QUERIES
+# What does 'globally unique' mean - what is 'global'?
+# NOTE SOMEWHERE (client API docs?)
+# Feature (toggle?) names cannot have spaces. List of legal characters?
+# 
 openapi: 3.0.0
-tags:
-  - name: "Admin - Feature Toggles"
-    description: Funny nosed pig-head racoon.
-  - name: "Admin - archive"
-    description: Angry short-legged omnivores.
 servers:
   - description: Local host.
     url: 'http://localhost:4242/api'
+tags:
+  - name: Admin - Feature toggles
+    description: Accessing feature toggles on the Unleash admin server
+  - name: Admin - archive
+    description: Handling Feature Toggle archiving and un-archiving on the Unleash admin server
 info:
   title: Unleash API
-  description: Unleash is a open source feature flag and toggle system. It gives you a great overview over all feature toggles across all your applications and services.
+  description: Unleash is a open source feature flag and toggle system for all your applications and services.
   version: 3.5.6
   contact:
-    name: "The Unleash team"
-    url: "https://unleash.github.io/"
-    email: "some_email@gmail.com"
+    name: The Unleash team
+    url: 'https://unleash.github.io/'
+    email: some_email@gmail.com
 externalDocs:
-  description: Documentation
-  url: 'https://openweathermap.org/api'
+  description: Unleash documentation
+  url: 'https://unleash.github.io/docs/getting_started'
 paths:
-  /admin/features:
+  '/admin/features':
     get:
-      summary: Fetches all feature toggles from the *Unleash server*.
+      summary: Fetches all feature toggles from the Unleash server.
       description: |
-        The response returns all active feature toggles and their current strategy configuration.
+        The response returns all active feature toggles and their current strategy configuration:
         - A feature toggle will have *at least* one configured strategy.
         - A strategy will have a `name` and `parameters` map.
+
+        **Note:** To only return one feature, add the feature name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Sepcification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
+      externalDocs:
+        description: Activation strategies
+        url: https://unleash.github.io/docs/activation_strategy
       operationId: getFeatures
       tags:
-        - "Admin - Feature Toggles"
-      parameters:
-        - $ref: '#/components/parameters/featureNameOptional'
+        - Admin - Feature toggles
       responses:
         '200':
           description: Successful response
@@ -47,7 +71,7 @@ paths:
     post:
       description: Create a new Feature Toggle
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       operationId: createFeatureToggle
       requestBody:
         required: true
@@ -62,12 +86,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-        '403':
-          description: '*name* is not globally unique'
+        '409':
+          description: '*name* is not unique'
           content:
             text/plain:
               schema:
-                title: '*name* is not globally unique'
+                title: '*name* is not unique'
                 type: string
       summary: Create a Feature Toggle
     put:
@@ -75,7 +99,7 @@ paths:
       description: Used by the admin dashboard to update a Feature Toggle.
       operationId: updateFeatureToggle
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/toggleNameRequired'
       requestBody:
@@ -93,10 +117,13 @@ paths:
                 $ref: '#/components/schemas/200'
     delete:
       summary: Archive a Feature Toggle.
-      description: 'Feature toggles can only be archived - they cannot be deleted.<br><br>If an old Feature Toggle ''re-appears'', this is because someone else has created a Feature Toggle with the same name.'
+      description: |
+        Feature toggles can only be archived - they cannot be deleted.
+
+        If an old Feature Toggle *re-appears*, this is because someone else has created a Feature Toggle with the same name.
       operationId: archiveFeatureToggle
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/toggleNameRequired'
       responses:
@@ -106,13 +133,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  '/admin/features/{featureNameRequired}/toggle/on':
+  '/admin/features/{featureName}/toggle/on':
     post:
       summary: Enable a Feature Toggle.
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: enableFeatureToggle
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNameRequired'
       responses:
@@ -122,13 +149,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  '/admin/features/{featureNameRequired}/toggle/off':
+  '/admin/features/{featureName}/toggle/off':
     post:
       summary: Disable a Feature Toggle.
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: disableFeatureToggle
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNameRequired'
       responses:
@@ -138,13 +165,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  '/admin/features/{featureNameRequired}/stale/on':
+  '/admin/features/{featureName}/stale/on':
     post:
       summary: Mark a Feature Toggle as 'stale' (deprecated).
       description: '*featureName* must match an existing Feature Toggle.'
+      externalDocs:
+        description: Feature Toggle types
+        url: https://unleash.github.io/docs/feature_toggle_types
       operationId: markFeatureToggleStale
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNameRequired'
       responses:
@@ -154,13 +184,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  '/admin/features/{featureNameRequired}/stale/off':
+  '/admin/features/{featureName}/stale/off':
     post:
       summary: Mark a Feature Toggle as active.
       description: '*featureName* must match an existing Feature Toggle.'
+      externalDocs:
+        description: Feature Toggle types
+        url: https://unleash.github.io/docs/feature_toggle_types
       operationId: markFeatureToggleActive
       tags:
-        - Admin - Feature Toggles
+        - Admin - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNameRequired'
       responses:
@@ -170,13 +203,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '409':
+          description: Feature Toggle name is not unique.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/409'
   /admin/archive/features:
     get:
       summary: List all the archived Feature Toggles on the Unleash server'
       description: Archived Features are those that have been previously deleted
       operationId: fetchArchivedToggles
       tags:
-        - "Admin - archive"
+        - Admin - archive
       responses:
         '200':
           description: Successful response
@@ -205,14 +244,8 @@ paths:
                 $ref: '#/components/schemas/200'
 components:
   parameters:
-    featureNameOptional:
-      name: featureName
-      in: query
-      description: Used to fetch details about a specific Feature Toggle. This is mostly provided to make it easy to debug the API and should not be used by the client implementations.
-      schema:
-        type: string
     featureNameRequired:
-      name: featureNameRequired
+      name: featureName
       required: true
       in: path
       description: Must match an existing Feature Toggle.
@@ -310,12 +343,12 @@ components:
         name:
           type: string
           minLength: 1
-          description: '*name* must be **globally unique**; otherwise, you will get a *403-response*.'
-          example: Feature A
+          description: '*name* must be **unique**; otherwise, you will get a *403-response*.'
+          example: FeatureA
         description:
           type: string
           minLength: 1
-          example: Toggles Feature A on and off
+          example: Toggles FeatureA on and off
         type:
           type: string
           enum:
@@ -326,6 +359,9 @@ components:
             - permission
           minLength: 1
           description: '*type* is optional. If not defined, it defaults to `release`'
+          externalDocs:
+            description: Feature Toggle types
+            url: https://unleash.github.io/docs/feature_toggle_types
           example: release
         enabled:
           type: boolean
@@ -354,6 +390,29 @@ components:
         - enabled
         - stale
         - strategies
+    '409':
+      type: object
+      properties:
+        isJoi:
+          type: boolean
+        name:
+          type: string
+          minLength: 1
+        details:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - message
+            properties:
+              message:
+                type: string
+                minLength: 1
+      required:
+        - isJoi
+        - name
+        - details
     updateFeatureToggle:
       type: object
       properties:
@@ -361,11 +420,11 @@ components:
           type: string
           minLength: 1
           description: '*name* must match an existing Feature Toggle.'
-          example: Feature B
+          example: FeatureB
         description:
           type: string
           minLength: 1
-          example: Toggles Feature B on and off
+          example: Toggles FeatureB on and off
         type:
           type: string
           minLength: 1
@@ -391,11 +450,23 @@ components:
                 example: default
               parameters:
                 type: object
-                properties: {}
-        variants:
-          type: array
-          items:
-            properties: {}
+                properties:
+                  rollout:
+                    type: number
+                  stickiness:
+                    type: string
+                    minLength: 1
+                  groupId:
+                    type: string
+                    minLength: 1
+                required:
+                  - rollout
+                  - stickiness
+                  - groupId
+        variants: {}
+        createdAt:
+          type: string
+          minLength: 1
       required:
         - name
         - description
@@ -403,3 +474,4 @@ components:
         - stale
         - strategies
         - variants
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,8 +1,10 @@
-# simpleStrategySchema works (and may be correct for some responses)
-# strategySchema can't render in Swagger UI. use simple for now
 # Add questions list
-# Check for $ref substitutions - see the 'required' items
-# Need to define variants schema
+# Add style guide MD. UK/US, Newspaper/Movie, JS/OAS. Nouns: UBleash, Feature Toggle. Strategy. Plurals. &. Glossary
+# Move responses to root responses section in components (from schema section)
+# Issues with rendering as externaldocs from Swagger UI
+# Only use backticks for code samples (there is just one). Use bold for schema items and italic for schema item settings
+# Add descriptions and examples to everything in components. (Almost) every description needs an example
+# Up to updateFeatureToggle. Fix Feature Toggle $ref first
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -11,7 +13,7 @@ tags:
   - name: Archive
     description: Handling Feature Toggle archiving and un-archiving
   - name: Events
-    description: Idientifying events on the Unleash server
+    description: Identifying events on the Unleash server
   - name: Feature toggles
     description: Accessing feature toggles
   - name: Feature types
@@ -62,7 +64,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/401'
+
     post:
+      summary: Create a Feature Toggle
       description: Create a new Feature Toggle
       tags:
         - Feature toggles
@@ -72,21 +76,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/newFeatureToggle'
+              $ref: '#/components/schemas/featureToggleSchema'
       responses:
-        '200':
-          description: Successful response
+        '201':
+          description: Feature Toggle successfully created
+        '400':
+          description: Bad body request (for example, Feature Toggle name is not unique)
+        '401':
+          description: Not authorised
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/200'
-        '409':
-          description: Feature Toggle name is not unique
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/409'
-      summary: Create a Feature Toggle
+                $ref: '#/components/schemas/401'
+
   '/admin/features/{featureName}':
     put:
       summary: Update a Feature Toggle
@@ -101,14 +103,25 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/updateFeatureToggle'
+              $ref: '#/components/schemas/featureToggleSchema'
       responses:
         '200':
-          description: Successful response
+          description: Feature Toggle successfully updated
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '400':
+          description: Bad body request (for example 'strategies' is not an array)
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
     delete:
       summary: Archive a Feature Toggle.
       description: |
@@ -118,6 +131,7 @@ paths:
       operationId: archiveFeatureToggle
       tags:
         - Feature toggles
+        - Archive
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -127,10 +141,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
   '/admin/features/{featureName}/toggle/on':
     post:
       summary: Enable a Feature Toggle.
-      description: '*featureName* must match an existing Feature Toggle.'
+      description: '**featureName** must match an existing Feature Toggle.'
       operationId: enableFeatureToggle
       tags:
         - Feature toggles
@@ -143,10 +166,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
   '/admin/features/{featureName}/toggle/off':
     post:
       summary: Disable a Feature Toggle.
-      description: '*featureName* must match an existing Feature Toggle.'
+      description: '**featureName** must match an existing Feature Toggle.'
       operationId: disableFeatureToggle
       tags:
         - Feature toggles
@@ -159,10 +191,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
   '/admin/features/{featureName}/stale/on':
     post:
       summary: Mark a Feature Toggle as 'stale' (deprecated).
-      description: '*featureName* must match an existing Feature Toggle.'
+      description: '**featureName** must match an existing Feature Toggle.'
       externalDocs:
         description: Feature Toggle types
         url: 'https://unleash.github.io/docs/feature_toggle_types'
@@ -178,10 +219,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
   '/admin/features/{featureName}/stale/off':
     post:
       summary: Mark a Feature Toggle as active.
-      description: '*featureName* must match an existing Feature Toggle.'
+      description: '**featureName** must match an existing Feature Toggle.'
       externalDocs:
         description: Feature Toggle types
         url: 'https://unleash.github.io/docs/feature_toggle_types'
@@ -197,13 +247,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-        '409':
-          description: Feature Toggle name is not unique.
+        '401':
+          description: Not authorised
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/409'
-  /admin/archive/features:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
+  '/admin/archive/features':
     get:
       summary: List all the archived feature toggles on the Unleash server
       description: Archived feature toggles are those that have been previously deleted
@@ -217,6 +270,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Feature Toggle not found
+
   '/admin/archive/revive/{featureName}':
     post:
       summary: Un-archive a Feature Toggle
@@ -233,7 +295,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  /admin/strategies:
+        '404':
+          description: Feature Toggle not found
+
+  '/admin/strategies':
     get:
       summary: Fetch all strategies and their parameters.
       description: Fetch all strategies and their parameters.
@@ -247,6 +312,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200strategy'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
     post:
       summary: Create Strategy
       description: Create Strategy
@@ -262,15 +334,24 @@ paths:
       responses:
         '201':
           description: Strategy successfully added
+        '400':
+          description: Bad body request (for example 'strategies' is not an array)
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
   '/admin/strategies/{strategyName}':
     put:
       summary: Update Strategy
       description: |
         Use to update a Strategy definition.
 
-        *name* and *strategyName* must match and must also match an existing Strategy name.
+        **name** and **strategyName** must match and must also match an existing Strategy name.
 
-        **Caution:** It can be dangerous to change a Strategy (as the implementation also might need to be changed).
+        **Caution: It can be dangerous to change a Strategy (as the implementation also might need to be changed).**
       operationId: updateStrategy
       tags:
         - Strategies
@@ -285,6 +366,15 @@ paths:
       responses:
         '200':
           description: Strategy successfully updated.
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Strategy not updated due to errors in query and/or request body (such as **name** and **strategyName** not matching).
+
   /admin/metrics/seen-toggles:
     get:
       summary: Returns a list of applications and the feature toggles that Unleash has 'seen' for each application.
@@ -299,11 +389,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seen'
+
   /admin/metrics/feature-toggles:
     get:
       summary: Gives 'last minute' and 'last hour' metrics for all active toggles (based on what was reported by the client applications).
-      description: |
-        - **Yes** is the number of times a given feature toggle was enabled in a client applcation
+      description: |-
+        - **Yes** is the number of times a given feature toggle was enabled in a client applucation
         - **No** is the number of times it was disabled.
       operationId: featureToggles
       tags:
@@ -315,6 +406,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200feature'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
   /admin/metrics/applications:
     get:
       summary: A list of known applications ('seen' by Unleash in the last two days)
@@ -331,6 +429,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200application'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '500':
+          description: Strategy name not found
+
   '/admin/metrics/applications/{appName}':
     get:
       summary: Details about a client application.
@@ -347,10 +454,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200appdetails'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '500':
+          description: Application name not found
+
   /admin/metrics/seen-apps:
     get:
-      summary: Details about application seen per Feature Toggle.
-      description: Details about application seen per Feature Toggle.
+      summary: Details about applications seen
+      description: (per Feature Toggle)
       operationId: seenApps
       tags:
         - Metrics
@@ -361,9 +477,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200seenapps'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
   /admin/events:
     get:
+      operationId: get-admin-events
       summary: Fetch all changes in the Unleash system
+      description: |-
+        Returns one of the five event types:
+        - feature-created
+        - feature-updated
+        - feature-archived
+        - feature-revived
+        - strategy-created
+        - strategy-deleted
       tags:
         - Events
       responses:
@@ -373,20 +505,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200-events'
-      operationId: get-admin-events
-      description: |-
-        Returns one of the five event types:
-        - feature-created
-        - feature-updated
-        - feature-archived
-        - feature-revived
-        - strategy-created
-        - strategy-deleted
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
   /admin/state/export:
     get:
+      operationId: get-admin-state-export
       summary: Export feature toggles and strategies
+      description: Exports a list of feature toggles and/or strategies in either JSON or YAML format.
       tags:
         - Import and export
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - json
+              - yaml
+          in: query
+          name: format
+          description: |
+            Choose export format, either json or yaml. json is the default
+          example: json
+        - schema:
+            type: boolean
+          in: query
+          name: download
+          example: false
+          description: Export the data as a file? Default is false
+        - schema:
+            type: boolean
+          in: query
+          name: featureToggles
+          description: Include feature toggles in the export? Default is true
+          example: true
+        - schema:
+            type: boolean
+          in: query
+          name: strategies
+          description: Include strategies in the export? Default is true
+          example: true
       responses:
         '200':
           description: OK
@@ -394,53 +555,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200export'
-      operationId: get-admin-state-export
-      parameters:
-        - schema:
-            type: string
-          in: query
-          name: format
-          description: |
-            Choose export format, either json or yaml. json is the default
-        - schema:
-            type: boolean
-          in: query
-          name: download
-          description: Export the data as a file? Default is false
-        - schema:
-            type: boolean
-          in: query
-          name: featureToggles
-          description: Include feature toggles in the export? Default is true
-        - schema:
-            type: boolean
-          in: query
-          name: strategies
-          description: Include strategies in the export? Default is true
-      description: Exports a list of feature toggles and/or strategies in either JSON or YAML format.
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+
   /admin/state/import:
     post:
       summary: Import feature toggles and strategies
       operationId: post-admin-state-import
       tags:
         - Import and export
-      responses:
-        '200':
-          description: Successful import.
-      description: Upload the data, in JSON or YAML format, in the POST body. What schema must the import file adopt? Same as the export 200 response?
+      description: |-
+        Upload the data, in JSON or YAML format.
+        You can add in the POST body or upload a file
+        - **POST body** (JSON format only) - next to **Request body**, choose the *application/json* dropdown option.
+        - **File upload** (JOSN or YAML format) - next to **Request body**, choose the *multipart/form-data* dropdown option. This adopts the same schema as `GET /admin/state/export`
       parameters:
         - schema:
             type: boolean
             default: 'false'
+            example: false
           in: query
           name: drop
           description: Be careful using this in production environments. Set to true if you want the to remove all strategies and feature toggles from the datebase before import. Default is false.
         - schema:
             type: boolean
-            default: 'true'
+            default: 'false'
+            example: false
           in: query
           name: keep
-          description: Set to true if you want keep all existing feature toggles and strategies as is; only the missing feature toggles and strategies will be inserted from the import data. Default is true.
+          description: Set to *true* if you want keep all existing feature toggles and strategies as is; only the missing feature toggles and strategies will be inserted from the import data. Default is true.
+          example: true
       requestBody:
         content:
           multipart/form-data:
@@ -450,6 +598,21 @@ paths:
                 fileName:
                   type: string
                   format: binary
+          application/json:
+            schema:
+              $ref: '#/components/schemas/200export'
+      responses:
+        '200':
+          description: Successful import.
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: No import data provided.
+  
   /admin/feature-types:
     get:
       summary: Fetch the list of Unleash feature types
@@ -469,20 +632,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200featuretype'
+        '401':
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
 
 components:
   parameters:
     strategyQuery:
       name: strategyName
-      in: query
       description: (Optional). Return all applications implementing the specified Strategy. Must match an existing Strategy name.
+      example: remoteAddress
+      in: query
       schema:
         type: string
     featureNamePath:
       name: featureName
+      description: Must match an existing Feature Toggle name.
+      example: featureX
       required: true
       in: path
-      description: Must match an existing Feature Toggle.
       schema:
         type: string
     strategyNamePath:
@@ -490,6 +661,7 @@ components:
       required: true
       in: path
       description: Must match an existing Strategy name.
+      example: flexibleRollout
       schema:
         type: string
     appNamePath:
@@ -497,8 +669,10 @@ components:
       required: true
       in: path
       description: Must match an existing application name.
+      example: my-application
       schema:
         type: string
+
   schemas:
     '200':
       title: Successful response
@@ -508,49 +682,8 @@ components:
           type: number
         features:
           type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            properties:
-              name:
-                description: Feature Toggle name
-                type: string
-                minLength: 1
-                example: featureX
-              description:
-                description: What the Feature Toggle does
-                type: string
-                minLength: 1
-              type:
-                description: One of the five types of Feature Toggle
-                externalDocs:
-                  description: Feature Toggle types
-                  url: 'https://unleash.github.io/docs/feature_toggle_types'
-                type: string
-                minLength: 1
-                example: release
-              enabled:
-                description: Is the Feature Toggle enabled?
-                type: boolean
-              stale:
-                description: Is the Feature Toggle 'stale' (deprecated)?
-                type: boolean
-              strategies:
-                $ref: '#/components/schemas/simpleStrategySchema'
-              variants:
-                type: array
-                uniqueItems: true
-                minItems: 1
-                items:
-                  required:
-                    - name
-                    - weight
-                  properties:
-                    name:
-                      type: string
-                      minLength: 1
-                    weight:
-                      type: number
+          $ref: '#/components/schemas/featureToggleSchema'
+
     '401':
       description: Not authorised
       type: object
@@ -568,31 +701,8 @@ components:
         - type
         - path
         - message
-    '409':
-      type: object
-      properties:
-        isJoi:
-          type: boolean
-        name:
-          type: string
-          minLength: 1
-        details:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - message
-            properties:
-              message:
-                type: string
-                minLength: 1
-      required:
-        - isJoi
-        - name
-        - details
+
     200strategy:
-      description: Successful.
       type: object
       required:
         - version
@@ -600,82 +710,11 @@ components:
       properties:
         version:
           type: number
+          description: What is this?
           example: 1
         strategies:
-          $ref: '#/components/schemas/simpleStrategySchema'
-    newFeatureToggle:
-      type: object
-      required:
-        - name
-        - description
-        - enabled
-        - stale
-        - strategies
-      properties:
-        name:
-          description: Feature Toggle name must be unique.
-          type: string
-          minLength: 1
-          example: FeatureA
-        description:
-          description: What the Feature Toggle does
-          type: string
-          minLength: 1
-          example: Toggles FeatureA on and off
-        type:
-          type: string
-          description: '*type* is optional. If not defined, it defaults to `release`'
-          externalDocs:
-            description: Feature Toggle types
-            url: 'https://unleash.github.io/docs/feature_toggle_types'
-          enum:
-            - release
-            - experiment
-            - ops
-            - killswitch
-            - permission
-          minLength: 1
-          example: release
-        enabled:
-          type: boolean
-          example: false
-        stale:
-          description: Is the Feature Toggle deprecated (stale)?
-          type: boolean
-          example: false
-        strategies:
-          $ref: '#/components/schemas/simpleStrategySchema'
-    updateFeatureToggle:
-      type: object
-      properties:
-        description:
-          type: string
-          minLength: 1
-          example: Toggles FeatureB on and off
-        type:
-          type: string
-          minLength: 1
-          description: '*type* is optional. If not defined, it defaults to `release`'
-          example: release
-        enabled:
-          type: boolean
-          example: false
-        stale:
-          type: boolean
-          example: false
-        strategies:
-          $ref: '#/components/schemas/simpleStrategySchema'
-        variants: {}
-        createdAt:
-          type: string
-          minLength: 1
-      required:
-        - name
-        - description
-        - enabled
-        - stale
-        - strategies
-        - variants
+          $ref: '#/components/schemas/strategySchema'
+
     createStrategy:
       type: object
       properties:
@@ -712,13 +751,14 @@ components:
                 example: What percent of users should the new Feature Toggle be active for?
               required:
                 type: boolean
+                example: true
       required:
         - name
         - description
         - parameters
+
     200seen:
       type: array
-      description: ''
       minItems: 1
       uniqueItems: true
       items:
@@ -737,8 +777,9 @@ components:
               properties: {}
           metricsCount:
             type: number
+
     200feature:
-      description: |
+      description: |-
         - **lastHour** - how many times a Feature Toggle was accessed in the last hour.
         - **lastMinute** - how many times a Feature Toggle was accessed in the last minute.
       type: array
@@ -770,6 +811,7 @@ components:
                   - 'no'
               metricsCount:
                 type: number
+
     200application:
       type: object
       required:
@@ -846,7 +888,7 @@ components:
           description: The icon to use for something. Link?
           type: string
         strategies:
-          $ref: '#/components/schemas/simpleStrategySchema'
+          $ref: '#/components/schemas/strategySchema'
         instances:
           type: object
           required:
@@ -918,14 +960,15 @@ components:
               enabled:
                 description: Is the Feature Toggle enabled?
                 type: boolean
+                example: true
               stale:
-                description: Is the Feature Toggle
+                description: Is the Feature Toggle deprecated (stale)?
                 type: boolean
+                example: false
               strategies:
                 $ref: '#/components/schemas/strategySchema'
               variants:
-                description: What is this?
-                type: string
+                $ref: '#/components/schemas/variantsSchema'
               createdAt:
                 description: Date and time when the application was initially created
                 type: string
@@ -940,6 +983,7 @@ components:
               minLength: 1
           required:
             - self
+
     200seenapps:
       type: object
       properties:
@@ -987,25 +1031,79 @@ components:
                 description: The icon to use for something. Link?
                 type: string
                 minLength: 1
-    strategySchema:
-      type: array
+
+    featureToggleTypeSchema:
+      type: string
+      enum:
+        - release
+        - experiment
+        - ops
+        - killswitch
+        - permission
+      description: '**type** is optional. If not defined, it defaults to *release*'
+      default: 'release'
+      externalDocs:
+        description: Feature Toggle types
+        url: 'https://unleash.github.io/docs/feature_toggle_types'
+      minLength: 1
+      example: release
+
+    featureToggleSchema:
+      type: object
+      required:
+      - name
+      - description
+      - type
+      - enabled
+      - stale
+      - strategies
       properties:
         name:
-          description: Name of the Strategy
+          description: Feature Toggle name must be unique.
           type: string
           minLength: 1
-          example: default
-        editable:
-          type: boolean
+          example: featureX
         description:
-          description: What the Strategy is
           type: string
-          example: Default on/off strategy.
-        parameters:
-          type: array
-          items:
-            required:
-              - parameter
+          minLength: 1
+          example: Toggles featureX on and off
+        type:
+          $ref: '#/components/schemas/featureToggleTypeSchema'
+        enabled:
+          description: Is the Feature Toggle enabled?
+          type: boolean
+          example: true
+        stale:
+          description: Is the Feature Toggle 'stale' (deprecated)?
+          type: boolean
+          example: false
+        strategies:
+          $ref: '#/components/schemas/strategySchema'
+        variants:
+          $ref: '#/components/schemas/variantsSchema'
+        createdAt:
+          type: string
+          minLength: 1
+
+    strategySchema:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            description: Name of the Strategy
+            type: string
+            minLength: 1
+            example: default
+          editable:
+            type: boolean
+            example: true
+          description:
+            description: What the Strategy is
+            type: string
+            example: Default on/off strategy.
+          parameters:
+            type: object
             properties:
               parameter:
                 type: object
@@ -1028,6 +1126,21 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
+                    example: false
+
+    variantsSchema:
+      type: array
+      items:
+        required:
+          - name
+          - weight
+        properties:
+          name:
+            type: string
+            minLength: 1
+          weight:
+            type: number
+
     simpleStrategySchema:
       type: object
       required:
@@ -1049,6 +1162,7 @@ components:
                 description: Name of Strategy's parameter
                 type: string
                 example: extra
+
     200-events:
       type: object
       properties:
@@ -1092,55 +1206,7 @@ components:
                 type: string
                 example: '2016-12-09T14:56:36.730Z'
               data:
-                type: object
-                required:
-                  - name
-                  - description
-                  - type
-                  - enabled
-                  - stale
-                  - strategies
-                  - createdAt
-                properties:
-                  name:
-                    description: Feature Toggle name .
-                    type: string
-                    minLength: 1
-                    example: FeatureA
-                  description:
-                    description: What the Feature Toggle does
-                    type: string
-                    minLength: 1
-                    example: Toggles FeatureA on and off
-                  type:
-                    type: string
-                    description: '*type* is optional. If not defined, it defaults to `release`'
-                    externalDocs:
-                      description: Feature Toggle types
-                      url: 'https://unleash.github.io/docs/feature_toggle_types'
-                    enum:
-                      - release
-                      - experiment
-                      - ops
-                      - killswitch
-                      - permission
-                    minLength: 1
-                    example: release
-                  enabled:
-                    type: boolean
-                    example: false
-                  stale:
-                    description: Is the Feature Toggle deprecated (stale)?
-                    type: boolean
-                    example: false
-                  strategies:
-                    $ref: '#/components/schemas/simpleStrategySchema'
-                  variants: {}
-                  createdAt:
-                    description: Date and time when the Feature Toggle was created?
-                    type: string
-                    minLength: 1
-                    example: '2020-11-09T13:51:08.949Z'
+                $ref: '#/components/schemas/featureToggleSchema'
               diffs:
                 description: What are diffs? I don't think this part of the schema is correct
                 type: array
@@ -1166,9 +1232,12 @@ components:
                     lhs:
                       description: Left-hand side of something?
                       type: boolean
+                      example: true
                     rhs:
                       description: Left-hand side of something?
                       type: boolean
+                      example: false
+
     200export:
       type: object
       required:
@@ -1194,7 +1263,7 @@ components:
               - createdAt
             properties:
               name:
-                description: Feature Toggle name .
+                description: Feature Toggle name.
                 type: string
                 minLength: 1
                 example: FeatureA
@@ -1217,6 +1286,7 @@ components:
                   - permission
                 minLength: 1
                 example: release
+                default: 'release'
               enabled:
                 type: boolean
                 example: false
@@ -1225,13 +1295,15 @@ components:
                 type: boolean
                 example: false
               strategies:
-                $ref: '#/components/schemas/simpleStrategySchema'
-              variants: {}
+                $ref: '#/components/schemas/strategySchema'
+              variants:
+                $ref: '#/components/schemas/variantsSchema'
               createdAt:
                 type: string
                 minLength: 1
         strategies:
-          $ref: '#/components/schemas/simpleStrategySchema'
+          $ref: '#/components/schemas/strategySchema'
+
     200featuretype:
       type: object
       properties:
@@ -1251,13 +1323,7 @@ components:
               - lifetimeDays
             properties:
               id:
-                description: The *id* string for the Feature Toggle type
-                externalDocs:
-                  description: Feature Toggle types
-                  url: 'https://unleash.github.io/docs/feature_toggle_types'
-                type: string
-                minLength: 1
-                example: release
+                $ref: '#/components/schemas/featureToggleTypeSchema'
               name:
                 description: The title of the Feature Toggle type
                 type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -306,7 +306,8 @@ paths:
                 $ref: '#/components/schemas/200feature'
   /admin/metrics/applications:
     get:
-      summary: A list of known applications ('seen' by unleash in the last two days) and a link for more details.
+      summary: A list of known applications ('seen' by unleash in the last two days)
+      description: Also has a link for more details.
       operationId: getApplications
       tags:
         - Admin - metrics
@@ -321,7 +322,8 @@ paths:
                 $ref: '#/components/schemas/200application'
   '/admin/metrics/applications/{appName}':
     get:
-      summary: 'Details about a client application, such as instances, strategies implemented and seen feature toggles.'
+      summary: 'Details about a client application.'
+      description: 'Details include things such as instances, strategies implemented and seen feature toggles.'
       operationId: getApplicationDetails
       tags:
         - Admin - metrics

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -306,10 +306,7 @@ paths:
                 $ref: '#/components/schemas/200feature'
   /admin/metrics/applications:
     get:
-      summary: A list of known applications ('seen' by unleash ib the last two days) and a link for more details.
-      description: |
-        - **Yes** is the number of times a given feature toggle was enabled in a client application
-        - **No** is the number of times it was disabled.
+      summary: A list of known applications ('seen' by unleash in the last two days) and a link for more details.
       operationId: getApplications
       tags:
         - Admin - metrics
@@ -322,6 +319,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200application'
+  '/admin/metrics/applications/{appName}':
+    get:
+      summary: 'Details about a client application, such as instances, strategies implemented and seen feature toggles.'
+      operationId: getApplicationDetails
+      tags:
+        - Admin - metrics
+      parameters:
+        - $ref: '#/components/parameters/appNamePath'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200appdetails'
 components:
   parameters:
     strategyQuery:
@@ -342,6 +354,13 @@ components:
       required: true
       in: path
       description: Must match an existing Strategy name.
+      schema:
+        type: string
+    appNamePath:
+      name: appName
+      required: true
+      in: path
+      description: Must match an existing application name.
       schema:
         type: string
   schemas:
@@ -776,3 +795,59 @@ components:
                   - appDetails
       required:
         - applications
+    200appdetails:
+      description: ''
+      type: object
+      properties:
+        appName:
+          type: string
+          minLength: 1
+        instances:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - instanceId
+              - clientIp
+              - lastSeen
+              - createdAt
+            properties:
+              instanceId:
+                type: string
+                minLength: 1
+              clientIp:
+                type: string
+                minLength: 1
+              lastSeen:
+                type: string
+                minLength: 1
+              createdAt:
+                type: string
+                minLength: 1
+        strategies:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - appName
+            properties:
+              appName:
+                type: string
+                minLength: 1
+              strategies:
+                type: array
+                items:
+                  required: []
+                  properties: {}
+        seenToggles:
+          type: array
+          items:
+            required: []
+            properties: {}
+      required:
+        - appName
+        - instances
+        - strategies
+        - seenToggles

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,449 @@
+# IMPLEMENT
+# Check code for toggle type strings
+# REVIEW
+# Is putting 'Required' in the description adding any value? If so, colour-code it (not italics, not code block)
+# Make sure all operation IDs are unique and in JS-style
+# Are features, toggles and feature toggles all the same thing?
+# Rationalise component parameters. No point in having several iterations of the same schema
+# Enable and Update a Feature toggle have same bodies as much of the response 200 (can we use $ref to simplify the OAS?)
+# Can feature names have spaces. mit a full-stop be used instead? Feature C vs Feature.C
+# TEST
+# Is colon before a query parameter in the documentation a literal colon or is it used to denote the type of parameter?
+# EXTEND
+# 
+# DOCUMENTATION STYLE NOTES
+# Use 'and' instead of &
+# Use newspaper-style headings 'This is a heading' instead of movie-style 'This is a Heading'
+# Proper nouns for Unleash: Unleash, Feature, Toggle
+# TERMINOLOGY QUERIES
+# What does 'globally unique' mean - what is 'global'?
+#
+# #################
+# OpenAPI object
+# #################
+openapi: "3.0.0"
+servers:
+- description: "Local host."
+  url: https://localhost:4242/api
+- description: "Online demo. Add your own server details to the Open API specification, too (in the *servers* section)."
+  url: https://unleash.herokuapp.com/api
+- description: Secure online demo.
+  url: https://secure-unleash.herokuapp.com/api
+  # Added by API Auto Mocking Plugin
+- description: SwaggerHub API mocking
+  url: https://unleash.github.io/docs/getting_started
+info:
+  title: "Unleash API"
+  description: "Unleash is a open source feature flag and toggle system. It gives you a great overview over all feature toggles across all your applications and services."
+  version: "3.5.6"
+security:
+  - auth:
+      - read
+      - write
+externalDocs:
+  description: Documentation
+  url: https://openweathermap.org/api
+paths:
+  /admin/features:
+    get:
+      summary: "Fetches all available feature toggles from the *Unleash server*."
+      description: |
+         The response returns all active feature toggles and their current strategy configuration.
+         - A feature toggle will have *at least* one configured strategy.
+         - A strategy will have a `name` and `parameters` map.
+      operationId: getFeatures
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/featureNameOptional"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+        "401":
+          description: Not authorised
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/401"
+
+    post:
+      description: Create a new Feature Toggle
+      tags:
+       - Admin - Feature Toggles
+      operationId: createFeatureToggle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/newFeatureToggle"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+        "403":
+          description: "*name* is not globally unique"
+          content:
+            text/plain:
+              schema:
+                title: "*name* is not globally unique"
+              
+                type: string
+    put:
+      summary: Update a Feature Toggle
+      description: Used by the admin dashboard to update a Feature Toggle.
+      operationId: updateFeatureToggle
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/toggleNameRequired"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateFeatureToggle"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+
+    delete:
+      summary: Archive a Feature Toggle.
+      description: "Feature toggles can only be archived - they cannot be deleted.<br><br>If an old Feature Toggle 're-appears', this is because someone else has created a Feature Toggle with the same name."
+      operationId: archiveFeatureToggle
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+      - $ref: "#/components/parameters/toggleNameRequired"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+
+  /admin/features/{featureNameRequired}/toggle/on:
+    post:
+      summary: Enable a Feature Toggle.
+      description: "*featureName* must match an existing Feature Toggle."
+      operationId: enableFeatureToggle
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/featureNameRequired"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+
+  /admin/features/{featureNameRequired}/toggle/off:
+    post:
+      summary: Disable a Feature Toggle.
+      description: "*featureName* must match an existing Feature Toggle."
+      operationId: disableFeatureToggle
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/featureNameRequired"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"    
+
+  /admin/features/{featureNameRequired}/stale/on:
+    post:
+      summary: Mark a Feature Toggle as 'stale' (deprecated).
+      description: "*featureName* must match an existing Feature Toggle."
+      operationId: markFeatureToggleStale
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/featureNameRequired"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"    
+
+  /admin/features/{featureNameRequired}/stale/off:
+    post:
+      summary: Mark a Feature Toggle as active.
+      description: "*featureName* must match an existing Feature Toggle."
+      operationId: markFeatureToggleActive
+      tags:
+        - Admin - Feature Toggles
+      parameters:
+        - $ref: "#/components/parameters/featureNameRequired"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+
+  /admin/archive/features:
+    get:
+      summary: List all the archived Feature Toggles on the Unleash server'
+      description: "Archived Features are those that have been previously deleted"
+      operationId: fetchArchivedToggles
+      tags:
+        - Admin - archive
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+
+    post:
+      summary: Un-archive a Feature Toggle
+      description: The Feature Toggle had been previously deleted
+      operationId: reviveFeatureToggle
+      tags:
+        - Admin - archive
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/reviveFeature"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/200"
+components:
+  parameters:
+    featureNameOptional:
+      name: featureName
+      in: query
+      description: "Used to fetch details about a specific Feature Toggle. This is mostly provided to make it easy to debug the API and should not be used by the client implementations."
+      schema:
+        type: string
+    featureNameRequired:
+      name: featureNameRequired
+      required: true
+      in: path
+      description: "Must match an existing Feature Toggle."
+      schema:
+        type: string     
+    toggleNameRequired:
+      name: toggleName
+      required: true
+      in: query
+      schema:
+        type: string
+# Schemas
+  schemas:
+      reviveFeature:
+        type: object
+        properties:
+          name:
+            type: string
+            minLength: 1
+            example: Feature.C
+        required:
+          - name
+
+      newFeatureToggle:
+        type: object
+        properties:
+          name:
+            type: string
+            minLength: 1
+            description: "*name* must be **globally unique**; otherwise, you will get a *403-response*."
+            example: Feature A
+          description:
+            type: string
+            minLength: 1
+            example: Toggles Feature A on and off
+          type:
+            type: string
+            enum: [release,experiment,ops,killswitch,permission]
+            minLength: 1
+            description: "*type* is optional. If not defined, it defaults to `release`"
+            example: release
+          enabled:
+            type: boolean
+            example: false
+          stale:
+            type: boolean
+            example: false
+          strategies:
+            type: array
+            uniqueItems: true
+            minItems: 1
+            items:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  example: default
+                parameters:
+                  type: object
+                  properties: {}
+        required:
+          - name
+          - description
+          - enabled
+          - stale
+          - strategies
+
+      updateFeatureToggle:
+        type: object
+        properties:
+          name:
+            type: string
+            minLength: 1
+            description: "*name* must match an existing Feature Toggle."
+            example: Feature B
+          description:
+            type: string
+            minLength: 1
+            example: Toggles Feature B on and off
+          type:
+            type: string
+            minLength: 1
+            description: "*type* is optional. If not defined, it defaults to `release`"
+            example: release
+          enabled:
+            type: boolean
+            example: false
+          stale:
+            type: boolean
+            example: false
+          strategies:
+            type: array
+            uniqueItems: true
+            minItems: 1
+            items:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  example: default
+                parameters:
+                  type: object
+                  properties: {}
+          variants:
+            type: array
+            items:
+              properties: {}
+        required:
+          - name
+          - description
+          - enabled
+          - stale
+          - strategies
+          - variants
+
+# http responses
+      "401":
+        description: "Not authorised"
+        type: object
+        properties:
+          type:
+            type: string
+            minLength: 1
+          path:
+            type: string
+            minLength: 1
+          message:
+            type: string
+            minLength: 1
+        required:
+          - type
+          - path
+          - message
+      "200":
+        title: Successful response
+        type: object
+        properties:
+          version:
+            type: number
+          features:
+            type: array
+            uniqueItems: true
+            minItems: 1
+            items:
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                description:
+                  type: string
+                  minLength: 1
+                type:
+                  type: string
+                  minLength: 1
+                enabled:
+                  type: boolean
+                stale:
+                  type: boolean
+                strategies:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  items:
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                      parameters:
+                        type: object
+                        properties: {}
+                variants:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  items:
+                    required:
+                      - name
+                      - weight
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                      weight:
+                        type: number
+  securitySchemes:
+    auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          refreshUrl: http://localhost:4242/api/auth/callback
+          scopes:
+            write: allows modifying resources
+            read: allows reading resources

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -370,14 +370,13 @@ paths:
                 $ref: '#/components/schemas/200-events'
       operationId: get-admin-events
       description: |-
-          Returns one of the five event types:
-          - feature-created
-          - feature-updated
-          - feature-archived
-          - feature-revived
-          - strategy-created
-          - strategy-deleted
-
+        Returns one of the five event types:
+        - feature-created
+        - feature-updated
+        - feature-archived
+        - feature-revived
+        - strategy-created
+        - strategy-deleted
   /admin/state/export:
     get:
       summary: Export feature toggles and strategies
@@ -414,6 +413,38 @@ paths:
           name: strategies
           description: Include strategies in the export? Default is true
       description: Exports a list of feature toggles and/or strategies in either JSON or YAML format.
+  /admin/state/import:
+    post:
+      summary: Import feature toggles and strategies
+      operationId: post-admin-state-import
+      tags:
+        - Import and export
+      responses:
+        '200':
+          description: Successful import.
+      description: You can either send the data as JSON in the POST body or send a *file* parameter with *multipart/form-data* (YAML files are also accepted here). What format/schema must the file adopt? Same as the export 200 response?
+      parameters:
+        - schema:
+            type: boolean
+            default: 'false'
+          in: query
+          name: drop
+          description: Be careful using this in production environments. Set to true if you want the to remove all strategies and feature toggles from the datebase before import. Default is false.
+        - schema:
+            type: boolean
+          in: query
+          name: keep
+          description: Set to true if you want keep all existing feature toggles and strategies as is; only the missing feature toggles and strategies will be inserted from the import data. Deafult is true.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                fileName:
+                  type: string
+                  format: binary
+
 components:
   parameters:
     strategyQuery:
@@ -992,7 +1023,6 @@ components:
                 description: Name of Strategy's parameter
                 type: string
                 example: extra
-                
     200-events:
       type: object
       properties:
@@ -1175,5 +1205,4 @@ components:
                 type: string
                 minLength: 1
         strategies:
-          $ref: '#/components/schemas/simpleStrategySchema' # Strategies twice? How does this vary to the other strategies schema in the response?
-
+          $ref: '#/components/schemas/simpleStrategySchema'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,3 @@
-# simpleStrategySchema works (and may be correct for some responses)
-# strategySchema can't render in Swagger UI. use simple for now
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -432,9 +430,10 @@ paths:
           description: Be careful using this in production environments. Set to true if you want the to remove all strategies and feature toggles from the datebase before import. Default is false.
         - schema:
             type: boolean
+            default: 'true'
           in: query
           name: keep
-          description: Set to true if you want keep all existing feature toggles and strategies as is; only the missing feature toggles and strategies will be inserted from the import data. Deafult is true.
+          description: Set to true if you want keep all existing feature toggles and strategies as is; only the missing feature toggles and strategies will be inserted from the import data. Default is true.
       requestBody:
         content:
           multipart/form-data:
@@ -444,7 +443,24 @@ paths:
                 fileName:
                   type: string
                   format: binary
-
+  /admin/feature-types:
+    get:
+      summary: Fetch the list of Unleash feature types
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200featuretype'
+      operationId: get-admin-feature-types
+      description: |-
+        - release
+        - experiment
+        - ops
+        - killswitch
+        - permission
 components:
   parameters:
     strategyQuery:
@@ -1206,3 +1222,34 @@ components:
                 minLength: 1
         strategies:
           $ref: '#/components/schemas/simpleStrategySchema'
+    200featuretype:
+      description: ''
+      type: object
+      properties:
+        version:
+          type: number
+        types:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - id
+              - name
+              - description
+              - lifetimeDays
+            properties:
+              id:
+                type: string
+                minLength: 1
+              name:
+                type: string
+                minLength: 1
+              description:
+                type: string
+                minLength: 1
+              lifetimeDays:
+                type: number
+      required:
+        - version
+        - types

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-
 openapi: 3.0.0
 servers:
   - description: Local host.
@@ -11,7 +10,7 @@ tags:
   - name: Admin - strategies
     description: Accessing and updating strategies
   - name: Admin - metrics
-    description: Determining usage of feature toggles and applications   
+    description: Determining usage of feature toggles and applications
 info:
   title: Unleash API
   description: Unleash is a open source feature flag and toggle system for all your applications and services.
@@ -207,7 +206,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  /admin/archive/revive/{featureName}:
+  '/admin/archive/revive/{featureName}':
     post:
       summary: Un-archive a Feature Toggle
       description: The Feature Toggle had been previously deleted
@@ -252,7 +251,7 @@ paths:
       responses:
         '201':
           description: Strategy successfully added
-  /admin/strategies/{strategyName}:
+  '/admin/strategies/{strategyName}':
     put:
       summary: Update Strategy
       description: |
@@ -275,16 +274,36 @@ paths:
       responses:
         '200':
           description: Strategy successfully updated.
-  /admin/seen-toggles:
+  /admin/metrics/seen-toggles:
     get:
       summary: Returns a list of applications and the feature toggles that unleash has 'seen' for each application.
-      description:  It is only guaranteed that feature toggles reported by client applications within the last hour will be returned. However, in most cases, earlier reported feature toggles will also be returned.
+      description: 'It is only guaranteed that feature toggles reported by client applications within the last hour will be returned. However, in most cases, earlier reported feature toggles will also be returned.'
       operationId: seenToggles
       tags:
         - Admin - metrics
       responses:
         '200':
-          description: Gotcha!
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200seen'
+  /admin/metrics/feature-toggles:
+    get:
+      summary: Gives *last minute* and *last hour* metrics for all active toggles (based on what was reported by the client applications).
+      description: |
+        - **Yes** is the number of times a given feature toggle was enabled in a client applcation
+        - **No** is the number of times it was disabled.
+      operationId: featureToggles
+      tags:
+        - Admin - metrics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/200feature'
 components:
   parameters:
     featureNamePath:
@@ -355,8 +374,48 @@ components:
                       minLength: 1
                     weight:
                       type: number
-    '200strategy':
-      description: 'Successful.'
+    '401':
+      description: Not authorised
+      type: object
+      properties:
+        type:
+          type: string
+          minLength: 1
+        path:
+          type: string
+          minLength: 1
+        message:
+          type: string
+          minLength: 1
+      required:
+        - type
+        - path
+        - message
+    '409':
+      type: object
+      properties:
+        isJoi:
+          type: boolean
+        name:
+          type: string
+          minLength: 1
+        details:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - message
+            properties:
+              message:
+                type: string
+                minLength: 1
+      required:
+        - isJoi
+        - name
+        - details
+    200strategy:
+      description: Successful.
       type: object
       properties:
         version:
@@ -405,46 +464,6 @@ components:
       required:
         - version
         - strategies
-    '401':
-      description: Not authorised
-      type: object
-      properties:
-        type:
-          type: string
-          minLength: 1
-        path:
-          type: string
-          minLength: 1
-        message:
-          type: string
-          minLength: 1
-      required:
-        - type
-        - path
-        - message
-    '409':
-      type: object
-      properties:
-        isJoi:
-          type: boolean
-        name:
-          type: string
-          minLength: 1
-        details:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - message
-            properties:
-              message:
-                type: string
-                minLength: 1
-      required:
-        - isJoi
-        - name
-        - details
     newFeatureToggle:
       type: object
       properties:
@@ -594,3 +613,106 @@ components:
         - name
         - description
         - parameters
+    200seen:
+      type: array
+      description: ''
+      minItems: 1
+      uniqueItems: true
+      items:
+        type: object
+        required:
+          - appName
+          - seenToggles
+          - metricsCount
+        properties:
+          appName:
+            type: string
+            minLength: 1
+          seenToggles:
+            type: array
+            items:
+              required: []
+              properties: {}
+          metricsCount:
+            type: number
+    200feature:
+      description: ''
+      type: object
+      properties:
+        lastHour:
+          type: object
+          properties:
+            add-feature-2:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+            toggle-2:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+            toggle-3:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+          required:
+            - add-feature-2
+            - toggle-2
+            - toggle-3
+        lastMinute:
+          type: object
+          properties:
+            add-feature-2:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+            toggle-2:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+            toggle-3:
+              type: object
+              properties:
+                'yes':
+                  type: number
+                'no':
+                  type: number
+              required:
+                - 'yes'
+                - 'no'
+          required:
+            - add-feature-2
+            - toggle-2
+            - toggle-3
+      required:
+        - lastHour
+        - lastMinute

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,16 +1,24 @@
+# Continue from events
+# Add examples to everything (inclusing response schemas)
+# Verify response schemas match object structure
+# Check question marks with unleash team
+# $ref any duplicate aspects
+# British English or American English?
+# {} in a definition means 'I don't know' - fix
+# Need a variants schema
 openapi: 3.0.0
 servers:
   - description: Local host.
     url: 'http://localhost:4242/api'
 tags:
-  - name: Admin - feature toggles
-    description: Accessing feature toggles
-  - name: Admin - archive
+  - name: Archive
     description: Handling Feature Toggle archiving and un-archiving
-  - name: Admin - strategies
-    description: Accessing and updating strategies
-  - name: Admin - metrics
+  - name: Feature toggles
+    description: Accessing feature toggles
+  - name: Metrics
     description: Determining usage of feature toggles and applications
+  - name: Strategies
+    description: Accessing and updating strategies
 info:
   title: Unleash API
   description: Unleash is a open source feature flag and toggle system for all your applications and services.
@@ -31,13 +39,13 @@ paths:
         - A feature toggle will have *at least* one configured strategy.
         - A strategy will have a `name` and `parameters` map.
 
-        **Note:** To only return one Feature Toggle, add the Feature Toggle name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Sepcification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
+        **Note:** To only return one Feature Toggle, add the Feature Toggle name as a suffix to the request. For example: `GET [Your host]/api/admin/features/featureX`. It is not possible to add this parameter as a *Try it out* option due to restrictions in the [Open API Specification](https://swagger.io/docs/specification/describing-parameters/), (that is, *optional* path variables cannot be created).
       externalDocs:
         description: Activation strategies
         url: 'https://unleash.github.io/docs/activation_strategy'
       operationId: getFeatures
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       responses:
         '200':
           description: Successful response
@@ -54,7 +62,7 @@ paths:
     post:
       description: Create a new Feature Toggle
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       operationId: createFeatureToggle
       requestBody:
         required: true
@@ -82,7 +90,7 @@ paths:
       description: Update a Feature Toggle.
       operationId: featureName
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       requestBody:
@@ -106,7 +114,7 @@ paths:
         If an old Feature Toggle *re-appears*, this is because someone else has created a new one with the same name.
       operationId: archiveFeatureToggle
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -122,7 +130,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: enableFeatureToggle
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -138,7 +146,7 @@ paths:
       description: '*featureName* must match an existing Feature Toggle.'
       operationId: disableFeatureToggle
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -157,7 +165,7 @@ paths:
         url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleStale
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -176,7 +184,7 @@ paths:
         url: 'https://unleash.github.io/docs/feature_toggle_types'
       operationId: markFeatureToggleActive
       tags:
-        - Admin - feature toggles
+        - Feature toggles
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -198,7 +206,7 @@ paths:
       description: Archived feature toggles are those that have been previously deleted
       operationId: fetchArchivedToggles
       tags:
-        - Admin - archive
+        - Archive
       responses:
         '200':
           description: Successful response
@@ -212,7 +220,7 @@ paths:
       description: The Feature Toggle had been previously deleted
       operationId: reviveFeatureToggle
       tags:
-        - Admin - archive
+        - Archive
       parameters:
         - $ref: '#/components/parameters/featureNamePath'
       responses:
@@ -228,7 +236,7 @@ paths:
       description: Fetch all strategies and their parameters.
       operationId: getStrategies
       tags:
-        - Admin - strategies
+        - Strategies
       responses:
         '200':
           description: Successful response
@@ -241,7 +249,7 @@ paths:
       description: Create Strategy
       operationId: createStrategy
       tags:
-        - Admin - strategies
+        - Strategies
       requestBody:
         required: true
         content:
@@ -262,7 +270,7 @@ paths:
         **Caution:** It can be dangerous to change a Strategy (as the implementation also might need to be changed).
       operationId: updateStrategy
       tags:
-        - Admin - strategies
+        - Strategies
       parameters:
         - $ref: '#/components/parameters/strategyNamePath'
       requestBody:
@@ -276,11 +284,11 @@ paths:
           description: Strategy successfully updated.
   /admin/metrics/seen-toggles:
     get:
-      summary: Returns a list of applications and the feature toggles that unleash has 'seen' for each application.
+      summary: Returns a list of applications and the feature toggles that Unleash has 'seen' for each application.
       description: 'It is only guaranteed that feature toggles reported by client applications within the last hour will be returned. However, in most cases, earlier reported feature toggles will also be returned.'
       operationId: seenToggles
       tags:
-        - Admin - metrics
+        - Metrics
       responses:
         '200':
           description: Successful response
@@ -290,13 +298,13 @@ paths:
                 $ref: '#/components/schemas/200seen'
   /admin/metrics/feature-toggles:
     get:
-      summary: Gives *last minute* and *last hour* metrics for all active toggles (based on what was reported by the client applications).
+      summary: 'Gives ''last minute'' and ''last hour'' metrics for all active toggles (based on what was reported by the client applications).'
       description: |
         - **Yes** is the number of times a given feature toggle was enabled in a client applcation
         - **No** is the number of times it was disabled.
       operationId: featureToggles
       tags:
-        - Admin - metrics
+        - Metrics
       responses:
         '200':
           description: Successful response
@@ -306,11 +314,11 @@ paths:
                 $ref: '#/components/schemas/200feature'
   /admin/metrics/applications:
     get:
-      summary: A list of known applications ('seen' by unleash in the last two days)
+      summary: A list of known applications ('seen' by Unleash in the last two days)
       description: Also has a link for more details.
       operationId: getApplications
       tags:
-        - Admin - metrics
+        - Metrics
       parameters:
         - $ref: '#/components/parameters/strategyQuery'
       responses:
@@ -326,7 +334,7 @@ paths:
       description: 'Details include things such as instances, strategies implemented and seen feature toggles.'
       operationId: getApplicationDetails
       tags:
-        - Admin - metrics
+        - Metrics
       parameters:
         - $ref: '#/components/parameters/appNamePath'
       responses:
@@ -342,7 +350,7 @@ paths:
       description: Details about application seen per Feature Toggle.
       operationId: seenApps
       tags:
-        - Admin - metrics
+        - Metrics
       responses:
         '200':
           description: Successful response
@@ -355,7 +363,7 @@ components:
     strategyQuery:
       name: strategyName
       in: query
-      description: Return all applications implementing the specified Strategy. Must match an existing Strategy name.
+      description: '(Optional). Return all applications implementing the specified Strategy. Must match an existing Strategy name.'
       schema:
         type: string
     featureNamePath:
@@ -406,19 +414,7 @@ components:
               stale:
                 type: boolean
               strategies:
-                type: array
-                uniqueItems: true
-                minItems: 1
-                items:
-                  required:
-                    - name
-                  properties:
-                    name:
-                      type: string
-                      minLength: 1
-                    parameters:
-                      type: object
-                      properties: {}
+                $ref: '#/components/schemas/strategySchema'
               variants:
                 type: array
                 uniqueItems: true
@@ -476,55 +472,24 @@ components:
     200strategy:
       description: Successful.
       type: object
+      required:
+        - version
+        - strategies
       properties:
         version:
           type: number
           example: 1
         strategies:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - name
-              - editable
-              - description
-            properties:
-              name:
-                type: string
-                minLength: 1
-              editable:
-                type: boolean
-              description:
-                type: string
-                minLength: 1
-              parameters:
-                type: array
-                uniqueItems: true
-                minItems: 1
-                items:
-                  required:
-                    - name
-                    - type
-                    - description
-                    - required
-                  properties:
-                    name:
-                      type: string
-                      minLength: 1
-                    type:
-                      type: string
-                      minLength: 1
-                    description:
-                      type: string
-                      minLength: 1
-                    required:
-                      type: boolean
-      required:
-        - version
-        - strategies
+          $ref: '#/components/schemas/strategySchema'
+
     newFeatureToggle:
       type: object
+      required:
+        - name
+        - description
+        - enabled
+        - stale
+        - strategies
       properties:
         name:
           type: string
@@ -553,29 +518,12 @@ components:
           type: boolean
           example: false
         stale:
+          description: Is the Feature Toggle deprecated (stale)?
           type: boolean
           example: false
         strategies:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - name
-            properties:
-              name:
-                type: string
-                minLength: 1
-                example: default
-              parameters:
-                type: object
-                properties: {}
-      required:
-        - name
-        - description
-        - enabled
-        - stale
-        - strategies
+          $ref: '#/components/schemas/strategySchema'
+
     updateFeatureToggle:
       type: object
       properties:
@@ -595,32 +543,7 @@ components:
           type: boolean
           example: false
         strategies:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - name
-            properties:
-              name:
-                type: string
-                minLength: 1
-                example: default
-              parameters:
-                type: object
-                properties:
-                  rollout:
-                    type: number
-                  stickiness:
-                    type: string
-                    minLength: 1
-                  groupId:
-                    type: string
-                    minLength: 1
-                required:
-                  - rollout
-                  - stickiness
-                  - groupId
+          $ref: '#/components/schemas/strategySchema'
         variants: {}
         createdAt:
           type: string
@@ -632,6 +555,7 @@ components:
         - stale
         - strategies
         - variants
+
     createStrategy:
       type: object
       properties:
@@ -690,95 +614,39 @@ components:
           seenToggles:
             type: array
             items:
-              required: []
               properties: {}
           metricsCount:
             type: number
     200feature:
       description: |
-        - **lastHour** - 'hour projection collected' metrics for all feature toggles.
-        - **lastMinute** - 'minute projection collected' metrics for all feature toggles.
-      type: object
-      properties:
-        lastHour:
-          type: object
-          properties:
-            add-feature-2:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-            toggle-2:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-            toggle-3:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-          required:
-            - add-feature-2
-            - toggle-2
-            - toggle-3
-        lastMinute:
-          type: object
-          properties:
-            add-feature-2:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-            toggle-2:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-            toggle-3:
-              type: object
-              properties:
-                'yes':
-                  type: number
-                'no':
-                  type: number
-              required:
-                - 'yes'
-                - 'no'
-          required:
-            - add-feature-2
-            - toggle-2
-            - toggle-3
-      required:
-        - lastHour
-        - lastMinute
+        - **lastHour** - how many times a Feature Toggle was accessed in the last hour.
+        - **lastMinute** - how many times a Feature Toggle was accessed in the last minute.
+      type: array
+      minItems: 1
+      uniqueItems: true
+      items:
+        type: object
+        required:
+          - appName
+          - seenToggles
+        properties:
+          appName:
+            type: string
+            enum: [lastHour, lastMinute]
+            minLength: 1
+            example: lastHour
+          seenToggles:
+            type: object
+            required:
+            - yesno
+            - metricsCount
+            properties:
+              yesno:
+                type: string
+                enum: [yes, no]
+              metricsCount:
+                type: number
     200application:
-      description: ''
       type: object
       properties:
         applications:
@@ -789,86 +657,171 @@ components:
             required:
               - appName
               - createdAt
+              - updatedAt
             properties:
               appName:
+                description: Application name
                 type: string
                 minLength: 1
-              strategies:
-                type: array
-                items:
-                  required: []
-                  properties: {}
+                example: my-application
               createdAt:
+                description: Date and time when the application was initially created
                 type: string
                 minLength: 1
-              links:
-                type: object
-                properties:
-                  appDetails:
-                    type: string
-                    minLength: 1
-                required:
-                  - appDetails
+                example: '2016-12-09T14:56:36.730Z'
+              updatedAt:
+                description: Date and time when the application was last updated
+                type: string
+                minLength: 1
+                example: '2020-11-14T09:55:23.653Z'
+              description:
+                description: A description of what the application does
+                type: string
+              strategies:
+                description: The Strategy's name
+                type: array
+                minLength: 1
+              url:
+                description: Link to more information about the application? Relative only?
+                type: string
+                example: https://medium.com/keptn
+              color:
+                description: The colour (American English?) of something. Hex code?
+                type: string
+              icon:
+                description: The icon to use for something. Link?
+                type: string
       required:
         - applications
+
     200appdetails:
-      description: ''
       type: object
-      properties:
-        appName:
-          type: string
-          minLength: 1
-        instances:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - instanceId
-              - clientIp
-              - lastSeen
-              - createdAt
-            properties:
-              instanceId:
-                type: string
-                minLength: 1
-              clientIp:
-                type: string
-                minLength: 1
-              lastSeen:
-                type: string
-                minLength: 1
-              createdAt:
-                type: string
-                minLength: 1
-        strategies:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            required:
-              - appName
-            properties:
-              appName:
-                type: string
-                minLength: 1
-              strategies:
-                type: array
-                items:
-                  required: []
-                  properties: {}
-        seenToggles:
-          type: array
-          items:
-            required: []
-            properties: {}
       required:
         - appName
         - instances
         - strategies
         - seenToggles
-    200seenapps:
-      description: ''
+      properties:
+        appName:
+          description: Application name
+          type: string
+          minLength: 1
+          example: my-application
+        createdAt:
+          description: Date and time when the application was initially created
+          type: string
+          minLength: 1
+          example: '2016-12-09T14:56:36.730Z'
+        description:
+          description: A description of what the application does
+          type: string
+        url:
+          description: Link to more information about the application? Relative only?
+          type: string
+          example: https://medium.com/keptn
+        color:
+          description: The colour (American English?) of something. Hex code?
+          type: string
+        icon:
+          description: The icon to use for something. Link?
+          type: string
+        strategies:
+          $ref: '#/components/schemas/strategySchema'
+        instances:
+          type: object
+          required:
+            - appName
+            - instanceId
+            - sdkVersion
+            - clientIp
+            - lastSeen
+            - createdAt
+          properties:
+            appName:
+              description: Application name
+              type: string
+              minLength: 1
+              example: my-application
+            instanceId:
+              description: The name of the system running the application
+              type: string
+              minLength: 1
+              example: generated-732038-17080
+            sdkVersion:
+              description: The version of the Unleash client SDK running the application
+              type: string
+              minLength: 1
+              example: unleash-client-node:3.4.0
+            clientIp:
+              description: The IP address of the system running this instance of the application. What is the prefix on the string?
+              type: string
+              minLength: 1
+              example: ::ffff:127.0.0.1
+            lastSeen:
+              description: The last time the application accessed Unleash?
+              type: string
+              minLength: 1
+              example: '2020-11-14T11:17:24.482Z'
+            createdAt:
+              description: When the application was created?
+              type: string
+              minLength: 1
+              example: '2020-11-13T16:56:29.279Z'
+        seenToggles:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            required:
+              - name
+              - type
+              - enabled
+              - stale
+              - createdAt
+            properties:
+              name:
+                description: Name of the Feature Toggle
+                type: string
+                minLength: 1
+                example: FeatureX
+              description:
+                description: What the Feture Toggle does
+                type: string
+              type:
+                description: One of the five types of Feature Toggle
+                type: string
+                externalDocs:
+                  description: Feature Toggle types
+                  url: 'https://unleash.github.io/docs/feature_toggle_types'
+                minLength: 1
+                example: release
+              enabled:
+                description: Is the Feature Toggle enabled?
+                type: boolean
+              stale:
+                description: Is the Feature Toggle 
+                type: boolean
+              strategies:
+                $ref: '#/components/schemas/strategySchema'
+              variants:
+                description: What is this?
+                type: string
+              createdAt:
+                description: Date and time when the application was initially created
+                type: string
+                minLength: 1
+                example: '2020-11-09T15:25:59.517Z'
+        links:
+          type: object
+          properties:
+            self:
+              description: What is this?
+              type: string
+              minLength: 1
+          required:
+            - self
+
+    '200seenapps':
       type: object
       properties:
         my-toggle:
@@ -897,10 +850,7 @@ components:
                 type: string
                 minLength: 1
               strategies:
-                type: array
-                items:
-                  required: []
-                  properties: {}
+                $ref: '#/components/schemas/strategySchema'
               url:
                 type: string
                 minLength: 1
@@ -908,5 +858,45 @@ components:
               icon:
                 type: string
                 minLength: 1
-      required:
-        - my-toggle
+
+    strategySchema:
+      type: array
+      properties:
+        name:
+          description: Name of the Strategy
+          type: string
+          minLength: 1
+          example: default
+        editable:
+          type: boolean
+        description:
+          description: What the Strategy is
+          type: string
+          example: Default on/off strategy.
+        parameters:
+          type: array
+          items:
+            required:
+              - parameter
+            properties:
+              parameter:
+                type: object
+                required:
+                  - name
+                  - type
+                properties:
+                  name:
+                    description: The name of the parameter
+                    type: string
+                    example: groupId
+                  type:
+                    description: The type of the parameter
+                    type: string
+                    example: string
+                  description:
+                    description: What the parameter does
+                    type: string
+                    example: Define activation groups to allow you to correlate across feature toggles.
+                  required:
+                    description: Is this a required parameter?
+                    type: boolean

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,4 @@
-# Continue from components/schemas/200seenapps and 200appdetails (schemas needs work and aren't displaying in Swagger UI). 200appdetails schema appears simpler from the markdown
+# Continue from components/schemas/200appdetails (schema needs work and isn't displaying in Swagger UI)
 # Run tests against prevous items (I've done a global strategies $ref replacement)
 # Add examples to everything (inclusing response schemas)
 # Verify response schemas match object structure
@@ -231,7 +231,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200'
-  /admin/strategies:
+  '/admin/strategies':
     get:
       summary: Fetch all strategies and their parameters.
       description: Fetch all strategies and their parameters.
@@ -329,6 +329,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200application'
+
   '/admin/metrics/applications/{appName}':
     get:
       summary: Details about a client application.
@@ -345,6 +346,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200appdetails'
+
   '/admin/metrics/seen-apps':
     get:
       summary: Details about application seen per Feature Toggle.
@@ -390,46 +392,56 @@ components:
         type: string
   schemas:
     '200':
-      title: Successful response
-      type: object
-      properties:
-        version:
-          type: number
-        features:
-          type: array
-          uniqueItems: true
-          minItems: 1
-          items:
-            properties:
-              name:
-                type: string
-                minLength: 1
-              description:
-                type: string
-                minLength: 1
-              type:
-                type: string
-                minLength: 1
-              enabled:
-                type: boolean
-              stale:
-                type: boolean
-              strategies:
-                $ref: '#/components/schemas/strategySchema'
-              variants:
-                type: array
-                uniqueItems: true
-                minItems: 1
-                items:
-                  required:
-                    - name
-                    - weight
-                  properties:
-                    name:
-                      type: string
-                      minLength: 1
-                    weight:
-                      type: number
+        title: Successful response
+        type: object
+        properties:
+          version:
+            type: number
+          features:
+            type: array
+            uniqueItems: true
+            minItems: 1
+            items:
+              properties:
+                name:
+                  description: Feature Toggle name
+                  type: string
+                  minLength: 1
+                  example: featureX
+                description:
+                  description: What the Feature Toggle does
+                  type: string
+                  minLength: 1
+                type:
+                  description: One of the five types of Feature Toggle
+                  externalDocs:
+                    description: Feature Toggle types
+                    url: 'https://unleash.github.io/docs/feature_toggle_types'
+                  type: string
+                  minLength: 1
+                  example: release
+                enabled:
+                  description: Is the Feature Toggle enabled?
+                  type: boolean
+                stale:
+                  description: Is the Feature Toggle 'stale' (deprecated)?
+                  type: boolean
+                strategies:
+                  $ref: '#/components/schemas/simpleStrategySchema'
+                variants:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  items:
+                    required:
+                      - name
+                      - weight
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                      weight:
+                        type: number
     '401':
       description: Not authorised
       type: object
@@ -470,6 +482,7 @@ components:
         - isJoi
         - name
         - details
+
     200strategy:
       description: Successful.
       type: object
@@ -481,7 +494,7 @@ components:
           type: number
           example: 1
         strategies:
-          $ref: '#/components/schemas/strategySchema'
+          $ref: '#/components/schemas/simpleStrategySchema'
 
     newFeatureToggle:
       type: object
@@ -523,7 +536,7 @@ components:
           type: boolean
           example: false
         strategies:
-          $ref: '#/components/schemas/strategySchema'
+          $ref: '#/components/schemas/simpleStrategySchema'
 
     updateFeatureToggle:
       type: object
@@ -544,7 +557,7 @@ components:
           type: boolean
           example: false
         strategies:
-          $ref: '#/components/schemas/strategySchema'
+          $ref: '#/components/schemas/simpleStrategySchema'
         variants: {}
         createdAt:
           type: string
@@ -590,13 +603,15 @@ components:
               description:
                 type: string
                 minLength: 1
-                example: How many percent of users should the new Feature Toggle be active for.
+                example: What percent of users should the new Feature Toggle be active for?
               required:
                 type: boolean
       required:
         - name
         - description
         - parameters
+
+  
     200seen:
       type: array
       description: ''
@@ -647,8 +662,11 @@ components:
                 enum: [yes, no]
               metricsCount:
                 type: number
-    200application:
+
+    '200application':
       type: object
+      required:
+        - applications
       properties:
         applications:
           type: array
@@ -659,29 +677,27 @@ components:
               - appName
               - createdAt
               - updatedAt
+              - strategies
             properties:
               appName:
                 description: Application name
                 type: string
-                minLength: 1
                 example: my-application
               createdAt:
                 description: Date and time when the application was initially created
                 type: string
-                minLength: 1
                 example: '2016-12-09T14:56:36.730Z'
               updatedAt:
                 description: Date and time when the application was last updated
                 type: string
-                minLength: 1
                 example: '2020-11-14T09:55:23.653Z'
               description:
                 description: A description of what the application does
                 type: string
               strategies:
-                description: The Strategy's name
-                type: array
-                minLength: 1
+                description: A description of what the application does
+                type: string
+ #               $ref: '#/components/schemas/simpleStrategySchema'
               url:
                 description: Link to more information about the application? Relative only?
                 type: string
@@ -692,8 +708,6 @@ components:
               icon:
                 description: The icon to use for something. Link?
                 type: string
-      required:
-        - applications
 
     '200appdetails':
       type: object
@@ -711,7 +725,6 @@ components:
         createdAt:
           description: Date and time when the application was initially created
           type: string
-          minLength: 1
           example: '2016-12-09T14:56:36.730Z'
         description:
           description: A description of what the application does
@@ -727,7 +740,7 @@ components:
           description: The icon to use for something. Link?
           type: string
         strategies:
-          $ref: '#/components/schemas/appStrategySchema'
+          $ref: '#/components/schemas/strategySchema'
         instances:
           type: object
           required:
@@ -856,7 +869,7 @@ components:
                 type: string
                 minLength: 1
               strategies:
-                $ref: '#/components/schemas/strategySchema'
+                $ref: '#/components/schemas/simpleStrategySchema'
               url:
                 description: Link to more information about the application? Relative only?
                 type: string
@@ -870,8 +883,7 @@ components:
                 type: string
                 minLength: 1
 
-
-    strategySchema:
+    'strategySchema':
       type: array
       properties:
         name:
@@ -912,12 +924,12 @@ components:
                   required:
                     description: Is this a required parameter?
                     type: boolean
-    appStrategySchema:
-      title: appStrategySchema
+
+    'simpleStrategySchema':
       type: object
       required:
         - appName
-        - strategies
+        - parameterName
       properties:
         appName:
           description: Application name
@@ -930,7 +942,7 @@ components:
             required:
               - strategyName
             properties:
-              strategyName:
-                description: Name of Strategy
+              parameterName:
+                description: Name of Strategy's parameter
                 type: string
                 example: extra

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,7 +29,7 @@ info:
   contact:
     name: The Unleash team
     url: 'https://unleash.github.io/'
-    email: some_email@gmail.com
+#    email: some_email@gmail.com
 externalDocs:
   description: Unleash documentation
   url: 'https://unleash.github.io/docs/getting_started'
@@ -427,7 +427,7 @@ paths:
       responses:
         '200':
           description: Successful import.
-      description: You can either send the data as JSON in the POST body or send a *file* parameter with *multipart/form-data* (YAML files are also accepted here). What format/schema must the file adopt? Same as the export 200 response?
+      description: Upload the data, in JSON or YAML format, in the POST body. What schema must the import file adopt? Same as the export 200 response?
       parameters:
         - schema:
             type: boolean
@@ -453,6 +453,13 @@ paths:
   /admin/feature-types:
     get:
       summary: Fetch the list of Unleash feature types
+      description: |-
+        - release
+        - experiment
+        - ops
+        - killswitch
+        - permission
+      operationId: get-admin-feature-types
       tags:
         - Feature types
       responses:
@@ -462,13 +469,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/200featuretype'
-      operationId: get-admin-feature-types
-      description: |-
-        - release
-        - experiment
-        - ops
-        - killswitch
-        - permission
+
 components:
   parameters:
     strategyQuery:


### PR DESCRIPTION
This is a partial specification that gives an idea of the 'direction of travel'. It just covers Feature Toggles on the server for now but I will extend (if this is something that is still of interest).

I'd like to add more descriptions to the schema objects, it's a bit skimpy at this stage, but that may become self-evident as the rest of the OAS builds.

This particular OAS has no authentication. I've been running unleash-server on localhost (thanks @ivarconr ). Note that to test the 'try it out' features, you may run into [CORS issues](https://swagger.io/docs/open-source-tools/swagger-ui/usage/cors/) (depending on where you host things).

Although, index.html renders the OpenAPI in Swagger UI. It's far from the only such [documentation tool](https://openapi.tools/) but it is the most popular (probably since it's both free and interactive).