### PR TITLE
Fix Project members SQL query performance issue

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -258,11 +258,9 @@ class ProjectStore implements IProjectStore {
             .whereIn('role_id', rolesFromProject)
             .first();
         const { members } = numbers;
-
         if (typeof members === 'string') {
             return parseInt(members, 10);
         }
-
         return members;
     }
 

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -250,17 +250,19 @@ class ProjectStore implements IProjectStore {
     async getMembers(projectId: string): Promise<number> {
         const rolesFromProject = this.db('role_permission')
             .select('role_id')
-            .distinct()
-            .where({ project: projectId });
+            .distinct();
 
         const numbers = await this.db('role_user')
             .countDistinct('user_id as members')
+            .where('project', projectId)
             .whereIn('role_id', rolesFromProject)
             .first();
         const { members } = numbers;
+
         if (typeof members === 'string') {
             return parseInt(members, 10);
         }
+
         return members;
     }
 


### PR DESCRIPTION
This PR fixes the **slowest query in Unleash** (the average execution time on specific client was **~171ms**, where normal time would be 5-10ms), which is

```
SELECT count(DISTINCT "user_id") AS "members"
FROM "role_user"
WHERE "role_id" in
    (SELECT DISTINCT "role_id"
     FROM "role_permission"
     WHERE "project" = 'default')
LIMIT 1
```

There is interesting thing happening, the **inner query** is querying **project** column, but the column does not exist in that table. So through some magic, Postgres seems to make it work through **SubPlans**. This means that the inner query will be ran for every row in parent query. This makes the query with a big cost of **~31.35**.

```
"Limit  (cost=31.35..31.36 rows=1 width=8)"
"  ->  Aggregate  (cost=31.35..31.36 rows=1 width=8)"
"        ->  Seq Scan on role_user  (cost=0.00..31.34 rows=5 width=4)"
"              Filter: (SubPlan 1)"
"              SubPlan 1"
"                ->  HashAggregate  (cost=2.99..3.04 rows=5 width=4)"
"                      Group Key: role_permission.role_id"
"                      ->  Result  (cost=0.00..2.79 rows=79 width=4)"
"                            One-Time Filter: ((role_user.project)::text = 'default'::text)"
"                            ->  Seq Scan on role_permission  (cost=0.00..2.79 rows=79 width=4)"
```

Instead, we should call the project filter on correct table

```
SELECT count(DISTINCT "user_id") AS "members"
FROM "role_user"
WHERE "project" = 'default'
  AND "role_id" in
    (SELECT DISTINCT "role_id"
     FROM "role_permission")
LIMIT 1
```

Which makes the inner query run only once and reduces the cost of the query **six** times to **~4.32**

```
"Limit  (cost=4.31..4.32 rows=1 width=8)"
"  ->  Aggregate  (cost=4.31..4.32 rows=1 width=8)"
"        ->  Hash Join  (cost=3.15..4.30 rows=5 width=4)"
"              Hash Cond: (role_user.role_id = role_permission.role_id)"
"              ->  Seq Scan on role_user  (cost=0.00..1.12 rows=5 width=8)"
"                    Filter: ((project)::text = 'default'::text)"
"              ->  Hash  (cost=3.09..3.09 rows=5 width=4)"
"                    ->  HashAggregate  (cost=2.99..3.04 rows=5 width=4)"
"                          Group Key: role_permission.role_id"
"                          ->  Seq Scan on role_permission  (cost=0.00..2.79 rows=79 width=4)"
```
