### PR TITLE
docs: adjust primary color scale, fix search dropdown a11y issues

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -42,9 +42,9 @@ html[data-theme='dark'] {
     --ifm-color-primary-lighter: #c9c9ff;
     --ifm-color-primary-light: #c2c0ff;
     --ifm-color-primary: #bab8ff;
-    --ifm-color-primary-dark: #b2afff;
-    --ifm-color-primary-darker: #aba7ff;
-    --ifm-color-primary-darkest: #a39eff;
+    --ifm-color-primary-dark: #a09de4;
+    --ifm-color-primary-darker: #8582c9;
+    --ifm-color-primary-darkest: #6b67ae;
 
     --unleash-color-purple: var(--ifm-color-primary);
     --unleash-color-gray: #333;
@@ -57,8 +57,9 @@ html[data-theme='dark'] {
         --ifm-color-secondary-contrast-background
     );
 
-
     --unleash-img-background-color: #fff;
+
+    --docsearch-primary-color: var(--ifm-color-primary-darkest);
 }
 
 main img {


### PR DESCRIPTION
This changes the darker end of the primary color scale to make it even
darker. This means that at the lower end of the scale, white text also
gets enough contrast to be accessible.

For the record: these variables do not seem to be in use anywhere else
in the code base (based on a text search), so it shouldn't affect any
other bits or pieces.

## Screenies:

**Before**:

![image](https://user-images.githubusercontent.com/17786332/153849677-e53586c9-1b31-48ee-927f-0d62890874b3.png)


**After**: 

![image](https://user-images.githubusercontent.com/17786332/153849722-9b862e0c-cedd-4193-b706-0e97f18ff566.png)
