### PR TITLE
1568 fix datadog type/value order in addon

### DIFF
--- a/src/lib/addons/datadog.ts
+++ b/src/lib/addons/datadog.ts
@@ -29,7 +29,7 @@ export default class DatadogAddon extends Addon {
 
         const { tags: eventTags } = event;
         const tags =
-            eventTags && eventTags.map((tag) => `${tag.value}:${tag.type}`);
+            eventTags && eventTags.map((tag) => `${tag.type}:${tag.value}`);
         const body = {
             text: `%%% \n ${text} \n %%% `,
             title: 'Unleash notification update',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
When adding a tag to a specific feature toggle, as shown below. I would expect the format to show up as `tag.type:tag.value`
![image](https://user-images.githubusercontent.com/20389664/166971744-b08ce38b-557a-44be-87c1-63fed8c607ec.png)

When receiving a notification in Datadog Events the tags shows up backwards...
![image](https://user-images.githubusercontent.com/20389664/166972025-9042086c-8dd8-4eb6-87af-48f6403db201.png)

<!-- Does it close an issue? Multiple? -->
Closes #1568  .

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
src/lib/addons/datadog.ts is the only changed file


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
