### PR TITLE
Make feature-toggle-store return 409

### DIFF
--- a/lib/db/feature-toggle-store.js
+++ b/lib/db/feature-toggle-store.js
@@ -3,6 +3,7 @@
 const metricsHelper = require('../metrics-helper');
 const { DB_TIME } = require('../events');
 const NotFoundError = require('../error/notfound-error');
+const FeatureHasTagError = require('../error/feature-has-tag-error');
 
 const FEATURE_COLUMNS = [
     'name',
@@ -240,8 +241,15 @@ class FeatureToggleStore {
         const stopTimer = this.timer('tagFeature');
         await this.db(FEATURE_TAG_TABLE)
             .insert(this.featureAndTagToRow(featureName, tag))
-            .onConflict(['feature_name', 'tag_type', 'tag_value'])
-            .ignore();
+            .catch(err => {
+                if (err.code === '23505') {
+                    throw new FeatureHasTagError(
+                        `${featureName} already had the tag: [${tag.type}:${tag.value}]`,
+                    );
+                } else {
+                    throw err;
+                }
+            });
         stopTimer();
         return tag;
     }

--- a/lib/db/feature-toggle-store.js
+++ b/lib/db/feature-toggle-store.js
@@ -4,6 +4,7 @@ const metricsHelper = require('../metrics-helper');
 const { DB_TIME } = require('../events');
 const NotFoundError = require('../error/notfound-error');
 const FeatureHasTagError = require('../error/feature-has-tag-error');
+const { UNIQUE_CONSTRAINT_VIOLATION } = require('../error/db-error');
 
 const FEATURE_COLUMNS = [
     'name',
@@ -242,7 +243,7 @@ class FeatureToggleStore {
         await this.db(FEATURE_TAG_TABLE)
             .insert(this.featureAndTagToRow(featureName, tag))
             .catch(err => {
-                if (err.code === '23505') {
+                if (err.code === UNIQUE_CONSTRAINT_VIOLATION) {
                     throw new FeatureHasTagError(
                         `${featureName} already had the tag: [${tag.type}:${tag.value}]`,
                     );

--- a/lib/error/db-error.js
+++ b/lib/error/db-error.js
@@ -1,0 +1,3 @@
+module.exports = {
+    UNIQUE_CONSTRAINT_VIOLATION: '23505',
+};

--- a/lib/error/feature-has-tag-error.js
+++ b/lib/error/feature-has-tag-error.js
@@ -1,0 +1,26 @@
+'use strict';
+
+class FeatureHasTagError extends Error {
+    constructor(message) {
+        super();
+        Error.captureStackTrace(this, this.constructor);
+
+        this.name = this.constructor.name;
+        this.message = message;
+    }
+
+    toJSON() {
+        const obj = {
+            isJoi: false,
+            name: this.constructor.name,
+            details: [
+                {
+                    message: this.message,
+                },
+            ],
+        };
+        return obj;
+    }
+}
+
+module.exports = FeatureHasTagError;

--- a/lib/error/feature-has-tag-error.js
+++ b/lib/error/feature-has-tag-error.js
@@ -11,7 +11,7 @@ class FeatureHasTagError extends Error {
 
     toJSON() {
         const obj = {
-            isJoi: false,
+            isJoi: true,
             name: this.constructor.name,
             details: [
                 {

--- a/lib/routes/admin-api/util.js
+++ b/lib/routes/admin-api/util.js
@@ -42,6 +42,11 @@ const handleErrors = (res, logger, error) => {
                 .status(400)
                 .json(error)
                 .end();
+        case 'FeatureHasTagError':
+            return res
+                .status(409)
+                .json(error)
+                .end();
         default:
             logger.error('Server failed executing request', error);
             return res.status(500).end();

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.3",
+    "faker": "^5.3.1",
     "fetch-mock": "^9.11.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.7",

--- a/test/e2e/api/admin/feature.e2e.test.js
+++ b/test/e2e/api/admin/feature.e2e.test.js
@@ -397,7 +397,7 @@ test.serial('Can get features tagged by tag', async t => {
         });
 });
 test.serial('Can query for multiple tags using OR', async t => {
-    t.plan(2);
+    t.plan(3);
     const request = await setupApp(stores);
     const feature1Name = faker.helpers.slugify(faker.lorem.words(3));
     const feature2Name = faker.helpers.slugify(faker.lorem.words(3));
@@ -431,7 +431,8 @@ test.serial('Can query for multiple tags using OR', async t => {
         .expect(200)
         .expect(res => {
             t.is(res.body.features.length, 2);
-            t.is(res.body.features[0].name, feature1Name);
+            t.true(res.body.features.some(f => f.name === feature1Name));
+            t.true(res.body.features.some(f => f.name === feature2Name));
         });
 });
 test.serial('Querying with multiple filters ANDs the filters', async t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,6 +2284,11 @@ eyes@0.1.x:
   resolved "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
+faker@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.3.1.tgz#67f8f5c170b97a76b875389e0e8b9155da7b4853"
+  integrity sha512-sVdoApX/awJHO9DZHZsHVaJBNFiJW0n3lPs0q/nFxp/Mtya1dr2sCMktST3mdxNMHjkvKTTMAW488E+jH1eSbg==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"


### PR DESCRIPTION
- After seeing frontend behaviour where the user could add the same
tag multiple times, and not get errors or be stopped doing so, we'll
change the backend to return a 409 if you tag a feature with a tag it
already has.

- Previous to this commit, the setup was to do `onConflict().ignore()`
  which caused the frontend to not get any help from the backend as to
  whether or not the operation was allowed

- This fix adds a custom error and adds a branch to the handleError util
  method for handling just that error type with a 409.

- This caused a couple of tests to receive 409, probably due to
  insufficient cleanup between tests. Adding faker as a dev-dependency and randomising
  toggle names and tag values for each test reduces the chance that
  we'll run into duplicate issues in the future for the tests that
  touches this problem

fixes: #711