### PR TITLE
docs: use named export instead of default

### DIFF
--- a/website/docs/sdks/proxy-vue.md
+++ b/website/docs/sdks/proxy-vue.md
@@ -23,7 +23,7 @@ npm install @unleash/proxy-client-vue
 Import the provider like this in your entrypoint file (typically App.vue):
 
 ```jsx
-import FlagProvider from '@unleash/proxy-client-vue'
+import { FlagProvider } from '@unleash/proxy-client-vue'
 
 const config = {
   url: 'https://HOSTNAME/proxy',
@@ -43,7 +43,7 @@ const config = {
 Alternatively, you can pass your own client in to the FlagProvider:
 
 ```jsx
-import FlagProvider, { UnleashClient } from '@unleash/proxy-client-vue'
+import { FlagProvider, UnleashClient } from '@unleash/proxy-client-vue'
 
 const config = {
   url: 'https://HOSTNAME/proxy',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Updated the docs to specify using the named FlagProvider export instead of the default export.

Keeps proxy-client usage consistent with `proxy-client-react`. See: https://github.com/Unleash/proxy-client-react/pull/58

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
We might want to remove the default export at a later major version and only use named exports.
