### PR TITLE
docs: add link to migration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 
 [Open Live Demo →](https://www.getunleash.io/interactive-demo)
 
-
 </div>
 
 ## About Unleash
@@ -212,6 +211,12 @@ If none of the official SDKs fit your need, there's also a number of [community-
 **Proud Open-Source users:** (send us a message if you want to add your logo here)
 
 ![The Unleash logo encircled by logos for Finn.no, nav (the Norwegian Labour and Welfare Administration), Budgets, Otovo, and Amedia. The encircling logos are all connected to the Unleash logo.](./.github/github_unleash_users.svg)
+
+<br/>
+
+## Migration guides
+
+Unleash has evolved significantly over the past few years, and we know how hard it can be to keep software up to date. If you're using the current major version, upgrading shouldn't be an issue. If you're on a previous major version, check out the [Unleash migration guide](https://docs.getunleash.io/deploy/migration_guide)!
 
 <br/>
 


### PR DESCRIPTION
## What

This adds a short section on Unleash migration and a link to the migration guide to the readme.

## Why

There was some concern that the readme was too focused on new users and that existing users (especially ones who are still on v3) might not find what they need. To try and make their life easier, this PR adds a short section on upgrading and migrating and links to the official guide.