### PR TITLE
Wip: #1391: fix url issues

### DIFF
--- a/src/lib/openapi/index.test.ts
+++ b/src/lib/openapi/index.test.ts
@@ -45,13 +45,22 @@ describe('createOpenApiSchema', () => {
         ).toEqual('https://example.com');
     });
 
-    test('if baseurl is set strips from serverUrl', () => {
+    test('does not strip baseUri from serverUrl', () => {
         expect(
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/demo2',
                 baseUriPath: '/demo2',
             }).servers[0].url,
-        ).toEqual('https://example.com');
+        ).toEqual('https://example.com/demo2');
+    });
+
+    test('adds baseurl serverUrl if it is not already there', () => {
+        expect(
+            createOpenApiSchema({
+                unleashUrl: 'https://example.com',
+                baseUriPath: '/demo2',
+            }).servers[0].url,
+        ).toEqual('https://example.com/demo2');
     });
 
     test('if baseurl does not end with suffix, cowardly refuses to strip', () => {
@@ -74,6 +83,12 @@ describe('createOpenApiSchema', () => {
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/example/',
                 baseUriPath: '/example',
+            }).servers[0].url,
+        ).toEqual('https://example.com');
+        expect(
+            createOpenApiSchema({
+                unleashUrl: 'https://example.com/example/',
+                baseUriPath: '/example/',
             }).servers[0].url,
         ).toEqual('https://example.com');
     });

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -266,11 +266,12 @@ const findRootUrl: (unleashUrl: string, baseUriPath: string) => string = (
     if (!baseUriPath) {
         return unleashUrl;
     }
+
     const baseUrl = new URL(unleashUrl);
     if (baseUrl.pathname.indexOf(baseUriPath) >= 0) {
         return `${baseUrl.protocol}//${baseUrl.host}`;
     }
-    return baseUrl.toString();
+    return new URL(baseUriPath, unleashUrl).toString();
 };
 
 export const createOpenApiSchema = ({


### PR DESCRIPTION
## Discussion

As of today, the OpenAPI spec uses only the host for the server address. For our hosted solutions, that means that the URLs listed in the API description start with /ushosted or /customer-x

I don't think that's useful. Instead, I think the first path section should be part of the host url, so that all endpoints start with /api or their equivalent part, and not /ushosted or /customer-x

### Examples

This is what our `ushosted` instance looks like. Notice how the "server" is `https://us.app.unleash-hosted.com` and how all API paths start with `/ushosted`
 
![image](https://user-images.githubusercontent.com/17786332/191938407-1b31e928-6e17-43c3-b761-baa0bd2eefc6.png)

The same goes for our demo app

![image](https://user-images.githubusercontent.com/17786332/191939179-75a68586-7f0a-4519-8c94-2ddf793cdf76.png)

As far as I understand, the way we do things today, the actual _unleash instance_ is hosted at `/ushosted`, `/demo` or whatever. As such, I think that that path fragment should be added to the server url (in the dropdown at the top) and removed from the path.

From talks with @chriswk and @sighphyre, that should be configurable based on the variables `unleashUrl` and `baseUriPath`.

## Assumptions

Best I can tell, the `baseUriPath` should be _appended to_ the `unleashUrl` to create the full path to Unleash. This seems to be different than what the existing tests assume. I also assume that if `unleashUrl` ends with a string that is equal to `baseUriPath`, then they should _still_ be concatenated.

## What

This PR changes how we handle URLs in the openapi spec. It uses the entire Unleash url as the "url" in the openapi spec

## Why

See the discussion section above.

## How