### PR TITLE
feat: fetch project and environment from body

### DIFF
--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -54,6 +54,9 @@ const rbacMiddleware = (
                 projectId = await featureToggleStore.getProjectId(featureName);
             } else if (permission === CREATE_FEATURE) {
                 projectId = projectId || req.body.project || 'default';
+            } else if (permission.endsWith('FEATURE_STRATEGY')) {
+                projectId = projectId || req.body.projectId;
+                environment = environment || req.body.environmentId;
             }
 
             return accessService.hasPermission(


### PR DESCRIPTION
## About the changes
To improve OpenAPI documentation, we'd like to document the required permissions. In order to do that, we need to be able to get the project and environment parameters that come in the request body. Following a similar workaround as we used previously this should be considered a temporary solution until we standardise how we send parameters and the names we use.
