### PR TITLE
fix: cleanup test console output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,8 @@
 name: Build & Tests
 
 on:
-  push:
-    branches:
-    - master
   pull_request_target:
+  push:
     branches:
     - master
 

--- a/lib/db/client-applications-store.js
+++ b/lib/db/client-applications-store.js
@@ -1,6 +1,6 @@
 /* eslint camelcase:off */
 
-'use strict';
+const NotFoundError = require('../error/notfound-error');
 
 const COLUMNS = [
     'app_name',
@@ -83,6 +83,10 @@ class ClientApplicationsDb {
             .where('app_name', appName)
             .from(TABLE)
             .first();
+
+        if (!row) {
+            throw new NotFoundError(`Could not find appName=${appName}`);
+        }
 
         return mapRow(row);
     }

--- a/lib/db/client-metrics-store.test.js
+++ b/lib/db/client-metrics-store.test.js
@@ -43,6 +43,7 @@ test.cb('should call database on startup', t => {
 });
 
 test.cb('should start poller even if inital database fetch fails', t => {
+    getLogger.setMuteError(true);
     const clock = lolex.install();
     const mock = getMockDb();
     mock.getMetricsLastHour = () => Promise.reject(new Error('oops'));
@@ -62,6 +63,7 @@ test.cb('should start poller even if inital database fetch fails', t => {
             t.end();
         });
     });
+    getLogger.setMuteError(false);
 });
 
 test.cb('should poll for updates', t => {

--- a/lib/routes/admin-api/metrics.js
+++ b/lib/routes/admin-api/metrics.js
@@ -83,7 +83,7 @@ class MetricsController extends Controller {
         try {
             await this.clientApplicationsStore.getApplication(appName);
         } catch (e) {
-            this.logger.error(e);
+            this.logger.warn(e);
             res.status(409).end();
             return;
         }

--- a/lib/routes/admin-api/strategy.test.js
+++ b/lib/routes/admin-api/strategy.test.js
@@ -36,6 +36,10 @@ function getSetup() {
     };
 }
 
+test.afterEach(() => {
+    getLogger.setMuteError(false);
+});
+
 test('add version numbers for /stategies', t => {
     t.plan(1);
     const { request, base } = getSetup();
@@ -142,6 +146,7 @@ test('validate format when updating strategy', t => {
 });
 
 test('editable=false will stop delete request', t => {
+    getLogger.setMuteError(true);
     t.plan(0);
     const name = 'default';
     const { request, base, perms } = getSetup();
@@ -151,6 +156,7 @@ test('editable=false will stop delete request', t => {
 });
 
 test('editable=false will stop edit request', t => {
+    getLogger.setMuteError(true);
     t.plan(0);
     const name = 'default';
     const { request, base, perms } = getSetup();

--- a/lib/routes/client-api/register.test.js
+++ b/lib/routes/client-api/register.test.js
@@ -24,6 +24,10 @@ function getSetup() {
     };
 }
 
+test.afterEach(() => {
+    getLogger.setMuteError(false);
+});
+
 test('should register client', t => {
     t.plan(0);
     const { request } = getSetup();
@@ -78,6 +82,7 @@ test('should require strategies field', t => {
 
 test('should fail if store fails', t => {
     t.plan(0);
+    getLogger.setMuteError(true);
 
     // --- start custom config
     const stores = store.createStores();

--- a/lib/routes/health-check.test.js
+++ b/lib/routes/health-check.test.js
@@ -25,7 +25,12 @@ function getSetup() {
     };
 }
 
+test.afterEach(() => {
+    getLogger.setMuteError(false);
+});
+
 test('should give 500 when db is failing', t => {
+    getLogger.setMuteError(true);
     t.plan(2);
     const { request, db } = getSetup();
     db.select = () => ({

--- a/test/e2e/helpers/database-init.js
+++ b/test/e2e/helpers/database-init.js
@@ -81,6 +81,7 @@ module.exports = async function init(databaseSchema = 'test', getLogger) {
     await migrator(options);
     await db.destroy();
     const stores = await createStores(options, eventBus);
+    stores.clientMetricsStore.setMaxListeners(0);
     await resetDatabase(stores);
     await setupDatabase(stores);
 

--- a/test/fixtures/fake-metrics-store.js
+++ b/test/fixtures/fake-metrics-store.js
@@ -3,6 +3,11 @@
 const { EventEmitter } = require('events');
 
 class FakeMetricsStore extends EventEmitter {
+    constructor() {
+        super();
+        this.setMaxListeners(0);
+    }
+
     getMetricsLastHour() {
         return Promise.resolve([]);
     }

--- a/test/fixtures/no-logger.js
+++ b/test/fixtures/no-logger.js
@@ -1,13 +1,19 @@
 /* eslint-disable no-console */
 
-'use strict';
+let muteError = false;
 
-module.exports = function noLoggerProvider() {
+function noLoggerProvider() {
     // do something with the name
     return {
         debug: () => {},
         info: () => {},
         warn: () => {},
-        error: console.error,
+        error: muteError ? () => {} : console.error,
     };
+}
+
+noLoggerProvider.setMuteError = mute => {
+    muteError = mute;
 };
+
+module.exports = noLoggerProvider;


### PR DESCRIPTION
After this change output is now cleaned and shows the following:

```bash
npm run test                         

> unleash-server@3.9.0 pretest /home/ivaosthu/code/unleash
> npm run lint


> unleash-server@3.9.0 lint /home/ivaosthu/code/unleash
> eslint .


> unleash-server@3.9.0 test /home/ivaosthu/code/unleash
> NODE_ENV=test PORT=4243 ava


285 tests passed
```