### PR TITLE
Enabled environments override

### DIFF
--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -224,3 +224,47 @@ test('should handle cases where no env var specified for tokens', async () => {
 
     expect(config.authentication.initApiTokens).toHaveLength(1);
 });
+
+test('should load environment overrides from env var', async () => {
+    process.env.ENABLED_ENVIRONMENTS = 'default,production';
+
+    const config = createConfig({
+        db: {
+            host: 'localhost',
+            port: 4242,
+            user: 'unleash',
+            password: 'password',
+            database: 'unleash_db',
+        },
+        server: {
+            port: 4242,
+        },
+        authentication: {
+            initApiTokens: [],
+        },
+    });
+
+    expect(config.environmentEnableOverrides).toHaveLength(2);
+    expect(config.environmentEnableOverrides).toContain('production');
+    delete process.env.ENABLED_ENVIRONMENTS;
+});
+
+test('should yield an empty list when no environment overrides are specified', async () => {
+    const config = createConfig({
+        db: {
+            host: 'localhost',
+            port: 4242,
+            user: 'unleash',
+            password: 'password',
+            database: 'unleash_db',
+        },
+        server: {
+            port: 4242,
+        },
+        authentication: {
+            initApiTokens: [],
+        },
+    });
+
+    expect(config.environmentEnableOverrides).toStrictEqual([]);
+});

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -217,6 +217,14 @@ const loadInitApiTokens = () => {
     ];
 };
 
+const loadEnvironmentEnableOverrides = () => {
+    const environmentsString = process.env.ENABLED_ENVIRONMENTS;
+    if (environmentsString) {
+        return environmentsString.split(',');
+    }
+    return [];
+};
+
 export function createConfig(options: IUnleashOptions): IUnleashConfig {
     let extraDbOptions = {};
 
@@ -275,6 +283,8 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         { initApiTokens: initApiTokens },
     ]);
 
+    const environmentEnableOverrides = loadEnvironmentEnableOverrides();
+
     const importSetting: IImportOption = mergeAll([
         defaultImport,
         options.import,
@@ -323,6 +333,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         eventHook: options.eventHook,
         enterpriseVersion: options.enterpriseVersion,
         eventBus: new EventEmitter(),
+        environmentEnableOverrides,
     };
 }
 

--- a/src/lib/db/environment-store.ts
+++ b/src/lib/db/environment-store.ts
@@ -163,20 +163,26 @@ export default class EnvironmentStore implements IEnvironmentStore {
         return mapRow(row[0]);
     }
 
-    async disableAllExcept(environments: string[]): Promise<void> {
+    async disable(environments: IEnvironment[]): Promise<void> {
         await this.db(TABLE)
             .update({
                 enabled: false,
             })
-            .whereNotIn('name', environments);
+            .whereIn(
+                'name',
+                environments.map((env) => env.name),
+            );
     }
 
-    async enable(environments: string[]): Promise<void> {
+    async enable(environments: IEnvironment[]): Promise<void> {
         await this.db(TABLE)
             .update({
                 enabled: true,
             })
-            .whereIn('name', environments);
+            .whereIn(
+                'name',
+                environments.map((env) => env.name),
+            );
     }
 
     async delete(name: string): Promise<void> {

--- a/src/lib/db/environment-store.ts
+++ b/src/lib/db/environment-store.ts
@@ -163,6 +163,22 @@ export default class EnvironmentStore implements IEnvironmentStore {
         return mapRow(row[0]);
     }
 
+    async disableAllExcept(environments: string[]): Promise<void> {
+        await this.db(TABLE)
+            .update({
+                enabled: false,
+            })
+            .whereNotIn('name', environments);
+    }
+
+    async enable(environments: string[]): Promise<void> {
+        await this.db(TABLE)
+            .update({
+                enabled: true,
+            })
+            .whereIn('name', environments);
+    }
+
     async delete(name: string): Promise<void> {
         await this.db(TABLE).where({ name, protected: false }).del();
     }

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -24,6 +24,11 @@ const COLUMNS = [
 ];
 const TABLE = 'projects';
 
+export interface IEnvironmentProjectLink {
+    environmentName: string;
+    projectId: string;
+}
+
 class ProjectStore implements IProjectStore {
     private db: Knex;
 
@@ -197,6 +202,15 @@ class ProjectStore implements IProjectStore {
         }
     }
 
+    async getProjectLinksForEnvironments(
+        environments: string[],
+    ): Promise<IEnvironmentProjectLink[]> {
+        let rows = await this.db('project_environments')
+            .select(['project_id', 'environment_name'])
+            .whereIn('environment_name', environments);
+        return rows.map(this.mapLinkRow);
+    }
+
     async deleteEnvironmentForProject(
         id: string,
         environment: string,
@@ -249,6 +263,14 @@ class ProjectStore implements IProjectStore {
             .count('*')
             .from(TABLE)
             .then((res) => Number(res[0].count));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    mapLinkRow(row): IEnvironmentProjectLink {
+        return {
+            environmentName: row.environment_name,
+            projectId: row.project_id,
+        };
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -87,6 +87,12 @@ async function createApp(
         });
     }
 
+    if (config.environmentEnableOverrides?.length > 0) {
+        await services.environmentService.overrideEnabledProjects(
+            config.environmentEnableOverrides,
+        );
+    }
+
     return new Promise((resolve, reject) => {
         if (startApp) {
             const server = stoppable(

--- a/src/lib/services/environment-service.ts
+++ b/src/lib/services/environment-service.ts
@@ -94,6 +94,28 @@ export default class EnvironmentService {
         }
     }
 
+    async overrideEnabledProjects(
+        environmentsToEnable: string[],
+    ): Promise<void> {
+        if (environmentsToEnable.length === 0) {
+            return Promise.resolve();
+        }
+
+        const environmentsExist = await Promise.all(
+            environmentsToEnable.map((env) =>
+                this.environmentStore.exists(env),
+            ),
+        );
+        if (!environmentsExist.every((exists) => exists)) {
+            this.logger.error(
+                "Found environment enabled overrides but some of the specified environments don't exist, no overrides will be executed",
+            );
+            return;
+        }
+        await this.environmentStore.disableAllExcept(environmentsToEnable);
+        await this.environmentStore.enable(environmentsToEnable);
+    }
+
     async removeEnvironmentFromProject(
         environment: string,
         projectId: string,

--- a/src/lib/services/environment-service.ts
+++ b/src/lib/services/environment-service.ts
@@ -95,25 +95,87 @@ export default class EnvironmentService {
     }
 
     async overrideEnabledProjects(
-        environmentsToEnable: string[],
+        environmentNamesToEnable: string[],
     ): Promise<void> {
-        if (environmentsToEnable.length === 0) {
+        if (environmentNamesToEnable.length === 0) {
             return Promise.resolve();
         }
 
-        const environmentsExist = await Promise.all(
-            environmentsToEnable.map((env) =>
-                this.environmentStore.exists(env),
-            ),
+        const allEnvironments = await this.environmentStore.getAll();
+        const existingEnvironmentsToEnable = allEnvironments.filter((env) =>
+            environmentNamesToEnable.includes(env.name),
         );
-        if (!environmentsExist.every((exists) => exists)) {
-            this.logger.error(
+
+        if (
+            existingEnvironmentsToEnable.length !==
+            environmentNamesToEnable.length
+        ) {
+            this.logger.warn(
                 "Found environment enabled overrides but some of the specified environments don't exist, no overrides will be executed",
             );
-            return;
+            return Promise.resolve();
         }
-        await this.environmentStore.disableAllExcept(environmentsToEnable);
-        await this.environmentStore.enable(environmentsToEnable);
+
+        const environmentsNotAlreadyEnabled =
+            existingEnvironmentsToEnable.filter((env) => env.enabled == false);
+        const environmentsToDisable = allEnvironments.filter((env) => {
+            return (
+                !environmentNamesToEnable.includes(env.name) &&
+                env.enabled == true
+            );
+        });
+
+        await this.environmentStore.disable(environmentsToDisable);
+        await this.environmentStore.enable(environmentsNotAlreadyEnabled);
+
+        await this.remapProjectsLinks(
+            environmentsToDisable,
+            environmentsNotAlreadyEnabled,
+        );
+    }
+
+    private async remapProjectsLinks(
+        toDisable: IEnvironment[],
+        toEnable: IEnvironment[],
+    ) {
+        const projectLinks =
+            await this.projectStore.getProjectLinksForEnvironments(
+                toDisable.map((env) => env.name),
+            );
+
+        const unlinkTasks = projectLinks.map((link) => {
+            return this.forceRemoveEnvironmentFromProject(
+                link.environmentName,
+                link.projectId,
+            );
+        });
+        await Promise.all(unlinkTasks.flat());
+
+        const uniqueProjects = [
+            ...new Set(projectLinks.map((link) => link.projectId)),
+        ];
+
+        let linkTasks = uniqueProjects.map((project) => {
+            return toEnable.map((enabledEnv) => {
+                return this.addEnvironmentToProject(enabledEnv.name, project);
+            });
+        });
+
+        await Promise.all(linkTasks.flat());
+    }
+
+    async forceRemoveEnvironmentFromProject(
+        environment: string,
+        projectId: string,
+    ): Promise<void> {
+        await this.featureEnvironmentStore.disconnectFeatures(
+            environment,
+            projectId,
+        );
+        await this.featureEnvironmentStore.disconnectProject(
+            environment,
+            projectId,
+        );
     }
 
     async removeEnvironmentFromProject(
@@ -125,11 +187,7 @@ export default class EnvironmentService {
         );
 
         if (projectEnvs.length > 1) {
-            await this.featureEnvironmentStore.disconnectFeatures(
-                environment,
-                projectId,
-            );
-            await this.featureEnvironmentStore.disconnectProject(
+            await this.forceRemoveEnvironmentFromProject(
                 environment,
                 projectId,
             );

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -158,4 +158,5 @@ export interface IUnleashConfig {
     enterpriseVersion?: string;
     eventBus: EventEmitter;
     disableLegacyFeaturesApi?: boolean;
+    environmentEnableOverrides?: string[];
 }

--- a/src/lib/types/stores/environment-store.ts
+++ b/src/lib/types/stores/environment-store.ts
@@ -16,6 +16,6 @@ export interface IEnvironmentStore extends Store<IEnvironment, string> {
     updateSortOrder(id: string, value: number): Promise<void>;
     importEnvironments(environments: IEnvironment[]): Promise<IEnvironment[]>;
     delete(name: string): Promise<void>;
-    disableAllExcept(environments: string[]): Promise<void>;
-    enable(environments: string[]): Promise<void>;
+    disable(environments: IEnvironment[]): Promise<void>;
+    enable(environments: IEnvironment[]): Promise<void>;
 }

--- a/src/lib/types/stores/environment-store.ts
+++ b/src/lib/types/stores/environment-store.ts
@@ -16,4 +16,6 @@ export interface IEnvironmentStore extends Store<IEnvironment, string> {
     updateSortOrder(id: string, value: number): Promise<void>;
     importEnvironments(environments: IEnvironment[]): Promise<IEnvironment[]>;
     delete(name: string): Promise<void>;
+    disableAllExcept(environments: string[]): Promise<void>;
+    enable(environments: string[]): Promise<void>;
 }

--- a/src/lib/types/stores/project-store.ts
+++ b/src/lib/types/stores/project-store.ts
@@ -1,3 +1,4 @@
+import { IEnvironmentProjectLink } from 'lib/db/project-store';
 import { IProject, IProjectWithCount } from '../model';
 import { Store } from './store';
 
@@ -35,4 +36,7 @@ export interface IProjectStore extends Store<IProject, string> {
     getProjectsWithCounts(query?: IProjectQuery): Promise<IProjectWithCount[]>;
     count(): Promise<number>;
     getAll(query?: IProjectQuery): Promise<IProject[]>;
+    getProjectLinksForEnvironments(
+        environments: string[],
+    ): Promise<IEnvironmentProjectLink[]>;
 }

--- a/src/test/fixtures/fake-environment-store.ts
+++ b/src/test/fixtures/fake-environment-store.ts
@@ -10,16 +10,18 @@ export default class FakeEnvironmentStore implements IEnvironmentStore {
 
     environments: IEnvironment[] = [];
 
-    disableAllExcept(environments: string[]): Promise<void> {
+    disable(environments: IEnvironment[]): Promise<void> {
         for (let env of this.environments) {
-            if (!environments.includes(env.name)) env.enabled = false;
+            if (environments.map((e) => e.name).includes(env.name))
+                env.enabled = false;
         }
         return Promise.resolve();
     }
 
-    enable(environments: string[]): Promise<void> {
+    enable(environments: IEnvironment[]): Promise<void> {
         for (let env of this.environments) {
-            if (environments.includes(env.name)) env.enabled = true;
+            if (environments.map((e) => e.name).includes(env.name))
+                env.enabled = true;
         }
         return Promise.resolve();
     }

--- a/src/test/fixtures/fake-environment-store.ts
+++ b/src/test/fixtures/fake-environment-store.ts
@@ -10,6 +10,20 @@ export default class FakeEnvironmentStore implements IEnvironmentStore {
 
     environments: IEnvironment[] = [];
 
+    disableAllExcept(environments: string[]): Promise<void> {
+        for (let env of this.environments) {
+            if (!environments.includes(env.name)) env.enabled = false;
+        }
+        return Promise.resolve();
+    }
+
+    enable(environments: string[]): Promise<void> {
+        for (let env of this.environments) {
+            if (environments.includes(env.name)) env.enabled = true;
+        }
+        return Promise.resolve();
+    }
+
     async getAll(): Promise<IEnvironment[]> {
         return this.environments;
     }

--- a/src/test/fixtures/fake-project-store.ts
+++ b/src/test/fixtures/fake-project-store.ts
@@ -5,15 +5,23 @@ import {
 } from '../../lib/types/stores/project-store';
 import { IProject, IProjectWithCount } from '../../lib/types/model';
 import NotFoundError from '../../lib/error/notfound-error';
+import { IEnvironmentProjectLink } from 'lib/db/project-store';
 
 export default class FakeProjectStore implements IProjectStore {
+    projects: IProject[] = [];
+
+    projectEnvironment: Map<string, Set<string>> = new Map();
+
     getEnvironmentsForProject(): Promise<string[]> {
         throw new Error('Method not implemented.');
     }
 
-    projects: IProject[] = [];
-
-    projectEnvironment: Map<string, Set<string>> = new Map();
+    getProjectLinksForEnvironments(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        environments: string[],
+    ): Promise<IEnvironmentProjectLink[]> {
+        throw new Error('Method not implemented.');
+    }
 
     async addEnvironmentToProject(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This PR adds a new environment variable that Unleash will respond to: ENABLED_ENVIRONMENTS. This should be set to a comma delimited string. Unleash will read this and take the following behaviours:

- If the env var is not present, no change in behaviour
- If the env var contains a string that doesn't match an environment exactly, a warning will be logged, no other behaviour will change, so "default,notexists" will do nothing even if default exists as an environment
- For all environments in Unleash the following will occur
  - If the environment is in the list and already enabled, it will be unaffected
  - If the environment is in the list and not enabled, it will be enabled
  - If the environment is not in the list, it will be set to disabled and all its projects and toggles will be linked to each environment that got touched in step 2