### PR TITLE
Update /api/admin/events doc

### DIFF
--- a/src/lib/services/state-service.ts
+++ b/src/lib/services/state-service.ts
@@ -417,7 +417,7 @@ export default class StateService {
             await this.eventStore.store({
                 type: DROP_ENVIRONMENTS,
                 createdBy: userName,
-                data: { name: 'all-projects' },
+                data: { name: 'all-environments' },
             });
         }
         const envsImport = environments.filter((env) =>

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -82,7 +82,6 @@ When called with a `project` query parameter: all events related to that project
 
 Fetch all events related to a specified toggle.
 
-
 #### Responses
 
 <details>
@@ -128,7 +127,38 @@ The list of events related to the given toggle.
 
 ## Event types
 
-Unleash emits a large number of different events. They are described below.
+Unleash emits a large number of different events (described in more detail in the following sections). The exact fields an event contains varies from event to event, but they all conform to the following TypeScript interface before being transformed to JSON:
+
+```ts
+
+interface IEvent {
+    id: number;
+    createdAt: Date;
+    type: string;
+    createdBy: string;
+    project?: string;
+    environment?: string;
+    featureName?: string;
+    data?: any;
+    preData?: any;
+    tags?: ITag[];
+}
+```
+
+The event properties are described in short in the table below. For more info regarding specific event types, refer to the corresponding, following sections.
+
+| Property      | Description                                                                                           |
+|---------------|-------------------------------------------------------------------------------------------------------|
+| `id`          | The ID of the event. An increasing natural number.                                                    |
+| `createdAt`   | The time the event happened as a RFC 3339-conformant timestamp.                                       |
+| `type`        | The event type, as described in the rest of this section.                                             |
+| `project`     | The project the event relates to, if applicable.                                                      |
+| `environment` | The feature toggle environment the event relates to, if applicable.                                   |
+| `featureName` | The name of the feature toggle the event relates to, if applicable.                                   |
+| `data`        | Any extra associated data related to the event, such as feature toggle state, if applicable.          |
+| `preData`     | For events with new state in the `data` property, the `preData` property contains the previous state. |
+| `tags`        | Any tags related to the event, if applicable.                                                         |
+
 
 ### Feature Toggle events:
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -125,9 +125,9 @@ The list of events related to the given toggle.
 
 </details>
 
-# Event types
+## Event type description
 
-Unleash emits a large number of different events (described in more detail in the following sections). The exact fields an event contains varies from event to event, but they all conform to the following TypeScript interface before being transformed to JSON:
+Unleash emits a large number of different events (described in more detail in the next sections). The exact fields an event contains varies from event to event, but they all conform to the following TypeScript interface before being transformed to JSON:
 
 ```ts
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -366,7 +366,7 @@ This event fires when you import a feature as part of an import process. The `da
 {
   "id": 26,
   "type": "feature-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.570Z",
   "data": {
     "name": "feature",
@@ -417,7 +417,7 @@ This event fires when you import a tagged feature as part of an import job. The 
 {
   "id": 43,
   "type": "feature-tag-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.606Z",
   "data": {
     "featureName": "new-feature",
@@ -531,7 +531,7 @@ This event fires when you drop all existing tags as part of a configuration impo
 {
   "id": 36,
   "type": "drop-feature-tags",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.596Z",
   "data": {
     "name": "all-feature-tags"
@@ -630,7 +630,7 @@ This event fires when you delete existing features as part of an import job.
 {
   "id": 25,
   "type": "drop-features",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.563Z",
   "data": {
     "name": "all-features"
@@ -824,7 +824,7 @@ This event fires when you import a strategy as part of an import job. The `data`
 {
   "id": 29,
   "type": "strategy-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.583Z",
   "data": {
     "name": "gradualRolloutSessionId",
@@ -861,7 +861,7 @@ This event fires when you delete existing strategies as part of an important job
 {
   "id": 28,
   "type": "drop-strategies",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.579Z",
   "data": {
     "name": "all-strategies"
@@ -1046,7 +1046,7 @@ This event fires when you import a project. The `data` property contains the pro
 {
   "id": 35,
   "type": "project-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.591Z",
   "data": {
     "id": "default",
@@ -1072,7 +1072,7 @@ This event fires when you delete existing projects as part of an import job.
 {
   "id": 33,
   "type": "drop-projects",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.586Z",
   "data": {
     "name": "all-projects"
@@ -1140,7 +1140,7 @@ This event fires when you import a tag as part of an import job. The `data` prop
 {
   "id": 41,
   "type": "tag-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.603Z",
   "data": {
     "type": "simple",
@@ -1162,7 +1162,7 @@ This event fires when you delete existing tags as part of an import job.
 {
   "id": 37,
   "type": "drop-tags",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.596Z",
   "data": {
     "name": "all-tags"
@@ -1256,7 +1256,7 @@ This event fires when you import a tag type as part of an import job. The `data`
 {
   "id": 40,
   "type": "tag-type-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.599Z",
   "data": {
     "name": "custom-tag-type",
@@ -1279,7 +1279,7 @@ This event fires when you drop all existing tag types as part of a configuration
 {
   "id": 38,
   "type": "drop-tag-types",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.596Z",
   "data": {
     "name": "all-tag-types"
@@ -1450,7 +1450,7 @@ This event fires when you delete existing environments as part of an import job.
 {
   "id": 21,
   "type": "drop-environments",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.549Z",
   "data": {
     "name": "all-projects"
@@ -1472,7 +1472,7 @@ This event fires when you import an environment (custom or otherwise) as part of
 {
   "id": 24,
   "type": "environment-import",
-  "createdBy": "import/export",
+  "createdBy": "import-API-token",
   "createdAt": "2022-06-03T11:30:40.557Z",
   "data": {
     "name": "custom-environment",

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -22,14 +22,14 @@ The Events API lets you retrieve events from your Unleash instance.
 |-----------------|----------------------------------------------------------------------------|----------|
 | `project`       | When applied, the endpoint will only return events from the given project. | No       |
 
-The `api/admin/events` endpoint returns all the events on the Unleash instance from the last X days. It accepts an optional query parameter `project`. When provided, the returned list of events all belong to the given project.
+When called without any query parameters, the endpoint will return the **last 100 events** from the Unleash instance.  When called with a `project` query parameter, it will return only events related to that project, but it will return **all the events**, and not just the last 100.
 
 
 #### Get events by project
 
 <ApiRequest verb="get" url="api/admin/events?project=<project-name>" title="Retrieve all events belonging to the given project."/>
 
-Use the `project` query parameter to make the API only return events pertaining to the given project.
+Use the `project` query parameter to make the API return *all* events pertaining to the given project.
 
 #### Responses
 
@@ -38,7 +38,9 @@ Use the `project` query parameter to make the API only return events pertaining 
 
 ##### 200 OK
 
-The list of events matching the provided query, or all events if no query params were provided.
+The last 100 events from the Unleash server when called without a `project` query parameter.
+
+When called with a `project` query parameter: all events related to that project.
 
 ``` json
 {

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -149,15 +149,15 @@ The event properties are described in short in the table below. For more info re
 
 | Property      | Description                                                                                           |
 |---------------|-------------------------------------------------------------------------------------------------------|
-| `id`          | The ID of the event. An increasing natural number.                                                    |
 | `createdAt`   | The time the event happened as a RFC 3339-conformant timestamp.                                       |
-| `type`        | The event type, as described in the rest of this section.                                             |
-| `project`     | The project the event relates to, if applicable.                                                      |
+| `data`        | Any extra associated data related to the event, such as feature toggle state, if applicable.          |
 | `environment` | The feature toggle environment the event relates to, if applicable.                                   |
 | `featureName` | The name of the feature toggle the event relates to, if applicable.                                   |
-| `data`        | Any extra associated data related to the event, such as feature toggle state, if applicable.          |
+| `id`          | The ID of the event. An increasing natural number.                                                    |
 | `preData`     | For events with new state in the `data` property, the `preData` property contains the previous state. |
+| `project`     | The project the event relates to, if applicable.                                                      |
 | `tags`        | Any tags related to the event, if applicable.                                                         |
+| `type`        | The event type, as described in the rest of this section.                                             |
 
 
 ### Feature Toggle events:

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -160,28 +160,91 @@ The event properties are described in short in the table below. For more info re
 | `type`        | The event type, as described in the rest of this section.                                             |
 
 
-### Feature Toggle events:
+### Feature Toggle events
 
-- feature-created
-- feature-deleted
-- feature-updated
-- feature-metadata-updated
-- feature-project-change
-- feature-archived
-- feature-revived
-- feature-import
-- feature-tagged
-- feature-tag-import
-- feature-strategy-update
-- feature-strategy-add
-- feature-strategy-remove
-- drop-feature-tags
-- feature-untagged
-- feature-stale-on
-- feature-stale-off
-- drop-features
-- feature-environment-enabled
-- feature-environment-disabled
+These events pertain to feature toggles and their life cycle.
+
+#### `feature-created`
+
+This event fires when you create a feature. The `data` property contains the details for the new feature.
+
+``` json title="example event: feature-created"
+{
+  "id": 899,
+  "type": "feature-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T13:32:20.560Z",
+  "data": {
+    "name": "new-toggle",
+    "description": "Toggle description",
+    "type": "release",
+    "project": "heartman-for-test",
+    "stale": false,
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "impressionData": true
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartman-for-test",
+  "environment": null
+}
+```
+
+#### `feature-deleted`
+
+#### `feature-updated`
+:::caution Deprecation notice
+This event type was replaced by more granular event types in Unleash 4.3. From Unleash 4.3 onwards, you'll need to use the events listed later in this section instead.
+:::
+
+This event fires when a feature gets updated in some way. The `data` property contains the new state of the toggle. This is a legacy event, so it does not populate `preData` property.
+
+
+``` json title="example event: feature-updated"
+{
+  "id": 899,
+  "type": "feature-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T13:32:20.560Z",
+  "data": {
+    "name": "new-toggle",
+    "description": "Toggle description",
+    "type": "release",
+    "project": "heartman-for-test",
+    "stale": false,
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "impressionData": true
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartman-for-test",
+  "environment": null
+}
+```
+
+#### `feature-metadata-updated`
+#### `feature-project-change`
+#### `feature-archived`
+#### `feature-revived`
+#### `feature-import`
+#### `feature-tagged`
+#### `feature-tag-import`
+#### `feature-strategy-update`
+#### `feature-strategy-add`
+#### `feature-strategy-remove`
+#### `drop-feature-tags`
+#### `feature-untagged`
+#### `feature-stale-on`
+#### `feature-stale-off`
+#### `drop-features`
+#### `feature-environment-enabled`
+#### `feature-environment-disabled`
 
 ### Strategy Events
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -348,21 +348,3 @@ The event properties are described in short in the table below. For more info re
 	}]
 }
 ```
-
-All events will implement the following interface:
-
-```js
-
-interface IEvent {
-    id: number;
-    createdAt: Date;
-    type: string;
-    createdBy: string;
-    project?: string;
-    environment?: string;
-    featureName?: string;
-    data?: any;
-    preData?: any;
-    tags?: ITag[];
-}
-```

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -195,6 +195,31 @@ This event fires when you create a feature. The `data` property contains the det
 
 #### `feature-deleted`
 
+``` json title="example event: feature-deleted"
+{
+  "id": 903,
+  "type": "feature-deleted",
+  "createdBy": "admin-account",
+  "createdAt": "2022-05-31T14:06:14.574Z",
+  "data": null,
+  "preData": {
+    "name": "new-toggle",
+    "type": "experiment",
+    "stale": false,
+    "project": "heartman-for-test",
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "description": "Toggle description",
+    "impressionData": true
+  },
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartman-for-test",
+  "environment": null
+}
+```
+
 #### `feature-updated`
 :::caution Deprecation notice
 This event type was replaced by more granular event types in Unleash 4.3. From Unleash 4.3 onwards, you'll need to use the events listed later in this section instead.
@@ -229,22 +254,350 @@ This event fires when a feature gets updated in some way. The `data` property co
 ```
 
 #### `feature-metadata-updated`
+
+This event fires when a feature's metadata (its description, toggle type, or impression data settings) are changed. The `data` property contains the new toggle data. The `preData` property contains the toggle's previous data.
+
+The below example changes the toggle's type from *release* to *experiment*.
+
+``` json title="example event: feature-metadata-updated"
+{
+  "id": 901,
+  "type": "feature-metadata-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T13:35:25.244Z",
+  "data": {
+    "name": "new-toggle",
+    "description": "Toggle description",
+    "type": "experiment",
+    "project": "heartman-for-test",
+    "stale": false,
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "impressionData": true
+  },
+  "preData": {
+    "name": "new-toggle",
+    "type": "release",
+    "stale": false,
+    "project": "heartman-for-test",
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "description": "Toggle description",
+    "impressionData": true
+  },
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartman-for-test",
+  "environment": null
+}
+```
+
 #### `feature-project-change`
+
+This event fires when you move a feature from one project to another.
+
+[... explain more in depth]
+
 #### `feature-archived`
+
+This event fires when you archive a toggle.
+
+``` json title="example event: feature-archived"
+{
+  "id": 902,
+  "type": "feature-archived",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T14:04:38.661Z",
+  "data": null,
+  "preData": null,
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartman-for-test",
+  "environment": null
+}
+```
+
 #### `feature-revived`
+
+This event fires when you revive an archived feature toggle (when you take a toggle out from the archive).
+
+``` json title="example-event: feature-revived"
+{
+  "id": 914,
+  "type": "feature-revived",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T09:57:10.719Z",
+  "data": null,
+  "preData": null,
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": null
+}
+```
+
 #### `feature-import`
+
+This event fires when you import a feature ...
+
 #### `feature-tagged`
+
+This event fires when you add a tag to a feature. The `data` property contains the new tag.
+
+``` json title="example event: feature-tagged"
+{
+  "id": 897,
+  "type": "feature-tagged",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T13:06:31.047Z",
+  "data": {
+    "type": "simple",
+    "value": "tag2"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "heartmans-constrained-toggle",
+  "project": null,
+  "environment": null
+}
+```
+
 #### `feature-tag-import`
+
+This event fires when you import a tag. ...
+
 #### `feature-strategy-update`
+
+This event fires when you update a feature strategy. The `data` property contains the new strategy configuration. The `preData` property contains the previous strategy configuration.
+
+``` json title="example event: feature-strategy-update"
+{
+  "id": 920,
+  "type": "feature-strategy-update",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T10:03:11.549Z",
+  "data": {
+    "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
+    "name": "flexibleRollout",
+    "constraints": [],
+    "parameters": {
+      "groupId": "new-toggle",
+      "rollout": "32",
+      "stickiness": "default"
+    }
+  },
+  "preData": {
+    "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
+    "name": "flexibleRollout",
+    "parameters": {
+      "groupId": "new-toggle",
+      "rollout": "67",
+      "stickiness": "default"
+    },
+    "constraints": []
+  },
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": "default"
+}
+```
+
 #### `feature-strategy-add`
+
+This event fires when you add a strategy to a feature. The `data` property contains the configuration for the new strategy.
+
+``` json title="example event: feature-strategy-add"
+{
+  "id": 919,
+  "type": "feature-strategy-add",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T10:03:08.290Z",
+  "data": {
+    "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
+    "name": "flexibleRollout",
+    "constraints": [],
+    "parameters": {
+      "groupId": "new-toggle",
+      "rollout": "67",
+      "stickiness": "default"
+    }
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": "default"
+}
+```
+
 #### `feature-strategy-remove`
+
+This event fires when you remove a strategy from a feature. The `preData` contains the configuration of the strategy that was removed.
+
+``` json title="example event: feature-strategy-remove"
+{
+  "id": 918,
+  "type": "feature-strategy-remove",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T10:03:00.229Z",
+  "data": null,
+  "preData": {
+    "id": "9591090e-acb0-4088-8958-21faaeb7147d",
+    "name": "default",
+    "parameters": {},
+    "constraints": []
+  },
+  "tags": [],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": "default"
+}
+```
+
 #### `drop-feature-tags`
+
+This event fires when you drop all existing tags as part of a configuration import.
+
+...
+
 #### `feature-untagged`
+
+This event fires when you remove a tag from a toggle. The `data` property contains the tag that was removed.
+
+``` json title="example event: feature-untagged"
+{
+  "id": 893,
+  "type": "feature-untagged",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T12:58:10.241Z",
+  "data": {
+    "type": "simple",
+    "value": "thisisatag"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "heartmans-constrained-toggle",
+  "project": null,
+  "environment": null
+}
+```
+
 #### `feature-stale-on`
+
+This event fires when you mark a feature as stale.
+
+``` json title="example event: feature-stale-on"
+{
+  "id": 926,
+  "type": "feature-stale-on",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T10:10:46.737Z",
+  "data": null,
+  "preData": null,
+  "tags": [
+    {
+      "value": "tag",
+      "type": "simple"
+    },
+    {
+      "value": "tog",
+      "type": "simple"
+    }
+  ],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": null
+}
+```
+
 #### `feature-stale-off`
+
+This event fires when you mark a stale feature as no longer being stale.
+
+``` json title="example event: feature-stale-off"
+{
+  "id": 928,
+  "type": "feature-stale-off",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-01T10:10:52.790Z",
+  "data": null,
+  "preData": null,
+  "tags": [
+    {
+      "value": "tag",
+      "type": "simple"
+    },
+    {
+      "value": "tog",
+      "type": "simple"
+    }
+  ],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": null
+}
+```
+
 #### `drop-features`
+
 #### `feature-environment-enabled`
+
+This event fires when you enable an environment for a feature. The `environment` property contains the name of the environment.
+
+``` json title="example event: feature-environment-enabled"
+{
+  "id": 930,
+  "type": "feature-environment-enabled",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:09:03.045Z",
+  "data": null,
+  "preData": null,
+  "tags": [
+    {
+      "value": "tag",
+      "type": "simple"
+    },
+    {
+      "value": "tog",
+      "type": "simple"
+    }
+  ],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": "development"
+}
+```
+
 #### `feature-environment-disabled`
+
+This event fires when you disable an environment for a feature. The `environment` property contains the name of the environment.
+
+``` json title="example event: feature-environment-disabled"
+{
+  "id": 931,
+  "type": "feature-environment-disabled",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:09:04.469Z",
+  "data": null,
+  "preData": null,
+  "tags": [
+    {
+      "value": "tag",
+      "type": "simple"
+    },
+    {
+      "value": "tog",
+      "type": "simple"
+    }
+  ],
+  "featureName": "new-toggle",
+  "project": "heartmans-other-project",
+  "environment": "development"
+}
+```
 
 ### Strategy Events
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -147,17 +147,17 @@ interface IEvent {
 
 The event properties are described in short in the table below. For more info regarding specific event types, refer to the corresponding, following sections.
 
-| Property      | Description                                                                                           |
-|---------------|-------------------------------------------------------------------------------------------------------|
-| `createdAt`   | The time the event happened as a RFC 3339-conformant timestamp.                                       |
-| `data`        | Any extra associated data related to the event, such as feature toggle state, if applicable.          |
-| `environment` | The feature toggle environment the event relates to, if applicable.                                   |
-| `featureName` | The name of the feature toggle the event relates to, if applicable.                                   |
-| `id`          | The ID of the event. An increasing natural number.                                                    |
-| `preData`     | For events with new state in the `data` property, the `preData` property contains the previous state. |
-| `project`     | The project the event relates to, if applicable.                                                      |
-| `tags`        | Any tags related to the event, if applicable.                                                         |
-| `type`        | The event type, as described in the rest of this section.                                             |
+| Property      | Description                                                                                                           |
+|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| `createdAt`   | The time the event happened as a RFC 3339-conformant timestamp.                                                       |
+| `data`        | Extra associated data related to the event, such as feature toggle state, segment configuration, etc., if applicable. |
+| `environment` | The feature toggle environment the event relates to, if applicable.                                                   |
+| `featureName` | The name of the feature toggle the event relates to, if applicable.                                                   |
+| `id`          | The ID of the event. An increasing natural number.                                                                    |
+| `preData`     | Data relating to the previous state of the event's subject. of                                                        |
+| `project`     | The project the event relates to, if applicable.                                                                      |
+| `tags`        | Any tags related to the event, if applicable.                                                                         |
+| `type`        | The event type, as described in the rest of this section.                                                             |
 
 
 ## Feature toggle events

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -172,13 +172,13 @@ This event fires when you create a feature. The `data` property contains the det
 {
   "id": 899,
   "type": "feature-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:32:20.560Z",
   "data": {
     "name": "new-toggle",
     "description": "Toggle description",
     "type": "release",
-    "project": "heartman-for-test",
+    "project": "my-project",
     "stale": false,
     "variants": [],
     "createdAt": "2022-05-31T13:32:20.547Z",
@@ -188,7 +188,7 @@ This event fires when you create a feature. The `data` property contains the det
   "preData": null,
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartman-for-test",
+  "project": "my-project",
   "environment": null
 }
 ```
@@ -208,7 +208,7 @@ This event fires when you delete a feature toggle. The `preData` property contai
     "name": "new-toggle",
     "type": "experiment",
     "stale": false,
-    "project": "heartman-for-test",
+    "project": "my-project",
     "variants": [],
     "createdAt": "2022-05-31T13:32:20.547Z",
     "lastSeenAt": null,
@@ -217,7 +217,7 @@ This event fires when you delete a feature toggle. The `preData` property contai
   },
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartman-for-test",
+  "project": "my-project",
   "environment": null
 }
 ```
@@ -234,13 +234,13 @@ This event fires when a feature gets updated in some way. The `data` property co
 {
   "id": 899,
   "type": "feature-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:32:20.560Z",
   "data": {
     "name": "new-toggle",
     "description": "Toggle description",
     "type": "release",
-    "project": "heartman-for-test",
+    "project": "my-project",
     "stale": false,
     "variants": [],
     "createdAt": "2022-05-31T13:32:20.547Z",
@@ -250,7 +250,7 @@ This event fires when a feature gets updated in some way. The `data` property co
   "preData": null,
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartman-for-test",
+  "project": "my-project",
   "environment": null
 }
 ```
@@ -265,13 +265,13 @@ The below example changes the toggle's type from *release* to *experiment*.
 {
   "id": 901,
   "type": "feature-metadata-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:35:25.244Z",
   "data": {
     "name": "new-toggle",
     "description": "Toggle description",
     "type": "experiment",
-    "project": "heartman-for-test",
+    "project": "my-project",
     "stale": false,
     "variants": [],
     "createdAt": "2022-05-31T13:32:20.547Z",
@@ -282,7 +282,7 @@ The below example changes the toggle's type from *release* to *experiment*.
     "name": "new-toggle",
     "type": "release",
     "stale": false,
-    "project": "heartman-for-test",
+    "project": "my-project",
     "variants": [],
     "createdAt": "2022-05-31T13:32:20.547Z",
     "lastSeenAt": null,
@@ -291,7 +291,7 @@ The below example changes the toggle's type from *release* to *experiment*.
   },
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartman-for-test",
+  "project": "my-project",
   "environment": null
 }
 ```
@@ -310,13 +310,13 @@ This event fires when you archive a toggle.
 {
   "id": 902,
   "type": "feature-archived",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T14:04:38.661Z",
   "data": null,
   "preData": null,
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartman-for-test",
+  "project": "my-project",
   "environment": null
 }
 ```
@@ -329,13 +329,13 @@ This event fires when you revive an archived feature toggle (when you take a tog
 {
   "id": 914,
   "type": "feature-revived",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T09:57:10.719Z",
   "data": null,
   "preData": null,
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -352,7 +352,7 @@ This event fires when you add a tag to a feature. The `data` property contains t
 {
   "id": 897,
   "type": "feature-tagged",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:06:31.047Z",
   "data": {
     "type": "simple",
@@ -360,7 +360,7 @@ This event fires when you add a tag to a feature. The `data` property contains t
   },
   "preData": null,
   "tags": [],
-  "featureName": "heartmans-constrained-toggle",
+  "featureName": "example-feature-name",
   "project": null,
   "environment": null
 }
@@ -378,7 +378,7 @@ This event fires when you update a feature strategy. The `data` property contain
 {
   "id": 920,
   "type": "feature-strategy-update",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T10:03:11.549Z",
   "data": {
     "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
@@ -402,7 +402,7 @@ This event fires when you update a feature strategy. The `data` property contain
   },
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": "default"
 }
 ```
@@ -415,7 +415,7 @@ This event fires when you add a strategy to a feature. The `data` property conta
 {
   "id": 919,
   "type": "feature-strategy-add",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T10:03:08.290Z",
   "data": {
     "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
@@ -430,7 +430,7 @@ This event fires when you add a strategy to a feature. The `data` property conta
   "preData": null,
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": "default"
 }
 ```
@@ -443,7 +443,7 @@ This event fires when you remove a strategy from a feature. The `preData` contai
 {
   "id": 918,
   "type": "feature-strategy-remove",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T10:03:00.229Z",
   "data": null,
   "preData": {
@@ -454,7 +454,7 @@ This event fires when you remove a strategy from a feature. The `preData` contai
   },
   "tags": [],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": "default"
 }
 ```
@@ -473,7 +473,7 @@ This event fires when you remove a tag from a toggle. The `data` property contai
 {
   "id": 893,
   "type": "feature-untagged",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T12:58:10.241Z",
   "data": {
     "type": "simple",
@@ -481,7 +481,7 @@ This event fires when you remove a tag from a toggle. The `data` property contai
   },
   "preData": null,
   "tags": [],
-  "featureName": "heartmans-constrained-toggle",
+  "featureName": "example-feature-name",
   "project": null,
   "environment": null
 }
@@ -495,7 +495,7 @@ This event fires when you mark a feature as stale.
 {
   "id": 926,
   "type": "feature-stale-on",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T10:10:46.737Z",
   "data": null,
   "preData": null,
@@ -510,7 +510,7 @@ This event fires when you mark a feature as stale.
     }
   ],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -523,7 +523,7 @@ This event fires when you mark a stale feature as no longer being stale.
 {
   "id": 928,
   "type": "feature-stale-off",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-01T10:10:52.790Z",
   "data": null,
   "preData": null,
@@ -538,7 +538,7 @@ This event fires when you mark a stale feature as no longer being stale.
     }
   ],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -553,7 +553,7 @@ This event fires when you enable an environment for a feature. The `environment`
 {
   "id": 930,
   "type": "feature-environment-enabled",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:09:03.045Z",
   "data": null,
   "preData": null,
@@ -568,7 +568,7 @@ This event fires when you enable an environment for a feature. The `environment`
     }
   ],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": "development"
 }
 ```
@@ -581,7 +581,7 @@ This event fires when you disable an environment for a feature. The `environment
 {
   "id": 931,
   "type": "feature-environment-disabled",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:09:04.469Z",
   "data": null,
   "preData": null,
@@ -596,7 +596,7 @@ This event fires when you disable an environment for a feature. The `environment
     }
   ],
   "featureName": "new-toggle",
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": "development"
 }
 ```
@@ -611,7 +611,7 @@ This event fires when you create a strategy. The `data` property contains the st
 {
   "id": 932,
   "type": "strategy-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:20:52.111Z",
   "data": {
     "name": "new-strategy",
@@ -636,7 +636,7 @@ This event fires when you delete a strategy. The `data` property contains the na
 {
   "id": 936,
   "type": "strategy-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:22:01.302Z",
   "data": {
     "name": "new-strategy"
@@ -657,7 +657,7 @@ This event fires when you deprecate a strategy. The `data` property contains the
 {
   "id": 934,
   "type": "strategy-deprecated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:21:45.041Z",
   "data": {
     "name": "new-strategy"
@@ -679,7 +679,7 @@ The `data` property contains the name of the reactivated strategy.
 {
   "id": 935,
   "type": "strategy-reactivated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:21:49.010Z",
   "data": {
     "name": "new-strategy"
@@ -701,7 +701,7 @@ The `data` property contains the new strategy configuration.
 {
   "id": 933,
   "type": "strategy-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T12:21:23.741Z",
   "data": {
     "name": "new-strategy",
@@ -746,7 +746,7 @@ The `data` property contains the context field configuration.
 {
   "id": 937,
   "type": "context-field-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:17:17.499Z",
   "data": {
     "name": "new-context-field",
@@ -771,7 +771,7 @@ The `data` property contains the new context field configuration.
 {
   "id": 939,
   "type": "context-field-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:19:19.422Z",
   "data": {
     "name": "new-context-field",
@@ -805,7 +805,7 @@ The `data` property contains the name of the deleted context field.
 {
   "id": 940,
   "type": "context-field-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:20:41.386Z",
   "data": {
     "name": "new-context-field"
@@ -831,17 +831,17 @@ The `data` property contains the project configuration.
 {
   "id": 905,
   "type": "project-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-05-31T14:16:14.498Z",
   "data": {
-    "id": "heartmans-other-project",
-    "name": "heartman's other project",
-    "description": "a project for heartman's testing and doc work"
+    "id": "my-other-project",
+    "name": "my other project",
+    "description": "a project for important work"
   },
   "preData": null,
   "tags": [],
   "featureName": null,
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -856,24 +856,24 @@ The `preData` property contains the previous project configuration.
 {
   "id": 941,
   "type": "project-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:23:55.025Z",
   "data": {
-    "id": "heartmans-other-project",
-    "name": "heartman's other project",
-    "description": "a project for heartman's testing and doc work!"
+    "id": "my-other-project",
+    "name": "my other project",
+    "description": "a project for important work!"
   },
   "preData": {
-    "id": "heartmans-other-project",
-    "name": "heartman's other project",
+    "id": "my-other-project",
+    "name": "my other project",
     "health": 50,
     "createdAt": "2022-05-31T14:16:14.483Z",
     "updatedAt": "2022-06-02T12:30:48.095Z",
-    "description": "a project for heartman's testing and doc work"
+    "description": "a project for important work"
   },
   "tags": [],
   "featureName": null,
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -887,13 +887,13 @@ The `project` property contains the name of the deleted project.
 {
   "id": 944,
   "type": "project-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:25:53.820Z",
   "data": null,
   "preData": null,
   "tags": [],
   "featureName": null,
-  "project": "heartmans-other-project",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -925,7 +925,7 @@ This event fires when you create a new tag. The `data` property contains the tag
 {
   "id": 959,
   "type": "feature-tagged",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:13:39.401Z",
   "data": {
     "type": "heartag",
@@ -947,7 +947,7 @@ This event fires when you delete a tag. The `data` property contains the tag tha
 {
   "id": 957,
   "type": "tag-deleted",
-  "createdBy": "heartman-admin-testing",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:12:17.310Z",
   "data": {
     "type": "heartag",
@@ -990,7 +990,7 @@ The `data` property contains the tag type configuration.
 {
   "id": 945,
   "type": "tag-type-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:27:01.235Z",
   "data": {
     "name": "new-tag-type",
@@ -1014,7 +1014,7 @@ The `data` property contains the name of the deleted tag type.
 {
   "id": 947,
   "type": "tag-type-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:27:37.277Z",
   "data": {
     "name": "new-tag-type"
@@ -1036,7 +1036,7 @@ The `data` property contains the new tag type configuration.
 {
   "id": 946,
   "type": "tag-type-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-02T13:27:31.126Z",
   "data": {
     "name": "new-tag-type",
@@ -1079,7 +1079,7 @@ The `data` property contains the addon's ID and provider type.
 {
   "id": 960,
   "type": "addon-config-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:15:45.040Z",
   "data": {
     "provider": "webhook"
@@ -1101,7 +1101,7 @@ The `data` property contains the addon's ID and provider type.
 {
   "id": 961,
   "type": "addon-config-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:16:11.732Z",
   "data": {
     "id": "2",
@@ -1124,7 +1124,7 @@ The `data` property contains the addon's ID.
 {
   "id": 964,
   "type": "addon-config-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:16:59.723Z",
   "data": {
     "id": "2"
@@ -1149,7 +1149,7 @@ This event fires when you create a new user. The `data` property contains the us
 {
   "id": 965,
   "type": "user-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:23:47.713Z",
   "data": {
     "id": 44,
@@ -1172,7 +1172,7 @@ This event fires when you update a user. The `data` property contains the update
 {
   "id": 967,
   "type": "user-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:24:26.301Z",
   "data": {
     "id": 44,
@@ -1199,7 +1199,7 @@ This event fires when you delete a user. The `preData` property contains the del
 {
   "id": 968,
   "type": "user-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:24:49.153Z",
   "data": null,
   "preData": {
@@ -1245,7 +1245,7 @@ This event fires when you create a segment. The `data` property contains the new
 {
   "id": 969,
   "type": "segment-created",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:29:43.977Z",
   "data": {
     "id": 5,
@@ -1264,7 +1264,7 @@ This event fires when you create a segment. The `data` property contains the new
         "caseInsensitive": false
       }
     ],
-    "createdBy": "thomas@getunleash.ai",
+    "createdBy": "user@company.com",
     "createdAt": "2022-06-03T10:29:43.974Z"
   },
   "preData": null,
@@ -1283,21 +1283,21 @@ This event fires when you update a segment's configuration. The `data` property 
 {
   "id": 970,
   "type": "segment-updated",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:29:59.892Z",
   "data": {
     "id": 5,
     "name": "new segment",
     "description": "this segment is for events",
     "constraints": [],
-    "createdBy": "thomas@getunleash.ai",
+    "createdBy": "user@company.com",
     "createdAt": "2022-06-03T10:29:43.974Z"
   },
   "preData": {
     "id": 5,
     "name": "new segment",
     "createdAt": "2022-06-03T10:29:43.974Z",
-    "createdBy": "thomas@getunleash.ai",
+    "createdBy": "user@company.com",
     "constraints": [
       {
         "values": [
@@ -1328,7 +1328,7 @@ This event fires when you delete a segment.
 {
   "id": 971,
   "type": "segment-deleted",
-  "createdBy": "thomas@getunleash.ai",
+  "createdBy": "user@company.com",
   "createdAt": "2022-06-03T10:30:08.128Z",
   "data": {},
   "preData": null,

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -660,6 +660,7 @@ This event fires when you disable an environment for a feature. The `environment
 ### `drop-features`
 
 This event fires when you delete existing features as part of an import job.
+The `data.name` property will always be `"all-features"`.
 
 ``` json title="example event: drop-features"
 {
@@ -682,6 +683,7 @@ This event fires when you delete existing features as part of an import job.
 ### `drop-feature-tags`
 
 This event fires when you drop all existing tags as part of a configuration import.
+The `data.name` property will always be `"all-feature-tags"`.
 
 ``` json title="example event: drop-feature-tags"
 {
@@ -858,6 +860,8 @@ This event fires when you import a strategy as part of an import job. The `data`
 ### `drop-strategies`
 
 This event fires when you delete existing strategies as part of an important job.
+The `data.name` property will always be `"all-strategies"`.
+
 
 ``` json title="example event: drop-strategies"
 {
@@ -1071,6 +1075,8 @@ This event fires when you import a project. The `data` property contains the pro
 ### `drop-projects`
 
 This event fires when you delete existing projects as part of an import job.
+The `data.name` property will always be `"all-projects"`.
+
 
 ``` json title="example event: drop-projects"
 {
@@ -1163,6 +1169,8 @@ This event fires when you import a tag as part of an import job. The `data` prop
 ### `drop-tags`
 
 This event fires when you delete existing tags as part of an import job.
+The `data.name` property will always be `"all-tags"`.
+
 
 ``` json title="example event: drop-tags"
 {
@@ -1280,6 +1288,8 @@ This event fires when you import a tag type as part of an import job. The `data`
 ### `drop-tag-types`
 
 This event fires when you drop all existing tag types as part of a configuration import.
+The `data.name` property will always be `"all-tag-types"`.
+
 
 ``` json title="example event: drop-tag-types"
 {
@@ -1478,6 +1488,7 @@ This event fires when you import an environment (custom or otherwise) as part of
 ### `drop-environments`
 
 This event fires when you delete existing environments as part of an import job.
+The `data.name` property will always be `"all-environments"`.
 
 ``` json title="example event: drop-environments"
 {

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -42,7 +42,7 @@ The last 100 events from the Unleash server when called without a `project` quer
 
 When called with a `project` query parameter: all events related to that project.
 
-``` json
+``` json title="Successful response; a list of events"
 {
   "version": 1,
   "events": [
@@ -91,7 +91,7 @@ Fetch all events related to a specified toggle.
 
 The list of events related to the given toggle.
 
-``` json
+``` json title="Successful response; all events relating to the specified toggle"
 {
   "toggleName": "my-constrained-toggle",
   "events": [
@@ -607,7 +607,7 @@ This event fires when you disable an environment for a feature. The `environment
 
 This event fires when you create a strategy. The `data` property contains the strategy configuration.
 
-``` json
+``` json title="example event: strategy-created"
 {
   "id": 932,
   "type": "strategy-created",
@@ -632,7 +632,7 @@ This event fires when you create a strategy. The `data` property contains the st
 
 This event fires when you delete a strategy. The `data` property contains the name of the deleted strategy.
 
-``` json
+``` json title="example event: strategy-deleted"
 {
   "id": 936,
   "type": "strategy-deleted",
@@ -653,7 +653,7 @@ This event fires when you delete a strategy. The `data` property contains the na
 
 This event fires when you deprecate a strategy. The `data` property contains the name of the deprecated strategy.
 
-``` json
+``` json title="example event: strategy-deprecated"
 {
   "id": 934,
   "type": "strategy-deprecated",
@@ -675,7 +675,7 @@ This event fires when you deprecate a strategy. The `data` property contains the
 This event fires when you bring reactivate a deprecated strategy.
 The `data` property contains the name of the reactivated strategy.
 
-``` json
+``` json title="example event: strategy-reactivated"
 {
   "id": 935,
   "type": "strategy-reactivated",
@@ -697,7 +697,7 @@ The `data` property contains the name of the reactivated strategy.
 This event fires when you change a strategy's configuration.
 The `data` property contains the new strategy configuration.
 
-``` json
+``` json title="example event: strategy-updated"
 {
   "id": 933,
   "type": "strategy-updated",
@@ -722,7 +722,7 @@ The `data` property contains the new strategy configuration.
 
 This event fires when you import a strategy ...
 
-``` json
+``` json title="example event: strategy-import"
 
 ```
 
@@ -730,7 +730,7 @@ This event fires when you import a strategy ...
 
 This event fires when
 
-``` json
+``` json title="example event: drop-strategies"
 
 ```
 
@@ -742,7 +742,7 @@ This event fires when
 This event fires when you create a context field.
 The `data` property contains the context field configuration.
 
-``` json
+``` json title="example event: context-field-created"
 {
   "id": 937,
   "type": "context-field-created",
@@ -767,7 +767,7 @@ The `data` property contains the context field configuration.
 This event fires when you update a context field.
 The `data` property contains the new context field configuration.
 
-``` json
+``` json title="example event: context-field-updated"
 {
   "id": 939,
   "type": "context-field-updated",
@@ -801,7 +801,7 @@ The `data` property contains the new context field configuration.
 This event fires when you delete a context field.
 The `data` property contains the name of the deleted context field.
 
-``` json
+``` json title="example event: context-field-deleted"
 {
   "id": 940,
   "type": "context-field-deleted",
@@ -827,7 +827,7 @@ This event fires when you create a project.
 The `data` property contains the project configuration.
 
 
-``` json
+``` json title="example event: project-created"
 {
   "id": 905,
   "type": "project-created",
@@ -852,7 +852,7 @@ This event fires when you update a project's configuration.
 The `data` property contains the new project configuration.
 The `preData` property contains the previous project configuration.
 
-``` json
+``` json title="example event: project-updated"
 {
   "id": 941,
   "type": "project-updated",
@@ -883,7 +883,7 @@ The `preData` property contains the previous project configuration.
 This event fires when you delete a project.
 The `project` property contains the name of the deleted project.
 
-``` json
+``` json title="example event: project-deleted"
 {
   "id": 944,
   "type": "project-deleted",
@@ -902,7 +902,7 @@ The `project` property contains the name of the deleted project.
 
 This event fires when
 
-``` json
+``` json title="example event: project-import"
 
 ```
 
@@ -910,7 +910,7 @@ This event fires when
 
 This event fires when
 
-``` json
+``` json title="example event: drop-projects"
 
 ```
 
@@ -921,7 +921,7 @@ This event fires when
 
 This event fires when you create a new tag. The `data` property contains the tag that was created.
 
-``` json
+``` json title="example event: tag-created"
 {
   "id": 959,
   "type": "feature-tagged",
@@ -943,7 +943,7 @@ This event fires when you create a new tag. The `data` property contains the tag
 
 This event fires when you delete a tag. The `data` property contains the tag that was deleted.
 
-``` json
+``` json title="example event: tag-deleted"
 {
   "id": 957,
   "type": "tag-deleted",
@@ -965,7 +965,7 @@ This event fires when you delete a tag. The `data` property contains the tag tha
 
 This event fires when
 
-``` json
+``` json title="example event: tag-import"
 
 ```
 
@@ -973,7 +973,7 @@ This event fires when
 
 This event fires when
 
-``` json
+``` json title="example event: drop-tags"
 
 ```
 
@@ -986,7 +986,7 @@ This event fires when
 This event fires when you create a new tag type.
 The `data` property contains the tag type configuration.
 
-``` json
+``` json title="example event: tag-type-created"
 {
   "id": 945,
   "type": "tag-type-created",
@@ -1010,7 +1010,7 @@ This event fires when you delete a tag type.
 The `data` property contains the name of the deleted tag type.
 
 
-``` json
+``` json title="example event: tag-type-deleted"
 {
   "id": 947,
   "type": "tag-type-deleted",
@@ -1032,7 +1032,7 @@ The `data` property contains the name of the deleted tag type.
 This event fires when you update a tag type.
 The `data` property contains the new tag type configuration.
 
-``` json
+``` json title="example event: tag-type-updated"
 {
   "id": 946,
   "type": "tag-type-updated",
@@ -1054,7 +1054,7 @@ The `data` property contains the new tag type configuration.
 
 This event fires when
 
-``` json
+``` json title="example event: tag-type-import"
 
 ```
 
@@ -1062,7 +1062,7 @@ This event fires when
 
 This event fires when
 
-``` json
+``` json title="example event: drop-tag-types"
 
 ```
 
@@ -1075,7 +1075,7 @@ This event fires when
 This event fires when you create an addon configuration.
 The `data` property contains the addon's ID and provider type.
 
-``` json
+``` json title="example event: addon-config-created"
 {
   "id": 960,
   "type": "addon-config-created",
@@ -1097,7 +1097,7 @@ The `data` property contains the addon's ID and provider type.
 This event fires when you update an addon configuration.
 The `data` property contains the addon's ID and provider type.
 
-``` json
+``` json title="example event: addon-config-updated"
 {
   "id": 961,
   "type": "addon-config-updated",
@@ -1120,7 +1120,7 @@ The `data` property contains the addon's ID and provider type.
 This event fires when you update an addon configuration.
 The `data` property contains the addon's ID.
 
-``` json
+``` json title="example event: addon-config-deleted"
 {
   "id": 964,
   "type": "addon-config-deleted",
@@ -1145,7 +1145,7 @@ The `data` property contains the addon's ID.
 
 This event fires when you create a new user. The `data` property contains the user's information.
 
-``` json
+``` json title="example event: user-created"
 {
   "id": 965,
   "type": "user-created",
@@ -1168,7 +1168,7 @@ This event fires when you create a new user. The `data` property contains the us
 
 This event fires when you update a user. The `data` property contains the updated user information; the `preData` property contains the previous state of the user's information.
 
-``` json
+``` json title="example event: user-updated"
 {
   "id": 967,
   "type": "user-updated",
@@ -1195,7 +1195,7 @@ This event fires when you update a user. The `data` property contains the update
 
 This event fires when you delete a user. The `preData` property contains the deleted users information.
 
-``` json
+``` json title="example event: user-deleted"
 {
   "id": 968,
   "type": "user-deleted",
@@ -1222,7 +1222,7 @@ This event fires when you delete a user. The `preData` property contains the del
 
 This event fires when
 
-``` json
+``` json title="example event: drop-environments"
 
 ```
 
@@ -1230,7 +1230,7 @@ This event fires when
 
 This event fires when
 
-``` json
+``` json title="example event: environment-import"
 
 ```
 
@@ -1241,7 +1241,7 @@ This event fires when
 
 This event fires when you create a segment. The `data` property contains the newly created segment.
 
-``` json
+``` json title="example event: segment-created"
 {
   "id": 969,
   "type": "segment-created",
@@ -1279,7 +1279,7 @@ This event fires when you create a segment. The `data` property contains the new
 
 This event fires when you update a segment's configuration. The `data` property contains the new segment configuration; the `preData` property contains the previous segment configuration.
 
-``` json
+``` json title="example event: segment-updated"
 {
   "id": 970,
   "type": "segment-updated",
@@ -1324,7 +1324,7 @@ This event fires when you update a segment's configuration. The `data` property 
 
 This event fires when you delete a segment.
 
-``` json
+``` json title="example event: segment-deleted"
 {
   "id": 971,
   "type": "segment-deleted",

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -154,7 +154,7 @@ The event properties are described in short in the table below. For more info re
 | `environment` | The feature toggle environment the event relates to, if applicable.                                                   |
 | `featureName` | The name of the feature toggle the event relates to, if applicable.                                                   |
 | `id`          | The ID of the event. An increasing natural number.                                                                    |
-| `preData`     | Data relating to the previous state of the event's subject. of                                                        |
+| `preData`     | Data relating to the previous state of the event's subject.                                                        |
 | `project`     | The project the event relates to, if applicable.                                                                      |
 | `tags`        | Any tags related to the event, if applicable.                                                                         |
 | `type`        | The event type, as described in the rest of this section.                                                             |
@@ -1433,7 +1433,7 @@ This event fires when you update a user. The `data` property contains the update
 
 ### `user-deleted`
 
-This event fires when you delete a user. The `preData` property contains the deleted users information.
+This event fires when you delete a user. The `preData` property contains the deleted user's information.
 
 ``` json title="example event: user-deleted"
 {

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -8,13 +8,15 @@ import ApiRequest from '@site/src/components/ApiRequest'
 In order to access the admin API endpoints you need to identify yourself. Unless you're using the `none` authentication method, you'll need to [create an ADMIN token](/user_guide/api-token) and add an Authorization header using the token.
 :::
 
-## The Events API
+The Events API lets you retrieve events from your Unleash instance.
 
-## Get all events
+## Event endpoints
+
+### Get all events
 
 <ApiRequest verb="get" url="api/admin/events" title="Retrieve all events from the Unleash instance."/>
 
-### Query parameters
+#### Query parameters
 
 | Query parameter | Description                                                                | Required |
 |-----------------|----------------------------------------------------------------------------|----------|
@@ -23,13 +25,13 @@ In order to access the admin API endpoints you need to identify yourself. Unless
 The `api/admin/events` endpoint returns all the events on the Unleash instance from the last X days. It accepts an optional query parameter `project`. When provided, the returned list of events all belong to the given project.
 
 
-### Get events by project
+#### Get events by project
 
 <ApiRequest verb="get" url="api/admin/events?project=<project-name>" title="Retrieve all events belonging to the given project."/>
 
 Use the `project` query parameter to make the API only return events pertaining to the given project.
 
-### Responses
+#### Responses
 
 <details>
 <summary>Responses</summary>
@@ -72,19 +74,19 @@ The list of events matching the provided query, or all events if no query params
 
 </details>
 
-## Get events for a specific toggle
+### Get events for a specific toggle
 
 <ApiRequest verb="get" url="api/admin/events/<toggle-name>" title="Retrieve all events related to the given toggle."/>
 
 Fetch all events related to a specified toggle.
 
 
-### Responses
+#### Responses
 
 <details>
 <summary>Responses</summary>
 
-##### 200 OK
+###### 200 OK
 
 The list of events related to the given toggle.
 
@@ -122,14 +124,11 @@ The list of events related to the given toggle.
 
 </details>
 
+## Event types
 
-The Events API lets you fetch all
+Unleash emits a large number of different events. They are described below.
 
-Used to fetch all changes in the unleash system.
-
-Defined event types:
-
-## Feature Toggle events:
+### Feature Toggle events:
 
 - feature-created
 - feature-deleted
@@ -152,7 +151,7 @@ Defined event types:
 - feature-environment-enabled
 - feature-environment-disabled
 
-## Strategy Events
+### Strategy Events
 
 - strategy-created
 - strategy-deleted
@@ -162,13 +161,13 @@ Defined event types:
 - strategy-import
 - drop-strategies
 
-## Context field events
+### Context field events
 
 - context-field-created
 - context-field-updated
 - context-field-deleted
 
-## Project events
+### Project events
 
 - project-created
 - project-updated
@@ -176,7 +175,7 @@ Defined event types:
 - project-import
 - drop-projects
 
-## Tag events
+### Tag events
 
 - tag-created
 - tag-deleted
@@ -184,7 +183,7 @@ Defined event types:
 - drop-tags
 
 
-## Tag type events
+### Tag type events
 
 - tag-type-created
 - tag-type-deleted
@@ -193,21 +192,21 @@ Defined event types:
 - drop-tag-types
 
 
-## Addon events
+### Addon events
 
 - addon-config-created
 - addon-config-updated
 - addon-config-deleted
 
 
-## User events
+### User events
 
 - user-created
 - user-updated
 - user-deleted
 
 
-## Environment events (Enterprise)
+### Environment events (Enterprise)
 
 - drop-environments
 - environment-import

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -1303,7 +1303,7 @@ This event fires when you drop all existing tag types as part of a configuration
 ### `addon-config-created`
 
 This event fires when you create an addon configuration.
-The `data` property contains the addon's ID and provider type.
+The `data` property contains the provider type.
 
 ``` json title="example event: addon-config-created"
 {

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -360,7 +360,32 @@ This event fires when you revive an archived feature toggle (when you take a tog
 
 ### `feature-import`
 
-This event fires when you import a feature ...
+This event fires when you import a feature as part of an import process. The `data` property contains the feature data.
+
+``` json title="example event: feature-import"
+{
+  "id": 26,
+  "type": "feature-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.570Z",
+  "data": {
+    "name": "feature",
+    "description": "",
+    "type": "release",
+    "project": "default",
+    "stale": false,
+    "variants": [],
+    "impressionData": false,
+    "enabled": false,
+    "archived": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
 
 ### `feature-tagged`
 
@@ -386,7 +411,28 @@ This event fires when you add a tag to a feature. The `data` property contains t
 
 ### `feature-tag-import`
 
-This event fires when you import a tag. ...
+This event fires when you import a tagged feature as part of an import job. The `data` property contains the name of the feature and the tag.
+
+``` json title="example event: feature-tag-import"
+{
+  "id": 43,
+  "type": "feature-tag-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.606Z",
+  "data": {
+    "featureName": "new-feature",
+    "tag": {
+      "type": "simple",
+      "value": "tag1"
+    }
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
 
 ### `feature-strategy-update`
 
@@ -481,7 +527,22 @@ This event fires when you remove a strategy from a feature. The `preData` contai
 
 This event fires when you drop all existing tags as part of a configuration import.
 
-...
+``` json title="example event: drop-feature-tags"
+{
+  "id": 36,
+  "type": "drop-feature-tags",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.596Z",
+  "data": {
+    "name": "all-feature-tags"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
 
 ### `feature-untagged`
 
@@ -562,6 +623,25 @@ This event fires when you mark a stale feature as no longer being stale.
 ```
 
 ### `drop-features`
+
+This event fires when you delete existing features as part of an import job.
+
+``` json title="example event: drop-features"
+{
+  "id": 25,
+  "type": "drop-features",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.563Z",
+  "data": {
+    "name": "all-features"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
 
 ### `feature-environment-enabled`
 
@@ -738,18 +818,60 @@ The `data` property contains the new strategy configuration.
 
 ### `strategy-import`
 
-This event fires when you import a strategy ...
+This event fires when you import a strategy as part of an import job. The `data` property contains the strategy's configuration.
 
 ``` json title="example event: strategy-import"
-
+{
+  "id": 29,
+  "type": "strategy-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.583Z",
+  "data": {
+    "name": "gradualRolloutSessionId",
+    "description": "Gradually activate feature toggle. Stickiness based on session id.",
+    "parameters": [
+      {
+        "name": "percentage",
+        "type": "percentage",
+        "description": "",
+        "required": false
+      },
+      {
+        "name": "groupId",
+        "type": "string",
+        "description": "Used to define a activation groups, which allows you to correlate across feature toggles.",
+        "required": true
+      }
+    ],
+    "deprecated": true
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 ### `drop-strategies`
 
-This event fires when
+This event fires when you delete existing strategies as part of an important job.
 
 ``` json title="example event: drop-strategies"
-
+{
+  "id": 28,
+  "type": "drop-strategies",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.579Z",
+  "data": {
+    "name": "all-strategies"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -918,18 +1040,49 @@ The `project` property contains the name of the deleted project.
 
 ### `project-import`
 
-This event fires when
+This event fires when you import a project. The `data` property contains the project's configuration details.
 
 ``` json title="example event: project-import"
-
+{
+  "id": 35,
+  "type": "project-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.591Z",
+  "data": {
+    "id": "default",
+    "name": "Default",
+    "description": "Default project",
+    "createdAt": "2022-06-03T09:30:40.587Z",
+    "health": 100,
+    "updatedAt": "2022-06-03T11:30:40.587Z"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 ### `drop-projects`
 
-This event fires when
+This event fires when you delete existing projects as part of an import job.
 
 ``` json title="example event: drop-projects"
-
+{
+  "id": 33,
+  "type": "drop-projects",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.586Z",
+  "data": {
+    "name": "all-projects"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -981,18 +1134,45 @@ This event fires when you delete a tag. The `data` property contains the tag tha
 
 ### `tag-import`
 
-This event fires when
+This event fires when you import a tag as part of an import job. The `data` property contains the imported tag.
 
 ``` json title="example event: tag-import"
-
+{
+  "id": 41,
+  "type": "tag-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.603Z",
+  "data": {
+    "type": "simple",
+    "value": "tag1"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 ### `drop-tags`
 
-This event fires when
+This event fires when you delete existing tags as part of an import job.
 
 ``` json title="example event: drop-tags"
-
+{
+  "id": 37,
+  "type": "drop-tags",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.596Z",
+  "data": {
+    "name": "all-tags"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -1070,21 +1250,47 @@ The `data` property contains the new tag type configuration.
 
 ### `tag-type-import`
 
-This event fires when
+This event fires when you import a tag type as part of an import job. The `data` property contains the imported tag.
 
 ``` json title="example event: tag-type-import"
-
+{
+  "id": 40,
+  "type": "tag-type-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.599Z",
+  "data": {
+    "name": "custom-tag-type",
+    "description": "custom tag type",
+    "icon": null
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 ### `drop-tag-types`
 
-This event fires when
+This event fires when you drop all existing tag types as part of a configuration import.
 
 ``` json title="example event: drop-tag-types"
-
+{
+  "id": 38,
+  "type": "drop-tag-types",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.596Z",
+  "data": {
+    "name": "all-tag-types"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
-
-
 
 ## Addon events
 
@@ -1234,23 +1440,55 @@ This event fires when you delete a user. The `preData` property contains the del
 
 
 
-## Environment events (Enterprise)
+## Environment events
 
 ### `drop-environments`
 
-This event fires when
+This event fires when you delete existing environments as part of an import job.
 
 ``` json title="example event: drop-environments"
-
+{
+  "id": 21,
+  "type": "drop-environments",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.549Z",
+  "data": {
+    "name": "all-projects"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
+
 
 ### `environment-import`
 
-This event fires when
+This event fires when you import an environment (custom or otherwise) as part of an import job. The `data` property contains the configuration of the imported environment.
 
 ``` json title="example event: environment-import"
-
+{
+  "id": 24,
+  "type": "environment-import",
+  "createdBy": "import/export",
+  "createdAt": "2022-06-03T11:30:40.557Z",
+  "data": {
+    "name": "custom-environment",
+    "type": "test",
+    "sortOrder": 9999,
+    "enabled": true,
+    "protected": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
+
 
 
 ## Segment events

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -601,166 +601,310 @@ This event fires when you disable an environment for a feature. The `environment
 
 ### Strategy Events
 
-- strategy-created
-- strategy-deleted
-- strategy-deprecated
-- strategy-reactivated
-- strategy-updated
-- strategy-import
-- drop-strategies
+#### `strategy-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `strategy-deleted`
+
+This event fires when
+
+``` json
+
+```
+
+#### `strategy-deprecated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `strategy-reactivated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `strategy-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `strategy-import`
+
+This event fires when
+
+``` json
+
+```
+
+#### `drop-strategies`
+
+This event fires when
+
+``` json
+
+```
+
 
 ### Context field events
 
-- context-field-created
-- context-field-updated
-- context-field-deleted
+#### `context-field-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `context-field-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `context-field-deleted`
+
+This event fires when
+
+``` json
+
+```
+
 
 ### Project events
 
-- project-created
-- project-updated
-- project-deleted
-- project-import
-- drop-projects
+#### `project-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `project-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `project-deleted`
+
+This event fires when
+
+``` json
+
+```
+
+#### `project-import`
+
+This event fires when
+
+``` json
+
+```
+
+#### `drop-projects`
+
+This event fires when
+
+``` json
+
+```
+
 
 ### Tag events
 
-- tag-created
-- tag-deleted
-- tag-import
-- drop-tags
+#### `tag-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `tag-deleted`
+
+This event fires when
+
+``` json
+
+```
+
+#### `tag-import`
+
+This event fires when
+
+``` json
+
+```
+
+#### `drop-tags`
+
+This event fires when
+
+``` json
+
+```
+
 
 
 ### Tag type events
 
-- tag-type-created
-- tag-type-deleted
-- tag-type-updated
-- tag-type-import
-- drop-tag-types
+#### `tag-type-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `tag-type-deleted`
+
+This event fires when
+
+``` json
+
+```
+
+#### `tag-type-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `tag-type-import`
+
+This event fires when
+
+``` json
+
+```
+
+#### `drop-tag-types`
+
+This event fires when
+
+``` json
+
+```
+
 
 
 ### Addon events
 
-- addon-config-created
-- addon-config-updated
-- addon-config-deleted
+#### `addon-config-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `addon-config-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `addon-config-deleted`
+
+This event fires when
+
+``` json
+
+```
+
 
 
 ### User events
 
-- user-created
-- user-updated
-- user-deleted
+#### `user-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `user-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `user-deleted`
+
+This event fires when
+
+``` json
+
+```
+
 
 
 ### Environment events (Enterprise)
 
-- drop-environments
-- environment-import
+#### `drop-environments`
 
-**Response**
+This event fires when
 
-```json
-{
-	"version": 2,
-	"events": [{
-		"id": 187,
-		"type": "feature-metadata-updated",
-		"createdBy": "admin",
-		"createdAt": "2021-11-11T09:42:14.271Z",
-		"data": {
-			"name": "HelloEvents!",
-			"description": "Hello Events update!",
-			"type": "release",
-			"project": "default",
-			"stale": false,
-			"variants": [],
-			"createdAt": "2021-11-11T09:40:51.077Z",
-			"lastSeenAt": null
-		},
-		"preData": {
-			"name": "HelloEvents!",
-			"description": "Hello Events!",
-			"type": "release",
-			"project": "default",
-			"stale": false,
-			"variants": [],
-			"createdAt": "2021-11-11T09:40:51.077Z",
-			"lastSeenAt": null
-		},
-		"tags": [{
-			"value": "team-x",
-			"type": "simple"
-		}],
-		"featureName": "HelloEvents!",
-		"project": "default",
-		"environment": null
-	}, {
-		"id": 186,
-		"type": "feature-tagged",
-		"createdBy": "admin",
-		"createdAt": "2021-11-11T09:41:20.464Z",
-		"data": {
-			"type": "simple",
-			"value": "team-x"
-		},
-		"preData": null,
-		"tags": [],
-		"featureName": "HelloEvents!",
-		"project": null,
-		"environment": null
-	}, {
-		"id": 184,
-		"type": "feature-environment-enabled",
-		"createdBy": "admin",
-		"createdAt": "2021-11-11T09:41:03.782Z",
-		"data": null,
-		"preData": null,
-		"tags": [],
-		"featureName": "HelloEvents!",
-		"project": "default",
-		"environment": "default"
-	}, {
-		"id": 183,
-		"type": "feature-strategy-add",
-		"createdBy": "admin",
-		"createdAt": "2021-11-11T09:41:00.740Z",
-		"data": {
-			"id": "88e1df00-1951-452f-a063-6f5e18476f87",
-			"name": "flexibleRollout",
-			"constraints": [],
-			"parameters": {
-				"groupId": "HelloEvents!",
-				"rollout": 51,
-				"stickiness": "default"
-			}
-		},
-		"preData": null,
-		"tags": [],
-		"featureName": "HelloEvents!",
-		"project": "default",
-		"environment": "default"
-	}, {
-		"id": 182,
-		"type": "feature-created",
-		"createdBy": "admin",
-		"createdAt": "2021-11-11T09:40:51.083Z",
-		"data": {
-			"name": "HelloEvents!",
-			"description": "Hello Events!",
-			"type": "release",
-			"project": "default",
-			"stale": false,
-			"variants": [],
-			"createdAt": "2021-11-11T09:40:51.077Z",
-			"lastSeenAt": null
-		},
-		"preData": null,
-		"tags": [],
-		"featureName": "HelloEvents!",
-		"project": "default",
-		"environment": null
-	}]
-}
+``` json
+
+```
+
+#### `environment-import`
+
+This event fires when
+
+``` json
+
+```
+
+
+### Segment events
+
+#### `segment-created`
+
+This event fires when
+
+``` json
+
+```
+
+#### `segment-updated`
+
+This event fires when
+
+``` json
+
+```
+
+#### `segment-deleted`
+
+This event fires when
+
+``` json
+
 ```

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -125,7 +125,7 @@ The list of events related to the given toggle.
 
 </details>
 
-## Event types
+# Event types
 
 Unleash emits a large number of different events (described in more detail in the following sections). The exact fields an event contains varies from event to event, but they all conform to the following TypeScript interface before being transformed to JSON:
 
@@ -160,11 +160,11 @@ The event properties are described in short in the table below. For more info re
 | `type`        | The event type, as described in the rest of this section.                                             |
 
 
-### Feature toggle events
+## Feature toggle events
 
 These events pertain to feature toggles and their life cycle.
 
-#### `feature-created`
+### `feature-created`
 
 This event fires when you create a feature. The `data` property contains the details for the new feature.
 
@@ -175,7 +175,7 @@ This event fires when you create a feature. The `data` property contains the det
   "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:32:20.560Z",
   "data": {
-    "name": "new-toggle",
+    "name": "new-feature",
     "description": "Toggle description",
     "type": "release",
     "project": "my-project",
@@ -187,13 +187,13 @@ This event fires when you create a feature. The `data` property contains the det
   },
   "preData": null,
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-project",
   "environment": null
 }
 ```
 
-#### `feature-deleted`
+### `feature-deleted`
 
 This event fires when you delete a feature toggle. The `preData` property contains the deleted toggle data.
 
@@ -205,7 +205,7 @@ This event fires when you delete a feature toggle. The `preData` property contai
   "createdAt": "2022-05-31T14:06:14.574Z",
   "data": null,
   "preData": {
-    "name": "new-toggle",
+    "name": "new-feature",
     "type": "experiment",
     "stale": false,
     "project": "my-project",
@@ -216,13 +216,14 @@ This event fires when you delete a feature toggle. The `preData` property contai
     "impressionData": true
   },
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-project",
   "environment": null
 }
 ```
 
-#### `feature-updated`
+### `feature-updated`
+
 :::caution Deprecation notice
 This event type was replaced by more granular event types in Unleash 4.3. From Unleash 4.3 onwards, you'll need to use the events listed later in this section instead.
 :::
@@ -237,7 +238,7 @@ This event fires when a feature gets updated in some way. The `data` property co
   "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:32:20.560Z",
   "data": {
-    "name": "new-toggle",
+    "name": "new-feature",
     "description": "Toggle description",
     "type": "release",
     "project": "my-project",
@@ -249,13 +250,13 @@ This event fires when a feature gets updated in some way. The `data` property co
   },
   "preData": null,
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-project",
   "environment": null
 }
 ```
 
-#### `feature-metadata-updated`
+### `feature-metadata-updated`
 
 This event fires when a feature's metadata (its description, toggle type, or impression data settings) are changed. The `data` property contains the new toggle data. The `preData` property contains the toggle's previous data.
 
@@ -268,7 +269,7 @@ The below example changes the toggle's type from *release* to *experiment*.
   "createdBy": "user@company.com",
   "createdAt": "2022-05-31T13:35:25.244Z",
   "data": {
-    "name": "new-toggle",
+    "name": "new-feature",
     "description": "Toggle description",
     "type": "experiment",
     "project": "my-project",
@@ -279,7 +280,7 @@ The below example changes the toggle's type from *release* to *experiment*.
     "impressionData": true
   },
   "preData": {
-    "name": "new-toggle",
+    "name": "new-feature",
     "type": "release",
     "stale": false,
     "project": "my-project",
@@ -290,19 +291,19 @@ The below example changes the toggle's type from *release* to *experiment*.
     "impressionData": true
   },
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-project",
   "environment": null
 }
 ```
 
-#### `feature-project-change`
+### `feature-project-change`
 
 This event fires when you move a feature from one project to another.
 
 [... explain more in depth]
 
-#### `feature-archived`
+### `feature-archived`
 
 This event fires when you archive a toggle.
 
@@ -315,13 +316,13 @@ This event fires when you archive a toggle.
   "data": null,
   "preData": null,
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-project",
   "environment": null
 }
 ```
 
-#### `feature-revived`
+### `feature-revived`
 
 This event fires when you revive an archived feature toggle (when you take a toggle out from the archive).
 
@@ -334,17 +335,17 @@ This event fires when you revive an archived feature toggle (when you take a tog
   "data": null,
   "preData": null,
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": null
 }
 ```
 
-#### `feature-import`
+### `feature-import`
 
 This event fires when you import a feature ...
 
-#### `feature-tagged`
+### `feature-tagged`
 
 This event fires when you add a tag to a feature. The `data` property contains the new tag.
 
@@ -366,11 +367,11 @@ This event fires when you add a tag to a feature. The `data` property contains t
 }
 ```
 
-#### `feature-tag-import`
+### `feature-tag-import`
 
 This event fires when you import a tag. ...
 
-#### `feature-strategy-update`
+### `feature-strategy-update`
 
 This event fires when you update a feature strategy. The `data` property contains the new strategy configuration. The `preData` property contains the previous strategy configuration.
 
@@ -385,7 +386,7 @@ This event fires when you update a feature strategy. The `data` property contain
     "name": "flexibleRollout",
     "constraints": [],
     "parameters": {
-      "groupId": "new-toggle",
+      "groupId": "new-feature",
       "rollout": "32",
       "stickiness": "default"
     }
@@ -394,20 +395,20 @@ This event fires when you update a feature strategy. The `data` property contain
     "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
     "name": "flexibleRollout",
     "parameters": {
-      "groupId": "new-toggle",
+      "groupId": "new-feature",
       "rollout": "67",
       "stickiness": "default"
     },
     "constraints": []
   },
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "default"
 }
 ```
 
-#### `feature-strategy-add`
+### `feature-strategy-add`
 
 This event fires when you add a strategy to a feature. The `data` property contains the configuration for the new strategy.
 
@@ -422,20 +423,20 @@ This event fires when you add a strategy to a feature. The `data` property conta
     "name": "flexibleRollout",
     "constraints": [],
     "parameters": {
-      "groupId": "new-toggle",
+      "groupId": "new-feature",
       "rollout": "67",
       "stickiness": "default"
     }
   },
   "preData": null,
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "default"
 }
 ```
 
-#### `feature-strategy-remove`
+### `feature-strategy-remove`
 
 This event fires when you remove a strategy from a feature. The `preData` contains the configuration of the strategy that was removed.
 
@@ -453,19 +454,19 @@ This event fires when you remove a strategy from a feature. The `preData` contai
     "constraints": []
   },
   "tags": [],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "default"
 }
 ```
 
-#### `drop-feature-tags`
+### `drop-feature-tags`
 
 This event fires when you drop all existing tags as part of a configuration import.
 
 ...
 
-#### `feature-untagged`
+### `feature-untagged`
 
 This event fires when you remove a tag from a toggle. The `data` property contains the tag that was removed.
 
@@ -487,7 +488,7 @@ This event fires when you remove a tag from a toggle. The `data` property contai
 }
 ```
 
-#### `feature-stale-on`
+### `feature-stale-on`
 
 This event fires when you mark a feature as stale.
 
@@ -509,13 +510,13 @@ This event fires when you mark a feature as stale.
       "type": "simple"
     }
   ],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": null
 }
 ```
 
-#### `feature-stale-off`
+### `feature-stale-off`
 
 This event fires when you mark a stale feature as no longer being stale.
 
@@ -537,15 +538,15 @@ This event fires when you mark a stale feature as no longer being stale.
       "type": "simple"
     }
   ],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": null
 }
 ```
 
-#### `drop-features`
+### `drop-features`
 
-#### `feature-environment-enabled`
+### `feature-environment-enabled`
 
 This event fires when you enable an environment for a feature. The `environment` property contains the name of the environment.
 
@@ -567,13 +568,13 @@ This event fires when you enable an environment for a feature. The `environment`
       "type": "simple"
     }
   ],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "development"
 }
 ```
 
-#### `feature-environment-disabled`
+### `feature-environment-disabled`
 
 This event fires when you disable an environment for a feature. The `environment` property contains the name of the environment.
 
@@ -595,15 +596,15 @@ This event fires when you disable an environment for a feature. The `environment
       "type": "simple"
     }
   ],
-  "featureName": "new-toggle",
+  "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "development"
 }
 ```
 
-### Strategy events
+## Strategy events
 
-#### `strategy-created`
+### `strategy-created`
 
 This event fires when you create a strategy. The `data` property contains the strategy configuration.
 
@@ -628,7 +629,7 @@ This event fires when you create a strategy. The `data` property contains the st
 }
 ```
 
-#### `strategy-deleted`
+### `strategy-deleted`
 
 This event fires when you delete a strategy. The `data` property contains the name of the deleted strategy.
 
@@ -649,7 +650,7 @@ This event fires when you delete a strategy. The `data` property contains the na
 }
 ```
 
-#### `strategy-deprecated`
+### `strategy-deprecated`
 
 This event fires when you deprecate a strategy. The `data` property contains the name of the deprecated strategy.
 
@@ -670,7 +671,7 @@ This event fires when you deprecate a strategy. The `data` property contains the
 }
 ```
 
-#### `strategy-reactivated`
+### `strategy-reactivated`
 
 This event fires when you bring reactivate a deprecated strategy.
 The `data` property contains the name of the reactivated strategy.
@@ -692,7 +693,7 @@ The `data` property contains the name of the reactivated strategy.
 }
 ```
 
-#### `strategy-updated`
+### `strategy-updated`
 
 This event fires when you change a strategy's configuration.
 The `data` property contains the new strategy configuration.
@@ -718,7 +719,7 @@ The `data` property contains the new strategy configuration.
 }
 ```
 
-#### `strategy-import`
+### `strategy-import`
 
 This event fires when you import a strategy ...
 
@@ -726,7 +727,7 @@ This event fires when you import a strategy ...
 
 ```
 
-#### `drop-strategies`
+### `drop-strategies`
 
 This event fires when
 
@@ -735,9 +736,9 @@ This event fires when
 ```
 
 
-### Context field events
+## Context field events
 
-#### `context-field-created`
+### `context-field-created`
 
 This event fires when you create a context field.
 The `data` property contains the context field configuration.
@@ -762,7 +763,7 @@ The `data` property contains the context field configuration.
 }
 ```
 
-#### `context-field-updated`
+### `context-field-updated`
 
 This event fires when you update a context field.
 The `data` property contains the new context field configuration.
@@ -796,7 +797,7 @@ The `data` property contains the new context field configuration.
 }
 ```
 
-#### `context-field-deleted`
+### `context-field-deleted`
 
 This event fires when you delete a context field.
 The `data` property contains the name of the deleted context field.
@@ -819,9 +820,9 @@ The `data` property contains the name of the deleted context field.
 ```
 
 
-### Project events
+## Project events
 
-#### `project-created`
+### `project-created`
 
 This event fires when you create a project.
 The `data` property contains the project configuration.
@@ -846,7 +847,7 @@ The `data` property contains the project configuration.
 }
 ```
 
-#### `project-updated`
+### `project-updated`
 
 This event fires when you update a project's configuration.
 The `data` property contains the new project configuration.
@@ -878,7 +879,7 @@ The `preData` property contains the previous project configuration.
 }
 ```
 
-#### `project-deleted`
+### `project-deleted`
 
 This event fires when you delete a project.
 The `project` property contains the name of the deleted project.
@@ -898,7 +899,7 @@ The `project` property contains the name of the deleted project.
 }
 ```
 
-#### `project-import`
+### `project-import`
 
 This event fires when
 
@@ -906,7 +907,7 @@ This event fires when
 
 ```
 
-#### `drop-projects`
+### `drop-projects`
 
 This event fires when
 
@@ -915,9 +916,9 @@ This event fires when
 ```
 
 
-### Tag events
+## Tag events
 
-#### `tag-created`
+### `tag-created`
 
 This event fires when you create a new tag. The `data` property contains the tag that was created.
 
@@ -933,13 +934,13 @@ This event fires when you create a new tag. The `data` property contains the tag
   },
   "preData": null,
   "tags": [],
-  "featureName": "newer-toggle",
+  "featureName": "new-feature",
   "project": null,
   "environment": null
 }
 ```
 
-#### `tag-deleted`
+### `tag-deleted`
 
 This event fires when you delete a tag. The `data` property contains the tag that was deleted.
 
@@ -961,7 +962,7 @@ This event fires when you delete a tag. The `data` property contains the tag tha
 }
 ```
 
-#### `tag-import`
+### `tag-import`
 
 This event fires when
 
@@ -969,7 +970,7 @@ This event fires when
 
 ```
 
-#### `drop-tags`
+### `drop-tags`
 
 This event fires when
 
@@ -979,9 +980,9 @@ This event fires when
 
 
 
-### Tag type events
+## Tag type events
 
-#### `tag-type-created`
+### `tag-type-created`
 
 This event fires when you create a new tag type.
 The `data` property contains the tag type configuration.
@@ -1004,7 +1005,7 @@ The `data` property contains the tag type configuration.
 }
 ```
 
-#### `tag-type-deleted`
+### `tag-type-deleted`
 
 This event fires when you delete a tag type.
 The `data` property contains the name of the deleted tag type.
@@ -1027,7 +1028,7 @@ The `data` property contains the name of the deleted tag type.
 }
 ```
 
-#### `tag-type-updated`
+### `tag-type-updated`
 
 This event fires when you update a tag type.
 The `data` property contains the new tag type configuration.
@@ -1050,7 +1051,7 @@ The `data` property contains the new tag type configuration.
 }
 ```
 
-#### `tag-type-import`
+### `tag-type-import`
 
 This event fires when
 
@@ -1058,7 +1059,7 @@ This event fires when
 
 ```
 
-#### `drop-tag-types`
+### `drop-tag-types`
 
 This event fires when
 
@@ -1068,9 +1069,9 @@ This event fires when
 
 
 
-### Addon events
+## Addon events
 
-#### `addon-config-created`
+### `addon-config-created`
 
 This event fires when you create an addon configuration.
 The `data` property contains the addon's ID and provider type.
@@ -1092,7 +1093,7 @@ The `data` property contains the addon's ID and provider type.
 }
 ```
 
-#### `addon-config-updated`
+### `addon-config-updated`
 
 This event fires when you update an addon configuration.
 The `data` property contains the addon's ID and provider type.
@@ -1115,7 +1116,7 @@ The `data` property contains the addon's ID and provider type.
 }
 ```
 
-#### `addon-config-deleted`
+### `addon-config-deleted`
 
 This event fires when you update an addon configuration.
 The `data` property contains the addon's ID.
@@ -1139,9 +1140,9 @@ The `data` property contains the addon's ID.
 
 
 
-### User events
+## User events
 
-#### `user-created`
+### `user-created`
 
 This event fires when you create a new user. The `data` property contains the user's information.
 
@@ -1164,7 +1165,7 @@ This event fires when you create a new user. The `data` property contains the us
 }
 ```
 
-#### `user-updated`
+### `user-updated`
 
 This event fires when you update a user. The `data` property contains the updated user information; the `preData` property contains the previous state of the user's information.
 
@@ -1191,7 +1192,7 @@ This event fires when you update a user. The `data` property contains the update
 }
 ```
 
-#### `user-deleted`
+### `user-deleted`
 
 This event fires when you delete a user. The `preData` property contains the deleted users information.
 
@@ -1216,9 +1217,9 @@ This event fires when you delete a user. The `preData` property contains the del
 
 
 
-### Environment events (Enterprise)
+## Environment events (Enterprise)
 
-#### `drop-environments`
+### `drop-environments`
 
 This event fires when
 
@@ -1226,7 +1227,7 @@ This event fires when
 
 ```
 
-#### `environment-import`
+### `environment-import`
 
 This event fires when
 
@@ -1235,9 +1236,9 @@ This event fires when
 ```
 
 
-### Segment events
+## Segment events
 
-#### `segment-created`
+### `segment-created`
 
 This event fires when you create a segment. The `data` property contains the newly created segment.
 
@@ -1275,7 +1276,7 @@ This event fires when you create a segment. The `data` property contains the new
 }
 ```
 
-#### `segment-updated`
+### `segment-updated`
 
 This event fires when you update a segment's configuration. The `data` property contains the new segment configuration; the `preData` property contains the previous segment configuration.
 
@@ -1320,7 +1321,7 @@ This event fires when you update a segment's configuration. The `data` property 
 }
 ```
 
-#### `segment-deleted`
+### `segment-deleted`
 
 This event fires when you delete a segment.
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -608,7 +608,24 @@ This event fires when you disable an environment for a feature. The `environment
 This event fires when you create a strategy. The `data` property contains the strategy configuration.
 
 ``` json
-
+{
+  "id": 932,
+  "type": "strategy-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:20:52.111Z",
+  "data": {
+    "name": "new-strategy",
+    "description": "this strategy does ...",
+    "parameters": [],
+    "editable": true,
+    "deprecated": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `strategy-deleted`
@@ -616,7 +633,20 @@ This event fires when you create a strategy. The `data` property contains the st
 This event fires when you delete a strategy. The `data` property contains the name of the deleted strategy.
 
 ``` json
-
+{
+  "id": 936,
+  "type": "strategy-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:22:01.302Z",
+  "data": {
+    "name": "new-strategy"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `strategy-deprecated`
@@ -624,7 +654,20 @@ This event fires when you delete a strategy. The `data` property contains the na
 This event fires when you deprecate a strategy. The `data` property contains the name of the deprecated strategy.
 
 ``` json
-
+{
+  "id": 934,
+  "type": "strategy-deprecated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:21:45.041Z",
+  "data": {
+    "name": "new-strategy"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `strategy-reactivated`
@@ -633,7 +676,20 @@ This event fires when you bring reactivate a deprecated strategy.
 The `data` property contains the name of the reactivated strategy.
 
 ``` json
-
+{
+  "id": 935,
+  "type": "strategy-reactivated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:21:49.010Z",
+  "data": {
+    "name": "new-strategy"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `strategy-updated`
@@ -642,7 +698,24 @@ This event fires when you change a strategy's configuration.
 The `data` property contains the new strategy configuration.
 
 ``` json
-
+{
+  "id": 933,
+  "type": "strategy-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T12:21:23.741Z",
+  "data": {
+    "name": "new-strategy",
+    "description": "this strategy does something else!",
+    "parameters": [],
+    "editable": true,
+    "deprecated": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `strategy-import`
@@ -670,7 +743,23 @@ This event fires when you create a context field.
 The `data` property contains the context field configuration.
 
 ``` json
-
+{
+  "id": 937,
+  "type": "context-field-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:17:17.499Z",
+  "data": {
+    "name": "new-context-field",
+    "description": "this context field is for describing events",
+    "legalValues": [],
+    "stickiness": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `context-field-updated`
@@ -679,7 +768,32 @@ This event fires when you update a context field.
 The `data` property contains the new context field configuration.
 
 ``` json
-
+{
+  "id": 939,
+  "type": "context-field-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:19:19.422Z",
+  "data": {
+    "name": "new-context-field",
+    "description": "this context field is for describing events",
+    "legalValues": [
+      {
+        "value": "0fcf7d07-276c-41e1-a207-e62876d9c949",
+        "description": "Red team"
+      },
+      {
+        "value": "176ab647-4d50-41bf-afe0-f8b856d9bbb9",
+        "description": "Blue team"
+      }
+    ],
+    "stickiness": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `context-field-deleted`
@@ -688,7 +802,20 @@ This event fires when you delete a context field.
 The `data` property contains the name of the deleted context field.
 
 ``` json
-
+{
+  "id": 940,
+  "type": "context-field-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:20:41.386Z",
+  "data": {
+    "name": "new-context-field"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -696,26 +823,79 @@ The `data` property contains the name of the deleted context field.
 
 #### `project-created`
 
-This event fires when
+This event fires when you create a project.
+The `data` property contains the project configuration.
+
 
 ``` json
-
+{
+  "id": 905,
+  "type": "project-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-05-31T14:16:14.498Z",
+  "data": {
+    "id": "heartmans-other-project",
+    "name": "heartman's other project",
+    "description": "a project for heartman's testing and doc work"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": "heartmans-other-project",
+  "environment": null
+}
 ```
 
 #### `project-updated`
 
-This event fires when
+This event fires when you update a project's configuration.
+The `data` property contains the new project configuration.
+The `preData` property contains the previous project configuration.
 
 ``` json
-
+{
+  "id": 941,
+  "type": "project-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:23:55.025Z",
+  "data": {
+    "id": "heartmans-other-project",
+    "name": "heartman's other project",
+    "description": "a project for heartman's testing and doc work!"
+  },
+  "preData": {
+    "id": "heartmans-other-project",
+    "name": "heartman's other project",
+    "health": 50,
+    "createdAt": "2022-05-31T14:16:14.483Z",
+    "updatedAt": "2022-06-02T12:30:48.095Z",
+    "description": "a project for heartman's testing and doc work"
+  },
+  "tags": [],
+  "featureName": null,
+  "project": "heartmans-other-project",
+  "environment": null
+}
 ```
 
 #### `project-deleted`
 
-This event fires when
+This event fires when you delete a project.
+The `project` property contains the name of the deleted project.
 
 ``` json
-
+{
+  "id": 944,
+  "type": "project-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:25:53.820Z",
+  "data": null,
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": "heartmans-other-project",
+  "environment": null
+}
 ```
 
 #### `project-import`
@@ -739,18 +919,46 @@ This event fires when
 
 #### `tag-created`
 
-This event fires when
+This event fires when you create a new tag. The `data` property contains the tag that was created.
 
 ``` json
-
+{
+  "id": 959,
+  "type": "feature-tagged",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:13:39.401Z",
+  "data": {
+    "type": "heartag",
+    "value": "tag-value"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "newer-toggle",
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `tag-deleted`
 
-This event fires when
+This event fires when you delete a tag. The `data` property contains the tag that was deleted.
 
 ``` json
-
+{
+  "id": 957,
+  "type": "tag-deleted",
+  "createdBy": "heartman-admin-testing",
+  "createdAt": "2022-06-03T10:12:17.310Z",
+  "data": {
+    "type": "heartag",
+    "value": "tag-value"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `tag-import`
@@ -775,26 +983,71 @@ This event fires when
 
 #### `tag-type-created`
 
-This event fires when
+This event fires when you create a new tag type.
+The `data` property contains the tag type configuration.
 
 ``` json
-
+{
+  "id": 945,
+  "type": "tag-type-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:27:01.235Z",
+  "data": {
+    "name": "new-tag-type",
+    "description": "event testing"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `tag-type-deleted`
 
-This event fires when
+This event fires when you delete a tag type.
+The `data` property contains the name of the deleted tag type.
+
 
 ``` json
-
+{
+  "id": 947,
+  "type": "tag-type-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:27:37.277Z",
+  "data": {
+    "name": "new-tag-type"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `tag-type-updated`
 
-This event fires when
+This event fires when you update a tag type.
+The `data` property contains the new tag type configuration.
 
 ``` json
-
+{
+  "id": 946,
+  "type": "tag-type-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-02T13:27:31.126Z",
+  "data": {
+    "name": "new-tag-type",
+    "description": "This tag is for testing events."
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `tag-type-import`
@@ -819,26 +1072,69 @@ This event fires when
 
 #### `addon-config-created`
 
-This event fires when
+This event fires when you create an addon configuration.
+The `data` property contains the addon's ID and provider type.
 
 ``` json
-
+{
+  "id": 960,
+  "type": "addon-config-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:15:45.040Z",
+  "data": {
+    "provider": "webhook"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `addon-config-updated`
 
-This event fires when
+This event fires when you update an addon configuration.
+The `data` property contains the addon's ID and provider type.
 
 ``` json
-
+{
+  "id": 961,
+  "type": "addon-config-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:16:11.732Z",
+  "data": {
+    "id": "2",
+    "provider": "webhook"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `addon-config-deleted`
 
-This event fires when
+This event fires when you update an addon configuration.
+The `data` property contains the addon's ID.
 
 ``` json
-
+{
+  "id": 964,
+  "type": "addon-config-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:16:59.723Z",
+  "data": {
+    "id": "2"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -847,26 +1143,75 @@ This event fires when
 
 #### `user-created`
 
-This event fires when
+This event fires when you create a new user. The `data` property contains the user's information.
 
 ``` json
-
+{
+  "id": 965,
+  "type": "user-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:23:47.713Z",
+  "data": {
+    "id": 44,
+    "name": "New User Name",
+    "email": "newuser@company.com"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `user-updated`
 
-This event fires when
+This event fires when you update a user. The `data` property contains the updated user information; the `preData` property contains the previous state of the user's information.
 
 ``` json
-
+{
+  "id": 967,
+  "type": "user-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:24:26.301Z",
+  "data": {
+    "id": 44,
+    "name": "New User's Name",
+    "email": "newuser@company.com"
+  },
+  "preData": {
+    "id": 44,
+    "name": "New User Name",
+    "email": "newuser@company.com"
+  },
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `user-deleted`
 
-This event fires when
+This event fires when you delete a user. The `preData` property contains the deleted users information.
 
 ``` json
-
+{
+  "id": 968,
+  "type": "user-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:24:49.153Z",
+  "data": null,
+  "preData": {
+    "id": 44,
+    "name": "New User's Name",
+    "email": "newuser@company.com"
+  },
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 
@@ -894,24 +1239,102 @@ This event fires when
 
 #### `segment-created`
 
-This event fires when
+This event fires when you create a segment. The `data` property contains the newly created segment.
 
 ``` json
-
+{
+  "id": 969,
+  "type": "segment-created",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:29:43.977Z",
+  "data": {
+    "id": 5,
+    "name": "new segment",
+    "description": "this segment is for events",
+    "constraints": [
+      {
+        "values": [
+          "appA",
+          "appB",
+          "appC"
+        ],
+        "inverted": false,
+        "operator": "IN",
+        "contextName": "appName",
+        "caseInsensitive": false
+      }
+    ],
+    "createdBy": "thomas@getunleash.ai",
+    "createdAt": "2022-06-03T10:29:43.974Z"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `segment-updated`
 
-This event fires when
+This event fires when you update a segment's configuration. The `data` property contains the new segment configuration; the `preData` property contains the previous segment configuration.
 
 ``` json
-
+{
+  "id": 970,
+  "type": "segment-updated",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:29:59.892Z",
+  "data": {
+    "id": 5,
+    "name": "new segment",
+    "description": "this segment is for events",
+    "constraints": [],
+    "createdBy": "thomas@getunleash.ai",
+    "createdAt": "2022-06-03T10:29:43.974Z"
+  },
+  "preData": {
+    "id": 5,
+    "name": "new segment",
+    "createdAt": "2022-06-03T10:29:43.974Z",
+    "createdBy": "thomas@getunleash.ai",
+    "constraints": [
+      {
+        "values": [
+          "appA",
+          "appB",
+          "appC"
+        ],
+        "inverted": false,
+        "operator": "IN",
+        "contextName": "appName",
+        "caseInsensitive": false
+      }
+    ],
+    "description": "this segment is for events"
+  },
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```
 
 #### `segment-deleted`
 
-This event fires when
+This event fires when you delete a segment.
 
 ``` json
-
+{
+  "id": 971,
+  "type": "segment-deleted",
+  "createdBy": "thomas@getunleash.ai",
+  "createdAt": "2022-06-03T10:30:08.128Z",
+  "data": {},
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
 ```

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -2,18 +2,134 @@
 id: events
 title: /api/admin/events
 ---
+import ApiRequest from '@site/src/components/ApiRequest'
 
-> In order to access the admin API endpoints you need to identify yourself. Unless you're using the `none` authentication method, you'll need to [create an ADMIN token](/user_guide/api-token) and add an Authorization header using the token.
+:::note
+In order to access the admin API endpoints you need to identify yourself. Unless you're using the `none` authentication method, you'll need to [create an ADMIN token](/user_guide/api-token) and add an Authorization header using the token.
+:::
 
-# Events API
+## The Events API
 
-`GET: http://unleash.host.com/api/admin/events`
+## Get all events
+
+<ApiRequest verb="get" url="api/admin/events" title="Retrieve all events from the Unleash instance."/>
+
+### Query parameters
+
+| Query parameter | Description                                                                | Required |
+|-----------------|----------------------------------------------------------------------------|----------|
+| `project`       | When applied, the endpoint will only return events from the given project. | No       |
+
+The `api/admin/events` endpoint returns all the events on the Unleash instance from the last X days. It accepts an optional query parameter `project`. When provided, the returned list of events all belong to the given project.
+
+
+### Get events by project
+
+<ApiRequest verb="get" url="api/admin/events?project=<project-name>" title="Retrieve all events belonging to the given project."/>
+
+Use the `project` query parameter to make the API only return events pertaining to the given project.
+
+### Responses
+
+<details>
+<summary>Responses</summary>
+
+##### 200 OK
+
+The list of events matching the provided query, or all events if no query params were provided.
+
+``` json
+{
+  "version": 1,
+  "events": [
+    {
+      "id": 842,
+      "type": "feature-environment-enabled",
+      "createdBy": "user@company.com",
+      "createdAt": "2022-05-12T08:49:49.521Z",
+      "data": null,
+      "preData": null,
+      "tags": [],
+      "featureName": "my-constrained-toggle",
+      "project": "my-project",
+      "environment": "development"
+    },
+    {
+      "id": 841,
+      "type": "feature-environment-disabled",
+      "createdBy": "user@company.com",
+      "createdAt": "2022-05-12T08:49:45.986Z",
+      "data": null,
+      "preData": null,
+      "tags": [],
+      "featureName": "my-constrained-toggle",
+      "project": "my-project",
+      "environment": "development"
+    }
+  ]
+}
+```
+
+</details>
+
+## Get events for a specific toggle
+
+<ApiRequest verb="get" url="api/admin/events/<toggle-name>" title="Retrieve all events related to the given toggle."/>
+
+Fetch all events related to a specified toggle.
+
+
+### Responses
+
+<details>
+<summary>Responses</summary>
+
+##### 200 OK
+
+The list of events related to the given toggle.
+
+``` json
+{
+  "toggleName": "my-constrained-toggle",
+  "events": [
+    {
+      "id": 842,
+      "type": "feature-environment-enabled",
+      "createdBy": "user@company.com",
+      "createdAt": "2022-05-12T08:49:49.521Z",
+      "data": null,
+      "preData": null,
+      "tags": [],
+      "featureName": "my-constrained-toggle",
+      "project": "my-project",
+      "environment": "development"
+    },
+    {
+      "id": 841,
+      "type": "feature-environment-disabled",
+      "createdBy": "user@company.com",
+      "createdAt": "2022-05-12T08:49:45.986Z",
+      "data": null,
+      "preData": null,
+      "tags": [],
+      "featureName": "my-constrained-toggle",
+      "project": "my-project",
+      "environment": "development"
+    }
+  ]
+}
+```
+
+</details>
+
+
+The Events API lets you fetch all
 
 Used to fetch all changes in the unleash system.
 
 Defined event types:
 
-### Feature Toggle events:
+## Feature Toggle events:
 
 - feature-created
 - feature-deleted
@@ -36,7 +152,7 @@ Defined event types:
 - feature-environment-enabled
 - feature-environment-disabled
 
-### Strategy Events
+## Strategy Events
 
 - strategy-created
 - strategy-deleted
@@ -46,13 +162,13 @@ Defined event types:
 - strategy-import
 - drop-strategies
 
-### Context field events
+## Context field events
 
 - context-field-created
 - context-field-updated
 - context-field-deleted
 
-### Project events
+## Project events
 
 - project-created
 - project-updated
@@ -60,7 +176,7 @@ Defined event types:
 - project-import
 - drop-projects
 
-### Tag events
+## Tag events
 
 - tag-created
 - tag-deleted
@@ -68,7 +184,8 @@ Defined event types:
 - drop-tags
 
 
-### Tag type events
+## Tag type events
+
 - tag-type-created
 - tag-type-deleted
 - tag-type-updated
@@ -76,19 +193,21 @@ Defined event types:
 - drop-tag-types
 
 
-### Addon events
+## Addon events
+
 - addon-config-created
 - addon-config-updated
 - addon-config-deleted
 
 
-### User events
+## User events
+
 - user-created
 - user-updated
 - user-deleted
 
 
-### Environment events (Enterprise)
+## Environment events (Enterprise)
 
 - drop-environments
 - environment-import
@@ -216,5 +335,3 @@ interface IEvent {
     tags?: ITag[];
 }
 ```
-
-

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -193,35 +193,6 @@ This event fires when you create a feature. The `data` property contains the det
 }
 ```
 
-### `feature-deleted`
-
-This event fires when you delete a feature toggle. The `preData` property contains the deleted toggle data.
-
-``` json title="example event: feature-deleted"
-{
-  "id": 903,
-  "type": "feature-deleted",
-  "createdBy": "admin-account",
-  "createdAt": "2022-05-31T14:06:14.574Z",
-  "data": null,
-  "preData": {
-    "name": "new-feature",
-    "type": "experiment",
-    "stale": false,
-    "project": "my-project",
-    "variants": [],
-    "createdAt": "2022-05-31T13:32:20.547Z",
-    "lastSeenAt": null,
-    "description": "Toggle description",
-    "impressionData": true
-  },
-  "tags": [],
-  "featureName": "new-feature",
-  "project": "my-project",
-  "environment": null
-}
-```
-
 ### `feature-updated`
 
 :::caution Deprecation notice
@@ -252,6 +223,73 @@ This event fires when a feature gets updated in some way. The `data` property co
   "tags": [],
   "featureName": "new-feature",
   "project": "my-project",
+  "environment": null
+}
+```
+
+### `feature-deleted`
+
+This event fires when you delete a feature toggle. The `preData` property contains the deleted toggle data.
+
+``` json title="example event: feature-deleted"
+{
+  "id": 903,
+  "type": "feature-deleted",
+  "createdBy": "admin-account",
+  "createdAt": "2022-05-31T14:06:14.574Z",
+  "data": null,
+  "preData": {
+    "name": "new-feature",
+    "type": "experiment",
+    "stale": false,
+    "project": "my-project",
+    "variants": [],
+    "createdAt": "2022-05-31T13:32:20.547Z",
+    "lastSeenAt": null,
+    "description": "Toggle description",
+    "impressionData": true
+  },
+  "tags": [],
+  "featureName": "new-feature",
+  "project": "my-project",
+  "environment": null
+}
+```
+
+### `feature-archived`
+
+This event fires when you archive a toggle.
+
+``` json title="example event: feature-archived"
+{
+  "id": 902,
+  "type": "feature-archived",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-05-31T14:04:38.661Z",
+  "data": null,
+  "preData": null,
+  "tags": [],
+  "featureName": "new-feature",
+  "project": "my-project",
+  "environment": null
+}
+```
+
+### `feature-revived`
+
+This event fires when you revive an archived feature toggle (when you take a toggle out from the archive).
+
+``` json title="example-event: feature-revived"
+{
+  "id": 914,
+  "type": "feature-revived",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-06-01T09:57:10.719Z",
+  "data": null,
+  "preData": null,
+  "tags": [],
+  "featureName": "new-feature",
+  "project": "my-other-project",
   "environment": null
 }
 ```
@@ -320,44 +358,6 @@ This event fires when you move a feature from one project to another. The `data`
 ```
 
 
-### `feature-archived`
-
-This event fires when you archive a toggle.
-
-``` json title="example event: feature-archived"
-{
-  "id": 902,
-  "type": "feature-archived",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-05-31T14:04:38.661Z",
-  "data": null,
-  "preData": null,
-  "tags": [],
-  "featureName": "new-feature",
-  "project": "my-project",
-  "environment": null
-}
-```
-
-### `feature-revived`
-
-This event fires when you revive an archived feature toggle (when you take a toggle out from the archive).
-
-``` json title="example-event: feature-revived"
-{
-  "id": 914,
-  "type": "feature-revived",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-06-01T09:57:10.719Z",
-  "data": null,
-  "preData": null,
-  "tags": [],
-  "featureName": "new-feature",
-  "project": "my-other-project",
-  "environment": null
-}
-```
-
 ### `feature-import`
 
 This event fires when you import a feature as part of an import process. The `data` property contains the feature data.
@@ -409,6 +409,28 @@ This event fires when you add a tag to a feature. The `data` property contains t
 }
 ```
 
+### `feature-untagged`
+
+This event fires when you remove a tag from a toggle. The `data` property contains the tag that was removed.
+
+``` json title="example event: feature-untagged"
+{
+  "id": 893,
+  "type": "feature-untagged",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-05-31T12:58:10.241Z",
+  "data": {
+    "type": "simple",
+    "value": "thisisatag"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "example-feature-name",
+  "project": null,
+  "environment": null
+}
+```
+
 ### `feature-tag-import`
 
 This event fires when you import a tagged feature as part of an import job. The `data` property contains the name of the feature and the tag.
@@ -431,6 +453,34 @@ This event fires when you import a tagged feature as part of an import job. The 
   "featureName": null,
   "project": null,
   "environment": null
+}
+```
+
+### `feature-strategy-add`
+
+This event fires when you add a strategy to a feature. The `data` property contains the configuration for the new strategy.
+
+``` json title="example event: feature-strategy-add"
+{
+  "id": 919,
+  "type": "feature-strategy-add",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-06-01T10:03:08.290Z",
+  "data": {
+    "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
+    "name": "flexibleRollout",
+    "constraints": [],
+    "parameters": {
+      "groupId": "new-feature",
+      "rollout": "67",
+      "stickiness": "default"
+    }
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "new-feature",
+  "project": "my-other-project",
+  "environment": "default"
 }
 ```
 
@@ -471,34 +521,6 @@ This event fires when you update a feature strategy. The `data` property contain
 }
 ```
 
-### `feature-strategy-add`
-
-This event fires when you add a strategy to a feature. The `data` property contains the configuration for the new strategy.
-
-``` json title="example event: feature-strategy-add"
-{
-  "id": 919,
-  "type": "feature-strategy-add",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-06-01T10:03:08.290Z",
-  "data": {
-    "id": "3f4bf713-696c-43a4-8ce7-d6c607108858",
-    "name": "flexibleRollout",
-    "constraints": [],
-    "parameters": {
-      "groupId": "new-feature",
-      "rollout": "67",
-      "stickiness": "default"
-    }
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": "new-feature",
-  "project": "my-other-project",
-  "environment": "default"
-}
-```
-
 ### `feature-strategy-remove`
 
 This event fires when you remove a strategy from a feature. The `preData` contains the configuration of the strategy that was removed.
@@ -520,49 +542,6 @@ This event fires when you remove a strategy from a feature. The `preData` contai
   "featureName": "new-feature",
   "project": "my-other-project",
   "environment": "default"
-}
-```
-
-### `drop-feature-tags`
-
-This event fires when you drop all existing tags as part of a configuration import.
-
-``` json title="example event: drop-feature-tags"
-{
-  "id": 36,
-  "type": "drop-feature-tags",
-  "createdBy": "import-API-token",
-  "createdAt": "2022-06-03T11:30:40.596Z",
-  "data": {
-    "name": "all-feature-tags"
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": null,
-  "project": null,
-  "environment": null
-}
-```
-
-### `feature-untagged`
-
-This event fires when you remove a tag from a toggle. The `data` property contains the tag that was removed.
-
-``` json title="example event: feature-untagged"
-{
-  "id": 893,
-  "type": "feature-untagged",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-05-31T12:58:10.241Z",
-  "data": {
-    "type": "simple",
-    "value": "thisisatag"
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": "example-feature-name",
-  "project": null,
-  "environment": null
 }
 ```
 
@@ -618,27 +597,6 @@ This event fires when you mark a stale feature as no longer being stale.
   ],
   "featureName": "new-feature",
   "project": "my-other-project",
-  "environment": null
-}
-```
-
-### `drop-features`
-
-This event fires when you delete existing features as part of an import job.
-
-``` json title="example event: drop-features"
-{
-  "id": 25,
-  "type": "drop-features",
-  "createdBy": "import-API-token",
-  "createdAt": "2022-06-03T11:30:40.563Z",
-  "data": {
-    "name": "all-features"
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": null,
-  "project": null,
   "environment": null
 }
 ```
@@ -699,6 +657,50 @@ This event fires when you disable an environment for a feature. The `environment
 }
 ```
 
+### `drop-features`
+
+This event fires when you delete existing features as part of an import job.
+
+``` json title="example event: drop-features"
+{
+  "id": 25,
+  "type": "drop-features",
+  "createdBy": "import-API-token",
+  "createdAt": "2022-06-03T11:30:40.563Z",
+  "data": {
+    "name": "all-features"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
+
+
+### `drop-feature-tags`
+
+This event fires when you drop all existing tags as part of a configuration import.
+
+``` json title="example event: drop-feature-tags"
+{
+  "id": 36,
+  "type": "drop-feature-tags",
+  "createdBy": "import-API-token",
+  "createdAt": "2022-06-03T11:30:40.596Z",
+  "data": {
+    "name": "all-feature-tags"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
+
+
 ## Strategy events
 
 ### `strategy-created`
@@ -714,6 +716,32 @@ This event fires when you create a strategy. The `data` property contains the st
   "data": {
     "name": "new-strategy",
     "description": "this strategy does ...",
+    "parameters": [],
+    "editable": true,
+    "deprecated": false
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
+
+### `strategy-updated`
+
+This event fires when you change a strategy's configuration.
+The `data` property contains the new strategy configuration.
+
+``` json title="example event: strategy-updated"
+{
+  "id": 933,
+  "type": "strategy-updated",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-06-02T12:21:23.741Z",
+  "data": {
+    "name": "new-strategy",
+    "description": "this strategy does something else!",
     "parameters": [],
     "editable": true,
     "deprecated": false
@@ -790,32 +818,6 @@ The `data` property contains the name of the reactivated strategy.
 }
 ```
 
-### `strategy-updated`
-
-This event fires when you change a strategy's configuration.
-The `data` property contains the new strategy configuration.
-
-``` json title="example event: strategy-updated"
-{
-  "id": 933,
-  "type": "strategy-updated",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-06-02T12:21:23.741Z",
-  "data": {
-    "name": "new-strategy",
-    "description": "this strategy does something else!",
-    "parameters": [],
-    "editable": true,
-    "deprecated": false
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": null,
-  "project": null,
-  "environment": null
-}
-```
-
 ### `strategy-import`
 
 This event fires when you import a strategy as part of an import job. The `data` property contains the strategy's configuration.
@@ -873,6 +875,7 @@ This event fires when you delete existing strategies as part of an important job
   "environment": null
 }
 ```
+
 
 
 ## Context field events
@@ -957,6 +960,7 @@ The `data` property contains the name of the deleted context field.
   "environment": null
 }
 ```
+
 
 
 ## Project events
@@ -1086,6 +1090,8 @@ This event fires when you delete existing projects as part of an import job.
 ```
 
 
+
+
 ## Tag events
 
 ### `tag-created`
@@ -1202,29 +1208,6 @@ The `data` property contains the tag type configuration.
 }
 ```
 
-### `tag-type-deleted`
-
-This event fires when you delete a tag type.
-The `data` property contains the name of the deleted tag type.
-
-
-``` json title="example event: tag-type-deleted"
-{
-  "id": 947,
-  "type": "tag-type-deleted",
-  "createdBy": "user@company.com",
-  "createdAt": "2022-06-02T13:27:37.277Z",
-  "data": {
-    "name": "new-tag-type"
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": null,
-  "project": null,
-  "environment": null
-}
-```
-
 ### `tag-type-updated`
 
 This event fires when you update a tag type.
@@ -1239,6 +1222,29 @@ The `data` property contains the new tag type configuration.
   "data": {
     "name": "new-tag-type",
     "description": "This tag is for testing events."
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
+
+### `tag-type-deleted`
+
+This event fires when you delete a tag type.
+The `data` property contains the name of the deleted tag type.
+
+
+``` json title="example event: tag-type-deleted"
+{
+  "id": 947,
+  "type": "tag-type-deleted",
+  "createdBy": "user@company.com",
+  "createdAt": "2022-06-02T13:27:37.277Z",
+  "data": {
+    "name": "new-tag-type"
   },
   "preData": null,
   "tags": [],
@@ -1442,28 +1448,6 @@ This event fires when you delete a user. The `preData` property contains the del
 
 ## Environment events
 
-### `drop-environments`
-
-This event fires when you delete existing environments as part of an import job.
-
-``` json title="example event: drop-environments"
-{
-  "id": 21,
-  "type": "drop-environments",
-  "createdBy": "import-API-token",
-  "createdAt": "2022-06-03T11:30:40.549Z",
-  "data": {
-    "name": "all-projects"
-  },
-  "preData": null,
-  "tags": [],
-  "featureName": null,
-  "project": null,
-  "environment": null
-}
-```
-
-
 ### `environment-import`
 
 This event fires when you import an environment (custom or otherwise) as part of an import job. The `data` property contains the configuration of the imported environment.
@@ -1489,6 +1473,28 @@ This event fires when you import an environment (custom or otherwise) as part of
 }
 ```
 
+
+
+### `drop-environments`
+
+This event fires when you delete existing environments as part of an import job.
+
+``` json title="example event: drop-environments"
+{
+  "id": 21,
+  "type": "drop-environments",
+  "createdBy": "import-API-token",
+  "createdAt": "2022-06-03T11:30:40.549Z",
+  "data": {
+    "name": "all-projects"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": null,
+  "project": null,
+  "environment": null
+}
+```
 
 
 ## Segment events

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -195,6 +195,8 @@ This event fires when you create a feature. The `data` property contains the det
 
 #### `feature-deleted`
 
+This event fires when you delete a feature toggle. The `preData` property contains the deleted toggle data.
+
 ``` json title="example event: feature-deleted"
 {
   "id": 903,
@@ -599,11 +601,11 @@ This event fires when you disable an environment for a feature. The `environment
 }
 ```
 
-### Custom strategy events
+### Strategy events
 
 #### `strategy-created`
 
-This event fires when
+This event fires when you create a strategy. The `data` property contains the strategy configuration.
 
 ``` json
 
@@ -611,7 +613,7 @@ This event fires when
 
 #### `strategy-deleted`
 
-This event fires when
+This event fires when you delete a strategy. The `data` property contains the name of the deleted strategy.
 
 ``` json
 
@@ -619,7 +621,7 @@ This event fires when
 
 #### `strategy-deprecated`
 
-This event fires when
+This event fires when you deprecate a strategy. The `data` property contains the name of the deprecated strategy.
 
 ``` json
 
@@ -627,7 +629,8 @@ This event fires when
 
 #### `strategy-reactivated`
 
-This event fires when
+This event fires when you bring reactivate a deprecated strategy.
+The `data` property contains the name of the reactivated strategy.
 
 ``` json
 
@@ -635,7 +638,8 @@ This event fires when
 
 #### `strategy-updated`
 
-This event fires when
+This event fires when you change a strategy's configuration.
+The `data` property contains the new strategy configuration.
 
 ``` json
 
@@ -643,7 +647,7 @@ This event fires when
 
 #### `strategy-import`
 
-This event fires when
+This event fires when you import a strategy ...
 
 ``` json
 
@@ -662,7 +666,8 @@ This event fires when
 
 #### `context-field-created`
 
-This event fires when
+This event fires when you create a context field.
+The `data` property contains the context field configuration.
 
 ``` json
 
@@ -670,7 +675,8 @@ This event fires when
 
 #### `context-field-updated`
 
-This event fires when
+This event fires when you update a context field.
+The `data` property contains the new context field configuration.
 
 ``` json
 
@@ -678,7 +684,8 @@ This event fires when
 
 #### `context-field-deleted`
 
-This event fires when
+This event fires when you delete a context field.
+The `data` property contains the name of the deleted context field.
 
 ``` json
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -160,7 +160,7 @@ The event properties are described in short in the table below. For more info re
 | `type`        | The event type, as described in the rest of this section.                                             |
 
 
-### Feature Toggle events
+### Feature toggle events
 
 These events pertain to feature toggles and their life cycle.
 
@@ -599,7 +599,7 @@ This event fires when you disable an environment for a feature. The `environment
 }
 ```
 
-### Strategy Events
+### Custom strategy events
 
 #### `strategy-created`
 

--- a/website/docs/api/admin/events-api.md
+++ b/website/docs/api/admin/events-api.md
@@ -299,9 +299,26 @@ The below example changes the toggle's type from *release* to *experiment*.
 
 ### `feature-project-change`
 
-This event fires when you move a feature from one project to another.
+This event fires when you move a feature from one project to another. The `data` property contains the names of the old and the new project.
 
-[... explain more in depth]
+``` json title="example event: feature-project-change"
+{
+  "id": 11,
+  "type": "feature-project-change",
+  "createdBy": "admin",
+  "createdAt": "2022-06-03T11:09:41.444Z",
+  "data": {
+    "newProject": "default",
+    "oldProject": "2"
+  },
+  "preData": null,
+  "tags": [],
+  "featureName": "feature",
+  "project": "default",
+  "environment": null
+}
+```
+
 
 ### `feature-archived`
 


### PR DESCRIPTION
This PR updates the docs for the events endpoint of the admin API. It more clearly describes the existing endpoints and it documents **all** the existing event types.

![image](https://user-images.githubusercontent.com/17786332/171861548-f1c6f7fa-4cb4-414a-a1e2-054f46801e98.png)
