### PR TITLE
fix: add migration for old feature events

### DIFF
--- a/src/migrations/20220125200908-convert-old-feature-events.js
+++ b/src/migrations/20220125200908-convert-old-feature-events.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        UPDATE events
+        SET feature_name = E.feature_name
+        FROM (
+            SELECT id, data->>'name' AS feature_name 
+            FROM events 
+            WHERE type IN ('feature-created', 'feature-updated', 'feature-archived', 'feature-stale-on', 'feature-stale-off') 
+            AND feature_name is null
+        ) AS E
+        WHERE events.id = E.id;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    cb();
+};


### PR DESCRIPTION
When we change the feature events we introduced a new column
on the events table to ease resolving of feature related events,
instead of knowing the types and require the data object to include
a name property. This commit adds a migration to make sure we
convert all feature events.

fixes: #1299