### PR TITLE
fix(docs/a11y): fix lack of contrast in on hovered links in footer

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -20,6 +20,10 @@
     --navbar-link-color: #122d33;
 }
 
+footer {
+    --ifm-footer-link-hover-color: var(--ifm-footer-link-color);
+}
+
 [class^='docTitle'] {
     font-size: 2.5rem !important;
 }


### PR DESCRIPTION
This commit changes the hover color of links in the footer to keep it
accessible.

The color will be the exact same as the un-hovered version. This is in
line with the other links in the documentation. The links _do_ get
underlined when hovered, so there is still a visual distinction
between the states.

I've added the variable in the `footer` section instead of in `:root`
because the variable I assign it to (`--ifm-footer-link-color`) gets
overridden closer to the footer, so if you set it in `:root`, you end
up with the wrong value.

addresses and closes https://github.com/Unleash/unleash.github.io/issues/8