### PR TITLE
refactor: add an hoursBack query param to the raw metrics endpoint

### DIFF
--- a/src/lib/routes/admin-api/client-metrics.ts
+++ b/src/lib/routes/admin-api/client-metrics.ts
@@ -34,7 +34,7 @@ class ClientMetricsController extends Controller {
         const { hoursBack } = req.query;
         const data = await this.metrics.getClientMetricsForToggle(
             name,
-            ClientMetricsController.parseHoursBackQueryParam(hoursBack),
+            this.parseHoursBackQueryParam(hoursBack),
         );
         res.json({
             version: 1,
@@ -53,9 +53,7 @@ class ClientMetricsController extends Controller {
         });
     }
 
-    private static parseHoursBackQueryParam(
-        param: unknown,
-    ): number | undefined {
+    private parseHoursBackQueryParam(param: unknown): number | undefined {
         if (typeof param !== 'string') {
             return undefined;
         }

--- a/src/lib/routes/admin-api/client-metrics.ts
+++ b/src/lib/routes/admin-api/client-metrics.ts
@@ -57,7 +57,7 @@ class ClientMetricsController extends Controller {
         param: unknown,
     ): number | undefined {
         if (typeof param !== 'string') {
-            return;
+            return undefined;
         }
 
         const parsed = Number(param);

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -114,8 +114,12 @@ export default class ClientMetricsServiceV2 {
 
     async getClientMetricsForToggle(
         toggleName: string,
+        hoursBack?: number,
     ): Promise<IClientMetricsEnv[]> {
-        return this.clientMetricsStoreV2.getMetricsForFeatureToggle(toggleName);
+        return this.clientMetricsStoreV2.getMetricsForFeatureToggle(
+            toggleName,
+            hoursBack,
+        );
     }
 
     destroy(): void {

--- a/src/test/e2e/api/admin/client-metrics.e2e.test.ts
+++ b/src/test/e2e/api/admin/client-metrics.e2e.test.ts
@@ -136,11 +136,13 @@ test('should support the hoursBack query param for raw metrics', async () => {
             .then((res) => res.body);
     };
 
+    const hours1 = await fetchHoursBack(1);
     const hours24 = await fetchHoursBack(24);
     const hours48 = await fetchHoursBack(48);
     const hoursTooFew = await fetchHoursBack(-999);
     const hoursTooMany = await fetchHoursBack(999);
 
+    expect(hours1.data).toHaveLength(1);
     expect(hours24.data).toHaveLength(2);
     expect(hours48.data).toHaveLength(3);
     expect(hoursTooFew.data).toHaveLength(2);

--- a/src/test/e2e/api/admin/client-metrics.e2e.test.ts
+++ b/src/test/e2e/api/admin/client-metrics.e2e.test.ts
@@ -126,9 +126,11 @@ test('should support the hoursBack query param for raw metrics', async () => {
 
     await db.stores.clientMetricsStoreV2.batchInsertMetrics(metrics);
 
-    const fetchHoursBack = (h: number) => {
+    const fetchHoursBack = (hoursBack: number) => {
         return app.request
-            .get(`/api/admin/client-metrics/features/demo/raw?hoursBack=${h}`)
+            .get(
+                `/api/admin/client-metrics/features/demo/raw?hoursBack=${hoursBack}`,
+            )
             .expect('Content-Type', /json/)
             .expect(200)
             .then((res) => res.body);


### PR DESCRIPTION
Needed by the the new feature toggle metrics page.