### PR TITLE
docs: add `npm2yarn` annotation to all npm commands

### DIFF
--- a/website/docs/deploy/getting-started.md
+++ b/website/docs/deploy/getting-started.md
@@ -73,7 +73,7 @@ docker run -p 4242:4242 \
 1. Create a new folder/directory on your development computer.
 2. From a terminal/bash shell, install the dependencies:
 
-   ```sh
+   ```shell npm2yarn
    npm init
    npm install unleash-server --save
    ```

--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -94,7 +94,7 @@ Strategies are stored in separate JavaScript files and loaded into the container
 1. **Create a strategies directory.** Create a directory that Docker has access to where you can store your strategies. The next steps assume you called it `strategies`
 2. **Initialize a node project** and **install the Unleash Client**:
 
-   ``` shell
+   ``` shell npm2yarn
    npm init -y && \
    npm install unleash-client
    ```
@@ -140,7 +140,7 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
 
 1. **Install the `unleash-client` package**. You'll need this to implement the custom strategy:
 
-   ``` shell
+   ``` shell npm2yarn
    npm install unleash-client
    ```
 

--- a/website/docs/sdks/node.md
+++ b/website/docs/sdks/node.md
@@ -11,7 +11,7 @@ In this guide we explain how to use feature toggles in a Node application using 
 
 First we must install Node.js dependency:
 
-```sh
+```shell npm2yarn
 npm install unleash-client
 ```
 

--- a/website/docs/sdks/proxy-javascript.md
+++ b/website/docs/sdks/proxy-javascript.md
@@ -15,7 +15,7 @@ For single-page apps we have a tiny proxy-client in JavaScript, without any exte
 
 **Step 1: Install**
 
-```
+```shell npm2yarn
 npm install unleash-proxy-client
 ```
 

--- a/website/docs/sdks/proxy-react.md
+++ b/website/docs/sdks/proxy-react.md
@@ -10,10 +10,8 @@ For more detailed information, check out [the React Proxy SDK on GitHub](https:/
 
 ## Installation
 
-```sh
+```shell npm2yarn
 npm install @unleash/proxy-client-react
-// or
-yarn add @unleash/proxy-client-react
 ```
 
 ## Initialize the client

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -110,6 +110,9 @@ module.exports = {
                     editUrl:
                         'https://github.com/Unleash/unleash/edit/master/website/',
                     routeBasePath: '/',
+                    remarkPlugins: [
+                        [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}]
+                    ]
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "@docusaurus/core": "2.0.0-beta.9",
     "@docusaurus/plugin-client-redirects": "2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/remark-plugin-npm2yarn": "^2.0.0-beta.14",
     "@mdx-js/react": "1.6.22",
     "@svgr/webpack": "6.1.2",
     "clsx": "1.1.1",


### PR DESCRIPTION
This lets us show both `npm` and `yarn` versions of the commands to all users. It's implemented as a tabs component and will sync across the docs site. This means that if you've indicated a preference for one or the other, all other `npm` commands will display using the same tool (`npm` or `yarn`).

This is what it looks like:
![image](https://user-images.githubusercontent.com/17786332/147938954-19c853c9-be32-47a6-9803-e71e2218ca5f.png)

![image](https://user-images.githubusercontent.com/17786332/147938982-6accdf2e-4136-4603-90e1-5ef8373f3016.png)
