### PR TITLE
added db-schema to the docs page

### DIFF
--- a/website/docs/deploy/configuring-unleash.md
+++ b/website/docs/deploy/configuring-unleash.md
@@ -206,6 +206,7 @@ The available options are listed in the table below. Options can be specified ei
 | `pool.max`               | `DATABASE_POOL_MAX`             | 4              | The maximum number of connections in the connection pool.                                                                                                                                |
 | `pool.idleTimeoutMillis` | `DATABASE_POOL_IDLE_TIMEOUT_MS` | 30000          | The amount of time (in milliseconds) that a connection must be idle for before it is marked as a candidate for eviction.                                                                 |
 | `applicationName`        | `DATABASE_APPLICATION_NAME`     | `unleash`      | The name of the application that created this Client instance.                                                                                    |
+| `schema`        | `DATABASE_SCHEMA`     | `public`      | The schema to use in the database.                                                                                    |
 
 Alternatively, you can use a [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to connect to the database. You can provide it directly or from a file by using one of the below options. In JavaScript, these are top-level properties of the root configuration object, *not* the `db` object.
 


### PR DESCRIPTION
I added the "schema" option to the Database configuration in the Configuring unleash documentation page.

This is related to https://github.com/Unleash/unleash/issues/1565 which can be closed after.

The schema option was not available in the docs, now it should be complete