### PR TITLE
Feat/exp flag loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ts-toolbelt": "^9.6.0",
     "type-is": "^1.6.18",
     "unleash-client": "3.15.0",
-    "unleash-frontend": "4.15.0-beta.1",
+    "unleash-frontend": "4.14.8",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ts-toolbelt": "^9.6.0",
     "type-is": "^1.6.18",
     "unleash-client": "3.15.0",
-    "unleash-frontend": "4.14.8",
+    "unleash-frontend": "4.15.0-beta.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -64,18 +64,19 @@ Object {
   "experimental": Object {
     "batchMetrics": false,
     "embedProxy": false,
-  },
-  "flagResolver": FlagResolver {
-    "dynamicFlags": Array [
-      "ENABLE_DARK_MODE_SUPPORT",
-    ],
-    "experiments": Object {},
     "externalResolver": Object {
       "isEnabled": [Function],
     },
-    "uiFlags": Object {
-      "E": true,
+    "flags": Object {
       "ENABLE_DARK_MODE_SUPPORT": false,
+    },
+  },
+  "flagResolver": FlagResolver {
+    "experiments": Object {
+      "ENABLE_DARK_MODE_SUPPORT": false,
+    },
+    "externalResolver": Object {
+      "isEnabled": [Function],
     },
   },
   "frontendApiOrigins": Array [],

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -62,18 +62,22 @@ Object {
   },
   "eventHook": undefined,
   "experimental": Object {
-    "batchMetrics": false,
-    "embedProxy": false,
     "externalResolver": Object {
       "isEnabled": [Function],
     },
     "flags": Object {
       "ENABLE_DARK_MODE_SUPPORT": false,
+      "anonymiseEventLog": false,
+      "batchMetrics": false,
+      "embedProxy": false,
     },
   },
   "flagResolver": FlagResolver {
     "experiments": Object {
       "ENABLE_DARK_MODE_SUPPORT": false,
+      "anonymiseEventLog": false,
+      "batchMetrics": false,
+      "embedProxy": false,
     },
     "externalResolver": Object {
       "isEnabled": [Function],

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -65,6 +65,19 @@ Object {
     "batchMetrics": false,
     "embedProxy": false,
   },
+  "flagResolver": FlagResolver {
+    "dynamicFlags": Array [
+      "ENABLE_DARK_MODE_SUPPORT",
+    ],
+    "experiments": Object {},
+    "externalResolver": Object {
+      "isEnabled": [Function],
+    },
+    "uiFlags": Object {
+      "E": true,
+      "ENABLE_DARK_MODE_SUPPORT": false,
+    },
+  },
   "frontendApiOrigins": Array [],
   "getLogger": [Function],
   "import": Object {
@@ -106,6 +119,7 @@ Object {
   "ui": Object {
     "flags": Object {
       "E": true,
+      "ENABLE_DARK_MODE_SUPPORT": false,
     },
   },
   "versionCheck": Object {

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -70,7 +70,7 @@ export default async function getApp(
     }
 
     if (
-        config.experimental.embedProxy &&
+        config.experimental.flags.embedProxy &&
         config.frontendApiOrigins.length > 0
     ) {
         // Support CORS preflight requests for the frontend endpoints.

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -34,7 +34,10 @@ import {
     parseEnvVarNumber,
     parseEnvVarStrings,
 } from './util/parseEnvVar';
-import { IExperimentalOptions } from './types/experimental';
+import {
+    defaultExperimentalOptions,
+    IExperimentalOptions,
+} from './types/experimental';
 import {
     DEFAULT_SEGMENT_VALUES_LIMIT,
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
@@ -56,15 +59,12 @@ function mergeAll<T>(objects: Partial<T>[]): T {
 
 function loadExperimental(options: IUnleashOptions): IExperimentalOptions {
     return {
+        ...defaultExperimentalOptions,
         ...options.experimental,
-        embedProxy: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
-            Boolean(options.experimental?.embedProxy),
-        ),
-        batchMetrics: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_BATCH_METRICS,
-            Boolean(options.experimental?.batchMetrics),
-        ),
+        flags: {
+            ...defaultExperimentalOptions.flags,
+            ...options.experimental?.flags,
+        },
     };
 }
 
@@ -377,6 +377,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     ]);
 
     const experimental = loadExperimental(options);
+    const flagResolver = new FlagResolver(experimental);
 
     const ui = loadUI(options);
 
@@ -424,8 +425,6 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         parseEnvVarStrings(process.env.UNLEASH_FRONTEND_API_ORIGINS, []);
 
     const clientFeatureCaching = loadClientCachingOptions(options);
-
-    const flagResolver = new FlagResolver(ui.flags, experimental);
 
     return {
         db,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -39,7 +39,7 @@ import {
     DEFAULT_SEGMENT_VALUES_LIMIT,
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
 } from './util/segments';
-import FlagsResolver from './util/flag-resolver';
+import FlagResolver from './util/flag-resolver';
 
 const safeToUpper = (s: string) => (s ? s.toUpperCase() : s);
 
@@ -425,7 +425,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
 
     const clientFeatureCaching = loadClientCachingOptions(options);
 
-    const flagsResolver = new FlagsResolver(ui.flags, experimental);
+    const flagResolver = new FlagResolver(ui.flags, experimental);
 
     return {
         db,
@@ -438,7 +438,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ui,
         import: importSetting,
         experimental,
-        flagsResolver,
+        flagResolver,
         email,
         secureHeaders,
         enableOAS,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -34,11 +34,12 @@ import {
     parseEnvVarNumber,
     parseEnvVarStrings,
 } from './util/parseEnvVar';
-import { IExperimentalOptions } from './experimental';
+import { IExperimentalOptions } from './types/experimental';
 import {
     DEFAULT_SEGMENT_VALUES_LIMIT,
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
 } from './util/segments';
+import FlagsResolver from './util/flag-resolver';
 
 const safeToUpper = (s: string) => (s ? s.toUpperCase() : s);
 
@@ -102,6 +103,7 @@ function loadUI(options: IUnleashOptions): IUIConfig {
 
     ui.flags = {
         E: true,
+        ENABLE_DARK_MODE_SUPPORT: false,
     };
     return mergeAll([uiO, ui]);
 }
@@ -423,6 +425,8 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
 
     const clientFeatureCaching = loadClientCachingOptions(options);
 
+    const flagsResolver = new FlagsResolver(ui.flags, experimental);
+
     return {
         db,
         session,
@@ -434,6 +438,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ui,
         import: importSetting,
         experimental,
+        flagsResolver,
         email,
         secureHeaders,
         enableOAS,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -61,7 +61,7 @@ export const createStores = (
             db,
             eventBus,
             getLogger,
-            config?.experimental?.userGroups,
+            config?.experimental?.flags.userGroups,
         ),
         apiTokenStore: new ApiTokenStore(db, eventBus, getLogger),
         resetTokenStore: new ResetTokenStore(db, eventBus, getLogger),

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -57,12 +57,7 @@ export const createStores = (
         tagStore: new TagStore(db, eventBus, getLogger),
         tagTypeStore: new TagTypeStore(db, eventBus, getLogger),
         addonStore: new AddonStore(db, eventBus, getLogger),
-        accessStore: new AccessStore(
-            db,
-            eventBus,
-            getLogger,
-            config?.experimental?.flags.userGroups,
-        ),
+        accessStore: new AccessStore(db, eventBus, getLogger),
         apiTokenStore: new ApiTokenStore(db, eventBus, getLogger),
         resetTokenStore: new ResetTokenStore(db, eventBus, getLogger),
         sessionStore: new SessionStore(db, eventBus, getLogger),

--- a/src/lib/experimental.ts
+++ b/src/lib/experimental.ts
@@ -1,11 +1,6 @@
 export interface IExperimentalOptions {
-    metricsV2?: IExperimentalToggle;
     userGroups?: boolean;
     anonymiseEventLog?: boolean;
     embedProxy?: boolean;
     batchMetrics?: boolean;
-}
-
-export interface IExperimentalToggle {
-    enabled: boolean;
 }

--- a/src/lib/experimental.ts
+++ b/src/lib/experimental.ts
@@ -1,6 +1,0 @@
-export interface IExperimentalOptions {
-    userGroups?: boolean;
-    anonymiseEventLog?: boolean;
-    embedProxy?: boolean;
-    batchMetrics?: boolean;
-}

--- a/src/lib/experimental.ts
+++ b/src/lib/experimental.ts
@@ -1,6 +1,5 @@
 export interface IExperimentalOptions {
     metricsV2?: IExperimentalToggle;
-    clientFeatureMemoize?: IExperimentalToggle;
     userGroups?: boolean;
     anonymiseEventLog?: boolean;
     embedProxy?: boolean;

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -42,7 +42,8 @@ const apiAccessMiddleware = (
                 if (
                     (apiUser.type === CLIENT && !isClientApi(req)) ||
                     (apiUser.type === FRONTEND && !isProxyApi(req)) ||
-                    (apiUser.type === FRONTEND && !experimental.embedProxy)
+                    (apiUser.type === FRONTEND &&
+                        !experimental.flags.embedProxy)
                 ) {
                     res.status(403).send({ message: TOKEN_TYPE_ERROR_MESSAGE });
                     return;

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -77,11 +77,14 @@ class ConfigController extends Controller {
             simpleAuthSettings?.disabled ||
             this.config.authentication.type == IAuthType.NONE;
 
+        const expFlags = this.config.flagResolver.getAll({
+            email: req.user.email,
+        });
+        const flags = { ...this.config.ui.flags, ...expFlags };
+
         const response: UiConfigSchema = {
             ...this.config.ui,
-            flags: this.config.flagResolver.getUIFlags({
-                email: req.user.email,
-            }),
+            flags,
             version,
             emailEnabled: this.emailService.isEnabled(),
             unleashUrl: this.config.server.unleashUrl,
@@ -91,7 +94,7 @@ class ConfigController extends Controller {
             strategySegmentsLimit: this.config.strategySegmentsLimit,
             versionInfo: this.versionService.getVersionInfo(),
             disablePasswordAuth,
-            embedProxy: this.config.experimental.embedProxy,
+            embedProxy: this.config.experimental.flags.embedProxy,
         };
 
         this.openApiService.respondWithValidation(

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -1,4 +1,5 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
+import { AuthedRequest } from '../../types/core';
 import { IUnleashServices } from '../../types/services';
 import { IAuthType, IUnleashConfig } from '../../types/option';
 import version from '../../util/version';
@@ -66,7 +67,7 @@ class ConfigController extends Controller {
     }
 
     async getUIConfig(
-        req: Request,
+        req: AuthedRequest,
         res: Response<UiConfigSchema>,
     ): Promise<void> {
         const simpleAuthSettings =
@@ -78,6 +79,9 @@ class ConfigController extends Controller {
 
         const response: UiConfigSchema = {
             ...this.config.ui,
+            flags: this.config.flagsResolver.getUIFlags({
+                email: req.user.email,
+            }),
             version,
             emailEnabled: this.emailService.isEnabled(),
             unleashUrl: this.config.server.unleashUrl,

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -79,7 +79,7 @@ class ConfigController extends Controller {
 
         const response: UiConfigSchema = {
             ...this.config.ui,
-            flags: this.config.flagsResolver.getUIFlags({
+            flags: this.config.flagResolver.getUIFlags({
                 email: req.user.email,
             }),
             version,

--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -21,12 +21,13 @@ import {
 import { getStandardResponses } from '../../../lib/openapi/util/standard-responses';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { SearchEventsSchema } from '../../openapi/spec/search-events-schema';
+import { IFlagResolver } from '../../types/experimental';
 
 const version = 1;
 export default class EventController extends Controller {
     private eventService: EventService;
 
-    private anonymise: boolean = false;
+    private flagResolver: IFlagResolver;
 
     private openApiService: OpenApiService;
 
@@ -39,7 +40,7 @@ export default class EventController extends Controller {
     ) {
         super(config);
         this.eventService = eventService;
-        this.anonymise = config.experimental?.anonymiseEventLog;
+        this.flagResolver = config.flagResolver;
         this.openApiService = openApiService;
 
         this.route({
@@ -106,7 +107,7 @@ export default class EventController extends Controller {
     }
 
     maybeAnonymiseEvents(events: IEvent[]): IEvent[] {
-        if (this.anonymise) {
+        if (this.flagResolver.isEnabled('anonymiseEventLog')) {
             return events.map((e: IEvent) => ({
                 ...e,
                 createdBy: anonymise(e.createdBy),

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -12,7 +12,7 @@ async function getSetup(anonymise: boolean = false) {
     const stores = createStores();
     const config = createTestConfig({
         server: { baseUriPath: base },
-        experimental: { anonymiseEventLog: anonymise },
+        experimental: { flags: { anonymiseEventLog: anonymise } },
     });
     const services = createServices(stores, config);
     const app = await getApp(config, stores, services);

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -37,9 +37,10 @@ import {
     usersGroupsBaseSchema,
 } from '../../openapi/spec/users-groups-base-schema';
 import { IGroup } from '../../types/group';
+import { IFlagResolver } from '../../types/experimental';
 
 export default class UserAdminController extends Controller {
-    private anonymise: boolean = false;
+    private flagResolver: IFlagResolver;
 
     private userService: UserService;
 
@@ -90,7 +91,7 @@ export default class UserAdminController extends Controller {
         this.groupService = groupService;
         this.logger = config.getLogger('routes/user-controller.ts');
         this.unleashUrl = config.server.unleashUrl;
-        this.anonymise = config.experimental?.anonymiseEventLog;
+        this.flagResolver = config.flagResolver;
 
         this.route({
             method: 'post',
@@ -294,7 +295,7 @@ export default class UserAdminController extends Controller {
             typeof q === 'string' && q.length > 1
                 ? await this.userService.search(q)
                 : [];
-        if (this.anonymise) {
+        if (this.flagResolver.isEnabled('anonymiseEventLog')) {
             users = this.anonymiseUsers(users);
         }
         this.openApiService.respondWithValidation(

--- a/src/lib/routes/client-api/metrics.test.ts
+++ b/src/lib/routes/client-api/metrics.test.ts
@@ -82,9 +82,7 @@ test('should accept client metrics with yes/no', () => {
 });
 
 test('should accept client metrics with yes/no with metricsV2', async () => {
-    const testRunner = await getSetup({
-        experimental: { metricsV2: { enabled: true } },
-    });
+    const testRunner = await getSetup();
     await testRunner.request
         .post('/api/client/metrics')
         .send({

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -28,7 +28,7 @@ class IndexRouter extends Controller {
         this.use('/api/admin', new AdminApi(config, services).router);
         this.use('/api/client', new ClientApi(config, services).router);
 
-        if (config.experimental.embedProxy) {
+        if (config.experimental.flags.embedProxy) {
             this.use(
                 '/api/frontend',
                 new ProxyController(config, services).router,

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -16,7 +16,6 @@ import ApiUser from '../../types/api-user';
 import { ALL } from '../../types/models/api-token';
 import User from '../../types/user';
 import { collapseHourlyMetrics } from '../../util/collapseHourlyMetrics';
-import { IExperimentalOptions } from '../../types/experimental';
 
 export default class ClientMetricsServiceV2 {
     private timers: NodeJS.Timeout[] = [];
@@ -27,7 +26,7 @@ export default class ClientMetricsServiceV2 {
 
     private featureToggleStore: IFeatureToggleStore;
 
-    private experimental: IExperimentalOptions;
+    private batchMetricsEnabled: boolean;
 
     private eventBus: EventEmitter;
 
@@ -47,13 +46,13 @@ export default class ClientMetricsServiceV2 {
     ) {
         this.featureToggleStore = featureToggleStore;
         this.clientMetricsStoreV2 = clientMetricsStoreV2;
-        this.experimental = experimental;
+        this.batchMetricsEnabled = experimental.flags.batchMetrics;
         this.eventBus = eventBus;
         this.logger = getLogger(
             '/services/client-metrics/client-metrics-service-v2.ts',
         );
 
-        if (this.experimental.batchMetrics) {
+        if (this.batchMetricsEnabled) {
             this.timers.push(
                 setInterval(() => {
                     this.bulkAdd().catch(console.error);
@@ -91,7 +90,7 @@ export default class ClientMetricsServiceV2 {
             }))
             .filter((item) => !(item.yes === 0 && item.no === 0));
 
-        if (this.experimental.batchMetrics) {
+        if (this.batchMetricsEnabled) {
             this.unsavedMetrics = collapseHourlyMetrics([
                 ...this.unsavedMetrics,
                 ...clientMetrics,
@@ -104,7 +103,7 @@ export default class ClientMetricsServiceV2 {
     }
 
     async bulkAdd(): Promise<void> {
-        if (this.experimental.batchMetrics && this.unsavedMetrics.length > 0) {
+        if (this.batchMetricsEnabled && this.unsavedMetrics.length > 0) {
             // Make a copy of `unsavedMetrics` in case new metrics
             // arrive while awaiting `batchInsertMetrics`.
             const copy = [...this.unsavedMetrics];

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -16,7 +16,7 @@ import ApiUser from '../../types/api-user';
 import { ALL } from '../../types/models/api-token';
 import User from '../../types/user';
 import { collapseHourlyMetrics } from '../../util/collapseHourlyMetrics';
-import { IExperimentalOptions } from '../../experimental';
+import { IExperimentalOptions } from '../../types/experimental';
 
 export default class ClientMetricsServiceV2 {
     private timers: NodeJS.Timeout[] = [];

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -1,0 +1,31 @@
+export interface IFlags {
+    [key: string]: boolean;
+}
+export interface IExperimentalOptions {
+    flags?: {
+        [key: string]: boolean;
+    };
+    anonymiseEventLog?: boolean;
+    userGroups?: boolean;
+    embedProxy?: boolean;
+    batchMetrics?: boolean;
+    dynamicFlags?: string[];
+    externalResolver?: IExternalFlagsResolver;
+}
+
+export interface IUIFlags extends IFlags {
+    ENABLE_DARK_MODE_SUPPORT?: boolean;
+}
+
+export interface IFlagContext {
+    [key: string]: string;
+}
+
+export interface IFlagsResolver {
+    getUIFlags: (context?: IFlagContext) => IUIFlags;
+    isExperimentEnabled: (flagName: string, context?: IFlagContext) => boolean;
+}
+
+export interface IExternalFlagsResolver {
+    isEnabled: (flagName: string, context?: IFlagContext) => boolean;
+}

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -1,20 +1,34 @@
-export interface IFlags {
-    [key: string]: boolean;
-}
-export interface IExperimentalOptions {
-    flags?: {
-        [key: string]: boolean;
-    };
-    anonymiseEventLog?: boolean;
-    userGroups?: boolean;
-    embedProxy?: boolean;
-    batchMetrics?: boolean;
-    dynamicFlags?: string[];
-    externalResolver?: IExternalFlagResolver;
-}
+import { parseEnvVarBoolean } from '../util/parseEnvVar';
 
-export interface IUIFlags extends IFlags {
-    ENABLE_DARK_MODE_SUPPORT?: boolean;
+export type IFlags = Partial<Record<string, boolean>>;
+
+export const defaultExperimentalOptions = {
+    flags: {
+        ENABLE_DARK_MODE_SUPPORT: false,
+        anonymiseEventLog: false,
+        userGroups: false,
+        embedProxy: parseEnvVarBoolean(
+            process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
+            false,
+        ),
+        batchMetrics: parseEnvVarBoolean(
+            process.env.UNLEASH_EXPERIMENTAL_BATCH_METRICS,
+            false,
+        ),
+    },
+    externalResolver: { isEnabled: (): boolean => false },
+};
+
+export interface IExperimentalOptions {
+    flags: {
+        [key: string]: boolean;
+        ENABLE_DARK_MODE_SUPPORT?: boolean;
+        embedProxy?: boolean;
+        batchMetrics?: boolean;
+        anonymiseEventLog?: boolean;
+        userGroups?: boolean;
+    };
+    externalResolver: IExternalFlagResolver;
 }
 
 export interface IFlagContext {
@@ -22,8 +36,8 @@ export interface IFlagContext {
 }
 
 export interface IFlagResolver {
-    getUIFlags: (context?: IFlagContext) => IUIFlags;
-    isExperimentEnabled: (flagName: string, context?: IFlagContext) => boolean;
+    getAll: (context?: IFlagContext) => IFlags;
+    isEnabled: (expName: string, context?: IFlagContext) => boolean;
 }
 
 export interface IExternalFlagResolver {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -10,7 +10,7 @@ export interface IExperimentalOptions {
     embedProxy?: boolean;
     batchMetrics?: boolean;
     dynamicFlags?: string[];
-    externalResolver?: IExternalFlagsResolver;
+    externalResolver?: IExternalFlagResolver;
 }
 
 export interface IUIFlags extends IFlags {
@@ -21,11 +21,11 @@ export interface IFlagContext {
     [key: string]: string;
 }
 
-export interface IFlagsResolver {
+export interface IFlagResolver {
     getUIFlags: (context?: IFlagContext) => IUIFlags;
     isExperimentEnabled: (flagName: string, context?: IFlagContext) => boolean;
 }
 
-export interface IExternalFlagsResolver {
+export interface IExternalFlagResolver {
     isEnabled: (flagName: string, context?: IFlagContext) => boolean;
 }

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -6,7 +6,6 @@ export const defaultExperimentalOptions = {
     flags: {
         ENABLE_DARK_MODE_SUPPORT: false,
         anonymiseEventLog: false,
-        userGroups: false,
         embedProxy: parseEnvVarBoolean(
             process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
             false,
@@ -26,7 +25,6 @@ export interface IExperimentalOptions {
         embedProxy?: boolean;
         batchMetrics?: boolean;
         anonymiseEventLog?: boolean;
-        userGroups?: boolean;
     };
     externalResolver: IExternalFlagResolver;
 }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
 import { ILegacyApiTokenCreate } from './models/api-token';
-import { IFlagResolver, IExperimentalOptions, IUIFlags } from './experimental';
+import { IFlagResolver, IExperimentalOptions, IFlags } from './experimental';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 export type EventHook = (eventName: string, data: object) => void;
@@ -102,7 +102,7 @@ export interface IUnleashOptions {
     authentication?: Partial<IAuthOption>;
     ui?: object;
     import?: Partial<IImportOption>;
-    experimental?: IExperimentalOptions;
+    experimental?: Partial<IExperimentalOptions>;
     email?: Partial<IEmailOption>;
     secureHeaders?: boolean;
     additionalCspAllowedDomains?: ICspDomainOptions;
@@ -147,7 +147,7 @@ export interface IUIConfig {
             title: string;
         },
     ];
-    flags?: IUIFlags;
+    flags?: IFlags;
 }
 
 export interface ICspDomainOptions {

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
 import { ILegacyApiTokenCreate } from './models/api-token';
-import { IExperimentalOptions } from '../experimental';
+import { IFlagsResolver, IExperimentalOptions, IUIFlags } from './experimental';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 export type EventHook = (eventName: string, data: object) => void;
@@ -139,7 +139,6 @@ export interface IListeningHost {
 export interface IUIConfig {
     slogan?: string;
     name?: string;
-    flags?: { [key: string]: boolean };
     links?: [
         {
             value: string;
@@ -148,6 +147,7 @@ export interface IUIConfig {
             title: string;
         },
     ];
+    flags?: IUIFlags;
 }
 
 export interface ICspDomainOptions {
@@ -177,6 +177,7 @@ export interface IUnleashConfig {
     ui: IUIConfig;
     import: IImportOption;
     experimental?: IExperimentalOptions;
+    flagsResolver: IFlagsResolver;
     email: IEmailOption;
     secureHeaders: boolean;
     additionalCspAllowedDomains: ICspDomainConfig;

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
 import { ILegacyApiTokenCreate } from './models/api-token';
-import { IFlagsResolver, IExperimentalOptions, IUIFlags } from './experimental';
+import { IFlagResolver, IExperimentalOptions, IUIFlags } from './experimental';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 export type EventHook = (eventName: string, data: object) => void;
@@ -177,7 +177,7 @@ export interface IUnleashConfig {
     ui: IUIConfig;
     import: IImportOption;
     experimental?: IExperimentalOptions;
-    flagsResolver: IFlagsResolver;
+    flagResolver: IFlagResolver;
     email: IEmailOption;
     secureHeaders: boolean;
     additionalCspAllowedDomains: ICspDomainConfig;

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -1,0 +1,113 @@
+import FlagResolver from './flag-resolver';
+
+test('should produce UI flags', () => {
+    const uiFlags = {
+        E: true,
+        F: false,
+    };
+    const resolver = new FlagResolver(uiFlags, {});
+
+    const result = resolver.getUIFlags();
+
+    expect(result.E).toBe(true);
+    expect(result.F).toBe(false);
+
+    expect(result.ENABLE_DARK_MODE_SUPPORT).toBe(false);
+});
+
+test('should produce UI flags with extra dynamic flags', () => {
+    const uiFlags = {
+        E: true,
+    };
+    const resolver = new FlagResolver(uiFlags, { dynamicFlags: ['extraFlag'] });
+
+    const result = resolver.getUIFlags();
+
+    expect(result.E).toBe(true);
+    expect(result.extraFlag).toBe(false);
+});
+
+test('should use external resolver for dynamic flags', () => {
+    const uiFlags = {
+        E: true,
+    };
+
+    const externalResolver = {
+        isEnabled: (name: string) => {
+            if (name === 'extraFlag') {
+                return true;
+            }
+        },
+    };
+
+    const resolver = new FlagResolver(uiFlags, {
+        dynamicFlags: ['extraFlag'],
+        externalResolver,
+    });
+
+    const result = resolver.getUIFlags();
+
+    expect(result.E).toBe(true);
+    expect(result.extraFlag).toBe(true);
+});
+
+test('should not use external resolver for enabled UI flags', () => {
+    const uiFlags = {
+        E: true,
+        should_be_enabled: true,
+    };
+
+    const externalResolver = {
+        isEnabled: () => {
+            return false;
+        },
+    };
+
+    const resolver = new FlagResolver(uiFlags, {
+        dynamicFlags: ['extraFlag'],
+        externalResolver,
+    });
+
+    const result = resolver.getUIFlags();
+
+    expect(result.should_be_enabled).toBe(true);
+});
+
+test('should load experimental flags', () => {
+    const resolver = new FlagResolver(
+        {},
+        {
+            dynamicFlags: ['extraFlag'],
+            flags: {
+                someFlag: true,
+            },
+        },
+    );
+
+    expect(resolver.isExperimentEnabled('someFlag')).toBe(true);
+    expect(resolver.isExperimentEnabled('extraFlag')).toBe(false);
+});
+
+test('should load experimental flags from external provide', () => {
+    const externalResolver = {
+        isEnabled: (name: string) => {
+            if (name === 'extraFlag') {
+                return true;
+            }
+        },
+    };
+
+    const resolver = new FlagResolver(
+        {},
+        {
+            dynamicFlags: ['extraFlag'],
+            flags: {
+                someFlag: true,
+            },
+            externalResolver,
+        },
+    );
+
+    expect(resolver.isExperimentEnabled('someFlag')).toBe(true);
+    expect(resolver.isExperimentEnabled('extraFlag')).toBe(true);
+});

--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -1,0 +1,53 @@
+import {
+    IExperimentalOptions,
+    IExternalFlagsResolver,
+    IFlagContext,
+    IFlags,
+    IFlagsResolver,
+    IUIFlags,
+} from '../types/experimental';
+
+const DEFAULT_DYNAMIC_FLAGS = ['ENABLE_DARK_MODE_SUPPORT'];
+
+const DEFAULT_EXT_RESOLVER = { isEnabled: () => false };
+
+export default class FlagsResolver implements IFlagsResolver {
+    private uiFlags: IFlags;
+
+    private experiments: IFlags;
+
+    private dynamicFlags: string[] = [];
+
+    private externalResolver: IExternalFlagsResolver;
+
+    constructor(uiFlags: IUIFlags, expOpt: IExperimentalOptions) {
+        this.uiFlags = uiFlags || {};
+        this.experiments = expOpt.flags || {};
+        this.dynamicFlags = [
+            ...DEFAULT_DYNAMIC_FLAGS,
+            ...(expOpt.dynamicFlags || []),
+        ];
+        this.externalResolver = expOpt.externalResolver || DEFAULT_EXT_RESOLVER;
+    }
+
+    getUIFlags(context?: IFlagContext): IFlags {
+        const flags = { ...this.uiFlags };
+        this.dynamicFlags.forEach((name: string) => {
+            //Only test external resolver if disabled
+            if (!flags[name]) {
+                flags[name] = this.externalResolver.isEnabled(name, context);
+            }
+        });
+        return flags;
+    }
+
+    isExperimentEnabled(name: string, context?: IFlagContext): boolean {
+        if (this.experiments[name]) {
+            return true;
+        }
+        if (this.dynamicFlags.includes(name)) {
+            return this.externalResolver.isEnabled(name, context);
+        }
+        return false;
+    }
+}

--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -1,9 +1,9 @@
 import {
     IExperimentalOptions,
-    IExternalFlagsResolver,
+    IExternalFlagResolver,
     IFlagContext,
     IFlags,
-    IFlagsResolver,
+    IFlagResolver,
     IUIFlags,
 } from '../types/experimental';
 
@@ -11,14 +11,14 @@ const DEFAULT_DYNAMIC_FLAGS = ['ENABLE_DARK_MODE_SUPPORT'];
 
 const DEFAULT_EXT_RESOLVER = { isEnabled: () => false };
 
-export default class FlagsResolver implements IFlagsResolver {
+export default class FlagResolver implements IFlagResolver {
     private uiFlags: IFlags;
 
     private experiments: IFlags;
 
     private dynamicFlags: string[] = [];
 
-    private externalResolver: IExternalFlagsResolver;
+    private externalResolver: IExternalFlagResolver;
 
     constructor(uiFlags: IUIFlags, expOpt: IExperimentalOptions) {
         this.uiFlags = uiFlags || {};

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -2,17 +2,19 @@ import { start } from './lib/server-impl';
 import { createConfig } from './lib/create-config';
 import { LogLevel } from './lib/logger';
 import { ApiTokenType } from './lib/types/models/api-token';
-import { Unleash } from 'unleash-client';
 
+/*
+import { Unleash } from 'unleash-client';
 const unleash = new Unleash({
     appName: 'unleash',
     url: 'https://app.unleash-hosted.com/hosted/api/',
     refreshInterval: 1000,
     customHeaders: {
         Authorization:
-            'unleash-cloud:development.f719679e65c7367b7c36b4f08f04237116b862897f0c2808c976a48c',
+            'TOKEN',
     },
 });
+*/
 
 process.nextTick(async () => {
     try {
@@ -46,7 +48,7 @@ process.nextTick(async () => {
                     embedProxy: true,
                     batchMetrics: true,
                     anonymiseEventLog: false,
-                    externalResolver: unleash,
+                    // externalResolver: unleash,
                     flags: {},
                     dynamicFlags: [],
                 },

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -3,19 +3,6 @@ import { createConfig } from './lib/create-config';
 import { LogLevel } from './lib/logger';
 import { ApiTokenType } from './lib/types/models/api-token';
 
-/*
-import { Unleash } from 'unleash-client';
-const unleash = new Unleash({
-    appName: 'unleash',
-    url: 'https://app.unleash-hosted.com/hosted/api/',
-    refreshInterval: 1000,
-    customHeaders: {
-        Authorization:
-            'TOKEN',
-    },
-});
-*/
-
 process.nextTick(async () => {
     try {
         await start(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -44,13 +44,12 @@ process.nextTick(async () => {
                     enable: false,
                 },
                 experimental: {
-                    userGroups: true,
-                    embedProxy: true,
-                    batchMetrics: true,
-                    anonymiseEventLog: false,
                     // externalResolver: unleash,
-                    flags: {},
-                    dynamicFlags: [],
+                    flags: {
+                        embedProxy: true,
+                        batchMetrics: true,
+                        anonymiseEventLog: false,
+                    },
                 },
                 authentication: {
                     initApiTokens: [

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -31,7 +31,6 @@ process.nextTick(async () => {
                     enable: false,
                 },
                 experimental: {
-                    metricsV2: { enabled: true },
                     anonymiseEventLog: false,
                     userGroups: true,
                     embedProxy: true,

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -2,6 +2,17 @@ import { start } from './lib/server-impl';
 import { createConfig } from './lib/create-config';
 import { LogLevel } from './lib/logger';
 import { ApiTokenType } from './lib/types/models/api-token';
+import { Unleash } from 'unleash-client';
+
+const unleash = new Unleash({
+    appName: 'unleash',
+    url: 'https://app.unleash-hosted.com/hosted/api/',
+    refreshInterval: 1000,
+    customHeaders: {
+        Authorization:
+            'unleash-cloud:development.f719679e65c7367b7c36b4f08f04237116b862897f0c2808c976a48c',
+    },
+});
 
 process.nextTick(async () => {
     try {
@@ -31,10 +42,13 @@ process.nextTick(async () => {
                     enable: false,
                 },
                 experimental: {
-                    anonymiseEventLog: false,
                     userGroups: true,
                     embedProxy: true,
                     batchMetrics: true,
+                    anonymiseEventLog: false,
+                    externalResolver: unleash,
+                    flags: {},
+                    dynamicFlags: [],
                 },
                 authentication: {
                     initApiTokens: [

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -23,9 +23,11 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
             enabled: false,
         },
         experimental: {
-            userGroups: true,
-            embedProxy: true,
-            batchMetrics: true,
+            flags: {
+                userGroups: true,
+                embedProxy: true,
+                batchMetrics: true,
+            },
         },
     };
     const options = mergeAll<IUnleashOptions>([testConfig, config]);

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -24,7 +24,6 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
         },
         experimental: {
             flags: {
-                userGroups: true,
                 embedProxy: true,
                 batchMetrics: true,
             },

--- a/src/test/e2e/api/admin/client-metrics.e2e.test.ts
+++ b/src/test/e2e/api/admin/client-metrics.e2e.test.ts
@@ -9,9 +9,7 @@ let db: ITestDb;
 
 beforeAll(async () => {
     db = await dbInit('client_metrics_serial', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {
-        experimental: { metricsV2: { enabled: true } },
-    });
+    app = await setupAppWithCustomConfig(db.stores, {});
 });
 
 afterAll(async () => {

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -11,9 +11,7 @@ let defaultToken;
 
 beforeAll(async () => {
     db = await dbInit('metrics_two_api_client', getLogger);
-    app = await setupAppWithAuth(db.stores, {
-        experimental: { metricsV2: { enabled: true } },
-    });
+    app = await setupAppWithAuth(db.stores, {});
     defaultToken = await app.services.apiTokenService.createApiToken({
         type: ApiTokenType.CLIENT,
         project: 'default',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7243,10 +7243,10 @@ unleash-client@3.15.0:
     murmurhash3js "^3.0.1"
     semver "^7.3.5"
 
-unleash-frontend@4.14.8:
-  version "4.14.8"
-  resolved "https://registry.yarnpkg.com/unleash-frontend/-/unleash-frontend-4.14.8.tgz#c31ded48d8f6de859bde39833fc78ad8bd74c770"
-  integrity sha512-CcqyFhIZyb8qCHe6iX3saHTdIfN0TzAES2PaSWDCRPt17L9KcV1t+fns1nFvCIzH/XmM416uQC4HgKyoLtR9tw==
+unleash-frontend@4.15.0-beta.1:
+  version "4.15.0-beta.1"
+  resolved "https://registry.yarnpkg.com/unleash-frontend/-/unleash-frontend-4.15.0-beta.1.tgz#c98255af5408c7cce3aa5f3a38fe2c634813a93b"
+  integrity sha512-6kHYetlytLVibTfi+QAweve7YWFmXdWzl6aDcYg2XMYj2Ago0gMHwTqtkG7JfZonG1vU5dkfk/KwBKTFKLJn/g==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7243,10 +7243,10 @@ unleash-client@3.15.0:
     murmurhash3js "^3.0.1"
     semver "^7.3.5"
 
-unleash-frontend@4.15.0-beta.1:
-  version "4.15.0-beta.1"
-  resolved "https://registry.yarnpkg.com/unleash-frontend/-/unleash-frontend-4.15.0-beta.1.tgz#c98255af5408c7cce3aa5f3a38fe2c634813a93b"
-  integrity sha512-6kHYetlytLVibTfi+QAweve7YWFmXdWzl6aDcYg2XMYj2Ago0gMHwTqtkG7JfZonG1vU5dkfk/KwBKTFKLJn/g==
+unleash-frontend@4.14.8:
+  version "4.14.8"
+  resolved "https://registry.yarnpkg.com/unleash-frontend/-/unleash-frontend-4.14.8.tgz#c31ded48d8f6de859bde39833fc78ad8bd74c770"
+  integrity sha512-CcqyFhIZyb8qCHe6iX3saHTdIfN0TzAES2PaSWDCRPt17L9KcV1t+fns1nFvCIzH/XmM416uQC4HgKyoLtR9tw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## About the changes

Introduces the concept of an external flag resolver. This would allow us to use Unleash in Unleash to enable/disable experimental features. 

An example on how to use the Unleash SDK as an flag resolver:

```js
import { start } from './lib/server-impl';
import { createConfig } from './lib/create-config';
import { Unleash } from 'unleash-client';

const unleash = new Unleash({
    appName: 'unleash',
    url: 'https://app.unleash-hosted.com/hosted/api/',
    refreshInterval: 1000,
    customHeaders: {
        Authorization:
            'unleash-cloud:development.xxxxx',
    },
});

process.nextTick(async () => {
    try {
        await start(
            createConfig({
                db: {
                    user: 'unleash_user',
                    password: 'passord',
                    host: 'localhost',
                    port: 5432,
                    database: process.env.UNLEASH_DATABASE_NAME || 'unleash',
                    schema: process.env.UNLEASH_DATABASE_SCHEMA,
                    ssl: false,
                    applicationName: 'unleash',
                },
                experimental: {
                    externalResolver: unleash,
                },
            }),
        );
    } catch (error) {
        console.error(error);
        process.exit();
    }
}, 0);
```

## Discussion points

- **dynamicFlags** provides the names of the flags that can be dynamically enabled. The intention is to protect "non-dynamic flags" to be controlled by an external resolver. It also allows us to "know" which ui flags to check-for in addition to the statically configured UI flags. 
- Enabled static ui flags and experimental flags will not be possible to override with a dynamic flag. The intention is that these are expected to be enabled regardless of what the external resolver (unleash) thinks. 
- Removed userGroups flag. Can @sighphyre validate that (https://github.com/Unleash/unleash/pull/1961/commits/e01b86333a5cd2b30dfe9702a77a1428a67ed881)? 
- Removed the **metricsV2** flag. 