### PR TITLE
docs: group sdks into non-collapsible categories: server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build & Tests](https://github.com/Unleash/unleash/workflows/Build%20%26%20Tests/badge.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash/badge.svg?branch=master&)](https://coveralls.io/github/Unleash/unleash?branch=master) [![npm](https://img.shields.io/npm/v/unleash-server)](https://www.npmjs.com/package/unleash-server) [![Docker Pulls](https://img.shields.io/docker/pulls/unleashorg/unleash-server)](https://hub.docker.com/r/unleashorg/unleash-server)
 
 [![Deploy to Heroku](./.github/deploy-heroku-20.png)](https://www.heroku.com/deploy/?template=https://github.com/Unleash/unleash) [![Deploy to DigitalOcean](./.github/deploy-digital.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Unleash/unleash/tree/master&refcode=0e1d75187044) [![Twitter Follow](https://img.shields.io/twitter/follow/getunleash)](https://twitter.com/intent/follow?screen_name=getunleash)
-    
+
 
 <a href="https://getunleash.io" title="Unleash - Create with freedom. Release with confidence">
     <img src="./.github/Logo_DarkBlue_Transparent_Portrait.svg" width="200">
@@ -59,7 +59,7 @@ In order to connect your application to Unleash you need to use a client SDK for
 - [Go SDK](https://docs.getunleash.io/sdks/go_sdk)
 - [Ruby SDK](https://docs.getunleash.io/sdks/ruby_sdk)
 - [Python SDK](https://docs.getunleash.io/sdks/python_sdk)
-- [.Net SDK](https://docs.getunleash.io/sdks/dot_net_sdk)
+- [.NET SDK](https://docs.getunleash.io/sdks/dot_net_sdk)
 - [PHP SDK](https://docs.getunleash.io/sdks/php_sdk)
 
 **Official Frontend SDKs:**

--- a/website/docs/sdks/dot_net.md
+++ b/website/docs/sdks/dot_net.md
@@ -1,6 +1,6 @@
 ---
 id: dot_net_sdk
-title: .net SDK
+title: .NET SDK
 ---
 
 In this guide we explain how to use feature toggles in a .NET application using Unleash-hosted. We will be using the open source Unleash [.net Client SDK](https://github.com/Unleash/unleash-client-dotnet).
@@ -9,7 +9,7 @@ In this guide we explain how to use feature toggles in a .NET application using 
 
 ## Step 1: Install client SDK {#step-1-install-client-sdk}
 
-First we must add Unleash Client SDK as a dependency to your project. Below is an example of how you would add it via the .Net cli. Please see [NuGet](https://www.nuget.org/packages/Unleash.Client/) for other alternatives.
+First we must add Unleash Client SDK as a dependency to your project. Below is an example of how you would add it via the .NET cli. Please see [NuGet](https://www.nuget.org/packages/Unleash.Client/) for other alternatives.
 
 ```sh
 dotnet add package unleash.client

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -14,7 +14,6 @@ Unleash provides official client SDKs for a number of programming language. Addi
 
 Server-side clients run on your server and communicate directly with your Unleash instance. We provide these official clients:
 
-- [.Net SDK](/sdks/dot_net_sdk)
 - [Go SDK](/sdks/go_sdk)
 - [Java SDK](/sdks/java_sdk)
 - [Node.js SDK](/sdks/node_sdk)
@@ -22,6 +21,7 @@ Server-side clients run on your server and communicate directly with your Unleas
 - [Python SDK](/sdks/python_sdk)
 - [Ruby SDK](/sdks/ruby_sdk)
 - [Rust SDK](https://github.com/unleash/unleash-client-rust)
+- [.NET SDK](/sdks/dot_net_sdk)
 
 ### Front-end SDKs
 

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -49,7 +49,7 @@ If you see an item marked with a ❌ that you would find useful, feel free to re
 :::
 
 
-| Capability                                                                                        | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.Net](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Unleash Proxy Server](unleash-proxy.md) |
+| Capability                                                                                        | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.NET](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Unleash Proxy Server](unleash-proxy.md) |
 |---------------------------------------------------------------------------------------------------|:----------------------:|:-------------------------:|:------------------:|:--------------------------:|:----------------------:|:-------------------------:|:--------------------:|:----------------------------------------:|
 | **Category: Initialization**                                                                      |                        |                           |                    |                            |                        |                           |                      |                                          |
 | Async initialization                                                                              | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | N/A                                      |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,6 +41,11 @@ module.exports = {
                     'sdks/php_sdk',
                     'sdks/python_sdk',
                     'sdks/ruby_sdk',
+                    {
+                        type: 'link',
+                        href: 'https://github.com/unleash/unleash-client-rust',
+                        label: 'Rust SDK',
+                    },
                     'sdks/dot_net_sdk',
                 ],
             },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -30,18 +30,36 @@ module.exports = {
         'Unleash SDKs': [
             'sdks/index',
             'sdks/unleash-proxy',
-            'sdks/dot_net_sdk',
-            'sdks/android_proxy_sdk',
-            'sdks/go_sdk',
-            'sdks/proxy-ios',
-            'sdks/java_sdk',
-            'sdks/proxy-javascript',
-            'sdks/node_sdk',
-            'sdks/php_sdk',
-            'sdks/python_sdk',
-            'sdks/proxy-react',
-            'sdks/ruby_sdk',
-            { type: 'link', label: 'Community SDKs', href: '/sdks#community-sdks'}
+            {
+                type: 'category',
+                collapsible: false,
+                label: 'Server-side SDKs',
+                items: [
+                    'sdks/go_sdk',
+                    'sdks/java_sdk',
+                    'sdks/node_sdk',
+                    'sdks/php_sdk',
+                    'sdks/python_sdk',
+                    'sdks/ruby_sdk',
+                    'sdks/dot_net_sdk',
+                ],
+            },
+            {
+                type: 'category',
+                collapsible: false,
+                label: 'Client-side SDKs',
+                items: [
+                    'sdks/android_proxy_sdk',
+                    'sdks/proxy-ios',
+                    'sdks/proxy-javascript',
+                    'sdks/proxy-react',
+                ],
+            },
+            {
+                type: 'link',
+                label: 'Community SDKs',
+                href: '/sdks#community-sdks',
+            },
         ],
         Addons: [
             'addons/index',


### PR DESCRIPTION
This PR groups the SDKs into server-side and client-side sdks.

I have made the categories non-collapsible for now, but would be happy to make them collapsible if anyone has any strong feelings towards it.

I have also updated all uses of ".net"/".Net" and changed them to ".NET" as is the standard.

Finally, though it's a little on the side, I've added a link to the Rust SDK in the sidebar. It's an external link for now.

New sidebar:

![image](https://user-images.githubusercontent.com/17786332/149305223-301cb082-fad6-4531-be24-9201ec316e93.png)
