### PR TITLE
fix: admin global features endpoint

### DIFF
--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -162,20 +162,6 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             : queryBuilder.whereNull('archived_at');
     };
 
-    static filterByTags: Knex.QueryCallbackWithArgs = (
-        queryBuilder: Knex.QueryBuilder,
-        tag?: string[][],
-    ) => {
-        if (tag && tag.length > 0) {
-            const tagQuery = queryBuilder
-                .from('feature_tag')
-                .select('feature_name')
-                .whereIn(['tag_type', 'tag_value'], tag);
-            return queryBuilder.whereIn('feature.name', tagQuery);
-        }
-        return queryBuilder;
-    };
-
     static filterByProject: Knex.QueryCallbackWithArgs = (
         queryBuilder: Knex.QueryBuilder,
         project?: string | string[],

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -177,7 +177,11 @@ class FeatureController extends Controller {
         req: Request,
         res: Response<FeaturesSchema>,
     ): Promise<void> {
-        const features = await this.service.getMetadataForAllFeatures(false);
+        const query = await this.prepQuery(req.query);
+        const features = await this.service.getMetadataForAllFeatures(
+            false,
+            query,
+        );
         this.openApiService.respondWithValidation(
             200,
             res,

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -177,9 +177,7 @@ class FeatureController extends Controller {
         req: Request,
         res: Response<FeaturesSchema>,
     ): Promise<void> {
-        const query = await this.prepQuery(req.query);
-        const features = await this.service.getFeatureToggles(query);
-
+        const features = await this.service.getMetadataForAllFeatures(false);
         this.openApiService.respondWithValidation(
             200,
             res,

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -988,8 +988,9 @@ class FeatureToggleService {
 
     async getMetadataForAllFeatures(
         archived: boolean,
+        query?: Partial<IFeatureToggleQuery>,
     ): Promise<FeatureToggle[]> {
-        return this.featureToggleStore.getAll({ archived });
+        return this.featureToggleStore.getAll({ ...query, archived });
     }
 
     async getMetadataForAllFeaturesByProjectId(

--- a/src/lib/types/stores/feature-toggle-store.ts
+++ b/src/lib/types/stores/feature-toggle-store.ts
@@ -3,8 +3,10 @@ import { Store } from './store';
 
 export interface IFeatureToggleQuery {
     archived: boolean;
-    project: string;
+    project: string | string[];
+    namePrefix?: string;
     stale: boolean;
+    tag?: string[][];
 }
 
 export interface IFeatureToggleStore extends Store<FeatureToggle, string> {

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -180,8 +180,8 @@ afterAll(async () => {
 test('returns list of feature toggles', async () =>
     app.request
         .get('/api/admin/features')
-        .expect('Content-Type', /json/)
         .expect(200)
+        .expect('Content-Type', /json/)
         .expect((res) => {
             expect(res.body.features).toHaveLength(4);
         }));
@@ -628,8 +628,8 @@ test('Can get features tagged by tag', async () => {
         .expect(201);
     return app.request
         .get(`/api/admin/features?tag=${tag.type}:${tag.value}`)
-        .expect('Content-Type', /json/)
         .expect(200)
+        .expect('Content-Type', /json/)
         .expect((res) => {
             expect(res.body.features).toHaveLength(1);
             expect(res.body.features[0].name).toBe(feature1Name);
@@ -665,8 +665,8 @@ test('Can query for multiple tags using OR', async () => {
         .get(
             `/api/admin/features?tag[]=${tag.type}:${tag.value}&tag[]=${tag2.type}:${tag2.value}`,
         )
-        .expect('Content-Type', /json/)
         .expect(200)
+        .expect('Content-Type', /json/)
         .expect((res) => {
             expect(res.body.features).toHaveLength(2);
             expect(res.body.features.some((f) => f.name === feature1Name)).toBe(
@@ -715,8 +715,8 @@ test('Querying with multiple filters ANDs the filters', async () => {
         .expect(201);
     await app.request
         .get(`/api/admin/features?tag=${tag.type}:${tag.value}`)
-        .expect('Content-Type', /json/)
         .expect(200)
+        .expect('Content-Type', /json/)
         .expect((res) => expect(res.body.features).toHaveLength(2));
     await app.request
         .get(`/api/admin/features?namePrefix=test&tag=${tag.type}:${tag.value}`)

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -26,10 +26,8 @@ const fetchSegments = (): Promise<ISegment[]> => {
 };
 
 const fetchFeatures = (): Promise<IFeatureToggleClient[]> => {
-    return app.request
-        .get(FEATURES_ADMIN_BASE_PATH)
-        .expect(200)
-        .then((res) => res.body.features);
+    //@ts-expect-error
+    return app.services.featureToggleService.getFeatureToggles({}, false);
 };
 
 const fetchClientFeatures = (): Promise<IFeatureToggleClient[]> => {


### PR DESCRIPTION
The Admin global features endpoint was using the client features store
to join in environments, strategies and segments, when all we actually
need is the feature metadata. This PR swaps which method we use for
getting the data.

Co-authored-by: Fredrik Strand Oseberg <fredrik.no@gmail.com>
Co-authored-by: Simon Hornby <liquidwicked64@gmail.com>
