### PR TITLE
fix: Stop healthrating from including archived

### DIFF
--- a/src/lib/services/project-health-service.ts
+++ b/src/lib/services/project-health-service.ts
@@ -129,6 +129,7 @@ export default class ProjectHealthService {
     async calculateHealthRating(project: IProject): Promise<number> {
         const toggles = await this.featureToggleStore.getAll({
             project: project.id,
+            archived: false,
         });
 
         const activeToggles = toggles.filter((feature) => !feature.stale);


### PR DESCRIPTION
- Since the archived toggles are not visible in the health dashboard,
  including them in the health rating calculation makes for some really
  confusing dashboards. This PR makes sure we only include non-archived
  toggles when calculating health.