### PR TITLE
docs: Update docusaurus to 2.0.0-rc.1

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,6 +22,7 @@ module.exports = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
         algolia: {
+            appId: 'BH4D9OD16A',
             apiKey: '9772249a7262b377ac876853d32bd760',
             indexName: 'getunleash',
         },

--- a/website/package.json
+++ b/website/package.json
@@ -16,11 +16,11 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.15",
-    "@docusaurus/plugin-client-redirects": "2.0.0-beta.15",
-    "@docusaurus/plugin-google-analytics": "2.0.0-beta.15",
-    "@docusaurus/preset-classic": "2.0.0-beta.15",
-    "@docusaurus/remark-plugin-npm2yarn": "2.0.0-beta.15",
+    "@docusaurus/core": "2.0.0-rc.1",
+    "@docusaurus/plugin-client-redirects": "2.0.0-rc.1",
+    "@docusaurus/plugin-google-analytics": "2.0.0-rc.1",
+    "@docusaurus/preset-classic": "2.0.0-rc.1",
+    "@docusaurus/remark-plugin-npm2yarn": "2.0.0-rc.1",
     "@mdx-js/react": "1.6.22",
     "@svgr/webpack": "6.2.1",
     "clsx": "1.2.1",
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.18.6",
-    "@docusaurus/module-type-aliases": "2.0.0-beta.18",
+    "@docusaurus/module-type-aliases": "2.0.0-rc.1",
     "@storybook/addon-actions": "6.5.9",
     "@storybook/addon-essentials": "6.5.9",
     "@storybook/addon-interactions": "6.5.9",

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "websitev-2",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": ">=16.14"
+  },
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
This PR updates docusaurus to the most recent 'stable' version (well, at least it's not a beta anymore, right? 😅).

In addition to just updating the packages, it also requires adding an algolia app ID as [described in this migration guide](https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration#upgrading-your-docusaurus-site). As also mentioned in the guide, app IDs 'are not secrets and can be added to your Git repository'.

Further, the PR also updates the minimum required node version to run this. This is due to some of the changes in docusaurus requiring at least 16.14 to function.

Supersedes #1398.