### PR TITLE
fix: upgrade prom-client from 12.0.0 to 13.1.0

### DIFF
--- a/lib/metrics.test.js
+++ b/lib/metrics.test.js
@@ -34,7 +34,7 @@ test.after(() => {
     monitor.stopMonitoring();
 });
 
-test('should collect metrics for requests', t => {
+test('should collect metrics for requests', async t => {
     eventBus.emit(REQUEST_TIME, {
         path: 'somePath',
         method: 'GET',
@@ -42,23 +42,23 @@ test('should collect metrics for requests', t => {
         time: 1337,
     });
 
-    const metrics = prometheusRegister.metrics();
+    const metrics = await prometheusRegister.metrics();
     t.regex(
         metrics,
         /http_request_duration_milliseconds{quantile="0\.99",path="somePath",method="GET",status="200"} 1337/,
     );
 });
 
-test('should collect metrics for updated toggles', t => {
+test('should collect metrics for updated toggles', async t => {
     eventStore.emit(FEATURE_UPDATED, {
         data: { name: 'TestToggle' },
     });
 
-    const metrics = prometheusRegister.metrics();
+    const metrics = await prometheusRegister.metrics();
     t.regex(metrics, /feature_toggle_update_total{toggle="TestToggle"} 1/);
 });
 
-test('should collect metrics for client metric reports', t => {
+test('should collect metrics for client metric reports', async t => {
     clientMetricsStore.emit('metrics', {
         bucket: {
             toggles: {
@@ -70,28 +70,28 @@ test('should collect metrics for client metric reports', t => {
         },
     });
 
-    const metrics = prometheusRegister.metrics();
+    const metrics = await prometheusRegister.metrics();
     t.regex(
         metrics,
         /feature_toggle_usage_total{toggle="TestToggle",active="true",appName="undefined"} 10\nfeature_toggle_usage_total{toggle="TestToggle",active="false",appName="undefined"} 5/,
     );
 });
 
-test('should collect metrics for db query timings', t => {
+test('should collect metrics for db query timings', async t => {
     eventBus.emit(DB_TIME, {
         store: 'foo',
         action: 'bar',
         time: 0.1337,
     });
 
-    const metrics = prometheusRegister.metrics();
+    const metrics = await prometheusRegister.metrics();
     t.regex(
         metrics,
         /db_query_duration_seconds{quantile="0\.99",store="foo",action="bar"} 0.1337/,
     );
 });
 
-test('should collect metrics for feature toggle size', t => {
-    const metrics = prometheusRegister.metrics();
+test('should collect metrics for feature toggle size', async t => {
+    const metrics = await prometheusRegister.metrics();
     t.regex(metrics, /feature_toggles_total{version="(.*)"} 123/);
 });

--- a/lib/routes/backstage.js
+++ b/lib/routes/backstage.js
@@ -7,10 +7,12 @@ class BackstageController extends Controller {
     constructor(config) {
         super();
 
+        this.logger = config.getLogger('backstage.js');
+
         if (config.serverMetrics) {
-            this.get('/prometheus', (req, res) => {
+            this.get('/prometheus', async (req, res) => {
                 res.set('Content-Type', prometheusRegister.contentType);
-                res.end(prometheusRegister.metrics());
+                res.end(await prometheusRegister.metrics());
             });
         }
     }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "parse-database-url": "^0.3.0",
     "pg": "^8.0.3",
     "pkginfo": "^0.4.1",
-    "prom-client": "^12.0.0",
+    "prom-client": "^13.1.0",
     "response-time": "^2.3.2",
     "serve-favicon": "^2.5.0",
     "unleash-frontend": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4512,10 +4512,10 @@ progress@^2.0.0:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-13.1.0.tgz#1185caffd8691e28d32e373972e662964e3dba45"
+  integrity sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
I guess this is a breaking change in some very specific cases if you expose the Prometheus metrics in your own code. I don't see that being a remotely common use case, though, so it's possibly not necessary to wait for a major release of Unleash(?).

I "need" this change because our metrics library depends on prometheus ^13.0.0 and is used by our logging library to measure log messages by severity/level. That doesn't work since I end up with two versions of `prom-client`, with separate registers.