### PR TITLE
fix: correct the description of disabled variants

### DIFF
--- a/website/docs/sdks/unleash-proxy.md
+++ b/website/docs/sdks/unleash-proxy.md
@@ -215,7 +215,7 @@ The data for a toggle without [variants](../advanced/feature-toggle-variants.md)
 
 - **`name`**: the name of the feature.
 - **`enabled`**: whether the toggle is enabled or not. Will always be `true`.
-- **`variant`**: describes whether the toggle has variants and, if it does, what variant is active for this user. If a toggle doesn't have any variants, it will always be `{"name": "disabled", "enabled": true}`.
+- **`variant`**: describes whether the toggle has variants and, if it does, what variant is active for this user. If a toggle doesn't have any variants, it will always be `{"name": "disabled", "enabled": false}`.
 
 :::note
 Unleash uses a fallback variant called "disabled" to indicate that a toggle has no variants. However, you are free to create a variant called "disabled" yourself. In that case you can tell them apart by checking the variant's `enabled` property: if the toggle has no variants, `enabled` will be `false`. If the toggle is the "disabled" variant that you created, it will have `enabled` set to `true`.


### PR DESCRIPTION
As reported in slack, the description here was wrong. This is a little fix.