### PR TITLE
feat: add all feature variants to the playground payload

### DIFF
--- a/src/lib/openapi/spec/playground-feature-schema.test.ts
+++ b/src/lib/openapi/spec/playground-feature-schema.test.ts
@@ -1,5 +1,5 @@
 import fc, { Arbitrary } from 'fast-check';
-import { urlFriendlyString } from '../../../test/arbitraries.test';
+import { urlFriendlyString, variants } from '../../../test/arbitraries.test';
 import { validateSchema } from '../validate';
 import {
     playgroundFeatureSchema,
@@ -7,42 +7,67 @@ import {
 } from './playground-feature-schema';
 
 export const generate = (): Arbitrary<PlaygroundFeatureSchema> =>
-    fc.boolean().chain((isEnabled) =>
-        fc.record({
-            isEnabled: fc.constant(isEnabled),
-            projectId: urlFriendlyString(),
-            name: urlFriendlyString(),
-            variant: fc.record(
-                {
-                    name: urlFriendlyString(),
-                    enabled: fc.constant(isEnabled),
-                    payload: fc.oneof(
-                        fc.record({
-                            type: fc.constant('json' as 'json'),
-                            value: fc.json(),
-                        }),
-                        fc.record({
-                            type: fc.constant('csv' as 'csv'),
-                            value: fc
-                                .array(fc.lorem())
-                                .map((words) => words.join(',')),
-                        }),
-                        fc.record({
-                            type: fc.constant('string' as 'string'),
-                            value: fc.string(),
-                        }),
-                    ),
-                },
-                { requiredKeys: ['name', 'enabled'] },
-            ),
-        }),
-    );
+    fc
+        .tuple(
+            fc.boolean(),
+            variants(),
+            fc.nat(),
+            fc.record({
+                projectId: urlFriendlyString(),
+                name: urlFriendlyString(),
+            }),
+        )
+        .map(([isEnabled, generatedVariants, activeVariantIndex, feature]) => {
+            // the active variant is the disabled variant if the feature is
+            // disabled or has no variants.
+            let activeVariant = { name: 'disabled', enabled: false } as {
+                name: string;
+                enabled: boolean;
+                payload?: {
+                    type: 'string' | 'json' | 'csv';
+                    value: string;
+                };
+            };
+
+            if (generatedVariants.length && isEnabled) {
+                const targetVariant =
+                    generatedVariants[
+                        activeVariantIndex % generatedVariants.length
+                    ];
+                const targetPayload = targetVariant.payload
+                    ? (targetVariant.payload as {
+                          type: 'string' | 'json' | 'csv';
+                          value: string;
+                      })
+                    : undefined;
+
+                activeVariant = {
+                    enabled: isEnabled,
+                    name: targetVariant.name,
+                    payload: targetPayload,
+                };
+            }
+
+            return {
+                ...feature,
+                isEnabled,
+                variants: generatedVariants,
+                variant: activeVariant,
+            };
+        });
 
 test('playgroundFeatureSchema', () =>
     fc.assert(
         fc.property(
             generate(),
-            (data: PlaygroundFeatureSchema) =>
-                validateSchema(playgroundFeatureSchema.$id, data) === undefined,
+            fc.context(),
+            (data: PlaygroundFeatureSchema, ctx) => {
+                const results = validateSchema(
+                    playgroundFeatureSchema.$id,
+                    data,
+                );
+                ctx.log(JSON.stringify(results));
+                return results === undefined;
+            },
         ),
     ));

--- a/src/lib/openapi/spec/playground-feature-schema.ts
+++ b/src/lib/openapi/spec/playground-feature-schema.ts
@@ -1,4 +1,6 @@
 import { FromSchema } from 'json-schema-to-ts';
+import { variantSchema } from './variant-schema';
+import { overrideSchema } from './override-schema';
 
 export const playgroundFeatureSchema = {
     $id: '#/components/schemas/playgroundFeatureSchema',
@@ -6,7 +8,7 @@ export const playgroundFeatureSchema = {
         'A simplified feature toggle model intended for the Unleash playground.',
     type: 'object',
     additionalProperties: false,
-    required: ['name', 'projectId', 'isEnabled', 'variant'],
+    required: ['name', 'projectId', 'isEnabled', 'variant', 'variants'],
     properties: {
         name: { type: 'string', examples: ['my-feature'] },
         projectId: { type: 'string', examples: ['my-project'] },
@@ -34,8 +36,9 @@ export const playgroundFeatureSchema = {
             nullable: true,
             examples: ['green'],
         },
+        variants: { type: 'array', items: { $ref: variantSchema.$id } },
     },
-    components: { schemas: {} },
+    components: { schemas: { variantSchema, overrideSchema } },
 } as const;
 
 export type PlaygroundFeatureSchema = FromSchema<

--- a/src/lib/openapi/spec/playground-response-schema.test.ts
+++ b/src/lib/openapi/spec/playground-response-schema.test.ts
@@ -5,12 +5,14 @@ import {
 } from '../../../lib/openapi/spec/playground-response-schema';
 import { validateSchema } from '../validate';
 import { generate as generateInput } from './playground-request-schema.test';
-import { generate as generateToggles } from './playground-feature-schema.test';
+import { generate as generateFeature } from './playground-feature-schema.test';
 
 const generate = (): Arbitrary<PlaygroundResponseSchema> =>
     fc.record({
         input: generateInput(),
-        features: fc.array(generateToggles()),
+        features: fc.uniqueArray(generateFeature(), {
+            selector: (feature) => feature.name,
+        }),
     });
 
 test('playgroundResponseSchema', () =>

--- a/src/lib/openapi/spec/playground-response-schema.ts
+++ b/src/lib/openapi/spec/playground-response-schema.ts
@@ -2,6 +2,7 @@ import { FromSchema } from 'json-schema-to-ts';
 import { sdkContextSchema } from './sdk-context-schema';
 import { playgroundRequestSchema } from './playground-request-schema';
 import { playgroundFeatureSchema } from './playground-feature-schema';
+import { featureVariantsSchema } from './feature-variants-schema';
 
 export const playgroundResponseSchema = {
     $id: '#/components/schemas/playgroundResponseSchema',
@@ -16,15 +17,30 @@ export const playgroundResponseSchema = {
         features: {
             type: 'array',
             items: {
-                $ref: playgroundFeatureSchema.$id,
+                allOf: [
+                    { $ref: playgroundFeatureSchema.$id },
+                    {
+                        type: 'object',
+                        required: ['variants'],
+                        properties: {
+                            variants: {
+                                type: 'array',
+                                items: {
+                                    $ref: featureVariantsSchema.$id,
+                                },
+                            },
+                        },
+                    },
+                ],
             },
         },
     },
     components: {
         schemas: {
-            sdkContextSchema,
-            playgroundRequestSchema,
+            featureVariantsSchema,
             playgroundFeatureSchema,
+            playgroundRequestSchema,
+            sdkContextSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/playground-response-schema.ts
+++ b/src/lib/openapi/spec/playground-response-schema.ts
@@ -2,7 +2,8 @@ import { FromSchema } from 'json-schema-to-ts';
 import { sdkContextSchema } from './sdk-context-schema';
 import { playgroundRequestSchema } from './playground-request-schema';
 import { playgroundFeatureSchema } from './playground-feature-schema';
-import { featureVariantsSchema } from './feature-variants-schema';
+import { variantSchema } from './variant-schema';
+import { overrideSchema } from './override-schema';
 
 export const playgroundResponseSchema = {
     $id: '#/components/schemas/playgroundResponseSchema',
@@ -16,31 +17,16 @@ export const playgroundResponseSchema = {
         },
         features: {
             type: 'array',
-            items: {
-                allOf: [
-                    { $ref: playgroundFeatureSchema.$id },
-                    {
-                        type: 'object',
-                        required: ['variants'],
-                        properties: {
-                            variants: {
-                                type: 'array',
-                                items: {
-                                    $ref: featureVariantsSchema.$id,
-                                },
-                            },
-                        },
-                    },
-                ],
-            },
+            items: { $ref: playgroundFeatureSchema.$id },
         },
     },
     components: {
         schemas: {
-            featureVariantsSchema,
             playgroundFeatureSchema,
             playgroundRequestSchema,
             sdkContextSchema,
+            variantSchema,
+            overrideSchema,
         },
     },
 } as const;

--- a/src/lib/services/playground-service.ts
+++ b/src/lib/services/playground-service.ts
@@ -60,6 +60,7 @@ export class PlaygroundService {
                         ),
                         variant: client.getVariant(feature.name, clientContext),
                         name: feature.name,
+                        variants: [],
                     };
                 }),
             );

--- a/src/lib/services/playground-service.ts
+++ b/src/lib/services/playground-service.ts
@@ -36,6 +36,11 @@ export class PlaygroundService {
         if (!head) {
             return [];
         } else {
+            const variantsMap = toggles.reduce((acc, feature) => {
+                acc[feature.name] = feature.variants;
+                return acc;
+            }, {});
+
             const client = await offlineUnleashClient(
                 [head, ...rest],
                 context,
@@ -60,7 +65,7 @@ export class PlaygroundService {
                         ),
                         variant: client.getVariant(feature.name, clientContext),
                         name: feature.name,
-                        variants: [],
+                        variants: variantsMap[feature.name] || [],
                     };
                 }),
             );

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1877,7 +1877,25 @@ Object {
         "properties": Object {
           "features": Object {
             "items": Object {
-              "$ref": "#/components/schemas/playgroundFeatureSchema",
+              "allOf": Array [
+                Object {
+                  "$ref": "#/components/schemas/playgroundFeatureSchema",
+                },
+                Object {
+                  "properties": Object {
+                    "variants": Object {
+                      "items": Object {
+                        "$ref": "#/components/schemas/featureVariantsSchema",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": Array [
+                    "variants",
+                  ],
+                  "type": "object",
+                },
+              ],
             },
             "type": "array",
           },

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1821,12 +1821,19 @@ Object {
             ],
             "type": "object",
           },
+          "variants": Object {
+            "items": Object {
+              "$ref": "#/components/schemas/variantSchema",
+            },
+            "type": "array",
+          },
         },
         "required": Array [
           "name",
           "projectId",
           "isEnabled",
           "variant",
+          "variants",
         ],
         "type": "object",
       },
@@ -1877,25 +1884,7 @@ Object {
         "properties": Object {
           "features": Object {
             "items": Object {
-              "allOf": Array [
-                Object {
-                  "$ref": "#/components/schemas/playgroundFeatureSchema",
-                },
-                Object {
-                  "properties": Object {
-                    "variants": Object {
-                      "items": Object {
-                        "$ref": "#/components/schemas/featureVariantsSchema",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "variants",
-                  ],
-                  "type": "object",
-                },
-              ],
+              "$ref": "#/components/schemas/playgroundFeatureSchema",
             },
             "type": "array",
           },


### PR DESCRIPTION
This PR adds all variants that exist on a feature toggle to the playground payload for that toggle.

## Background / motivation

Being able to see which variant a feature has received is nice, but it would be more helpful if you could also see what other variants exist for that toggle and how they are weighted or overridden.

## Changes

Because this PR changes the output of the playground API, most of the changes are to schemas related to that API. There are also updates to arbitrary generators for related property tests and to the snapshot of the openapi schema.

Additionally, this PR removes some of the additionalProperties: false annotations on some of the existing schemas. This is done so that the schemas can be extended via OpenAPI's 'allOf' property as documented in [the swagger docs on polymorphism and inheritance](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/).

## Discussion

Removing the additionalProperties annotations from some of the existing schemas has pros and cons. The big pro is that you can now use that schema as part of an inheritance structure, saving you from typing it out many time. The biggest con is that we're no longer restricted to not sending out any additional properties.

There may be a better way to do this (to both be able to extend and to restrict), but I decided to avoid extra duplication for now. That said, I'm happy to split it up if we think that's better.