### PR TITLE
Add missing URL path element to featureLink

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -100,7 +100,7 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
         if (type === FEATURE_ARCHIVED) {
             return `${this.unleashUrl}/archive`;
         }
-        return `${this.unleashUrl}/projects/${project}/${featureName}`;
+        return `${this.unleashUrl}/projects/${project}/features/${featureName}`;
     }
 
     getAction(type: string): string {


### PR DESCRIPTION
The link for the feature ("Open in Unleash") posted to Slack (and others) using featureLink is wrong. 
The path element '/features' is missing.
