### PR TITLE
Add a counter for total number of environments

### DIFF
--- a/src/lib/db/environment-store.ts
+++ b/src/lib/db/environment-store.ts
@@ -81,6 +81,13 @@ export default class EnvironmentStore implements IEnvironmentStore {
         await this.db(TABLE).del();
     }
 
+    count(): Promise<number> {
+        return this.db
+            .from(TABLE)
+            .count('*')
+            .then((res) => Number(res[0].count));
+    }
+
     async get(key: string): Promise<IEnvironment> {
         const row = await this.db<IEnvironmentsTable>(TABLE)
             .where({ name: key })

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -40,8 +40,13 @@ export default class MetricsMonitor {
             return;
         }
 
-        const { eventStore, featureToggleStore, userStore, projectStore } =
-            stores;
+        const {
+            eventStore,
+            featureToggleStore,
+            userStore,
+            projectStore,
+            environmentStore,
+        } = stores;
 
         client.collectDefaultMetrics();
 
@@ -80,6 +85,10 @@ export default class MetricsMonitor {
             name: 'projects_total',
             help: 'Number of projects',
         });
+        const environmentsTotal = new client.Gauge({
+            name: 'environments_total',
+            help: 'Number of environments',
+        });
 
         const clientSdkVersionUsage = new client.Counter({
             name: 'client_sdk_versions',
@@ -91,12 +100,14 @@ export default class MetricsMonitor {
             let togglesCount: number = 0;
             let usersCount: number;
             let projectsCount: number;
+            let environmentsCount: number;
             try {
                 togglesCount = await featureToggleStore.count({
                     archived: false,
                 });
                 usersCount = await userStore.count();
                 projectsCount = await projectStore.count();
+                environmentsCount = await environmentStore.count();
                 // eslint-disable-next-line no-empty
             } catch (e) {}
 
@@ -109,6 +120,10 @@ export default class MetricsMonitor {
             if (projectsCount) {
                 projectsTotal.reset();
                 projectsTotal.set(projectsCount);
+            }
+            if (environmentsCount) {
+                environmentsTotal.reset();
+                environmentsTotal.set(environmentsCount);
             }
         }
 

--- a/src/lib/types/stores/environment-store.ts
+++ b/src/lib/types/stores/environment-store.ts
@@ -18,4 +18,5 @@ export interface IEnvironmentStore extends Store<IEnvironment, string> {
     delete(name: string): Promise<void>;
     disable(environments: IEnvironment[]): Promise<void>;
     enable(environments: IEnvironment[]): Promise<void>;
+    count(): Promise<number>;
 }

--- a/src/test/fixtures/fake-environment-store.ts
+++ b/src/test/fixtures/fake-environment-store.ts
@@ -26,8 +26,12 @@ export default class FakeEnvironmentStore implements IEnvironmentStore {
         return Promise.resolve();
     }
 
+    count(): Promise<number> {
+        return Promise.resolve(this.environments.length);
+    }
+
     async getAll(): Promise<IEnvironment[]> {
-        return this.environments;
+        return Promise.resolve(this.environments);
     }
 
     async exists(name: string): Promise<boolean> {


### PR DESCRIPTION
As an attempt from our Customer Success representatives, we'd like to keep track of how much use of our Pro/Enterprise features our customers are making. This PR adds number of environments as a metric (we already had number of projects). If we have users that have more than 2 environments, this will tell us they're using an upgraded feature.