### PR TITLE
chore: upped postgres version for Heroku.

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "10"
+        "version": "13"
       }
     }
   ]


### PR DESCRIPTION
Heroku no longer supports Postgres 10. Upped to version number to the latest version supported, 13.