### PR TITLE
fix: equality check on feature strategy

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -20,13 +20,13 @@ import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/perm
 import { ISegment } from 'interfaces/segment';
 import { useSegmentsApi } from 'hooks/api/actions/useSegmentsApi/useSegmentsApi';
 import { formatStrategyName } from 'utils/strategyNames';
-import { useFeatureImmutable } from 'hooks/api/getters/useFeature/useFeatureImmutable';
 import { useFormErrors } from 'hooks/useFormErrors';
 import { createFeatureStrategy } from 'utils/createFeatureStrategy';
 import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
 import { useCollaborateData } from 'hooks/useCollaborateData';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { IFeatureToggle } from 'interfaces/featureToggle';
+import { comparisonModerator } from '../featureStrategy.utils';
 
 export const FeatureStrategyCreate = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -60,7 +60,8 @@ export const FeatureStrategyCreate = () => {
             feature,
             {
                 afterSubmitAction: refetchFeature,
-            }
+            },
+            comparisonModerator
         );
 
     useEffect(() => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -24,6 +24,7 @@ import { sortStrategyParameters } from 'utils/sortStrategyParameters';
 import { useCollaborateData } from 'hooks/useCollaborateData';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { IFeatureToggle } from 'interfaces/featureToggle';
+import { comparisonModerator } from '../featureStrategy.utils';
 
 export const FeatureStrategyEdit = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -58,7 +59,8 @@ export const FeatureStrategyEdit = () => {
             feature,
             {
                 afterSubmitAction: refetchFeature,
-            }
+            },
+            comparisonModerator
         );
 
     useEffect(() => {

--- a/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
+++ b/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
@@ -1,0 +1,8 @@
+import { IFeatureToggle } from 'interfaces/featureToggle';
+
+export const comparisonModerator = (data: IFeatureToggle) => {
+    const tempData = { ...data };
+    delete tempData.lastSeenAt;
+
+    return tempData;
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

When we added equality checks on feature strategies, we failed to account for the fact that `lastUpdatedAt` will update on the feature toggle every time an SDK has asked for that feature. This triggers the stale data notification, because the feature toggle has in fact changed, but not in any meaningful way. Furthermore, it will trigger on every polling interval, which can be annoying for the user. 

This adds a formatter to the hook that allows you to decide how the data should look before performing the equality check.


<!-- Does it close an issue? Multiple? -->
Closes # .

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
