### PR TITLE
docs: Add NODE_EXTRA_CA_CERTS documentation for webhook addons

### DIFF
--- a/website/docs/addons/webhook.md
+++ b/website/docs/addons/webhook.md
@@ -60,4 +60,4 @@ If your webhook endpoint uses a custom SSL certificate,
 you will need to start Unleash with the `NODE_EXTRA_CA_CERTS` environment variable set.
 It needs to point to your custom certificate file in pem format.
 
-For more information: [see node documentation](https://nodejs.org/api/cli.html#node_extra_ca_certsfile)
+For more information, see the [official Node.js documentation on setting extra certificate files](https://nodejs.org/api/cli.html#node_extra_ca_certsfile).

--- a/website/docs/addons/webhook.md
+++ b/website/docs/addons/webhook.md
@@ -53,3 +53,11 @@ Example:
 ```
 
 If you don't specify anything Unleash will use the [Unleash event format](/api/admin/events).
+
+#### Custom SSL certificates {#certificates}
+
+If your webhook endpoint uses a custom SSL certificate,
+you will need to start Unleash with the `NODE_EXTRA_CA_CERTS` environment variable set.
+It needs to point to your custom certificate file in pem format.
+
+For more information: [see node documentation](https://nodejs.org/api/cli.html#node_extra_ca_certsfile)


### PR DESCRIPTION
We've had customers self-hosting reporting issues with webhooks erroring out with 500 errors due to custom SSL certificates. This PR adds a note to the webhook addon documentation orienting users about the possibility of setting the NODE_EXTRA_CA_CERTS environment variable when starting their application to support custom SSL certs for webhook endpoints.
