### PR TITLE
docs: add steps for running the proxy in node with custom strats.

### DIFF
--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -183,6 +183,7 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
        unleashApiToken: '*:default.56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
        proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
        refreshInterval: 1000,
+       // highlight-next-line
        customStrategies: [new TimeStampStrategy()]
    });
 

--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -83,7 +83,7 @@ The steps to implement a custom strategy for your client depend on the kind of c
 
 ### Option B: Implement the strategy for a front-end client SDK {#step-3-b}
 
-Front-end client SDK don't evaluate strategies directly, so you need to implement the **custom strategy in the [Unleash Proxy](../sdks/unleash-proxy.md)**. Depending on how you run the Unleash Proxy, follow one of the below series of steps:
+Front-end client SDKs don't evaluate strategies directly, so you need to implement the **custom strategy in the [Unleash Proxy](../sdks/unleash-proxy.md)**. Depending on how you run the Unleash Proxy, follow one of the below series of steps:
 - If you're running the Unleash Proxy as a Docker container, refer to the [steps for using a containerized Proxy](#step-3-b-docker).
 - If you're using the Unleash Proxy via Node.js, refer to the [steps for using custom strategies via Node.js](#step-3-b-node).
 

--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -43,7 +43,7 @@ The steps to implement a custom strategy for your client depend on the kind of c
      }
 
      isEnabled(parameters, context) {
-       return Date.parse(parameters.enableAfter) > Date.now();
+       return Date.parse(parameters.enableAfter) < Date.now();
      }
    }
    ```
@@ -61,7 +61,7 @@ The steps to implement a custom strategy for your client depend on the kind of c
      }
 
      isEnabled(parameters, context) {
-       return Date.parse(parameters.enableAfter) > Date.now();
+       return Date.parse(parameters.enableAfter) < Date.now();
      }
    }
 
@@ -110,7 +110,7 @@ Strategies are stored in separate JavaScript files and loaded into the container
      }
 
      isEnabled(parameters, context) {
-       return Date.parse(parameters.enableAfter) > Date.now();
+       return Date.parse(parameters.enableAfter) < Date.now();
      }
    }
 
@@ -155,7 +155,7 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
      }
 
      isEnabled(parameters, context) {
-       return Date.parse(parameters.enableAfter) > Date.now();
+       return Date.parse(parameters.enableAfter) < Date.now();
      }
    }
    ```
@@ -172,7 +172,7 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
      }
 
      isEnabled(parameters, context) {
-       return Date.parse(parameters.enableAfter) > Date.now();
+       return Date.parse(parameters.enableAfter) < Date.now();
      }
    }
 

--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -162,32 +162,32 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
 
 3. **Pass the strategy to the Proxy Client** using the **`customStrategies`** option. A full code example:
 
-``` javascript
-const { createApp } = require('@unleash/proxy');
-const { Strategy } = require('unleash-client');
+   ``` javascript
+   const { createApp } = require('@unleash/proxy');
+   const { Strategy } = require('unleash-client');
 
-class TimeStampStrategy extends Strategy {
-  constructor() {
-    super('TimeStamp');
-  }
+   class TimeStampStrategy extends Strategy {
+     constructor() {
+       super('TimeStamp');
+     }
 
-  isEnabled(parameters, context) {
-    return Date.parse(parameters.enableAfter) > Date.now();
-  }
-}
+     isEnabled(parameters, context) {
+       return Date.parse(parameters.enableAfter) > Date.now();
+     }
+   }
 
-const port = 3000;
+   const port = 3000;
 
-const app = createApp({
-    unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
-    unleashApiToken: '*:default.56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-    proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
-    refreshInterval: 1000,
-    customStrategies: [new TimeStampStrategy()]
-});
+   const app = createApp({
+       unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
+       unleashApiToken: '*:default.56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
+       proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
+       refreshInterval: 1000,
+       customStrategies: [new TimeStampStrategy()]
+   });
 
-app.listen(port, () =>
-    // eslint-disable-next-line no-console
-    console.log(`Unleash Proxy listening on http://localhost:${port}/proxy`),
-);
-```
+   app.listen(port, () =>
+       // eslint-disable-next-line no-console
+       console.log(`Unleash Proxy listening on http://localhost:${port}/proxy`),
+   );
+   ```


### PR DESCRIPTION
As mentioned in [this issue comment on the previous changes](https://github.com/Unleash/proxy-client-react/issues/25#issuecomment-1000260964), we could clarify the steps for custom strategies when running the proxy with Node.

This PR adds separate steps for the different ways of running the proxy.

Before merging, I'd love to know whether this is indeed the right way of passing custom strategies when running as a Node process.