### PR TITLE
fix: Revert breaking change for incoming token creation reqs

### DIFF
--- a/src/lib/openapi/spec/create-api-token-schema.ts
+++ b/src/lib/openapi/spec/create-api-token-schema.ts
@@ -30,7 +30,7 @@ export const createApiTokenSchema = {
         },
         type: {
             type: 'string',
-            enum: Object.values(ApiTokenType),
+            description: `One of ${Object.values(ApiTokenType).join(', ')}`,
         },
         environment: {
             type: 'string',


### PR DESCRIPTION
## What

This change reverts the spec change to create-api-token-schema that was introduced in 97c2b3c089c29c79f97b30a2417333efcd4f631c

That commit changed the endpoint from allowing any string to only allowing strings that match the values of the ApiTokenType value.

## Why

Because we already validate this on the backend, I didn't think it would break anything. However, because OpenAPI enums are case sensitive (and do not currently support anything else), it _did_ break the API. ([stack overflow post that explains how this works](https://stackoverflow.com/questions/60772786/case-insensitive-string-parameter-in-schema-of-openapi))

## Of note

This should have been caught by the tests, but it didn't show up until it was merged to the main branch. I think it might be worth looking into how we do the PR testing.