### PR TITLE
Update how project member count works

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -269,18 +269,6 @@ class ProjectStore implements IProjectStore {
                                 'group_role.group_id',
                             );
                     })
-                    .union((queryBuilder) => {
-                        queryBuilder
-                            .select('user_id', 'projects.id as project')
-                            .from('role_user')
-                            .leftJoin('roles', 'role_user.role_id', 'roles.id')
-                            .crossJoin('projects')
-                            .where((builder) =>
-                                builder
-                                    .where('type', 'root')
-                                    .where('roles.name', 'Editor'),
-                            );
-                    })
                     .as('query');
             })
             .groupBy('project')
@@ -324,9 +312,6 @@ class ProjectStore implements IProjectStore {
                         builder
                             .where('project', projectId)
                             .whereNot('type', 'root'),
-                    )
-                    .orWhere((builder) =>
-                        builder.where('type', 'root').where('name', 'Editor'),
                     )
                     .union((queryBuilder) => {
                         queryBuilder


### PR DESCRIPTION
Previously project member count relied on this logic:

```
1. Exclude global admin and global viewer
2. Include everyone that is on the access tab , whether is user or group
3. Include global editor  ( from role_user, role_id 2)
```

This PR removes simplifies the logic. Global roles are not counted at all. The rules is following

```
1. Include everyone that is on the access tab , whether is user or group
```