### PR TITLE
fix: allow missing instanceId in client metrics

### DIFF
--- a/src/lib/routes/client-api/register.test.ts
+++ b/src/lib/routes/client-api/register.test.ts
@@ -84,12 +84,26 @@ test('should require strategies field', () => {
         .expect(400);
 });
 
+test('should allow an no instanceId field', () => {
+    expect.assertions(0);
+    return request
+        .post('/api/client/register')
+        .send({
+            appName: 'demo',
+            strategies: ['default'],
+            started: Date.now(),
+            interval: 10,
+        })
+        .expect(202);
+});
+
 test('should allow an empty instanceId field', () => {
     expect.assertions(0);
     return request
         .post('/api/client/register')
         .send({
             appName: 'demo',
+            instanceId: '',
             strategies: ['default'],
             started: Date.now(),
             interval: 10,

--- a/src/lib/services/client-metrics/schema.test.ts
+++ b/src/lib/services/client-metrics/schema.test.ts
@@ -1,0 +1,99 @@
+import { clientRegisterSchema, clientMetricsSchema } from './schema';
+
+test('clientRegisterSchema should allow empty ("") instanceId', () => {
+    const { value } = clientRegisterSchema.validate({
+        appName: 'test',
+        instanceId: '',
+        strategies: ['default'],
+        started: Date.now(),
+        interval: 100,
+    });
+    //@ts-ignore
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientRegisterSchema should allow undefined instanceId', () => {
+    const { value } = clientRegisterSchema.validate({
+        appName: 'test',
+        strategies: ['default'],
+        started: Date.now(),
+        interval: 100,
+    });
+
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientRegisterSchema should allow null instanceId', () => {
+    const { value } = clientRegisterSchema.validate({
+        appName: 'test',
+        instanceId: null,
+        strategies: ['default'],
+        started: Date.now(),
+        interval: 100,
+    });
+    //@ts-ignore
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientRegisterSchema should use instanceId', () => {
+    const { value } = clientRegisterSchema.validate({
+        appName: 'test',
+        instanceId: 'some',
+        strategies: ['default'],
+        started: Date.now(),
+        interval: 100,
+    });
+    //@ts-ignore
+    expect(value.instanceId).toBe('some');
+});
+
+test('clientMetricsSchema should allow null instanceId', () => {
+    const { value } = clientMetricsSchema.validate({
+        appName: 'test',
+        instanceId: null,
+        bucket: {
+            started: Date.now(),
+            stopped: Date.now(),
+        },
+    });
+    //@ts-ignore
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientMetricsSchema should allow empty ("") instanceId', () => {
+    const { value } = clientMetricsSchema.validate({
+        appName: 'test',
+        instanceId: '',
+        bucket: {
+            started: Date.now(),
+            stopped: Date.now(),
+        },
+    });
+    //@ts-ignore
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientMetricsSchema should allow undefined instanceId', () => {
+    const { value } = clientMetricsSchema.validate({
+        appName: 'test',
+        bucket: {
+            started: Date.now(),
+            stopped: Date.now(),
+        },
+    });
+
+    expect(value.instanceId).toBe('default');
+});
+
+test('clientMetricsSchema should use instanceId', () => {
+    const { value } = clientMetricsSchema.validate({
+        appName: 'test',
+        instanceId: 'some',
+        bucket: {
+            started: Date.now(),
+            stopped: Date.now(),
+        },
+    });
+
+    expect(value.instanceId).toBe('some');
+});

--- a/src/lib/services/client-metrics/schema.test.ts
+++ b/src/lib/services/client-metrics/schema.test.ts
@@ -31,7 +31,6 @@ test('clientRegisterSchema should allow null instanceId', () => {
         started: Date.now(),
         interval: 100,
     });
-    //@ts-ignore
     expect(value.instanceId).toBe('default');
 });
 
@@ -43,7 +42,6 @@ test('clientRegisterSchema should use instanceId', () => {
         started: Date.now(),
         interval: 100,
     });
-    //@ts-ignore
     expect(value.instanceId).toBe('some');
 });
 
@@ -56,7 +54,6 @@ test('clientMetricsSchema should allow null instanceId', () => {
             stopped: Date.now(),
         },
     });
-    //@ts-ignore
     expect(value.instanceId).toBe('default');
 });
 
@@ -69,7 +66,6 @@ test('clientMetricsSchema should allow empty ("") instanceId', () => {
             stopped: Date.now(),
         },
     });
-    //@ts-ignore
     expect(value.instanceId).toBe('default');
 });
 

--- a/src/lib/services/client-metrics/schema.ts
+++ b/src/lib/services/client-metrics/schema.ts
@@ -15,7 +15,7 @@ export const clientMetricsSchema = joi
     .keys({
         environment: joi.string().optional(),
         appName: joi.string().required(),
-        instanceId: joi.string().default('default'),
+        instanceId: joi.string().empty(['', null]).default('default'),
         bucket: joi
             .object()
             .required()
@@ -48,7 +48,7 @@ export const clientRegisterSchema = joi
     .options({ stripUnknown: true })
     .keys({
         appName: joi.string().required(),
-        instanceId: joi.string().default('default'),
+        instanceId: joi.string().empty(['', null]).default('default'),
         sdkVersion: joi.string().optional(),
         strategies: joi
             .array()


### PR DESCRIPTION
Allows "instanceId" to be missing in client registrations and metrics. Will set it to "default". 
