### PR TITLE
fix: set name type to be min 1 character

### DIFF
--- a/src/lib/routes/admin-api/util.js
+++ b/src/lib/routes/admin-api/util.js
@@ -20,7 +20,7 @@ const customJoi = joi.extend(j => ({
 
 const nameType = customJoi
     .isUrlFriendly()
-    .min(2)
+    .min(1)
     .max(100)
     .required();
 


### PR DESCRIPTION
I noticed nameType is used in multiple places. Do we want to change nameType for all validations where it is used, or should we create a new nameType for variants specifically?