### PR TITLE
task: update health endpoint to only say if express is ready

### DIFF
--- a/src/lib/routes/health-check.ts
+++ b/src/lib/routes/health-check.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express';
 import { IUnleashConfig } from '../types/option';
 import { IUnleashServices } from '../types/services';
 import { Logger } from '../logger';
-import HealthService from '../services/health-service';
 import { OpenApiService } from '../services/openapi-service';
 
 import Controller from './controller';
@@ -15,19 +14,13 @@ export class HealthCheckController extends Controller {
 
     private openApiService: OpenApiService;
 
-    private healthService: HealthService;
-
     constructor(
         config: IUnleashConfig,
-        {
-            healthService,
-            openApiService,
-        }: Pick<IUnleashServices, 'healthService' | 'openApiService'>,
+        { openApiService }: Pick<IUnleashServices, 'openApiService'>,
     ) {
         super(config);
         this.logger = config.getLogger('health-check.js');
         this.openApiService = openApiService;
-        this.healthService = healthService;
 
         this.route({
             method: 'get',
@@ -51,12 +44,6 @@ export class HealthCheckController extends Controller {
         _: Request,
         res: Response<HealthCheckSchema>,
     ): Promise<void> {
-        try {
-            await this.healthService.dbIsUp();
-            res.status(200).json({ health: 'GOOD' });
-        } catch (e) {
-            this.logger.error('Could not select from features, error was: ', e);
-            res.status(500).json({ health: 'BAD' });
-        }
+        res.status(200).json({ health: 'GOOD' });
     }
 }


### PR DESCRIPTION
To avoid our health check failing due to the db pool being busy, this PR makes the health endpoint simply return `200: { "health": "GOOD" }`.

We've been using this for our hosted version for quite some time, since hard errors still restarts the process, we don't need to check the database connection every 10 seconds.