### PR TITLE
feat: pool min 1, max 4 DB connections & limit Jest workers to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "jest": {
     "automock": false,
+    "maxWorkers": 4,
     "setupFiles": [
       "./setupJest.js"
     ],

--- a/src/test/e2e/helpers/database-init.ts
+++ b/src/test/e2e/helpers/database-init.ts
@@ -84,7 +84,7 @@ export default async function init(
     const config = createTestConfig({
         db: {
             ...getDbConfig(),
-            pool: { min: 2, max: 8 },
+            pool: { min: 1, max: 4 },
             schema: databaseSchema,
             ssl: false,
         },


### PR DESCRIPTION
Hi! :wave:

The tests are very flaky on my macbook running macOS Big Sur, but they consistently pass if I run them with no parallelism. The culprit seems to be too many connections to the Postgres database:

![image](https://user-images.githubusercontent.com/1404650/138903327-33d30a83-208c-4e7d-a9e9-27034f21521e.png)

Postgres defaults to allowing 100 connections (plus 15 extra for the superuser). The e2e tests (at least) are initialised with min 2, max 8 pooled connections.

Since Jest defaults to running each test file as its own worker (limited to `number of CPU cores - 1)`, that 2-to-8 connection count scales drastically. I monitored the number of connections through a test run, and it quickly spins out of control:

```
connections at 17:23:40:    1
connections at 17:23:41:    1
connections at 17:23:42:    5
connections at 17:23:43:    9
connections at 17:23:44:   12
connections at 17:23:45:   18
connections at 17:23:47:   29
connections at 17:23:48:   33
connections at 17:23:49:   32
connections at 17:23:50:   46
connections at 17:23:51:   63
connections at 17:23:52:   63
connections at 17:23:53:   61
connections at 17:23:54:   73
connections at 17:23:55:   79
connections at 17:23:56:  [errored]
connections at 17:23:58:   97
connections at 17:23:59:  [errored]
connections at 17:24:00:  [errored]
```

I tried only tweaking the size of the database pool. When I forced it to for example min 2 and max 2 connections, a bunch of test suites got stuck in their `beforeEach` blocks, presumably waiting for a connection even though I never saw more than 31 concurrent Postgres connections. Not entirely sure what's up with that.

Either way, I think it makes sense to set a sensible limit on both the database connection pool and on the number of Jest workers.

With the database pool set to min=1 and max=4, as well as Jest's maxWorkers set to 4, the tests pass consistently on my machine. I've seen it take in the range of 55–63 seconds.

Do you think these changes make sense?