### PR TITLE
fix: when payload type is 'json' validate value on toggle variable validation

### DIFF
--- a/src/lib/schema/feature-schema.ts
+++ b/src/lib/schema/feature-schema.ts
@@ -1,6 +1,7 @@
 import joi from 'joi';
 import { ALL_OPERATORS } from '../util/constants';
 import { nameType } from '../routes/util';
+import { validateJsonString } from '../util/validateJsonString';
 
 export const nameSchema = joi
     .object()
@@ -35,7 +36,25 @@ export const variantsSchema = joi.object().keys({
         .object()
         .keys({
             type: joi.string().required(),
-            value: joi.string().required(),
+            value: joi
+                .string()
+                .required()
+                // perform additional validation
+                // when provided 'type' is 'json'
+                .when('type', {
+                    is: 'json',
+                    then: joi.custom((val, helper) => {
+                        const isValidJsonString = validateJsonString(val);
+                        if (isValidJsonString === false) {
+                            return helper.error('invalidJsonString');
+                        }
+                        return val;
+                    }),
+                })
+                .messages({
+                    invalidJsonString:
+                        "'value' must be a valid json string when 'type' is json",
+                }),
         })
         .optional(),
     stickiness: joi.string().default('default'),

--- a/src/lib/util/validateJsonString.test.ts
+++ b/src/lib/util/validateJsonString.test.ts
@@ -1,0 +1,22 @@
+import { validateJsonString } from './validateJsonString';
+
+test('should return true for valid json string', () => {
+    const input = '{"test":1,"nested":[{"test1":{"testinner":true}}]}';
+    expect(validateJsonString(input)).toBe(true);
+});
+
+test('should return false for invalid json string (missing starting {)', () => {
+    // missing starting {
+    const input = '"test":1,"nested":[{"test1":{"testinner":true}}]}';
+    expect(validateJsonString(input)).toBe(false);
+});
+
+test('should return false for invalid json string (plain string)', () => {
+    const input = 'not a json';
+    expect(validateJsonString(input)).toBe(false);
+});
+
+test('should return false for invalid json string (null as a string)', () => {
+    const input = 'null';
+    expect(validateJsonString(input)).toBe(false);
+});

--- a/src/lib/util/validateJsonString.ts
+++ b/src/lib/util/validateJsonString.ts
@@ -1,0 +1,16 @@
+/**
+ * returns if the provided string is
+ * a valid json
+ */
+export const validateJsonString = (value: string): boolean => {
+    // from https://stackoverflow.com/a/20392392
+    try {
+        const parsedStr = JSON.parse(value);
+        if (parsedStr && typeof parsedStr === 'object') {
+            return true;
+        }
+    } catch (err) {}
+
+    // an error is considered a non valid json
+    return false;
+};

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -261,6 +261,34 @@ test('creates new feature toggle with createdBy unknown', async () => {
     });
 });
 
+test('refuses to create a new feature toggle with variant when type is json but value provided is not a valid json', async () => {
+    return app.request
+        .post('/api/admin/features')
+        .send({
+            name: 'com.test.featureInvalidValue',
+            variants: [
+                {
+                    name: 'variantTest',
+                    weight: 1,
+                    payload: {
+                        type: 'json',
+                        value: 'this should be a # valid json', // <--- testing value
+                    },
+                    weightType: 'variable',
+                },
+            ],
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400)
+        .expect((res) => {
+            expect(res.body.isJoi).toBe(true);
+            expect(res.body.details[0].type).toBe('invalidJsonString');
+            expect(res.body.details[0].message).toBe(
+                `'value' must be a valid json string when 'type' is json`,
+            );
+        });
+});
+
 test('require new feature toggle to have a name', async () => {
     expect.assertions(0);
     return app.request


### PR DESCRIPTION

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

On toggle variable validation added an additional custom joi validation on the `value` field when the provided `type` is `json`.

Example body:
```json
{
   "name":"com.test.featureInvalidValue",
   "variants":[
      {
         "name":"variantTest",
         "weight":1,
         "payload":{
            "type":"json",
            "value":"this should be a # valid json"
         },
         "weightType":"variable"
      }
   ]
}
```

Example response
(HTTP 400)

```json
{
   "_original":{
      "name":"com.test.featureInvalidValue",
      "variants":[
         {
            "name":"variantTest",
            "weight":1,
            "payload":{
               "type":"json",
               "value":"this should be a # valid json"
            },
            "weightType":"variable"
         }
      ]
   },
   "details":[
      {
         "message":"'value' must be a valid json string when 'type' is json",
         "path":[
            "variants",
            0,
            "payload",
            "value"
         ],
         "type":"invalidJsonString",
         "context":{
            "label":"variants[0].payload.value",
            "value":"this should be a # valid json",
            "key":"value"
         }
      }
   ],
   "isJoi":true
}
```

<!-- Does it close an issue? Multiple? -->
Closes #928

