### PR TITLE
feat/return feature on create

### DIFF
--- a/src/lib/db/feature-toggle-store.js
+++ b/src/lib/db/feature-toggle-store.js
@@ -177,7 +177,7 @@ class FeatureToggleStore {
         } catch (err) {
             this.logger.error('Could not insert feature, error: ', err);
         }
-        return null;
+        return undefined;
     }
 
     async updateFeature(data) {

--- a/src/lib/db/feature-toggle-store.js
+++ b/src/lib/db/feature-toggle-store.js
@@ -169,10 +169,15 @@ class FeatureToggleStore {
 
     async createFeature(data) {
         try {
-            await this.db(TABLE).insert(this.eventDataToRow(data));
+            const row = await this.db(TABLE)
+                .insert(this.eventDataToRow(data))
+                .returning(FEATURE_COLUMNS);
+
+            return this.rowToFeature(row[0]);
         } catch (err) {
             this.logger.error('Could not insert feature, error: ', err);
         }
+        return null;
     }
 
     async updateFeature(data) {

--- a/src/lib/routes/admin-api/feature.js
+++ b/src/lib/routes/admin-api/feature.js
@@ -126,8 +126,11 @@ class FeatureController extends Controller {
         const userName = extractUser(req);
 
         try {
-            await this.featureService.createFeatureToggle(req.body, userName);
-            res.status(201).end();
+            const createdFeature = await this.featureService.createFeatureToggle(
+                req.body,
+                userName,
+            );
+            res.status(201).json(createdFeature);
         } catch (error) {
             handleErrors(res, this.logger, error);
         }

--- a/src/lib/services/feature-toggle-service.js
+++ b/src/lib/services/feature-toggle-service.js
@@ -64,13 +64,16 @@ class FeatureToggleService {
 
     async createFeatureToggle(value, userName) {
         await this.validateName(value);
-        const feature = await featureSchema.validateAsync(value);
-        await this.featureToggleStore.createFeature(feature);
+        const featureData = await featureSchema.validateAsync(value);
+        const feature = await this.featureToggleStore.createFeature(
+            featureData,
+        );
         await this.eventStore.store({
             type: FEATURE_CREATED,
             createdBy: userName,
-            data: feature,
+            data: featureData,
         });
+        return feature;
     }
 
     async updateToggle(updatedFeature, userName) {

--- a/src/test/e2e/api/admin/feature.e2e.test.js
+++ b/src/test/e2e/api/admin/feature.e2e.test.js
@@ -47,7 +47,7 @@ test.serial('cant get feature that dose not exist', async t => {
 });
 
 test.serial('creates new feature toggle', async t => {
-    t.plan(0);
+    t.plan(3);
     const request = await setupApp(stores);
     return request
         .post('/api/admin/features')
@@ -57,7 +57,12 @@ test.serial('creates new feature toggle', async t => {
             strategies: [{ name: 'default' }],
         })
         .set('Content-Type', 'application/json')
-        .expect(201);
+        .expect(201)
+        .expect(res => {
+            t.is(res.body.name, 'com.test.feature');
+            t.is(res.body.enabled, false);
+            t.truthy(res.body.createdAt);
+        });
 });
 
 test.serial('creates new feature toggle with variants', async t => {


### PR DESCRIPTION
Adds support for returning the created feature from the create endpoint.

The feature toggle store now propagates back the feature toggle to the endpoint handler in order to send the created object back to the calling client. I've kept the data sent in the event the same, not sure if it makes sense to include the full object here.