### PR TITLE
fix: strategy name sort

### DIFF
--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -175,8 +175,9 @@ export const StrategiesList = () => {
                 disableGlobalFilter: true,
             },
             {
+                id: 'Name',
                 Header: 'Name',
-                accessor: 'name',
+                accessor: (row: any) => formatStrategyName(row.name),
                 width: '90%',
                 Cell: ({
                     row: {
@@ -247,7 +248,7 @@ export const StrategiesList = () => {
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'name', desc: false }],
+            sortBy: [{ id: 'Name', desc: false }],
             hiddenColumns: ['description', 'sortOrder'],
         }),
         []


### PR DESCRIPTION
## About the changes
Simple accessor change to use the `formatStrategyName(row.name)` string, the same string we are using to render the cell.

Closes #2129.