### PR TITLE
feat: Implement multi token support for client tokens

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -21,7 +21,11 @@ import { defaultCustomAuthDenyAll } from './default-custom-auth-deny-all';
 import { formatBaseUri } from './util/format-base-uri';
 import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns';
 import EventEmitter from 'events';
-import { ApiTokenType, validateApiToken } from './types/models/api-token';
+import {
+    ApiTokenType,
+    mapLegacyToken,
+    validateApiToken,
+} from './types/models/api-token';
 
 const safeToUpper = (s: string) => (s ? s.toUpperCase() : s);
 
@@ -198,7 +202,7 @@ const loadTokensFromString = (tokenString: String, tokenType: ApiTokenType) => {
             type: tokenType,
             username: 'admin',
         };
-        validateApiToken(token);
+        validateApiToken(mapLegacyToken(token));
         return token;
     });
     return tokens;

--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -10,7 +10,7 @@ import { IFeatureToggleQuery } from '../../types/model';
 import NotFoundError from '../../error/notfound-error';
 import { IAuthRequest } from '../unleash-types';
 import ApiUser from '../../types/api-user';
-import { ALL } from '../../types/models/api-token';
+import { ALL, isAllProjects } from '../../types/models/api-token';
 
 const version = 2;
 
@@ -65,8 +65,8 @@ export default class FeatureController extends Controller {
 
         const override: QueryOverride = {};
         if (user instanceof ApiUser) {
-            if (user.project !== ALL) {
-                override.project = [user.project];
+            if (!isAllProjects(user.projects)) {
+                override.project = user.projects;
             }
             if (user.environment !== ALL) {
                 override.environment = user.environment;

--- a/src/lib/schema/api-token-schema.test.ts
+++ b/src/lib/schema/api-token-schema.test.ts
@@ -1,0 +1,44 @@
+import { ALL } from '../types/models/api-token';
+import { createApiToken } from './api-token-schema';
+
+test('should reject token with projects and project', async () => {
+    expect.assertions(1);
+    try {
+        await createApiToken.validateAsync({
+            username: 'test',
+            type: 'admin',
+            project: 'default',
+            projects: ['default'],
+        });
+    } catch (error) {
+        expect(error.details[0].message).toEqual(
+            '"project" must not exist simultaneously with [projects]',
+        );
+    }
+});
+
+test('should not have default project set if projects is present', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'admin',
+        projects: ['default'],
+    });
+    expect(token.project).not.toBeDefined();
+});
+
+test('should have project set to default if projects is missing', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'admin',
+    });
+    expect(token.project).toBe(ALL);
+});
+
+test('should not have projects set if project is present', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'admin',
+        project: 'default',
+    });
+    expect(token.projects).not.toBeDefined();
+});

--- a/src/lib/schema/api-token-schema.ts
+++ b/src/lib/schema/api-token-schema.ts
@@ -12,11 +12,16 @@ export const createApiToken = joi
             .required()
             .valid(ApiTokenType.ADMIN, ApiTokenType.CLIENT),
         expiresAt: joi.date().optional(),
-        project: joi.string().optional().default(ALL),
+        project: joi.when('projects', {
+            not: joi.required(),
+            then: joi.string().optional().default(ALL),
+        }),
+        projects: joi.array().min(0).optional(),
         environment: joi.when('type', {
             is: joi.string().valid(ApiTokenType.CLIENT),
             then: joi.string().optional().default(DEFAULT_ENV),
             otherwise: joi.string().optional().default(ALL),
         }),
     })
+    .nand('project', 'projects')
     .options({ stripUnknown: true, allowUnknown: false, abortEarly: false });

--- a/src/lib/types/api-user.ts
+++ b/src/lib/types/api-user.ts
@@ -4,7 +4,8 @@ import { CLIENT } from './permissions';
 interface IApiUserData {
     username: string;
     permissions?: string[];
-    project: string;
+    projects?: string[];
+    project?: string;
     environment: string;
     type: ApiTokenType;
 }
@@ -16,7 +17,7 @@ export default class ApiUser {
 
     readonly permissions: string[];
 
-    readonly project: string;
+    readonly projects: string[];
 
     readonly environment: string;
 
@@ -25,6 +26,7 @@ export default class ApiUser {
     constructor({
         username,
         permissions = [CLIENT],
+        projects,
         project,
         environment,
         type,
@@ -34,8 +36,12 @@ export default class ApiUser {
         }
         this.username = username;
         this.permissions = permissions;
-        this.project = project;
         this.environment = environment;
         this.type = type;
+        if (projects && projects.length > 0) {
+            this.projects = projects;
+        } else {
+            this.projects = [project];
+        }
     }
 }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
-import { IApiTokenCreate } from './models/api-token';
+import { ILegacyApiTokenCreate } from './models/api-token';
 import { IExperimentalOptions } from '../experimental';
 
 export type EventHook = (eventName: string, data: object) => void;
@@ -55,7 +55,7 @@ export interface IAuthOption {
     type: IAuthType;
     customAuthHandler?: Function;
     createAdminUser: boolean;
-    initApiTokens: IApiTokenCreate[];
+    initApiTokens: ILegacyApiTokenCreate[];
 }
 
 export interface IImportOption {

--- a/src/migrations/20220331085057-add-api-link-table.js
+++ b/src/migrations/20220331085057-add-api-link-table.js
@@ -1,0 +1,41 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        CREATE TABLE IF NOT EXISTS api_token_project
+        (
+            secret     text NOT NULL,
+            project    text NOT NULL,
+            FOREIGN KEY (secret) REFERENCES api_tokens (secret) ON DELETE CASCADE,
+            FOREIGN KEY (project) REFERENCES projects(id) ON DELETE CASCADE
+        );
+
+        INSERT INTO api_token_project SELECT secret, project FROM api_tokens WHERE project IS NOT NULL;
+
+        ALTER TABLE api_tokens DROP COLUMN "project";
+      `,
+        cb,
+    );
+};
+
+//This is a lossy down migration, tokens with multiple projects are discarded
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE api_tokens ADD COLUMN project VARCHAR REFERENCES PROJECTS(id) ON DELETE CASCADE;
+        DELETE FROM api_tokens WHERE secret LIKE '[]%';
+
+        UPDATE api_tokens
+        SET project = subquery.project
+        FROM(
+            SELECT token.secret, link.project FROM api_tokens AS token LEFT JOIN api_token_project AS link ON
+                token.secret  = link.secret
+        ) AS subquery
+        WHERE api_tokens.project = subquery.project;
+
+        DROP TABLE api_token_project;
+`,
+        cb,
+    );
+};

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -194,7 +194,7 @@ test('creates new client token: project & environment defaults to "*"', async ()
             expect(res.body.type).toBe('client');
             expect(res.body.secret.length > 16).toBe(true);
             expect(res.body.environment).toBe(DEFAULT_ENV);
-            expect(res.body.project).toBe(ALL);
+            expect(res.body.projects[0]).toBe(ALL);
         });
 });
 
@@ -213,7 +213,7 @@ test('creates new client token with project & environment set', async () => {
             expect(res.body.type).toBe('client');
             expect(res.body.secret.length > 16).toBe(true);
             expect(res.body.environment).toBe(DEFAULT_ENV);
-            expect(res.body.project).toBe('default');
+            expect(res.body.projects[0]).toBe('default');
         });
 });
 

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -5,10 +5,14 @@ import { createTestConfig } from '../../config/test-config';
 import { ApiTokenType, IApiToken } from '../../../lib/types/models/api-token';
 import { DEFAULT_ENV } from '../../../lib/util/constants';
 import { addDays, subDays } from 'date-fns';
+import ProjectService from '../../../lib/services/project-service';
+import FeatureToggleService from '../../../lib/services/feature-toggle-service';
+import { AccessService } from '../../../lib/services/access-service';
 
 let db;
 let stores;
 let apiTokenService: ApiTokenService;
+let projectService: ProjectService;
 
 beforeAll(async () => {
     const config = createTestConfig({
@@ -16,7 +20,27 @@ beforeAll(async () => {
     });
     db = await dbInit('api_token_service_serial', getLogger);
     stores = db.stores;
-    // projectStore = stores.projectStore;
+    const accessService = new AccessService(stores, config);
+    const featureToggleService = new FeatureToggleService(stores, config);
+    const project = {
+        id: 'test-project',
+        name: 'Test Project',
+        description: 'Fancy',
+    };
+    const user = await stores.userStore.insert({
+        name: 'Some Name',
+        email: 'test@getunleash.io',
+    });
+
+    projectService = new ProjectService(
+        stores,
+        config,
+        accessService,
+        featureToggleService,
+    );
+
+    await projectService.createProject(project, user);
+
     apiTokenService = new ApiTokenService(stores, config);
 });
 
@@ -127,4 +151,76 @@ test('should only return valid tokens', async () => {
 
     expect(tokens.length).toBe(1);
     expect(activeToken.secret).toBe(tokens[0].secret);
+});
+
+test('should create client token with project list', async () => {
+    const token = await apiTokenService.createApiToken({
+        username: 'default-client',
+        type: ApiTokenType.CLIENT,
+        projects: ['default', 'test-project'],
+        environment: DEFAULT_ENV,
+    });
+
+    expect(token.secret.slice(0, 2)).toEqual('[]');
+    expect(token.projects).toStrictEqual(['default', 'test-project']);
+});
+
+test('should strip all other projects if ALL_PROJECTS is present', async () => {
+    const token = await apiTokenService.createApiToken({
+        username: 'default-client',
+        type: ApiTokenType.CLIENT,
+        projects: ['*', 'default'],
+        environment: DEFAULT_ENV,
+    });
+
+    expect(token.projects).toStrictEqual(['*']);
+});
+
+test('should return user with multiple projects', async () => {
+    const now = Date.now();
+    const tomorrow = addDays(now, 1);
+
+    await apiTokenService.createApiToken({
+        username: 'default-valid',
+        type: ApiTokenType.CLIENT,
+        expiresAt: tomorrow,
+        projects: ['test-project', 'default'],
+        environment: DEFAULT_ENV,
+    });
+
+    await apiTokenService.createApiToken({
+        username: 'default-also-valid',
+        type: ApiTokenType.CLIENT,
+        expiresAt: tomorrow,
+        projects: ['test-project'],
+        environment: DEFAULT_ENV,
+    });
+
+    const tokens = await apiTokenService.getAllActiveTokens();
+    const multiProjectUser = await apiTokenService.getUserForToken(
+        tokens[0].secret,
+    );
+    const singleProjectUser = await apiTokenService.getUserForToken(
+        tokens[1].secret,
+    );
+
+    expect(multiProjectUser.projects).toStrictEqual([
+        'test-project',
+        'default',
+    ]);
+    expect(singleProjectUser.projects).toStrictEqual(['test-project']);
+});
+
+test('should not partially create token if projects are invalid', async () => {
+    try {
+        await apiTokenService.createApiTokenWithProjects({
+            username: 'default-client',
+            type: ApiTokenType.CLIENT,
+            projects: ['non-existent-project'],
+            environment: DEFAULT_ENV,
+        });
+    } catch (e) {}
+    const allTokens = await apiTokenService.getAllTokens();
+
+    expect(allTokens.length).toBe(0);
 });

--- a/src/test/fixtures/fake-api-token-store.ts
+++ b/src/test/fixtures/fake-api-token-store.ts
@@ -50,6 +50,7 @@ export default class FakeApiTokenStore
     async insert(newToken: IApiTokenCreate): Promise<IApiToken> {
         const apiToken = {
             createdAt: new Date(),
+            project: newToken.projects?.join(',') || '*',
             ...newToken,
         };
         this.tokens.push(apiToken);

--- a/src/test/fixtures/fake-feature-strategies-store.ts
+++ b/src/test/fixtures/fake-feature-strategies-store.ts
@@ -148,13 +148,17 @@ export default class FakeFeatureStrategiesStore
                 if (featureQuery.project) {
                     return (
                         toggle.name.startsWith(featureQuery.namePrefix) &&
-                        featureQuery.project.includes(toggle.project)
+                        featureQuery.project.some((project) =>
+                            project.includes(toggle.project),
+                        )
                     );
                 }
                 return toggle.name.startsWith(featureQuery.namePrefix);
             }
             if (featureQuery.project) {
-                return featureQuery.project.includes(toggle.project);
+                return featureQuery.project.some((project) =>
+                    project.includes(toggle.project),
+                );
             }
             return toggle.archived === archived;
         });

--- a/src/test/fixtures/fake-feature-toggle-client-store.ts
+++ b/src/test/fixtures/fake-feature-toggle-client-store.ts
@@ -19,13 +19,17 @@ export default class FakeFeatureToggleClientStore
                 if (featureQuery.project) {
                     return (
                         toggle.name.startsWith(featureQuery.namePrefix) &&
-                        featureQuery.project.includes(toggle.project)
+                        featureQuery.project.some((project) =>
+                            project.includes(toggle.project),
+                        )
                     );
                 }
                 return toggle.name.startsWith(featureQuery.namePrefix);
             }
             if (featureQuery.project) {
-                return featureQuery.project.includes(toggle.project);
+                return featureQuery.project.some((project) =>
+                    project.includes(toggle.project),
+                );
             }
             return toggle.archived === archived;
         });


### PR DESCRIPTION
This adds support for multi project tokens to be created. Backward compatibility is handled at 3 different layers here:

- The API is made backwards compatible though a permissive data type that accepts either a project?: string or projects?: string[] property, validation is done through JOI here, which ensures that projects and project are not set together. In the case of neither, this defaults to the previous default of ALL_PROJECTS
- The service layer method to handle adding tokens has been made tolerant to either of the above case and has been deprecated, a new method supporting only the new structure of using projects has been added
- Existing compatibility for consumers of Unleash as a library should not be affected either, the ApiUser constructor is now tolerant to the the first input and will internally map to the new cleaned structure