### PR TITLE
fix: remove duplicate foreign key

### DIFF
--- a/src/migrations/20220408081222-clean-up-duplicate-foreign-key-role-permission.js
+++ b/src/migrations/20220408081222-clean-up-duplicate-foreign-key-role-permission.js
@@ -1,0 +1,12 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE role_permission DROP CONSTRAINT fk_role_permission;
+    `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    cb();
+};


### PR DESCRIPTION
We already created the foreign key when we created the table back in src/migrations/20210217195834-rbac-tables.js