### PR TITLE
fix: s/Never logged/Never/g in frontend

### DIFF
--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -115,7 +115,7 @@ export const Group: VFC = () => {
                 Header: 'Last login',
                 accessor: (row: IGroupUser) => row.seenAt || '',
                 Cell: ({ row: { original: user } }: any) => (
-                    <TimeAgoCell value={user.seenAt} emptyText="Never logged" />
+                    <TimeAgoCell value={user.seenAt} emptyText="Never" />
                 ),
                 sortType: 'date',
                 maxWidth: 150,

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -152,7 +152,7 @@ const UsersList = () => {
                 Header: 'Last login',
                 accessor: (row: any) => row.seenAt || '',
                 Cell: ({ row: { original: user } }: any) => (
-                    <TimeAgoCell value={user.seenAt} emptyText="Never logged" />
+                    <TimeAgoCell value={user.seenAt} emptyText="Never" />
                 ),
                 disableGlobalFilter: true,
                 sortType: 'date',

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
@@ -180,7 +180,7 @@ export const ProjectAccessTable: VFC = () => {
                     return userRow.addedAt || '';
                 },
                 Cell: ({ value }: { value: Date }) => (
-                    <TimeAgoCell value={value} emptyText="Never logged" />
+                    <TimeAgoCell value={value} emptyText="Never" />
                 ),
                 sortType: 'date',
                 maxWidth: 150,
@@ -200,7 +200,7 @@ export const ProjectAccessTable: VFC = () => {
                         .reverse()[0];
                 },
                 Cell: ({ value }: { value: Date }) => (
-                    <TimeAgoCell value={value} emptyText="Never logged" />
+                    <TimeAgoCell value={value} emptyText="Never" />
                 ),
                 sortType: 'date',
                 maxWidth: 150,

--- a/frontend/src/component/project/ProjectAccess/ProjectGroupView/ProjectGroupView.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectGroupView/ProjectGroupView.tsx
@@ -89,7 +89,7 @@ const columns = [
         Header: 'Last login',
         accessor: (row: IGroupUser) => row.seenAt || '',
         Cell: ({ row: { original: user } }: any) => (
-            <TimeAgoCell value={user.seenAt} emptyText="Never logged" />
+            <TimeAgoCell value={user.seenAt} emptyText="Never" />
         ),
         sortType: 'date',
         maxWidth: 150,


### PR DESCRIPTION
When a user has never been logged in "last login: never" reads better
than "last login: Never logged".

![image](https://user-images.githubusercontent.com/842541/191022296-ae246bd2-0d79-4a6b-8d69-76a222ad6bc1.png)
