### PR TITLE
Remove member count for default project

### DIFF
--- a/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
@@ -16,6 +16,7 @@ import {
     AccordionSummary,
 } from '@mui/material';
 import { UPDATE_PROJECT } from 'component/providers/AccessProvider/permissions';
+import { DEFAULT_PROJECT_ID } from '../../../../hooks/api/getters/useDefaultProject/useDefaultProjectId';
 
 interface IProjectInfoProps {
     id: string;
@@ -125,7 +126,6 @@ const ProjectInfo = ({
                         <p>projectId: {id}</p>
                     </div>
                 </div>
-
                 <div className={styles.infoSection}>
                     <div data-loading className={styles.percentageContainer}>
                         <PercentageCircle percentage={health} />
@@ -154,35 +154,39 @@ const ProjectInfo = ({
                         />
                     </Link>
                 </div>
-
-                <div
-                    className={styles.infoSection}
-                    style={{ marginBottom: '0' }}
-                >
-                    <p className={styles.subtitle} data-loading>
-                        Project members
-                    </p>
-                    <p data-loading className={styles.emphazisedText}>
-                        {memberCount}
-                    </p>
-                    <Link
-                        data-loading
-                        className={classnames(
-                            themeStyles.flexRow,
-                            themeStyles.justifyCenter,
-                            styles.infoLink
-                        )}
-                        to={link}
-                    >
-                        <span className={styles.linkText} data-loading>
-                            view more{' '}
-                        </span>
-                        <ArrowForwardIcon
-                            data-loading
-                            className={styles.arrowIcon}
-                        />
-                    </Link>
-                </div>
+                <ConditionallyRender
+                    condition={id !== DEFAULT_PROJECT_ID}
+                    show={
+                        <div
+                            className={styles.infoSection}
+                            style={{ marginBottom: '0' }}
+                        >
+                            <p className={styles.subtitle} data-loading>
+                                Project members
+                            </p>
+                            <p data-loading className={styles.emphazisedText}>
+                                {memberCount}
+                            </p>
+                            <Link
+                                data-loading
+                                className={classnames(
+                                    themeStyles.flexRow,
+                                    themeStyles.justifyCenter,
+                                    styles.infoLink
+                                )}
+                                to={link}
+                            >
+                                <span className={styles.linkText} data-loading>
+                                    view more{' '}
+                                </span>
+                                <ArrowForwardIcon
+                                    data-loading
+                                    className={styles.arrowIcon}
+                                />
+                            </Link>
+                        </div>
+                    }
+                />
             </div>
         </aside>
     );

--- a/frontend/src/component/project/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/ProjectCard.tsx
@@ -3,7 +3,7 @@ import { useStyles } from './ProjectCard.styles';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { ReactComponent as ProjectIcon } from 'assets/icons/projectIcon.svg';
 import React, { useState, SyntheticEvent, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Delete, Edit } from '@mui/icons-material';
 import { getProjectEditPath } from 'utils/routePathHelpers';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
@@ -15,6 +15,9 @@ import AccessContext from 'contexts/AccessContext';
 import { DEFAULT_PROJECT_ID } from 'hooks/api/getters/useDefaultProject/useDefaultProjectId';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { DeleteProjectDialogue } from '../Project/DeleteProject/DeleteProjectDialogue';
+import classnames from 'classnames';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { ConditionallyRender } from '../../common/ConditionallyRender/ConditionallyRender';
 
 interface IProjectCardProps {
     name: string;
@@ -120,12 +123,17 @@ export const ProjectCard = ({
                     <p data-loading>health</p>
                 </div>
 
-                <div className={classes.infoBox}>
-                    <p className={classes.infoStats} data-loading>
-                        {memberCount}
-                    </p>
-                    <p data-loading>members</p>
-                </div>
+                <ConditionallyRender
+                    condition={id !== DEFAULT_PROJECT_ID}
+                    show={
+                        <div className={classes.infoBox}>
+                            <p className={classes.infoStats} data-loading>
+                                {memberCount}
+                            </p>
+                            <p data-loading>members</p>
+                        </div>
+                    }
+                />
             </div>
             <DeleteProjectDialogue
                 project={id}

--- a/frontend/src/component/project/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/ProjectCard.tsx
@@ -3,7 +3,7 @@ import { useStyles } from './ProjectCard.styles';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { ReactComponent as ProjectIcon } from 'assets/icons/projectIcon.svg';
 import React, { useState, SyntheticEvent, useContext } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Delete, Edit } from '@mui/icons-material';
 import { getProjectEditPath } from 'utils/routePathHelpers';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
@@ -15,8 +15,6 @@ import AccessContext from 'contexts/AccessContext';
 import { DEFAULT_PROJECT_ID } from 'hooks/api/getters/useDefaultProject/useDefaultProjectId';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { DeleteProjectDialogue } from '../Project/DeleteProject/DeleteProjectDialogue';
-import classnames from 'classnames';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { ConditionallyRender } from '../../common/ConditionallyRender/ConditionallyRender';
 
 interface IProjectCardProps {


### PR DESCRIPTION
As discussed, for now we will remove member count from default project, because default project is special compared to other projects. Access tab is not available to them and members can not be added or removed