### PR TITLE
docs: Update the react client install instructions

### DIFF
--- a/website/docs/sdks/proxy-react.md
+++ b/website/docs/sdks/proxy-react.md
@@ -10,8 +10,10 @@ For more detailed information, check out [the React Proxy SDK on GitHub](https:/
 
 ## Installation
 
+Install the React proxy client and the [JavaScript proxy client](proxy-javascript.md) packages:
+
 ```shell npm2yarn
-npm install @unleash/proxy-client-react
+npm install @unleash/proxy-client-react unleash-proxy-client
 ```
 
 ## Initialization


### PR DESCRIPTION
The install instructions didn't previously add the
`unleash-proxy-client` package (presuming it'd be implicitly installed
by `npm`). This doesn't seem to be the case, so we'll list it explicitly.