### PR TITLE
improvement: mark github releases as prerelease

### DIFF
--- a/.github/workflows/release_changelog.yml
+++ b/.github/workflows/release_changelog.yml
@@ -22,5 +22,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: ${{ steps.github_release.outputs.changelog }}
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This marks alpha and beta releases as prereleases, so github's release
tab doesn't show beta releases as our latest releases anymore
