### PR TITLE
Added ability to set additional transport options to email service

### DIFF
--- a/src/lib/services/email-service.test.ts
+++ b/src/lib/services/email-service.test.ts
@@ -1,3 +1,4 @@
+import nodemailer from 'nodemailer';
 import { EmailService } from './email-service';
 import noLoggerProvider from '../../test/fixtures/no-logger';
 
@@ -46,4 +47,36 @@ test('Can send welcome mail', async () => {
     );
     expect(content.from).toBe('noreply@getunleash.ai');
     expect(content.subject).toBe('Welcome to Unleash');
+});
+
+test('Can supply additional SMTP transport options', async () => {
+    const spy = jest.spyOn(nodemailer, 'createTransport');
+
+    new EmailService(
+        {
+            host: 'smtp.unleash.test',
+            port: 9999,
+            secure: false,
+            sender: 'noreply@getunleash.ai',
+            transportOptions: {
+                tls: {
+                    rejectUnauthorized: true,
+                },
+            },
+        },
+        noLoggerProvider,
+    );
+
+    expect(spy).toHaveBeenCalledWith({
+        auth: {
+            user: '',
+            pass: '',
+        },
+        host: 'smtp.unleash.test',
+        port: 9999,
+        secure: false,
+        tls: {
+            rejectUnauthorized: true,
+        },
+    });
 });

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -21,15 +21,6 @@ export enum TransporterType {
     JSON = 'json',
 }
 
-export interface IEmailOptions {
-    host: string;
-    port: number;
-    secure: boolean;
-    sender: string;
-    auth: IAuthOptions;
-    transporterType: TransporterType;
-}
-
 export interface IEmailEnvelope {
     from: string;
     to: string;
@@ -57,10 +48,16 @@ export class EmailService {
             if (email.host === 'test') {
                 this.mailer = createTransport({ jsonTransport: true });
             } else {
-                const connectionString = `${email.smtpuser}:${email.smtppass}@${email.host}:${email.port}`;
-                this.mailer = email.secure
-                    ? createTransport(`smtps://${connectionString}`)
-                    : createTransport(`smtp://${connectionString}`);
+                this.mailer = createTransport({
+                    host: email.host,
+                    port: email.port,
+                    secure: email.secure,
+                    auth: {
+                        user: email.smtpuser ?? '',
+                        pass: email.smtppass ?? '',
+                    },
+                    ...email.transportOptions,
+                });
             }
             this.logger.info(
                 `Initialized transport to ${email.host} on port ${email.port} with user: ${email.smtpuser}`,

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
 import { ILegacyApiTokenCreate } from './models/api-token';
 import { IExperimentalOptions } from '../experimental';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 export type EventHook = (eventName: string, data: object) => void;
 
@@ -111,6 +112,7 @@ export interface IEmailOption {
     sender: string;
     smtpuser?: string;
     smtppass?: string;
+    transportOptions?: SMTPTransport.Options;
 }
 
 export interface IListeningPipe {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

When not supplying a username or password to email options it will now default to empty string for both.
Also added a new optional argument called `transportOptions` to allow users to configure SMTP in more detail.

<!-- Does it close an issue? Multiple? -->
Closes #1583.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

`email-service.ts`

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Not sure if using empty string (`''`) for auth works like expected, but in our smtp server (which has no auth configured) this seems to work.