### PR TITLE
Fix user/group role primary keys

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -375,13 +375,13 @@ export class AccessStore implements IAccessStore {
             if (userRows.length > 0) {
                 await tx(T.ROLE_USER)
                     .insert(userRows)
-                    .onConflict(['project', 'role_id', 'user_id'])
+                    .onConflict(['project', 'user_id'])
                     .merge();
             }
             if (groupRows.length > 0) {
                 await tx(T.GROUP_ROLE)
                     .insert(groupRows)
-                    .onConflict(['project', 'role_id', 'group_id'])
+                    .onConflict(['project', 'group_id'])
                     .merge();
             }
         });

--- a/src/migrations/20220722221524-update-access-constraints.js
+++ b/src/migrations/20220722221524-update-access-constraints.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE role_user DROP CONSTRAINT role_user_pkey;
+            ALTER TABLE role_user ADD PRIMARY KEY (user_id, project);
+            ALTER TABLE group_role DROP CONSTRAINT group_role_pkey;
+            ALTER TABLE group_role ADD PRIMARY KEY (group_id, project);
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE role_user DROP CONSTRAINT role_user_pkey;
+            ALTER TABLE role_user ADD PRIMARY KEY (user_id, role_id, project);
+            ALTER TABLE group_role DROP CONSTRAINT group_role_pkey;
+            ALTER TABLE group_role ADD PRIMARY KEY (group_id, role_id, project);
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
Table `group_role` and `role_user` primary keys were wrong. They allowed to create multiple sets of permissions to user/group in a same project. This PR fixes this.