### PR TITLE
Fix failing segment test

### DIFF
--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -309,5 +309,5 @@ test('should send all segments that are in use by feature', async () => {
         .flat()
         .filter((x) => !!x);
     const toggleSegmentIds = [...new Set(allSegmentIds)];
-    expect(globalSegmentIds).toEqual(toggleSegmentIds);
+    expect(globalSegmentIds).toEqual(expect.arrayContaining(toggleSegmentIds));
 });

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -13,6 +13,7 @@ import {
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
 } from '../../../../lib/util/segments';
 import { collectIds } from '../../../../lib/util/collect-ids';
+import { arraysHaveSameItems } from '../../../../lib/util/arraysHaveSameItems';
 
 let db: ITestDb;
 let app: IUnleashTest;
@@ -309,5 +310,7 @@ test('should send all segments that are in use by feature', async () => {
         .flat()
         .filter((x) => !!x);
     const toggleSegmentIds = [...new Set(allSegmentIds)];
-    expect(globalSegmentIds).toEqual(expect.arrayContaining(toggleSegmentIds));
+    expect(arraysHaveSameItems(globalSegmentIds, toggleSegmentIds)).toEqual(
+        true,
+    );
 });


### PR DESCRIPTION
I had a test named `should send all segments that are in use by feature` failing, because expected was [1,2] and actual was [2,1].
In reality the order of ids should not matter, so test should ignore the ID order.

Fixed it with this PR.