### PR TITLE
docs: fix python sdk syntax highlighting, header levels

### DIFF
--- a/website/docs/sdks/python.md
+++ b/website/docs/sdks/python.md
@@ -23,20 +23,20 @@ from UnleashClient import UnleashClient
 A check of a simple toggle:
 
 ```python
-client.is_enabled("My Toggle")
+client.is_enabled("my_toggle")
 ```
 
 Specifying a default value:
 
 ```python
-client.is_enabled("My Toggle", default_value=True)
+client.is_enabled("my_toggle", default_value=True)
 ```
 
 Supplying application context:
 
 ```python
 app_context = {"userId": "test@email.com"}
-client.is_enabled("User ID Toggle", app_context)
+client.is_enabled("user_id_toggle", app_context)
 ```
 
 Supplying a fallback function:
@@ -45,7 +45,7 @@ Supplying a fallback function:
 def custom_fallback(feature_name: str, context: dict) -> bool:
     return True
 
-client.is_enabled("My Toggle", fallback_function=custom_fallback)
+client.is_enabled("my_toggle", fallback_function=custom_fallback)
 ```
 
 - Must accept the feature name and context as an argument.
@@ -59,7 +59,7 @@ Checking for a variant:
 ```python
 context = {'userId': '2'}  # Context must have userId, sessionId, or remoteAddr.  If none are present, distribution will be random.
 
-variant = client.get_variant("MyvariantToggle", context)
+variant = client.get_variant("my_variant_toggle", context)
 
 print(variant)
 > {

--- a/website/docs/sdks/python.md
+++ b/website/docs/sdks/python.md
@@ -18,30 +18,30 @@ from UnleashClient import UnleashClient
     client.is_enabled("unleash.beta.variants")
 ```
 
-### Checking if a feature is enabled {#checking-if-a-feature-is-enabled}
+## Checking if a feature is enabled {#checking-if-a-feature-is-enabled}
 
 A check of a simple toggle:
 
-```Python
+```python
 client.is_enabled("My Toggle")
 ```
 
 Specifying a default value:
 
-```Python
+```python
 client.is_enabled("My Toggle", default_value=True)
 ```
 
 Supplying application context:
 
-```Python
+```python
 app_context = {"userId": "test@email.com"}
 client.is_enabled("User ID Toggle", app_context)
 ```
 
 Supplying a fallback function:
 
-```Python
+```python
 def custom_fallback(feature_name: str, context: dict) -> bool:
     return True
 
@@ -52,7 +52,7 @@ client.is_enabled("My Toggle", fallback_function=custom_fallback)
 - Client will evaluate the fallback function only if exception occurs when calling the `is_enabled()` method i.e. feature flag not found or other general exception.
 - If both a `default_value` and `fallback_function` are supplied, client will define the default value by `OR`ing the default value and the output of the fallback function.
 
-### Getting a variant {#getting-a-variant}
+## Getting a variant {#getting-a-variant}
 
 Checking for a variant:
 


### PR DESCRIPTION
This PR fixes syntax highlighting and header levels in the python SDK docs. It also changes previously invalid toggle names in examples.

Turns out that `Python` doesn't work for syntax highlighting, but `python` (lowercase `p`) _does_ 💁‍

The headers also jumped from level 1 to level 3. Now they go from 1 to 2 instead.

Some of the examples also used "My Toggle" as the toggle name. We don't allow spaces in toggle names, so I changed them for consistency.