### PR TITLE
Feat/option clear site data

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -87,6 +87,8 @@ Object {
     "unleashUrl": "http://localhost:4242",
   },
   "session": Object {
+    "clearSiteDataOnLogout": true,
+    "cookieName": "unleash-session",
     "db": true,
     "ttlHours": 48,
   },

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -106,6 +106,11 @@ const defaultDbOptions: IDBOption = {
 
 const defaultSessionOption: ISessionOption = {
     ttlHours: safeNumber(process.env.SESSION_TTL_HOURS, 48),
+    clearSiteDataOnLogout: safeBoolean(
+        process.env.SESSION_CLEAR_SITE_DATA_ON_LOGOUT,
+        true,
+    ),
+    cookieName: 'unleash-session',
     db: true,
 };
 

--- a/src/lib/middleware/session-db.ts
+++ b/src/lib/middleware/session-db.ts
@@ -10,7 +10,7 @@ function sessionDb(
     knex: Knex,
 ): RequestHandler {
     let store;
-    const { db } = config.session;
+    const { db, cookieName } = config.session;
     const age =
         hoursToMilliseconds(config.session.ttlHours) || hoursToMilliseconds(48);
     const KnexSessionStore = knexSessionStore(session);
@@ -25,7 +25,7 @@ function sessionDb(
         store = new session.MemoryStore();
     }
     return session({
-        name: 'unleash-session',
+        name: cookieName,
         rolling: false,
         resave: false,
         saveUninitialized: false,

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -5,13 +5,12 @@ import SimplePasswordProvider from './auth/simple-password-provider';
 import { IUnleashConfig } from '../types/option';
 import { IUnleashServices } from '../types/services';
 import { api } from './api-def';
+import LogoutController from './logout';
 
 const AdminApi = require('./admin-api');
 const ClientApi = require('./client-api');
 const Controller = require('./controller');
 const HealthCheckController = require('./health-check');
-const LogoutController = require('./logout');
-
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
         super(config);

--- a/src/lib/routes/logout.ts
+++ b/src/lib/routes/logout.ts
@@ -4,11 +4,17 @@ import Controller from './controller';
 import { IAuthRequest } from './unleash-types';
 
 class LogoutController extends Controller {
+    private clearSiteDataOnLogout: boolean;
+
+    private cookieName: string;
+
     private baseUri: string;
 
     constructor(config: IUnleashConfig) {
         super(config);
         this.baseUri = config.server.baseUriPath;
+        this.clearSiteDataOnLogout = config.session.clearSiteDataOnLogout;
+        this.cookieName = config.session.cookieName;
         this.get('/', this.logout);
     }
 
@@ -27,10 +33,14 @@ class LogoutController extends Controller {
             req.logout();
         }
 
-        res.set('Clear-Site-Data', '"cookies", "storage"');
+        res.clearCookie(this.cookieName);
+
+        if (this.clearSiteDataOnLogout) {
+            res.set('Clear-Site-Data', '"cookies", "storage"');
+        }
+
         res.redirect(`${this.baseUri}/`);
     }
 }
 
-module.exports = LogoutController;
 export default LogoutController;

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -37,6 +37,8 @@ export interface IDBOption {
 export interface ISessionOption {
     ttlHours: number;
     db: boolean;
+    clearSiteDataOnLogout: boolean;
+    cookieName: string;
 }
 
 export interface IVersionOption {


### PR DESCRIPTION
## About the changes
Adds an option to disable "Clear-Site-Data" header to be set on logout request. This is useful when you only want Unleash logout to clear local unleash session, but not clear all cookies and session data on the same domain. 

Can be disabled by setting the following environment variable `SESSION_CLEAR_SITE_DATA_ON_LOGOUT=false`. 