### PR TITLE
fix: Add deprecated openapi tags as valid tags for operations

### DIFF
--- a/src/lib/openapi/util/api-operation.ts
+++ b/src/lib/openapi/util/api-operation.ts
@@ -1,7 +1,9 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { OpenApiTag } from './openapi-tags';
 
-export interface ApiOperation<Tag = OpenApiTag>
+type DeprecatedOpenAPITag = 'client' | 'other' | 'auth' | 'admin';
+
+export interface ApiOperation<Tag = OpenApiTag | DeprecatedOpenAPITag>
     extends Omit<OpenAPIV3.OperationObject, 'tags'> {
     operationId: string;
     tags: [Tag];


### PR DESCRIPTION
I realized that the tag changes we introduced in #1907 would be breaking for people who use the `unleash-server` package and implement their own endpoints on top of it (as we do in `unleash-enterprise`).

This change makes it possible to still use the old tags. However, these tags are purposefully not added to the root schema or the list of OpenAPI tag types. Any of our endpoints still using them (I think there is _one_ in Unleash enterprise, see https://github.com/ivarconr/unleash-enterprise/pull/109) should switch over when possible.