### PR TITLE
fix: make new variant api validate name uniqueness

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -286,6 +286,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 );
                 return e;
             });
+            featureToggle.variants = featureToggle.variants || [];
             featureToggle.archived = archived;
             return featureToggle;
         }

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -161,7 +161,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             type: row.type,
             project: row.project,
             stale: row.stale,
-            variants: row.variants as unknown as IVariant[],
+            variants: (row.variants as unknown as IVariant[]) || [],
             createdAt: row.created_at,
             lastSeenAt: row.last_seen_at,
         };
@@ -182,7 +182,9 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             project,
             archived: data.archived || false,
             stale: data.stale,
-            variants: data.variants ? JSON.stringify(data.variants) : null,
+            variants: data.variants
+                ? JSON.stringify(data.variants)
+                : JSON.stringify([]),
             created_at: data.createdAt,
         };
         if (!row.created_at) {

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -43,7 +43,7 @@ export default class VariantsController extends Controller {
     ): Promise<void> {
         const { featureName } = req.params;
         const variants = await this.featureService.getVariants(featureName);
-        res.status(200).json({ version: '1', variants });
+        res.status(200).json({ version: '1', variants: variants || [] });
     }
 
     async patchVariants(

--- a/src/lib/schema/feature-schema.ts
+++ b/src/lib/schema/feature-schema.ts
@@ -42,7 +42,11 @@ export const variantsSchema = joi.object().keys({
     ),
 });
 
-export const variantsArraySchema = joi.array().min(0).items(variantsSchema);
+export const variantsArraySchema = joi
+    .array()
+    .min(0)
+    .items(variantsSchema)
+    .unique((a, b) => a.name === b.name);
 
 export const featureMetadataSchema = joi
     .object()


### PR DESCRIPTION
Since the old schema did validate variants uniqueness, we need to make sure new endpoint also validates it