### PR TITLE
docs: fix typo for password in configuring unleash

### DIFF
--- a/website/docs/deploy/configuring-unleash.md
+++ b/website/docs/deploy/configuring-unleash.md
@@ -15,7 +15,7 @@ In order for Unleash server to work, you must setup database connection details.
   - `DATABASE_HOST` - the database hostname - defaults to `localhost`
   - `DATABASE_PORT` - the port the database is listening on - defaults to `5432`
   - `DATABASE_USERNAME` - the user configured for access - defaults to `unleash_user`
-  - `DATABASE_PASSWORD` - the password for the user - defaults to `passord`
+  - `DATABASE_PASSWORD` - the password for the user - defaults to `password`
   - `DATABASE_NAME` - the name of the database - defaults to `unleash`
   - `DATABASE_SSL` - a json object representing SSL configuration or `false` for not using SSL
   - `DATABASE_SCHEMA` - Which schema to use - defaults to `public`
@@ -48,7 +48,7 @@ const unleash = require('unleash-server');
 const unleashOptions = {
   db: {
     user: 'unleash_user',
-    password: 'passord',
+    password: 'password',
     host: 'localhost',
     port: 5432,
     database: 'unleash',


### PR DESCRIPTION
Fix typo for database password ('passord' instead of 'password') in further customization section:
![image](https://user-images.githubusercontent.com/4197222/157476355-6a012dc7-d9d8-4515-80b6-2235f579636b.png)

And on database details section:
![image](https://user-images.githubusercontent.com/4197222/157476609-92380e65-ee47-46d1-b39c-a9d4093c3f66.png)
