### PR TITLE
Add support for `req.logout` with passport version 0.6.0 and onwards

### DIFF
--- a/src/lib/routes/logout.test.ts
+++ b/src/lib/routes/logout.test.ts
@@ -116,7 +116,7 @@ test('should call destroy on session', async () => {
 });
 
 test('should handle req.logout with callback function', async () => {
-    // passport <0.6.0
+    // passport >=0.6.0
     const baseUriPath = '';
     const logoutFunction = jest.fn((cb: (err?: any) => void) => cb());
     const app = express();
@@ -134,7 +134,7 @@ test('should handle req.logout with callback function', async () => {
 });
 
 test('should handle req.logout without callback function', async () => {
-    // passport >=0.6.0
+    // passport <0.6.0
     const baseUriPath = '';
     const logoutFunction = jest.fn();
     const app = express();

--- a/src/lib/routes/logout.test.ts
+++ b/src/lib/routes/logout.test.ts
@@ -97,22 +97,22 @@ test('should clear "unleash-session" cookie even when disabled clear site data',
         );
 });
 
-test('should remove the req.session during logout', async () => {
+test('should call destroy on session', async () => {
     const baseUriPath = '';
-    const fakeSession = { foo: 'bar' };
+    const fakeSession = {
+        destroy: jest.fn(),
+    };
     const app = express();
     const config = createTestConfig({ server: { baseUriPath } });
-    let reqObject = null;
     app.use((req: IAuthRequest, res, next) => {
         req.session = fakeSession;
-        reqObject = req;
         next();
     });
     app.use('/logout', new LogoutController(config).router);
     const request = supertest(app);
     await request.get(`${baseUriPath}/logout`);
 
-    expect(reqObject.session).toBeNull();
+    expect(fakeSession.destroy.mock.calls.length).toBe(1);
 });
 
 test('should handle req.logout with callback function', async () => {

--- a/src/lib/routes/logout.ts
+++ b/src/lib/routes/logout.ts
@@ -41,7 +41,7 @@ class LogoutController extends Controller {
         }
 
         if (req.session) {
-            req.session = null;
+            req.session.destroy();
         }
         res.clearCookie(this.cookieName);
 

--- a/src/lib/routes/logout.ts
+++ b/src/lib/routes/logout.ts
@@ -25,16 +25,30 @@ class LogoutController extends Controller {
                 res.redirect(req.session.logoutUrl);
                 return;
             }
-
-            req.session.destroy();
         }
 
         if (req.logout) {
-            req.logout();
+            if (req.logout.length === 0) {
+                // passport < 0.6.0
+                req.logout();
+                this.afterLogout(req, res);
+            } else {
+                // for passport >= 0.6.0, try to call with a callback function
+                req.logout((err) => {
+                    if (err) {
+                        throw err;
+                    }
+                    this.afterLogout(req, res);
+                });
+            }
         }
+    }
 
+    private afterLogout(req: IAuthRequest, res: Response) {
+        if (req.session) {
+            req.session = null;
+        }
         res.clearCookie(this.cookieName);
-
         if (this.clearSiteDataOnLogout) {
             res.set('Clear-Site-Data', '"cookies", "storage"');
         }

--- a/src/lib/routes/unleash-types.ts
+++ b/src/lib/routes/unleash-types.ts
@@ -8,7 +8,7 @@ export interface IAuthRequest<
     ReqQuery = any,
 > extends Request<PARAM, ResBody, ReqBody, ReqQuery> {
     user: User;
-    logout: () => void;
+    logout: any;
     session: any;
 }
 

--- a/src/lib/routes/unleash-types.ts
+++ b/src/lib/routes/unleash-types.ts
@@ -8,7 +8,7 @@ export interface IAuthRequest<
     ReqQuery = any,
 > extends Request<PARAM, ResBody, ReqBody, ReqQuery> {
     user: User;
-    logout: (() => void) | ((callback: (err: any) => void) => void);
+    logout: (() => void) | ((callback: (err?: any) => void) => void);
     session: any;
 }
 

--- a/src/lib/routes/unleash-types.ts
+++ b/src/lib/routes/unleash-types.ts
@@ -8,7 +8,7 @@ export interface IAuthRequest<
     ReqQuery = any,
 > extends Request<PARAM, ResBody, ReqBody, ReqQuery> {
     user: User;
-    logout: any;
+    logout: (() => void) | ((callback: (err: any) => void) => void);
     session: any;
 }
 


### PR DESCRIPTION
## About the changes
This change introduces support for using `unleash-server` with passport version `0.6.0`. Currently logout from unleash-server fails with that version, due to a change in the API of the passport library for `req.logout`. Issue #1947 describes this in detail.

Closes #1947  .

## Discussion points
The change is rather small. What should be noted though is a small change for the session handling. Passport >= `0.6.0` requires the session to still exist before `req.logout` is being called. Therefore I moved the session termination behind the logout.