### PR TITLE
Fix/variants ordering

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -287,6 +287,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 return e;
             });
             featureToggle.variants = featureToggle.variants || [];
+            featureToggle.variants.sort((a, b) => a.name.localeCompare(b.name));
             featureToggle.archived = archived;
             return featureToggle;
         }


### PR DESCRIPTION
We found that for existing variants, the sorting by name wasn't applied, so the index in the patches were wrong. This PR adds the sort also when we're getting variants as part of the getFeature call, not just when we're getting the variants. This should make the UX consistent, and prevent our patches from hitting the wrong index in the variants array.