### PR TITLE
fix: resolve correct environment for admin tokens

### DIFF
--- a/src/lib/proxy/proxy-repository.ts
+++ b/src/lib/proxy/proxy-repository.ts
@@ -8,7 +8,7 @@ import {
     mapFeaturesForClient,
     mapSegmentsForClient,
 } from '../util/offline-unleash-client';
-import { ALL_PROJECTS } from '../util/constants';
+import { ALL_ENVS, ALL_PROJECTS } from '../util/constants';
 import { UnleashEvents } from 'unleash-client';
 import { ANY_EVENT } from '../util/anyEventEmitter';
 import { Logger } from '../logger';
@@ -99,7 +99,7 @@ export class ProxyRepository
         return mapFeaturesForClient(
             await this.services.featureToggleServiceV2.getClientFeatures({
                 project: await this.projectIdsForToken(),
-                environment: this.token.environment,
+                environment: this.environmentNameForToken(),
             }),
         );
     }
@@ -117,5 +117,13 @@ export class ProxyRepository
         }
 
         return this.token.projects;
+    }
+
+    private environmentNameForToken(): string {
+        if (this.token.environment === ALL_ENVS) {
+            return 'default';
+        }
+
+        return this.token.environment;
     }
 }

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -190,6 +190,12 @@ test('should allow requests with a token secret alias', async () => {
 });
 
 test('should allow requests with an admin token', async () => {
+    const featureA = randomId();
+    await createFeatureToggle({
+        name: featureA,
+        enabled: true,
+        strategies: [{ name: 'default', constraints: [], parameters: {} }],
+    });
     const adminToken = await createApiToken(ApiTokenType.ADMIN, {
         projects: ['*'],
         environment: '*',
@@ -199,7 +205,8 @@ test('should allow requests with an admin token', async () => {
         .set('Authorization', adminToken.secret)
         .expect('Content-Type', /json/)
         .expect(200)
-        .expect((res) => expect(res.body).toEqual({ toggles: [] }));
+        .expect((res) => expect(res.body.toggles).toHaveLength(1))
+        .expect((res) => expect(res.body.toggles[0].name).toEqual(featureA));
 });
 
 test('should not allow admin requests with a frontend token', async () => {


### PR DESCRIPTION
Admin tokens have `"*"` as their environment, which must be resolved.