### PR TITLE
Fix(#1391): fix edge case URLs in code samples

### DIFF
--- a/website/clean-generated-docs.js
+++ b/website/clean-generated-docs.js
@@ -22,9 +22,9 @@ const options = {
     from: [
         /\/ushosted/g,
         /"https:\/\/us.app.unleash-hosted.com(\/ushosted)?"/g,
-        '"path":["ushosted","api"',
+        '"path":["ushosted",',
     ],
-    to: ['', '"<your-unleash-url>"', '"path":["api"'],
+    to: ['', '"<your-unleash-url>"', '"path":['],
 };
 
 replace(options);


### PR DESCRIPTION
## What

This change fixes URLs in code samples for endpoints that don't start with /api. Most endpoints do, but there are some edge cases, such as the edge and auth endpoints that don't. This change makes sure that those code samples are also correct.

## Why

So that code samples don't present the wrong URL. That'd be really confusing to users.

## How

By loosening one of the replacement regexes.