### PR TITLE
chore: Add workflow file to auto-add items to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add new item to project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+      uses: unleash/.github/.github/workflows/add-item-to-project.yml
+      secrets: inherit


### PR DESCRIPTION
This change adds a workflow file that references the reusable workflow
in the unleash/.github repo. It should (if all goes well),
automatically add new issues and prs to the project board.