### PR TITLE
Docs: Update compatibility matrix for php

### DIFF
--- a/website/docs/advanced/impression-data.md
+++ b/website/docs/advanced/impression-data.md
@@ -3,7 +3,7 @@ title: Impression data
 ---
 
 :::info Availability
-The impression data feature was introduced in **Unleash 4.7**. Listening for events requires [an SDK that supports impression data events](../sdks/index.md#server-side-sdk-compatibility-table). Currently, it's only supported in the [Unleash Proxy client](../sdks/proxy-javascript.md) and [React Proxy client](../sdks/proxy-react.md).
+The impression data feature was introduced in **Unleash 4.7**. Listening for events requires [an SDK that supports impression data events](../sdks/index.md#server-side-sdk-compatibility-table).
 :::
 
 Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** whenever it calls `isEnabled` or `getVariant`.
@@ -79,7 +79,7 @@ You can enable impression data via the impression data toggle in the admin UI's 
 ## Example setup
 
 :::caution
-This functionality is currently only supported in the [Unleash Proxy client](../sdks/proxy-javascript.md) and [React Proxy client](../sdks/proxy-react.md).
+This functionality is currently only supported in some of our SDKs, please see the [compatibility table for SDKs](../sdks/index.md#server-side-sdk-compatibility-table).
 :::
 
 The exact setup will vary depending on your [client SDK](../sdks/index.md). The below example configures the [Unleash Proxy client](/sdks/proxy-javascript) to listen for impression events and log them to the console. If "my-feature-toggle" is configured to emit impression data, then it will trigger an impression event as soon as Unleash is ready.

--- a/website/docs/advanced/impression-data.md
+++ b/website/docs/advanced/impression-data.md
@@ -3,7 +3,7 @@ title: Impression data
 ---
 
 :::info Availability
-The impression data feature was introduced in **Unleash 4.7**. Listening for events requires [an SDK that supports impression data events](../sdks/index.md#server-side-sdk-compatibility-table).
+The impression data feature was introduced in **Unleash 4.7**. Listening for events requires [an SDK that supports impression data events](../sdks/index.md#server-side-sdk-compatibility-table). In addition to supported server side SDKs impression data are available in JavaScript-based proxy clients.
 :::
 
 Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** whenever it calls `isEnabled` or `getVariant`.
@@ -79,7 +79,7 @@ You can enable impression data via the impression data toggle in the admin UI's 
 ## Example setup
 
 :::caution
-This functionality is currently only supported in some of our SDKs, please see the [compatibility table for SDKs](../sdks/index.md#server-side-sdk-compatibility-table).
+This functionality is currently only supported in the JavaScript-based proxy clients and some of our SDKs, please see the [compatibility table for SDKs](../sdks/index.md#server-side-sdk-compatibility-table).
 :::
 
 The exact setup will vary depending on your [client SDK](../sdks/index.md). The below example configures the [Unleash Proxy client](/sdks/proxy-javascript) to listen for impression events and log them to the console. If "my-feature-toggle" is configured to emit impression data, then it will trigger an impression event as soon as Unleash is ready.

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -72,7 +72,7 @@ If you see an item marked with a ❌ that you would find useful, feel free to re
 | [Gradual rollout: custom stickiness](../user_guide/activation_strategy#customize-stickiness-beta) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ |
 | [UserID](../user_guide/activation_strategy#userids) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [IP](../user_guide/activation_strategy#ips) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [IP](../user_guide/activation_strategy#ips): CIDR syntax | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ⭕ | ✅ | ✅ |
+| [IP](../user_guide/activation_strategy#ips): CIDR syntax | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅ | ✅ | ✅ |
 | [Hostname](../user_guide/activation_strategy#hostnames) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Category: [Custom strategies](../advanced/custom_activation_strategy)** |  |  |  |  |  |  |  |  |  |
 | Basic support | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/website/docs/sdks/index.md
+++ b/website/docs/sdks/index.md
@@ -60,8 +60,8 @@ If you see an item marked with a ❌ that you would find useful, feel free to re
 | Default metrics interval | 60s | 60s | 60s | 60s | 60s | 60s | 30s | 15s | 30s |
 | Context provider | ✅ | N/A | N/A | N/A | N/A | ✅ | ✅ | N/A | N/A |
 | Global fallback function | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A |
-| Toggle Query: `namePrefix` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Toggle Query: `tags` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Toggle Query: `namePrefix` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Toggle Query: `tags` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
 | Toggle Query: `project_name` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ⭕ | ✅ |
 | **Category: Custom Headers** |  |  |  |  |  |  |  |  |  |
 | static | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ | N/A |
@@ -98,7 +98,7 @@ If you see an item marked with a ❌ that you would find useful, feel free to re
 | Can disable metrics | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Client registration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Basic usage metrics (yes/no) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [Impression data](../advanced/impression-data.md) | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | N/A |
+| [Impression data](../advanced/impression-data.md) | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ✅ | ⭕ | N/A |
 | **Category: Bootstrap (beta)** |  |  |  |  |  |  |  |  |  |
 | Bootstrap from file | ✅ | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅ | ⭕ | ✅ |
 | Custom Bootstrap implementation | ✅ | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅ | ⭕ | ✅ |


### PR DESCRIPTION
## About the changes

Updated the compatibility table for php, `namePrefix` and `tags` filters and IP CIDR syntax were added some time ago, impression data just today (not released yet but will be during today, more specifically after https://github.com/Unleash/unleash-client-php/pull/104 gets merged).

## Discussion points

- Will the global segments be added to the compatibility table? If so, should it be added as part of this PR or a separate one?
