### PR TITLE
docs: Updated maven coordinates for java sdk

### DIFF
--- a/website/docs/sdks/java.md
+++ b/website/docs/sdks/java.md
@@ -13,7 +13,7 @@ First we must add Unleash Client SDK as a dependency to your project. Below is a
 
 ```xml
 <dependency>
-    <groupId>no.finn.unleash</groupId>
+    <groupId>io.getunleash</groupId>
     <artifactId>unleash-client-java</artifactId>
     <version>Latest version here</version>
 </dependency>


### PR DESCRIPTION
From 5.0 java sdk we've moved our maven coords to `io.getunleash`