### PR TITLE
fix: client registration events are on eventStore

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -226,7 +226,7 @@ export default class MetricsMonitor {
                     .inc(entry[1].no);
             }
         });
-        eventBus.on(CLIENT_REGISTER, (m) => {
+        eventStore.on(CLIENT_REGISTER, (m) => {
             if (m.sdkVersion && m.sdkVersion.indexOf(':') > -1) {
                 const [sdkName, sdkVersion] = m.sdkVersion.split(':');
                 clientSdkVersionUsage.labels(sdkName, sdkVersion).inc();


### PR DESCRIPTION
Client registration events are on eventStore and not on eventBus. This change makes us have sdk name and version metrics in unleash.
