### PR TITLE
task: Ban changes to variants through feature

### DIFF
--- a/src/lib/error/operation-denied-error.ts
+++ b/src/lib/error/operation-denied-error.ts
@@ -1,0 +1,21 @@
+export class OperationDeniedError extends Error {
+    constructor(message: string) {
+        super();
+        Error.captureStackTrace(this, this.constructor);
+
+        this.name = this.constructor.name;
+        this.message = message;
+    }
+
+    toJSON(): object {
+        return {
+            isJoi: true,
+            name: this.constructor.name,
+            details: [
+                {
+                    message: this.message,
+                },
+            ],
+        };
+    }
+}

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -145,6 +145,7 @@ class FeatureController extends Controller {
             validatedToggle.project,
             validatedToggle,
             userName,
+            true,
         );
         const strategies = await Promise.all(
             toggle.strategies.map(async (s) =>

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -30,34 +30,34 @@ export const handleErrors: (
     // eslint-disable-next-line no-param-reassign
     error.isJoi = true;
     switch (error.name) {
-        case 'NoAccessError':
-            return res.status(403).json(error).end();
-        case 'NotFoundError':
-            return res.status(404).json(error).end();
-        case 'InvalidOperationError':
-            return res.status(403).json(error).end();
-        case 'NameExistsError':
-            return res.status(409).json(error).end();
         case 'ValidationError':
             return res.status(400).json(error).end();
         case 'BadDataError':
             return res.status(400).json(error).end();
-        case 'FeatureHasTagError':
-            return res.status(409).json(error).end();
-        case 'UsedTokenError':
-            return res.status(403).json(error).end();
-        case 'InvalidTokenError':
-            return res.status(401).json(error).end();
         case 'OwaspValidationError':
             return res.status(400).json(error).end();
         case 'PasswordUndefinedError':
             return res.status(400).json(error).end();
-        case 'IncompatibleProjectError':
-            return res.status(403).json(error).end();
         case 'MinimumOneEnvironmentError':
             return res.status(400).json(error).end();
+        case 'InvalidTokenError':
+            return res.status(401).json(error).end();
+        case 'NoAccessError':
+            return res.status(403).json(error).end();
+        case 'UsedTokenError':
+            return res.status(403).json(error).end();
+        case 'InvalidOperationError':
+            return res.status(403).json(error).end();
+        case 'IncompatibleProjectError':
+            return res.status(403).json(error).end();
         case 'OperationDeniedError':
             return res.status(403).json(error).end();
+        case 'NotFoundError':
+            return res.status(404).json(error).end();
+        case 'NameExistsError':
+            return res.status(409).json(error).end();
+        case 'FeatureHasTagError':
+            return res.status(409).json(error).end();
         default:
             logger.error('Server failed executing request', error);
             return res.status(500).end();

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -56,6 +56,8 @@ export const handleErrors: (
             return res.status(403).json(error).end();
         case 'MinimumOneEnvironmentError':
             return res.status(400).json(error).end();
+        case 'OperationDeniedError':
+            return res.status(403).json(error).end();
         default:
             logger.error('Server failed executing request', error);
             return res.status(500).end();

--- a/src/lib/schema/feature-schema.ts
+++ b/src/lib/schema/feature-schema.ts
@@ -56,12 +56,6 @@ export const featureMetadataSchema = joi
         archived: joi.boolean().default(false),
         type: joi.string().default('release'),
         description: joi.string().allow('').allow(null).optional(),
-        variants: joi
-            .array()
-            .allow(null)
-            .unique((a, b) => a.name === b.name)
-            .optional()
-            .items(variantsSchema),
         createdAt: joi.date().optional().allow(null),
     })
     .options({ allowUnknown: false, stripUnknown: true, abortEarly: false });


### PR DESCRIPTION
After adding the new `/variants` endpoint for features we now have a way
to access control adding/modifying variants, so the /:featureName
endpoint should no longer allow editing/adding variants.

This removes variants as a known field from the featureMetadata schema
and tells joi to stripUnknown, thus making sure we never include
variants in the initial creation or future update calls.

For the old features v1 API we allow it to declare that it has already
validated the data coming with its own schema, so we should use the data
we get from it. Thus keeping the old v1 functionality intact

Co-authored-by: Simon Hornby <simon@getunleash.ai>