### PR TITLE
Add Stalebot and No-Response Action Config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+limitPerRun: 30
+daysUntilStale: 30
+daysUntilClose: 7
+
+exemptLabels:
+  - pinned
+  - security
+  - "[Status] Maybe Later"
+
+exemptAssignees: true
+
+staleLabel: wontfix
+
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+issues:
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.

--- a/.github/workflows/flag-no-response.yaml
+++ b/.github/workflows/flag-no-response.yaml
@@ -1,0 +1,15 @@
+name: No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
This adds two configuration files for Stalebot and the No-Response Action (No-Response bot has been deprecated and the No-Response Action is the recommended alternative).

The No-Response Action config has been left as default (more details on the defaults can be found here: https://github.com/lee-dohm/no-response/blob/main/action.yml and more details on the action itself in the root project).

The stalebot config has been slightly altered (original config here: https://github.com/probot/stale). Notably, the message for PRs and Issues has been customised and the time until being marked as stale has been reduced from 60 days to 30. Default config for exempt issues remains, which means that issues that are pinned, marked with a security label or a "[Status] Maybe Later" label won't be marked as stale