### PR TITLE
feat: add event log to project

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -23,6 +23,7 @@ import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { DeleteProjectDialogue } from './DeleteProject/DeleteProjectDialogue';
+import ProjectLog from './ProjectLog/ProjectLog';
 
 const StyledDiv = styled('div')(() => ({
     display: 'flex',
@@ -83,6 +84,11 @@ const Project = () => {
             title: 'Archive',
             path: `${basePath}/archive`,
             name: 'archive',
+        },
+        {
+            title: 'Event log',
+            path: `${basePath}/logs`,
+            name: 'logs',
         },
     ];
 
@@ -211,6 +217,7 @@ const Project = () => {
                 <Route path="access/*" element={<ProjectAccess />} />
                 <Route path="environments" element={<ProjectEnvironment />} />
                 <Route path="archive" element={<ProjectFeaturesArchive />} />
+                <Route path="logs" element={<ProjectLog />} />
                 <Route path="*" element={<ProjectOverview />} />
             </Routes>
         </div>

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -23,7 +23,7 @@ import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { DeleteProjectDialogue } from './DeleteProject/DeleteProjectDialogue';
-import ProjectLog from './ProjectLog/ProjectLog';
+import { ProjectLog } from './ProjectLog/ProjectLog';
 
 const StyledDiv = styled('div')(() => ({
     display: 'flex',

--- a/frontend/src/component/project/Project/ProjectLog/ProjectLog.styles.ts
+++ b/frontend/src/component/project/Project/ProjectLog/ProjectLog.styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from 'tss-react/mui';
+
+export const useStyles = makeStyles()(theme => ({
+    container: {
+        borderRadius: '12.5px',
+        backgroundColor: theme.palette.background.paper,
+        padding: '2rem',
+    },
+}));

--- a/frontend/src/component/project/Project/ProjectLog/ProjectLog.styles.ts
+++ b/frontend/src/component/project/Project/ProjectLog/ProjectLog.styles.ts
@@ -1,9 +1,0 @@
-import { makeStyles } from 'tss-react/mui';
-
-export const useStyles = makeStyles()(theme => ({
-    container: {
-        borderRadius: '12.5px',
-        backgroundColor: theme.palette.background.paper,
-        padding: '2rem',
-    },
-}));

--- a/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
+++ b/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
@@ -1,21 +1,23 @@
 import { EventLog } from 'component/events/EventLog/EventLog';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useStyles } from './ProjectLog.styles';
+import { styled } from '@mui/material';
 
-const ProjectLog = () => {
+const StyledDiv = styled('div')(({ theme }) => ({
+    borderRadius: '12.5px',
+    backgroundColor: theme.palette.background.paper,
+    padding: '2rem',
+}));
+
+export const ProjectLog = () => {
     const projectId = useRequiredPathParam('projectId');
 
-    const { classes: styles } = useStyles();
-
     return (
-        <div className={styles.container}>
+        <StyledDiv>
             <EventLog
                 title="Event Log"
                 project={projectId}
                 displayInline
             ></EventLog>
-        </div>
+        </StyledDiv>
     );
 };
-
-export default ProjectLog;

--- a/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
+++ b/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
@@ -1,0 +1,22 @@
+import { EventLog } from 'component/events/EventLog/EventLog';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useStyles } from './ProjectLog.styles';
+
+const ProjectLog = () => {
+    const projectId = useRequiredPathParam('projectId');
+
+    const { classes: styles } = useStyles();
+
+    return (
+        <div className={styles.container}>
+            <EventLog
+                title="Event Log"
+                project={projectId}
+                feature={'test'}
+                displayInline
+            ></EventLog>
+        </div>
+    );
+};
+
+export default ProjectLog;

--- a/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
+++ b/frontend/src/component/project/Project/ProjectLog/ProjectLog.tsx
@@ -12,7 +12,6 @@ const ProjectLog = () => {
             <EventLog
                 title="Event Log"
                 project={projectId}
-                feature={'test'}
                 displayInline
             ></EventLog>
         </div>


### PR DESCRIPTION
## About the changes
Adding Event log tab to Project view to show all events within a project at one place

<!-- Does it close an issue? Multiple? -->
Closes #2060

### Important files


## Discussion points
Initially thought that a new `useProjectEvents` would be needed, but getting onto the code realised, it might not be. The current `useEventSearch` hook relies on the common event API and if a feature isn't passed to that it provides all project-level events. Just adding a new component and tab on the Project view seemed to work. Tested it with a few cases of search and multiple toggles and projects, seemed to work fine. Not sure if this is all that was needed
