### PR TITLE
Fix/frontendapi synchronization

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -405,6 +405,13 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         listen = { host: server.host || undefined, port: server.port };
     }
 
+    const frontendApi = options.frontendApi || {
+        refreshIntervalInMs: parseEnvVarNumber(
+            process.env.FRONTEND_API_REFRESH_INTERVAL_MS,
+            10000,
+        ),
+    };
+
     const secureHeaders =
         options.secureHeaders ||
         parseEnvVarBoolean(process.env.SECURE_HEADERS, false);
@@ -449,6 +456,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         import: importSetting,
         experimental,
         flagResolver,
+        frontendApi,
         email,
         secureHeaders,
         enableOAS,

--- a/src/lib/proxy/proxy-repository.ts
+++ b/src/lib/proxy/proxy-repository.ts
@@ -40,6 +40,8 @@ export class ProxyRepository
 
     private segments: Segment[];
 
+    private timer: NodeJS.Timeout;
+
     constructor(
         config: Config,
         stores: Stores,
@@ -74,12 +76,18 @@ export class ProxyRepository
         // For now, simply reload all the data on any EventStore event.
         this.stores.eventStore.on(ANY_EVENT, this.onAnyEvent);
 
+        // Reload from DB every 5 seconds
+        this.timer = setInterval(() => {
+            this.loadDataForToken();
+        }, 5000).unref();
+
         this.emit(UnleashEvents.Ready);
         this.emit(UnleashEvents.Changed);
     }
 
     stop(): void {
         this.stores.eventStore.off(ANY_EVENT, this.onAnyEvent);
+        clearInterval(this.timer);
     }
 
     private async loadDataForToken() {

--- a/src/lib/proxy/proxy-repository.ts
+++ b/src/lib/proxy/proxy-repository.ts
@@ -13,7 +13,7 @@ import { UnleashEvents } from 'unleash-client';
 import { ANY_EVENT } from '../util/anyEventEmitter';
 import { Logger } from '../logger';
 
-type Config = Pick<IUnleashConfig, 'getLogger'>;
+type Config = Pick<IUnleashConfig, 'getLogger' | 'frontendApi'>;
 
 type Stores = Pick<IUnleashStores, 'projectStore' | 'eventStore'>;
 
@@ -57,7 +57,7 @@ export class ProxyRepository
         this.services = services;
         this.token = token;
         this.onAnyEvent = this.onAnyEvent.bind(this);
-        this.interval = 5000;
+        this.interval = config.frontendApi.refreshIntervalInMs;
     }
 
     getSegment(id: number): Segment | undefined {

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -118,6 +118,10 @@ export class ProxyService {
         this.clients.delete(secret);
     }
 
+    stopAll(): void {
+        this.clients.forEach((client) => client.destroy());
+    }
+
     private static assertExpectedTokenType({ type }: ApiUser) {
         assert(type === ApiTokenType.FRONTEND || type === ApiTokenType.ADMIN);
     }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -101,6 +101,7 @@ export interface IUnleashOptions {
     versionCheck?: Partial<IVersionOption>;
     authentication?: Partial<IAuthOption>;
     ui?: object;
+    frontendApi?: IFrontendApi;
     import?: Partial<IImportOption>;
     experimental?: Partial<IExperimentalOptions>;
     email?: Partial<IEmailOption>;
@@ -167,6 +168,10 @@ export interface ICspDomainConfig {
     imgSrc: string[];
 }
 
+interface IFrontendApi {
+    refreshIntervalInMs: number;
+}
+
 export interface IUnleashConfig {
     db: IDBOption;
     session: ISessionOption;
@@ -191,6 +196,7 @@ export interface IUnleashConfig {
     eventBus: EventEmitter;
     disableLegacyFeaturesApi?: boolean;
     environmentEnableOverrides?: string[];
+    frontendApi: IFrontendApi;
     inlineSegmentConstraints: boolean;
     segmentValuesLimit: number;
     strategySegmentsLimit: number;

--- a/website/docs/reference/front-end-api.md
+++ b/website/docs/reference/front-end-api.md
@@ -47,3 +47,14 @@ The client needs to point to the correct API endpoint. The front-end API is avai
 ### API token
 
 You can create appropriate token, with type `FRONTEND` on `<YOUR_UNLEASH_URL>/admin/api/create-token` page or with a request to `/api/admin/api-tokens`. See our guide on [how to create API tokens](../user_guide/token.mdx) for more details.
+
+### Refresh interval for tokens
+
+Internally, unleash will set up a new unleash client per token it sees and configure the client with the project and environment specified in the token. By default
+the refresh interval is set to 10 seconds, plus a 10 second stagger to avoid thundering herd. This means that if you have 1000 users, unleash will refresh the client data within a window of 10s + a random number between 0 and 10s. This is to avoid all clients hitting the database simultaneously to refresh their data. If you need to change this interval, you can do so by setting the `FRONTEND_API_REFRESH_INTERVAL_MS` environment variable or by setting it directly in the config on startup. Note that the interval is in milliseconds: 
+
+```
+const unleashConfig = {
+    ... // previous values 
+    frontendApi: { refreshIntervalInMs: 4000 }
+}


### PR DESCRIPTION
Introduces a way to sync the frontend api endpoints. Since we instantiate unleash client with a custom repository, that repository needs a way to refresh it's data. Previously we used the event system in unleash to do this, which doesn't work when we have multiple pods/instances running at the same time. The event system will only refresh the cache of the instance that receives the update request. This ensures that all instances refresh the cache on a staggered interval.

[#1875](https://github.com/Unleash/unleash/issues/1875)