### PR TITLE
Fix an empty row appearing in features list

### DIFF
--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -105,7 +105,7 @@ export default class FeatureToggleClientStore
                 `fss.feature_strategy_id`,
                 `fs.id`,
             )
-            .fullOuterJoin('segments', `segments.id`, `fss.segment_id`);
+            .leftJoin('segments', `segments.id`, `fss.segment_id`);
 
         if (featureQuery) {
             if (featureQuery.tag) {


### PR DESCRIPTION
This PR fixes a bug where empty row appeared in features list. 

`FULL OUTER JOIN` was joining null rows and after joining segments, that were not linked to any features, empty row appeared.

Fixed it by replacing it with `LEFT JOIN`, which allows all features to appear, but only shows segments, that are linked to features.