### PR TITLE
docs(fix): correct custom activation strategies param types

### DIFF
--- a/website/docs/advanced/custom-activation-strategy.md
+++ b/website/docs/advanced/custom-activation-strategy.md
@@ -40,19 +40,17 @@ Each parameter consists of three parts:
 
 Each parameter has one of five different parameter types. A parameter's type impacts the kind of controls shown in the admin UI and how it's represented in code.
 
-Here's an overview over how the types are represented in the JSON payload returned from the Unleash server. The exact types will vary based on your programming language's type system.
+The below table lists the types and how they're represented in the JSON payload returned from the Unleash server. When parsed, the exact types will vary based on your programming language's type system.
 
-:::note Unset values
-Values of *all types* have an empty string (`""`) as the default value. As such, if you don't interact with a control or otherwise set a value, the value will be an empty string, regardless of the value's type.
-:::
+All values have an **empty string (`""`) as the default value**. As such, if you don't interact with a control or otherwise set a value, the value will be an empty string.
 
-| type name  | code representation                    | example value | UI control               |
-|------------|----------------------------------------|---------------|--------------------------|
-| string     | `string`                               | `"a string"`  | A standard input field   |
-| percentage | an `int` between 0 and 100 (inclusive) | `99`          | A value slider           |
-| list       | `string` (values are comma-separated)  | `"one,two"`   | A multi-input text field |
-| number     | `string`                               | `"123"`       | A numeric text field     |
-| boolean    | `"true"` or `"false"`                  | `"true"`      | An on/off toggle         |
+| type name  | code representation                                            | example value | UI control               |
+|------------|----------------------------------------------------------------|---------------|--------------------------|
+| string     | `string`                                                       | `"a string"`  | A standard input field   |
+| percentage | a `string` representing a number between 0 and 100 (inclusive) | `"99"`        | A value slider           |
+| list       | `string` (values are comma-separated)                          | `"one,two"`   | A multi-input text field |
+| number     | `string`                                                       | `"123"`       | A numeric text field     |
+| boolean    | a `string`: one of `"true"` or `"false"`                       | `"true"`      | An on/off toggle         |
 
 
 ![A strategy with five parameters, one of each type.](/img/strategy-parameters-ui-controls.png)


### PR DESCRIPTION
This PR fixes the listed types for custom activation strategy parameters.