### PR TITLE
Create a apiuser for demo auth.

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -94,7 +94,12 @@ export default function getApp(
         }
         case IAuthType.DEMO: {
             app.use(baseUriPath, apiTokenMiddleware(config, services));
-            demoAuthentication(app, config.server.baseUriPath, services);
+            demoAuthentication(
+                app,
+                config.server.baseUriPath,
+                services,
+                config,
+            );
             break;
         }
         case IAuthType.CUSTOM: {
@@ -107,7 +112,13 @@ export default function getApp(
             break;
         }
         default: {
-            demoAuthentication(app, config.server.baseUriPath, services);
+            app.use(baseUriPath, apiTokenMiddleware(config, services));
+            demoAuthentication(
+                app,
+                config.server.baseUriPath,
+                services,
+                config,
+            );
             break;
         }
     }


### PR DESCRIPTION
- If api token middleware is disabled, still allow calls to /api/client with a
  populated fake api user with client access.