### PR TITLE
chore: expose an endpoint to really delete a toggle

### DIFF
--- a/src/lib/db/feature-toggle-store.js
+++ b/src/lib/db/feature-toggle-store.js
@@ -222,6 +222,12 @@ class FeatureToggleStore {
         }
     }
 
+    async deleteFeature(name) {
+        await this.db(TABLE)
+            .where({ name })
+            .del();
+    }
+
     async reviveFeature({ name }) {
         try {
             await this.db(TABLE)

--- a/src/lib/db/feature-toggle-store.js
+++ b/src/lib/db/feature-toggle-store.js
@@ -224,7 +224,7 @@ class FeatureToggleStore {
 
     async deleteFeature(name) {
         await this.db(TABLE)
-            .where({ name })
+            .where({ name, archived: 1 }) // Feature toggle must be archived to allow deletion
             .del();
     }
 

--- a/src/lib/routes/admin-api/archive.test.js
+++ b/src/lib/routes/admin-api/archive.test.js
@@ -47,7 +47,7 @@ test('should get empty getFeatures via admin', t => {
 test('should be allowed to reuse deleted toggle name', async t => {
     t.plan(0);
     const { request, archiveStore, base } = getSetup();
-    archiveStore.createFeature({
+    await archiveStore.createFeature({
         name: 'ts.really.delete',
         strategies: [{ name: 'default' }],
     });

--- a/src/lib/routes/admin-api/archive.test.js
+++ b/src/lib/routes/admin-api/archive.test.js
@@ -44,6 +44,23 @@ test('should get empty getFeatures via admin', t => {
         });
 });
 
+test('should be allowed to reuse deleted toggle name', async t => {
+    t.plan(0);
+    const { request, archiveStore, base } = getSetup();
+    archiveStore.createFeature({
+        name: 'ts.really.delete',
+        strategies: [{ name: 'default' }],
+    });
+    await request
+        .delete(`${base}/api/admin/archive/ts.really.delete`)
+        .expect(200);
+    return request
+        .post(`${base}/api/admin/features/validate`)
+        .send({ name: 'ts.really.delete' })
+        .set('Content-Type', 'application/json')
+        .expect(409);
+});
+
 test('should get archived toggles via admin', t => {
     t.plan(1);
     const { request, base, archiveStore } = getSetup();

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -47,7 +47,8 @@ class FeatureController extends Controller {
         this.post('/', this.createToggle, CREATE_FEATURE);
         this.get('/:featureName', this.getToggle);
         this.put('/:featureName', this.updateToggle, UPDATE_FEATURE);
-        this.delete('/:featureName', this.deleteToggle, DELETE_FEATURE);
+        this.delete('/:featureName', this.archiveToggle, DELETE_FEATURE);
+        this.delete('/:featureName/really', this.deleteToggle, DELETE_FEATURE);
         this.post('/validate', this.validate);
         this.post('/:featureName/toggle', this.toggle, UPDATE_FEATURE);
         this.post('/:featureName/toggle/on', this.toggleOn, UPDATE_FEATURE);
@@ -233,12 +234,25 @@ class FeatureController extends Controller {
         }
     }
 
-    async deleteToggle(req: Request, res: Response): Promise<void> {
+    async archiveToggle(req: Request, res: Response): Promise<void> {
         const { featureName } = req.params;
-        const userName = extractUser(req);
 
         try {
-            await this.featureService.archiveToggle(featureName, userName);
+            await this.featureService.archiveToggle(featureName);
+            res.status(200).end();
+        } catch (error) {
+            handleErrors(res, this.logger, error);
+        }
+    }
+
+    async deleteToggle(
+        req: Request<any, { featureName: string }, any, any>,
+        res: Response,
+    ): Promise<void> {
+        const { featureName } = req.params;
+        const userName = extractUser(req);
+        try {
+            await this.featureService.deleteFeature(featureName, userName);
             res.status(200).end();
         } catch (error) {
             handleErrors(res, this.logger, error);

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -48,7 +48,6 @@ class FeatureController extends Controller {
         this.get('/:featureName', this.getToggle);
         this.put('/:featureName', this.updateToggle, UPDATE_FEATURE);
         this.delete('/:featureName', this.archiveToggle, DELETE_FEATURE);
-        this.delete('/:featureName/really', this.deleteToggle, DELETE_FEATURE);
         this.post('/validate', this.validate);
         this.post('/:featureName/toggle', this.toggle, UPDATE_FEATURE);
         this.post('/:featureName/toggle/on', this.toggleOn, UPDATE_FEATURE);
@@ -239,20 +238,6 @@ class FeatureController extends Controller {
 
         try {
             await this.featureService.archiveToggle(featureName);
-            res.status(200).end();
-        } catch (error) {
-            handleErrors(res, this.logger, error);
-        }
-    }
-
-    async deleteToggle(
-        req: Request<any, { featureName: string }, any, any>,
-        res: Response,
-    ): Promise<void> {
-        const { featureName } = req.params;
-        const userName = extractUser(req);
-        try {
-            await this.featureService.deleteFeature(featureName, userName);
             res.status(200).end();
         } catch (error) {
             handleErrors(res, this.logger, error);

--- a/src/lib/services/feature-toggle-service.js
+++ b/src/lib/services/feature-toggle-service.js
@@ -58,6 +58,10 @@ export default class FeatureToggleService {
         await this.featureToggleStore.addArchivedFeature(feature);
     }
 
+    async deleteFeature(name) {
+        await this.featureToggleStore.deleteFeature(name);
+    }
+
     async getFeature(name) {
         return this.featureToggleStore.getFeature(name);
     }

--- a/src/test/e2e/api/admin/feature-archive.e2e.test.js
+++ b/src/test/e2e/api/admin/feature-archive.e2e.test.js
@@ -56,3 +56,59 @@ test.serial('must set name when reviving toggle', async t => {
     const request = await setupApp(stores);
     return request.post('/api/admin/archive/revive/').expect(404);
 });
+
+test.serial('should be allowed to reuse deleted toggle name', async t => {
+    t.plan(3);
+    const request = await setupApp(stores);
+    await request
+        .post('/api/admin/features')
+        .send({
+            name: 'really.delete.feature',
+            enabled: false,
+            strategies: [{ name: 'default' }],
+        })
+        .set('Content-Type', 'application/json')
+        .expect(201)
+        .expect(res => {
+            t.is(res.body.name, 'really.delete.feature');
+            t.is(res.body.enabled, false);
+            t.truthy(res.body.createdAt);
+        });
+    await request
+        .delete(`/api/admin/features/really.delete.feature`)
+        .expect(200);
+    await request
+        .delete(`/api/admin/archive/really.delete.feature`)
+        .expect(200);
+    return request
+        .post(`/api/admin/features/validate`)
+        .send({ name: 'really.delete.feature' })
+        .set('Content-Type', 'application/json')
+        .expect(200);
+});
+test.serial('Deleting an unarchived toggle should not take effect', async t => {
+    t.plan(3);
+    const request = await setupApp(stores);
+    await request
+        .post('/api/admin/features')
+        .send({
+            name: 'really.delete.feature',
+            enabled: false,
+            strategies: [{ name: 'default' }],
+        })
+        .set('Content-Type', 'application/json')
+        .expect(201)
+        .expect(res => {
+            t.is(res.body.name, 'really.delete.feature');
+            t.is(res.body.enabled, false);
+            t.truthy(res.body.createdAt);
+        });
+    await request
+        .delete(`/api/admin/archive/really.delete.feature`)
+        .expect(200);
+    return request
+        .post(`/api/admin/features/validate`)
+        .send({ name: 'really.delete.feature' })
+        .set('Content-Type', 'application/json')
+        .expect(409); // because it still exists
+});

--- a/src/test/fixtures/fake-feature-toggle-store.js
+++ b/src/test/fixtures/fake-feature-toggle-store.js
@@ -64,6 +64,13 @@ module.exports = (databaseIsUp = true) => {
             _features.splice(0, _features.length);
             _archive.splice(0, _archive.length);
         },
+        deleteFeature: featureName => {
+            const archivedIdx = _archive.findIndex(f => f.name === featureName);
+            if (archivedIdx > -1) {
+                _archive.splice(archivedIdx, 1);
+            }
+            return Promise.resolve();
+        },
         importFeature: feat => Promise.resolve(_features.push(feat)),
         getFeatures: query => {
             if (!databaseIsUp) {


### PR DESCRIPTION
- To provide a way to run end-to-end tests without cluttering
  our demo instance with way too many feature-toggles, making this
  endpoint available will allow end-to-end tests to clean up properly
  after themselves