### PR TITLE
If baseUriPath is set format it, but if it's not, don't override default with empty string

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -115,7 +115,7 @@ exports[`should create default config 1`] = `
   "secureHeaders": false,
   "segmentValuesLimit": 100,
   "server": {
-    "baseUriPath": undefined,
+    "baseUriPath": "",
     "cdnPrefix": undefined,
     "enableRequestLogger": false,
     "gracefulShutdownEnable": true,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -115,7 +115,7 @@ exports[`should create default config 1`] = `
   "secureHeaders": false,
   "segmentValuesLimit": 100,
   "server": {
-    "baseUriPath": "",
+    "baseUriPath": undefined,
     "cdnPrefix": undefined,
     "enableRequestLogger": false,
     "gracefulShutdownEnable": true,

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -428,3 +428,37 @@ test('Environment variables for frontend CORS origins takes priority over option
     delete process.env.UNLEASH_FRONTEND_API_ORIGINS;
     expect(create()).toEqual(['*']);
 });
+
+test('baseUriPath defaults to the empty string', async () => {
+    let config = createConfig({});
+    expect(config.server.baseUriPath).toBe('');
+});
+test('BASE_URI_PATH defined in env is passed through', async () => {
+    process.env.BASE_URI_PATH = '/demo';
+    let config = createConfig({});
+    expect(config.server.baseUriPath).toBe('/demo');
+    delete process.env.BASE_URI_PATH;
+});
+
+test('environment variable takes precedence over configured variable', async () => {
+    process.env.BASE_URI_PATH = '/demo';
+    let config = createConfig({
+        server: {
+            baseUriPath: '/other',
+        },
+    });
+    expect(config.server.baseUriPath).toBe('/demo');
+    delete process.env.BASE_URI_PATH;
+});
+
+test.each(['demo', '/demo', '/demo/'])(
+    'Trailing and leading slashes gets normalized for base path %s',
+    async (path) => {
+        let config = createConfig({
+            server: {
+                baseUriPath: path,
+            },
+        });
+        expect(config.server.baseUriPath).toBe('/demo');
+    },
+);

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -234,7 +234,9 @@ const formatServerOptions = (
     /* eslint-disable-next-line */
     return {
         ...serverOptions,
-        baseUriPath: serverOptions.baseUriPath ? formatBaseUri(serverOptions.baseUriPath) : undefined,
+        baseUriPath: serverOptions.baseUriPath
+            ? formatBaseUri(serverOptions.baseUriPath)
+            : undefined,
     };
 };
 
@@ -364,9 +366,19 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const getLogger = options.getLogger || getDefaultLogProvider(logLevel);
     validateLogProvider(getLogger);
 
+    let basePath = process.env.BASE_URI_PATH
+        ? formatBaseUri(process.env.BASE_URI_PATH)
+        : undefined;
+    let serverEnvs;
+    if (basePath) {
+        serverEnvs = {
+            baseUriPath: basePath,
+        };
+    }
     const server: IServerOption = mergeAll([
         defaultServerOption,
         formatServerOptions(options.server),
+        serverEnvs,
     ]);
 
     const versionCheck: IVersionOption = mergeAll([

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -232,14 +232,10 @@ const formatServerOptions = (
     if (!serverOptions) return;
 
     /* eslint-disable-next-line */
-    if(serverOptions.baseUriPath) {
-        return {
-            ...serverOptions,
-            baseUriPath: formatBaseUri(serverOptions.baseUriPath),
-        };
-    } else {
-        return serverOptions;
-    }
+    return {
+        ...serverOptions,
+        baseUriPath: serverOptions.baseUriPath ? formatBaseUri(serverOptions.baseUriPath) : undefined,
+    };
 };
 
 const loadTokensFromString = (tokenString: String, tokenType: ApiTokenType) => {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -229,14 +229,20 @@ const removeUndefinedKeys = (o: object): object =>
 const formatServerOptions = (
     serverOptions?: Partial<IServerOption>,
 ): Partial<IServerOption> | undefined => {
-    if (!serverOptions) return;
+    if (!serverOptions) {
+        return {
+            baseUriPath: formatBaseUri(process.env.BASE_URI_PATH),
+        };
+    }
 
     /* eslint-disable-next-line */
     return {
         ...serverOptions,
-        baseUriPath: serverOptions.baseUriPath
+        baseUriPath: process.env.BASE_URI_PATH
+            ? formatBaseUri(process.env.BASE_URI_PATH)
+            : serverOptions.baseUriPath
             ? formatBaseUri(serverOptions.baseUriPath)
-            : undefined,
+            : '',
     };
 };
 
@@ -366,19 +372,9 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const getLogger = options.getLogger || getDefaultLogProvider(logLevel);
     validateLogProvider(getLogger);
 
-    let basePath = process.env.BASE_URI_PATH
-        ? formatBaseUri(process.env.BASE_URI_PATH)
-        : undefined;
-    let serverEnvs;
-    if (basePath) {
-        serverEnvs = {
-            baseUriPath: basePath,
-        };
-    }
     const server: IServerOption = mergeAll([
         defaultServerOption,
         formatServerOptions(options.server),
-        serverEnvs,
     ]);
 
     const versionCheck: IVersionOption = mergeAll([

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -238,11 +238,9 @@ const formatServerOptions = (
     /* eslint-disable-next-line */
     return {
         ...serverOptions,
-        baseUriPath: process.env.BASE_URI_PATH
-            ? formatBaseUri(process.env.BASE_URI_PATH)
-            : serverOptions.baseUriPath
-            ? formatBaseUri(serverOptions.baseUriPath)
-            : '',
+        baseUriPath: formatBaseUri(
+            process.env.BASE_URI_PATH || serverOptions.baseUriPath,
+        ),
     };
 };
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -232,10 +232,14 @@ const formatServerOptions = (
     if (!serverOptions) return;
 
     /* eslint-disable-next-line */
-    return {
-        ...serverOptions,
-        baseUriPath: formatBaseUri(serverOptions.baseUriPath),
-    };
+    if(serverOptions.baseUriPath) {
+        return {
+            ...serverOptions,
+            baseUriPath: formatBaseUri(serverOptions.baseUriPath),
+        };
+    } else {
+        return serverOptions;
+    }
 };
 
 const loadTokensFromString = (tokenString: String, tokenType: ApiTokenType) => {
@@ -364,10 +368,13 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const getLogger = options.getLogger || getDefaultLogProvider(logLevel);
     validateLogProvider(getLogger);
 
+    console.log(process.env.BASE_URI_PATH);
+    console.log(defaultServerOption);
     const server: IServerOption = mergeAll([
         defaultServerOption,
         formatServerOptions(options.server),
     ]);
+    console.log(server);
 
     const versionCheck: IVersionOption = mergeAll([
         defaultVersionOption,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -368,13 +368,10 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const getLogger = options.getLogger || getDefaultLogProvider(logLevel);
     validateLogProvider(getLogger);
 
-    console.log(process.env.BASE_URI_PATH);
-    console.log(defaultServerOption);
     const server: IServerOption = mergeAll([
         defaultServerOption,
         formatServerOptions(options.server),
     ]);
-    console.log(server);
 
     const versionCheck: IVersionOption = mergeAll([
         defaultVersionOption,


### PR DESCRIPTION
From Thomas and mine testing. BaseUriPath can't be set as an environment variable because we override it when trying to format the URI from the server config. This PR makes sure we only format if the custom server options actually have baseUriPath set.