### PR TITLE
Docs: add segments explainer video + fix formatting

### DIFF
--- a/website/docs/reference/segments.mdx
+++ b/website/docs/reference/segments.mdx
@@ -2,35 +2,41 @@
 title: Segments
 ---
 
+import VideoContent from '@site/src/components/VideoContent.jsx'
+
 :::info Availability
 
 Segments are available to Unleash Pro and Unleash Enterprise users since **Unleash 4.13**.
 
 :::
 
-A **segment** is a reusable collection of [strategy constraints](../advanced/strategy-constraints.md).
-Like with strategy constraints, you apply segments to [feature toggle activation strategies](../user_guide/activation-strategies.md).
+<VideoContent videoUrls={["https://www.youtube.com/embed/LWMCCFcRic0"]}>
 
-You can apply the same segment to multiple activation strategies.
-If you update the segment, the changes will affect every strategy that uses that segment.
+Want a quick overview of what segments are and what they're used for? Well, then you're in luck: we've got this short segment explainer video to help you out 📽️
 
-Segments let you create user groups based on data available in the Unleash context.
-These groups can be as simple or as complex as you want to make them.
-You could, for example, use segments to target:
-- Users in a specific region
-- Users on a specific device type
-- Users who signed up before a specific point in time
-or any combination thereof.
+</VideoContent>
+
+A **segment** is a reusable collection of [strategy constraints](../advanced/strategy-constraints.md). Like with strategy constraints, you apply segments to [feature toggle activation strategies](../user_guide/activation-strategies.md).
+
+You can apply the same segment to multiple activation strategies. If you update the segment, the changes will affect every strategy that uses that segment.
+
+Segments let you create user groups based on data available in the Unleash context. These groups can be as simple or as complex as you want to make them. You could, for example, use segments to target:
+
+-   Users in a specific region
+-   Users on a specific device type
+-   Users who signed up before a specific point in time
+-   ... Or any combination of the above.
 
 Because segments stay in sync across strategies, any changes will propagate to all the activation strategies that use them. This also makes them ideal for use cases such as activating or deactivating multiple feature toggles at the same time. In other words, you can use segments to
-- release one or more new features at a specified time
-- create events with start and end times and guarantee that features will only be active during that period
+
+-   release one or more new features at a specified time
+-   create events with start and end times and guarantee that features will only be active during that period
 
 ## Structure and evaluation
 
-Segments are collections of strategy constraints. To satisfy a segment, *all* the constraints in the collection must be satisfied.
+Segments are collections of strategy constraints. To satisfy a segment, _all_ the constraints in the collection must be satisfied.
 
-If an activation strategy has a segment *and* additional constraints applied, the segment *and* the strategies must all be satisfied. Similarly, if an activation strategy has multiple segments, then they must *must all be satisfied*.
+If an activation strategy has a segment _and_ additional constraints applied, the segment _and_ the strategies must all be satisfied. Similarly, if an activation strategy has multiple segments, then they must _must all be satisfied_.
 
 ## Creating, updating, and deleting segments
 


### PR DESCRIPTION
This change adds the new segments explainer video to the Segments documentation. It also fixes some formatting that prettier was unhappy with and does some minor restructuring of the segment capability list.