### PR TITLE
docs: update import to use named export instead of default

### DIFF
--- a/website/docs/sdks/proxy-react.md
+++ b/website/docs/sdks/proxy-react.md
@@ -42,7 +42,7 @@ The configuration variables are:
 
 
 ```jsx
-import FlagProvider from '@unleash/proxy-client-react';
+import { FlagProvider } from '@unleash/proxy-client-react';
 
 const config = {
   url: 'https://HOSTNAME/api/proxy',


### PR DESCRIPTION
## About the changes
Updated docs to specify using the named `FlagProvider` export instead of the default export, which was causing issues with Vite prod builds.

See: https://github.com/Unleash/proxy-client-react/pull/58

### Important files
 - `website/docs/sdks/proxy-react.md`

## Discussion points
We might want to remove the default export at a later major version and only use named exports.