### PR TITLE
fix: Playground variants don't show correctly

### DIFF
--- a/src/lib/services/playground-service.ts
+++ b/src/lib/services/playground-service.ts
@@ -58,7 +58,7 @@ export class PlaygroundService {
                         projectId: await this.featureToggleService.getProjectId(
                             feature.name,
                         ),
-                        variant: client.getVariant(feature.name),
+                        variant: client.getVariant(feature.name, clientContext),
                         name: feature.name,
                     };
                 }),

--- a/src/test/e2e/api/admin/playground.e2e.test.ts
+++ b/src/test/e2e/api/admin/playground.e2e.test.ts
@@ -6,6 +6,7 @@ import { IUnleashTest, setupAppWithAuth } from '../../helpers/test-helper';
 import { FeatureToggle, WeightType } from '../../../../lib/types/model';
 import getLogger from '../../../fixtures/no-logger';
 import {
+    ALL,
     ApiTokenType,
     IApiToken,
 } from '../../../../lib/types/models/api-token';
@@ -25,8 +26,8 @@ beforeAll(async () => {
     token = await apiTokenService.createApiTokenWithProjects({
         type: ApiTokenType.ADMIN,
         username: 'tester',
-        environment: '*',
-        projects: ['*'],
+        environment: ALL,
+        projects: [ALL],
     });
 });
 
@@ -172,7 +173,7 @@ describe('Playground API E2E', () => {
                         // get a subset of projects that exist among the features
                         const [projects] = fc.sample(
                             fc.oneof(
-                                fc.constant('*' as '*'),
+                                fc.constant(ALL as '*'),
                                 fc.uniqueArray(
                                     fc.constantFrom(
                                         ...features.map(
@@ -194,7 +195,7 @@ describe('Playground API E2E', () => {
                         );
 
                         switch (projects) {
-                            case '*':
+                            case ALL:
                                 // no features have been filtered out
                                 return body.features.length === features.length;
                             case []:
@@ -228,7 +229,7 @@ describe('Playground API E2E', () => {
                             app,
                             token.secret,
                             {
-                                projects: '*',
+                                projects: ALL,
                                 environment: 'default',
                                 context: {
                                     appName: 'playground-test',


### PR DESCRIPTION
This PR fixes a bug in the playground, wherein variants on toggles with constraints on the context would show as the disabled variant.

This happened because the `getVariant` call didn't receive the provided context as an argument. This has now been rectified and a test added.

## Changes

The two main changes are:

1. Add a test for variant values with constraints
2. Pass the context into the `getVariant` call.

### Bonus changes

I also took the opportunity to switch from using the raw string `'*'` to using the constant `ALL` in the test suite. While they have the same value for now, they might change in the future. This should make keeping the tests up to date easier.

## Background

This was discovered during internal testing of the playground feature.