### PR TITLE
docs(fix): fix broken link to front-end API tokens

### DIFF
--- a/website/docs/reference/front-end-api.md
+++ b/website/docs/reference/front-end-api.md
@@ -32,7 +32,7 @@ When using the front-end API in an SDK, there's three things you need to configu
 
 ### Front-end API tokens
 
-As a client-side API, you should use a [front-end API token](../reference/api-tokens-and-client-keys.mdx#front-end-api-tokens) to interact with it. Refer to the [how to create API tokens](../user_guide/token.mdx) guide for steps on how to create API tokens.
+As a client-side API, you should use a [front-end API token](../reference/api-tokens-and-client-keys.mdx#front-end-tokens) to interact with it. Refer to the [how to create API tokens](../user_guide/token.mdx) guide for steps on how to create API tokens.
 
 ### Cross-origin resource sharing (CORS) configuration {#cors}
 


### PR DESCRIPTION
This change fixes a broken link to front-end API tokens from the front-end API page. The anchor had changed