### PR TITLE
fix: avoid stale feature strategy enabled status message

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEnabled/FeatureStrategyEnabled.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEnabled/FeatureStrategyEnabled.tsx
@@ -4,17 +4,21 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { Alert } from '@mui/material';
 import { IFeatureToggle } from 'interfaces/featureToggle';
 import { formatFeaturePath } from '../FeatureStrategyEdit/FeatureStrategyEdit';
+import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 
 interface IFeatureStrategyEnabledProps {
-    feature: IFeatureToggle;
+    projectId: string;
+    featureId: string;
     environmentId: string;
 }
 
 export const FeatureStrategyEnabled = ({
-    feature,
+    projectId,
+    featureId,
     environmentId,
 }: IFeatureStrategyEnabledProps) => {
-    const featurePagePath = formatFeaturePath(feature.project, feature.name);
+    const featurePagePath = formatFeaturePath(projectId, featureId);
+    const { feature } = useFeature(projectId, featureId);
 
     const featurePageLink = (
         <Link to={featurePagePath} style={{ color: 'inherit' }}>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -126,7 +126,8 @@ export const FeatureStrategyForm = ({
         <form className={styles.form} onSubmit={onSubmitWithValidation}>
             <div>
                 <FeatureStrategyEnabled
-                    feature={feature}
+                    projectId={feature.project}
+                    featureId={feature.name}
                     environmentId={environmentId}
                 />
             </div>


### PR DESCRIPTION
Ensures that `FeatureStrategyEnabled` uses fresh feature data, and not what's cached in the form.

https://linear.app/unleash/issue/1-199/the-general-message-inside-strategies-if-feature-toggle-is-enabled-in