### PR TITLE
docs(fix): fix quickstart image not being displayed.

### DIFF
--- a/website/docs/user_guide/quickstart.md
+++ b/website/docs/user_guide/quickstart.md
@@ -255,9 +255,7 @@ Follow steps outlined in the [Run Unleash with Docker](#run-unleash-with-docker)
 
    To get an API key, access your Unleash instance in a web browser. First, navigate to the API access screen.
 
-   [![The Unleash UI showing a dropdown menu under the Configure menu
-entry. The dropdown menu's API Access option is highlighted and
-you're told to navigate there.]](/img/api_access_navigation.png 'Navigate to the API access page.')
+   ![The Unleash UI showing a dropdown menu under the Configure menu entry. The dropdown menu's API Access option is highlighted and you're told to navigate there.](/img/api_access_navigation.png 'Navigate to the API access page.')
 
    Next, create an API key with these details
 


### PR DESCRIPTION
The issue was that the image link was encased in an extra set of
brackets. However, the extra bracket set was added because docusaurus
wouldn't compile otherwise. Instead it complained about an
unterminated string literal in the alt text.

As it turns out, this had nothing to do with the contents of the alt
text, but rather with the fact that the alt text was split over
multiple lines.