### PR TITLE
Feat/environment creation schema

### DIFF
--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -27,6 +27,7 @@ import { createUserSchema } from './spec/create-user-schema';
 import { dateSchema } from './spec/date-schema';
 import { emailSchema } from './spec/email-schema';
 import { environmentSchema } from './spec/environment-schema';
+import { environmentCreateSchema } from './spec/environment-create-schema';
 import { environmentsSchema } from './spec/environments-schema';
 import { eventSchema } from './spec/event-schema';
 import { eventsSchema } from './spec/events-schema';
@@ -135,6 +136,7 @@ export const schemas = {
     dateSchema,
     emailSchema,
     environmentSchema,
+    environmentCreateSchema,
     environmentsSchema,
     eventSchema,
     eventsSchema,

--- a/src/lib/openapi/spec/environment-create-schema.test.ts
+++ b/src/lib/openapi/spec/environment-create-schema.test.ts
@@ -1,0 +1,33 @@
+import { validateSchema } from '../validate';
+import { EnvironmentCreateSchema } from './environment-create-schema';
+
+test('environmentCreateSchema', () => {
+    const data: EnvironmentCreateSchema[] = [
+        {
+            name: 'new-feature-1',
+            type: 'release',
+        },
+        {
+            name: 'new-feature-2',
+            type: 'release',
+            enabled: false,
+        },
+        {
+            name: 'new-feature-3',
+            type: 'release',
+            sortOrder: 5,
+        },
+        {
+            name: 'new-feature-4',
+            type: 'release',
+            sortOrder: 7,
+            enabled: false,
+        },
+    ];
+
+    data.forEach((obj) =>
+        expect(
+            validateSchema('#/components/schemas/environmentCreateSchema', obj),
+        ).toBeUndefined(),
+    );
+});

--- a/src/lib/openapi/spec/environment-create-schema.ts
+++ b/src/lib/openapi/spec/environment-create-schema.ts
@@ -1,0 +1,27 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const environmentCreateSchema = {
+    $id: '#/components/schemas/environmentCreateSchema',
+    type: 'object',
+    additionalProperties: false,
+    required: ['name', 'type'],
+    properties: {
+        name: {
+            type: 'string',
+        },
+        type: {
+            type: 'string',
+        },
+        enabled: {
+            type: 'boolean',
+        },
+        sortOrder: {
+            type: 'number',
+        },
+    },
+    components: {},
+} as const;
+
+export type EnvironmentCreateSchema = FromSchema<
+    typeof environmentCreateSchema
+>;

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -124,6 +124,9 @@ export interface IEnvironment {
     protected: boolean;
 }
 
+/*
+ * @deprecated prefer EnvironmentCreateSchema type instead
+ */
 export interface IEnvironmentCreate {
     name: string;
     type: string;

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -3,7 +3,7 @@ import { LogProvider } from '../logger';
 import { IRole } from './stores/access-store';
 import { IUser } from './user';
 import { ALL_OPERATORS } from '../util/constants';
-
+import { EnvironmentCreateSchema } from '../openapi/spec/environment-create-schema';
 export type Operator = typeof ALL_OPERATORS[number];
 
 export interface IConstraint {
@@ -127,12 +127,7 @@ export interface IEnvironment {
 /*
  * @deprecated prefer EnvironmentCreateSchema type instead
  */
-export interface IEnvironmentCreate {
-    name: string;
-    type: string;
-    sortOrder?: number;
-    enabled?: boolean;
-}
+export interface IEnvironmentCreate extends EnvironmentCreateSchema {}
 
 export interface IEnvironmentOverview {
     name: string;

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -905,6 +905,28 @@ Object {
         ],
         "type": "object",
       },
+      "environmentCreateSchema": Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "enabled": Object {
+            "type": "boolean",
+          },
+          "name": Object {
+            "type": "string",
+          },
+          "sortOrder": Object {
+            "type": "number",
+          },
+          "type": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "name",
+          "type",
+        ],
+        "type": "object",
+      },
       "environmentSchema": Object {
         "additionalProperties": false,
         "properties": Object {


### PR DESCRIPTION
## About the changes
This change registers a type that was self-created as a generated type that can be used as part of an openapi spec.

Relates to roadmap item: https://github.com/Unleash/unleash/issues/1391

### Important files
This type is used [here](https://github.com/Unleash/unleash/blob/8f60dd69585b0acddcfbcff29580123562aca7db/src/lib/db/environment-store.ts#L158) and [here](https://github.com/Unleash/unleash/blob/8f60dd69585b0acddcfbcff29580123562aca7db/src/lib/types/stores/environment-store.ts#L6)


## Discussion points
Should we just replace `IEnvironmentCreate`?