### PR TITLE
feat: Add permission calculation for new user group feature

### DIFF
--- a/src/lib/db/group-store.ts
+++ b/src/lib/db/group-store.ts
@@ -88,7 +88,7 @@ export default class GroupStore implements IGroupStore {
         const rows = users.map((user) => {
             return {
                 group_id: id,
-                user_ud: user.user.id,
+                user_id: user.user.id,
                 type: user.type,
                 created_by: userName,
             };

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -57,7 +57,12 @@ export const createStores = (
         tagStore: new TagStore(db, eventBus, getLogger),
         tagTypeStore: new TagTypeStore(db, eventBus, getLogger),
         addonStore: new AddonStore(db, eventBus, getLogger),
-        accessStore: new AccessStore(db, eventBus, getLogger),
+        accessStore: new AccessStore(
+            db,
+            eventBus,
+            getLogger,
+            config?.experimental?.userGroups,
+        ),
         apiTokenStore: new ApiTokenStore(db, eventBus, getLogger),
         resetTokenStore: new ResetTokenStore(db, eventBus, getLogger),
         sessionStore: new SessionStore(db, eventBus, getLogger),

--- a/src/lib/experimental.ts
+++ b/src/lib/experimental.ts
@@ -1,6 +1,7 @@
 export interface IExperimentalOptions {
     metricsV2?: IExperimentalToggle;
     clientFeatureMemoize?: IExperimentalToggle;
+    userGroups?: boolean;
     anonymiseEventLog?: boolean;
 }
 

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -174,6 +174,14 @@ export class AccessService {
         return this.store.addUserToRole(userId, roleId, projectId);
     }
 
+    async addGroupToRole(
+        groupId: number,
+        roleId: number,
+        projectId: string,
+    ): Promise<void> {
+        return this.store.addGroupToRole(groupId, roleId, projectId);
+    }
+
     async getRoleByName(roleName: string): Promise<IRole> {
         return this.roleStore.getRoleByName(roleName);
     }
@@ -216,6 +224,14 @@ export class AccessService {
         projectId: string,
     ): Promise<void> {
         return this.store.removeUserFromRole(userId, roleId, projectId);
+    }
+
+    async removeGroupFromRole(
+        groupId: number,
+        roleId: number,
+        projectId: string,
+    ): Promise<void> {
+        return this.store.removeGroupFromRole(groupId, roleId, projectId);
     }
 
     async updateUserProjectRole(

--- a/src/lib/types/stores/access-store.ts
+++ b/src/lib/types/stores/access-store.ts
@@ -52,6 +52,16 @@ export interface IAccessStore extends Store<IRole, number> {
         roleId: number,
         projectId?: string,
     ): Promise<void>;
+    addGroupToRole(
+        groupId: number,
+        roleId: number,
+        projectId?: string,
+    ): Promise<void>;
+    removeGroupFromRole(
+        groupId: number,
+        roleId: number,
+        projectId?: string,
+    ): Promise<void>;
     updateUserProjectRole(
         userId: number,
         roleId: number,

--- a/src/migrations/20220704115624-add-user-groups.js
+++ b/src/migrations/20220704115624-add-user-groups.js
@@ -27,6 +27,7 @@ exports.up = function (db, callback) {
                 role_id integer not null references roles (id) ON DELETE CASCADE,
                 created_by text,
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+                project text,
                 PRIMARY KEY (group_id, role_id)
             );
         `,

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -33,6 +33,7 @@ process.nextTick(async () => {
                 experimental: {
                     metricsV2: { enabled: true },
                     anonymiseEventLog: false,
+                    userGroups: true,
                 },
                 authentication: {
                     initApiTokens: [

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -22,6 +22,9 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
         clientFeatureCaching: {
             enabled: false,
         },
+        experimental: {
+            userGroups: true,
+        },
     };
     const options = mergeAll<IUnleashOptions>([testConfig, config]);
     return createConfig(options);

--- a/src/test/fixtures/fake-access-store.ts
+++ b/src/test/fixtures/fake-access-store.ts
@@ -9,6 +9,22 @@ import {
 import { IAvailablePermissions, IPermission } from 'lib/types/model';
 
 class AccessStoreMock implements IAccessStore {
+    addGroupToRole(
+        groupId: number,
+        roleId: number,
+        projectId?: string,
+    ): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    removeGroupFromRole(
+        groupId: number,
+        roleId: number,
+        projectId?: string,
+    ): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
     updateUserProjectRole(
         userId: number,
         roleId: number,


### PR DESCRIPTION
This adds permission calculations to the usergroup feature so that when users are added to groups the permissions of those groups are respected 