### PR TITLE
feat: Add support for global segments

### DIFF
--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -78,15 +78,9 @@ export default class FeatureToggleClientStore
             'fs.strategy_name as strategy_name',
             'fs.parameters as parameters',
             'fs.constraints as constraints',
+            'segments.id as segment_id',
+            'segments.constraints as segment_constraints',
         ];
-
-        if (inlineSegmentConstraints) {
-            selectColumns = [
-                ...selectColumns,
-                'segments.id as segment_id',
-                'segments.constraints as segment_constraints',
-            ];
-        }
 
         let query = this.db('features')
             .select(selectColumns)
@@ -105,17 +99,13 @@ export default class FeatureToggleClientStore
                     .as('fe'),
                 'fe.feature_name',
                 'features.name',
-            );
-
-        if (inlineSegmentConstraints) {
-            query = query
-                .fullOuterJoin(
-                    'feature_strategy_segment as fss',
-                    `fss.feature_strategy_id`,
-                    `fs.id`,
-                )
-                .fullOuterJoin('segments', `segments.id`, `fss.segment_id`);
-        }
+            )
+            .fullOuterJoin(
+                'feature_strategy_segment as fss',
+                `fss.feature_strategy_id`,
+                `fs.id`,
+            )
+            .fullOuterJoin('segments', `segments.id`, `fss.segment_id`);
 
         query = query.where({
             archived,
@@ -155,6 +145,8 @@ export default class FeatureToggleClientStore
             }
             if (inlineSegmentConstraints && r.segment_id) {
                 this.addSegmentToStrategy(feature, r);
+            } else if (!inlineSegmentConstraints && r.segment_id) {
+                this.addSegmentIdsToStrategy(feature, r);
             }
             feature.impressionData = r.impression_data;
             feature.enabled = !!r.enabled;
@@ -218,6 +210,22 @@ export default class FeatureToggleClientStore
         feature.strategies
             .find((s) => s.id === row.strategy_id)
             ?.constraints.push(...row.segment_constraints);
+    }
+
+    private addSegmentIdsToStrategy(
+        feature: PartialDeep<IFeatureToggleClient>,
+        row: Record<string, any>,
+    ) {
+        const strategy = feature.strategies.find(
+            (s) => s.id === row.strategy_id,
+        );
+        if (!strategy) {
+            return;
+        }
+        if (strategy.segments == null) {
+            strategy.segments = [];
+        }
+        strategy.segments.push(row.segment_id);
     }
 
     async getClient(

--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -222,7 +222,7 @@ export default class FeatureToggleClientStore
         if (!strategy) {
             return;
         }
-        if (strategy.segments == null) {
+        if (!strategy.segments) {
             strategy.segments = [];
         }
         strategy.segments.push(row.segment_id);

--- a/src/lib/routes/client-api/feature.test.ts
+++ b/src/lib/routes/client-api/feature.test.ts
@@ -60,13 +60,19 @@ test('should get empty getFeatures via client', () => {
 
 test('if caching is enabled should memoize', async () => {
     const getClientFeatures = jest.fn().mockReturnValue([]);
+    const getActive = jest.fn().mockReturnValue([]);
 
     const featureToggleServiceV2 = {
         getClientFeatures,
     };
+
+    const segmentService = {
+        getActive,
+    };
+
     const controller = new FeatureController(
         // @ts-ignore
-        { featureToggleServiceV2 },
+        { featureToggleServiceV2, segmentService },
         {
             getLogger,
             experimental: {
@@ -87,12 +93,19 @@ test('if caching is enabled should memoize', async () => {
 test('if caching is not enabled all calls goes to service', async () => {
     const getClientFeatures = jest.fn().mockReturnValue([]);
 
+    const getActive = jest.fn().mockReturnValue([]);
+
     const featureToggleServiceV2 = {
         getClientFeatures,
     };
+
+    const segmentService = {
+        getActive,
+    };
+
     const controller = new FeatureController(
         // @ts-ignore
-        { featureToggleServiceV2 },
+        { featureToggleServiceV2, segmentService },
         {
             getLogger,
             experimental: {

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -23,6 +23,7 @@ export interface IStrategyConfig {
     id?: string;
     name: string;
     constraints?: IConstraint[];
+    segments?: string[];
     parameters?: { [key: string]: string };
     sortOrder?: number;
 }

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -23,7 +23,7 @@ export interface IStrategyConfig {
     id?: string;
     name: string;
     constraints?: IConstraint[];
-    segments?: string[];
+    segments?: number[];
     parameters?: { [key: string]: string };
     sortOrder?: number;
 }

--- a/src/test/e2e/api/client/global.segment.e2e.test.ts
+++ b/src/test/e2e/api/client/global.segment.e2e.test.ts
@@ -1,0 +1,139 @@
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import {
+    IUnleashTest,
+    setupAppWithCustomConfig,
+} from '../../helpers/test-helper';
+import {
+    IConstraint,
+    IFeatureToggleClient,
+    ISegment,
+} from '../../../../lib/types/model';
+import { randomId } from '../../../../lib/util/random-id';
+import User from '../../../../lib/types/user';
+
+let db: ITestDb;
+let app: IUnleashTest;
+
+const FEATURES_ADMIN_BASE_PATH = '/api/admin/features';
+const FEATURES_CLIENT_BASE_PATH = '/api/client/features';
+
+interface ApiResponse {
+    features: IFeatureToggleClient[];
+    version: number;
+    segments: ISegment[];
+}
+
+const fetchSegments = (): Promise<ISegment[]> => {
+    return app.services.segmentService.getAll();
+};
+
+const fetchFeatures = (): Promise<IFeatureToggleClient[]> => {
+    return app.request
+        .get(FEATURES_ADMIN_BASE_PATH)
+        .expect(200)
+        .then((res) => res.body.features);
+};
+
+const fetchClientResponse = (): Promise<ApiResponse> => {
+    return app.request
+        .get(FEATURES_CLIENT_BASE_PATH)
+        .expect(200)
+        .then((res) => res.body);
+};
+
+const createSegment = (postData: object): Promise<unknown> => {
+    const user = { email: 'test@example.com' } as User;
+    return app.services.segmentService.create(postData, user);
+};
+
+const createFeatureToggle = (
+    postData: object,
+    expectStatusCode = 201,
+): Promise<unknown> => {
+    return app.request
+        .post(FEATURES_ADMIN_BASE_PATH)
+        .send(postData)
+        .expect(expectStatusCode);
+};
+
+const addSegmentToStrategy = (
+    segmentId: number,
+    strategyId: string,
+): Promise<unknown> => {
+    return app.services.segmentService.addToStrategy(segmentId, strategyId);
+};
+
+const mockFeatureToggle = (): object => {
+    return {
+        name: randomId(),
+        strategies: [{ name: randomId(), constraints: [], parameters: {} }],
+    };
+};
+
+const mockConstraints = (): IConstraint[] => {
+    return Array.from({ length: 5 }).map(() => ({
+        values: ['x', 'y', 'z'],
+        operator: 'IN',
+        contextName: 'a',
+    }));
+};
+
+const createTestSegments = async (): Promise<void> => {
+    const constraints = mockConstraints();
+    await createSegment({ name: 'S1', constraints });
+    await createSegment({ name: 'S2', constraints });
+    await createSegment({ name: 'S3', constraints });
+    await createFeatureToggle(mockFeatureToggle());
+    await createFeatureToggle(mockFeatureToggle());
+    await createFeatureToggle(mockFeatureToggle());
+    const [feature1, feature2] = await fetchFeatures();
+    const [segment1, segment2] = await fetchSegments();
+
+    await addSegmentToStrategy(segment1.id, feature1.strategies[0].id);
+    await addSegmentToStrategy(segment2.id, feature1.strategies[0].id);
+    await addSegmentToStrategy(segment2.id, feature2.strategies[0].id);
+};
+
+beforeAll(async () => {
+    const experimentalConfig = {
+        segments: {
+            enableSegmentsAdminApi: true,
+            enableSegmentsClientApi: true,
+            inlineSegmentConstraints: false,
+        },
+    };
+
+    db = await dbInit('global_segments', getLogger, {
+        experimental: experimentalConfig,
+    });
+
+    app = await setupAppWithCustomConfig(db.stores, {
+        experimental: experimentalConfig,
+    });
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+afterEach(async () => {
+    await db.stores.segmentStore.deleteAll();
+    await db.stores.featureToggleStore.deleteAll();
+});
+
+test('should return segments in base of toggle response if inline is disabled', async () => {
+    await createTestSegments();
+
+    const clientFeatures = await fetchClientResponse();
+    expect(clientFeatures.segments.length).toBeDefined();
+});
+
+test('should only send segments that are in use', async () => {
+    await createTestSegments();
+
+    const clientFeatures = await fetchClientResponse();
+    //3 segments were created in createTestSegments, only 2 are in use
+    expect(clientFeatures.segments.length).toEqual(2);
+});

--- a/src/test/e2e/api/client/global.segment.e2e.test.ts
+++ b/src/test/e2e/api/client/global.segment.e2e.test.ts
@@ -137,3 +137,19 @@ test('should only send segments that are in use', async () => {
     //3 segments were created in createTestSegments, only 2 are in use
     expect(clientFeatures.segments.length).toEqual(2);
 });
+
+test('should send all segments that are in use by feature', async () => {
+    await createTestSegments();
+
+    const clientFeatures = await fetchClientResponse();
+    const globalSegments = clientFeatures.segments;
+    const globalSegmentIds = globalSegments.map((segment) => segment.id);
+    const allSegmentIds = clientFeatures.features
+        .map((feat) => feat.strategies.map((strategy) => strategy.segments))
+        .flat()
+        .flat()
+        .filter((x) => !!x);
+    const toggleSegmentIds = [...new Set(allSegmentIds)];
+
+    expect(globalSegmentIds).toEqual(toggleSegmentIds);
+});

--- a/src/test/e2e/helpers/database-init.ts
+++ b/src/test/e2e/helpers/database-init.ts
@@ -10,6 +10,7 @@ import EnvironmentStore from '../../../lib/db/environment-store';
 import { IUnleashStores } from '../../../lib/types';
 import { IFeatureEnvironmentStore } from '../../../lib/types/stores/feature-environment-store';
 import { DEFAULT_ENV } from '../../../lib/util/constants';
+import { IUnleashOptions } from 'lib/server-impl';
 
 // require('db-migrate-shared').log.silence(false);
 
@@ -79,7 +80,7 @@ export interface ITestDb {
 export default async function init(
     databaseSchema: string = 'test',
     getLogger: LogProvider = noLoggerProvider,
-    configOverride: any = {},
+    configOverride: Partial<IUnleashOptions> = {},
 ): Promise<ITestDb> {
     const config = createTestConfig({
         db: {

--- a/src/test/e2e/helpers/database-init.ts
+++ b/src/test/e2e/helpers/database-init.ts
@@ -79,6 +79,7 @@ export interface ITestDb {
 export default async function init(
     databaseSchema: string = 'test',
     getLogger: LogProvider = noLoggerProvider,
+    configOverride: any = {},
 ): Promise<ITestDb> {
     const config = createTestConfig({
         db: {
@@ -87,6 +88,7 @@ export default async function init(
             schema: databaseSchema,
             ssl: false,
         },
+        ...configOverride,
         getLogger,
     });
 


### PR DESCRIPTION
This implements global segments as an alternative to inline segments. The approach here is to make two modifications. Firstly, to the the toggle response itself, to add in add relevant global segments (segments that are defined but not in use are not delivered).  This is an optional property and will only appear if `inlinesegments` is turned off. The second change here is to insert onto each strategy a `segments` property that contains a list of IDs mapping back to the global segments in the base response. This is purely to conserve network resources and the intent is that the SDKs translate this back to a constraint.