### PR TITLE
docs: hide 'back-to-main-menu' entry in narrow menu

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -29,13 +29,17 @@
     --navbar-link-color: #122d33;
 }
 
-
 footer {
     --ifm-footer-link-hover-color: var(--ifm-footer-link-color);
 }
 
 [class^='docTitle'] {
     font-size: 2.5rem !important;
+}
+
+.navbar-sidebar__back {
+    /* hide the 'back to main menu' item in the narrow menu. */
+    display: none;
 }
 
 li.theme-doc-sidebar-item-category-level-1 > div::before {


### PR DESCRIPTION
This hides the 'back to main menu' button from the narrowed site menu.
There is no main menu to speak of, so having it take you back to
'unleash enterprise' and the GitHub icon seems unnecessary.