### PR TITLE
feat: add method for migrating proxies without environment validation

### DIFF
--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -171,6 +171,18 @@ export class ApiTokenService {
         return this.insertNewApiToken(createNewToken);
     }
 
+    // TODO: Remove this service method after embedded proxy has been released in
+    // 4.16.0
+    public async createMigratedProxyApiToken(
+        newToken: Omit<IApiTokenCreate, 'secret'>,
+    ): Promise<IApiToken> {
+        validateApiToken(newToken);
+
+        const secret = this.generateSecretKey(newToken);
+        const createNewToken = { ...newToken, secret };
+        return this.insertNewApiToken(createNewToken);
+    }
+
     private async insertNewApiToken(
         newApiToken: IApiTokenCreate,
     ): Promise<IApiToken> {


### PR DESCRIPTION
This method is necessary to add because we're migrating the proxy keys in unleash cloud and we have instances with proxies enabled for environments that might be disabled. The current method will throw a bad data error in this instance, because we do not allow you to create API token for disabled environments. Caused by this line: https://github.com/Unleash/unleash/pull/2056/files#diff-c7747d86059ec3422885e79411b8ef7323c0804df081c110268dd3250ace3696R167

This is a useful validation to have, but in this instance it's blocking a migration that needs to happen regardless of whether or not the environment is disabled, because we might have users that have added configuration and are actively using that configuration in environments that have later been disabled.