### PR TITLE
docs: Add deprecation notice to old slack guide

### DIFF
--- a/website/docs/guides/feature-updates-to-slack.md
+++ b/website/docs/guides/feature-updates-to-slack.md
@@ -4,7 +4,7 @@ title: Feature Updates To slack
 ---
 
 :::caution
-As of **Unleash v4**, this method of doing things is deprecated. If you're looking for ways to integrate with Slack, you should refer to [the Slack add-on guide](../addons/slack.md) instead.
+This guide is deprecated. If you're looking for ways to integrate with Slack, you should refer to [the Slack add-on guide](../addons/slack.md) instead.
 :::
 
 ## Create a custom Slack WebHook url: {#create-a-custom-slack-webhook-url}

--- a/website/docs/guides/feature-updates-to-slack.md
+++ b/website/docs/guides/feature-updates-to-slack.md
@@ -3,6 +3,10 @@ id: feature_updates_to_slack
 title: Feature Updates To slack
 ---
 
+:::caution
+As of **Unleash v4**, this method of doing things is deprecated. If you're looking for ways to integrate with Slack, you should refer to [the Slack add-on guide](../addons/slack.md) instead.
+:::
+
 ## Create a custom Slack WebHook url: {#create-a-custom-slack-webhook-url}
 
 1. Go to [https://slack.com/apps/manage/custom-integrations](https://slack.com/apps/manage/custom-integrations)


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This PR adds a deprecation notice to the old Slack integration docs, pointing the user at the new(er) Slack add-on docs instead.

<!-- Does it close an issue? Multiple? -->