### PR TITLE
fix: force resolution of es5-ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
   "resolutions": {
     "async": "^3.2.3",
     "db-migrate/rc/minimist": "^1.2.5",
+    "es5-ext": "0.10.53",
     "knex/liftoff/object.map/**/kind-of": "^6.0.3",
     "knex/liftoff/findup-sync/micromatc/kind-of": "^6.0.3",
     "knex/liftoff/findup-sync/micromatc/nanomatch/kind-of": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,7 +2769,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+es5-ext@0.10.53, es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.53"
   resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
@@ -5387,7 +5387,7 @@ media-typer@0.3.0:
 
 memoizee@^0.4.15:
   version "0.4.15"
-  resolved "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
   integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
   dependencies:
     d "^1.0.1"


### PR DESCRIPTION
Fixing modules is being flagged as malware https://github.com/Unleash/unleash-docker/issues/74
Because of postinstall script of a dependency printing out a message to users in Russian time zones. https://github.com/medikoo/es5-ext/issues/116
Relevant to https://github.com/medikoo/es5-ext/issues/186 ("package being detected as a virus")