### PR TITLE
feat: add new standard errors

### DIFF
--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -26,7 +26,7 @@ const standardResponses = {
     409: conflictResponse,
 } as const;
 
-export type StandardResponses = typeof standardResponses;
+type StandardResponses = typeof standardResponses;
 
 export const getStandardResponses = (
     ...statusCodes: (keyof StandardResponses)[]

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -11,12 +11,22 @@ const badRequestResponse = {
     description: 'The request data does not match what we expect.',
 } as const;
 
+const notFoundResponse = {
+    description: 'The resource was not found.',
+} as const;
+
+const conflictResponse = {
+    description: 'The resource is in conflict with an existing one.',
+} as const;
+
 const standardResponses = {
     400: badRequestResponse,
     401: unauthorizedResponse,
+    404: notFoundResponse,
+    409: conflictResponse,
 } as const;
 
-type StandardResponses = typeof standardResponses;
+export type StandardResponses = typeof standardResponses;
 
 export const getStandardResponses = (
     ...statusCodes: (keyof StandardResponses)[]

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -16,7 +16,7 @@ const notFoundResponse = {
 } as const;
 
 const conflictResponse = {
-    description: 'The resource is in conflict with an existing one.',
+    description: 'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively .',
 } as const;
 
 const standardResponses = {

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -12,7 +12,7 @@ const badRequestResponse = {
 } as const;
 
 const notFoundResponse = {
-    description: 'The resource was not found.',
+    description: 'The requested resource was not found.',
 } as const;
 
 const conflictResponse = {

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -17,7 +17,7 @@ const notFoundResponse = {
 
 const conflictResponse = {
     description:
-        'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively .',
+        'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively.',
 } as const;
 
 const standardResponses = {

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -16,7 +16,8 @@ const notFoundResponse = {
 } as const;
 
 const conflictResponse = {
-    description: 'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively .',
+    description:
+        'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively .',
 } as const;
 
 const standardResponses = {


### PR DESCRIPTION
## About the changes
Adding new standard errors that are used widely across multiple endpoints. This should help improve OpenAPI documentation

Relates to:  https://github.com/Unleash/unleash/issues/1391

## Discussion points
409 is also being used for things like wrong status: `ProjectWithoutOwnerError`
