### PR TITLE
Feat/variant api

### DIFF
--- a/.github/workflows/build_doc_prs.yaml
+++ b/.github/workflows/build_doc_prs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: setup git config
+      - name: Build docs
         run: |
           # Build the site
           cd website && yarn && yarn build

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -167,6 +167,13 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         };
     }
 
+    rowToVariants(row: FeaturesTable): IVariant[] {
+        if (!row) {
+            throw new NotFoundError('No feature toggle found');
+        }
+        return row.variants as unknown as IVariant[];
+    }
+
     dtoToRow(project: string, data: FeatureToggleDTO): FeaturesTable {
         const row = {
             name: data.name,
@@ -229,6 +236,24 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         const row = await this.db(TABLE)
             .where({ name })
             .update({ archived: false })
+            .returning(FEATURE_COLUMNS);
+        return this.rowToFeature(row[0]);
+    }
+
+    async getVariants(featureName: string): Promise<IVariant[]> {
+        const row = await this.db(TABLE)
+            .select('variants')
+            .where({ name: featureName });
+        return this.rowToVariants(row[0]);
+    }
+
+    async saveVariants(
+        featureName: string,
+        newVariants: IVariant[],
+    ): Promise<FeatureToggle> {
+        const row = await this.db(TABLE)
+            .update({ variants: newVariants })
+            .where({ name: featureName })
             .returning(FEATURE_COLUMNS);
         return this.rowToFeature(row[0]);
     }

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -171,7 +171,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         if (!row) {
             throw new NotFoundError('No feature toggle found');
         }
-        return row.variants as unknown as IVariant[];
+        return (row.variants as unknown as IVariant[]) || [];
     }
 
     dtoToRow(project: string, data: FeatureToggleDTO): FeaturesTable {

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -252,7 +252,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         newVariants: IVariant[],
     ): Promise<FeatureToggle> {
         const row = await this.db(TABLE)
-            .update({ variants: newVariants })
+            .update({ variants: JSON.stringify(newVariants) })
             .where({ name: featureName })
             .returning(FEATURE_COLUMNS);
         return this.rowToFeature(row[0]);

--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -6,6 +6,7 @@ import ProjectFeaturesController from './features';
 import EnvironmentsController from './environments';
 import ProjectHealthReport from './health-report';
 import ProjectService from '../../../services/project-service';
+import VariantsController from './variants';
 
 export default class ProjectApi extends Controller {
     private projectService: ProjectService;
@@ -17,6 +18,7 @@ export default class ProjectApi extends Controller {
         this.use('/', new ProjectFeaturesController(config, services).router);
         this.use('/', new EnvironmentsController(config, services).router);
         this.use('/', new ProjectHealthReport(config, services).router);
+        this.use('/', new VariantsController(config, services).router);
     }
 
     async getProjects(req: Request, res: Response): Promise<void> {

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -1,0 +1,72 @@
+import FeatureToggleService from '../../../services/feature-toggle-service';
+import { Logger } from '../../../logger';
+import Controller from '../../controller';
+import { IUnleashConfig } from '../../../types/option';
+import { IUnleashServices } from '../../../types';
+import { Request, Response } from 'express';
+import { Operation } from 'fast-json-patch';
+import { UPDATE_FEATURE } from '../../../types/permissions';
+import { IVariant } from '../../../types/model';
+
+const PREFIX = '/:projectId/features/:featureName/variants';
+
+interface FeatureParams extends ProjectParam {
+    featureName: string;
+}
+
+interface ProjectParam {
+    projectId: string;
+}
+
+export default class VariantsController extends Controller {
+    private logger: Logger;
+
+    private featureService: FeatureToggleService;
+
+    constructor(
+        config: IUnleashConfig,
+        {
+            featureToggleService,
+        }: Pick<IUnleashServices, 'featureToggleService'>,
+    ) {
+        super(config);
+        this.logger = config.getLogger('admin-api/project/variants.ts');
+        this.featureService = featureToggleService;
+        this.get(PREFIX, this.getVariants);
+        this.patch(PREFIX, this.patchVariants, UPDATE_FEATURE);
+        this.put(PREFIX, this.overwriteVariants, UPDATE_FEATURE);
+    }
+
+    async getVariants(
+        req: Request<FeatureParams, any, any, any>,
+        res: Response,
+    ): Promise<void> {
+        const { featureName } = req.params;
+        const variants = await this.featureService.getVariants(featureName);
+        res.status(200).json({ version: '1', variants: variants || [] });
+    }
+
+    async patchVariants(
+        req: Request<FeatureParams, any, Operation[], any>,
+        res: Response,
+    ): Promise<void> {
+        const { featureName } = req.params;
+        const updatedFeature = await this.featureService.updateVariants(
+            featureName,
+            req.body,
+        );
+        res.status(200).json(updatedFeature);
+    }
+
+    async overwriteVariants(
+        req: Request<FeatureParams, any, IVariant[], any>,
+        res: Response,
+    ): Promise<void> {
+        const { featureName } = req.params;
+        const updatedFeature = await this.featureService.saveVariants(
+            featureName,
+            req.body,
+        );
+        res.status(200).json(updatedFeature);
+    }
+}

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -70,6 +70,9 @@ export default class VariantsController extends Controller {
             featureName,
             req.body,
         );
-        res.status(200).json(updatedFeature);
+        res.status(200).json({
+            version: '1',
+            variants: updatedFeature.variants,
+        });
     }
 }

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -43,7 +43,7 @@ export default class VariantsController extends Controller {
     ): Promise<void> {
         const { featureName } = req.params;
         const variants = await this.featureService.getVariants(featureName);
-        res.status(200).json({ version: '1', variants: variants || [] });
+        res.status(200).json({ version: '1', variants });
     }
 
     async patchVariants(
@@ -57,7 +57,7 @@ export default class VariantsController extends Controller {
         );
         res.status(200).json({
             version: '1',
-            variants: updatedFeature.variants || [],
+            variants: updatedFeature.variants,
         });
     }
 

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -55,7 +55,10 @@ export default class VariantsController extends Controller {
             featureName,
             req.body,
         );
-        res.status(200).json(updatedFeature);
+        res.status(200).json({
+            version: '1',
+            variants: updatedFeature.variants || [],
+        });
     }
 
     async overwriteVariants(

--- a/src/lib/schema/feature-schema.ts
+++ b/src/lib/schema/feature-schema.ts
@@ -42,6 +42,8 @@ export const variantsSchema = joi.object().keys({
     ),
 });
 
+export const variantsArraySchema = joi.array().min(0).items(variantsSchema);
+
 export const featureMetadataSchema = joi
     .object()
     .keys({

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -932,6 +932,11 @@ class FeatureToggleService {
 
         let fixedWeights = fixedVariants.reduce((a, v) => a + v.weight, 0);
 
+        if (fixedWeights > 1000) {
+            throw new BadDataError(
+                'The traffic distribution total must equal 100%',
+            );
+        }
         let averageWeight = Math.floor(
             (1000 - fixedWeights) / variableVariants.length,
         );

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -40,6 +40,7 @@ import {
     IFeatureStrategy,
     IFeatureToggleQuery,
     IStrategyConfig,
+    IVariant,
 } from '../types/model';
 import { IFeatureEnvironmentStore } from '../types/stores/feature-environment-store';
 import { IFeatureToggleClientStore } from '../types/stores/feature-toggle-client-store';
@@ -387,6 +388,15 @@ class FeatureToggleService {
             featureName,
             archived,
         );
+    }
+
+    /**
+     * GET /api/admin/projects/:project/features/:featureName/variants
+     * @param featureName
+     * @return The list of variants
+     */
+    async getVariants(featureName: string): Promise<IVariant[]> {
+        return this.featureToggleStore.getVariants(featureName);
     }
 
     async getFeatureMetadata(featureName: string): Promise<FeatureToggle> {
@@ -881,6 +891,16 @@ class FeatureToggleService {
             featureName,
             newProjectId,
         );
+    }
+
+    async updateVariants(featureName: string, newVariants: Operation[]) {
+        const oldVariants = await this.getVariants(featureName);
+        const { newDocument } = await applyPatch(oldVariants, newVariants);
+        await this.saveVariants(featureName, newDocument);
+    }
+
+    async saveVariants(featureName: string, newVariants: IVariant[]) {
+        this.featureToggleStore.saveVariants(featureName, newVariants);
     }
 }
 

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -5,7 +5,12 @@ import BadDataError from '../error/bad-data-error';
 import NameExistsError from '../error/name-exists-error';
 import InvalidOperationError from '../error/invalid-operation-error';
 import { FOREIGN_KEY_VIOLATION } from '../error/db-error';
-import { featureMetadataSchema, nameSchema } from '../schema/feature-schema';
+import {
+    featureMetadataSchema,
+    nameSchema,
+    variantsArraySchema,
+    variantsSchema,
+} from '../schema/feature-schema';
 import {
     FeatureArchivedEvent,
     FeatureChangeProjectEvent,
@@ -906,6 +911,7 @@ class FeatureToggleService {
         featureName: string,
         newVariants: IVariant[],
     ): Promise<FeatureToggle> {
+        await variantsArraySchema.validateAsync(newVariants);
         return this.featureToggleStore.saveVariants(featureName, newVariants);
     }
 }

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -45,6 +45,7 @@ import {
     IFeatureToggleQuery,
     IStrategyConfig,
     IVariant,
+    WeightType,
 } from '../types/model';
 import { IFeatureEnvironmentStore } from '../types/stores/feature-environment-store';
 import { IFeatureToggleClientStore } from '../types/stores/feature-toggle-client-store';
@@ -917,7 +918,7 @@ class FeatureToggleService {
 
     fixVariantWeights(variants: IVariant[]): IVariant[] {
         let variableVariants = variants.filter((x) => {
-            return x.weightType === 'variable';
+            return x.weightType === WeightType.VARIABLE;
         });
 
         if (variants.length > 0 && variableVariants.length === 0) {
@@ -927,7 +928,7 @@ class FeatureToggleService {
         }
 
         let fixedVariants = variants.filter((x) => {
-            return x.weightType === 'fix';
+            return x.weightType === WeightType.FIX;
         });
 
         let fixedWeights = fixedVariants.reduce((a, v) => a + v.weight, 0);

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -9,7 +9,6 @@ import {
     featureMetadataSchema,
     nameSchema,
     variantsArraySchema,
-    variantsSchema,
 } from '../schema/feature-schema';
 import {
     FeatureArchivedEvent,
@@ -51,7 +50,6 @@ import { IFeatureEnvironmentStore } from '../types/stores/feature-environment-st
 import { IFeatureToggleClientStore } from '../types/stores/feature-toggle-client-store';
 import { DEFAULT_ENV } from '../util/constants';
 import { applyPatch, deepClone, Operation } from 'fast-json-patch';
-import { ValidationError } from 'joi';
 
 interface IFeatureContext {
     featureName: string;

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -893,14 +893,20 @@ class FeatureToggleService {
         );
     }
 
-    async updateVariants(featureName: string, newVariants: Operation[]) {
+    async updateVariants(
+        featureName: string,
+        newVariants: Operation[],
+    ): Promise<FeatureToggle> {
         const oldVariants = await this.getVariants(featureName);
         const { newDocument } = await applyPatch(oldVariants, newVariants);
-        await this.saveVariants(featureName, newDocument);
+        return this.saveVariants(featureName, newDocument);
     }
 
-    async saveVariants(featureName: string, newVariants: IVariant[]) {
-        this.featureToggleStore.saveVariants(featureName, newVariants);
+    async saveVariants(
+        featureName: string,
+        newVariants: IVariant[],
+    ): Promise<FeatureToggle> {
+        return this.featureToggleStore.saveVariants(featureName, newVariants);
     }
 }
 

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -937,12 +937,18 @@ class FeatureToggleService {
                 'The traffic distribution total must equal 100%',
             );
         }
+
         let averageWeight = Math.floor(
             (1000 - fixedWeights) / variableVariants.length,
         );
+        let remainder = (1000 - fixedWeights) % variableVariants.length;
 
         variableVariants = variableVariants.map((x) => {
             x.weight = averageWeight;
+            if (remainder > 0) {
+                x.weight += 1;
+                remainder--;
+            }
             return x;
         });
         return variableVariants.concat(fixedVariants);

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -8,7 +8,10 @@ export interface IConstraint {
     operator: string;
     values: string[];
 }
-
+export enum WeightType {
+    VARIABLE = 'variable',
+    FIX = 'fix',
+}
 export interface IStrategyConfig {
     id?: string;
     name: string;

--- a/src/lib/types/stores/feature-toggle-store.ts
+++ b/src/lib/types/stores/feature-toggle-store.ts
@@ -1,4 +1,4 @@
-import { FeatureToggle, FeatureToggleDTO } from '../model';
+import { FeatureToggle, FeatureToggleDTO, IVariant } from '../model';
 import { Store } from './store';
 
 export interface IFeatureToggleQuery {
@@ -16,4 +16,9 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
     archive(featureName: string): Promise<FeatureToggle>;
     revive(featureName: string): Promise<FeatureToggle>;
     getAll(query?: Partial<IFeatureToggleQuery>): Promise<FeatureToggle[]>;
+    getVariants(featureName: string): Promise<IVariant[]>;
+    saveVariants(
+        featureName: string,
+        newVariants: IVariant[],
+    ): Promise<FeatureToggle>;
 }

--- a/src/test/e2e/api/admin/client-metrics.e2e.test.ts
+++ b/src/test/e2e/api/admin/client-metrics.e2e.test.ts
@@ -173,7 +173,7 @@ test('should return toggle summary', async () => {
 
 test('should only include last hour of metrics return toggle summary', async () => {
     const now = new Date();
-    const dateOneHourAgo = subHours(now, 1);
+    const dateTwoHoursAgo = subHours(now, 2);
     const metrics: IClientMetricsEnv[] = [
         {
             featureName: 'demo',
@@ -211,7 +211,7 @@ test('should only include last hour of metrics return toggle summary', async () 
             featureName: 'demo',
             appName: 'backend-api',
             environment: 'test',
-            timestamp: dateOneHourAgo,
+            timestamp: dateTwoHoursAgo,
             yes: 55,
             no: 55,
         },

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -442,6 +442,9 @@ test('Patching with a fixed variant and variable variants splits remaining weigh
         .expect((res) => {
             let body = res.body;
             expect(body.variants).toHaveLength(7);
+            expect(
+                body.variants.reduce((total, v) => total + v.weight, 0),
+            ).toEqual(1000);
             body.variants.sort((a, b) => b.weight - a.weight);
             expect(
                 body.variants.find((v) => v.name === 'variant1').weight,

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -1,6 +1,7 @@
 import { IUnleashTest, setupApp } from '../../../helpers/test-helper';
 import dbInit, { ITestDb } from '../../../helpers/database-init';
 import getLogger from '../../../../fixtures/no-logger';
+import * as jsonpatch from 'fast-json-patch';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -36,5 +37,120 @@ test('Can get variants for a feature', async () => {
             expect(res.body.version).toBe('1');
             expect(res.body.variants).toHaveLength(1);
             expect(res.body.variants[0].name).toBe(variantName);
+        });
+});
+
+test('Can patch variants for a feature and get a response of new variant', async () => {
+    const featureName = 'feature-variants-patch';
+    const variantName = 'fancy-variant-patch';
+    const expectedVariantName = 'not-so-cool-variant-name';
+    const variants = [
+        {
+            name: variantName,
+            stickiness: 'default',
+            weight: 100,
+            weightType: 'variable',
+        },
+    ];
+
+    await db.stores.featureToggleStore.create('default', {
+        name: featureName,
+        variants,
+    });
+
+    const observer = jsonpatch.observe(variants);
+    variants[0].name = expectedVariantName;
+    const patch = jsonpatch.generate(observer);
+
+    await app.request
+        .patch(`/api/admin/projects/default/features/${featureName}/variants`)
+        .send(patch)
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.version).toBe('1');
+            expect(res.body.variants).toHaveLength(1);
+            expect(res.body.variants[0].name).toBe(expectedVariantName);
+        });
+});
+
+test('Can add variant for a feature', async () => {
+    const featureName = 'feature-variants-patch-add';
+    const variantName = 'fancy-variant-patch';
+    const expectedVariantName = 'not-so-cool-variant-name';
+    const variants = [
+        {
+            name: variantName,
+            stickiness: 'default',
+            weight: 100,
+            weightType: 'variable',
+        },
+    ];
+
+    await db.stores.featureToggleStore.create('default', {
+        name: featureName,
+        variants,
+    });
+
+    const observer = jsonpatch.observe(variants);
+    variants.push({
+        name: expectedVariantName,
+        stickiness: 'default',
+        weight: 100,
+        weightType: 'variable',
+    });
+    const patch = jsonpatch.generate(observer);
+
+    await app.request
+        .patch(`/api/admin/projects/default/features/${featureName}/variants`)
+        .send(patch)
+        .expect(200);
+
+    await app.request
+        .get(`/api/admin/projects/default/features/${featureName}/variants`)
+        .expect((res) => {
+            console.log(res.body);
+            expect(res.body.version).toBe('1');
+            expect(res.body.variants).toHaveLength(2);
+            expect(
+                res.body.variants.find((x) => x.name === expectedVariantName),
+            ).toBeTruthy();
+            expect(
+                res.body.variants.find((x) => x.name === variantName),
+            ).toBeTruthy();
+        });
+});
+
+test('Can remove variant for a feature', async () => {
+    const featureName = 'feature-variants-patch-remove';
+    const variantName = 'fancy-variant-patch';
+    const variants = [
+        {
+            name: variantName,
+            stickiness: 'default',
+            weight: 100,
+            weightType: 'variable',
+        },
+    ];
+
+    await db.stores.featureToggleStore.create('default', {
+        name: featureName,
+        variants,
+    });
+
+    const observer = jsonpatch.observe(variants);
+    variants.pop();
+    const patch = jsonpatch.generate(observer);
+
+    await app.request
+        .patch(`/api/admin/projects/default/features/${featureName}/variants`)
+        .send(patch)
+        .expect(200);
+
+    await app.request
+        .get(`/api/admin/projects/default/features/${featureName}/variants`)
+        .expect((res) => {
+            console.log(res.body);
+            expect(res.body.version).toBe('1');
+            expect(res.body.variants).toHaveLength(0);
         });
 });

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -322,10 +322,11 @@ test('PATCHING with all variable weightTypes forces weights to sum to no less th
         .send(patch)
         .expect(200)
         .expect((res) => {
+            res.body.variants.sort((v, other) => other.weight - v.weight);
             expect(res.body.variants).toHaveLength(3);
-            expect(
-                res.body.variants.every((x) => x.weight === 333),
-            ).toBeTruthy();
+            expect(res.body.variants[0].weight).toBe(334);
+            expect(res.body.variants[1].weight).toBe(333);
+            expect(res.body.variants[2].weight).toBe(333);
         });
 
     newVariants.push({
@@ -441,21 +442,22 @@ test('Patching with a fixed variant and variable variants splits remaining weigh
         .expect((res) => {
             let body = res.body;
             expect(body.variants).toHaveLength(7);
+            body.variants.sort((a, b) => b.weight - a.weight);
             expect(
                 body.variants.find((v) => v.name === 'variant1').weight,
             ).toEqual(900);
             expect(
                 body.variants.find((v) => v.name === 'variant2').weight,
-            ).toEqual(16);
+            ).toEqual(17);
             expect(
                 body.variants.find((v) => v.name === 'variant3').weight,
-            ).toEqual(16);
+            ).toEqual(17);
             expect(
                 body.variants.find((v) => v.name === 'variant4').weight,
-            ).toEqual(16);
+            ).toEqual(17);
             expect(
                 body.variants.find((v) => v.name === 'variant5').weight,
-            ).toEqual(16);
+            ).toEqual(17);
             expect(
                 body.variants.find((v) => v.name === 'variant6').weight,
             ).toEqual(16);

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -1,0 +1,40 @@
+import { IUnleashTest, setupApp } from '../../../helpers/test-helper';
+import dbInit, { ITestDb } from '../../../helpers/database-init';
+import getLogger from '../../../../fixtures/no-logger';
+
+let app: IUnleashTest;
+let db: ITestDb;
+
+beforeAll(async () => {
+    db = await dbInit('project_feature_variants_api_serial', getLogger);
+    app = await setupApp(db.stores);
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+test('Can get variants for a feature', async () => {
+    const featureName = 'feature-variants';
+    const variantName = 'fancy-variant';
+    await db.stores.featureToggleStore.create('default', {
+        name: featureName,
+        variants: [
+            {
+                name: variantName,
+                stickiness: 'default',
+                weight: 100,
+                weightType: 'variable',
+            },
+        ],
+    });
+    await app.request
+        .get(`/api/admin/projects/default/features/${featureName}/variants`)
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.version).toBe('1');
+            expect(res.body.variants).toHaveLength(1);
+            expect(res.body.variants[0].name).toBe(variantName);
+        });
+});

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -41,6 +41,40 @@ test('Can get variants for a feature', async () => {
         });
 });
 
+test('Trying to do operations on a non-existing feature yields 404', async () => {
+    await app.request
+        .get(
+            '/api/admin/projects/default/features/non-existing-feature/variants',
+        )
+        .expect(404);
+    const variants = [
+        {
+            name: 'variant-put-overwrites',
+            stickiness: 'default',
+            weight: 1000,
+            weightType: 'variable',
+        },
+    ];
+    await app.request
+        .put('/api/admin/projects/default/features/${featureName}/variants')
+        .send(variants)
+        .expect(404);
+
+    const newVariants: IVariant[] = [];
+    const observer = jsonpatch.observe(newVariants);
+    newVariants.push({
+        name: 'variant1',
+        stickiness: 'default',
+        weight: 700,
+        weightType: 'variable',
+    });
+    let patch = jsonpatch.generate(observer);
+    await app.request
+        .patch('/api/admin/projects/default/features/${featureName}/variants')
+        .send(patch)
+        .expect(404);
+});
+
 test('Can patch variants for a feature and get a response of new variant', async () => {
     const featureName = 'feature-variants-patch';
     const variantName = 'fancy-variant-patch';

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -2,7 +2,7 @@ import { IUnleashTest, setupApp } from '../../../helpers/test-helper';
 import dbInit, { ITestDb } from '../../../helpers/database-init';
 import getLogger from '../../../../fixtures/no-logger';
 import * as jsonpatch from 'fast-json-patch';
-import { IVariant } from '../../../../../lib/types/model';
+import { IVariant, WeightType } from '../../../../../lib/types/model';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -27,7 +27,7 @@ test('Can get variants for a feature', async () => {
                 name: variantName,
                 stickiness: 'default',
                 weight: 1000,
-                weightType: 'variable',
+                weightType: WeightType.VARIABLE,
             },
         ],
     });
@@ -52,7 +52,7 @@ test('Trying to do operations on a non-existing feature yields 404', async () =>
             name: 'variant-put-overwrites',
             stickiness: 'default',
             weight: 1000,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
     await app.request
@@ -66,7 +66,7 @@ test('Trying to do operations on a non-existing feature yields 404', async () =>
         name: 'variant1',
         stickiness: 'default',
         weight: 700,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     let patch = jsonpatch.generate(observer);
     await app.request
@@ -84,7 +84,7 @@ test('Can patch variants for a feature and get a response of new variant', async
             name: variantName,
             stickiness: 'default',
             weight: 1000,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
 
@@ -117,7 +117,7 @@ test('Can add variant for a feature', async () => {
             name: variantName,
             stickiness: 'default',
             weight: 1000,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
 
@@ -131,7 +131,7 @@ test('Can add variant for a feature', async () => {
         name: expectedVariantName,
         stickiness: 'default',
         weight: 1000,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     const patch = jsonpatch.generate(observer);
     await app.request
@@ -161,7 +161,7 @@ test('Can remove variant for a feature', async () => {
             name: variantName,
             stickiness: 'default',
             weight: 1000,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
 
@@ -195,7 +195,7 @@ test('PUT overwrites current variant on feature', async () => {
             name: variantName,
             stickiness: 'default',
             weight: 1000,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
     await db.stores.featureToggleStore.create('default', {
@@ -208,19 +208,19 @@ test('PUT overwrites current variant on feature', async () => {
             name: 'variant1',
             stickiness: 'default',
             weight: 250,
-            weightType: 'fix',
+            weightType: WeightType.FIX,
         },
         {
             name: 'variant2',
             stickiness: 'default',
             weight: 375,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
         {
             name: 'variant3',
             stickiness: 'default',
             weight: 450,
-            weightType: 'variable',
+            weightType: WeightType.VARIABLE,
         },
     ];
     await app.request
@@ -309,7 +309,7 @@ test('PATCHING with all variable weightTypes forces weights to sum to no less th
         name: 'variant1',
         stickiness: 'default',
         weight: 700,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     let patch = jsonpatch.generate(observer);
 
@@ -326,7 +326,7 @@ test('PATCHING with all variable weightTypes forces weights to sum to no less th
         name: 'variant2',
         stickiness: 'default',
         weight: 700,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     patch = jsonpatch.generate(observer);
@@ -346,7 +346,7 @@ test('PATCHING with all variable weightTypes forces weights to sum to no less th
         name: 'variant3',
         stickiness: 'default',
         weight: 700,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     patch = jsonpatch.generate(observer);
@@ -367,7 +367,7 @@ test('PATCHING with all variable weightTypes forces weights to sum to no less th
         name: 'variant4',
         stickiness: 'default',
         weight: 700,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     patch = jsonpatch.generate(observer);
@@ -397,7 +397,7 @@ test('PATCHING with no variable variants fails with 400', async () => {
         name: 'variant1',
         stickiness: 'default',
         weight: 900,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
 
     const patch = jsonpatch.generate(observer);
@@ -425,43 +425,43 @@ test('Patching with a fixed variant and variable variants splits remaining weigh
         name: 'variant1',
         stickiness: 'default',
         weight: 900,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant2',
         stickiness: 'default',
         weight: 20,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant3',
         stickiness: 'default',
         weight: 123,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant4',
         stickiness: 'default',
         weight: 123,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant5',
         stickiness: 'default',
         weight: 123,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant6',
         stickiness: 'default',
         weight: 123,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant7',
         stickiness: 'default',
         weight: 123,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     const patch = jsonpatch.generate(observer);
@@ -517,19 +517,19 @@ test('Multiple fixed variants gets added together to decide how much weight vari
         name: 'variant1',
         stickiness: 'default',
         weight: 600,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant2',
         stickiness: 'default',
         weight: 350,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant3',
         stickiness: 'default',
         weight: 350,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     const patch = jsonpatch.generate(observer);
@@ -562,19 +562,19 @@ test('If sum of fixed variant weight exceed 1000 fails with 400', async () => {
         name: 'variant1',
         stickiness: 'default',
         weight: 900,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant2',
         stickiness: 'default',
         weight: 900,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant3',
         stickiness: 'default',
         weight: 350,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     const patch = jsonpatch.generate(observer);
@@ -603,25 +603,25 @@ test('If sum of fixed variant weight equals 1000 variable variants gets weight 0
         name: 'variant1',
         stickiness: 'default',
         weight: 900,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant2',
         stickiness: 'default',
         weight: 100,
-        weightType: 'fix',
+        weightType: WeightType.FIX,
     });
     newVariants.push({
         name: 'variant3',
         stickiness: 'default',
         weight: 350,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
     newVariants.push({
         name: 'variant4',
         stickiness: 'default',
         weight: 350,
-        weightType: 'variable',
+        weightType: WeightType.VARIABLE,
     });
 
     const patch = jsonpatch.generate(observer);

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -108,7 +108,6 @@ test('Can add variant for a feature', async () => {
     await app.request
         .get(`/api/admin/projects/default/features/${featureName}/variants`)
         .expect((res) => {
-            console.log(res.body);
             expect(res.body.version).toBe('1');
             expect(res.body.variants).toHaveLength(2);
             expect(
@@ -149,7 +148,6 @@ test('Can remove variant for a feature', async () => {
     await app.request
         .get(`/api/admin/projects/default/features/${featureName}/variants`)
         .expect((res) => {
-            console.log(res.body);
             expect(res.body.version).toBe('1');
             expect(res.body.variants).toHaveLength(0);
         });

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -3,7 +3,6 @@ import dbInit, { ITestDb } from '../../../helpers/database-init';
 import getLogger from '../../../../fixtures/no-logger';
 import * as jsonpatch from 'fast-json-patch';
 import { IVariant } from '../../../../../lib/types/model';
-import faker from 'faker';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -174,21 +173,21 @@ test('PUT overwrites current variant on feature', async () => {
 
     const newVariants: IVariant[] = [
         {
-            name: faker.hacker.verb(),
+            name: 'variant1',
             stickiness: 'default',
             weight: 250,
             weightType: 'fix',
         },
         {
-            name: faker.hacker.noun(),
+            name: 'variant2',
             stickiness: 'default',
             weight: 375,
             weightType: 'variable',
         },
         {
-            name: faker.hacker.ingverb(),
+            name: 'variant3',
             stickiness: 'default',
-            weight: 375,
+            weight: 450,
             weightType: 'variable',
         },
     ];
@@ -228,7 +227,6 @@ test('PUTing an invalid variant throws 400 exception', async () => {
         .send(invalidJson)
         .expect(400)
         .expect((res) => {
-            console.log(res.body);
             expect(res.body.details).toHaveLength(1);
             expect(res.body.details[0].message).toMatch(
                 /.*weightType\" must be one of/,
@@ -259,7 +257,6 @@ test('Invalid variant in PATCH also throws 400 exception', async () => {
         .send(invalidPatch)
         .expect(400)
         .expect((res) => {
-            console.log(res.body);
             expect(res.body.details).toHaveLength(1);
             expect(res.body.details[0].message).toMatch(
                 /.*weight\" must be less than or equal to 1000/,

--- a/src/test/fixtures/fake-feature-toggle-store.ts
+++ b/src/test/fixtures/fake-feature-toggle-store.ts
@@ -2,7 +2,11 @@ import {
     IFeatureToggleQuery,
     IFeatureToggleStore,
 } from '../../lib/types/stores/feature-toggle-store';
-import { FeatureToggle, FeatureToggleDTO } from '../../lib/types/model';
+import {
+    FeatureToggle,
+    FeatureToggleDTO,
+    IVariant,
+} from '../../lib/types/model';
 import NotFoundError from '../../lib/error/notfound-error';
 
 export default class FakeFeatureToggleStore implements IFeatureToggleStore {
@@ -122,5 +126,19 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
                 toUpdate.lastSeenAt = new Date();
             }
         });
+    }
+
+    async getVariants(featureName: string): Promise<IVariant[]> {
+        const feature = await this.get(featureName);
+        return feature.variants;
+    }
+
+    async saveVariants(
+        featureName: string,
+        newVariants: IVariant[],
+    ): Promise<FeatureToggle> {
+        const feature = await this.get(featureName);
+        feature.variants = newVariants;
+        return feature;
     }
 }


### PR DESCRIPTION
This adds 
GET `/api/admin/projects/:projectId/features/:featureName/variants` which returns `{ version: '1', variants: IVariant[] }`
PATCH `/api/admin/projects/:projectId/features/:featureName/variants` which accepts a json patch set and updates the feature's variants field and then returns `{ version: '1', variants: IVariant[] }`
PUT `/api/admin/projects/:projectId/features/:featureName/variants` which accepts a IVariant[] and overwrites the current variants list for the feature defined in `:featureName`

----
Thoughts:
We're currently only performing validation of IVariants in the frontend, though we do coerce the json into IVariant, we're not actually guaranteed that the weights of the list sum up to 100%.

- This PR probably should add validation to the saveVariants call in the featureService, making sure that we adhere to the data format and that the weight math adds up.