### PR TITLE
Fix validate-edge-tokens OpenAPI schema

### DIFF
--- a/src/lib/openapi/spec/validate-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validate-edge-tokens-schema.ts
@@ -9,10 +9,12 @@ export const validateEdgeTokensSchema = {
     properties: {
         tokens: {
             type: 'array',
-            anyOf: [
-                { items: { $ref: '#/components/schemas/edgeTokenSchema' } },
-                { items: { type: 'string' } },
-            ],
+            items: {
+                anyOf: [
+                    { $ref: '#/components/schemas/edgeTokenSchema' },
+                    { type: 'string' },
+                ],
+            },
         },
     },
     components: {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -3169,18 +3169,16 @@ exports[`should serve the OpenAPI spec 1`] = `
         "additionalProperties": false,
         "properties": {
           "tokens": {
-            "anyOf": [
-              {
-                "items": {
+            "items": {
+              "anyOf": [
+                {
                   "$ref": "#/components/schemas/edgeTokenSchema",
                 },
-              },
-              {
-                "items": {
+                {
                   "type": "string",
                 },
-              },
-            ],
+              ],
+            },
             "type": "array",
           },
         },


### PR DESCRIPTION
## What

This change fixes the description of the 'tokens' array of the validate edge tokens schema.

The source of the error was a simple inverson of anyOf and items.

## How

Swap `anyOf`and `items` ordering

## Why

So that the swagger editor and openapi tools don't complain about invalid schemas.

![image](https://user-images.githubusercontent.com/17786332/189653928-48f42047-34fb-40f0-9bcf-7a8c6a558560.png)
