### PR TITLE
fix: PAT secret no longer returned (except new), use id instead

### DIFF
--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/CreatePersonalAPIToken/CreatePersonalAPIToken.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/CreatePersonalAPIToken/CreatePersonalAPIToken.tsx
@@ -12,7 +12,7 @@ import SelectMenu from 'component/common/select';
 import { formatDateYMD } from 'utils/formatDate';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { IPersonalAPIToken } from 'interfaces/personalAPIToken';
+import { INewPersonalAPIToken } from 'interfaces/personalAPIToken';
 
 const StyledForm = styled('form')(() => ({
     display: 'flex',
@@ -85,7 +85,7 @@ const expirationOptions = [
 interface ICreatePersonalAPITokenProps {
     open: boolean;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    newToken: (token: IPersonalAPIToken) => void;
+    newToken: (token: INewPersonalAPIToken) => void;
 }
 
 export const CreatePersonalAPIToken: FC<ICreatePersonalAPITokenProps> = ({

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
@@ -25,7 +25,7 @@ export const DeletePersonalAPIToken: FC<IDeletePersonalAPITokenProps> = ({
     const onRemoveClick = async () => {
         if (token) {
             try {
-                await deletePersonalAPIToken(token?.secret);
+                await deletePersonalAPIToken(token?.id);
                 refetchTokens();
                 setOpen(false);
                 setToastData({

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokenDialog/PersonalAPITokenDialog.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokenDialog/PersonalAPITokenDialog.tsx
@@ -1,7 +1,7 @@
 import { Alert, styled, Typography } from '@mui/material';
 import { UserToken } from 'component/admin/apiToken/ConfirmToken/UserToken/UserToken';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
-import { IPersonalAPIToken } from 'interfaces/personalAPIToken';
+import { INewPersonalAPIToken } from 'interfaces/personalAPIToken';
 import { FC } from 'react';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
@@ -11,7 +11,7 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
 interface IPersonalAPITokenDialogProps {
     open: boolean;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    token?: IPersonalAPIToken;
+    token?: INewPersonalAPIToken;
 }
 
 export const PersonalAPITokenDialog: FC<IPersonalAPITokenDialogProps> = ({

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
@@ -17,7 +17,6 @@ import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
-import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { usePersonalAPITokens } from 'hooks/api/getters/usePersonalAPITokens/usePersonalAPITokens';
 import { useSearch } from 'hooks/useSearch';

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
@@ -20,7 +20,10 @@ import { HighlightCell } from 'component/common/Table/cells/HighlightCell/Highli
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { usePersonalAPITokens } from 'hooks/api/getters/usePersonalAPITokens/usePersonalAPITokens';
 import { useSearch } from 'hooks/useSearch';
-import { IPersonalAPIToken } from 'interfaces/personalAPIToken';
+import {
+    INewPersonalAPIToken,
+    IPersonalAPIToken,
+} from 'interfaces/personalAPIToken';
 import { IUser } from 'interfaces/user';
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -98,6 +101,7 @@ export const PersonalAPITokensTab = ({ user }: IPersonalAPITokensTabProps) => {
     const [createOpen, setCreateOpen] = useState(false);
     const [dialogOpen, setDialogOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
+    const [newToken, setNewToken] = useState<INewPersonalAPIToken>();
     const [selectedToken, setSelectedToken] = useState<IPersonalAPIToken>();
 
     const columns = useMemo(
@@ -308,15 +312,15 @@ export const PersonalAPITokensTab = ({ user }: IPersonalAPITokensTabProps) => {
             <CreatePersonalAPIToken
                 open={createOpen}
                 setOpen={setCreateOpen}
-                newToken={(token: IPersonalAPIToken) => {
-                    setSelectedToken(token);
+                newToken={(token: INewPersonalAPIToken) => {
+                    setNewToken(token);
                     setDialogOpen(true);
                 }}
             />
             <PersonalAPITokenDialog
                 open={dialogOpen}
                 setOpen={setDialogOpen}
-                token={selectedToken}
+                token={newToken}
             />
             <DeletePersonalAPIToken
                 open={deleteOpen}

--- a/frontend/src/hooks/api/actions/usePersonalAPITokensApi/usePersonalAPITokensApi.ts
+++ b/frontend/src/hooks/api/actions/usePersonalAPITokensApi/usePersonalAPITokensApi.ts
@@ -1,3 +1,4 @@
+import { INewPersonalAPIToken } from 'interfaces/personalAPIToken';
 import useAPI from '../useApi/useApi';
 
 interface ICreatePersonalApiTokenPayload {
@@ -12,7 +13,7 @@ export const usePersonalAPITokensApi = () => {
 
     const createPersonalAPIToken = async (
         payload: ICreatePersonalApiTokenPayload
-    ) => {
+    ): Promise<INewPersonalAPIToken> => {
         const req = createRequest('api/admin/user/tokens', {
             method: 'POST',
             body: JSON.stringify(payload),
@@ -25,8 +26,8 @@ export const usePersonalAPITokensApi = () => {
         }
     };
 
-    const deletePersonalAPIToken = async (secret: string) => {
-        const req = createRequest(`api/admin/user/tokens/${secret}`, {
+    const deletePersonalAPIToken = async (id: string) => {
+        const req = createRequest(`api/admin/user/tokens/${id}`, {
             method: 'DELETE',
         });
         try {

--- a/frontend/src/interfaces/personalAPIToken.ts
+++ b/frontend/src/interfaces/personalAPIToken.ts
@@ -1,6 +1,10 @@
 export interface IPersonalAPIToken {
+    id: string;
     description: string;
     expiresAt: string;
     createdAt: string;
+}
+
+export interface INewPersonalAPIToken extends IPersonalAPIToken {
     secret: string;
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-315/adapt-front-end-to-use-id-instead-of-secret-for-the-pats