### PR TITLE
sort feature strategies by created_at first and then sort_order

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -193,6 +193,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 feature_name: featureName,
                 environment,
             })
+            .orderBy('created_at', 'asc')
             .orderBy('sort_order', 'asc');
         stopTimer();
         return rows.map(mapRow);

--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -193,8 +193,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 feature_name: featureName,
                 environment,
             })
-            .orderBy('created_at', 'asc')
-            .orderBy('sort_order', 'asc');
+            .orderBy('sort_order', 'created_at');
         stopTimer();
         return rows.map(mapRow);
     }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->
Currently the query to list featureStrategies is only sorted by sortOrder.  
When we create feature strategies the sort order is not specified.
This creates a bug where editing any other than the first feature strategy, moves it to the top of the list.  Essentially being sorted by updated_at (since sort order is not defined,  all the feature strategies have the same value for sort order)
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Fix: Sort by createdAt before sorting with sortOrder in store
<!-- Does it close an issue? Multiple? -->
Closes # .

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
