### PR TITLE
Refactor(#1391): don't check for OpenAPI version in snapshot tests

### DIFF
--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -3437,7 +3437,6 @@ exports[`should serve the OpenAPI spec 1`] = `
   },
   "info": {
     "title": "Unleash API",
-    "version": "4.15.1",
   },
   "openapi": "3.0.3",
   "paths": {

--- a/src/test/e2e/api/openapi/openapi.e2e.test.ts
+++ b/src/test/e2e/api/openapi/openapi.e2e.test.ts
@@ -33,8 +33,9 @@ test('should serve the OpenAPI spec', async () => {
         .expect((res) => {
             // Don't use the version field in snapshot tests. Having the version
             // listed in automated testing causes issues when trying to deploy
-            // new versions of the API (dueto mismatch between new tag versions etc).
+            // new versions of the API (due to mismatch between new tag versions etc).
             delete res.body.info.version;
+
             // This test will fail whenever there's a change to the API spec.
             // If the change is intended, update the snapshot with `jest -u`.
             expect(res.body).toMatchSnapshot();

--- a/src/test/e2e/api/openapi/openapi.e2e.test.ts
+++ b/src/test/e2e/api/openapi/openapi.e2e.test.ts
@@ -42,6 +42,17 @@ test('should serve the OpenAPI spec', async () => {
         });
 });
 
+test('should serve the OpenAPI spec with a `version` property', async () => {
+    return app.request
+        .get('/docs/openapi.json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+            // ensure that the version field is present
+            expect(res.body.info.version).toBeTruthy();
+        });
+});
+
 test('the generated OpenAPI spec is valid', async () => {
     const { body } = await app.request
         .get('/docs/openapi.json')

--- a/src/test/e2e/api/openapi/openapi.e2e.test.ts
+++ b/src/test/e2e/api/openapi/openapi.e2e.test.ts
@@ -30,6 +30,12 @@ test('should serve the OpenAPI spec', async () => {
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((res) => {
+            // remove the version from the received specification. The version
+            // _is_ a required field, but having the version listed in automated
+            // testing causes issues when trying to deploy new versions of the
+            // API (due to mismatch between new tag versions etc). That's why we
+            // remove it.
+            delete res.body.info.version;
             // This test will fail whenever there's a change to the API spec.
             // If the change is intended, update the snapshot with `jest -u`.
             expect(res.body).toMatchSnapshot();


### PR DESCRIPTION
remove the version from the received specification. The version _is_ a required field, but having the version listed in automated testing causes issues when trying to deploy new versions of the API (due to mismatch between new tag versions etc). That's why we remove it.