### PR TITLE
Fix features returning empty row

### DIFF
--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -100,7 +100,7 @@ export default class FeatureToggleClientStore
                 'fe.feature_name',
                 'features.name',
             )
-            .fullOuterJoin(
+            .leftJoin(
                 'feature_strategy_segment as fss',
                 `fss.feature_strategy_id`,
                 `fs.id`,


### PR DESCRIPTION
We discovered a bug, where features query from database is broken and returning empty rows. 
**It was hidden for some time due to accidental code, that removed the empty rows.**

This PR contains following:

1. Outer join replaced with left join, which helps to not create empty rows.
2. Also added test that no rows will be returned, when there is segment that is not linked to any features.

