### PR TITLE
Fix openapi snapshot so tests will not fail

### DIFF
--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -668,11 +668,7 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "string",
           },
           "type": {
-            "enum": [
-              "client",
-              "admin",
-              "frontend",
-            ],
+            "description": "One of client, admin, frontend",
             "type": "string",
           },
           "username": {


### PR DESCRIPTION
Seems to be related to https://github.com/Unleash/unleash/pull/2084, OpenAPI spec was changed but new snapshot was not generated.