### PR TITLE
fix: invite link page docs

### DIFF
--- a/frontend/src/component/admin/users/InviteLink/InviteLink.tsx
+++ b/frontend/src/component/admin/users/InviteLink/InviteLink.tsx
@@ -136,9 +136,9 @@ export const InviteLink: VFC<ICreateInviteLinkProps> = () => {
         <FormTemplate
             loading={loading || isSending}
             title={isUpdating ? 'Update invite link' : 'Create invite link'}
-            description="When you send an invite link to a someone, they will be able to create an account and get access to Unleash. This new user will only have read access, until you change their assigned role."
-            documentationLink="https://docs.getunleash.io/user_guide/rbac#standard-roles" // FIXME: update
-            documentationLinkLabel="User management documentation"
+            description="When you send an invite link to someone, they will be able to create an account and get access to Unleash. This new user will only have read access, until you change their assigned role."
+            documentationLink="https://docs.getunleash.io/reference/public-signup"
+            documentationLinkLabel="Invite link documentation"
             formatApiCode={formatApiCode}
         >
             <Box

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from 'react';
+import { useCallback, useContext } from 'react';
 import { PlausibleContext } from 'contexts/PlausibleContext';
 import { EventOptions, PlausibleOptions } from 'plausible-tracker';
 


### PR DESCRIPTION
Proper link to documentation on "invite link" page.