### PR TITLE
fix: filter empty metrics before we collect last seen toggles.

### DIFF
--- a/src/lib/routes/client-api/metrics.test.ts
+++ b/src/lib/routes/client-api/metrics.test.ts
@@ -4,7 +4,7 @@ import getApp from '../../app';
 import { createTestConfig } from '../../../test/config/test-config';
 import { clientMetricsSchema } from '../../services/client-metrics/schema';
 import { createServices } from '../../services';
-import { IUnleashOptions, IUnleashStores } from '../../types';
+import { IUnleashOptions, IUnleashServices, IUnleashStores } from '../../types';
 
 async function getSetup(opts?: IUnleashOptions) {
     const stores = createStores();
@@ -16,6 +16,7 @@ async function getSetup(opts?: IUnleashOptions) {
     return {
         request: supertest(app),
         stores,
+        services,
         destroy: () => {
             services.versionService.destroy();
             services.clientInstanceService.destroy();
@@ -26,6 +27,7 @@ async function getSetup(opts?: IUnleashOptions) {
 
 let request;
 let stores: IUnleashStores;
+let services: IUnleashServices;
 let destroy;
 
 beforeEach(async () => {
@@ -33,6 +35,7 @@ beforeEach(async () => {
     request = setup.request;
     stores = setup.stores;
     destroy = setup.destroy;
+    services = setup.services;
 });
 
 afterEach(() => {
@@ -202,6 +205,7 @@ test('should set lastSeen on toggle', async () => {
         })
         .expect(202);
 
+    await services.lastSeenService.store();
     const toggle = await stores.featureToggleStore.get('toggleLastSeen');
 
     expect(toggle.lastSeenAt).toBeTruthy();

--- a/src/lib/services/client-metrics/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen-service.ts
@@ -44,8 +44,8 @@ export class LastSeenService {
 
     updateLastSeen(clientMetrics: IClientMetricsEnv[]): void {
         clientMetrics
-            .filter((c) => c.yes > 0 || c.no > 0)
-            .forEach((c) => this.lastSeenToggles.add(c.featureName));
+            .filter((clientMetric) => clientMetric.yes > 0 || clientMetric.no > 0)
+            .forEach((clientMetric) => this.lastSeenToggles.add(clientMetric.featureName));
     }
 
     destroy(): void {

--- a/src/lib/services/client-metrics/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen-service.ts
@@ -1,0 +1,54 @@
+import { secondsToMilliseconds } from 'date-fns';
+import { Logger } from '../../logger';
+import { IUnleashConfig } from '../../server-impl';
+import { IUnleashStores } from '../../types';
+import { IClientMetricsEnv } from '../../types/stores/client-metrics-store-v2';
+import { IFeatureToggleStore } from '../../types/stores/feature-toggle-store';
+
+export class LastSeenService {
+    private timers: NodeJS.Timeout[] = [];
+
+    private lastSeenToggles: Set<string> = new Set();
+
+    private logger: Logger;
+
+    private featureToggleStore: IFeatureToggleStore;
+
+    constructor(
+        { featureToggleStore }: Pick<IUnleashStores, 'featureToggleStore'>,
+        config: IUnleashConfig,
+        lastSeenInterval = secondsToMilliseconds(30),
+    ) {
+        this.featureToggleStore = featureToggleStore;
+        this.logger = config.getLogger(
+            '/services/client-metrics/last-seen-service.ts',
+        );
+
+        this.timers.push(
+            setInterval(() => this.store(), lastSeenInterval).unref(),
+        );
+    }
+
+    async store(): Promise<number> {
+        const count = this.lastSeenToggles.size;
+        if (count > 0) {
+            const lastSeenToggles = [...this.lastSeenToggles];
+            this.lastSeenToggles = new Set();
+            this.logger.debug(
+                `Updating last seen for ${lastSeenToggles.length} toggles`,
+            );
+            await this.featureToggleStore.setLastSeen(lastSeenToggles);
+        }
+        return count;
+    }
+
+    updateLastSeen(clientMetrics: IClientMetricsEnv[]): void {
+        clientMetrics
+            .filter((c) => c.yes > 0 || c.no > 0)
+            .forEach((c) => this.lastSeenToggles.add(c.featureName));
+    }
+
+    destroy(): void {
+        this.timers.forEach(clearInterval);
+    }
+}

--- a/src/lib/services/client-metrics/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen-service.ts
@@ -44,8 +44,12 @@ export class LastSeenService {
 
     updateLastSeen(clientMetrics: IClientMetricsEnv[]): void {
         clientMetrics
-            .filter((clientMetric) => clientMetric.yes > 0 || clientMetric.no > 0)
-            .forEach((clientMetric) => this.lastSeenToggles.add(clientMetric.featureName));
+            .filter(
+                (clientMetric) => clientMetric.yes > 0 || clientMetric.no > 0,
+            )
+            .forEach((clientMetric) =>
+                this.lastSeenToggles.add(clientMetric.featureName),
+            );
     }
 
     destroy(): void {

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -38,14 +38,12 @@ export default class ClientMetricsServiceV2 {
             clientMetricsStoreV2,
         }: Pick<IUnleashStores, 'featureToggleStore' | 'clientMetricsStoreV2'>,
         config: IUnleashConfig,
+        lastSeenService: LastSeenService,
         bulkInterval = secondsToMilliseconds(5),
     ) {
         this.featureToggleStore = featureToggleStore;
         this.clientMetricsStoreV2 = clientMetricsStoreV2;
-        this.lastSeenService = new LastSeenService(
-            { featureToggleStore },
-            config,
-        );
+        this.lastSeenService = lastSeenService;
         this.config = config;
         this.logger = config.getLogger(
             '/services/client-metrics/client-metrics-service-v2.ts',

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -35,6 +35,7 @@ import { ProxyService } from './proxy-service';
 import EdgeService from './edge-service';
 import PatService from './pat-service';
 import { PublicSignupTokenService } from './public-signup-token-service';
+import { LastSeenService } from './client-metrics/last-seen-service';
 export const createServices = (
     stores: IUnleashStores,
     config: IUnleashConfig,
@@ -43,7 +44,12 @@ export const createServices = (
     const accessService = new AccessService(stores, config, groupService);
     const apiTokenService = new ApiTokenService(stores, config);
     const clientInstanceService = new ClientInstanceService(stores, config);
-    const clientMetricsServiceV2 = new ClientMetricsServiceV2(stores, config);
+    const lastSeenService = new LastSeenService(stores, config);
+    const clientMetricsServiceV2 = new ClientMetricsServiceV2(
+        stores,
+        config,
+        lastSeenService,
+    );
     const contextService = new ContextService(stores, config);
     const emailService = new EmailService(config.email, config.getLogger);
     const eventService = new EventService(stores, config);
@@ -147,6 +153,7 @@ export const createServices = (
         edgeService,
         patService,
         publicSignupTokenService,
+        lastSeenService,
     };
 };
 

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -33,6 +33,7 @@ import { ProxyService } from '../services/proxy-service';
 import EdgeService from '../services/edge-service';
 import PatService from '../services/pat-service';
 import { PublicSignupTokenService } from '../services/public-signup-token-service';
+import { LastSeenService } from '../services/client-metrics/last-seen-service';
 
 export interface IUnleashServices {
     accessService: AccessService;
@@ -71,4 +72,5 @@ export interface IUnleashServices {
     openApiService: OpenApiService;
     clientSpecService: ClientSpecService;
     patService: PatService;
+    lastSeenService: LastSeenService;
 }

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -141,6 +141,7 @@ test('should set lastSeen for toggles with metrics', async () => {
         .expect(202);
 
     await app.services.clientMetricsServiceV2.bulkAdd();
+    await app.services.lastSeenService.store();
     const t1 = await db.stores.featureToggleStore.get('t1');
     const t2 = await db.stores.featureToggleStore.get('t2');
     expect(t1.lastSeenAt.getTime()).toBeGreaterThanOrEqual(start);

--- a/src/test/e2e/services/last-seen-service.e2e.test.ts
+++ b/src/test/e2e/services/last-seen-service.e2e.test.ts
@@ -128,7 +128,7 @@ test('Should not update last seen toggles with 0 metrics', async () => {
     const t2 = await stores.featureToggleStore.get('tb2');
 
     expect(t2.lastSeenAt).toBeNull();
-    expect(t1.lastSeenAt.getTime()).toBeGreaterThan(time);
+    expect(t1.lastSeenAt.getTime()).toBeGreaterThanOrEqual(time);
 
     service.destroy();
 });

--- a/src/test/e2e/services/last-seen-service.e2e.test.ts
+++ b/src/test/e2e/services/last-seen-service.e2e.test.ts
@@ -1,0 +1,170 @@
+import { createTestConfig } from '../../config/test-config';
+import dbInit from '../helpers/database-init';
+import { IUnleashStores } from '../../../lib/types/stores';
+import { LastSeenService } from '../../../lib/services/client-metrics/last-seen-service';
+import { IClientMetricsEnv } from '../../../lib/types/stores/client-metrics-store-v2';
+import { secondsToMilliseconds } from 'date-fns';
+
+let stores: IUnleashStores;
+let db;
+let config;
+
+beforeAll(async () => {
+    config = createTestConfig();
+    db = await dbInit('last_seen_service_serial', config.getLogger);
+    stores = db.stores;
+});
+beforeEach(async () => {
+    await stores.featureToggleStore.deleteAll();
+});
+afterAll(async () => {
+    await db.destroy();
+});
+
+/**
+ * A utility to wait for any pending promises in the test subject code.
+ * For instance, if the test needs to wait for a timeout/interval handler,
+ * and that handler does something async, advancing the timers is not enough:
+ * We have to explicitly wait for the second promise.
+ * For more info, see https://stackoverflow.com/a/51045733/2868829
+ *
+ * Usage in test code after advancing timers, but before making assertions:
+ *
+ * test('hello', async () => {
+ *    jest.useFakeTimers('modern');
+ *
+ *    // Schedule a timeout with a callback that does something async
+ *    // before calling our spy
+ *    const spy = jest.fn();
+ *    setTimeout(async () => {
+ *        await Promise.resolve();
+ *        spy();
+ *    }, 1000);
+ *
+ *    expect(spy).not.toHaveBeenCalled();
+ *
+ *    jest.advanceTimersByTime(1500);
+ *    await flushPromises(); // this is required to make it work!
+ *
+ *    expect(spy).toHaveBeenCalledTimes(1);
+ *
+ *    jest.useRealTimers();
+ * });
+ */
+function flushPromises() {
+    return Promise.resolve(setImmediate);
+}
+
+test('Should update last seen for known toggles after 30s', async () => {
+    jest.useFakeTimers();
+    const service = new LastSeenService(stores, config);
+    const time = Date.now();
+    await stores.featureToggleStore.create('default', { name: 'ta1' });
+
+    const metrics: IClientMetricsEnv[] = [
+        {
+            featureName: 'ta1',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 1,
+            no: 0,
+        },
+        {
+            featureName: 'ta2',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 1,
+            no: 0,
+        },
+    ];
+
+    service.updateLastSeen(metrics);
+    jest.advanceTimersByTime(secondsToMilliseconds(31));
+    await flushPromises();
+
+    const t1 = await stores.featureToggleStore.get('ta1');
+
+    expect(t1.lastSeenAt.getTime()).toBeGreaterThan(time);
+
+    service.destroy();
+
+    jest.useRealTimers();
+});
+
+test('Should not update last seen toggles with 0 metrics', async () => {
+    // jest.useFakeTimers();
+    const service = new LastSeenService(stores, config, 30);
+    const time = Date.now();
+    await stores.featureToggleStore.create('default', { name: 'tb1' });
+    await stores.featureToggleStore.create('default', { name: 'tb2' });
+
+    const metrics: IClientMetricsEnv[] = [
+        {
+            featureName: 'tb1',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 1,
+            no: 0,
+        },
+        {
+            featureName: 'tb2',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 0,
+            no: 0,
+        },
+    ];
+
+    service.updateLastSeen(metrics);
+
+    // bypass interval waiting
+    await service.store();
+
+    const t1 = await stores.featureToggleStore.get('tb1');
+    const t2 = await stores.featureToggleStore.get('tb2');
+
+    expect(t2.lastSeenAt).toBeNull();
+    expect(t1.lastSeenAt.getTime()).toBeGreaterThan(time);
+
+    service.destroy();
+});
+
+test('Should not update anything for 0 toggles', async () => {
+    // jest.useFakeTimers();
+    const service = new LastSeenService(stores, config, 30);
+    const time = Date.now();
+    await stores.featureToggleStore.create('default', { name: 'tb1' });
+    await stores.featureToggleStore.create('default', { name: 'tb2' });
+
+    const metrics: IClientMetricsEnv[] = [
+        {
+            featureName: 'tb1',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 0,
+            no: 0,
+        },
+        {
+            featureName: 'tb2',
+            appName: 'some-App',
+            environment: 'default',
+            timestamp: new Date(time),
+            yes: 0,
+            no: 0,
+        },
+    ];
+
+    service.updateLastSeen(metrics);
+
+    // bypass interval waiting
+    const count = await service.store();
+
+    expect(count).toBe(0);
+
+    service.destroy();
+});


### PR DESCRIPTION
This PR fixes two things related to lastSeen details for feature toggles.

1. Only update lastSeen when `yes` or `no` count is larger than 0. 
2. Allow batching of lastSeen updates, hidden behind feature flag named `batchMetrics`. With the flag enabled lastSeen will only be updated every 30th second. 

fixes: #2104
