### PR TITLE
docs: add more standard errors

### DIFF
--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -7,6 +7,11 @@ const unauthorizedResponse = {
         'Authorization information is missing or invalid. Provide a valid API token as the `authorization` header, e.g. `authorization:*.*.my-admin-token`.',
 } as const;
 
+const forbiddenResponse = {
+    description:
+        'User credentials are valid but does not have enough privileges to execute this operation',
+} as const;
+
 const badRequestResponse = {
     description: 'The request data does not match what we expect.',
 } as const;
@@ -23,6 +28,7 @@ const conflictResponse = {
 const standardResponses = {
     400: badRequestResponse,
     401: unauthorizedResponse,
+    403: forbiddenResponse,
     404: notFoundResponse,
     409: conflictResponse,
 } as const;


### PR DESCRIPTION
## About the changes
Add a standard error used when the user has not enough privileges to execute an operation