### PR TITLE
task: default to memoizing client features

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -16,6 +16,10 @@ Object {
     "initApiTokens": Array [],
     "type": "open-source",
   },
+  "clientFeatureCaching": Object {
+    "enabled": true,
+    "maxAge": 30000,
+  },
   "db": Object {
     "acquireConnectionTimeout": 30000,
     "applicationName": "unleash",

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -18,7 +18,7 @@ Object {
   },
   "clientFeatureCaching": Object {
     "enabled": true,
-    "maxAge": 30000,
+    "maxAge": 600,
   },
   "db": Object {
     "acquireConnectionTimeout": 30000,

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -365,3 +365,41 @@ test('Supports multiple domains comma separated in environment variables', () =>
         'googlefonts.com',
     ]);
 });
+
+test('Should enable client feature caching with 30 seconds max age by default', () => {
+    const config = createConfig({});
+    expect(config.clientFeatureCaching.enabled).toBe(true);
+    expect(config.clientFeatureCaching.maxAge).toBe(30000);
+});
+
+test('Should use overrides from options for client feature caching', () => {
+    const config = createConfig({
+        clientFeatureCaching: {
+            enabled: false,
+            maxAge: 120,
+        },
+    });
+    expect(config.clientFeatureCaching.enabled).toBe(false);
+    expect(config.clientFeatureCaching.maxAge).toBe(120);
+});
+
+test('Should be able to set client features caching using environment variables', () => {
+    process.env.CLIENT_FEATURE_CACHING_ENABLED = 'false';
+    process.env.CLIENT_FEATURE_CACHING_MAXAGE = '120';
+    const config = createConfig({});
+    expect(config.clientFeatureCaching.enabled).toBe(false);
+    expect(config.clientFeatureCaching.maxAge).toBe(120);
+    delete process.env.CLIENT_FEATURE_CACHING_ENABLED;
+    delete process.env.CLIENT_FEATURE_CACHING_MAXAGE;
+});
+
+test('Environment variables for client features caching takes priority over options', () => {
+    process.env.CLIENT_FEATURE_CACHING_MAXAGE = '120';
+    const config = createConfig({
+        clientFeatureCaching: {
+            maxAge: 180,
+        },
+    });
+    expect(config.clientFeatureCaching.enabled).toBe(true);
+    expect(config.clientFeatureCaching.maxAge).toBe(120);
+});

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -366,10 +366,10 @@ test('Supports multiple domains comma separated in environment variables', () =>
     ]);
 });
 
-test('Should enable client feature caching with 30 seconds max age by default', () => {
+test('Should enable client feature caching with .6 seconds max age by default', () => {
     const config = createConfig({});
     expect(config.clientFeatureCaching.enabled).toBe(true);
-    expect(config.clientFeatureCaching.maxAge).toBe(30000);
+    expect(config.clientFeatureCaching.maxAge).toBe(600);
 });
 
 test('Should use overrides from options for client feature caching', () => {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -54,7 +54,7 @@ function loadExperimental(options: IUnleashOptions): IExperimentalOptions {
 }
 const defaultClientCachingOptions: IClientCachingOption = {
     enabled: true,
-    maxAge: secondsToMilliseconds(30),
+    maxAge: 600,
 };
 
 function loadClientCachingOptions(
@@ -64,7 +64,7 @@ function loadClientCachingOptions(
     if (process.env.CLIENT_FEATURE_CACHING_MAXAGE) {
         envs.maxAge = parseEnvVarNumber(
             process.env.CLIENT_FEATURE_CACHING_MAXAGE,
-            secondsToMilliseconds(30),
+            600,
         );
     }
     if (process.env.CLIENT_FEATURE_CACHING_ENABLED) {

--- a/src/lib/routes/client-api/feature.test.ts
+++ b/src/lib/routes/client-api/feature.test.ts
@@ -84,11 +84,9 @@ test('if caching is enabled should memoize', async () => {
         },
         {
             getLogger,
-            experimental: {
-                clientFeatureMemoize: {
-                    enabled: true,
-                    maxAge: secondsToMilliseconds(10),
-                },
+            clientFeatureCaching: {
+                enabled: true,
+                maxAge: secondsToMilliseconds(10),
             },
         },
     );
@@ -115,11 +113,9 @@ test('if caching is not enabled all calls goes to service', async () => {
         },
         {
             getLogger,
-            experimental: {
-                clientFeatureMemoize: {
-                    enabled: false,
-                    maxAge: secondsToMilliseconds(10),
-                },
+            clientFeatureCaching: {
+                enabled: false,
+                maxAge: secondsToMilliseconds(10),
             },
         },
     );

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -84,6 +84,11 @@ export interface IServerOption {
     secret: string;
 }
 
+export interface IClientCachingOption {
+    enabled: boolean;
+    maxAge: number;
+}
+
 export interface IUnleashOptions {
     databaseUrl?: string;
     databaseUrlFile?: string;
@@ -107,6 +112,7 @@ export interface IUnleashOptions {
     enterpriseVersion?: string;
     disableLegacyFeaturesApi?: boolean;
     inlineSegmentConstraints?: boolean;
+    clientFeatureCaching?: Partial<IClientCachingOption>;
 }
 
 export interface IEmailOption {
@@ -182,4 +188,5 @@ export interface IUnleashConfig {
     inlineSegmentConstraints: boolean;
     segmentValuesLimit: number;
     strategySegmentsLimit: number;
+    clientFeatureCaching: IClientCachingOption;
 }

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -19,6 +19,9 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
         session: { db: false },
         versionCheck: { enable: false },
         enableOAS: true,
+        clientFeatureCaching: {
+            enabled: false,
+        },
     };
     const options = mergeAll<IUnleashOptions>([testConfig, config]);
     return createConfig(options);

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -91,7 +91,7 @@ afterAll(async () => {
     await db.destroy();
 });
 
-afterEach(async () => {
+beforeEach(async () => {
     await db.stores.segmentStore.deleteAll();
     await db.stores.featureToggleStore.deleteAll();
 });

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -91,7 +91,7 @@ afterAll(async () => {
     await db.destroy();
 });
 
-beforeEach(async () => {
+afterEach(async () => {
     await db.stores.segmentStore.deleteAll();
     await db.stores.featureToggleStore.deleteAll();
 });

--- a/website/docs/deploy/configuring-unleash.md
+++ b/website/docs/deploy/configuring-unleash.md
@@ -124,7 +124,7 @@ unleash.start(unleashOptions);
 - **environmentEnableOverrides** - A list of environment names to force enable at startup. This is feature should be used with caution. When passed a list, this will enable each environment in that list and disable all other environments. You can't use this to disable all environments, passing an empty list will do nothing. If one of the given environments is not already enabled on startup then it will also enable projects and toggles for that environment. Note that if one of the passed environments doesn't already exist this will do nothing aside from log a warning.
 - **clientFeatureCaching** - configuring memoization of the /api/client/features endpoint
   - `enabled` - set to true by default - Overridable with (`CLIENT_FEATURE_CACHING_ENABLED`)
-  - `maxAge` - the time to cache features, set to 30000 milliseconds by default - Overridable with (`CLIENT_FEATURE_CACHING_MAXAGE`) ) (accepts milliseconds)
+  - `maxAge` - the time to cache features, set to 600 milliseconds by default - Overridable with (`CLIENT_FEATURE_CACHING_MAXAGE`) ) (accepts milliseconds)
 
 You can also set the environment variable `ENABLED_ENVIRONMENTS` to a comma delimited string of environment names to override environments.
 

--- a/website/docs/deploy/configuring-unleash.md
+++ b/website/docs/deploy/configuring-unleash.md
@@ -2,9 +2,8 @@
 id: configuring_unleash
 title: Configuring Unleash
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 > This is the guide on how to configure **Unleash v4 self-hosted**. If you are still using Unleash v3 you should checkout [configuring Unleash v3](./configuring_unleash_v3)
 
@@ -60,6 +59,7 @@ unleash.start(unleashOptions);
 **Available Unleash options include:**
 
 - **authentication** - (object) - An object for configuring/implementing custom admin authentication
+
   - enableApiToken (boolean) - Should unleash require API tokens for access? Defaults to `true`
   - type (string) What kind of authentication to use. Possible values
     - `open-source` - Sign in with username and password. This is the default value.
@@ -68,20 +68,24 @@ unleash.start(unleashOptions);
     - `demo` - Only requires an email to sign in (was default in v3)
   - customAuthHandler: (function) - custom express middleware handling authentication. Used when type is set to `custom`
   - createAdminUser: (boolean) - whether to create an admin user with default password - Defaults to `true`
-  - initApiTokens: (ApiTokens[]) - Array of API tokens to create on startup. The tokens will only be created if the database doesn't already contain any API tokens.
-      Example:
-     ```ts
-     [{
+  - initApiTokens: (ApiTokens[]) - Array of API tokens to create on startup. The tokens will only be created if the database doesn't already contain any API tokens. Example:
+
+    ```ts
+    [
+      {
         environment: '*',
         project: '*',
         secret: '*:*.964a287e1b728cb5f4f3e0120df92cb5',
         type: ApiTokenType.ADMIN,
         username: 'some-user',
-    }]
-     ```
-      The tokens can be of any API token type. Note that _admin_ tokens **must** target all environments and projects (i.e. use `'*'` for `environments` and `project` and start the secret with `*:*.`).
+      },
+    ];
+    ```
 
-      You can also use the environment variables `INIT_ADMIN_API_TOKENS` or `INIT_CLIENT_API_TOKENS` to create API admin or client tokens on startup. Both variables require a comma-separated list of API tokens to initialize (for instance `*:*.some-random-string, *:*.some-other-token`). The tokens found in `INIT_ADMIN_API_TOKENS` and `INIT_CLIENT_API_TOKENS` will be created as admin and client tokens respectively and Unleash will assign a username automatically.
+    The tokens can be of any API token type. Note that _admin_ tokens **must** target all environments and projects (i.e. use `'*'` for `environments` and `project` and start the secret with `*:*.`).
+
+    You can also use the environment variables `INIT_ADMIN_API_TOKENS` or `INIT_CLIENT_API_TOKENS` to create API admin or client tokens on startup. Both variables require a comma-separated list of API tokens to initialize (for instance `*:*.some-random-string, *:*.some-other-token`). The tokens found in `INIT_ADMIN_API_TOKENS` and `INIT_CLIENT_API_TOKENS` will be created as admin and client tokens respectively and Unleash will assign a username automatically.
+
 - **databaseUrl** - (_deprecated_) the postgres database url to connect to. Only used if _db_ object is not specified, and overrides the _db_ object and any environment variables that change parts of it (like `DATABASE_SSL`). Should include username/password. This value may also be set via the `DATABASE_URL` environment variable. Alternatively, if you would like to read the database url from a file, you may set the `DATABASE_URL_FILE` environment variable with the full file path. The contents of the file must be the database url exactly.
 - **db** - The database configuration object. See [the database configuration section](#database-configuration) for a full overview of the available properties.
 - **disableLegacyFeaturesApi** (boolean) - whether to disable the [legacy features API](../api/admin/feature-toggles-api.md). Defaults to `false` (`DISABLE_LEGACY_FEATURES_API`). Introduced in Unleash 4.6.
@@ -117,10 +121,12 @@ unleash.start(unleashOptions);
 - **versionCheck** - the object deciding where to check for latest version
   - `url` - The url to check version (Defaults to `https://version.unleash.run`) - Overridable with (`UNLEASH_VERSION_URL`)
   - `enable` - Whether version checking is enabled (defaults to true) - Overridable with (`CHECK_VERSION`) (if anything other than `true`, does not check)
-- **environmentEnableOverrides** - A list of environment names to force enable at startup. This is feature should be
-  used with caution. When passed a list, this will enable each environment in that list and disable all other environments. You can't use this to disable all environments, passing an empty list will do nothing. If one of the given environments is not already enabled on startup then it will also enable projects and toggles for that environment. Note that if one of the passed environments doesn't already exist this will do nothing aside from log a warning.
+- **environmentEnableOverrides** - A list of environment names to force enable at startup. This is feature should be used with caution. When passed a list, this will enable each environment in that list and disable all other environments. You can't use this to disable all environments, passing an empty list will do nothing. If one of the given environments is not already enabled on startup then it will also enable projects and toggles for that environment. Note that if one of the passed environments doesn't already exist this will do nothing aside from log a warning.
+- **clientFeatureCaching** - configuring memoization of the /api/client/features endpoint
+  - `enabled` - set to true by default - Overridable with (`CLIENT_FEATURE_CACHING_ENABLED`)
+  - `maxAge` - the time to cache features, set to 30000 milliseconds by default - Overridable with (`CLIENT_FEATURE_CACHING_MAXAGE`) ) (accepts milliseconds)
 
-  You can also set the environment variable `ENABLED_ENVIRONMENTS` to a comma delimited string of environment names to override environments.
+You can also set the environment variable `ENABLED_ENVIRONMENTS` to a comma delimited string of environment names to override environments.
 
 ### Disabling Auto-Start {#disabling-auto-start}
 
@@ -191,43 +197,40 @@ The logger interface with its `debug`, `info`, `warn` and `error` methods expect
 
 ## Database configuration
 
-:::info
-In-code configuration values take precedence over environment values: If you provide a database username both via environment variables and in code with the Unleash options object, Unleash will use the in-code username.
-:::
+:::info In-code configuration values take precedence over environment values: If you provide a database username both via environment variables and in code with the Unleash options object, Unleash will use the in-code username. :::
 
 You cannot run the Unleash server without a database. You must provide Unleash with database connection details for it to start correctly.
 
 The available options are listed in the table below. Options can be specified either via JavaScript (only when starting Unleash via code) or via environment variables. The "property name" column below gives the name of the property on the Unleash options' `db` object.
 
-| Property name            | Environment variable            | Default value  | Description                                                                                                                                                                              |
-|--------------------------|---------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `user`                   | `DATABASE_USERNAME`             | `unleash_user` | The database username.                                                                                                                                                                   |
-| `password`               | `DATABASE_PASSWORD`             | `passord`      | The database password.                                                                                                                                                                   |
-| `host`                   | `DATABASE_HOST`                 | `localhost`    | The database hostname.                                                                                                                                                                   |
-| `port`                   | `DATABASE_PORT`                 | `5432`         | The database port.                                                                                                                                                                       |
-| `database`               | `DATABASE_NAME`                 | `unleash`      | The name of the database.                                                                                                                                                                |
-| `ssl`                    | `DATABASE_SSL`                  | N/A            | An object describing SSL options. In code, provide a regular JavaScript object. When using the environment variable, provide a **stringified JSON object**.                              |
-| `pool`                   | N/A (use the below variables)  |                | An object describing database pool options. With environment variables, use the options below directly.                                                                                  |
-| `pool.min`               | `DATABASE_POOL_MIN`             | 0              | The minimum number of connections in the connection pool.                                                                                                                                |
-| `pool.max`               | `DATABASE_POOL_MAX`             | 4              | The maximum number of connections in the connection pool.                                                                                                                                |
-| `pool.idleTimeoutMillis` | `DATABASE_POOL_IDLE_TIMEOUT_MS` | 30000          | The amount of time (in milliseconds) that a connection must be idle for before it is marked as a candidate for eviction.                                                                 |
-| `applicationName`        | `DATABASE_APPLICATION_NAME`     | `unleash`      | The name of the application that created this Client instance.                                                                                    |
-| `schema`        | `DATABASE_SCHEMA`     | `public`      | The schema to use in the database.                                                                                    |
+| Property name | Environment variable | Default value | Description |
+| --- | --- | --- | --- |
+| `user` | `DATABASE_USERNAME` | `unleash_user` | The database username. |
+| `password` | `DATABASE_PASSWORD` | `passord` | The database password. |
+| `host` | `DATABASE_HOST` | `localhost` | The database hostname. |
+| `port` | `DATABASE_PORT` | `5432` | The database port. |
+| `database` | `DATABASE_NAME` | `unleash` | The name of the database. |
+| `ssl` | `DATABASE_SSL` | N/A | An object describing SSL options. In code, provide a regular JavaScript object. When using the environment variable, provide a **stringified JSON object**. |
+| `pool` | N/A (use the below variables) |  | An object describing database pool options. With environment variables, use the options below directly. |
+| `pool.min` | `DATABASE_POOL_MIN` | 0 | The minimum number of connections in the connection pool. |
+| `pool.max` | `DATABASE_POOL_MAX` | 4 | The maximum number of connections in the connection pool. |
+| `pool.idleTimeoutMillis` | `DATABASE_POOL_IDLE_TIMEOUT_MS` | 30000 | The amount of time (in milliseconds) that a connection must be idle for before it is marked as a candidate for eviction. |
+| `applicationName` | `DATABASE_APPLICATION_NAME` | `unleash` | The name of the application that created this Client instance. |
+| `schema` | `DATABASE_SCHEMA` | `public` | The schema to use in the database. |
 
-Alternatively, you can use a [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to connect to the database. You can provide it directly or from a file by using one of the below options. In JavaScript, these are top-level properties of the root configuration object, *not* the `db` object.
+Alternatively, you can use a [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to connect to the database. You can provide it directly or from a file by using one of the below options. In JavaScript, these are top-level properties of the root configuration object, _not_ the `db` object.
 
-| Property name     | Environment variable | Default value | Description                                                                                                                                                                              |
-|-------------------|----------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `databaseUrl`     | `DATABASE_URL`       | N/A           | A string that matches the [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), such as `postgres://USER:PASSWORD@HOST:PORT/DATABASE`. |
-| `databaseUrlFile` | `DATABASE_URL_FILE`  | N/A           | The path to a file that contains a [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).                                               |
-
+| Property name | Environment variable | Default value | Description |
+| --- | --- | --- | --- |
+| `databaseUrl` | `DATABASE_URL` | N/A | A string that matches the [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), such as `postgres://USER:PASSWORD@HOST:PORT/DATABASE`. |
+| `databaseUrlFile` | `DATABASE_URL_FILE` | N/A | The path to a file that contains a [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). |
 
 Below is an example JavaScript configuration object.
 
-``` js
+```js
 const unleashOptions = {
-  databaseUrl: "postgres:/USER:PASSWORD@HOST:PORT/DATABASE",
-  databaseUrlFile: "/path/to/file",
+  databaseUrl: 'postgres:/USER:PASSWORD@HOST:PORT/DATABASE',
+  databaseUrlFile: '/path/to/file',
   db: {
     user: 'unleash_user',
     password: 'passord',
@@ -254,21 +257,22 @@ If you want to read content from a file, you should either initialize Unleash vi
 
 <TabItem value="js" label="JavaScript" default>
 
-``` js title="Reading from the file system in JavaScript"
+```js title="Reading from the file system in JavaScript"
 const unleashOptions = {
-    db: {
-        // other options omitted for brevity
-        ssl: {
-            ca: fs.readFileSync('/path/to/server-certificates/root.crt').toString(),
-        }
-    }}
+  db: {
+    // other options omitted for brevity
+    ssl: {
+      ca: fs.readFileSync('/path/to/server-certificates/root.crt').toString(),
+    },
+  },
+};
 ```
 
 </TabItem>
 
 <TabItem value="env" label="Environment variables (bash)">
 
-``` bash title="Reading from the file system with bash"
+```bash title="Reading from the file system with bash"
 DATABASE_SSL="{ \"key\": \"$(cat /path/to/server-certificates/root.crt)\" }"
 ```
 
@@ -276,10 +280,7 @@ DATABASE_SSL="{ \"key\": \"$(cat /path/to/server-certificates/root.crt)\" }"
 
 </Tabs>
 
-
-
 ### Enabling self-signed certificates
-
 
 To use self-signed certificates, you should set the SSL property `rejectUnauthorized` to `false` and set the `ca` property to the value of the certificate:
 
@@ -287,23 +288,23 @@ To use self-signed certificates, you should set the SSL property `rejectUnauthor
 
 <TabItem value="js" label="JavaScript" default>
 
-``` js title="Enable self-signed certificates"
+```js title="Enable self-signed certificates"
 const unleashOptions = {
-    db: {
-        // other options omitted for brevity
-        ssl: {
-            rejectUnauthorized: false,
-            ca: fs.readFileSync('/path/to/server-certificates/root.crt').toString(),
-        }
-    }}
-
+  db: {
+    // other options omitted for brevity
+    ssl: {
+      rejectUnauthorized: false,
+      ca: fs.readFileSync('/path/to/server-certificates/root.crt').toString(),
+    },
+  },
+};
 ```
 
 </TabItem>
 
 <TabItem value="env" label="Environment variables (bash)">
 
-``` bash title="Enable self-signed certificates"
+```bash title="Enable self-signed certificates"
 DATABASE_SSL="{ \"rejectUnauthorized\": false, \"key\": \"$(cat /path/to/server-certificates/root.crt)\" }"
 ```
 
@@ -328,6 +329,7 @@ Unleash builds directly on the [node-postgres library](https://node-postgres.com
 You can configure proxy services that intercept all outgoing requests from Unleash. This lets you use the Microsoft Teams or the Webhook addon for external services, even if the internet can only be reached via a proxy on your machine or container (for example if restricted by a firewall or similiar).
 
 As an example, here's how you could do it using the [node-global-proxy](https://www.npmjs.com/package/node-global-proxy) package:
+
 ```
 const proxy = require("node-global-proxy").default;
 
@@ -335,11 +337,10 @@ proxy.setConfig({
     http: "http://user:password@url:8080",      //proxy adress, replace values as needed
     //https: "https://user:password@url:1080",  //if a https proxy is needed
   });
-  
+
 proxy.start();      //this starts the proxy, after this call all requests will be proxied
 ```
 
-Using above code-snippet, every outgoing request from unleash or its addons will be subsequently routed through set proxy.
-If the proxy routing needs to be bypassed or stopped, its possible to stop it by using
+Using above code-snippet, every outgoing request from unleash or its addons will be subsequently routed through set proxy. If the proxy routing needs to be bypassed or stopped, its possible to stop it by using
 
 `proxy.stop();`


### PR DESCRIPTION
So this PR makes client features memoization a default, and moves configuration of it to the root config object rather than hiding it behind the experimental catch-all group.