### PR TITLE
Removed docker folder from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
+docker
 bundle.js
 website/blog
 website/build


### PR DESCRIPTION
Docker folder was added to project couple days ago.

Intellij was giving me linting errors for `index.js` in `docker` folder. 
```

/home/jaanus/Git/unleash/docker/index.js
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.

```

I am guessing we dont need to lint it. So added it to `.eslintignore` file.

