### PR TITLE
docs(a11y): fix a number of contrast issues with the dark theme

### DIFF
--- a/website/docs/sdks/unleash-proxy.md
+++ b/website/docs/sdks/unleash-proxy.md
@@ -168,7 +168,7 @@ Refer the [custom activation strategy documentation](../advanced/custom-activati
 
 The Unleash Proxy has a very simple API. It takes the [Unleash Context](../user_guide/unleash_context) as input and will return the feature toggles relevant for that specific context.
 
-![The Unleash Proxy](/img/The-Unleash-Proxy-API.png).
+![The Unleash Proxy](/img/The-Unleash-Proxy-API.png)
 
 ### Payload
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,11 +26,6 @@ module.exports = {
             },
             items: [
                 {
-                    to: '/',
-                    label: 'Documentation',
-                    activeBaseRegex: '(user_guide|sdks|addons|advanced)',
-                },
-                {
                     href: 'https://www.getunleash.io/plans',
                     label: 'Unleash Enterprise',
                     position: 'right',

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -38,19 +38,20 @@ html[data-theme='light'] {
 }
 
 html[data-theme='dark'] {
-    --ifm-color-primary-lightest: #ffffff;
-    --ifm-color-primary-lighter: #fcfcfc;
-    --ifm-color-primary-light: #f9f9f9;
-    --ifm-color-primary: #f6f6f6;
-    --ifm-color-primary-dark: #f2f2f2;
-    --ifm-color-primary-darker: #efefef;
-    --ifm-color-primary-darkest: #ececec;
+    --ifm-color-primary-lightest: #d1d1ff;
+    --ifm-color-primary-lighter: #c9c9ff;
+    --ifm-color-primary-light: #c2c0ff;
+    --ifm-color-primary: #bab8ff;
+    --ifm-color-primary-dark: #b2afff;
+    --ifm-color-primary-darker: #aba7ff;
+    --ifm-color-primary-darkest: #a39eff;
 
-    --unleash-color-gray: #3c3c3c;
+    --unleash-color-purple: var(--ifm-color-primary);
+    --unleash-color-gray: #333;
     --ifm-menu-color-background-active: var(--unleash-color-gray);
     --ifm-menu-color-background-hover: var(--unleash-color-gray);
 
-    --ifm-link-color: #aaa5ff;
+    --ifm-link-color: var(--ifm-color-primary);
 
     --unleash-color-admonition-background: var(
         --ifm-color-secondary-contrast-background

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -56,6 +56,18 @@ html[data-theme='dark'] {
     --unleash-color-admonition-background: var(
         --ifm-color-secondary-contrast-background
     );
+
+
+    --unleash-img-background-color: #fff;
+}
+
+img {
+    background: var(--unleash-img-background-color);
+    display: block;
+    margin: auto;
+    border: 1px solid var(--unleash-color-gray);
+    border-radius: var(--ifm-global-radius);
+    box-shadow: var(--ifm-global-shadow-lw);
 }
 
 [class^='docTitle'] {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -38,17 +38,23 @@ html[data-theme='light'] {
 }
 
 html[data-theme='dark'] {
-    --ifm-color-primary: #39535b;
-    --ifm-color-primary-dark: #334b52;
-    --ifm-color-primary-darker: #30474d;
-    --ifm-color-primary-darkest: #283a40;
-    --ifm-color-primary-light: #3f5b64;
-    --ifm-color-primary-lighter: #425f69;
-    --ifm-color-primary-lightest: #4a6c76;
+    --ifm-color-primary-lightest: #ffffff;
+    --ifm-color-primary-lighter: #fcfcfc;
+    --ifm-color-primary-light: #f9f9f9;
+    --ifm-color-primary: #f6f6f6;
+    --ifm-color-primary-dark: #f2f2f2;
+    --ifm-color-primary-darker: #efefef;
+    --ifm-color-primary-darkest: #ececec;
+
+    --unleash-color-gray: #3c3c3c;
+    --ifm-menu-color-background-active: var(--unleash-color-gray);
+    --ifm-menu-color-background-hover: var(--unleash-color-gray);
 
     --ifm-link-color: #aaa5ff;
 
-    --unleash-color-admonition-background: var(--ifm-color-secondary-contrast-background);
+    --unleash-color-admonition-background: var(
+        --ifm-color-secondary-contrast-background
+    );
 }
 
 [class^='docTitle'] {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -33,6 +33,10 @@ footer {
     --ifm-footer-link-hover-color: var(--ifm-footer-link-color);
 }
 
+html[data-theme='dark'] {
+    --ifm-link-color: #aaa5ff;
+}
+
 [class^='docTitle'] {
     font-size: 2.5rem !important;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -10,22 +10,8 @@
     --unleash-color-purple: #635dc5;
     --unleash-color-gray: #ecebeb;
 
-    --unleash-color-admonition-background: var(--unleash-color-gray);
-    --unleash-color-admonition-border: #999;
-    --unleash-color-admonition-text: #2b2b2b;
-
-    --ifm-color-primary: #39535b;
-    --ifm-color-primary-dark: #334b52;
-    --ifm-color-primary-darker: #30474d;
-    --ifm-color-primary-darkest: #283a40;
-    --ifm-color-primary-light: #3f5b64;
-    --ifm-color-primary-lighter: #425f69;
-    --ifm-color-primary-lightest: #4a6c76;
     --ifm-code-font-size: 90%;
     --ifm-font-size-base: 15px;
-    --ifm-link-color: var(--unleash-color-purple);
-    --ifm-menu-color-background-active: var(--unleash-color-gray);
-    --ifm-menu-color-background-hover: var(--unleash-color-gray);
     --navbar-link-color: #122d33;
 }
 
@@ -33,8 +19,36 @@ footer {
     --ifm-footer-link-hover-color: var(--ifm-footer-link-color);
 }
 
+html[data-theme='light'] {
+    --ifm-color-primary: #39535b;
+    --ifm-color-primary-dark: #334b52;
+    --ifm-color-primary-darker: #30474d;
+    --ifm-color-primary-darkest: #283a40;
+    --ifm-color-primary-light: #3f5b64;
+    --ifm-color-primary-lighter: #425f69;
+    --ifm-color-primary-lightest: #4a6c76;
+
+    --ifm-link-color: var(--unleash-color-purple);
+    --ifm-menu-color-background-active: var(--unleash-color-gray);
+    --ifm-menu-color-background-hover: var(--unleash-color-gray);
+
+    --unleash-color-admonition-background: var(--unleash-color-gray);
+    --unleash-color-admonition-border: #999;
+    --unleash-color-admonition-text: #2b2b2b;
+}
+
 html[data-theme='dark'] {
+    --ifm-color-primary: #39535b;
+    --ifm-color-primary-dark: #334b52;
+    --ifm-color-primary-darker: #30474d;
+    --ifm-color-primary-darkest: #283a40;
+    --ifm-color-primary-light: #3f5b64;
+    --ifm-color-primary-lighter: #425f69;
+    --ifm-color-primary-lightest: #4a6c76;
+
     --ifm-link-color: #aaa5ff;
+
+    --unleash-color-admonition-background: var(--ifm-color-secondary-contrast-background);
 }
 
 [class^='docTitle'] {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -65,7 +65,7 @@ img {
     background: var(--unleash-img-background-color);
     display: block;
     margin: auto;
-    border: 1px solid var(--unleash-color-gray);
+    border: var(--ifm-global-border-width) solid var(--unleash-color-gray);
     border-radius: var(--ifm-global-radius);
     box-shadow: var(--ifm-global-shadow-lw);
 }


### PR DESCRIPTION
It seems that some changes (some recent, some older) have introduced a number of contrast issues to the doc dark theme. This PR fixes issues with:
- the sidebar
- urls

Most changes should be pretty uncontroversial, but it might be worth discussing the new `--ifm-color-primary` gradient at some point.

Optionally: we should develop a dark mode palette for Unleash and use that.