### PR TITLE
Wrap the client into an event listener in the quickstart doc

### DIFF
--- a/website/docs/user_guide/quickstart.md
+++ b/website/docs/user_guide/quickstart.md
@@ -46,15 +46,17 @@ const unleash = new UnleashClient({
   appName: 'my-webapp',
 });
 
+unleash.on('synchronized', () => {
+  if (unleash.isEnabled('proxy.demo')) {
+    // do something
+  }
+});
+
 // Used to set the context fields, shared with the Unleash Proxy
 unleash.updateContext({ userId: '1233' });
 
 // Start the background polling
 unleash.start();
-
-if (unleash.isEnabled('proxy.demo')) {
-  // do something
-}
 ```
 
 Now you are ready to use the feature toggle you created in your client side application, using the appropriate proxy SDK.


### PR DESCRIPTION
This is a follow-up to https://github.com/Unleash/unleash-proxy-client-js/pull/43. Checking the feature toggles right after initializing the client can be misleading. The rest of the document already suggests using event emitter.

There's one thing I'm unsure about though: the `synchronized` event is not listed in the [Readme of unleash-proxy-client](https://github.com/Unleash/unleash-proxy-client-js#available-events). Is/was there such an event? 