### PR TITLE
feat: add contributors image generation workflow

### DIFF
--- a/.github/workflows/update_contributors.yaml
+++ b/.github/workflows/update_contributors.yaml
@@ -16,8 +16,7 @@ jobs:
         node-version: 14.x
     - name: install contributors
       run: |
-        npm i svg-contributors -g
-        dummysvg -o unleash -n unleash
+        npx svg-contributors -o unleash -n unleash
     - uses: aws-actions/configure-aws-credentials@v1
       with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update_contributors.yaml
+++ b/.github/workflows/update_contributors.yaml
@@ -1,0 +1,28 @@
+name: Update Contributors
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 14.x
+    - name: install contributors
+      run: |
+        npm i svg-contributors -g
+        dummysvg -o unleash -n unleash
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+    - name: Publish static assets to S3
+      run: |
+        aws s3 cp ./contributors.svg s3://getunleash-static/docs-assets/contributors.svg


### PR DESCRIPTION
This adds very basic a generation of a contributors image workflow and pushes the resulting SVG to our CDN