### PR TITLE
docs: update segments availability notices

### DIFF
--- a/website/docs/api/admin/segments.mdx
+++ b/website/docs/api/admin/segments.mdx
@@ -1,9 +1,8 @@
 ---
 title: /api/admin/segments
 ---
-import ApiRequest from '@site/src/components/ApiRequest'
-export const basePath = "api/admin/segments"
-export const path = (p) => `${basePath}/${p}`
+
+import ApiRequest from '@site/src/components/ApiRequest'; export const basePath = "api/admin/segments"; export const path = (p) => `${basePath}/${p}`;
 
 :::info Availability
 

--- a/website/docs/api/admin/segments.mdx
+++ b/website/docs/api/admin/segments.mdx
@@ -6,11 +6,15 @@ export const basePath = "api/admin/segments"
 export const path = (p) => `${basePath}/${p}`
 
 :::info Availability
-Segments are an **experimental feature** available to some Unleash Pro and Unleash Enterprise users. [Get in touch](https://slack.unleash.run) if you'd like to help us develop this feature.
+
+Segments are available to Unleash Pro and Unleash Enterprise users since **Unleash 4.13**.
+
 :::
 
 :::note
+
 To use the admin API, you'll need to [create and use an admin API token](../../user_guide/token.md).
+
 :::
 
 The segments API lets you create, read, update, and delete [segments](../../reference/segments.mdx).
@@ -326,7 +330,9 @@ This section describes the data objects returned by the endpoints in the segment
 #### Description
 
 :::note `values` and `value`
+
 Some constraint operators only support single values. If a constraint uses one of these operators, the payload will contain a `value` property with the correct value. However, for backwards compatibility reasons, the payload will *also* contain a `values` property. If the operator accepts multiple values, the `value` property will not be present. Visit the [strategy constraints documentation](../../advanced/strategy-constraints.md) for more information on what operators support what number of values.
+
 :::
 
 | Property          | Type                                                                                          | Required | Description                                                                                                                                                       | Example value            |

--- a/website/docs/reference/segments.mdx
+++ b/website/docs/reference/segments.mdx
@@ -3,7 +3,9 @@ title: Segments
 ---
 
 :::info Availability
-Segments are an **experimental feature** available to some Unleash Pro and Unleash Enterprise users. [Get in touch](https://slack.unleash.run) if you'd like to help us develop this feature.
+
+Segments are available to Unleash Pro and Unleash Enterprise users since **Unleash 4.13**.
+
 :::
 
 A **segment** is a reusable collection of [strategy constraints](../advanced/strategy-constraints.md).


### PR DESCRIPTION
The notices say segments are an "experimental feature", but with 4.13, they are now GA. These changes update the docs to match that.

