### PR TITLE
Docs: Impression events only fire on enabled front-end toggles

### DIFF
--- a/website/docs/advanced/impression-data.md
+++ b/website/docs/advanced/impression-data.md
@@ -8,7 +8,15 @@ Availability The impression data feature was introduced in **Unleash 4.7**. It i
 
 :::
 
-Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** whenever it calls `isEnabled` or `getVariant`.
+Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** when it calls `isEnabled` or `getVariant`. Front-end SDKs emit impression events **only when a toggle is enabled**.
+
+:::caution Note
+
+Front-end SDKs and other SDKs that connect the [Unleash proxy](../sdks/unleash-proxy.md) or the [Unleash front-end API](../reference/front-end-api.md) will **not** emit impression events when a toggle is disabled.
+
+This is because impression data is a **per-toggle** setting and the Proxy and front-end API only transmit information about toggles that are enabled. As such, the SDK will never know that it should emit an impression event if a toggle is disabled.
+
+:::
 
 Impression data was designed to make it easier for you to **collect analytics data**, **perform A/B tests**, and **enrich experiments** in your applications. It contains information about the feature toggle and the related [Unleash Context](../user_guide/unleash-context.md).
 

--- a/website/docs/advanced/impression-data.md
+++ b/website/docs/advanced/impression-data.md
@@ -8,13 +8,15 @@ Availability The impression data feature was introduced in **Unleash 4.7**. It i
 
 :::
 
-Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** when it calls `isEnabled` or `getVariant`. Front-end SDKs emit impression events **only when a toggle is enabled**.
+Unleash can provide you with **impression data** about the toggles in your application. Impression data contains information about a specific feature toggle activation check: The client SDK will emit an **impression event** when it calls `isEnabled` or `getVariant`. Some front-end SDKs emit impression events only when a toggle is enabled.
 
-:::caution Note
+:::caution Front-end SDKs and disabled toggles
 
-Front-end SDKs and other SDKs that connect the [Unleash proxy](../sdks/unleash-proxy.md) or the [Unleash front-end API](../reference/front-end-api.md) will **not** emit impression events when a toggle is disabled.
+Older versions of the front-end SDKs and other SDKs that connect the [Unleash proxy](../sdks/unleash-proxy.md) or the [Unleash front-end API](../reference/front-end-api.md) would **not** emit impression events when a toggle is disabled.
 
 This is because impression data is a **per-toggle** setting and the Proxy and front-end API only transmit information about toggles that are enabled. As such, the SDK will never know that it should emit an impression event if a toggle is disabled.
+
+Some of the front-end SDKs now include a include a configuration property that lets you turn on impression data for all toggles regardless of whether they're enabled or not.
 
 :::
 


### PR DESCRIPTION
## What

This change updates the description of when impression events are fired to clarify that impression events are **not** fired in front-end SDKs if the toggle is enabled.

It also adds a 'caution' admonition repeating this information with some more info on why.

## Why

We've had a couple questions about this as it hasn't been clearly stated before. Additionally, I, as a member of the team and the original author of this document, thought that impression events **did** fire for disabled toggles in the front-end.

As such, I consider this to be unexpected and different from what was originally written.