### PR TITLE
fix: auto add stratgy when enabling empty env.

### DIFF
--- a/src/lib/routes/admin-api/project/features.ts
+++ b/src/lib/routes/admin-api/project/features.ts
@@ -527,6 +527,7 @@ export default class ProjectFeaturesController extends Controller {
             environment,
             true,
             extractUsername(req),
+            req.user,
         );
         res.status(200).end();
     }
@@ -542,6 +543,7 @@ export default class ProjectFeaturesController extends Controller {
             environment,
             false,
             extractUsername(req),
+            req.user,
         );
         res.status(200).end();
     }

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -72,6 +72,10 @@ import { Saved, Unsaved } from '../types/saved';
 import { SegmentService } from './segment-service';
 import { SetStrategySortOrderSchema } from 'lib/openapi/spec/set-strategy-sort-order-schema';
 import { getDefaultStrategy } from '../util/feature-evaluator/helpers';
+import { AccessService } from './access-service';
+import { User } from '../server-impl';
+import { CREATE_FEATURE_STRATEGY } from '../types/permissions';
+import NoAccessError from '../error/no-access-error';
 
 interface IFeatureContext {
     featureName: string;
@@ -107,6 +111,8 @@ class FeatureToggleService {
 
     private segmentService: SegmentService;
 
+    private accessService: AccessService;
+
     constructor(
         {
             featureStrategiesStore,
@@ -130,6 +136,7 @@ class FeatureToggleService {
         >,
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
         segmentService: SegmentService,
+        accessService: AccessService,
     ) {
         this.logger = getLogger('services/feature-toggle-service.ts');
         this.featureStrategiesStore = featureStrategiesStore;
@@ -141,6 +148,7 @@ class FeatureToggleService {
         this.featureEnvironmentStore = featureEnvironmentStore;
         this.contextFieldStore = contextFieldStore;
         this.segmentService = segmentService;
+        this.accessService = accessService;
     }
 
     async validateFeatureContext({
@@ -835,6 +843,7 @@ class FeatureToggleService {
         environment: string,
         enabled: boolean,
         createdBy: string,
+        user?: User,
     ): Promise<FeatureToggle> {
         const hasEnvironment =
             await this.featureEnvironmentStore.featureHasEnvironment(
@@ -850,11 +859,23 @@ class FeatureToggleService {
                     environment,
                 );
                 if (strategies.length === 0) {
-                    await this.createStrategy(
-                        getDefaultStrategy(featureName),
-                        { environment, projectId: project, featureName },
-                        createdBy,
-                    );
+                    const canAddStrategies =
+                        user &&
+                        (await this.accessService.hasPermission(
+                            user,
+                            CREATE_FEATURE_STRATEGY,
+                            project,
+                            environment,
+                        ));
+                    if (canAddStrategies) {
+                        await this.createStrategy(
+                            getDefaultStrategy(featureName),
+                            { environment, projectId: project, featureName },
+                            createdBy,
+                        );
+                    } else {
+                        throw new NoAccessError(CREATE_FEATURE_STRATEGY);
+                    }
                 }
             }
             const updatedEnvironmentStatus =

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -71,6 +71,7 @@ import { IContextFieldStore } from 'lib/types/stores/context-field-store';
 import { Saved, Unsaved } from '../types/saved';
 import { SegmentService } from './segment-service';
 import { SetStrategySortOrderSchema } from 'lib/openapi/spec/set-strategy-sort-order-schema';
+import { getDefaultStrategy } from '../util/feature-evaluator/helpers';
 
 interface IFeatureContext {
     featureName: string;
@@ -849,8 +850,10 @@ class FeatureToggleService {
                     environment,
                 );
                 if (strategies.length === 0) {
-                    throw new InvalidOperationError(
-                        'You can not enable the environment before it has strategies',
+                    await this.createStrategy(
+                        getDefaultStrategy(featureName),
+                        { environment, projectId: project, featureName },
+                        createdBy,
                     );
                 }
             }

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -71,6 +71,7 @@ export const createServices = (
         stores,
         config,
         segmentService,
+        accessService,
     );
     const environmentService = new EnvironmentService(stores, config);
     const featureTagService = new FeatureTagService(stores, config);

--- a/src/lib/types/stores/access-store.ts
+++ b/src/lib/types/stores/access-store.ts
@@ -125,6 +125,6 @@ export interface IAccessStore extends Store<IRole, number> {
     removePermissionFromRole(
         roleId: number,
         permission: string,
-        projectId?: string,
+        environment?: string,
     ): Promise<void>;
 }

--- a/src/lib/util/feature-evaluator/helpers.ts
+++ b/src/lib/util/feature-evaluator/helpers.ts
@@ -1,3 +1,4 @@
+import { IStrategyConfig } from '../../types/model';
 import { FeatureStrategiesEvaluationResult } from './client';
 import { Context } from './context';
 
@@ -37,4 +38,16 @@ export function resolveContextValue(
 
 export function safeName(str: string = ''): string {
     return str.replace(/\//g, '_');
+}
+
+export function getDefaultStrategy(featureName: string): IStrategyConfig {
+    return {
+        name: 'flexibleRollout',
+        constraints: [],
+        parameters: {
+            rollout: '100',
+            stickiness: 'default',
+            groupId: featureName,
+        },
+    };
 }

--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -1166,7 +1166,7 @@ test('Trying to get a non existing feature strategy should yield 404', async () 
         .expect(404);
 });
 
-test('Can not enable environment for feature without strategies', async () => {
+test('Can enable environment for feature without strategies', async () => {
     const environment = 'some-env';
     const featureName = 'com.test.enable.environment.disabled';
 
@@ -1194,7 +1194,7 @@ test('Can not enable environment for feature without strategies', async () => {
             `/api/admin/projects/default/features/${featureName}/environments/${environment}/on`,
         )
         .set('Content-Type', 'application/json')
-        .expect(403);
+        .expect(200);
     await app.request
         .get(`/api/admin/projects/default/features/${featureName}`)
         .expect(200)
@@ -1203,7 +1203,7 @@ test('Can not enable environment for feature without strategies', async () => {
             const enabledFeatureEnv = res.body.environments.find(
                 (e) => e.name === environment,
             );
-            expect(enabledFeatureEnv.enabled).toBe(false);
+            expect(enabledFeatureEnv.enabled).toBe(true);
             expect(enabledFeatureEnv.type).toBe('test');
         });
 });

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -218,6 +218,7 @@ beforeAll(async () => {
         stores,
         config,
         new SegmentService(stores, config),
+        accessService,
     );
     projectService = new ProjectService(
         stores,

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -28,6 +28,7 @@ beforeAll(async () => {
         stores,
         config,
         new SegmentService(stores, config),
+        accessService,
     );
     const project = {
         id: 'test-project',

--- a/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
+++ b/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
@@ -6,6 +6,8 @@ import { SegmentService } from '../../../lib/services/segment-service';
 import { FeatureStrategySchema } from '../../../lib/openapi/spec/feature-strategy-schema';
 import User from '../../../lib/types/user';
 import { IConstraint } from '../../../lib/types/model';
+import { AccessService } from '../../../lib/services/access-service';
+import { GroupService } from '../../../lib/services/group-service';
 
 let stores;
 let db;
@@ -28,7 +30,14 @@ beforeAll(async () => {
     );
     stores = db.stores;
     segmentService = new SegmentService(stores, config);
-    service = new FeatureToggleService(stores, config, segmentService);
+    const groupService = new GroupService(stores, config);
+    const accessService = new AccessService(stores, config, groupService);
+    service = new FeatureToggleService(
+        stores,
+        config,
+        segmentService,
+        accessService,
+    );
 });
 
 afterAll(async () => {

--- a/src/test/e2e/services/playground-service.test.ts
+++ b/src/test/e2e/services/playground-service.test.ts
@@ -18,6 +18,8 @@ import { SdkContextSchema } from 'lib/openapi/spec/sdk-context-schema';
 import { SegmentSchema } from 'lib/openapi/spec/segment-schema';
 import { playgroundStrategyEvaluation } from '../../../lib/openapi/spec/playground-strategy-schema';
 import { PlaygroundSegmentSchema } from 'lib/openapi/spec/playground-segment-schema';
+import { GroupService } from '../../../lib/services/group-service';
+import { AccessService } from '../../../lib/services/access-service';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -30,10 +32,13 @@ beforeAll(async () => {
     db = await dbInit('playground_service_serial', config.getLogger);
     stores = db.stores;
     segmentService = new SegmentService(stores, config);
+    const groupService = new GroupService(stores, config);
+    const accessService = new AccessService(stores, config, groupService);
     featureToggleService = new FeatureToggleService(
         stores,
         config,
         segmentService,
+        accessService,
     );
     service = new PlaygroundService(config, {
         featureToggleServiceV2: featureToggleService,

--- a/src/test/e2e/services/project-health-service.e2e.test.ts
+++ b/src/test/e2e/services/project-health-service.e2e.test.ts
@@ -33,6 +33,7 @@ beforeAll(async () => {
         stores,
         config,
         new SegmentService(stores, config),
+        accessService,
     );
     projectService = new ProjectService(
         stores,

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -40,6 +40,7 @@ beforeAll(async () => {
         stores,
         config,
         new SegmentService(stores, config),
+        accessService,
     );
     environmentService = new EnvironmentService(stores, config);
     projectService = new ProjectService(


### PR DESCRIPTION
This makes it easier for the user to enable a feature in an env, simplifying UI and reduces number of steps. 

**Before:**
![previous](https://user-images.githubusercontent.com/158948/194045261-ecbe20ab-fd2d-4fdd-889d-2d8e56b3797c.gif)

**After:**
![new-flow](https://user-images.githubusercontent.com/158948/194045316-3c85b959-f89d-4310-a53c-90785e4db7c2.gif)
