### PR TITLE
fix: use correct column name for correct member count

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -271,7 +271,7 @@ class ProjectStore implements IProjectStore {
                     })
                     .union((queryBuilder) => {
                         queryBuilder
-                            .select('user_id', 'projects.name as project')
+                            .select('user_id', 'projects.id as project')
                             .from('role_user')
                             .leftJoin('roles', 'role_user.role_id', 'roles.id')
                             .crossJoin('projects')


### PR DESCRIPTION
## About the changes

The project name was being used in the query and was being mapped with `id` to get the `memberCount` which resulted in wrong counts

<!-- Does it close an issue? Multiple? -->
Closes #2123 
