### PR TITLE
docs: SDK Synchronization tips

### DIFF
--- a/website/docs/sdks/dot_net.md
+++ b/website/docs/sdks/dot_net.md
@@ -19,6 +19,14 @@ dotnet add package unleash.client
 
 Next we must initialize a new instance of the Unleash Client.
 
+:::tip Synchronous initialization
+
+The client SDK will synchronize with the Unleash API on initialization, so it can take a few hundred milliseconds for the client to reach the correct state. You can use the `SynchronousInitialization` option to block the client until it has successfully synced with the server.
+
+Read more about the [Unleash architecture](https://www.getunleash.io/blog/our-unique-architecture) to learn how it works.
+
+:::
+
 ```csharp
 var settings = new UnleashSettings()
 {
@@ -52,10 +60,6 @@ else
   //do old boring stuff
 }
 ```
-
-Please note the client SDK will synchronize with the Unleash-hosted API on initialization, and thus it can take a few milliseconds the first time before the client has the correct state. You can use the _SynchronousInitialization_ option to block the client until it has successfully synced with the server.
-
-Read more about the [Unleash architecture](https://www.getunleash.io/blog/our-unique-architecture) to learn how it works in more details
 
 ## Step 4: Provide Unleash Context {#step-4-provide-unleash-context}
 

--- a/website/docs/sdks/dot_net.md
+++ b/website/docs/sdks/dot_net.md
@@ -3,6 +3,8 @@ id: dot_net_sdk
 title: .NET SDK
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
+
 In this guide we explain how to use feature toggles in a .NET application using Unleash-hosted. We will be using the open source Unleash [.net Client SDK](https://github.com/Unleash/unleash-client-dotnet).
 
 > You will need your `API URL` and your `API token` in order to connect the Client SDK to you Unleash instance. You can find this information in the “Admin” section Unleash management UI. [Read more](../user_guide/api-token)
@@ -21,11 +23,16 @@ Next we must initialize a new instance of the Unleash Client.
 
 :::tip Synchronous initialization
 
-The client SDK will synchronize with the Unleash API on initialization, so it can take a few hundred milliseconds for the client to reach the correct state. You can use the `SynchronousInitialization` option to block the client until it has successfully synced with the server.
+By default, the client SDK asynchronously fetches toggles from the Unleash API on initialization. This means it can take a few hundred milliseconds for the client to reach the correct state.
+
+You can use the `synchronousInitialization` option of the `UnleashClientFactory` class's `CreateClientAsync` method to block the client until it has successfully synced with the server. See the following "synchronous initialization" code sample.
 
 Read more about the [Unleash architecture](https://www.getunleash.io/blog/our-unique-architecture) to learn how it works.
 
 :::
+
+<Tabs>
+  <TabItem value="async" label="Asynchronous initialization" default>
 
 ```csharp
 var settings = new UnleashSettings()
@@ -41,6 +48,31 @@ var settings = new UnleashSettings()
 
 IUnleash unleash = new DefaultUnleash(settings);
 ```
+
+  </TabItem>
+  <TabItem value="sync" label="Synchronous initializiation">
+
+```csharp
+var settings = new UnleashSettings()
+{
+  AppName = "dot-net-client",
+  Environment = "local",
+  UnleashApi = new Uri("API URL"),
+  CustomHttpHeaders = new Dictionary()
+  {
+    {"Authorization","API token" }
+  }
+};
+
+var unleashFactory = new UnleashClientFactory();
+
+// this `unleash` will fetch feature toggles and write them to its cache before returning from the await call.
+// if network errors or disk permissions prevent this from happening, the await will throw an exception.
+IUnleash unleash = await unleashFactory.CreateClientAsync(settings, synchronousInitialization: true);
+```
+
+  </TabItem>
+</Tabs>
 
 In your app you typically just want one instance of Unleash, and inject that where you need it.
 

--- a/website/docs/sdks/java.md
+++ b/website/docs/sdks/java.md
@@ -3,6 +3,8 @@ id: java_sdk
 title: Java SDK
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
+
 In this guide we explain how to use feature toggles in a Java application using Unleash-hosted. We will be using the open source Unleash [Java Client SDK](https://github.com/Unleash/unleash-client-java).
 
 > You will need your `API URL` and your `API token` in order to connect the Client SDK to you Unleash instance. You can find this information in the “Admin” section Unleash management UI. [Read more](../user_guide/api-token)
@@ -29,6 +31,9 @@ The client SDK will synchronize with the Unleash API on initialization, so it ca
 
 :::
 
+<Tabs>
+  <TabItem value="async" label="Asynchronous initialization" default>
+
 ```java
 UnleashConfig config = UnleashConfig.builder()
         .appName("my.java-app")
@@ -40,6 +45,25 @@ UnleashConfig config = UnleashConfig.builder()
 
 Unleash unleash = new DefaultUnleash(config);
 ```
+
+  </TabItem>
+  <TabItem value="sync" label="Synchronous initializiation">
+
+```java
+UnleashConfig config = UnleashConfig.builder()
+        .appName("my.java-app")
+        .instanceId("your-instance-1")
+        .environment(System.getenv("APP_ENV"))
+        .unleashAPI("API URL")
+        .customHttpHeader("Authorization", "API token")
+        .synchronousFetchOnInitialization(true)
+        .build();
+
+Unleash unleash = new DefaultUnleash(config);
+```
+
+  </TabItem>
+</Tabs>
 
 In your app you typically just want one instance of Unleash, and inject that where you need it. You will typically use a dependency injection frameworks such as Spring or Guice to manage this.
 

--- a/website/docs/sdks/java.md
+++ b/website/docs/sdks/java.md
@@ -23,6 +23,12 @@ First we must add Unleash Client SDK as a dependency to your project. Below is a
 
 Next we must initialize a new instance of the Unleash Client.
 
+:::tip Synchronous initialization
+
+The client SDK will synchronize with the Unleash API on initialization, so it can take a few hundred milliseconds for the client to reach the correct state. You can use the `synchronousFetchOnInitialisation` option to block the client until it has successfully synced with the server.
+
+:::
+
 ```java
 UnleashConfig config = UnleashConfig.builder()
         .appName("my.java-app")
@@ -50,8 +56,6 @@ if(unleash.isEnabled("AwesomeFeature")) {
   //do old boring stuff
 }
 ```
-
-Please note the client SDK will synchronize with the Unleash-hosted API on initialization, and thus it can take a few milliseconds the first time before the client has the correct state. You can use the _synchronousFetchOnInitialisation_ option to block the client until it has successfully synced with the server.
 
 Read more about the [Unleash architecture](https://www.unleash-hosted.com/articles/our-unique-architecture) to learn how it works in more details
 

--- a/website/docs/sdks/node.md
+++ b/website/docs/sdks/node.md
@@ -3,6 +3,8 @@ id: node_sdk
 title: Node SDK
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
+
 In this guide we explain how to use feature toggles in a Node application using Unleash-hosted. We will be using the open source Unleash [Node.js Client SDK](https://github.com/Unleash/unleash-client-node).
 
 > You will need your `API URL` and your `API token` in order to connect the Client SDK to you Unleash instance. You can find this information in the “Admin” section Unleash management UI. [Read more](../user_guide/api-token)
@@ -23,9 +25,12 @@ Next we must initialize the client SDK in the application:
 
 The client SDK will synchronize with the Unleash API on initialization, so it can take a few hundred milliseconds for the client to reach the correct state.
 
-See [block until Unleash is synchronized](https://github.com/Unleash/unleash-client-node#block-until-unleash-sdk-has-synchronized) for how to do this.
+See the following code sample or the [_block until Unleash is synchronized_ section of the readme](https://github.com/Unleash/unleash-client-node#block-until-unleash-sdk-has-synchronized) for the steps to do this.
 
 :::
+
+<Tabs>
+  <TabItem value="async" label="Asynchronous initialization" default>
 
 ```js
 const unleash = require('unleash-client');
@@ -37,6 +42,23 @@ unleash.initialize({
   customHeaders: { Authorization: 'SOME-SECRET' },
 });
 ```
+
+  </TabItem>
+  <TabItem value="sync" label="Synchronous initializiation">
+
+```js
+const { startUnleash } = require('unleash-client');
+
+const unleash = await startUnleash({
+  url: 'https://YOUR-API-URL',
+  appName: 'my-node-name',
+  environment: process.env.APP_ENV,
+  customHeaders: { Authorization: 'SOME-SECRET' },
+});
+```
+
+  </TabItem>
+</Tabs>
 
 The example code above will initialize the client SDK, and connect to the Unleash-hosted demo instance. It also uses the API token for the demo instance. You should change the URL and the Authorization header (API token) with the correct values for your instance, which you may locate under “Instance admin” in the menu.
 

--- a/website/docs/sdks/node.md
+++ b/website/docs/sdks/node.md
@@ -62,8 +62,6 @@ const unleash = await startUnleash({
 
 The example code above will initialize the client SDK, and connect to the Unleash-hosted demo instance. It also uses the API token for the demo instance. You should change the URL and the Authorization header (API token) with the correct values for your instance, which you may locate under “Instance admin” in the menu.
 
-Please also pay attention to the “environment” option. Setting this will allow you to use [strategy constraints](/advanced/strategy_constraints) which enables different roll-out strategies per environment.
-
 ## Step 3: Use the feature toggle {#step-3-use-the-feature-toggle}
 
 Now that we have initialized the client SDK in our application we can start using feature toggles defined in Unleash in our application. To achieve this we have the “isEnabled” method available, which will allow us to check the value of a feature toggle. This method will return **true** or **false** based on whether the feature should be enabled or disabled for the current request.

--- a/website/docs/sdks/node.md
+++ b/website/docs/sdks/node.md
@@ -19,6 +19,14 @@ npm install unleash-client
 
 Next we must initialize the client SDK in the application:
 
+:::tip Synchronous initialization
+
+The client SDK will synchronize with the Unleash API on initialization, so it can take a few hundred milliseconds for the client to reach the correct state.
+
+See [block until Unleash is synchronized](https://github.com/Unleash/unleash-client-node#block-until-unleash-sdk-has-synchronized) for how to do this.
+
+:::
+
 ```js
 const unleash = require('unleash-client');
 
@@ -52,7 +60,7 @@ Please note that in the above example we put the isEnabled-evaluation inside the
 
 It can also be nice to notice that if you use an undefined feature toggle the Unleash SDK will return false instead of crashing your application. The SDK will also report metrics back to Unleash-hosted on feature toggle usage, which makes it \_possible to spot toggles not yet defined. And this is a very neat way to help you debug if something does not work as expected.
 
-_Note that you can also wait until the Unleash SDK has fully syncrhonized similar to familiar "on-ready" hooks in other APIs. See [block until Unleashed is synchronized](https://github.com/Unleash/unleash-client-node#block-until-unleash-sdk-has-synchronized) for how to do this._
+_Note that you can also wait until the Unleash SDK has fully synchronized similar to familiar "on-ready" hooks in other APIs. See [block until Unleashed is synchronized](https://github.com/Unleash/unleash-client-node#block-until-unleash-sdk-has-synchronized) for how to do this._
 
 ## Step 4: Provide the Unleash-context {#step-4-provide-the-unleash-context}
 


### PR DESCRIPTION
We've seen multiple users complain that their client does not yield the correct enabled result. Most of the time this is due to the client not being synchronized with the server yet. This updates the docs for the clients we've seen the most cries for help with to include a more visible tip about synchronous initialization.


Co-authored-by: Thomas Heartman <thomas@getunleash.ai>