### PR TITLE
refactor: disallow additionalProperties in response schemas

### DIFF
--- a/src/lib/openapi/spec/constraint-schema.ts
+++ b/src/lib/openapi/spec/constraint-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['contextName', 'operator'],
     properties: {
         contextName: {

--- a/src/lib/openapi/spec/feature-schema.ts
+++ b/src/lib/openapi/spec/feature-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['name', 'project'],
     properties: {
         name: {

--- a/src/lib/openapi/spec/features-schema.ts
+++ b/src/lib/openapi/spec/features-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['version', 'features'],
     properties: {
         version: {

--- a/src/lib/openapi/spec/override-schema.ts
+++ b/src/lib/openapi/spec/override-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['contextName', 'values'],
     properties: {
         contextName: {

--- a/src/lib/openapi/spec/strategy-schema.ts
+++ b/src/lib/openapi/spec/strategy-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['id', 'name', 'constraints', 'parameters'],
     properties: {
         id: {

--- a/src/lib/openapi/spec/variant-schema.ts
+++ b/src/lib/openapi/spec/variant-schema.ts
@@ -2,6 +2,7 @@ import { createSchemaObject, CreateSchemaType } from '../types';
 
 export const schema = {
     type: 'object',
+    additionalProperties: false,
     required: ['name', 'weight', 'weightType', 'stickiness', 'overrides'],
     properties: {
         name: {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -52,6 +52,7 @@ Object {
   "components": Object {
     "schemas": Object {
       "constraintSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "contextName": Object {
             "type": "string",
@@ -93,6 +94,7 @@ Object {
         "type": "object",
       },
       "featureSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "createdAt": Object {
             "format": "date",
@@ -145,6 +147,7 @@ Object {
         "type": "object",
       },
       "featuresSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "features": Object {
             "items": Object {
@@ -163,6 +166,7 @@ Object {
         "type": "object",
       },
       "overrideSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "contextName": Object {
             "type": "string",
@@ -181,6 +185,7 @@ Object {
         "type": "object",
       },
       "strategySchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "constraints": Object {
             "items": Object {
@@ -207,6 +212,7 @@ Object {
         "type": "object",
       },
       "variantSchema": Object {
+        "additionalProperties": false,
         "properties": Object {
           "name": Object {
             "type": "string",


### PR DESCRIPTION
Avoids a tricky index signature in the generated Response types.