### PR TITLE
docs: Fixed syntax error for Ruby SDK example

### DIFF
--- a/website/docs/sdks/ruby.md
+++ b/website/docs/sdks/ruby.md
@@ -5,14 +5,14 @@ title: Ruby SDK
 
 > You will need your `API URL` and your `API token` in order to connect the Client SDK to you Unleash instance. You can find this information in the “Admin” section Unleash management UI. [Read more](../user_guide/api-token)
 
-```sh
-    require 'unleash'
+```ruby
+require 'unleash'
 
-    @unleash = Unleash::Client.new(
-      url: '<API url>',
-      app_name: 'simple-test',
-      custom_http_headers = {'Authorization': '<API token>'},
-    )
+@unleash = Unleash::Client.new(
+  url: '<API url>',
+  app_name: 'simple-test',
+  custom_http_headers: {'Authorization': '<API token>'},
+)
 ```
 
 ### Sample usage {#sample-usage}


### PR DESCRIPTION
Hi, thank you for awesome software 👍 

I found that official document of Ruby SDK has wrong example code. It occurred syntax error like below.
And more we can improved for markdown notation a little :)

```sh
$ ruby unleash.rb
unleash.rb:6: syntax error, unexpected ',', expecting =>
...Authorization': '<API token>'},
```

So I fixed its.

1. Fixed Ruby syntax of `custom_http_headers`
1. Deleted unnecessary indent
1. Updated syntax highlighting from `sh` to `ruby`

Thanks!