### PR TITLE
chore: update setup-node task to activate yarn cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,20 +27,19 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: yarn
-    - run: yarn lint
-    - run: yarn run test
-      env:
-        CI: true
-        TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-        DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn lint
+      - run: yarn run test
+        env:
+          CI: true
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/build_coverage.yaml
+++ b/.github/workflows/build_coverage.yaml
@@ -27,36 +27,35 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: yarn
-    - run: yarn run test:coverage
-      env:
-        CI: true
-        TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-        DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-    #- run: |
-    ##    git config --global user.name "${GH_NAME}"
-    #    git config --global user.email "${GH_EMAIL}"
-    #    GIT_USER="${GH_NAME}"
-    #    echo "machine github.com login ${GH_NAME} password ${GITHUB_TOKEN}" > ~/.netrc
-    #
-    #    git add coverage
-    #    git diff-index --quiet HEAD || git commit -m 'chore: update coverage reports'
-    #    git push origin main
-    #  env:
-    #      GH_NAME: 'ivarconr'
-    #      GH_EMAIL: 'ivarconr@gmail.com'
-    #      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn run test:coverage
+        env:
+          CI: true
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      #- run: |
+      ##    git config --global user.name "${GH_NAME}"
+      #    git config --global user.email "${GH_EMAIL}"
+      #    GIT_USER="${GH_NAME}"
+      #    echo "machine github.com login ${GH_NAME} password ${GITHUB_TOKEN}" > ~/.netrc
+      #
+      #    git add coverage
+      #    git diff-index --quiet HEAD || git commit -m 'chore: update coverage reports'
+      #    git push origin main
+      #  env:
+      #      GH_NAME: 'ivarconr'
+      #      GH_EMAIL: 'ivarconr@gmail.com'
+      #      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_prs.yaml
+++ b/.github/workflows/build_prs.yaml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -17,7 +16,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - run: yarn
       - run: yarn lint
       - run: yarn build
-

--- a/.github/workflows/build_prs_jest_report.yaml
+++ b/.github/workflows/build_prs_jest_report.yaml
@@ -22,16 +22,15 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Tests on ${{ matrix.node-version }}
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -14,17 +13,18 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Publish to npm
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - run: |
-        yarn install --frozen-lockfile
-    - run: |
-        LATEST=$(npm show unleash-server version)
-        TAG=$(node scripts/npm-tag.js $LATEST)
-        npm publish --tag ${TAG:-latest}
-      env:
+      - uses: actions/checkout@v3
+      - name: Publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+      - run: |
+          yarn install --frozen-lockfile
+      - run: |
+          LATEST=$(npm show unleash-server version)
+          TAG=$(node scripts/npm-tag.js $LATEST)
+          npm publish --tag ${TAG:-latest}
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
So, to reduce buildtimes, this PR updates setup-node to activate it's 'yarn' cache method, allowing us to cache yarn dependencies for our builders