### PR TITLE
fix: check variants before mapping

### DIFF
--- a/src/lib/util/offline-unleash-client.ts
+++ b/src/lib/util/offline-unleash-client.ts
@@ -19,16 +19,14 @@ export const mapFeaturesForBootstrap = (
     features.map((feature) => ({
         impressionData: false,
         ...feature,
-        variants:
-            feature.variants &&
-            feature.variants.map((variant) => ({
-                overrides: [],
-                ...variant,
-                payload: variant.payload && {
-                    ...variant.payload,
-                    type: variant.payload.type as unknown as PayloadType,
-                },
-            })),
+        variants: (feature.variants || []).map((variant) => ({
+            overrides: [],
+            ...variant,
+            payload: variant.payload && {
+                ...variant.payload,
+                type: variant.payload.type as unknown as PayloadType,
+            },
+        })),
         strategies: feature.strategies.map((strategy) => ({
             parameters: {},
             ...strategy,

--- a/src/lib/util/offline-unleash-client.ts
+++ b/src/lib/util/offline-unleash-client.ts
@@ -19,14 +19,16 @@ export const mapFeaturesForBootstrap = (
     features.map((feature) => ({
         impressionData: false,
         ...feature,
-        variants: feature.variants.map((variant) => ({
-            overrides: [],
-            ...variant,
-            payload: variant.payload && {
-                ...variant.payload,
-                type: variant.payload.type as unknown as PayloadType,
-            },
-        })),
+        variants:
+            feature.variants &&
+            feature.variants.map((variant) => ({
+                overrides: [],
+                ...variant,
+                payload: variant.payload && {
+                    ...variant.payload,
+                    type: variant.payload.type as unknown as PayloadType,
+                },
+            })),
         strategies: feature.strategies.map((strategy) => ({
             parameters: {},
             ...strategy,


### PR DESCRIPTION
Our type says that variants should always exists as an array, but we have bad data in some instances where variants may be set to null if they were created before we fixed it in a previous release. This checks that feature.variants exists before mapping over it.

It remains to be discussed if we can should the underlying data with a migration.