### PR TITLE
fix: don't apply extra image styling to images outside the main

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -61,7 +61,7 @@ html[data-theme='dark'] {
     --unleash-img-background-color: #fff;
 }
 
-img {
+main img {
     background: var(--unleash-img-background-color);
     display: block;
     margin: auto;


### PR DESCRIPTION
Without this modifier, the border, background color, etc, also applies
to logos in the header and footer, and that's not what we want.