### PR TITLE
fix: prevent deadlock for batchinserting usage metrics

### DIFF
--- a/src/test/e2e/api/admin/client-metrics.e2e.test.ts
+++ b/src/test/e2e/api/admin/client-metrics.e2e.test.ts
@@ -155,14 +155,19 @@ test('should return toggle summary', async () => {
         .expect('Content-Type', /json/)
         .expect(200);
 
+    const test = demo.lastHourUsage.find((u) => u.environment === 'test');
+    const defaultEnv = demo.lastHourUsage.find(
+        (u) => u.environment === 'default',
+    );
+
     expect(demo.featureName).toBe('demo');
     expect(demo.lastHourUsage).toHaveLength(2);
-    expect(demo.lastHourUsage[0].environment).toBe('default');
-    expect(demo.lastHourUsage[0].yes).toBe(5);
-    expect(demo.lastHourUsage[0].no).toBe(4);
-    expect(demo.lastHourUsage[1].environment).toBe('test');
-    expect(demo.lastHourUsage[1].yes).toBe(2);
-    expect(demo.lastHourUsage[1].no).toBe(6);
+    expect(test.environment).toBe('test');
+    expect(test.yes).toBe(2);
+    expect(test.no).toBe(6);
+    expect(defaultEnv.environment).toBe('default');
+    expect(defaultEnv.yes).toBe(5);
+    expect(defaultEnv.no).toBe(4);
     expect(demo.seenApplications).toStrictEqual(['backend-api', 'web']);
 });
 
@@ -219,13 +224,18 @@ test('should only include last hour of metrics return toggle summary', async () 
         .expect('Content-Type', /json/)
         .expect(200);
 
+    const test = demo.lastHourUsage.find((u) => u.environment === 'test');
+    const defaultEnv = demo.lastHourUsage.find(
+        (u) => u.environment === 'default',
+    );
+
     expect(demo.featureName).toBe('demo');
     expect(demo.lastHourUsage).toHaveLength(2);
-    expect(demo.lastHourUsage[0].environment).toBe('default');
-    expect(demo.lastHourUsage[0].yes).toBe(5);
-    expect(demo.lastHourUsage[0].no).toBe(4);
-    expect(demo.lastHourUsage[1].environment).toBe('test');
-    expect(demo.lastHourUsage[1].yes).toBe(2);
-    expect(demo.lastHourUsage[1].no).toBe(6);
+    expect(defaultEnv.environment).toBe('default');
+    expect(defaultEnv.yes).toBe(5);
+    expect(defaultEnv.no).toBe(4);
+    expect(test.environment).toBe('test');
+    expect(test.yes).toBe(2);
+    expect(test.no).toBe(6);
     expect(demo.seenApplications).toStrictEqual(['backend-api', 'web']);
 });


### PR DESCRIPTION
In client metrics v2 we utilize postgres to count the usage
across a few dimensions (feature_name, app_name, environment).

It turns out that if the UPDATE values are not executed in a predictable
order we can end up in a deadlock scenario with postgresql.

**We discovered this while testing in production, behind a feature flag.** 

In this fix we thus sort the metrics on the `feature_name`, `app_name` and
`environment`, to make sure they always are executed in a predictable
order, and thus avoiding independent inserts colliding in to a deadlock
waiting for each-other.