### PR TITLE
fix: remove fields from /api/client/features respnse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.1
+
+- fix: remove fields from /api/client/features respnse (#692)
+
 ## 3.10.0
 
 - feat: add tags (#655)
@@ -10,7 +14,6 @@
 - fix: upgrade knex to 0.21.15
 - fix: Updated docs about event-types (#684)
 - fix: Add application-created event (#595)
-
 
 ## 3.9.0
 

--- a/lib/db/feature-toggle-store.js
+++ b/lib/db/feature-toggle-store.js
@@ -18,6 +18,15 @@ const FEATURE_COLUMNS = [
 ];
 const TABLE = 'features';
 
+const FEATURE_COLUMNS_CLIENT = [
+    'name',
+    'type',
+    'enabled',
+    'stale',
+    'strategies',
+    'variants',
+];
+
 class FeatureToggleStore {
     constructor(db, eventBus, getLogger) {
         this.db = db;
@@ -30,6 +39,34 @@ class FeatureToggleStore {
     }
 
     async getFeatures() {
+        const stopTimer = this.timer('getAll');
+
+        const rows = await this.db
+            .select(FEATURE_COLUMNS)
+            .from(TABLE)
+            .where({ archived: 0 })
+            .orderBy('name', 'asc');
+
+        stopTimer();
+
+        return rows.map(this.rowToFeature);
+    }
+
+    async getFeaturesClient() {
+        const stopTimer = this.timer('getAllClient');
+
+        const rows = await this.db
+            .select(FEATURE_COLUMNS_CLIENT)
+            .from(TABLE)
+            .where({ archived: 0 })
+            .orderBy('name', 'asc');
+
+        stopTimer();
+
+        return rows.map(this.rowToFeature);
+    }
+
+    async getClientFeatures() {
         const stopTimer = this.timer('getAll');
 
         const rows = await this.db

--- a/lib/routes/client-api/feature.js
+++ b/lib/routes/client-api/feature.js
@@ -17,7 +17,7 @@ class FeatureController extends Controller {
     async getAll(req, res) {
         const nameFilter = filter('name', req.query.namePrefix);
 
-        const allFeatureToggles = await this.toggleService.getFeatures();
+        const allFeatureToggles = await this.toggleService.getFeaturesClient();
         const features = nameFilter(allFeatureToggles);
 
         res.json({ version, features });

--- a/lib/services/feature-toggle-service.js
+++ b/lib/services/feature-toggle-service.js
@@ -27,6 +27,10 @@ class FeatureToggleService {
         return this.featureToggleStore.getFeatures();
     }
 
+    async getFeaturesClient() {
+        return this.featureToggleStore.getFeaturesClient();
+    }
+
     async getArchivedFeatures() {
         return this.featureToggleStore.getArchivedFeatures();
     }

--- a/test/e2e/api/client/feature.e2e.test.js
+++ b/test/e2e/api/client/feature.e2e.test.js
@@ -23,7 +23,18 @@ test.serial('returns four feature toggles', async t => {
         .expect('Content-Type', /json/)
         .expect(200)
         .expect(res => {
-            t.true(res.body.features.length === 4);
+            t.is(res.body.features.length, 4);
+        });
+});
+
+test.serial('returns four feature toggles without createdAt', async t => {
+    const request = await setupApp(stores);
+    return request
+        .get('/api/client/features')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(res => {
+            t.falsy(res.body.features[0].createdAt);
         });
 });
 

--- a/test/fixtures/fake-feature-toggle-store.js
+++ b/test/fixtures/fake-feature-toggle-store.js
@@ -30,6 +30,7 @@ module.exports = () => {
             _features.push(updatedFeature);
         },
         getFeatures: () => Promise.resolve(_features),
+        getFeaturesClient: () => Promise.resolve(_features),
         createFeature: feature => _features.push(feature),
         getArchivedFeatures: () => Promise.resolve(_archive),
         addArchivedFeature: feature => _archive.push(feature),


### PR DESCRIPTION
3.10.0 introduced the lastSeenAt property on the feature toggle.
This causes 304 to never happen, as the feature toggles will
constantly update lastSeenAt field.

This commit removes the following fields from the /api/client/features
responses:

- createdAt
- lastSeeenAt
- description

These fields are unessary for the client SDKs to do their job.