### PR TITLE
docs: Add contributors svg with link to /graphs/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ Check out [the CONTRIBUTING.md file](./CONTRIBUTING.md) for contribution guideli
 
 ### Contributors
 
+<div align="center">
+
 [![The Unleash contributors](https://cdn.getunleash.io/docs-assets/contributors.svg)](https://github.com/Unleash/unleash/graphs/contributors)
+
+</div>
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ We'd love to have your help too: Please feel free to open issues or provide pull
 
 Check out [the CONTRIBUTING.md file](./CONTRIBUTING.md) for contribution guidelines and the [Unleash developer guide](./website/docs/contributing/developer-guide.md) for tips on environment setup, running the tests, and running Unleash from source.
 
+### Contributors
+
+[![The Unleash contributors](https://cdn.getunleash.io/docs-assets/contributors.svg)](https://github.com/Unleash/unleash/graphs/contributors)
+
 <br/>
 
 ## Features our users love


### PR DESCRIPTION
This PR adds a link to the auto-generated contributors svg to the contributors section.

Here's what it looks like today:
![image](https://user-images.githubusercontent.com/17786332/164624865-0a4aa69a-7ca0-4cec-943e-db49b9e64318.png)
