### PR TITLE
docs: Update docs with new constraint availability

### DIFF
--- a/website/docs/advanced/strategy-constraints.md
+++ b/website/docs/advanced/strategy-constraints.md
@@ -4,13 +4,18 @@ title: Strategy Constraints
 ---
 
 :::info Availability
-Strategy constraints are available to Unleash Pro and Enterprise users.
+
+Before Unleash 4.16, strategy constraints were only available to Unleash Pro and Enterprise users. From 4.16 onwards, they're **available to everyone**.
+
 
 Unleash 4.9 introduced a more comprehensive set of constraint operators. These require that both Unleash *and* your client SDK of choice support them. See the [SDK compatibility table](../sdks/index.md#strategy-constraints) for more information. Prior to Unleash 4.9, the only available operators were `IN` and `NOT_IN`.
+
 :::
 
 :::caution undefined behavior
+
 When using _advanced strategy constraints_ (any operator that isn't `IN` or `NOT_IN`), *make sure your client SDK is up to date* and supports this feature. For older versions of the client SDKs we **cannot guarantee** any specific behavior. Please see the [incompatibilities section](#incompatibilities) for more information.
+
 :::
 
 **Strategy constraints** are conditions that must be satisifed for an [activation strategy](../user_guide/activation_strategy) to be evaluated for a feature toggle.

--- a/website/docs/how-to/how-to-add-strategy-constraints.md
+++ b/website/docs/how-to/how-to-add-strategy-constraints.md
@@ -4,7 +4,7 @@ title: How to add strategy constraints
 
 :::info Availability
 
-Strategy constraints are available to Unleash Pro and Enterprise users.
+Before Unleash 4.16, strategy constraints were only available to Unleash Pro and Enterprise users. From 4.16 onwards, they're **available to everyone**.
 
 :::
 

--- a/website/docs/how-to/how-to-add-strategy-constraints.md
+++ b/website/docs/how-to/how-to-add-strategy-constraints.md
@@ -18,7 +18,7 @@ You'll need to have an existing feature toggle with a defined strategy to add a 
 
 On the strategy you're working with, find and select the "edit strategy" button.
 
-![A feature toggle with one strategy. The "edit strategy" button is highlighted.](/img/add-constraint.png)
+![A feature toggle with one strategy. The "edit strategy" button is highlighted.](/img/create-toggle-edit-strategy.png)
 
 On the "edit strategy" screen, select the "add custom constraint" button to open the constraints menu.
 

--- a/website/docs/how-to/how-to-define-custom-context-fields.md
+++ b/website/docs/how-to/how-to-define-custom-context-fields.md
@@ -3,7 +3,10 @@ title: How to define custom context fields
 ---
 
 :::info Availability
-Custom context fields are available to Pro and Enterprise users. They were introduced in Unleash 3.2.28.
+
+
+Before Unleash 4.16, custom context fields were only available to Unleash Pro and Enterprise users. From 4.16 onwards, they're **available to everyone**. They were introduced in Unleash 3.2.28.
+
 :::
 
 This guide shows you how to create [custom context field for the Unleash Context](../user_guide/unleash-context.md#custom-context-fields). You can use custom context fields for [strategy constraints](../advanced/strategy-constraints.md) and for [custom stickiness calculations](../advanced/stickiness.md#custom-stickiness). If there are [standard Unleash Context fields](../user_guide/unleash-context.md#structure) missing from the context fields page, you can use the same steps to add them too.

--- a/website/docs/user_guide/unleash-context.md
+++ b/website/docs/user_guide/unleash-context.md
@@ -44,7 +44,9 @@ As an example: You've created a custom field called `groupId`. You know group ID
 ## Custom context fields
 
 :::info Availability
-Custom context fields are available to Pro and Enterprise users.
+
+Before Unleash 4.16, custom context fields were only available to Unleash Pro and Enterprise users. From 4.16 onwards, they're **available to everyone**. They were introduced in Unleash 3.2.28.
+
 :::
 
 Custom context fields allow you to extend the Unleash Context with more data that is applicable to your situation. Each context field definition consists of a name and an optional description. Additionally, you can choose to define a set of [_legal values_](#legal-values "legal values for custom context fields"), and you can choose whether or not the context field can be used in [custom stickiness calculations](../advanced/stickiness.md#custom-stickiness) for the [gradual rollout strategy](activation-strategies.md#customize-stickiness-beta) and for [feature toggle variants](../advanced/feature-toggle-variants.md).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,6 +26,14 @@ module.exports = {
             apiKey: '9772249a7262b377ac876853d32bd760',
             indexName: 'getunleash',
         },
+        announcementBar: {
+            id: 'strategy-constraints-announcement',
+            content:
+                '🚀 Unleash brings powerful Constraints feature to OSS users. <a href=https://www.getunleash.io/blog/unleash-brings-powerful-constraints-feature-to-oss-users title="Unleash blog: Constraints are now available to open-source users">Read more</a> →',
+            isCloseable: true,
+            backgroundColor: '#635dc5',
+            textColor: '#fff',
+        },
         navbar: {
             title: 'Unleash',
             logo: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -31,8 +31,6 @@ module.exports = {
             content:
                 '🚀 Unleash brings powerful Constraints feature to OSS users. <a href=https://www.getunleash.io/blog/unleash-brings-powerful-constraints-feature-to-oss-users title="Unleash blog: Constraints are now available to open-source users">Read more</a> →',
             isCloseable: true,
-            // backgroundColor: '#635dc5',
-            // textColor: '#fff',
         },
         navbar: {
             title: 'Unleash',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -31,8 +31,8 @@ module.exports = {
             content:
                 '🚀 Unleash brings powerful Constraints feature to OSS users. <a href=https://www.getunleash.io/blog/unleash-brings-powerful-constraints-feature-to-oss-users title="Unleash blog: Constraints are now available to open-source users">Read more</a> →',
             isCloseable: true,
-            backgroundColor: '#635dc5',
-            textColor: '#fff',
+            // backgroundColor: '#635dc5',
+            // textColor: '#fff',
         },
         navbar: {
             title: 'Unleash',

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -63,6 +63,12 @@ html[data-theme='dark'] {
     --docsearch-primary-color: var(--ifm-color-primary-darkest);
 }
 
+div[class^='announcementBar_'],
+div[class^='announcementBar_'] svg {
+    background-color: var(--ifm-color-primary);
+    color: var(--ifm-color-primary-contrast-background);
+}
+
 .visually-hidden {
     border: 0;
     clip: rect(0 0 0 0);


### PR DESCRIPTION
## What

This PR updates the docs with the new constraints availability changes introduced by #2112

It also adds a little (dismissable) banner at the top of the docs that announce this change.

## Why

To keep the docs up-to-date with what's actually available.