### PR TITLE
fix: add version information to workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   add-to-project:
-      uses: unleash/.github/.github/workflows/add-item-to-project.yml
+      uses: unleash/.github/.github/workflows/add-item-to-project.yml@main
       secrets: inherit

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add new item to project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+      uses: unleash/.github/.github/workflows/add-item-to-project.yml
+      secrets: inherit


### PR DESCRIPTION
Without the version of the reusable workflow specified, it won't work.