### PR TITLE
fix: publish events about unannounced applications

### DIFF
--- a/src/migrations/20210304141005-add-announce-field-to-application.js
+++ b/src/migrations/20210304141005-add-announce-field-to-application.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+    ALTER TABLE client_applications ADD COLUMN announced boolean DEFAULT false;
+    UPDATE client_applications SET announced = true;
+  `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE client_applications DROP COLUMN announced;
+        `,
+        cb,
+    );
+};
+
+exports._meta = {
+    version: 1,
+};

--- a/src/migrations/20210304150739-add-created-by-to-application.js
+++ b/src/migrations/20210304150739-add-created-by-to-application.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+    ALTER TABLE client_applications ADD COLUMN created_by TEXT;
+  `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql('ALTER TABLE client_applications DROP COLUMN created_by;', cb);
+};
+
+exports._meta = {
+    version: 1,
+};

--- a/src/test/e2e/helpers/database.json
+++ b/src/test/e2e/helpers/database.json
@@ -24,17 +24,20 @@
   "applications": [
     {
       "appName": "demo-app-1",
-      "strategies": ["default"]
+      "strategies": ["default"],
+      "announced": true
     },
     {
       "appName": "demo-app-2",
       "strategies": ["default", "extra"],
-      "description": "hello"
+      "description": "hello",
+      "announced": true
     },
     {
       "appName": "deletable-app",
       "strategies": ["default"],
-      "description": "Some desc"
+      "description": "Some desc",
+      "announced": true
     }
   ],
   "clientInstances": [

--- a/src/test/e2e/services/client-metrics-service.e2e.test.js
+++ b/src/test/e2e/services/client-metrics-service.e2e.test.js
@@ -1,0 +1,58 @@
+const test = require('ava');
+const faker = require('faker');
+const dbInit = require('../helpers/database-init');
+const getLogger = require('../../fixtures/no-logger');
+const ClientMetricsService = require('../../../lib/services/client-metrics');
+const { APPLICATION_CREATED } = require('../../../lib/event-type');
+
+let stores;
+let clientMetricsService;
+
+test.before(async () => {
+    const db = await dbInit('client_metrics_service_serial', getLogger);
+    stores = db.stores;
+    clientMetricsService = new ClientMetricsService(stores, {
+        getLogger,
+        bulkInterval: 500,
+        announcementInterval: 2000,
+    });
+});
+
+test.after(async () => {
+    await stores.db.destroy();
+});
+test.serial('Apps registered should be announced', async t => {
+    t.plan(3);
+    const clientRegistration = {
+        appName: faker.internet.domainName(),
+        instanceId: faker.random.uuid(),
+        strategies: ['default'],
+        started: Date.now(),
+        interval: faker.random.number(),
+        icon: '',
+        description: faker.company.catchPhrase(),
+        color: faker.internet.color(),
+    };
+    const differentClient = {
+        appName: faker.lorem.slug(2),
+        instanceId: faker.random.uuid(),
+        strategies: ['default'],
+        started: Date.now(),
+        interval: faker.random.number(),
+        icon: '',
+        description: faker.company.catchPhrase(),
+        color: faker.internet.color(),
+    };
+    await clientMetricsService.registerClient(clientRegistration, '127.0.0.1');
+    await clientMetricsService.registerClient(differentClient, '127.0.0.1');
+    await new Promise(res => setTimeout(res, 1200));
+    const first = await stores.clientApplicationsStore.getUnannounced();
+    t.is(first.length, 2);
+    await clientMetricsService.registerClient(clientRegistration, '127.0.0.1');
+    await new Promise(res => setTimeout(res, 2000));
+    const second = await stores.clientApplicationsStore.getUnannounced();
+    t.is(second.length, 0);
+    const events = await stores.eventStore.getEvents();
+    const appCreatedEvents = events.filter(e => e.type === APPLICATION_CREATED);
+    t.is(appCreatedEvents.length, 2);
+});


### PR DESCRIPTION
Tried to get the test working with fake clocks, but just ended up in a weird pending state, as such, this isn't optimal and I'm more than happy if someone can think of a better way of checking that we do announce the created applications, and just once.