### PR TITLE
fix: slack back link url to point to the feature page

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -100,7 +100,7 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
         if (type === FEATURE_ARCHIVED) {
             return `${this.unleashUrl}/archive`;
         }
-        return `${this.unleashUrl}/projects/${project}/${featureName}`;
+        return `${this.unleashUrl}/projects/${project}/features/${featureName}`;
     }
 
     getAction(type: string): string {


### PR DESCRIPTION
## About the changes
Updated the slack action button URL to point to the correct feature page

<!-- Does it close an issue? Multiple? -->
Closes #2122 