### PR TITLE
Feat/api key scoping

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -4,14 +4,16 @@ import metricsHelper from '../util/metrics-helper';
 import { DB_TIME } from '../metric-events';
 import { Logger, LogProvider } from '../logger';
 import NotFoundError from '../error/notfound-error';
+import { IApiTokenStore } from '../types/stores/api-token-store';
 import {
     ApiTokenType,
     IApiToken,
     IApiTokenCreate,
-    IApiTokenStore,
-} from '../types/stores/api-token-store';
+} from '../types/models/api-token';
 
 const TABLE = 'api_tokens';
+
+const ALL = '*';
 
 interface ITokenTable {
     id: number;
@@ -21,12 +23,17 @@ interface ITokenTable {
     expires_at?: Date;
     created_at: Date;
     seen_at?: Date;
+    environment: string;
+    project: string;
 }
 
 const toRow = (newToken: IApiTokenCreate) => ({
     username: newToken.username,
     secret: newToken.secret,
     type: newToken.type,
+    project: newToken.project === ALL ? undefined : newToken.project,
+    environment:
+        newToken.environment === ALL ? undefined : newToken.environment,
     expires_at: newToken.expiresAt,
 });
 
@@ -34,6 +41,8 @@ const toToken = (row: ITokenTable): IApiToken => ({
     secret: row.secret,
     username: row.username,
     type: row.type,
+    environment: row.environment ? row.environment : ALL,
+    project: row.project ? row.project : ALL,
     expiresAt: row.expires_at,
     createdAt: row.created_at,
 });

--- a/src/lib/db/client-metrics-store.ts
+++ b/src/lib/db/client-metrics-store.ts
@@ -71,7 +71,12 @@ export class ClientMetricsStore
         }
     }
 
-    // Insert new client metrics
+    /**
+     * Insert client metrics. In the future we will isolate "appName" and "environment"
+     * in separate columns in the database to make it easier to query the data.
+     *
+     * @param metrics sent from the client SDK.
+     */
     async insert(metrics: IClientMetric): Promise<void> {
         const stopTimer = this.startTimer('insert');
 

--- a/src/lib/middleware/api-token-middleware.test.ts
+++ b/src/lib/middleware/api-token-middleware.test.ts
@@ -3,6 +3,7 @@ import getLogger from '../../test/fixtures/no-logger';
 import { CLIENT } from '../types/permissions';
 import { createTestConfig } from '../../test/config/test-config';
 import ApiUser from '../types/api-user';
+import { ALL } from '../types/models/api-token';
 
 let config: any;
 
@@ -59,8 +60,8 @@ test('should add user if unknown token', async () => {
     const apiUser = new ApiUser({
         username: 'default',
         permissions: [CLIENT],
-        project: '*',
-        environment: '*',
+        project: ALL,
+        environment: ALL,
     });
     const apiTokenService = {
         getUserForToken: jest.fn().mockReturnValue(apiUser),
@@ -86,8 +87,8 @@ test('should not add user if disabled', async () => {
     const apiUser = new ApiUser({
         username: 'default',
         permissions: [CLIENT],
-        project: '*',
-        environment: '*',
+        project: ALL,
+        environment: ALL,
     });
     const apiTokenService = {
         getUserForToken: jest.fn().mockReturnValue(apiUser),

--- a/src/lib/middleware/api-token-middleware.test.ts
+++ b/src/lib/middleware/api-token-middleware.test.ts
@@ -59,6 +59,8 @@ test('should add user if unknown token', async () => {
     const apiUser = new ApiUser({
         username: 'default',
         permissions: [CLIENT],
+        project: '*',
+        environment: '*',
     });
     const apiTokenService = {
         getUserForToken: jest.fn().mockReturnValue(apiUser),
@@ -84,6 +86,8 @@ test('should not add user if disabled', async () => {
     const apiUser = new ApiUser({
         username: 'default',
         permissions: [CLIENT],
+        project: '*',
+        environment: '*',
     });
     const apiTokenService = {
         getUserForToken: jest.fn().mockReturnValue(apiUser),

--- a/src/lib/middleware/demo-authentication.ts
+++ b/src/lib/middleware/demo-authentication.ts
@@ -30,7 +30,7 @@ function demoAuthentication(
         next();
     });
 
-    app.use(`${basePath}/api/admin/`, (req, res, next) => {
+    app.use(`${basePath}/api`, (req, res, next) => {
         // @ts-ignore
         if (req.user) {
             return next();

--- a/src/lib/middleware/oss-authentication.ts
+++ b/src/lib/middleware/oss-authentication.ts
@@ -1,4 +1,5 @@
-import { Application, NextFunction, Request, Response } from 'express';
+import { Application, NextFunction, Response } from 'express';
+import { IAuthRequest } from '../routes/unleash-types';
 import AuthenticationRequired from '../types/authentication-required';
 
 function ossAuthHook(app: Application, baseUriPath: string): void {
@@ -11,14 +12,11 @@ function ossAuthHook(app: Application, baseUriPath: string): void {
 
     app.use(
         `${baseUriPath}/api`,
-        async (req: Request, res: Response, next: NextFunction) => {
-            // @ts-ignore
+        async (req: IAuthRequest, res: Response, next: NextFunction) => {
             if (req.session && req.session.user) {
-                // @ts-ignore
                 req.user = req.session.user;
                 return next();
             }
-            // @ts-ignore
             if (req.user) {
                 return next();
             }

--- a/src/lib/middleware/rbac-middleware.test.ts
+++ b/src/lib/middleware/rbac-middleware.test.ts
@@ -46,6 +46,8 @@ test('should give api-user ADMIN permission', async () => {
         user: new ApiUser({
             username: 'api',
             permissions: [perms.ADMIN],
+            project: '*',
+            environment: '*',
         }),
     };
 
@@ -68,6 +70,8 @@ test('should not give api-user ADMIN permission', async () => {
         user: new ApiUser({
             username: 'api',
             permissions: [perms.CLIENT],
+            project: '*',
+            environment: '*',
         }),
     };
 

--- a/src/lib/middleware/rbac-middleware.test.ts
+++ b/src/lib/middleware/rbac-middleware.test.ts
@@ -6,6 +6,7 @@ import { createTestConfig } from '../../test/config/test-config';
 import ApiUser from '../types/api-user';
 import { IFeatureToggleStore } from '../types/stores/feature-toggle-store';
 import FakeFeatureToggleStore from '../../test/fixtures/fake-feature-toggle-store';
+import { ApiTokenType } from '../types/models/api-token';
 
 let config: IUnleashConfig;
 let featureToggleStore: IFeatureToggleStore;
@@ -48,6 +49,7 @@ test('should give api-user ADMIN permission', async () => {
             permissions: [perms.ADMIN],
             project: '*',
             environment: '*',
+            type: ApiTokenType.ADMIN,
         }),
     };
 
@@ -72,6 +74,7 @@ test('should not give api-user ADMIN permission', async () => {
             permissions: [perms.CLIENT],
             project: '*',
             environment: '*',
+            type: ApiTokenType.CLIENT,
         }),
     };
 

--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -22,8 +22,8 @@ const rbacMiddleware = (
     { featureToggleStore }: Pick<IUnleashStores, 'featureToggleStore'>,
     accessService: PermissionChecker,
 ): any => {
-    const logger = config.getLogger('/middleware/rbac-middleware.js');
-    logger.info('Enabling RBAC');
+    const logger = config.getLogger('/middleware/rbac-middleware.ts');
+    logger.debug('Enabling RBAC middleware');
 
     return (req, res, next) => {
         req.checkRbac = async (permission: string) => {

--- a/src/lib/routes/admin-api/api-token-controller.ts
+++ b/src/lib/routes/admin-api/api-token-controller.ts
@@ -66,7 +66,7 @@ class ApiTokenController extends Controller {
 
     async createApiToken(req: IAuthRequest, res: Response): Promise<any> {
         const createToken = await createApiToken.validateAsync(req.body);
-        const token = await this.apiTokenService.creteApiToken(createToken);
+        const token = await this.apiTokenService.createApiToken(createToken);
         return res.status(201).json(token);
     }
 

--- a/src/lib/routes/admin-api/api-token-controller.ts
+++ b/src/lib/routes/admin-api/api-token-controller.ts
@@ -13,7 +13,7 @@ import { AccessService } from '../../services/access-service';
 import { IAuthRequest } from '../unleash-types';
 import User from '../../types/user';
 import { IUnleashConfig } from '../../types/option';
-import { ApiTokenType } from '../../types/stores/api-token-store';
+import { ApiTokenType } from '../../types/models/api-token';
 
 interface IServices {
     apiTokenService: ApiTokenService;
@@ -64,7 +64,14 @@ class ApiTokenController extends Controller {
     }
 
     async createApiToken(req: IAuthRequest, res: Response): Promise<any> {
-        const { username, type, expiresAt } = req.body;
+        // TODO use joi schema
+        const {
+            username,
+            type,
+            expiresAt,
+            environment = '*',
+            project = '*',
+        } = req.body;
 
         if (!username || !type) {
             this.logger.error(req.body);
@@ -79,6 +86,8 @@ class ApiTokenController extends Controller {
         try {
             const token = await this.apiTokenService.creteApiToken({
                 type: tokenType,
+                environment,
+                project,
                 username,
                 expiresAt,
             });

--- a/src/lib/routes/admin-api/api-token-controller.ts
+++ b/src/lib/routes/admin-api/api-token-controller.ts
@@ -14,6 +14,7 @@ import { IAuthRequest } from '../unleash-types';
 import User from '../../types/user';
 import { IUnleashConfig } from '../../types/option';
 import { ApiTokenType } from '../../types/models/api-token';
+import { createApiToken } from '../../schema/api-token-schema';
 
 interface IServices {
     apiTokenService: ApiTokenService;
@@ -64,50 +65,16 @@ class ApiTokenController extends Controller {
     }
 
     async createApiToken(req: IAuthRequest, res: Response): Promise<any> {
-        // TODO use joi schema
-        const {
-            username,
-            type,
-            expiresAt,
-            environment = '*',
-            project = '*',
-        } = req.body;
-
-        if (!username || !type) {
-            this.logger.error(req.body);
-            return res.status(400).send();
-        }
-
-        const tokenType =
-            type.toLowerCase() === 'admin'
-                ? ApiTokenType.ADMIN
-                : ApiTokenType.CLIENT;
-
-        try {
-            const token = await this.apiTokenService.creteApiToken({
-                type: tokenType,
-                environment,
-                project,
-                username,
-                expiresAt,
-            });
-            return res.status(201).json(token);
-        } catch (error) {
-            this.logger.error('error creating api-token', error);
-            return res.status(500);
-        }
+        const createToken = await createApiToken.validateAsync(req.body);
+        const token = await this.apiTokenService.creteApiToken(createToken);
+        return res.status(201).json(token);
     }
 
     async deleteApiToken(req: IAuthRequest, res: Response): Promise<void> {
         const { token } = req.params;
 
-        try {
-            await this.apiTokenService.delete(token);
-            res.status(200).end();
-        } catch (error) {
-            this.logger.error('error creating api-token', error);
-            res.status(500);
-        }
+        await this.apiTokenService.delete(token);
+        res.status(200).end();
     }
 
     async updateApiToken(req: IAuthRequest, res: Response): Promise<any> {
@@ -119,13 +86,8 @@ class ApiTokenController extends Controller {
             return res.status(400).send();
         }
 
-        try {
-            await this.apiTokenService.updateExpiry(token, expiresAt);
-            return res.status(200).end();
-        } catch (error) {
-            this.logger.error('error creating api-token', error);
-            return res.status(500);
-        }
+        await this.apiTokenService.updateExpiry(token, expiresAt);
+        return res.status(200).end();
     }
 }
 

--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -1,5 +1,5 @@
 import memoizee from 'memoizee';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import Controller from '../controller';
 import { IUnleashServices } from '../../types/services';
 import { IUnleashConfig } from '../../types/option';
@@ -8,8 +8,16 @@ import { Logger } from '../../logger';
 import { querySchema } from '../../schema/feature-schema';
 import { IFeatureToggleQuery } from '../../types/model';
 import NotFoundError from '../../error/notfound-error';
+import { IAuthRequest } from '../unleash-types';
+import ApiUser from '../../types/api-user';
+import { ALL } from '../../types/models/api-token';
 
 const version = 2;
+
+interface QueryOverride {
+    project?: string[];
+    environment?: string;
+}
 
 export default class FeatureController extends Controller {
     private readonly logger: Logger;
@@ -50,20 +58,34 @@ export default class FeatureController extends Controller {
         }
     }
 
-    async getAll(req: Request, res: Response): Promise<void> {
-        const query = await this.prepQuery(req.query);
-        let features;
-        if (this.cache) {
-            features = await this.cachedFeatures(query);
-        } else {
-            features = await this.featureToggleServiceV2.getClientFeatures(
-                query,
-            );
+    private async resolveQuery(
+        req: IAuthRequest,
+    ): Promise<IFeatureToggleQuery> {
+        const { user, query } = req;
+
+        const override: QueryOverride = {};
+        if (user instanceof ApiUser) {
+            if (user.project !== ALL) {
+                override.project = [user.project];
+            }
+            if (user.environment !== ALL) {
+                override.environment = user.environment;
+            }
         }
-        res.json({ version, features });
+
+        const q = { ...query, ...override };
+        return this.prepQuery(q);
     }
 
-    async prepQuery({
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    private paramToArray(param: any) {
+        if (!param) {
+            return param;
+        }
+        return Array.isArray(param) ? param : [param];
+    }
+
+    private async prepQuery({
         tag,
         project,
         namePrefix,
@@ -86,29 +108,25 @@ export default class FeatureController extends Controller {
         return query;
     }
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    paramToArray(param: any) {
-        if (!param) {
-            return param;
+    async getAll(req: IAuthRequest, res: Response): Promise<void> {
+        const featureQuery = await this.resolveQuery(req);
+        let features;
+        if (this.cache) {
+            features = await this.cachedFeatures(featureQuery);
+        } else {
+            features = await this.featureToggleServiceV2.getClientFeatures(
+                featureQuery,
+            );
         }
-        return Array.isArray(param) ? param : [param];
+        res.json({ version, features, query: featureQuery });
     }
 
-    async getFeatureToggle(
-        req: Request<
-            { featureName: string },
-            any,
-            any,
-            { environment?: string }
-        >,
-        res: Response,
-    ): Promise<void> {
+    async getFeatureToggle(req: IAuthRequest, res: Response): Promise<void> {
         const name = req.params.featureName;
-        const { environment } = req.query;
-        const toggles = await this.featureToggleServiceV2.getClientFeatures({
-            namePrefix: name,
-            environment,
-        });
+        const featureQuery = await this.resolveQuery(req);
+        const q = { ...featureQuery, namePrefix: name };
+        const toggles = await this.featureToggleServiceV2.getClientFeatures(q);
+
         const toggle = toggles.find((t) => t.name === name);
         if (!toggle) {
             throw new NotFoundError(`Could not find feature toggle ${name}`);
@@ -116,5 +134,3 @@ export default class FeatureController extends Controller {
         res.json(toggle).end();
     }
 }
-
-module.exports = FeatureController;

--- a/src/lib/routes/client-api/metrics.test.ts
+++ b/src/lib/routes/client-api/metrics.test.ts
@@ -43,7 +43,6 @@ afterEach(() => {
 });
 
 test('should validate client metrics', () => {
-    expect.assertions(0);
     return request
         .post('/api/client/metrics')
         .send({ random: 'blush' })
@@ -51,7 +50,6 @@ test('should validate client metrics', () => {
 });
 
 test('should accept empty client metrics', () => {
-    expect.assertions(0);
     return request
         .post('/api/client/metrics')
         .send({
@@ -67,7 +65,6 @@ test('should accept empty client metrics', () => {
 });
 
 test('should accept client metrics with yes/no', () => {
-    expect.assertions(0);
     return request
         .post('/api/client/metrics')
         .send({
@@ -88,7 +85,6 @@ test('should accept client metrics with yes/no', () => {
 });
 
 test('should accept client metrics with variants', () => {
-    expect.assertions(0);
     return request
         .post('/api/client/metrics')
         .send({
@@ -113,7 +109,6 @@ test('should accept client metrics with variants', () => {
 });
 
 test('should accept client metrics without yes/no', () => {
-    expect.assertions(0);
     return request
         .post('/api/client/metrics')
         .send({
@@ -133,7 +128,7 @@ test('should accept client metrics without yes/no', () => {
         .expect(202);
 });
 
-test('shema allow empty strings', () => {
+test('schema allow empty strings', () => {
     const data = {
         appName: 'java-test',
         instanceId: 'instance y',

--- a/src/lib/routes/client-api/metrics.ts
+++ b/src/lib/routes/client-api/metrics.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import Controller from '../controller';
 import { IUnleashServices } from '../../types';
 import { IUnleashConfig } from '../../types/option';

--- a/src/lib/routes/client-api/metrics.ts
+++ b/src/lib/routes/client-api/metrics.ts
@@ -4,6 +4,9 @@ import { IUnleashServices } from '../../types';
 import { IUnleashConfig } from '../../types/option';
 import ClientMetricsService from '../../services/client-metrics';
 import { Logger } from '../../logger';
+import { IAuthRequest } from '../unleash-types';
+import ApiUser from '../../types/api-user';
+import { ALL } from '../../types/models/api-token';
 
 export default class ClientMetricsController extends Controller {
     logger: Logger;
@@ -23,13 +26,13 @@ export default class ClientMetricsController extends Controller {
         this.post('/', this.registerMetrics);
     }
 
-    async registerMetrics(
-        req: Request<any, any, any, any>,
-        res: Response,
-    ): Promise<void> {
-        const data = req.body;
-        const clientIp = req.ip;
-
+    async registerMetrics(req: IAuthRequest, res: Response): Promise<void> {
+        const { body: data, ip: clientIp, user } = req;
+        if (user instanceof ApiUser) {
+            if (user.environment !== ALL) {
+                data.environment = user.environment;
+            }
+        }
         await this.metrics.registerClientMetrics(data, clientIp);
         return res.status(202).end();
     }

--- a/src/lib/schema/api-token-schema.ts
+++ b/src/lib/schema/api-token-schema.ts
@@ -1,0 +1,17 @@
+import joi from 'joi';
+import { ALL, ApiTokenType } from '../types/models/api-token';
+
+export const createApiToken = joi
+    .object()
+    .keys({
+        username: joi.string().required(),
+        type: joi
+            .string()
+            .lowercase()
+            .required()
+            .valid(ApiTokenType.ADMIN, ApiTokenType.CLIENT),
+        expiresAt: joi.date().optional(),
+        project: joi.string().optional().default(ALL),
+        environment: joi.string().optional().default(ALL),
+    })
+    .options({ stripUnknown: true, allowUnknown: false, abortEarly: false });

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -115,9 +115,9 @@ async function start(opts: IUnleashOptions = {}): Promise<IUnleash> {
         if (config.db.disableMigration) {
             logger.info('DB migration: disabled');
         } else {
-            logger.info('DB migration: start');
+            logger.debug('DB migration: start');
             await migrateDb(config);
-            logger.info('DB migration: end');
+            logger.debug('DB migration: end');
         }
     } catch (err) {
         logger.error('Failed to migrate db', err);

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -88,7 +88,9 @@ export class ApiTokenService {
         const createNewToken = { ...creteTokenRequest, secret };
 
         try {
-            return await this.store.insert(createNewToken);
+            const token = await this.store.insert(createNewToken);
+            this.activeTokens.push(token);
+            return token;
         } catch (error) {
             if (error.code === FOREIGN_KEY_VIOLATION) {
                 let { message } = error;

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -65,6 +65,7 @@ export class ApiTokenService {
                 permissions,
                 project: token.project,
                 environment: token.environment,
+                type: token.type,
             });
         }
         return undefined;

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -4,7 +4,11 @@ import { ADMIN, CLIENT } from '../types/permissions';
 import { IUnleashStores } from '../types/stores';
 import { IUnleashConfig } from '../types/option';
 import ApiUser from '../types/api-user';
-import { ApiTokenType, IApiToken, IApiTokenCreate } from '../types/models/api-token';
+import {
+    ApiTokenType,
+    IApiToken,
+    IApiTokenCreate,
+} from '../types/models/api-token';
 import { IApiTokenStore } from '../types/stores/api-token-store';
 
 const ONE_MINUTE = 60_000;

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -79,7 +79,7 @@ export class ApiTokenService {
         return this.store.delete(secret);
     }
 
-    public async creteApiToken(
+    public async createApiToken(
         creteTokenRequest: Omit<IApiTokenCreate, 'secret'>,
     ): Promise<IApiToken> {
         const secret = this.generateSecretKey(creteTokenRequest);

--- a/src/lib/services/client-metrics/client-metrics-schema.ts
+++ b/src/lib/services/client-metrics/client-metrics-schema.ts
@@ -13,6 +13,7 @@ export const clientMetricsSchema = joi
     .object()
     .options({ stripUnknown: true })
     .keys({
+        environment: joi.string().optional(),
         appName: joi.string().required(),
         instanceId: joi.string().required(),
         bucket: joi

--- a/src/lib/types/api-user.ts
+++ b/src/lib/types/api-user.ts
@@ -1,3 +1,4 @@
+import { ApiTokenType } from './models/api-token';
 import { CLIENT } from './permissions';
 
 interface IApiUserData {
@@ -5,6 +6,7 @@ interface IApiUserData {
     permissions?: string[];
     project: string;
     environment: string;
+    type: ApiTokenType;
 }
 
 export default class ApiUser {
@@ -18,11 +20,14 @@ export default class ApiUser {
 
     readonly environment: string;
 
+    readonly type: ApiTokenType;
+
     constructor({
         username,
         permissions = [CLIENT],
         project,
         environment,
+        type,
     }: IApiUserData) {
         if (!username) {
             throw new TypeError('username is required');
@@ -31,6 +36,7 @@ export default class ApiUser {
         this.permissions = permissions;
         this.project = project;
         this.environment = environment;
+        this.type = type;
     }
 }
 

--- a/src/lib/types/api-user.ts
+++ b/src/lib/types/api-user.ts
@@ -3,21 +3,34 @@ import { CLIENT } from './permissions';
 interface IApiUserData {
     username: string;
     permissions?: string[];
+    project: string;
+    environment: string;
 }
 
 export default class ApiUser {
-    isAPI: boolean = true;
+    readonly isAPI: boolean = true;
 
-    username: string;
+    readonly username: string;
 
-    permissions: string[];
+    readonly permissions: string[];
 
-    constructor({ username, permissions = [CLIENT] }: IApiUserData) {
+    readonly project: string;
+
+    readonly environment: string;
+
+    constructor({
+        username,
+        permissions = [CLIENT],
+        project,
+        environment,
+    }: IApiUserData) {
         if (!username) {
             throw new TypeError('username is required');
         }
         this.username = username;
         this.permissions = permissions;
+        this.project = project;
+        this.environment = environment;
     }
 }
 

--- a/src/lib/types/models/api-token.ts
+++ b/src/lib/types/models/api-token.ts
@@ -1,0 +1,20 @@
+export enum ApiTokenType {
+    CLIENT = 'client',
+    ADMIN = 'admin',
+}
+
+export interface IApiTokenCreate {
+    secret: string;
+    username: string;
+    type: ApiTokenType;
+    environment: string;
+    project: string;
+    expiresAt?: Date;
+}
+
+export interface IApiToken extends IApiTokenCreate {
+    createdAt: Date;
+    seenAt?: Date;
+    environment: string;
+    project: string;
+}

--- a/src/lib/types/models/api-token.ts
+++ b/src/lib/types/models/api-token.ts
@@ -1,3 +1,5 @@
+export const ALL = '*';
+
 export enum ApiTokenType {
     CLIENT = 'client',
     ADMIN = 'admin',

--- a/src/lib/types/stores/api-token-store.ts
+++ b/src/lib/types/stores/api-token-store.ts
@@ -1,21 +1,5 @@
+import { IApiToken, IApiTokenCreate } from '../models/api-token';
 import { Store } from './store';
-
-export enum ApiTokenType {
-    CLIENT = 'client',
-    ADMIN = 'admin',
-}
-
-export interface IApiTokenCreate {
-    secret: string;
-    username: string;
-    type: ApiTokenType;
-    expiresAt?: Date;
-}
-
-export interface IApiToken extends IApiTokenCreate {
-    createdAt: Date;
-    seenAt?: Date;
-}
 
 export interface IApiTokenStore extends Store<IApiToken, string> {
     getAllActive(): Promise<IApiToken[]>;

--- a/src/lib/util/graceful-shutdown.ts
+++ b/src/lib/util/graceful-shutdown.ts
@@ -14,7 +14,7 @@ function registerGracefulShutdown(unleash: IUnleash, logger: Logger): void {
         }
     };
 
-    logger.info('Registering graceful shutdown');
+    logger.debug('Registering graceful shutdown');
 
     process.on('SIGINT', unleashCloser('SIGINT'));
     process.on('SIGHUP', unleashCloser('SIGHUP'));

--- a/src/migrations/20210913103159-api-keys-scoping.js
+++ b/src/migrations/20210913103159-api-keys-scoping.js
@@ -1,0 +1,19 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+          ALTER TABLE api_tokens ADD COLUMN project VARCHAR REFERENCES PROJECTS(id) ON DELETE CASCADE;; 
+          ALTER TABLE api_tokens ADD COLUMN environment VARCHAR REFERENCES environments(name) ON DELETE CASCADE;; 
+      `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE api_tokens DROP COLUMN project;
+        ALTER TABLE api_tokens DROP COLUMN environment;
+        `,
+        cb,
+    );
+};

--- a/src/test/e2e/api/admin/api-token.auth.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.auth.e2e.test.ts
@@ -1,7 +1,7 @@
 import { setupAppWithCustomAuth } from '../../helpers/test-helper';
 import dbInit from '../../helpers/database-init';
 import getLogger from '../../../fixtures/no-logger';
-import { ApiTokenType } from '../../../../lib/types/stores/api-token-store';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
 import { RoleName } from '../../../../lib/types/model';
 
 let stores;

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -1,7 +1,7 @@
 import { setupApp } from '../../helpers/test-helper';
 import dbInit from '../../helpers/database-init';
 import getLogger from '../../../fixtures/no-logger';
-import { ApiTokenType } from '../../../../lib/types/models/api-token';
+import { ALL, ApiTokenType } from '../../../../lib/types/models/api-token';
 
 let db;
 let app;
@@ -58,6 +58,25 @@ test('creates new admin token', async () => {
         .send({
             username: 'default-admin',
             type: 'admin',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(201)
+        .expect((res) => {
+            expect(res.body.username).toBe('default-admin');
+            expect(res.body.type).toBe('admin');
+            expect(res.body.createdAt).toBeTruthy();
+            expect(res.body.expiresAt).toBeFalsy();
+            expect(res.body.secret.length > 16).toBe(true);
+        });
+});
+
+test('creates new ADMIN token should fix casing', async () => {
+    expect.assertions(5);
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'ADMIN',
         })
         .set('Content-Type', 'application/json')
         .expect(201)
@@ -183,8 +202,8 @@ test('creates new client token: project & environment defaults to "*"', async ()
         .expect((res) => {
             expect(res.body.type).toBe('client');
             expect(res.body.secret.length > 16).toBe(true);
-            expect(res.body.environment).toBe('*');
-            expect(res.body.project).toBe('*');
+            expect(res.body.environment).toBe(ALL);
+            expect(res.body.project).toBe(ALL);
         });
 });
 

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -290,7 +290,7 @@ test('should not create token for invalid environment', async () => {
         });
 });
 
-test('should not create token for invalid environment', async () => {
+test('should not create token for invalid project & environment', async () => {
     return app.request
         .post('/api/admin/api-tokens')
         .send({

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -255,3 +255,50 @@ test('should prefix token with "project:environment."', async () => {
             expect(res.body.secret).toMatch(/default::global:\..*/);
         });
 });
+
+test('should not create token for invalid projectId', async () => {
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'admin',
+            project: 'bogus-project-something',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400)
+        .expect((res) => {
+            expect(res.body.details[0].message).toMatch(
+                /bogus-project-something/,
+            );
+        });
+});
+
+test('should not create token for invalid environment', async () => {
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'admin',
+            environment: 'bogus-environment-something',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400)
+        .expect((res) => {
+            expect(res.body.details[0].message).toMatch(
+                /bogus-environment-something/,
+            );
+        });
+});
+
+test('should not create token for invalid environment', async () => {
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'admin',
+            project: 'bogus-project-something',
+            environment: 'bogus-environment-something',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400);
+});

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -260,8 +260,8 @@ test('should not create token for invalid projectId', async () => {
     return app.request
         .post('/api/admin/api-tokens')
         .send({
-            username: 'default-admin',
-            type: 'admin',
+            username: 'default-client',
+            type: 'client',
             project: 'bogus-project-something',
         })
         .set('Content-Type', 'application/json')
@@ -277,8 +277,8 @@ test('should not create token for invalid environment', async () => {
     return app.request
         .post('/api/admin/api-tokens')
         .send({
-            username: 'default-admin',
-            type: 'admin',
+            username: 'default-client',
+            type: 'client',
             environment: 'bogus-environment-something',
         })
         .set('Content-Type', 'application/json')
@@ -298,6 +298,32 @@ test('should not create token for invalid project & environment', async () => {
             type: 'admin',
             project: 'bogus-project-something',
             environment: 'bogus-environment-something',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400);
+});
+
+test('admin token only supports ALL projects', async () => {
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'admin',
+            project: 'default',
+            environment: '*',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400);
+});
+
+test('admin token only supports ALL environments', async () => {
+    return app.request
+        .post('/api/admin/api-tokens')
+        .send({
+            username: 'default-admin',
+            type: 'admin',
+            project: '*',
+            environment: ':global:',
         })
         .set('Content-Type', 'application/json')
         .expect(400);

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -226,7 +226,7 @@ test('creates new client token with project & environment set', async () => {
         });
 });
 
-test('should prefix defaul token with "*:*."', async () => {
+test('should prefix default token with "*:*."', async () => {
     return app.request
         .post('/api/admin/api-tokens')
         .send({

--- a/src/test/e2e/api/client/feature.token.access.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.token.access.e2e.test.ts
@@ -1,0 +1,83 @@
+import { IUnleashTest, setupAppWithAuth } from '../../helpers/test-helper';
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import { ApiTokenService } from '../../../../lib/services/api-token-service';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
+
+let app: IUnleashTest;
+let db: ITestDb;
+
+let apiTokenService: ApiTokenService;
+
+const environment = 'testing';
+const project = 'default';
+const username = 'test';
+
+beforeAll(async () => {
+    db = await dbInit('feature_api_api_access_client', getLogger);
+    app = await setupAppWithAuth(db.stores);
+    apiTokenService = app.services.apiTokenService;
+
+    const { featureToggleServiceV2, environmentService } = app.services;
+    const { environmentStore } = db.stores;
+
+    await environmentStore.create({
+        name: environment,
+        displayName: '',
+        type: 'test',
+    });
+
+    await environmentService.addEnvironmentToProject(environment, project);
+
+    await featureToggleServiceV2.createFeatureToggle(
+        project,
+        {
+            name: 'f1.token.access',
+            description: 'the #1 feature',
+        },
+        username,
+    );
+
+    await featureToggleServiceV2.createStrategy(
+        {
+            name: 'default',
+            constraints: [],
+            parameters: {},
+        },
+        project,
+        'f1.token.access',
+    );
+
+    await featureToggleServiceV2.createStrategy(
+        {
+            name: 'custom-testing',
+            constraints: [],
+            parameters: {},
+        },
+        project,
+        'f1.token.access',
+        environment,
+    );
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+test('returns feature toggle with :global: config', async () => {
+    const token = await apiTokenService.createApiToken({
+        type: ApiTokenType.CLIENT,
+        username,
+        environment: ':global:',
+        project,
+    });
+    await app.request
+        .get('/api/client/features')
+        .set('Authorization', token.secret)
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.features).toHaveLength(1);
+        });
+});

--- a/src/test/e2e/api/client/metrics.e2e.access.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.e2e.access.e2e.test.ts
@@ -1,0 +1,45 @@
+import { setupApp, setupAppWithAuth } from '../../helpers/test-helper';
+import metricsExample from '../../../examples/client-metrics.json';
+import dbInit from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
+
+let app;
+let db;
+
+beforeAll(async () => {
+    db = await dbInit('metrics_api_client', getLogger);
+    app = await setupAppWithAuth(db.stores);
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+test('should enrich metrics with environment from api-token', async () => {
+    const { apiTokenService } = app.services;
+    const { environmentStore, clientMetricsStore } = db.stores;
+
+    await environmentStore.create({
+        name: 'some',
+        displayName: '',
+        type: 'test',
+    });
+
+    const token = await apiTokenService.createApiToken({
+        type: ApiTokenType.CLIENT,
+        username: 'test',
+        environment: 'some',
+        project: '*',
+    });
+
+    await app.request
+        .post('/api/client/metrics')
+        .set('Authorization', token.secret)
+        .send(metricsExample)
+        .expect(202);
+
+    const all = await clientMetricsStore.getAll();
+    expect(all[0].metrics.environment).toBe('some');
+});

--- a/src/test/e2e/api/client/metrics.e2e.access.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.e2e.access.e2e.test.ts
@@ -1,4 +1,4 @@
-import { setupApp, setupAppWithAuth } from '../../helpers/test-helper';
+import { setupAppWithAuth } from '../../helpers/test-helper';
 import metricsExample from '../../../examples/client-metrics.json';
 import dbInit from '../../helpers/database-init';
 import getLogger from '../../../fixtures/no-logger';

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -2,10 +2,7 @@ import dbInit from '../helpers/database-init';
 import getLogger from '../../fixtures/no-logger';
 import { ApiTokenService } from '../../../lib/services/api-token-service';
 import { createTestConfig } from '../../config/test-config';
-import {
-    ApiTokenType,
-    IApiToken,
-} from '../../../lib/types/stores/api-token-store';
+import { ApiTokenType, IApiToken } from '../../../lib/types/models/api-token';
 
 let db;
 let stores;
@@ -45,6 +42,8 @@ test('should create client token', async () => {
     const token = await apiTokenService.creteApiToken({
         username: 'default-client',
         type: ApiTokenType.CLIENT,
+        project: '*',
+        environment: '*',
     });
     const allTokens = await apiTokenService.getAllTokens();
 
@@ -59,6 +58,8 @@ test('should create admin token', async () => {
     const token = await apiTokenService.creteApiToken({
         username: 'admin',
         type: ApiTokenType.ADMIN,
+        project: '*',
+        environment: '*',
     });
 
     expect(token.secret.length > 32).toBe(true);
@@ -71,6 +72,8 @@ test('should set expiry of token', async () => {
         username: 'default-client',
         type: ApiTokenType.CLIENT,
         expiresAt: time,
+        project: '*',
+        environment: '*',
     });
 
     const [token] = await apiTokenService.getAllTokens();
@@ -86,6 +89,8 @@ test('should update expiry of token', async () => {
         username: 'default-client',
         type: ApiTokenType.CLIENT,
         expiresAt: time,
+        project: '*',
+        environment: '*',
     });
 
     await apiTokenService.updateExpiry(token.secret, newTime);
@@ -103,12 +108,16 @@ test('should only return valid tokens', async () => {
         username: 'default-expired',
         type: ApiTokenType.CLIENT,
         expiresAt: new Date('2021-01-01'),
+        project: '*',
+        environment: '*',
     });
 
     const activeToken = await apiTokenService.creteApiToken({
         username: 'default-valid',
         type: ApiTokenType.CLIENT,
         expiresAt: tomorrow,
+        project: '*',
+        environment: '*',
     });
 
     const tokens = await apiTokenService.getAllActiveTokens();

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -55,7 +55,7 @@ test('should create client token', async () => {
 });
 
 test('should create admin token', async () => {
-    const token = await apiTokenService.creteApiToken({
+    const token = await apiTokenService.createApiToken({
         username: 'admin',
         type: ApiTokenType.ADMIN,
         project: '*',

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -68,7 +68,7 @@ test('should create admin token', async () => {
 
 test('should set expiry of token', async () => {
     const time = new Date('2022-01-01');
-    await apiTokenService.creteApiToken({
+    await apiTokenService.createApiToken({
         username: 'default-client',
         type: ApiTokenType.CLIENT,
         expiresAt: time,
@@ -85,7 +85,7 @@ test('should update expiry of token', async () => {
     const time = new Date('2022-01-01');
     const newTime = new Date('2023-01-01');
 
-    const token = await apiTokenService.creteApiToken({
+    const token = await apiTokenService.createApiToken({
         username: 'default-client',
         type: ApiTokenType.CLIENT,
         expiresAt: time,
@@ -104,7 +104,7 @@ test('should only return valid tokens', async () => {
     const today = new Date();
     const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
 
-    await apiTokenService.creteApiToken({
+    await apiTokenService.createApiToken({
         username: 'default-expired',
         type: ApiTokenType.CLIENT,
         expiresAt: new Date('2021-01-01'),

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -112,7 +112,7 @@ test('should only return valid tokens', async () => {
         environment: '*',
     });
 
-    const activeToken = await apiTokenService.creteApiToken({
+    const activeToken = await apiTokenService.createApiToken({
         username: 'default-valid',
         type: ApiTokenType.CLIENT,
         expiresAt: tomorrow,

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -39,7 +39,7 @@ test('should have empty list of tokens', async () => {
 });
 
 test('should create client token', async () => {
-    const token = await apiTokenService.creteApiToken({
+    const token = await apiTokenService.createApiToken({
         username: 'default-client',
         type: ApiTokenType.CLIENT,
         project: '*',

--- a/src/test/fixtures/fake-api-token-store.ts
+++ b/src/test/fixtures/fake-api-token-store.ts
@@ -1,8 +1,6 @@
-import {
-    IApiToken,
-    IApiTokenCreate,
-    IApiTokenStore,
-} from '../../lib/types/stores/api-token-store';
+import { IApiTokenStore } from '../../lib/types/stores/api-token-store';
+import { IApiToken, IApiTokenCreate } from '../../lib/types/models/api-token';
+
 import NotFoundError from '../../lib/error/notfound-error';
 
 export default class FakeApiTokenStore implements IApiTokenStore {


### PR DESCRIPTION
Add support for scoping api-tokens to project and/or environments. Unleash still support global tokens via the wildcard selector (`"*"`). This will essentially reduce "what" an API token can consume. '

We have also extended the secret part to encode both project and environment info in to the token. Examples:

- `default:development.7e35e0bcdd6a3d51f9ed18` - only default project and only development environment. 
- `*:development.7e35e0bcdd6a3d51f9ed18` - all project but only development environment. 
- `*:*.7e35e0bcdd6a3d51f9ed18` - wildcard on both project and environment.
- `default:*.7e35e0bcdd6a3d51f9ed18` - all envs on default project. 




TODO:

- [x] api-token api should fail with `400` and not `500` if the user specifies an illegal project or environment. 
- [x] /api/client/features have no unit tests for verifying the project and environment is picked from the token. 
- [x] /api/client/metrics should also pick env from token. 
- [x] client tokens can still "READ" /api/admin resources. We should limit the access to only allow /api/client routes. 
- [x] admin tokens can not be scoped (yet)