### PR TITLE
docs: update client sdk overview title

### DIFF
--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -1,6 +1,6 @@
 ---
 id: index
-title: Introduction
+title: Client SDK overview
 slug: /sdks
 ---
 


### PR DESCRIPTION
When the title is only "Introduction" it's super hard to find via
search. Changing it to something more descriptive should make that easier.