### PR TITLE
docs: Add payload properties for user-admin post payload

### DIFF
--- a/website/docs/api/admin/user-admin.md
+++ b/website/docs/api/admin/user-admin.md
@@ -119,12 +119,12 @@ Creates a new user with the given root role.
 
 **Payload properties**
 
-| Property name | Required | Description                                                                     | Example value(s)       |
-|---------------|----------|---------------------------------------------------------------------------------|------------------------|
-| `email`       | Yes      | The user's email address.                                                       | `"user@getunleash.io"` |
-| `name`        | Yes      | The user's name                                                                 | `"Some Name"`          |
-| `rootRole`    | Yes      | The role to assign to the user. Can be either the role's ID or its unique name. | `2`, `"Editor"`        |
-| `sendEmail`   | No       | Whether to send a registration email to the user or not. Defaults to `true`.    | `false`                |
+| Property name | Required | Description                                                                               | Example value(s)       |
+|---------------|----------|-------------------------------------------------------------------------------------------|------------------------|
+| `email`       | Yes      | The user's email address.                                                                 | `"user@getunleash.io"` |
+| `name`        | Yes      | The user's name                                                                           | `"Some Name"`          |
+| `rootRole`    | Yes      | The role to assign to the user. Can be either the role's ID or its unique name.           | `2`, `"Editor"`        |
+| `sendEmail`   | No       | Whether to send a welcome email with a login link to the user or not. Defaults to `true`. | `false`                |
 
 
 **Body**

--- a/website/docs/api/admin/user-admin.md
+++ b/website/docs/api/admin/user-admin.md
@@ -115,7 +115,17 @@ You can also search for users via the search API. It will preform a simple searc
 
 `POST https://unleash.host.com/api/admin/user-admin`
 
-Creates a new use with the given root role.
+Creates a new user with the given root role.
+
+**Payload properties**
+
+| Property name | Required | Description                                                                     | Example value(s)       |
+|---------------|----------|---------------------------------------------------------------------------------|------------------------|
+| `email`       | Yes      | The user's email address.                                                       | `"user@getunleash.io"` |
+| `name`        | Yes      | The user's name                                                                 | `"Some Name"`          |
+| `rootRole`    | Yes      | The role to assign to the user. Can be either the role's ID or its unique name. | `2`, `"Editor"`        |
+| `sendEmail`   | No       | Whether to send a registration email to the user or not. Defaults to `true`.    | `false`                |
+
 
 **Body**
 
@@ -127,12 +137,6 @@ Creates a new use with the given root role.
   "sendEmail": true
 }
 ```
-
-**Notes**
-
-- `email` - Required field. 
-- `rootRole` - can either be the role id or the unique name of the role (e.g: `Editor`).
-- `sendEmail` - set to `true` if you want Unleash to send Welcome email to the new user. Do require the Unleash instance to be configured with email settings.
 
 #### Return values: {#return-values}
 

--- a/website/docs/api/admin/user-admin.md
+++ b/website/docs/api/admin/user-admin.md
@@ -119,10 +119,14 @@ Creates a new user with the given root role.
 
 **Payload properties**
 
+:::info Requirements
+The payload **must** contain **at least one of** the `name` and `email` properties, though which one is up to you. For the user to be able to log in to the system, the user **must** have an email.
+:::
+
 | Property name | Required | Description                                                                               | Example value(s)       |
 |---------------|----------|-------------------------------------------------------------------------------------------|------------------------|
-| `email`       | Yes      | The user's email address.                                                                 | `"user@getunleash.io"` |
-| `name`        | Yes      | The user's name                                                                           | `"Some Name"`          |
+| `email`       | No       | The user's email address. Must be provided if `name` is not provided.                     | `"user@getunleash.io"` |
+| `name`        | No       | The user's name. Must be provided if `email` is not provided.                             | `"Some Name"`          |
 | `rootRole`    | Yes      | The role to assign to the user. Can be either the role's ID or its unique name.           | `2`, `"Editor"`        |
 | `sendEmail`   | No       | Whether to send a welcome email with a login link to the user or not. Defaults to `true`. | `false`                |
 


### PR DESCRIPTION
Adds an explanation of what the various properties in the payload
object to the `user-admin` endpoint does. Most seem fairly
self-explanatory, but I'm not entirely sure what `sendEmail` does.

Requires validation by a third party before merging.