### PR TITLE
refactor: always add values to constraints

### DIFF
--- a/src/lib/schema/constraint-value-types.ts
+++ b/src/lib/schema/constraint-value-types.ts
@@ -2,6 +2,9 @@ import joi from 'joi';
 
 export const constraintNumberTypeSchema = joi.number();
 
-export const constraintStringTypeSchema = joi.array().items(joi.string());
+export const constraintStringTypeSchema = joi
+    .array()
+    .items(joi.string())
+    .min(1);
 
 export const constraintDateTypeSchema = joi.date();

--- a/src/lib/schema/feature-schema.test.ts
+++ b/src/lib/schema/feature-schema.test.ts
@@ -210,7 +210,7 @@ test('should not accept empty constraint values', () => {
     );
 });
 
-test('should not accept empty list of constraint values', () => {
+test('should accept empty list of constraint values', async () => {
     const toggle = {
         name: 'app.constraints.empty.value.list',
         type: 'release',
@@ -231,10 +231,10 @@ test('should not accept empty list of constraint values', () => {
         ],
     };
 
-    const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual(
-        '"strategies[0].constraints[0].values" must contain at least 1 items',
-    );
+    const validated = await featureSchema.validateAsync(toggle);
+    expect(validated.strategies.length).toEqual(1);
+    expect(validated.strategies[0].constraints.length).toEqual(1);
+    expect(validated.strategies[0].constraints[0].values).toEqual([]);
 });
 
 test('Filter queries should accept a list of tag values', () => {
@@ -288,4 +288,19 @@ test('constraint schema should only allow specified operators', async () => {
             '"operator" must be one of [NOT_IN, IN, STR_ENDS_WITH, STR_STARTS_WITH, STR_CONTAINS, NUM_EQ, NUM_GT, NUM_GTE, NUM_LT, NUM_LTE, DATE_AFTER, DATE_BEFORE, SEMVER_EQ, SEMVER_GT, SEMVER_LT]',
         );
     }
+});
+
+test('constraint schema should add a values array by default', async () => {
+    const validated = await constraintSchema.validateAsync({
+        contextName: 'x',
+        operator: 'NUM_EQ',
+        value: 1,
+    });
+
+    expect(validated).toEqual({
+        contextName: 'x',
+        operator: 'NUM_EQ',
+        value: 1,
+        values: [],
+    });
 });

--- a/src/lib/schema/feature-schema.ts
+++ b/src/lib/schema/feature-schema.ts
@@ -10,7 +10,8 @@ export const nameSchema = joi
 export const constraintSchema = joi.object().keys({
     contextName: joi.string(),
     operator: joi.string().valid(...ALL_OPERATORS),
-    values: joi.array().items(joi.string().min(1).max(100)).min(1).optional(),
+    // Constraints must have a values array to support legacy SDKs.
+    values: joi.array().items(joi.string().min(1).max(100)).default([]),
     value: joi.optional(),
     caseInsensitive: joi.boolean().optional(),
     inverted: joi.boolean().optional(),


### PR DESCRIPTION
https://trello.com/c/MRIBNNFX/963-unleash-backend-include-values-from-the-unleash-client-api-as-an-empty-array