### PR TITLE
docs: Add how-to video for impression data

### DIFF
--- a/website/docs/how-to/how-to-capture-impression-data.mdx
+++ b/website/docs/how-to/how-to-capture-impression-data.mdx
@@ -2,6 +2,7 @@
 title: How to capture impression data
 ---
 import ApiRequest from '@site/src/components/ApiRequest'
+import VideoContent from '@site/src/components/VideoContent.jsx'
 
 :::info Placeholders
 Placeholders in code samples below are delimited by angle brackets (i.e. `<placeholder-name>`). You will need to replace them with the values that are correct in _your_ situation for the code samples to run properly.
@@ -11,6 +12,9 @@ Unleash allows you to gather [**impression data**](../advanced/impression-data.m
 
 This guide will take you through everything you need to do in Unleash to facilitate such a workflow. It will show you how to send data to Posthog as an example sink, but the exact same principles will apply to any other service of the same kind.
 
+<VideoContent videoUrls={["https://www.youtube.com/embed/bxYdeMb9ffw"]}>
+This content in this guide is also available in video format.
+</VideoContent>
 
 ## Prerequisites
 


### PR DESCRIPTION
This change adds a video to the impression data how-to guide