### PR TITLE
docs: switch all slack links to slack.unleash.run

### DIFF
--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -45,7 +45,7 @@ The below table shows what features the various server-side SDKs support. Note t
 - **N/A**: Not applicable to this SDK
 
 :::note
-If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://join.slack.com/t/unleash-community/shared_invite/zt-8b6l1uut-LL67kLpIXm9bcN3~6RVaRQ), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.
+If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.
 :::
 
 

--- a/website/docs/user_guide/index.md
+++ b/website/docs/user_guide/index.md
@@ -6,14 +6,14 @@ sidebar_position: 1
 ---
 
 :::note
-The docs are currently undergoing some heavy restructuring and development 👷‍♀️👷🏽 If something is unclear, don't hesitate to [let us know on Slack](https://join.slack.com/t/unleash-community/shared_invite/enQtNjUxMjU2MDc0MTAxLTJjYmViYjkwYmE0ODVlNmY1YjcwZGRmZWU5MTU1YTQ1Nzg5ZWQ2YzBlY2U1MjlmZDg5ZDRmZTMzNmQ5YmEyOGE)!
+The docs are currently undergoing some heavy restructuring and development 👷‍♀️👷🏽 If something is unclear, don't hesitate to [let us know on Slack](https://slack.unleash.run/)!
 :::
 
 Welcome to the Unleash documentation, your one-stop shop to everything Unleash. Whether you're just getting started or have been using Unleash for years, you should be able to find answers to all your questions here.
 
 ## Getting help
 
-Have questions that you can't find the answer to in these docs? You can always turn to [the Unleash Slack community](https://join.slack.com/t/unleash-community/shared_invite/enQtNjUxMjU2MDc0MTAxLTJjYmViYjkwYmE0ODVlNmY1YjcwZGRmZWU5MTU1YTQ1Nzg5ZWQ2YzBlY2U1MjlmZDg5ZDRmZTMzNmQ5YmEyOGE) and ask us questions directly (or just come and hang out 😄).
+Have questions that you can't find the answer to in these docs? You can always turn to [the Unleash Slack community](https://slack.unleash.run/) and ask us questions directly (or just come and hang out 😄).
 
 ## Documentation structure
 
@@ -60,6 +60,6 @@ The reference docs are organized into the following topics:
 
 💻 The core of Unleash is all open source and [hosted on GitHub](https://www.heroku.com/deploy/?template=https://github.com/Unleash/unleash "Unleash on GitHub").
 
-💬 If you've got questions or just wanna chat to the team and other Unleash users, come [join our Slack community](https://join.slack.com/t/unleash-community/shared_invite/enQtNjUxMjU2MDc0MTAxLTJjYmViYjkwYmE0ODVlNmY1YjcwZGRmZWU5MTU1YTQ1Nzg5ZWQ2YzBlY2U1MjlmZDg5ZDRmZTMzNmQ5YmEyOGE)
+💬 If you've got questions or just wanna chat to the team and other Unleash users, come [join our Slack community](https://slack.unleash.run/)
 
 🐦 You can also follow us [on Twitter](https://twitter.com/getunleash "Unleash on Twitter"), [LinkedIn](https://www.linkedin.com/company/getunleash/ "Unleash on LinkedIn"), or [Instagram](https://www.instagram.com/getunleash/ "Unleash on Instagram") for more updates and extra content.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -85,7 +85,7 @@ module.exports = {
                         },
                         {
                             label: 'Slack',
-                            href: 'https://join.slack.com/t/unleash-community/shared_invite/zt-8b6l1uut-LL67kLpIXm9bcN3~6RVaRQ',
+                            href: 'https://slack.unleash.run/',
                         },
                         {
                             label: 'Twitter',


### PR DESCRIPTION
This PR replaces all join.slack links in the docs with slack.unleash.run links, as we have full control over how they work.