### PR TITLE
fix: update mime library method signature to 2.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/jest": "27.0.2",
     "@types/js-yaml": "4.0.4",
     "@types/memoizee": "0.4.6",
+    "@types/mime": "2.0.3",
     "@types/node": "16.6.1",
     "@types/node-fetch": "2.5.12",
     "@types/nodemailer": "6.4.4",

--- a/src/lib/services/state-util.ts
+++ b/src/lib/services/state-util.ts
@@ -12,7 +12,7 @@ export const readFile: (file: string) => Promise<string> = (file) =>
 export const parseFile: (file: string, data: string) => any = (
     file: string,
     data: string,
-) => (mime.lookup(file) === 'text/yaml' ? YAML.load(data) : JSON.parse(data));
+) => (mime.getType(file) === 'text/yaml' ? YAML.load(data) : JSON.parse(data));
 
 export const filterExisting: (
     keepExisting: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,6 +807,11 @@
   resolved "https://registry.yarnpkg.com/@types/memoizee/-/memoizee-0.4.6.tgz#a4ba7a3ea61fa45be916f148763bec2ca38c34cf"
   integrity sha512-qJezGqoi3pW9Pset2w1Gfv8jATvmHHHnpO9Dq8x8pJGyYIpiUZJqRU0NM7xenmN0AcXEe7vqshI8H98KeFLYcg==
 
+"@types/mime@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz"


### PR DESCRIPTION
Due to this error unleash.start({import: {file: './some_file.yaml'}}) is currently not possible

Originally done here
https://github.com/Unleash/unleash/commit/c66545e11e08c90d47bfda0fe051dec03a7a40be