### PR TITLE
fix: don't import from tsconfig's baseUrl

### DIFF
--- a/src/lib/types/stores/project-store.ts
+++ b/src/lib/types/stores/project-store.ts
@@ -1,4 +1,4 @@
-import { IEnvironmentProjectLink } from 'lib/db/project-store';
+import { IEnvironmentProjectLink } from '../../db/project-store';
 import { IProject, IProjectWithCount } from '../model';
 import { Store } from './store';
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

Hi! :wave:

This is a super small change, but it broke my upgrade, so I figured I'd send a patch.

## About the changes

I think this is the only place in the `unleash-server` module's code that uses an import from the `baseUrl`, so it probably makes sense to align it with the rest.

This also makes my build work:

Before:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1404650/165523601-6ded9f39-636c-45f7-9b57-ef382d97fa5c.png">

After:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1404650/165523660-d1a91ec8-93d8-4a4a-9cec-6a29b29c8dd6.png">

I could avoid the issue by turning on the `skipLibCheck` option, but I don't want to do that :smile:

