### PR TITLE
docs: use named export instead of default

### DIFF
--- a/website/docs/sdks/proxy-svelte.md
+++ b/website/docs/sdks/proxy-svelte.md
@@ -28,7 +28,7 @@ Import the provider like this in your entrypoint file (typically index.svelte):
 
 	onMount(async () => {
 		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-		FlagProvider = proxyClientSvelte.default;
+		({ FlagProvider } = proxyClientSvelte);
 	});
 
 	const config = {
@@ -40,7 +40,7 @@ Import the provider like this in your entrypoint file (typically index.svelte):
 	};
 </script>
 
-<svelte:component this="{FlagProvider}" {config}>
+<svelte:component this={FlagProvider} {config}>
 	<App />
 </svelte:component>
 ```
@@ -55,7 +55,7 @@ Alternatively, you can pass your own client in to the FlagProvider:
 
 	onMount(async () => {
 		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-		FlagProvider = proxyClientSvelte.default;
+		({ FlagProvider } = proxyClientSvelte);
 	});
 
 	const config = {
@@ -69,7 +69,7 @@ Alternatively, you can pass your own client in to the FlagProvider:
 	const client = new UnleashClient(config);
 </script>
 
-<svelte:component this="{FlagProvider}" unleashClient="{client}">
+<svelte:component this={FlagProvider} unleashClient={client}>
 	<App />
 </svelte:component>
 ```
@@ -82,7 +82,7 @@ By default, the Unleash client will start polling the Proxy for toggles immediat
 - passing a client instance to the `FlagProvider`
 
 ```html
-<svelte:component this="{FlagProvider}" unleashClient="{client}" startClient="{false}">
+<svelte:component this={FlagProvider} unleashClient={client} startClient={false}>
 	<App />
 </svelte:component>
 ```
@@ -106,7 +106,7 @@ To start the client, use the client's `start` method. The below snippet of pseud
 	});
 </script>
 
-<svelte:component this="{FlagProvider}" unleashClient="{client}" startClient="{false}">
+<svelte:component this={FlagProvider} unleashClient={client} startClient={false}>
 	<App />
 </svelte:component>
 ```
@@ -165,7 +165,7 @@ Follow the following steps in order to delay rendering until the flags have been
 {#if !$flagsReady}
 <Loading />
 {:else}
-<MyComponent error="{flagsError}" />
+<MyComponent error={flagsError} />
 {/if}
 ```
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Updated the docs to specify using the named FlagProvider export instead of the default export. Also fixed prop value format.

Keeps proxy-client usage consistent with `proxy-client-react`. See: https://github.com/Unleash/proxy-client-react/pull/58

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
We might want to remove the default export at a later major version and only use named exports.
