### PR TITLE
fix: Make additionalProperties true

### DIFF
--- a/src/lib/openapi/spec/update-user-schema.ts
+++ b/src/lib/openapi/spec/update-user-schema.ts
@@ -3,7 +3,7 @@ import { FromSchema } from 'json-schema-to-ts';
 export const updateUserSchema = {
     $id: '#/components/schemas/updateUserSchema',
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
     properties: {
         email: {
             type: 'string',

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -2603,7 +2603,7 @@ Object {
         "type": "object",
       },
       "updateUserSchema": Object {
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": Object {
           "email": Object {
             "type": "string",


### PR DESCRIPTION
So, currently you're not allowed to update users due to openapi validation breaking on additional unkown fields.