### PR TITLE
fix: Make Authorization header capitalized.

### DIFF
--- a/docs/deploy/securing-unleash.md
+++ b/docs/deploy/securing-unleash.md
@@ -75,7 +75,7 @@ unleash
     databaseUrl: 'postgres://unleash_user:passord@localhost:5432/unleash',
     preRouterHook: app => {
       app.use('/api/client', (req, res, next) => {
-        if (req.header('authorization') !== sharedSecret) {
+        if (req.header('Authorization') !== sharedSecret) {
           res.sendStatus(401);
         } else {
           next();

--- a/examples/client-auth-unleash.js
+++ b/examples/client-auth-unleash.js
@@ -11,7 +11,7 @@ unleash
         databaseUrl: 'postgres://unleash_user:passord@localhost:5432/unleash',
         preRouterHook: app => {
             app.use('/api/client', (req, res, next) => {
-                if (req.header('authorization') === sharedSecret) {
+                if (req.header('Authorization') === sharedSecret) {
                     next();
                 } else {
                     res.sendStatus(401);

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -21,7 +21,7 @@ const apiAccessMiddleware = (
         }
 
         try {
-            const apiToken = req.header('authorization');
+            const apiToken = req.header('Authorization');
             const apiUser = apiTokenService.getUserForToken(apiToken);
             if (apiUser) {
                 req.user = apiUser;

--- a/src/lib/middleware/oss-authentication.js
+++ b/src/lib/middleware/oss-authentication.js
@@ -18,7 +18,7 @@ function ossAuthHook(app, config) {
         if (req.user) {
             return next();
         }
-        if (req.header('authorization')) {
+        if (req.header('Authorization')) {
             // API clients should get 401 without body
             return res.sendStatus(401);
         }


### PR DESCRIPTION
The documentation often has `Authorization` capitalized (as well as the RFC https://tools.ietf.org/html/rfc7235#section-4.2) 

With the official client tokens (Yay!) we'll want to make it match. Alternatively, we could check it in a non-case sensitive way, though [other frameworks](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverter.java#L79) only look for the capitalized version).

This PR unifies the examples and the actual client API Key check to use capitalization