### PR TITLE
fix: rename duplicate operation IDs

### DIFF
--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -84,12 +84,12 @@ export default class UserAdminController extends Controller {
         this.route({
             method: 'post',
             path: '/validate-password',
-            handler: this.validatePassword,
+            handler: this.validateUserPassword,
             permission: NONE,
             middleware: [
                 openApiService.validPath({
                     tags: ['admin'],
-                    operationId: 'validatePassword',
+                    operationId: 'validateUserPassword',
                     requestBody: createRequestSchema('passwordSchema'),
                     responses: { 200: emptyResponse },
                 }),
@@ -99,12 +99,12 @@ export default class UserAdminController extends Controller {
         this.route({
             method: 'post',
             path: '/:id/change-password',
-            handler: this.changePassword,
+            handler: this.changeUserPassword,
             permission: ADMIN,
             middleware: [
                 openApiService.validPath({
                     tags: ['admin'],
-                    operationId: 'changePassword',
+                    operationId: 'changeUserPassword',
                     requestBody: createRequestSchema('passwordSchema'),
                     responses: { 200: emptyResponse },
                 }),
@@ -114,12 +114,12 @@ export default class UserAdminController extends Controller {
         this.route({
             method: 'post',
             path: '/reset-password',
-            handler: this.resetPassword,
+            handler: this.resetUserPassword,
             permission: ADMIN,
             middleware: [
                 openApiService.validPath({
                     tags: ['admin'],
-                    operationId: 'resetPassword',
+                    operationId: 'resetUserPassword',
                     requestBody: createRequestSchema('idSchema'),
                     responses: {
                         200: createResponseSchema('resetPasswordSchema'),
@@ -216,7 +216,7 @@ export default class UserAdminController extends Controller {
         });
     }
 
-    async resetPassword(
+    async resetUserPassword(
         req: IAuthRequest<unknown, ResetPasswordSchema, IdSchema>,
         res: Response<ResetPasswordSchema>,
     ): Promise<void> {
@@ -392,7 +392,7 @@ export default class UserAdminController extends Controller {
         res.status(200).send();
     }
 
-    async validatePassword(
+    async validateUserPassword(
         req: IAuthRequest<unknown, unknown, PasswordSchema>,
         res: Response,
     ): Promise<void> {
@@ -402,7 +402,7 @@ export default class UserAdminController extends Controller {
         res.status(200).send();
     }
 
-    async changePassword(
+    async changeUserPassword(
         req: IAuthRequest<{ id: string }, unknown, PasswordSchema>,
         res: Response,
     ): Promise<void> {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -5042,7 +5042,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/api/admin/user-admin/reset-password": Object {
       "post": Object {
-        "operationId": "resetPassword",
+        "operationId": "resetUserPassword",
         "requestBody": Object {
           "content": Object {
             "application/json": Object {
@@ -5093,7 +5093,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/api/admin/user-admin/validate-password": Object {
       "post": Object {
-        "operationId": "validatePassword",
+        "operationId": "validateUserPassword",
         "requestBody": Object {
           "content": Object {
             "application/json": Object {
@@ -5207,7 +5207,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/api/admin/user-admin/{id}/change-password": Object {
       "post": Object {
-        "operationId": "changePassword",
+        "operationId": "changeUserPassword",
         "parameters": Array [
           Object {
             "in": "path",


### PR DESCRIPTION
OpenAPI's `operationId`s must be globally unique.