### PR TITLE
docs: reword and add additional deets re: activation strategy impl

### DIFF
--- a/website/docs/user_guide/activation-strategies.md
+++ b/website/docs/user_guide/activation-strategies.md
@@ -7,8 +7,7 @@ It is powerful to be able to turn a feature on and off instantaneously, without 
 
 Unleash comes with a number of built-in strategies (described below) and also lets you add your own [custom activation strategies](../advanced/custom-activation-strategy.md) if you need more control.
 However, while activation strategies are *defined* on the server, the server does not *implement* the strategies. Instead, activation strategy *implementation* (and thus feature toggle *evaluation*) is done client-side.
-Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies
-(and allow you to add your own custom strategy implementations).
+Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies (and allow you to add your own custom strategy implementations).
 The [front-end client SDKs](../sdks/index.md#front-end-sdks) do not do the evaluation themselves: instead relying on the [Unleash Proxy](../sdks/unleash-proxy.md) to take care of the implementation and evaluation.
 
 Unleash comes with a few common activation strategies. Some of them require the client to provide the [unleash-context](unleash-context.md), which gives the necessary context for Unleash. The built-in activation strategies are:

--- a/website/docs/user_guide/activation-strategies.md
+++ b/website/docs/user_guide/activation-strategies.md
@@ -8,7 +8,7 @@ It is powerful to be able to turn a feature on and off instantaneously, without 
 Unleash comes with a number of built-in strategies (described below) and also lets you add your own [custom activation strategies](../advanced/custom-activation-strategy.md) if you need more control.
 However, while activation strategies are *defined* on the server, the server does not *implement* the strategies. Instead, activation strategy *implementation* (and thus feature toggle *evaluation*) is done client-side.
 Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies (and allow you to add your own custom strategy implementations).
-The [front-end client SDKs](../sdks/index.md#front-end-sdks) do not do the evaluation themselves: instead relying on the [Unleash Proxy](../sdks/unleash-proxy.md) to take care of the implementation and evaluation.
+The [front-end client SDKs](../sdks/index.md#front-end-sdks) do not do the evaluation themselves, instead relying on the [Unleash Proxy](../sdks/unleash-proxy.md) to take care of the implementation and evaluation.
 
 Some activation strategies require the client to provide the current [Unleash context](unleash-context.md) to the toggle evaluation function for the evaluation to be done correctly.
 

--- a/website/docs/user_guide/activation-strategies.md
+++ b/website/docs/user_guide/activation-strategies.md
@@ -5,7 +5,7 @@ title: Activation Strategies
 
 It is powerful to be able to turn a feature on and off instantaneously, without redeploying the application. The next level of control comes when you are able to enable a feature for specific users or enable it for a small subset of users. We achieve this level of control with the help of activation strategies. The most straightforward strategy is the standard strategy, which basically means that the feature should be enabled to everyone.
 
-Unleash comes with a number of built-in strategies (described below) and also lets you add your own [custom activation strategies](../custom-activation-strategy.md) if you need more control.
+Unleash comes with a number of built-in strategies (described below) and also lets you add your own [custom activation strategies](../advanced/custom-activation-strategy.md) if you need more control.
 However, while activation strategies are *defined* on the server, the server does not *implement* the strategies. Instead, activation strategy *implementation* (and thus feature toggle *evaluation*) is done client-side.
 Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies
 (and allow you to add your own custom strategy implementations).

--- a/website/docs/user_guide/activation-strategies.md
+++ b/website/docs/user_guide/activation-strategies.md
@@ -10,7 +10,9 @@ However, while activation strategies are *defined* on the server, the server doe
 Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies (and allow you to add your own custom strategy implementations).
 The [front-end client SDKs](../sdks/index.md#front-end-sdks) do not do the evaluation themselves: instead relying on the [Unleash Proxy](../sdks/unleash-proxy.md) to take care of the implementation and evaluation.
 
-Unleash comes with a few common activation strategies. Some of them require the client to provide the [unleash-context](unleash-context.md), which gives the necessary context for Unleash. The built-in activation strategies are:
+Some activation strategies require the client to provide the current [Unleash context](unleash-context.md) to the toggle evaluation function for the evaluation to be done correctly.
+
+The following activation strategies are bundled with Unleash and always available:
 
 - [Standard](#standard)
 - [UserIDs](#userids)

--- a/website/docs/user_guide/activation-strategies.md
+++ b/website/docs/user_guide/activation-strategies.md
@@ -5,7 +5,11 @@ title: Activation Strategies
 
 It is powerful to be able to turn a feature on and off instantaneously, without redeploying the application. The next level of control comes when you are able to enable a feature for specific users or enable it for a small subset of users. We achieve this level of control with the help of activation strategies. The most straightforward strategy is the standard strategy, which basically means that the feature should be enabled to everyone.
 
-The definition of an activation strategy lives in the Unleash API and can be created via the Unleash UI. The implementation of activation strategies lives in various client implementations.
+Unleash comes with a number of built-in strategies (described below) and also lets you add your own [custom activation strategies](../custom-activation-strategy.md) if you need more control.
+However, while activation strategies are *defined* on the server, the server does not *implement* the strategies. Instead, activation strategy *implementation* (and thus feature toggle *evaluation*) is done client-side.
+Thus, all [server-side client SDKs](../sdks/index.md#server-side-sdks) and the [Unleash Proxy](../sdks/unleash-proxy.md) implement the default strategies
+(and allow you to add your own custom strategy implementations).
+The [front-end client SDKs](../sdks/index.md#front-end-sdks) do not do the evaluation themselves: instead relying on the [Unleash Proxy](../sdks/unleash-proxy.md) to take care of the implementation and evaluation.
 
 Unleash comes with a few common activation strategies. Some of them require the client to provide the [unleash-context](unleash-context.md), which gives the necessary context for Unleash. The built-in activation strategies are:
 


### PR DESCRIPTION
This PR clarifies how and where activation strategies are implemented and evaluated in terms of the server, server-side sdks, the proxy, and front-end sdks.