### PR TITLE
feat: Add support for explicitly set database version.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,9 +47,10 @@ Available unleash options include:
   - _user_ - the database username (`DATABASE_USERNAME`)
   - _password_ - the database password (`DATABASE_PASSWORD`)
   - _host_ - the database hostname (`DATABASE_HOST`)
-  - _port_ - the datbase port defaults to 5432 (`DATABASE_PORT`)
+  - _port_ - the database port defaults to 5432 (`DATABASE_PORT`)
   - _database_ - the database name to be used (`DATABASE_NAME`)
   - _ssl_ - an object describing ssl options, see https://node-postgres.com/features/ssl (`DATABASE_SSL`, as a stringified json object)
+  - _version_ - the postgres database version. Used to connect a non-standard database. Defaults to `undefined`, which let the underlying adapter to detect the version automatically. (`DATABASE_VERSION`)
 - **databaseUrl** - the postgres database url to connect to. Only used if _db_ object is not specified. Should include username/password. This value may also be set via the `DATABASE_URL` environment variable. Alternatively, if you would like to read the database url from a file, you may set the `DATABASE_URL_FILE` environment variable with the full file path. The contents of the file must be the database url exactly.
 - **databaseSchema** - the postgres database schema to use. Defaults to 'public'.
 - **port** - which port the unleash-server should bind to. If port is omitted or is 0, the operating system will assign an arbitrary unused port. Will be ignored if pipe is specified. This value may also be set via the `HTTP_PORT` environment variable

--- a/lib/db/db-pool.js
+++ b/lib/db/db-pool.js
@@ -12,6 +12,7 @@ module.exports.createDb = function({
     const logger = getLogger('db-pool.js');
     return knex({
         client: 'pg',
+        version: db.version,
         connection: db,
         pool: { min: poolMin, max: poolMax },
         searchPath: databaseSchema,

--- a/lib/options.js
+++ b/lib/options.js
@@ -34,6 +34,7 @@ function defaultOptions() {
                     ? JSON.parse(process.env.DATABASE_SSL)
                     : false,
             driver: 'postgres',
+            version: process.env.DATABASE_VERSION,
         },
         port: process.env.HTTP_PORT || process.env.PORT || 4242,
         host: process.env.HTTP_HOST,

--- a/lib/options.test.js
+++ b/lib/options.test.js
@@ -135,6 +135,7 @@ test('should prefer custom db connection options', t => {
         database: 'db_database',
         ssl: false,
         driver: 'postgres',
+        version: '10',
     };
     const options = createOptions({ databaseUrl, db });
 


### PR DESCRIPTION
knex cannot detect the database version when a non-standard postgres database is used. See https://github.com/knex/knex/issues/1477#issuecomment-668965455.

knex offers support for explicitly declare the database version to overcome this issue, See [knex documentation](http://knexjs.org/#Installation-client)

> Note: The database version can be added in knex configuration, when you use the PostgreSQL adapter to connect a non-standard database.
```javascript
         var knex = require('knex')({
           client: 'pg',
           version: '7.2',
           connection: {
             host : '127.0.0.1',
             user : 'your_database_user',
             password : 'your_database_password',
             database : 'myapp_test'
           }
       });
```

This pull request aims to expose the version configuration.
