### PR TITLE
docs: change API how-tos label from "API" to "Using the APIs"

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -47,7 +47,7 @@ module.exports = {
                         description: 'Learn how to work with the Unleash API',
                         slug: '/how-to/api',
                     },
-                    label: 'API',
+                    label: 'Using the APIs',
                     items: ['user_guide/api-token', 'advanced/api_access'],
                 },
                 {


### PR DESCRIPTION
I keep getting confused and clicking the link to the how-to guides
when I wanna go to the API reference docs and I _wrote_ the damn thing
🙈 In other words, I betcha someone else is struggling with the same
thing.

So let's try and change it to something that's harder to click by mistake.