### PR TITLE
fix: gh-720 Use express path templates for prometheus metrics

### DIFF
--- a/src/lib/middleware/response-time.js
+++ b/src/lib/middleware/response-time.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const url = require('url');
 const responseTime = require('response-time');
 const { REQUEST_TIME } = require('../events');
 
 module.exports = function(config) {
     return responseTime((req, res, time) => {
         const { statusCode } = res;
-        const pathname = req.route
-            ? url.parse(req.originalUrl).pathname
-            : '(hidden)';
+
+        const pathname = req.route ? req.baseUrl + req.route.path : '(hidden)';
 
         const timingInfo = {
             path: pathname,


### PR DESCRIPTION
Changes from:

```
http_request_duration_milliseconds_sum{path="/api/admin/features/myFeature/toggle/on",method="POST",status="200"} 51.16884
http_request_duration_milliseconds_count{path="/api/admin/features/myFeature/toggle/on",method="POST",status="200"} 2
```

to
```
http_request_duration_milliseconds_sum{path="/api/admin/features/:featureName/toggle/on",method="POST",status="200"} 51.16884
http_request_duration_milliseconds_count{path="/api/admin/features/:featureName/toggle/on",method="POST",status="200"} 2
```

Note `:featureName`.  I didn't adopt the `express-prometheus-middleware` technique, because it just tried to regex out IDs and didn't seem to really solve it. The req had what we needed instead. (Just had to read the docs ;) )