### PR TITLE
Feat: Create frontend API key

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -45,6 +45,7 @@ const tokenRowReducer = (acc, tokenRow) => {
             environment: token.environment ? token.environment : ALL,
             expiresAt: token.expires_at,
             createdAt: token.created_at,
+            metadata: token.metadata,
         };
     }
     const currentToken = acc[tokenRow.secret];
@@ -65,6 +66,7 @@ const toRow = (newToken: IApiTokenCreate) => ({
     environment:
         newToken.environment === ALL ? undefined : newToken.environment,
     expires_at: newToken.expiresAt,
+    metadata: newToken.metadata || {},
 });
 
 const toTokens = (rows: any[]): IApiToken[] => {
@@ -150,6 +152,7 @@ export class ApiTokenStore implements IApiTokenStore {
             await Promise.all(updateProjectTasks);
             return {
                 ...newToken,
+                metadata: newToken.metadata || {},
                 project: newToken.projects?.join(',') || '*',
                 createdAt: row.created_at,
             };

--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -126,6 +126,7 @@ export class ApiTokenStore implements IApiTokenStore {
                 'type',
                 'expires_at',
                 'created_at',
+                'metadata',
                 'seen_at',
                 'environment',
                 'token_project_link.project',

--- a/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
@@ -16,3 +16,20 @@ Object {
   "schema": "#/components/schemas/apiTokenSchema",
 }
 `;
+
+exports[`apiTokenSchema metadata - does not allow custom metadata parameters 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "instancePath": "/metadata",
+      "keyword": "additionalProperties",
+      "message": "must NOT have additional properties",
+      "params": Object {
+        "additionalProperty": "arbitraryParameter",
+      },
+      "schemaPath": "#/properties/metadata/additionalProperties",
+    },
+  ],
+  "schema": "#/components/schemas/apiTokenSchema",
+}
+`;

--- a/src/lib/openapi/spec/api-token-schema.test.ts
+++ b/src/lib/openapi/spec/api-token-schema.test.ts
@@ -2,22 +2,62 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { validateSchema } from '../validate';
 import { ApiTokenSchema } from './api-token-schema';
 
+const defaultData: ApiTokenSchema = {
+    secret: '',
+    username: '',
+    type: ApiTokenType.CLIENT,
+    environment: '',
+    projects: [],
+    expiresAt: '2022-01-01T00:00:00.000Z',
+    createdAt: '2022-01-01T00:00:00.000Z',
+    seenAt: '2022-01-01T00:00:00.000Z',
+    project: '',
+};
+
 test('apiTokenSchema', () => {
-    const data: ApiTokenSchema = {
-        secret: '',
-        username: '',
-        type: ApiTokenType.CLIENT,
-        environment: '',
-        projects: [],
-        expiresAt: '2022-01-01T00:00:00.000Z',
-        createdAt: '2022-01-01T00:00:00.000Z',
-        seenAt: '2022-01-01T00:00:00.000Z',
-        project: '',
-    };
+    const data: ApiTokenSchema = { ...defaultData };
 
     expect(
         validateSchema('#/components/schemas/apiTokenSchema', data),
     ).toBeUndefined();
+});
+
+test('apiTokenSchema metadata - should allow empty object', () => {
+    const data: ApiTokenSchema = { ...defaultData, metadata: {} };
+
+    expect(
+        validateSchema('#/components/schemas/apiTokenSchema', data),
+    ).toBeUndefined();
+});
+
+test('apiTokenSchema metadata - allows for corsOrigins and/or alias', () => {
+    expect(
+        validateSchema('#/components/schemas/apiTokenSchema', {
+            ...defaultData,
+            metadata: { corsOrigins: ['*'] },
+        }),
+    ).toBeUndefined();
+    expect(
+        validateSchema('#/components/schemas/apiTokenSchema', {
+            ...defaultData,
+            metadata: { alias: 'secret' },
+        }),
+    ).toBeUndefined();
+    expect(
+        validateSchema('#/components/schemas/apiTokenSchema', {
+            ...defaultData,
+            metadata: { corsOrigins: ['*'], alias: 'abc' },
+        }),
+    ).toBeUndefined();
+});
+
+test('apiTokenSchema metadata - does not allow custom metadata parameters', () => {
+    expect(
+        validateSchema('#/components/schemas/apiTokenSchema', {
+            ...defaultData,
+            metadata: { arbitraryParameter: true },
+        }),
+    ).toMatchSnapshot();
 });
 
 test('apiTokenSchema empty', () => {

--- a/src/lib/openapi/spec/api-token-schema.ts
+++ b/src/lib/openapi/spec/api-token-schema.ts
@@ -44,6 +44,21 @@ export const apiTokenSchema = {
             format: 'date-time',
             nullable: true,
         },
+        metadata: {
+            type: 'object',
+            properties: {
+                corsOrigins: {
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                    },
+                },
+                alias: {
+                    type: 'string',
+                },
+            },
+            nullable: true,
+        },
     },
     components: {},
 } as const;

--- a/src/lib/openapi/spec/api-token-schema.ts
+++ b/src/lib/openapi/spec/api-token-schema.ts
@@ -46,6 +46,7 @@ export const apiTokenSchema = {
         },
         metadata: {
             type: 'object',
+            additionalProperties: false,
             properties: {
                 corsOrigins: {
                     type: 'array',

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -9,7 +9,10 @@ const AdminApi = require('./admin-api');
 const ClientApi = require('./client-api');
 const Controller = require('./controller');
 import { HealthCheckController } from './health-check';
+<<<<<<< HEAD
 import ProxyController from './proxy-api';
+=======
+>>>>>>> 1ba57014 (refactor: remove unused API definition routes)
 
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
@@ -27,6 +30,7 @@ class IndexRouter extends Controller {
         );
         this.use('/api/admin', new AdminApi(config, services).router);
         this.use('/api/client', new ClientApi(config, services).router);
+<<<<<<< HEAD
 
         if (config.experimental.embedProxy) {
             this.use(
@@ -34,6 +38,8 @@ class IndexRouter extends Controller {
                 new ProxyController(config, services).router,
             );
         }
+=======
+>>>>>>> 1ba57014 (refactor: remove unused API definition routes)
     }
 }
 

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -9,10 +9,7 @@ const AdminApi = require('./admin-api');
 const ClientApi = require('./client-api');
 const Controller = require('./controller');
 import { HealthCheckController } from './health-check';
-<<<<<<< HEAD
 import ProxyController from './proxy-api';
-=======
->>>>>>> 1ba57014 (refactor: remove unused API definition routes)
 
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
@@ -30,7 +27,6 @@ class IndexRouter extends Controller {
         );
         this.use('/api/admin', new AdminApi(config, services).router);
         this.use('/api/client', new ClientApi(config, services).router);
-<<<<<<< HEAD
 
         if (config.experimental.embedProxy) {
             this.use(
@@ -38,8 +34,6 @@ class IndexRouter extends Controller {
                 new ProxyController(config, services).router,
             );
         }
-=======
->>>>>>> 1ba57014 (refactor: remove unused API definition routes)
     }
 }
 

--- a/src/lib/schema/api-token-schema.test.ts
+++ b/src/lib/schema/api-token-schema.test.ts
@@ -55,3 +55,27 @@ test('should set metadata', async () => {
     });
     expect(token.projects).toBeUndefined();
 });
+
+test('should allow for embedded proxy (frontend) key', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'proxy',
+        project: 'default',
+        metadata: {
+            corsOrigins: ['*'],
+        },
+    });
+    expect(token.error).toBeUndefined();
+});
+
+test('should set environment to default for proxy key', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'proxy',
+        project: 'default',
+        metadata: {
+            corsOrigins: ['*'],
+        },
+    });
+    expect(token.environment).toEqual('default');
+});

--- a/src/lib/schema/api-token-schema.test.ts
+++ b/src/lib/schema/api-token-schema.test.ts
@@ -42,3 +42,16 @@ test('should not have projects set if project is present', async () => {
     });
     expect(token.projects).not.toBeDefined();
 });
+
+test('should set metadata', async () => {
+    let token = await createApiToken.validateAsync({
+        username: 'test',
+        type: 'admin',
+        project: 'default',
+        metadata: {
+            corsOrigins: ['*'],
+            alias: 'secret',
+        },
+    });
+    expect(token.projects).toBeUndefined();
+});

--- a/src/lib/schema/api-token-schema.ts
+++ b/src/lib/schema/api-token-schema.ts
@@ -10,7 +10,7 @@ export const createApiToken = joi
             .string()
             .lowercase()
             .required()
-            .valid(ApiTokenType.ADMIN, ApiTokenType.CLIENT),
+            .valid(ApiTokenType.ADMIN, ApiTokenType.CLIENT, ApiTokenType.PROXY),
         expiresAt: joi.date().optional(),
         project: joi.when('projects', {
             not: joi.required(),
@@ -18,7 +18,7 @@ export const createApiToken = joi
         }),
         projects: joi.array().min(0).optional(),
         environment: joi.when('type', {
-            is: joi.string().valid(ApiTokenType.CLIENT),
+            is: joi.string().valid(ApiTokenType.CLIENT, ApiTokenType.PROXY),
             then: joi.string().optional().default(DEFAULT_ENV),
             otherwise: joi.string().optional().default(ALL),
         }),

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -102,7 +102,16 @@ export class ApiTokenService {
     }
 
     public getUserForToken(secret: string): ApiUser | undefined {
-        const token = this.activeTokens.find((t) => t.secret === secret);
+        let token = this.activeTokens.find((token) => t.secret === secret);
+
+        // If the token is not found, try to find it in the legacy format with the metadata alias
+        // This is to ensure that previous proxies we set up for our customers continue working
+        if (!token) {
+            token = this.activeTokens.find(
+                (token) => token.metadata.alias === secret,
+            );
+        }
+
         if (token) {
             return new ApiUser({
                 username: token.username,

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -102,14 +102,12 @@ export class ApiTokenService {
     }
 
     public getUserForToken(secret: string): ApiUser | undefined {
-        let token = this.activeTokens.find((token) => t.secret === secret);
+        let token = this.activeTokens.find((t) => t.secret === secret);
 
         // If the token is not found, try to find it in the legacy format with the metadata alias
         // This is to ensure that previous proxies we set up for our customers continue working
         if (!token) {
-            token = this.activeTokens.find(
-                (token) => token.metadata.alias === secret,
-            );
+            token = this.activeTokens.find((t) => t.metadata.alias === secret);
         }
 
         if (token) {

--- a/src/lib/types/models/api-token.ts
+++ b/src/lib/types/models/api-token.ts
@@ -22,17 +22,21 @@ export interface ILegacyApiTokenCreate {
 export interface IApiTokenCreate {
     secret: string;
     username: string;
+    metadata?: Metadata;
     type: ApiTokenType;
     environment: string;
     projects: string[];
     expiresAt?: Date;
 }
 
+type Metadata = { [key: string]: unknown };
+
 export interface IApiToken extends IApiTokenCreate {
     createdAt: Date;
     seenAt?: Date;
     environment: string;
     project: string;
+    metadata: Metadata;
 }
 
 export const isAllProjects = (projects: string[]): boolean => {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -212,6 +212,22 @@ Object {
             "nullable": true,
             "type": "string",
           },
+          "metadata": Object {
+            "additionalProperties": false,
+            "nullable": true,
+            "properties": Object {
+              "alias": Object {
+                "type": "string",
+              },
+              "corsOrigins": Object {
+                "items": Object {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
           "project": Object {
             "type": "string",
           },

--- a/src/test/fixtures/fake-api-token-store.ts
+++ b/src/test/fixtures/fake-api-token-store.ts
@@ -52,6 +52,7 @@ export default class FakeApiTokenStore
             createdAt: new Date(),
             project: newToken.projects?.join(',') || '*',
             ...newToken,
+            metadata: {},
         };
         this.tokens.push(apiToken);
         this.emit('insert');


### PR DESCRIPTION

## About the changes
Allow for creating new type of token for client-side API access. Add test coverage for it.


Relates to roadmap item: #1875 
