### PR TITLE
fixed missing role by calling get after insert

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -71,6 +71,7 @@ exports[`should create default config 1`] = `
       "batchMetrics": false,
       "embedProxy": false,
       "embedProxyFrontend": false,
+      "publicSignup": false,
     },
   },
   "flagResolver": FlagResolver {
@@ -80,6 +81,7 @@ exports[`should create default config 1`] = `
       "batchMetrics": false,
       "embedProxy": false,
       "embedProxyFrontend": false,
+      "publicSignup": false,
     },
     "externalResolver": {
       "isEnabled": [Function],

--- a/src/lib/db/public-signup-token-store.ts
+++ b/src/lib/db/public-signup-token-store.ts
@@ -152,9 +152,9 @@ export class PublicSignupTokenStore implements IPublicSignupTokenStore {
     ): Promise<PublicSignupTokenSchema> {
         const response = await this.db<ITokenRow>(TABLE).insert(
             toRow(newToken),
-            ['*'],
+            ['secret'],
         );
-        return toTokens(response)[0];
+        return this.get(response[0].secret);
     }
 
     async isValid(secret: string): Promise<boolean> {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->
There is a problem with the return object when inserting the public-signup-token in the db: The connection to `roles` table is not fetched

Solved by calling `get` after insert so that all the db table joins are used
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes # .

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
