### PR TITLE
Revert workflow

### DIFF
--- a/.github/workflows/release_changelog.yml
+++ b/.github/workflows/release_changelog.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: ${{ github.ref }}
+          body: ${{ steps.github_release.outputs.changelog }}
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
When merging `frontend` and `backend` we kept all the commits. This meant all `frontend` commits were added to this repository.

This brought up an issue, where release notes started failing, because the release notes included the whole history of `frontend`.

To bypass this, we disabled `backend` release notes until a minor release was done, which was 4.15.
Now we can reenable the full release notes. **This PR reverts the workflow to initial state.**