### PR TITLE
fix: retrieve project id from updated feature

### DIFF
--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -202,9 +202,9 @@ class FeatureController extends Controller {
         );
         if (featureToggleExists) {
             await this.featureService2.getFeature(featureName);
-            const projectId = await this.featureService2.getProjectId(
-                updatedFeature.name,
-            );
+
+            const projectId = updatedFeature.project;
+
             const value = await featureSchema.validateAsync(updatedFeature);
             const { enabled } = value;
             const updatedToggle = this.featureService2.updateFeatureToggle(


### PR DESCRIPTION
Retrieving projectId from DB ignores scenarios where projectId is the property being changed. I changed it to use the projectId property from the incoming request body. Is there any scenario where we want to update a feature toggle where we don't have the projectId in the request body?