### PR TITLE
Fix/correct old migrations

### DIFF
--- a/src/migrations/20210428103922-patch-role-table.js
+++ b/src/migrations/20210428103922-patch-role-table.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql('ALTER TABLE roles ADD COLUMN IF NOT EXISTS project text', cb);
+};
+
+exports.down = function (db, cb) {
+    cb();
+};

--- a/src/migrations/20210428103924-patch-admin-role-name.js
+++ b/src/migrations/20210428103924-patch-admin-role-name.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        UPDATE roles set name='Admin' where name='Super User';
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    cb();
+};

--- a/src/migrations/20210428103924-patch-admin_role.js
+++ b/src/migrations/20210428103924-patch-admin_role.js
@@ -1,0 +1,27 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        DO $$
+        declare
+        begin
+                WITH admin AS (
+                    SELECT * FROM roles WHERE name in ('Admin', 'Super User') LIMIT 1
+                )
+                INSERT into role_user(role_id, user_id)
+                VALUES 
+                    ((select id from admin), (select id FROM users where username='admin' LIMIT 1)); 
+
+        EXCEPTION WHEN OTHERS THEN
+            raise notice 'Ignored';
+        end;
+        $$;`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    // We can't just remove roles for users as we don't know if there has been any manual additions.
+    cb();
+};

--- a/src/migrations/20210428103924-patch-role_permissions.js
+++ b/src/migrations/20210428103924-patch-role_permissions.js
@@ -1,0 +1,53 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        DO $$
+        declare
+        begin
+                WITH editor AS (
+                    SELECT * FROM roles WHERE name in ('Editor', 'Regular') LIMIT 1
+                )
+
+                INSERT INTO role_permission(role_id, project, permission)
+                VALUES
+                    ((SELECT id from editor), '', 'CREATE_STRATEGY'),
+                    ((SELECT id from editor), '', 'UPDATE_STRATEGY'),
+                    ((SELECT id from editor), '', 'DELETE_STRATEGY'),
+        
+                    ((SELECT id from editor), '', 'UPDATE_APPLICATION'),
+        
+                    ((SELECT id from editor), '', 'CREATE_CONTEXT_FIELD'),
+                    ((SELECT id from editor), '', 'UPDATE_CONTEXT_FIELD'),
+                    ((SELECT id from editor), '', 'DELETE_CONTEXT_FIELD'),
+                    
+                    ((SELECT id from editor), '', 'CREATE_PROJECT'),
+        
+                    ((SELECT id from editor), '', 'CREATE_ADDON'),
+                    ((SELECT id from editor), '', 'UPDATE_ADDON'),
+                    ((SELECT id from editor), '', 'DELETE_ADDON'),
+                
+                    ((SELECT id from editor), 'default', 'UPDATE_PROJECT'),
+                    ((SELECT id from editor), 'default', 'DELETE_PROJECT'),
+                    ((SELECT id from editor), 'default', 'CREATE_FEATURE'),
+                    ((SELECT id from editor), 'default', 'UPDATE_FEATURE'),
+                    ((SELECT id from editor), 'default', 'DELETE_FEATURE');
+                
+                -- Clean up duplicates
+                DELETE FROM role_permission p1
+                USING           role_permission p2
+                WHERE  p1.created_at < p2.created_at   -- select the "older" ones
+                AND  p1.project    = p2.project       -- list columns that define duplicates
+                AND  p1.permission = p2.permission;
+        EXCEPTION WHEN OTHERS THEN
+            raise notice 'Ignored';
+        end;
+        $$;`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    cb();
+};

--- a/src/migrations/20220224081422-remove-project-column-from-roles.js
+++ b/src/migrations/20220224081422-remove-project-column-from-roles.js
@@ -1,0 +1,8 @@
+exports.up = function (db, cb) {
+    db.runSql('ALTER TABLE roles DROP COLUMN IF EXISTS project', cb);
+};
+
+exports.down = function (db, cb) {
+    // We can't just remove roles for users as we don't know if there has been any manual additions.
+    db.runSql('ALTER TABLE roles ADD COLUMN IF NOT EXISTS project text', cb);
+};

--- a/src/migrations/20220224081422-remove-project-column-from-roles.js
+++ b/src/migrations/20220224081422-remove-project-column-from-roles.js
@@ -3,6 +3,5 @@ exports.up = function (db, cb) {
 };
 
 exports.down = function (db, cb) {
-    // We can't just remove roles for users as we don't know if there has been any manual additions.
     db.runSql('ALTER TABLE roles ADD COLUMN IF NOT EXISTS project text', cb);
 };


### PR DESCRIPTION
Adds migrations that will correct the database if the user ever applied to error'ed migration introduced as part of v3.13.0.

b695178311e670d06caa050ff632cf0b64af7016 needs to be backported to all feature releases of v4. (Already included as part of v4.4.x).