### PR TITLE
fix: project environments order

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -311,7 +311,6 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     private static getEnvironment(r: any): IEnvironmentOverview {
         return {
             name: r.environment,

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -238,7 +238,14 @@ class ProjectStore implements IProjectStore {
             .where({
                 project_id: id,
             })
-            .pluck('environment_name');
+            .innerJoin(
+                'environments',
+                'project_environments.environment_name',
+                'environments.name',
+            )
+            .orderBy('environments.sort_order', 'asc')
+            .orderBy('project_environments.environment_name', 'asc')
+            .pluck('project_environments.environment_name');
     }
 
     async getMembers(projectId: string): Promise<number> {

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -518,6 +518,44 @@ test('A newly created project only gets connected to enabled environments', asyn
     expect(connectedEnvs.some((e) => e === disabledEnv)).toBeFalsy();
 });
 
+test('should have environments sorted in order', async () => {
+    const project = {
+        id: 'environment-order-test',
+        name: 'Environment testing project',
+        description: '',
+    };
+    const first = 'test';
+    const second = 'abc';
+    const third = 'example';
+    const fourth = 'mock';
+    await db.stores.environmentStore.create({
+        name: first,
+        type: 'test',
+        sortOrder: 1,
+    });
+    await db.stores.environmentStore.create({
+        name: fourth,
+        type: 'test',
+        sortOrder: 4,
+    });
+    await db.stores.environmentStore.create({
+        name: third,
+        type: 'test',
+        sortOrder: 3,
+    });
+    await db.stores.environmentStore.create({
+        name: second,
+        type: 'test',
+        sortOrder: 2,
+    });
+
+    await projectService.createProject(project, user);
+    const connectedEnvs =
+        await db.stores.projectStore.getEnvironmentsForProject(project.id);
+
+    expect(connectedEnvs).toEqual(['default', first, second, third, fourth]);
+});
+
 test('should add a user to the project with a custom role', async () => {
     const project = {
         id: 'add-users-custom-role',


### PR DESCRIPTION
## About the changes
Environments in `/api/admin/projects/$id` are not sorted. Having it in correct order from backend will make new _Single Project Overview - Features list_ table easier to implement.

### Important files
`src/lib/db/project-store.ts`
