### PR TITLE
docs: add svelte and vue front-end SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,12 @@ To connect your application to Unleash you'll need to use a client SDK for your 
 
 The front-end SDKs connects via the [Unleash Proxy](https://docs.getunleash.io/sdks/unleash-proxy) in order to ensure privacy, scalability and security.
 
-- [Android SDK](https://docs.getunleash.io/sdks/android_proxy_sdk)
-- [Javascript SDK](https://docs.getunleash.io/sdks/proxy-javascript)
-- [React SDK](https://docs.getunleash.io/sdks/proxy-react)
-- [iOS SDK](https://docs.getunleash.io/sdks/proxy-ios)
+- [Android Proxy SDK](https://docs.getunleash.io/sdks/android_proxy_sdk)
+- [iOS Proxy SDK](https://docs.getunleash.io/sdks/proxy-ios)
+- [JavaScript Proxy SDK](https://docs.getunleash.io/sdks/proxy-javascript)
+- [React Proxy SDK](https://docs.getunleash.io/sdks/proxy-react)
+- [Svelte Proxy SDK](https://docs.getunleash.io/sdks/proxy-svelte)
+- [Vue Proxy SDK](https://docs.getunleash.io/sdks/proxy-vue)
 
 **Community SDKs:**
 

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -109,12 +109,12 @@ Here's some of the fantastic work our community has done to make Unleash work in
 - [mikefrancis/laravel-unleash](https://github.com/mikefrancis/laravel-unleash) (Laravel - PHP)
 - [minds/unleash-client-php](https://gitlab.com/minds/unleash-client-php) (PHP)
 - [ngx-unleash-proxy-client](https://github.com/snowfrogdev/snowfrogdev/tree/main/packages/ngx-unleash-proxy-client) (Angular - TypeScript)
+- [nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native) (React Native / Expo)
+- [nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid) (Solid)
 - [pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash) (NestJS - Node.js)
 - [silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin) (Kotlin)
 - [Stogon/unleash-bundle](https://git.stogon.io/Stogon/unleash-bundle/) (PHP - Symfony)
 - [uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash) (Dart)
-- [nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid) (Solid)
-- [nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native) (React Native / Expo)
 - _...your implementation for your favorite language._
 
 ### Implement your own SDK {#implement-your-own-sdk}

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -34,7 +34,6 @@ For security and performance reasons, the front-end SDKs do not communicate dire
 - [Svelte Proxy SDK](/sdks/proxy-svelte)
 - [Vue Proxy SDK](/sdks/proxy-vue)
 
-
 ### Server-side SDK compatibility table
 
 The below table shows what features the various server-side SDKs support. Note that certain features make sense only for some clients due to how the programming language works or due to how the client works.
@@ -46,62 +45,59 @@ The below table shows what features the various server-side SDKs support. Note t
 - ❌: Not implemented, not planned
 - **N/A**: Not applicable to this SDK
 
-:::note
-If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.
-:::
+:::note If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it. :::
 
-
-| Capability                                                                                                                                     | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.NET](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Rust](https://github.com/unleash/unleash-client-rust) | [Unleash Proxy](unleash-proxy.md) |
-|------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------:|:-------------------------:|:------------------:|:--------------------------:|:----------------------:|:-------------------------:|:--------------------:|:------------------------------------------------------:|:---------------------------------:|
-| **Category: Initialization**                                                                                                                   |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Async initialization                                                                                                                           | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ❌                   | ✅                                                     | N/A                               |
-| Can block until synchronized                                                                                                                   | ✅                     | ✅                        | ✅                 | ⭕                         | ⭕                     | ✅                        | ✅                   | ⭕                                                     | N/A                               |
-| Default refresh interval                                                                                                                       | 10s                    | 15s                       | 15s                | 15s                        | 15s                    | 30s                       | 30s                  | 15s                                                    | 5s                                |
-| Default metrics interval                                                                                                                       | 60s                    | 60s                       | 60s                | 60s                        | 60s                    | 60s                       | 30s                  | 15s                                                    | 30s                               |
-| Context provider                                                                                                                               | ✅                     | N/A                       | N/A                | N/A                        | N/A                    | ✅                        | ✅                   | N/A                                                    | N/A                               |
-| Global fallback function                                                                                                                       | ✅                     | ✅                        | ✅                 | ✅                         | ❌                     | ❌                        | ❌                   | ❌                                                     | N/A                               |
-| Toggle Query: `namePrefix`                                                                                                                     | ✅                     | ✅                        | ❌                 | ❌                         | ❌                     | ❌                        | ❌                   | ❌                                                     | ✅                                |
-| Toggle Query: `tags`                                                                                                                           | ✅                     | ✅                        | ❌                 | ❌                         | ❌                     | ❌                        | ❌                   | ❌                                                     | ✅                                |
-| Toggle Query: `project_name`                                                                                                                   | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | N/A                  | ⭕                                                     | ✅                                |
-| **Category: Custom Headers**                                                                                                                   |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| static                                                                                                                                         | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | N/A                               |
-| function                                                                                                                                       | ✅                     | ✅                        | ⭕                 | ✅                         | ⭕                     | ✅                        | ✅                   | ⭕                                                     | N/A                               |
-| **Category: Built-in strategies**                                                                                                              |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| [Standard](../user_guide/activation_strategy#standard)                                                                                         | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| [Gradual rollout](../user_guide/activation_strategy#gradual-rollout)                                                                           | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| [Gradual rollout: custom stickiness](../user_guide/activation_strategy#customize-stickiness-beta)                                              | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | ✅                                |
-| [UserID](../user_guide/activation_strategy#userids)                                                                                            | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| [IP](../user_guide/activation_strategy#ips)                                                                                                    | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| [IP](../user_guide/activation_strategy#ips): CIDR syntax                                                                                       | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ⭕                        | ⭕                   | ✅                                                     | ✅                                |
-| [Hostname](../user_guide/activation_strategy#hostnames)                                                                                        | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| **Category: [Custom strategies](../advanced/custom_activation_strategy)**                                                                      |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Basic support                                                                                                                                  | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| <span id="strategy-constraints">**Category: [Strategy constraints](../advanced/strategy_constraints)**</span>                                  |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Basic support (`IN`, `NOT_IN` operators)                                                                                                       | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| <span id="strategy-constraints-advanced-support">Advanced support (Semver, date, numeric and extended string operators)</span> (introduced in) | ✅ (5.1)               | ✅ (3.12)                 | ✅ (3.3)           | ✅ (5.1)                   | ✅ (4.2)               | ✅ (2.1)                  | ✅ (1.3.1)           | ⭕                                                     | ✅ (0.8)                          |
-| **Category: [Unleash Context](../user_guide/unleash_context)**                                                                                 |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Static fields (`environment`, `appName`)                                                                                                       | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Defined fields                                                                                                                                 | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Custom properties                                                                                                                              | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| **Category: [`isEnabled`](../client-specification#implementation-of-isenabled)**                                                               |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Can take context                                                                                                                               | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Override fallback value                                                                                                                        | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Fallback function                                                                                                                              | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ⭕                        | ⭕                   | ⭕                                                     | ✅                                |
-| **Category: [Variants](../advanced/toggle_variants)**                                                                                          |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Basic support                                                                                                                                  | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Custom fallback variant                                                                                                                        | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | ✅                                |
-| Custom weight                                                                                                                                  | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | ✅                                |
-| [Custom stickiness (beta)](../advanced/stickiness#custom-stickiness-beta)                                                                      | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | ✅                                |
-| **Category: Local backup**                                                                                                                     |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| File based backup                                                                                                                              | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ⭕                                                     | ✅                                |
-| **Category: Usage metrics**                                                                                                                    |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Can disable metrics                                                                                                                            | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Client registration                                                                                                                            | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| Basic usage metrics (yes/no)                                                                                                                   | ✅                     | ✅                        | ✅                 | ✅                         | ✅                     | ✅                        | ✅                   | ✅                                                     | ✅                                |
-| [Impression data](../advanced/impression-data.md)                                                                                              | ⭕                     | ⭕                        | ⭕                 | ⭕                         | ⭕                     | ⭕                        | ⭕                   | ⭕                                                     | N/A                               |
-| **Category: Bootstrap (beta)**                                                                                                                 |                        |                           |                    |                            |                        |                           |                      |                                                        |                                   |
-| Bootstrap from file                                                                                                                            | ✅                     | ✅                        | ✅                 | ⭕                         | ✅                     | ⭕                        | ✅                   | ⭕                                                     | ✅                                |
-| Custom Bootstrap implementation                                                                                                                | ✅                     | ✅                        | ✅                 | ⭕                         | ✅                     | ⭕                        | ✅                   | ⭕                                                     | ✅                                |
+| Capability | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.NET](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Rust](https://github.com/unleash/unleash-client-rust) | [Unleash Proxy](unleash-proxy.md) |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| **Category: Initialization** |  |  |  |  |  |  |  |  |  |
+| Async initialization | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A |
+| Can block until synchronized | ✅ | ✅ | ✅ | ⭕ | ⭕ | ✅ | ✅ | ⭕ | N/A |
+| Default refresh interval | 10s | 15s | 15s | 15s | 15s | 30s | 30s | 15s | 5s |
+| Default metrics interval | 60s | 60s | 60s | 60s | 60s | 60s | 30s | 15s | 30s |
+| Context provider | ✅ | N/A | N/A | N/A | N/A | ✅ | ✅ | N/A | N/A |
+| Global fallback function | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A |
+| Toggle Query: `namePrefix` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Toggle Query: `tags` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Toggle Query: `project_name` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ⭕ | ✅ |
+| **Category: Custom Headers** |  |  |  |  |  |  |  |  |  |
+| static | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | N/A |
+| function | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅ | ✅ | ⭕ | N/A |
+| **Category: Built-in strategies** |  |  |  |  |  |  |  |  |  |
+| [Standard](../user_guide/activation_strategy#standard) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Gradual rollout](../user_guide/activation_strategy#gradual-rollout) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Gradual rollout: custom stickiness](../user_guide/activation_strategy#customize-stickiness-beta) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
+| [UserID](../user_guide/activation_strategy#userids) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [IP](../user_guide/activation_strategy#ips) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [IP](../user_guide/activation_strategy#ips): CIDR syntax | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ✅ | ✅ |
+| [Hostname](../user_guide/activation_strategy#hostnames) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Category: [Custom strategies](../advanced/custom_activation_strategy)** |  |  |  |  |  |  |  |  |  |
+| Basic support | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| <span id="strategy-constraints">**Category: [Strategy constraints](../advanced/strategy_constraints)**</span> |  |  |  |  |  |  |  |  |  |
+| Basic support (`IN`, `NOT_IN` operators) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| <span id="strategy-constraints-advanced-support">Advanced support (Semver, date, numeric and extended string operators)</span> (introduced in) | ✅ (5.1) | ✅ (3.12) | ✅ (3.3) | ✅ (5.1) | ✅ (4.2) | ✅ (2.1) | ✅ (1.3.1) | ⭕ | ✅ (0.8) |
+| **Category: [Unleash Context](../user_guide/unleash_context)** |  |  |  |  |  |  |  |  |  |
+| Static fields (`environment`, `appName`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Defined fields | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Custom properties | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Category: [`isEnabled`](../client-specification#implementation-of-isenabled)** |  |  |  |  |  |  |  |  |  |
+| Can take context | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Override fallback value | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fallback function | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ⭕ | ✅ |
+| **Category: [Variants](../advanced/toggle_variants)** |  |  |  |  |  |  |  |  |  |
+| Basic support | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Custom fallback variant | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
+| Custom weight | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
+| [Custom stickiness (beta)](../advanced/stickiness#custom-stickiness-beta) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
+| **Category: Local backup** |  |  |  |  |  |  |  |  |  |
+| File based backup | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
+| **Category: Usage metrics** |  |  |  |  |  |  |  |  |  |
+| Can disable metrics | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Client registration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Basic usage metrics (yes/no) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [Impression data](../advanced/impression-data.md) | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | N/A |
+| **Category: Bootstrap (beta)** |  |  |  |  |  |  |  |  |  |
+| Bootstrap from file | ✅ | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅ | ⭕ | ✅ |
+| Custom Bootstrap implementation | ✅ | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅ | ⭕ | ✅ |
 
 ## Community SDKs ❤️ {#community-sdks}
 
@@ -117,6 +113,8 @@ Here's some of the fantastic work our community has done to make Unleash work in
 - [silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin) (Kotlin)
 - [Stogon/unleash-bundle](https://git.stogon.io/Stogon/unleash-bundle/) (PHP - Symfony)
 - [uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash) (Dart)
+- [nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid) (Solid)
+- [nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native) (React Native / Expo)
 - _...your implementation for your favorite language._
 
 ### Implement your own SDK {#implement-your-own-sdk}
@@ -132,13 +130,14 @@ Once they have been initialised, all Unleash clients will continue to work perfe
 
 Because the SDKs and the Unleash Proxy cache their feature toggle states locally and only communicate with the Unleash server (in the case of the server-side SDKs and the Proxy) or the Proxy (in the case of front-end SDKs) at predetermined intervals, a broken connection only means that they won't get any new updates.
 
-Unless the SDK supports [bootstrapping](#bootstrapping) it *will* need to connect to Unleash at startup to get its initial feature toggle data set. If the SDK doesn't have a feature toggle data set available, all toggles will fall back to evaluating as disabled or as the specified default value (in SDKs that support that).
+Unless the SDK supports [bootstrapping](#bootstrapping) it _will_ need to connect to Unleash at startup to get its initial feature toggle data set. If the SDK doesn't have a feature toggle data set available, all toggles will fall back to evaluating as disabled or as the specified default value (in SDKs that support that).
 
 ### Bootstrapping
 
-By default, all SDKs reach out to the Unleash Server at startup to fetch their toggle configuration. Additionally some of the server-side SDKs and the Proxy (see the above [compatibility table](#server-side-sdk-compatibility-table)) also support *bootstrapping*, which allows them to get their toggle configuration from a file, the environment, or other local resources. These SDKs can work without any network connection whatsoever.
+By default, all SDKs reach out to the Unleash Server at startup to fetch their toggle configuration. Additionally some of the server-side SDKs and the Proxy (see the above [compatibility table](#server-side-sdk-compatibility-table)) also support _bootstrapping_, which allows them to get their toggle configuration from a file, the environment, or other local resources. These SDKs can work without any network connection whatsoever.
 
 Bootstrapping is also supported by the following front-end client SDKs:
+
 - [Android SDK](/sdks/android_proxy_sdk)
 - [Javascript SDK](/sdks/proxy-javascript)
 - [React Proxy SDK](/sdks/proxy-react)

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -45,7 +45,7 @@ The below table shows what features the various server-side SDKs support. Note t
 - ❌: Not implemented, not planned
 - **N/A**: Not applicable to this SDK
 
-:::note If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it. :::
+:::note If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.. :::
 
 | Capability | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.NET](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Rust](https://github.com/unleash/unleash-client-rust) | [Unleash Proxy](unleash-proxy.md) |
 | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -31,6 +31,8 @@ For security and performance reasons, the front-end SDKs do not communicate dire
 - [iOS Proxy SDK](/sdks/proxy-ios)
 - [Javascript SDK](/sdks/proxy-javascript)
 - [React Proxy SDK](/sdks/proxy-react)
+- [Svelte Proxy SDK](/sdks/proxy-svelte)
+- [Vue Proxy SDK](/sdks/proxy-vue)
 
 
 ### Server-side SDK compatibility table
@@ -137,6 +139,8 @@ Unless the SDK supports [bootstrapping](#bootstrapping) it *will* need to connec
 By default, all SDKs reach out to the Unleash Server at startup to fetch their toggle configuration. Additionally some of the server-side SDKs and the Proxy (see the above [compatibility table](#server-side-sdk-compatibility-table)) also support *bootstrapping*, which allows them to get their toggle configuration from a file, the environment, or other local resources. These SDKs can work without any network connection whatsoever.
 
 Bootstrapping is also supported by the following front-end client SDKs:
-- [the JavaScript proxy client](/sdks/proxy-javascript)
-- [the React Proxy client](/sdks/proxy-react)
-- [the Android proxy client](/sdks/android_proxy_sdk)
+- [Android SDK](/sdks/android_proxy_sdk)
+- [Javascript SDK](/sdks/proxy-javascript)
+- [React Proxy SDK](/sdks/proxy-react)
+- [Svelte Proxy SDK](/sdks/proxy-svelte)
+- [Vue Proxy SDK](/sdks/proxy-vue)

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -45,7 +45,11 @@ The below table shows what features the various server-side SDKs support. Note t
 - ❌: Not implemented, not planned
 - **N/A**: Not applicable to this SDK
 
-:::note If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.. :::
+:::note
+
+If you see an item marked with a ❌ that you would find useful, feel free to reach out to us ([on Slack](https://slack.unleash.run/), for instance) with your use case. It may not be something we can prioritize right now, but if you'd like to contribute it back to the community, we'd love to help you build it.
+
+:::
 
 | Capability | [Java](/sdks/java_sdk) | [Node.js](/sdks/node_sdk) | [Go](/sdks/go_sdk) | [Python](/sdks/python_sdk) | [Ruby](/sdks/ruby_sdk) | [.NET](/sdks/dot_net_sdk) | [PHP](/sdks/php_sdk) | [Rust](https://github.com/unleash/unleash-client-rust) | [Unleash Proxy](unleash-proxy.md) |
 | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
@@ -103,18 +107,18 @@ The below table shows what features the various server-side SDKs support. Note t
 
 Here's some of the fantastic work our community has done to make Unleash work in even more contexts. If you still can't find your favorite language, let us know and we'd love to help you create the client for it!
 
-- [afontaine/unleash_ex](https://gitlab.com/afontaine/unleash_ex) (Elixir)
-- [AppsFlyer/clojure-unleash](https://github.com/AppsFlyer/unleash-client-clojure) (Clojure)
-- [aruizs/unleash-client-cpp](https://github.com/aruizs/unleash-client-cpp) (C++)
-- [mikefrancis/laravel-unleash](https://github.com/mikefrancis/laravel-unleash) (Laravel - PHP)
-- [minds/unleash-client-php](https://gitlab.com/minds/unleash-client-php) (PHP)
-- [ngx-unleash-proxy-client](https://github.com/snowfrogdev/snowfrogdev/tree/main/packages/ngx-unleash-proxy-client) (Angular - TypeScript)
-- [nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native) (React Native / Expo)
-- [nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid) (Solid)
-- [pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash) (NestJS - Node.js)
-- [silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin) (Kotlin)
-- [Stogon/unleash-bundle](https://git.stogon.io/Stogon/unleash-bundle/) (PHP - Symfony)
-- [uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash) (Dart)
+- Angular - TypeScript ([ngx-unleash-proxy-client](https://github.com/snowfrogdev/snowfrogdev/tree/main/packages/ngx-unleash-proxy-client))
+- Clojure ([AppsFlyer/clojure-unleash](https://github.com/AppsFlyer/unleash-client-clojure))
+- C++ ([aruizs/unleash-client-cpp](https://github.com/aruizs/unleash-client-cpp))
+- Dart ([uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash))
+- Elixir ([afontaine/unleash_ex](https://gitlab.com/afontaine/unleash_ex))
+- Kotlin ([silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin))
+- Laravel - PHP ([mikefrancis/laravel-unleash](https://github.com/mikefrancis/laravel-unleash))
+- NestJS - Node.js ([pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash))
+- PHP ([minds/unleash-client-php](https://gitlab.com/minds/unleash-client-php))
+- PHP - Symfony ([Stogon/unleash-bundle](https://git.stogon.io/Stogon/unleash-bundle/))
+- React Native / Expo ([nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native))
+- Solid ([nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid))
 - _...your implementation for your favorite language._
 
 ### Implement your own SDK {#implement-your-own-sdk}

--- a/website/docs/sdks/proxy-react.md
+++ b/website/docs/sdks/proxy-react.md
@@ -1,12 +1,11 @@
 ---
 id: proxy-react
-title: React proxy SDK
+title: React Proxy SDK
 ---
 
 This library is meant to be used with the [unleash-proxy](https://github.com/Unleash/unleash-proxy). The proxy application layer will sit between your unleash instance and your client applications, and provides performance and security benefits. DO NOT TRY to connect this library directly to the unleash instance, as the datasets follow different formats because the proxy only returns evaluated toggle information.
 
-For more detailed information, check out [the React Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-react).
-
+For more detailed information, check out the [React Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-react).
 
 ## Installation
 
@@ -21,12 +20,14 @@ npm install @unleash/proxy-client-react unleash-proxy-client
 The snippet below shows you how to initialize the client. We recommend that you do this in your entry point file (typically index.js/ts) to ensure that you only have _one_ instance of it.
 
 The configuration variables are:
+
 - **`url`**
 
-    Your proxy's URL.
+  Your proxy's URL.
+
 - **`clientKey`**
 
-    One of your proxy's [designated client keys (also known as proxy secrets)](unleash-proxy#configuration-variables).
+  One of your proxy's [designated client keys (also known as proxy secrets)](unleash-proxy#configuration-variables).
 
 - **`refreshInterval`**
 
@@ -39,7 +40,6 @@ The configuration variables are:
 - **`environment`**
 
   The environment that your application runs in. This corresponds to the environment field in [the Unleash Context](../user_guide/unleash-context.md). Note that this is separate from the newer [Environments feature](../user_guide/environments.md).
-
 
 ```jsx
 import { FlagProvider } from '@unleash/proxy-client-react';
@@ -58,7 +58,7 @@ ReactDOM.render(
       <App />
     </FlagProvider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
 ```
 
@@ -73,9 +73,9 @@ const TestComponent = () => {
   const enabled = useFlag('travel.landing');
 
   if (enabled) {
-    return <SomeComponent />
+    return <SomeComponent />;
   }
-  return <AnotherComponent />
+  return <AnotherComponent />;
 };
 
 export default TestComponent;
@@ -89,12 +89,12 @@ import { useVariant } from '@unleash/proxy-client-react';
 const TestComponent = () => {
   const variant = useVariant('travel.landing');
 
-  if (variant.enabled && variant.name === "SomeComponent") {
-    return <SomeComponent />
-  } else if (variant.enabled && variant.name === "AnotherComponent") {
-    return <AnotherComponent />
+  if (variant.enabled && variant.name === 'SomeComponent') {
+    return <SomeComponent />;
+  } else if (variant.enabled && variant.name === 'AnotherComponent') {
+    return <AnotherComponent />;
   }
-  return <DefaultComponent />
+  return <DefaultComponent />;
 };
 
 export default TestComponent;
@@ -105,16 +105,15 @@ export default TestComponent;
 Follow the following steps in order to update the unleash context:
 
 ```jsx
-import { useUnleashContext, useFlag } from '@unleash/proxy-client-react'
+import { useUnleashContext, useFlag } from '@unleash/proxy-client-react';
 
 const MyComponent = ({ userId }) => {
-  const variant = useFlag("my-toggle");
+  const variant = useFlag('my-toggle');
   const updateContext = useUnleashContext();
 
   useEffect(() => {
     // context is updated with userId
-    updateContext({ userId })
-  }, [])
-}
-
+    updateContext({ userId });
+  }, []);
+};
 ```

--- a/website/docs/sdks/proxy-svelte.md
+++ b/website/docs/sdks/proxy-svelte.md
@@ -115,7 +115,7 @@ To start the client, use the client's `start` method. The below snippet of pseud
 </svelte:component>
 ```
 
-# Usage
+## Usage
 
 ## Check feature toggle status
 

--- a/website/docs/sdks/proxy-svelte.md
+++ b/website/docs/sdks/proxy-svelte.md
@@ -22,55 +22,55 @@ npm install @unleash/proxy-client-svelte
 
 Import the provider like this in your entrypoint file (typically index.svelte):
 
-```html
+```jsx
 <script lang="ts">
-  let FlagProvider;
+	let FlagProvider;
 
-  onMount(async () => {
-    const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-    ({ FlagProvider } = proxyClientSvelte);
-  });
+	onMount(async () => {
+		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
+		({ FlagProvider } = proxyClientSvelte);
+	});
 
-  const config = {
-    url: 'https://HOSTNAME/proxy',
-    clientKey: 'PROXYKEY',
-    refreshInterval: 15,
-    appName: 'your-app-name',
-    environment: 'dev',
-  };
+	const config = {
+		url: 'https://HOSTNAME/proxy',
+		clientKey: 'PROXYKEY',
+		refreshInterval: 15,
+		appName: 'your-app-name',
+		environment: 'dev'
+	};
 </script>
 
-<svelte:component this="{FlagProvider}" {config}>
-  <App />
+<svelte:component this={FlagProvider} {config}>
+	<App />
 </svelte:component>
 ```
 
 Alternatively, you can pass your own client in to the FlagProvider:
 
-```html
+```jsx
 <script lang="ts">
-  import { UnleashClient } from '@unleash/proxy-client-svelte';
+	import { UnleashClient } from '@unleash/proxy-client-svelte';
 
-  let FlagProvider;
+	let FlagProvider;
 
-  onMount(async () => {
-    const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-    ({ FlagProvider } = proxyClientSvelte);
-  });
+	onMount(async () => {
+		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
+		({ FlagProvider } = proxyClientSvelte);
+	});
 
-  const config = {
-    url: 'https://HOSTNAME/proxy',
-    clientKey: 'PROXYKEY',
-    refreshInterval: 15,
-    appName: 'your-app-name',
-    environment: 'dev',
-  };
+	const config = {
+		url: 'https://HOSTNAME/proxy',
+		clientKey: 'PROXYKEY',
+		refreshInterval: 15,
+		appName: 'your-app-name',
+		environment: 'dev'
+	};
 
-  const client = new UnleashClient(config);
+	const client = new UnleashClient(config);
 </script>
 
-<svelte:component this="{FlagProvider}" unleashClient="{client}">
-  <App />
+<svelte:component this={FlagProvider} unleashClient={client}>
+	<App />
 </svelte:component>
 ```
 
@@ -81,11 +81,11 @@ By default, the Unleash client will start polling the Proxy for toggles immediat
 - setting the `startClient` prop to `false`
 - passing a client instance to the `FlagProvider`
 
-```html
+```jsx
 <svelte:component
-  this="{FlagProvider}"
-  unleashClient="{client}"
-  startClient="{false}"
+  this={FlagProvider}
+  unleashClient={client}
+  startClient={false}
 >
   <App />
 </svelte:component>
@@ -95,41 +95,37 @@ Deferring the client start gives you more fine-grained control over when to star
 
 To start the client, use the client's `start` method. The below snippet of pseudocode will defer polling until the end of the `asyncProcess` function.
 
-```html
+```jsx
 <script lang="ts">
-  const client = new UnleashClient({
-    /* ... */
-  });
+	const client = new UnleashClient({
+		/* ... */
+	});
 
-  onMount(() => {
-    const asyncProcess = async () => {
-      // do async work ...
-      client.start();
-    };
-    asyncProcess();
-  });
+	onMount(() => {
+		const asyncProcess = async () => {
+			// do async work ...
+			client.start();
+		};
+		asyncProcess();
+	});
 </script>
 
-<svelte:component
-  this="{FlagProvider}"
-  unleashClient="{client}"
-  startClient="{false}"
->
-  <App />
+<svelte:component this={FlagProvider} unleashClient={client} startClient={false}>
+	<App />
 </svelte:component>
 ```
 
-## Usage
+# Usage
 
 ## Check feature toggle status
 
 To check if a feature is enabled:
 
-```html
+```jsx
 <script lang="ts">
-  import { useFlag } from '@unleash/proxy-client-svelte';
+	import { useFlag } from '@unleash/proxy-client-svelte';
 
-  const enabled = useFlag('travel.landing');
+	const enabled = useFlag('travel.landing');
 </script>
 
 {#if $enabled}
@@ -143,11 +139,11 @@ To check if a feature is enabled:
 
 To check variants:
 
-```html
+```jsx
 <script lang="ts">
-  import { useVariant } from '@unleash/proxy-client-svelte';
+	import { useVariant } from '@unleash/proxy-client-svelte';
 
-  const variant = useVariant('travel.landing');
+	const variant = useVariant('travel.landing');
 </script>
 
 {#if $variant.enabled && $variant.name === 'SomeComponent'}
@@ -163,16 +159,16 @@ To check variants:
 
 useFlagsStatus retrieves the ready state and error events. Follow the following steps in order to delay rendering until the flags have been fetched.
 
-```html
+```jsx
 <script lang="ts">
-  import { useFlagsStatus } from '@unleash/proxy-client-svelte';
-  const { flagsReady, flagsError } = useFlagsStatus();
+	import { useFlagsStatus } from '@unleash/proxy-client-svelte';
+	const { flagsReady, flagsError } = useFlagsStatus();
 </script>
 
 {#if !$flagsReady}
 <Loading />
 {:else}
-<MyComponent error="{flagsError}" />
+<MyComponent error={flagsError} />
 {/if}
 ```
 
@@ -180,24 +176,24 @@ useFlagsStatus retrieves the ready state and error events. Follow the following 
 
 Follow the following steps in order to update the unleash context:
 
-```html
+```jsx
 <script lang="ts">
-  import { useUnleashContext, useFlag } from '@unleash/proxy-client-svelte';
+	import { useUnleashContext, useFlag } from '@unleash/proxy-client-svelte';
 
-  export let userId: string = undefined;
+	export let userId: string = undefined;
 
-  const updateContext = useUnleashContext();
+	const updateContext = useUnleashContext();
 
-  onMount(() => {
-    updateContext({ userId });
-  });
+	onMount(() => {
+		updateContext({ userId });
+	});
 
-  $: {
-    async function run() {
-      await updateContext({ userId });
-      console.log('new flags loaded for', userId);
-    }
-    run();
-  }
+	$: {
+		async function run() {
+			await updateContext({ userId });
+			console.log('new flags loaded for', userId);
+		}
+		run();
+	}
 </script>
 ```

--- a/website/docs/sdks/proxy-svelte.md
+++ b/website/docs/sdks/proxy-svelte.md
@@ -117,7 +117,7 @@ To start the client, use the client's `start` method. The below snippet of pseud
 
 ## Usage
 
-## Check feature toggle status
+### Check feature toggle status
 
 To check if a feature is enabled:
 
@@ -135,7 +135,7 @@ To check if a feature is enabled:
 {/if}
 ```
 
-## Check variants
+### Check variants
 
 To check variants:
 
@@ -155,7 +155,7 @@ To check variants:
 {/if}
 ```
 
-## Defer rendering until flags fetched
+### Defer rendering until flags fetched
 
 useFlagsStatus retrieves the ready state and error events. Follow the following steps in order to delay rendering until the flags have been fetched.
 
@@ -172,7 +172,7 @@ useFlagsStatus retrieves the ready state and error events. Follow the following 
 {/if}
 ```
 
-## Updating context
+### Updating context
 
 Follow the following steps in order to update the unleash context:
 

--- a/website/docs/sdks/proxy-svelte.md
+++ b/website/docs/sdks/proxy-svelte.md
@@ -1,16 +1,16 @@
 ---
 id: proxy-svelte
-title: Svelte proxy SDK
+title: Svelte Proxy SDK
 ---
 
 <div class="alert alert--info" role="alert">
-  <em>Svelte proxy SDK is currently at version 0.0.2 and is experimental</em>.
+  <em>Svelte Proxy SDK is currently at version 0.0.2 and is experimental</em>.
 </div>
 <br/>
 
 This library is meant to be used with the [unleash-proxy](https://github.com/Unleash/unleash-proxy). The proxy application layer will sit between your unleash instance and your client applications, and provides performance and security benefits. DO NOT TRY to connect this library directly to the unleash instance, as the datasets follow different formats because the proxy only returns evaluated toggle information.
 
-For more detailed information, check out [the svelte Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-svelte).
+For more detailed information, check out the [Svelte Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-svelte).
 
 ## Installation
 
@@ -24,24 +24,24 @@ Import the provider like this in your entrypoint file (typically index.svelte):
 
 ```html
 <script lang="ts">
-	let FlagProvider;
+  let FlagProvider;
 
-	onMount(async () => {
-		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-		({ FlagProvider } = proxyClientSvelte);
-	});
+  onMount(async () => {
+    const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
+    ({ FlagProvider } = proxyClientSvelte);
+  });
 
-	const config = {
-		url: 'https://HOSTNAME/proxy',
-		clientKey: 'PROXYKEY',
-		refreshInterval: 15,
-		appName: 'your-app-name',
-		environment: 'dev'
-	};
+  const config = {
+    url: 'https://HOSTNAME/proxy',
+    clientKey: 'PROXYKEY',
+    refreshInterval: 15,
+    appName: 'your-app-name',
+    environment: 'dev',
+  };
 </script>
 
-<svelte:component this={FlagProvider} {config}>
-	<App />
+<svelte:component this="{FlagProvider}" {config}>
+  <App />
 </svelte:component>
 ```
 
@@ -49,28 +49,28 @@ Alternatively, you can pass your own client in to the FlagProvider:
 
 ```html
 <script lang="ts">
-	import { UnleashClient } from '@unleash/proxy-client-svelte';
+  import { UnleashClient } from '@unleash/proxy-client-svelte';
 
-	let FlagProvider;
+  let FlagProvider;
 
-	onMount(async () => {
-		const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
-		({ FlagProvider } = proxyClientSvelte);
-	});
+  onMount(async () => {
+    const proxyClientSvelte = await import('@unleash/proxy-client-svelte');
+    ({ FlagProvider } = proxyClientSvelte);
+  });
 
-	const config = {
-		url: 'https://HOSTNAME/proxy',
-		clientKey: 'PROXYKEY',
-		refreshInterval: 15,
-		appName: 'your-app-name',
-		environment: 'dev'
-	};
+  const config = {
+    url: 'https://HOSTNAME/proxy',
+    clientKey: 'PROXYKEY',
+    refreshInterval: 15,
+    appName: 'your-app-name',
+    environment: 'dev',
+  };
 
-	const client = new UnleashClient(config);
+  const client = new UnleashClient(config);
 </script>
 
-<svelte:component this={FlagProvider} unleashClient={client}>
-	<App />
+<svelte:component this="{FlagProvider}" unleashClient="{client}">
+  <App />
 </svelte:component>
 ```
 
@@ -82,8 +82,12 @@ By default, the Unleash client will start polling the Proxy for toggles immediat
 - passing a client instance to the `FlagProvider`
 
 ```html
-<svelte:component this={FlagProvider} unleashClient={client} startClient={false}>
-	<App />
+<svelte:component
+  this="{FlagProvider}"
+  unleashClient="{client}"
+  startClient="{false}"
+>
+  <App />
 </svelte:component>
 ```
 
@@ -93,21 +97,25 @@ To start the client, use the client's `start` method. The below snippet of pseud
 
 ```html
 <script lang="ts">
-	const client = new UnleashClient({
-		/* ... */
-	});
+  const client = new UnleashClient({
+    /* ... */
+  });
 
-	onMount(() => {
-		const asyncProcess = async () => {
-			// do async work ...
-			client.start();
-		};
-		asyncProcess();
-	});
+  onMount(() => {
+    const asyncProcess = async () => {
+      // do async work ...
+      client.start();
+    };
+    asyncProcess();
+  });
 </script>
 
-<svelte:component this={FlagProvider} unleashClient={client} startClient={false}>
-	<App />
+<svelte:component
+  this="{FlagProvider}"
+  unleashClient="{client}"
+  startClient="{false}"
+>
+  <App />
 </svelte:component>
 ```
 
@@ -119,9 +127,9 @@ To check if a feature is enabled:
 
 ```html
 <script lang="ts">
-	import { useFlag } from '@unleash/proxy-client-svelte';
+  import { useFlag } from '@unleash/proxy-client-svelte';
 
-	const enabled = useFlag('travel.landing');
+  const enabled = useFlag('travel.landing');
 </script>
 
 {#if $enabled}
@@ -137,9 +145,9 @@ To check variants:
 
 ```html
 <script lang="ts">
-	import { useVariant } from '@unleash/proxy-client-svelte';
+  import { useVariant } from '@unleash/proxy-client-svelte';
 
-	const variant = useVariant('travel.landing');
+  const variant = useVariant('travel.landing');
 </script>
 
 {#if $variant.enabled && $variant.name === 'SomeComponent'}
@@ -153,19 +161,18 @@ To check variants:
 
 ## Defer rendering until flags fetched
 
-useFlagsStatus retrieves the ready state and error events.
-Follow the following steps in order to delay rendering until the flags have been fetched.
+useFlagsStatus retrieves the ready state and error events. Follow the following steps in order to delay rendering until the flags have been fetched.
 
 ```html
 <script lang="ts">
-	import { useFlagsStatus } from '@unleash/proxy-client-svelte';
-	const { flagsReady, flagsError } = useFlagsStatus();
+  import { useFlagsStatus } from '@unleash/proxy-client-svelte';
+  const { flagsReady, flagsError } = useFlagsStatus();
 </script>
 
 {#if !$flagsReady}
 <Loading />
 {:else}
-<MyComponent error={flagsError} />
+<MyComponent error="{flagsError}" />
 {/if}
 ```
 
@@ -175,22 +182,22 @@ Follow the following steps in order to update the unleash context:
 
 ```html
 <script lang="ts">
-	import { useUnleashContext, useFlag } from '@unleash/proxy-client-svelte';
+  import { useUnleashContext, useFlag } from '@unleash/proxy-client-svelte';
 
-	export let userId: string = undefined;
+  export let userId: string = undefined;
 
-	const updateContext = useUnleashContext();
+  const updateContext = useUnleashContext();
 
-	onMount(() => {
-		updateContext({ userId });
-	});
+  onMount(() => {
+    updateContext({ userId });
+  });
 
-	$: {
-		async function run() {
-			await updateContext({ userId });
-			console.log('new flags loaded for', userId);
-		}
-		run();
-	}
+  $: {
+    async function run() {
+      await updateContext({ userId });
+      console.log('new flags loaded for', userId);
+    }
+    run();
+  }
 </script>
 ```

--- a/website/docs/sdks/proxy-vue.md
+++ b/website/docs/sdks/proxy-vue.md
@@ -101,9 +101,9 @@ onMounted(() => {
 </template>
 ```
 
-# Usage
+## Usage
 
-## Check feature toggle status
+### Check feature toggle status
 
 To check if a feature is enabled:
 
@@ -120,7 +120,7 @@ const enabled = useFlag('travel.landing')
 </template>
 ```
 
-## Check variants
+### Check variants
 
 To check variants:
 
@@ -138,7 +138,7 @@ const variant = useVariant('travel.landing')
 </template>
 ```
 
-## Defer rendering until flags fetched
+### Defer rendering until flags fetched
 
 useFlagsStatus retrieves the ready state and error events. Follow the following steps in order to delay rendering until the flags have been fetched.
 
@@ -151,7 +151,7 @@ const { flagsReady, flagsError } = useFlagsStatus()
 <MyComponent v-else error={flagsError} />
 ```
 
-## Updating context
+### Updating context
 
 Follow the following steps in order to update the unleash context:
 

--- a/website/docs/sdks/proxy-vue.md
+++ b/website/docs/sdks/proxy-vue.md
@@ -1,16 +1,16 @@
 ---
 id: proxy-vue
-title: Vue proxy SDK
+title: Vue Proxy SDK
 ---
 
 <div class="alert alert--info" role="alert">
-  <em>Vue proxy SDK is currently at version 0.0.1 and is experimental</em>.
+  <em>Vue Proxy SDK is currently at version 0.0.1 and is experimental</em>.
 </div>
 <br/>
 
 This library is meant to be used with the [unleash-proxy](https://github.com/Unleash/unleash-proxy). The proxy application layer will sit between your unleash instance and your client applications, and provides performance and security benefits. DO NOT TRY to connect this library directly to the unleash instance, as the datasets follow different formats because the proxy only returns evaluated toggle information.
 
-For more detailed information, check out [the vue Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-vue).
+For more detailed information, check out the [Vue Proxy SDK on GitHub](https://github.com/Unleash/proxy-client-vue).
 
 ## Installation
 
@@ -140,8 +140,7 @@ const variant = useVariant('travel.landing')
 
 ## Defer rendering until flags fetched
 
-useFlagsStatus retrieves the ready state and error events.
-Follow the following steps in order to delay rendering until the flags have been fetched.
+useFlagsStatus retrieves the ready state and error events. Follow the following steps in order to delay rendering until the flags have been fetched.
 
 ```jsx
 import { useFlagsStatus } from '@unleash/proxy-client-vue'

--- a/website/docs/sdks/unleash-proxy.md
+++ b/website/docs/sdks/unleash-proxy.md
@@ -266,9 +266,11 @@ The Unleash Proxy takes the heavy lifting of evaluating toggles and only returns
 
 However in some settings you would like a bit more logic around it to make it as fast as possible, and keep up to date with changes.
 
-- [JavaScript Proxy SDK](/sdks/proxy-javascript)
-- [React Proxy SDK](/sdks/proxy-react)
-- [Android Proxy SDK](/sdks/android_proxy_sdk)
-- [iOS Proxy SDK](/sdks/proxy-ios)
+- [Android Proxy SDK](sdks/android-proxy.md)
+- [iOS Proxy SDK](sdks/proxy-ios.md)
+- [Javascript Proxy SDK](sdks/proxy-javascript.md)
+- [React Proxy SDK](sdks/proxy-react.md)
+- [Svelte Proxy SDK](sdks/proxy-svelte.md)
+- [Vue Proxy SDK](sdks/proxy-vue.md)
 
 The proxy is also ideal fit for serverless functions such as AWS Lambda. In that scenario the proxy can run on a small container near the serverless function, preferably in the same VPC, giving the lambda extremely fast access to feature flags, at a predictable cost.

--- a/website/docs/user_guide/quickstart.md
+++ b/website/docs/user_guide/quickstart.md
@@ -30,12 +30,14 @@ Secret key: proxy-123
 
 Now you can open your application code and connect through one of the proxy SDKs:
 
-- [Javascript Proxy SDK](sdks/proxy-javascript.md)
-- [iOS Proxy SDK](sdks/proxy-ios.md)
 - [Android Proxy SDK](sdks/android-proxy.md)
-- [React](sdks/proxy-react.md)
+- [iOS Proxy SDK](sdks/proxy-ios.md)
+- [Javascript Proxy SDK](sdks/proxy-javascript.md)
+- [React Proxy SDK](sdks/proxy-react.md)
+- [Svelte Proxy SDK](sdks/proxy-svelte.md)
+- [Vue Proxy SDK](sdks/proxy-vue.md)
 
-Here is a connection example using the javascript proxy SDK:
+Here is a connection example using the JavaScript Proxy SDK:
 
 ```javascript
 import { UnleashClient } from 'unleash-proxy-client';


### PR DESCRIPTION
Also re-ordered them and made them more consistent on the `bootstrapping` section.