### PR TITLE
Implement group access edit for project

### DIFF
--- a/src/lib/db/group-store.ts
+++ b/src/lib/db/group-store.ts
@@ -17,10 +17,10 @@ const T = {
     GROUP_ROLE: 'group_role',
     USERS: 'users',
     PROJECTS: 'projects',
+    ROLES: 'roles',
 };
 
 const GROUP_COLUMNS = ['id', 'name', 'description', 'created_at', 'created_by'];
-const GROUP_ROLE_COLUMNS = ['group_id', 'role_id', 'created_at'];
 
 const rowToGroup = (row) => {
     if (!row) {
@@ -81,14 +81,17 @@ export default class GroupStore implements IGroupStore {
 
     async getProjectGroupRoles(projectId: string): Promise<IGroupRole[]> {
         const rows = await this.db
-            .select(GROUP_ROLE_COLUMNS)
-            .from(`${T.GROUP_ROLE}`)
+            .select('gr.group_id', 'gr.role_id', 'gr.created_at', 'r.name')
+            .from(`${T.GROUP_ROLE} as gr`)
+            .innerJoin(`${T.ROLES} as r`, 'gr.role_id', 'r.id')
             .where('project', projectId);
+
         return rows.map((r) => {
             return {
                 groupId: r.group_id,
                 roleId: r.role_id,
                 createdAt: r.created_at,
+                name: r.name,
             };
         });
     }

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -3,6 +3,7 @@ import {
     IGroupModel,
     IGroupModelWithProjectRole,
     IGroupProject,
+    IGroupRole,
     IGroupUser,
 } from '../types/group';
 import { IUnleashConfig, IUnleashStores } from '../types';
@@ -191,6 +192,10 @@ export class GroupService {
         if (users.length == 0 || !users.some((u) => u.role == 'Owner')) {
             throw new BadDataError('Group needs to have at least one Owner');
         }
+    }
+
+    async getRolesForProject(projectId: string): Promise<IGroupRole[]> {
+        return this.groupStore.getProjectGroupRoles(projectId);
     }
 
     private mapGroupWithUsers(

--- a/src/lib/types/group.ts
+++ b/src/lib/types/group.ts
@@ -17,6 +17,7 @@ export interface IGroupUser {
 }
 
 export interface IGroupRole {
+    name: string;
     groupId: number;
     roleId: number;
     createdAt: Date;


### PR DESCRIPTION
Implemented `changeGroupRole` instead of using general access method, because access method was using merge, which doesnt play nicely with our primary keys.