### PR TITLE
docs: add reference to developer-guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Before you begin:
 - This application is powered by Node.js v14.
 - Have you read the [code of conduct](CODE_OF_CONDUCT.md)?
 - Check out the [existing issues](https://github.com/unleash/Unleash/issues)
+- Browse the [developer-guide](./websitev2/docs/contributing/developer-guide.md) for tips on environment setup, running the tests, and running Unleash from source.
 
 ### Don't see your issue? Open one
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ _(PS! feel free to submit your logo!)_
 
 # Contribute to Unleash
 
-Unleash has been built with the help of many smart individuals. This ensures that we build a product that solves real problems for people. If you want to contribute to this project you are encouraged to send issue requests, or provide pull-requests. Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) to learn more on how you can contribute.
+Unleash has been built with the help of many smart individuals. This ensures that we build a product that solves real problems for people. If you want to contribute to this project you are encouraged to send issue requests, or provide pull-requests.
+
+1. Read [CONTRIBUTING.md](./CONTRIBUTING.md) to learn more on how you can contribute
+1. Browse the [developer-guide](./websitev2/docs/contributing/developer-guide.md) for tips on environment setup, running the tests, and running Unleash from source.
 
 # Community and Help
 


### PR DESCRIPTION
I didn't know about the developer-guide until it was mentioned to me in #1031.

This small PR places that link in the README and CONTRIBUTING docs, two places where newcomers commonly look to learn how to work with the code on the road to contributing.