### PR TITLE
docs: redirect old community SDKs url to new /sdks

### DIFF
--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -99,7 +99,7 @@ If you see an item marked with a ❌ that you would find useful, feel free to re
 | Bootstrap from file                                                                               | ✅                     | ⭕                        | ⭕                 | ⭕                         | ⭕                     | ⭕                        | ⭕                   | ⭕                                       |
 | Custom Bootstrap implementation                                                                   | ✅                     | ⭕                        | ⭕                 | ⭕                         | ⭕                     | ⭕                        | ⭕                   | ⭕                                       |
 
-## Clients written by awesome enthusiasts {#clients-written-by-awesome-enthusiasts}
+## Community SDKs ❤️ {#community-sdks}
 
 Here's some of the fantastic work our community has done to make Unleash work in even more contexts. If you still can't find your favorite language, let us know and we'd love to help you create the client for it!
 
@@ -113,7 +113,7 @@ Here's some of the fantastic work our community has done to make Unleash work in
 - [uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash) (Dart)
 - _...your implementation for your favorite language._
 
-### Implement your own SDK {#implement-your-own-sdk}
+## Implement your own SDK {#implement-your-own-sdk}
 
 If you can't find an SDK that fits your need, you can also develop your own SDK. To make implementation easier, check out these resources:
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -146,6 +146,10 @@ module.exports = {
                         to: '/advanced/toggle_variants',
                         from: '/toggle_variants',
                     },
+                    {
+                        to: '/sdks',
+                        from: '/sdks/community'
+                    }
                 ],
                 createRedirects: function(toPath) {
                     if (

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -132,6 +132,7 @@ module.exports = {
                             '/user_guide/client-sdk',
                             '/client-sdk',
                             '/user_guide/connect_sdk',
+                            '/sdks/community',
                         ],
                     },
                     {
@@ -146,10 +147,6 @@ module.exports = {
                         to: '/advanced/toggle_variants',
                         from: '/toggle_variants',
                     },
-                    {
-                        to: '/sdks',
-                        from: '/sdks/community'
-                    }
                 ],
                 createRedirects: function(toPath) {
                     if (

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,6 +41,7 @@ module.exports = {
             'sdks/proxy-javascript',
             'sdks/proxy-react',
             'sdks/proxy-ios',
+            { type: 'link', label: 'Community SDKs', href: '/sdks#community-sdks'}
         ],
         Addons: [
             'addons/index',


### PR DESCRIPTION
When I accidentally (🙈) pushed the deletion of the community SDKs page yesterday, I hadn't thought of adding a redirect from the old page. This PR takes care of that and cleans up the structure of the community SDKs section.