### PR TITLE
fix: set default DATABASE_SSL to not rejectUnauthorized

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -57,7 +57,7 @@ const defaultDbOptions: IDBOption = {
     ssl:
         process.env.DATABASE_SSL != null
             ? JSON.parse(process.env.DATABASE_SSL)
-            : undefined,
+            : { rejectUnauthorized: false },
     driver: 'postgres',
     version: process.env.DATABASE_VERSION,
     pool: {

--- a/src/test/e2e/helpers/database-init.js
+++ b/src/test/e2e/helpers/database-init.js
@@ -88,6 +88,7 @@ export default async function init(databaseSchema = 'test', getLogger) {
             ...dbConfig.getDb(),
             pool: { min: 2, max: 8 },
             schema: databaseSchema,
+            ssl: false,
         },
         getLogger,
     });


### PR DESCRIPTION
this will make Unleash "just work" on envrionments like
Heroku where SSL is required, but uses a self-signed
certificate.