### PR TITLE
fix: use the Unleash purple for links / increase contrast

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,7 +16,7 @@
     --ifm-color-primary-lightest: #4a6c76;
     --ifm-code-font-size: 90%;
     --ifm-font-size-base: 15px;
-    --ifm-link-color: #817afe;
+    --ifm-link-color: #635DC5;
     --navbar-link-color: #122d33;
 }
 


### PR DESCRIPTION
This increases the contrast from 3.42 to above 4.5, in compliance with
the AA standard. It also uses the same shade of purple that we have in the Unleash admin UI 🎉
