### PR TITLE
docs: remove references to deprecated proxy config variable

### DIFF
--- a/website/docs/how-to/how-to-use-custom-strategies.md
+++ b/website/docs/how-to/how-to-use-custom-strategies.md
@@ -10,12 +10,11 @@ In this example we want to define an activation strategy offers a scheduled rele
 
 1. **Navigate to the strategies view**. Interact with the "Configure" button in the page header and then go to the "Strategies" link in the dropdown menu that appears.
 
-    ![A visual guide for how to navigate to the strategies page in the Unleash admin UI. It shows the steps described in the preceding paragraph.](/img/custom-strategy-navigation.png)
+   ![A visual guide for how to navigate to the strategies page in the Unleash admin UI. It shows the steps described in the preceding paragraph.](/img/custom-strategy-navigation.png)
 
 2. **Define your strategy**. Use the "Add new strategy" button to open the strategy creation form. Fill in the form to define your strategy. Refer to [the custom strategy reference documentation](../advanced/custom-activation-strategy.md#definition) for a full list of options.
 
    ![A strategy creation form. It has fields labeled "strategy name" — "TimeStamp" — and "description" — "activate toggle after a given timestamp". It also has fields for a parameter named "enableAfter". The parameter is of type "string" and the parameter description is "Expected format: YYYY-MM-DD HH:MM". The parameter is required.](/img/timestamp_create_strategy.png)
-
 
 ## Step 2: Apply your custom strategy to a feature toggle {#step-2}
 
@@ -27,8 +26,8 @@ In this example we want to define an activation strategy offers a scheduled rele
 
 The steps to implement a custom strategy for your client depend on the kind of client SDK you're using:
 
-- if you're using a server-side client SDK, follow the steps in [option A](#step-3-a "Step 3 option A: implement the strategy for a server-side client SDK").
-- if you're using a front-end client SDK ([Android](../sdks/android-proxy.md), [JavaScript](../sdks/proxy-javascript.md), [React](../sdks/proxy-react.md), [iOS](../sdks/proxy-ios.md)), follow the steps in [option B](#step-3-b "Step 3 option B: implementing the strategy for a front-end client SDK")
+- if you're using a server-side client SDK, follow the steps in [option A](#step-3-a 'Step 3 option A: implement the strategy for a server-side client SDK').
+- if you're using a front-end client SDK ([Android](../sdks/android-proxy.md), [JavaScript](../sdks/proxy-javascript.md), [React](../sdks/proxy-react.md), [iOS](../sdks/proxy-ios.md)), follow the steps in [option B](#step-3-b 'Step 3 option B: implementing the strategy for a front-end client SDK')
 
 ### Option A: Implement the strategy for a server-side client SDK {#step-3-a}
 
@@ -48,7 +47,7 @@ The steps to implement a custom strategy for your client depend on the kind of c
    }
    ```
 
-2. **Register the custom strategy with the Unleash Client**.  When instantiating the Unleash Client, provide it with a list of the custom strategies you'd like to use — again: refer to _your_ client SDK's docs for the specifics.
+2. **Register the custom strategy with the Unleash Client**. When instantiating the Unleash Client, provide it with a list of the custom strategies you'd like to use — again: refer to _your_ client SDK's docs for the specifics.
 
    Here's a full, working example for Node.js. Notice the `strategies` property being passed to the `initialize` function.
 
@@ -78,12 +77,12 @@ The steps to implement a custom strategy for your client depend on the kind of c
        console.log(isEnabled('demo.TimeStampRollout'));
      }, 1000);
    });
-
    ```
 
 ### Option B: Implement the strategy for a front-end client SDK {#step-3-b}
 
 Front-end client SDKs don't evaluate strategies directly, so you need to implement the **custom strategy in the [Unleash Proxy](../sdks/unleash-proxy.md)**. Depending on how you run the Unleash Proxy, follow one of the below series of steps:
+
 - If you're running the Unleash Proxy as a Docker container, refer to the [steps for using a containerized Proxy](#step-3-b-docker).
 - If you're using the Unleash Proxy via Node.js, refer to the [steps for using custom strategies via Node.js](#step-3-b-node).
 
@@ -94,14 +93,14 @@ Strategies are stored in separate JavaScript files and loaded into the container
 1. **Create a strategies directory.** Create a directory that Docker has access to where you can store your strategies. The next steps assume you called it `strategies`
 2. **Initialize a Node.js project** and **install the Unleash Client**:
 
-   ``` shell npm2yarn
+   ```shell npm2yarn
    npm init -y && \
    npm install unleash-client
    ```
 
-3. **Create a strategy file** and **implement your strategies**. Remember to **export your list of strategies**. The next steps will assume you called the file `timestamp.js`.  An example implementation looks like this:
+3. **Create a strategy file** and **implement your strategies**. Remember to **export your list of strategies**. The next steps will assume you called the file `timestamp.js`. An example implementation looks like this:
 
-   ``` js
+   ```js
    const { Strategy } = require('unleash-client');
 
    class TimeStampStrategy extends Strategy {
@@ -119,9 +118,9 @@ Strategies are stored in separate JavaScript files and loaded into the container
 
 4. **Mount the strategies directory** and **point the [Unleash Proxy docker container](https://hub.docker.com/r/unleashorg/unleash-proxy) at your strategies file**. The highlighted lines below show the extra options you need to add. The following command assumes that your strategies directory is a direct subdirectory of your current working directory. Modify the rest of the command to suit your needs.
 
-   ``` shell
+   ```shell
    docker run --name unleash-proxy --pull=always \
-       -e UNLEASH_PROXY_SECRETS=some-secret \
+       -e UNLEASH_PROXY_CLIENT_KEYS=some-secret \
        -e UNLEASH_URL='http://unleash:4242/api/' \
        -e UNLEASH_API_TOKEN=${API_TOKEN} \
        # highlight-start
@@ -137,13 +136,13 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
 
 1. **Install the `unleash-client` package**. You'll need this to implement the custom strategy:
 
-   ``` shell npm2yarn
+   ```shell npm2yarn
    npm install unleash-client
    ```
 
 2. **Implement your strategy**. You can import it from a different file or put it in the same file as the Proxy initialization. For instance, a `TimeStampStrategy` could look like this:
 
-   ``` js
+   ```js
    const { Strategy } = require('unleash-client');
 
    class TimeStampStrategy extends Strategy {
@@ -159,7 +158,7 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
 
 3. **Pass the strategy to the Proxy Client** using the **`customStrategies`** option. A full code example:
 
-   ``` javascript
+   ```javascript
    const { createApp } = require('@unleash/proxy');
    const { Strategy } = require('unleash-client');
 
@@ -176,16 +175,17 @@ The Unleash Proxy accepts a `customStrategies` property as part of its initializ
    const port = 3000;
 
    const app = createApp({
-       unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
-       unleashApiToken: '*:default.56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
-       proxySecrets: ['proxy-secret', 'another-proxy-secret', 's1'],
-       refreshInterval: 1000,
-       // highlight-next-line
-       customStrategies: [new TimeStampStrategy()]
+     unleashUrl: 'https://app.unleash-hosted.com/demo/api/',
+     unleashApiToken:
+       '*:default.56907a2fa53c1d16101d509a10b78e36190b0f918d9f122d',
+     clientKeys: ['proxy-secret', 'another-proxy-secret', 's1'],
+     refreshInterval: 1000,
+     // highlight-next-line
+     customStrategies: [new TimeStampStrategy()],
    });
 
    app.listen(port, () =>
-       // eslint-disable-next-line no-console
-       console.log(`Unleash Proxy listening on http://localhost:${port}/proxy`),
+     // eslint-disable-next-line no-console
+     console.log(`Unleash Proxy listening on http://localhost:${port}/proxy`),
    );
    ```

--- a/website/docs/user_guide/quickstart.md
+++ b/website/docs/user_guide/quickstart.md
@@ -282,7 +282,7 @@ Follow steps outlined in the [Run Unleash with Docker](#run-unleash-with-docker)
 
    ```sh
    docker run \
-     -e UNLEASH_PROXY_SECRETS=some-secret \
+     -e UNLEASH_PROXY_CLIENT_KEYS=some-secret \
      -e UNLEASH_URL='http://unleash:4242/api/' \
      -e UNLEASH_API_TOKEN='${API_KEY}' \
      -p 3000:3000 \


### PR DESCRIPTION
This PR removes references to the deprecated configuration option `proxySecrets` from all code samples in the documentation.

The config option was superseded by `clientKeys` a while ago, but it turns out we forgot to update some of the docs. This PR fixes the remaining code samples.