### PR TITLE
task: add sdk version metric

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -12,6 +12,7 @@ import {
     FEATURE_STRATEGY_UPDATE,
     FEATURE_UPDATED,
     CLIENT_METRICS,
+    CLIENT_REGISTER,
 } from './types/events';
 import { IUnleashConfig } from './types/option';
 import { IUnleashStores } from './types/stores';
@@ -78,6 +79,12 @@ export default class MetricsMonitor {
         const projectsTotal = new client.Gauge({
             name: 'projects_total',
             help: 'Number of projects',
+        });
+
+        const clientSdkVersionUsage = new client.Counter({
+            name: 'client_sdk_versions',
+            help: 'Which sdk versions are being used',
+            labelNames: ['sdk_name', 'sdk_version'],
         });
 
         async function collectStaticCounters() {
@@ -155,6 +162,12 @@ export default class MetricsMonitor {
                     .labels(entry[0], 'false', m.appName)
                     // @ts-expect-error
                     .inc(entry[1].no);
+            }
+        });
+        eventBus.on(CLIENT_REGISTER, (m) => {
+            if (m.sdkVersion && m.sdkVersion.indexOf(':') > -1) {
+                const [sdkName, sdkVersion] = m.sdkVersion.split(':');
+                clientSdkVersionUsage.labels(sdkName, sdkVersion).inc();
             }
         });
 

--- a/src/lib/services/client-metrics/instance-service.test.ts
+++ b/src/lib/services/client-metrics/instance-service.test.ts
@@ -2,6 +2,7 @@ import ClientInstanceService from './instance-service';
 import getLogger from '../../../test/fixtures/no-logger';
 import { IClientApp } from '../../types/model';
 import { secondsToMilliseconds } from 'date-fns';
+import FakeEventStore from '../../../test/fixtures/fake-event-store';
 
 /**
  * A utility to wait for any pending promises in the test subject code.
@@ -54,7 +55,7 @@ test('Multiple registrations of same appname and instanceid within same time per
             featureToggleStore: null,
             clientApplicationsStore,
             clientInstanceStore,
-            eventStore: null,
+            eventStore: new FakeEventStore(),
         },
         { getLogger },
     );
@@ -104,7 +105,7 @@ test('Multiple unique clients causes multiple registrations', async () => {
             featureToggleStore: null,
             clientApplicationsStore,
             clientInstanceStore,
-            eventStore: null,
+            eventStore: new FakeEventStore(),
         },
         { getLogger },
     );
@@ -157,7 +158,7 @@ test('Same client registered outside of dedup interval will be registered twice'
             featureToggleStore: null,
             clientApplicationsStore,
             clientInstanceStore,
-            eventStore: null,
+            eventStore: new FakeEventStore(),
         },
         { getLogger },
         bulkInterval,
@@ -210,7 +211,7 @@ test('No registrations during a time period will not call stores', async () => {
             featureToggleStore: null,
             clientApplicationsStore,
             clientInstanceStore,
-            eventStore: null,
+            eventStore: new FakeEventStore(),
         },
         { getLogger },
     );

--- a/src/lib/services/client-metrics/instance-service.ts
+++ b/src/lib/services/client-metrics/instance-service.ts
@@ -1,5 +1,5 @@
 import { applicationSchema } from './schema';
-import { APPLICATION_CREATED } from '../../types/events';
+import { APPLICATION_CREATED, CLIENT_REGISTER } from '../../types/events';
 import { IApplication } from './models';
 import { IUnleashStores } from '../../types/stores';
 import { IUnleashConfig } from '../../types/option';
@@ -111,6 +111,7 @@ export default class ClientInstanceService {
         value.clientIp = clientIp;
         value.createdBy = clientIp;
         this.seenClients[this.clientKey(value)] = value;
+        this.eventStore.emit(CLIENT_REGISTER, value);
     }
 
     async announceUnannounced(): Promise<void> {

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -74,6 +74,7 @@ export const SETTING_UPDATED = 'setting-updated';
 export const SETTING_DELETED = 'setting-deleted';
 
 export const CLIENT_METRICS = 'client-metrics';
+export const CLIENT_REGISTER = 'client-register';
 
 export interface IBaseEvent {
     type: string;


### PR DESCRIPTION
So I know we have this in the database, but it's come up a couple of times in user discussions where the user asks how they're supposed to keep track of which SDK versions are being used. I don't think we currently expose a top level sdk version usage, so you need access to the database to do your own queries for figuring out which sdk version strings the server has seen.

This PR exposes this as a prometheus metric.

I'm a tad worried about the cardinality of this metric, but I've at least made sure that a client registration needs to include an sdkVersion field in the format `<sdkName>:<sdkVersion>`. So as to not accept anything into the labels for the metric. 

Maybe it would be better to parse the <sdkVersion> using the semantic library and then use major, minor, patch as separate labels. That would require all sdk's that register with sdkVersion to pass in a SemVer compatible version. 