### PR TITLE
Fix typo in /api/client/features docs

### DIFF
--- a/docs/api/client/feature-toggles-api.md
+++ b/docs/api/client/feature-toggles-api.md
@@ -143,7 +143,7 @@ In the example `environment` needs to be `production` AND `userId` must be eithe
 
 ### Variants
 
-All feature toggles can also thke an array of variants. You can read more about [feature toggle variants](../../feature-toggle-variants).
+All feature toggles can also take an array of variants. You can read more about [feature toggle variants](../../feature-toggle-variants).
 
 ```json
 {


### PR DESCRIPTION
This PR just fixes a small typo on this paragraph: https://unleash.github.io/docs/api/client/features#variants