### PR TITLE
fix: proxy api check

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -46,7 +46,7 @@ export default async function getApp(
     app.use(requestLogger(config));
 
     if (typeof config.preHook === 'function') {
-        await config.preHook(app, config, services);
+        config.preHook(app, config, services);
     }
 
     app.use(compression());

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -46,7 +46,7 @@ export default async function getApp(
     app.use(requestLogger(config));
 
     if (typeof config.preHook === 'function') {
-        config.preHook(app, config, services);
+        await config.preHook(app, config, services);
     }
 
     app.use(compression());

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -7,7 +7,16 @@ const isClientApi = ({ path }) => {
 };
 
 const isProxyApi = ({ path }) => {
-    return path && path.startsWith('/api/frontend');
+    if (!path) {
+        return;
+    }
+
+    return (
+        (!path.startsWith('/api/client') &&
+            !path.startsWith('/api/admin') &&
+            path.includes('proxy')) ||
+        (path && path.startsWith('/api/frontend'))
+    );
 };
 
 export const TOKEN_TYPE_ERROR_MESSAGE =

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -11,11 +11,13 @@ const isProxyApi = ({ path }) => {
         return;
     }
 
+    // Handle all our current proxy paths which will redirect to the new
+    // embedded proxy endpoint
     return (
-        (!path.startsWith('/api/client') &&
-            !path.startsWith('/api/admin') &&
-            path.includes('proxy')) ||
-        (path && path.startsWith('/api/frontend'))
+        path.startsWith('/api/default/proxy') ||
+        path.startsWith('/api/development/proxy') ||
+        path.startsWith('/api/production/proxy') ||
+        path.startsWith('/api/frontend')
     );
 };
 


### PR DESCRIPTION
Since we are mounting the current proxies under the following paths:
* /clientId/api/environment/proxy

And the current clientKeys are being migrated to frontend keys, we need to amend the api-token middleware to get access to the new endpoints.

#1875