### PR TITLE
feat: publish docker containers on tag builds

### DIFF
--- a/.github/workflows/docker_publish_tags.yaml
+++ b/.github/workflows/docker_publish_tags.yaml
@@ -1,0 +1,40 @@
+name: Push Tags
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup QEmu so we can build multiplatform
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker meta configuration
+        uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: |
+            unleashorg/unleash-server
+          tags: |
+            type=semver,pattern={{ version }}
+            type=semver,pattern={{ major.minor }}
+            type=semver,pattern={{ major }}
+      - name: Login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build tag and push image to Docker hub
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: NODE_VERSION=16-alpine


### PR DESCRIPTION
This moves the production of docker releases from Unleash/unleash-docker
to this repository.
