### PR TITLE
Fix(#1391): Expose API version even when not running via npm/yarn

### DIFF
--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -113,6 +113,7 @@ import { proxyMetricsSchema } from './spec/proxy-metrics-schema';
 import { setUiConfigSchema } from './spec/set-ui-config-schema';
 import { edgeTokenSchema } from './spec/edge-token-schema';
 import { validateEdgeTokensSchema } from './spec/validate-edge-tokens-schema';
+import version from '../util/version';
 
 // All schemas in `openapi/spec` should be listed here.
 export const schemas = {
@@ -273,7 +274,7 @@ export const createOpenApiSchema = ({
         servers: url ? [{ url }] : [],
         info: {
             title: 'Unleash API',
-            version: process.env.npm_package_version!,
+            version: version,
         },
         security: [{ apiKey: [] }],
         components: {

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -113,7 +113,7 @@ import { proxyMetricsSchema } from './spec/proxy-metrics-schema';
 import { setUiConfigSchema } from './spec/set-ui-config-schema';
 import { edgeTokenSchema } from './spec/edge-token-schema';
 import { validateEdgeTokensSchema } from './spec/validate-edge-tokens-schema';
-import version from '../util/version';
+import apiVersion from '../util/version';
 
 // All schemas in `openapi/spec` should be listed here.
 export const schemas = {
@@ -274,7 +274,7 @@ export const createOpenApiSchema = ({
         servers: url ? [{ url }] : [],
         info: {
             title: 'Unleash API',
-            version: version,
+            version: apiVersion,
         },
         security: [{ apiKey: [] }],
         components: {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -3316,6 +3316,7 @@ exports[`should serve the OpenAPI spec 1`] = `
   },
   "info": {
     "title": "Unleash API",
+    "version": "4.15.1",
   },
   "openapi": "3.0.3",
   "paths": {

--- a/src/test/e2e/api/openapi/openapi.e2e.test.ts
+++ b/src/test/e2e/api/openapi/openapi.e2e.test.ts
@@ -30,8 +30,6 @@ test('should serve the OpenAPI spec', async () => {
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((res) => {
-            // The version field is not set when running jest without yarn/npm.
-            delete res.body.info.version;
             // This test will fail whenever there's a change to the API spec.
             // If the change is intended, update the snapshot with `jest -u`.
             expect(res.body).toMatchSnapshot();


### PR DESCRIPTION
## What

Expose the current Unleash version in the generated OpenAPI docs, even when running via docker or other processes.

## Why

An OpenAPI spec without a version isn't valid. This causes some of our generation tools (such as the one for documentation) to fail.

## How

By changing how we fetch the current version:

Previously, we used `process.env.npm_package_version!`. However, when you're not running with yarn or npm, this is `undefined`. That causes the version number to not be included when running tests and when running using the official docker image.

Instead, we now use `version` from `lib/util/version`. This is the same version as the one used by the UI config endpoint, so it should be the same one as what the front end displays. To the best of my knowledge, this _is_ the version of the API.

## Discussion

It _may_ be that I have misunderstood what the version represents, but from what I can tell, it just exports what's listed as the version in package.json.

The source code of the `lib/util/version` file is:

```ts
// export module version
require('pkginfo')(module, 'version');

const { version } = module.exports;
export default version;
module.exports = version;
```