### PR TITLE
Update to pull_request_target

### DIFF
--- a/.github/workflows/build_prs_jest_report.yaml
+++ b/.github/workflows/build_prs_jest_report.yaml
@@ -1,7 +1,7 @@
 name: PR -> Test & Coverage
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:


### PR DESCRIPTION
External builds are failing to upload coverage report