### PR TITLE
feat: Add group sync settings to front end

### DIFF
--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -40,7 +40,6 @@ export const OidcAuth = () => {
     const { updateSettings, errors, loading } = useAuthSettingsApi('oidc');
     const ssoSyncHidden = !uiConfig.flags.syncSSOGroups;
 
-
     useEffect(() => {
         if (config.discoverUrl) {
             setData(config);

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -246,7 +246,8 @@ export const OidcAuth = () => {
                     <Grid item md={5}>
                         <strong>Enable Group Syncing</strong>
                         <p>
-                            Enables automatically syncing of users from the OIDC provider when a user logs in.
+                            Enables automatically syncing of users from the OIDC
+                            provider when a user logs in.
                         </p>
                     </Grid>
                     <Grid item md={6} style={{ padding: '20px' }}>
@@ -270,7 +271,8 @@ export const OidcAuth = () => {
                     <Grid item md={5}>
                         <strong>Group Field JSON Path</strong>
                         <p>
-                            Specifies the path in the OIDC token response from which to read the groups the user belongs to.
+                            Specifies the path in the OIDC token response from
+                            which to read the groups the user belongs to.
                         </p>
                     </Grid>
                     <Grid item md={6}>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -272,7 +272,7 @@ export const OidcAuth = () => {
                     <Grid item md={5}>
                         <strong>Group Field JSON Path</strong>
                         <p>
-                            Specifies the path in the OIDC token response from which to read the groups the user belongs to
+                            Specifies the path in the OIDC token response from which to read the groups the user belongs to.
                         </p>
                     </Grid>
                     <Grid item md={6}>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -244,7 +244,7 @@ export const OidcAuth = () => {
                     condition={ssoSyncShown}
                     show={
                         <SsoGroupSettings
-                            ssoType={'OIDC'}
+                            ssoType="OIDC"
                             data={data}
                             setValue={setValue}
                         ></SsoGroupSettings>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -261,9 +261,7 @@ export const OidcAuth = () => {
                                 />
                             }
                             label={
-                                data.enableGroupSyncing
-                                    ? 'Enabled'
-                                    : 'Disabled'
+                                data.enableGroupSyncing ? 'Enabled' : 'Disabled'
                             }
                         />
                     </Grid>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -247,7 +247,7 @@ export const OidcAuth = () => {
                             ssoType="OIDC"
                             data={data}
                             setValue={setValue}
-                        ></SsoGroupSettings>
+                        />
                     }
                 />
                 <AutoCreateForm data={data} setValue={setValue} />

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -40,7 +40,7 @@ export const OidcAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('oidc');
     const { updateSettings, errors, loading } = useAuthSettingsApi('oidc');
-    const ssoSyncShown = uiConfig.flags.syncSSOGroups || false;
+    const ssoSyncShown = Boolean(uiConfig.flags.syncSSOGroups);
 
     useEffect(() => {
         if (config.discoverUrl) {

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -17,6 +17,8 @@ import useAuthSettings from 'hooks/api/getters/useAuthSettings/useAuthSettings';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { removeEmptyStringFields } from 'utils/removeEmptyStringFields';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { SsoGroupSettings } from '../SsoGroupSettings';
 
 const initialState = {
     enabled: false,
@@ -38,7 +40,7 @@ export const OidcAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('oidc');
     const { updateSettings, errors, loading } = useAuthSettingsApi('oidc');
-    const ssoSyncHidden = !uiConfig.flags.syncSSOGroups;
+    const ssoSyncShown = uiConfig.flags.syncSSOGroups || false;
 
     useEffect(() => {
         if (config.discoverUrl) {
@@ -64,10 +66,6 @@ export const OidcAuth = () => {
 
     const updateSingleSignOut = () => {
         setData({ ...data, enableSingleSignOut: !data.enableSingleSignOut });
-    };
-
-    const updateGroupSyncing = () => {
-        setData({ ...data, enableGroupSyncing: !data.enableGroupSyncing });
     };
 
     const setValue = (name: string, value: string | boolean) => {
@@ -242,54 +240,16 @@ export const OidcAuth = () => {
                         />
                     </Grid>
                 </Grid>
-                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Enable Group Syncing</strong>
-                        <p>
-                            Enables automatically syncing of users from the OIDC
-                            provider when a user logs in.
-                        </p>
-                    </Grid>
-                    <Grid item md={6} style={{ padding: '20px' }}>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    onChange={updateGroupSyncing}
-                                    value={data.enableGroupSyncing}
-                                    disabled={!data.enabled}
-                                    name="enableGroupSyncing"
-                                    checked={data.enableGroupSyncing}
-                                />
-                            }
-                            label={
-                                data.enableGroupSyncing ? 'Enabled' : 'Disabled'
-                            }
-                        />
-                    </Grid>
-                </Grid>
-                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Group Field JSON Path</strong>
-                        <p>
-                            Specifies the path in the OIDC token response from
-                            which to read the groups the user belongs to.
-                        </p>
-                    </Grid>
-                    <Grid item md={6}>
-                        <TextField
-                            onChange={updateField}
-                            label="Group JSON Path"
-                            name="groupJsonPath"
-                            value={data.groupJsonPath}
-                            disabled={!data.enableGroupSyncing}
-                            style={{ width: '400px' }}
-                            variant="outlined"
-                            size="small"
-                            required
-                        />
-                    </Grid>
-                </Grid>
-
+                <ConditionallyRender
+                    condition={ssoSyncShown}
+                    show={
+                        <SsoGroupSettings
+                            ssoType={'OIDC'}
+                            data={data}
+                            setValue={setValue}
+                        ></SsoGroupSettings>
+                    }
+                />
                 <AutoCreateForm data={data} setValue={setValue} />
 
                 <Grid container spacing={3}>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -21,8 +21,10 @@ import { removeEmptyStringFields } from 'utils/removeEmptyStringFields';
 const initialState = {
     enabled: false,
     enableSingleSignOut: false,
+    enableGroupSyncing: false,
     autoCreate: false,
     unleashHostname: location.hostname,
+    groupJsonPath: '',
     clientId: '',
     discoverUrl: '',
     secret: '',
@@ -36,6 +38,8 @@ export const OidcAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('oidc');
     const { updateSettings, errors, loading } = useAuthSettingsApi('oidc');
+    const ssoSyncHidden = !uiConfig.flags.syncSSOGroups;
+
 
     useEffect(() => {
         if (config.discoverUrl) {
@@ -61,6 +65,10 @@ export const OidcAuth = () => {
 
     const updateSingleSignOut = () => {
         setData({ ...data, enableSingleSignOut: !data.enableSingleSignOut });
+    };
+
+    const updateGroupSyncing = () => {
+        setData({ ...data, enableGroupSyncing: !data.enableGroupSyncing });
     };
 
     const setValue = (name: string, value: string | boolean) => {
@@ -232,6 +240,53 @@ export const OidcAuth = () => {
                             style={{ width: '400px' }}
                             variant="outlined"
                             size="small"
+                        />
+                    </Grid>
+                </Grid>
+                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Enable Group Syncing</strong>
+                        <p>
+                            Enables automatically syncing of users from the OIDC provider when a user logs in
+                        </p>
+                    </Grid>
+                    <Grid item md={6} style={{ padding: '20px' }}>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    onChange={updateGroupSyncing}
+                                    value={data.enableGroupSyncing}
+                                    disabled={!data.enabled}
+                                    name="enableGroupSyncing"
+                                    checked={data.enableGroupSyncing}
+                                />
+                            }
+                            label={
+                                data.enableGroupSyncing
+                                    ? 'Enabled'
+                                    : 'Disabled'
+                            }
+                        />
+                    </Grid>
+                </Grid>
+                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Group Field JSON Path</strong>
+                        <p>
+                            Specifies the path in the OIDC token response from which to read the groups the user belongs to
+                        </p>
+                    </Grid>
+                    <Grid item md={6}>
+                        <TextField
+                            onChange={updateField}
+                            label="Group JSON Path"
+                            name="groupJsonPath"
+                            value={data.groupJsonPath}
+                            disabled={!data.enableGroupSyncing}
+                            style={{ width: '400px' }}
+                            variant="outlined"
+                            size="small"
+                            required
                         />
                     </Grid>
                 </Grid>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -246,7 +246,7 @@ export const OidcAuth = () => {
                     <Grid item md={5}>
                         <strong>Enable Group Syncing</strong>
                         <p>
-                            Enables automatically syncing of users from the OIDC provider when a user logs in
+                            Enables automatically syncing of users from the OIDC provider when a user logs in.
                         </p>
                     </Grid>
                     <Grid item md={6} style={{ padding: '20px' }}>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -21,12 +21,14 @@ import { removeEmptyStringFields } from 'utils/removeEmptyStringFields';
 const initialState = {
     enabled: false,
     autoCreate: false,
+    enableGroupSyncing: false,
     unleashHostname: location.hostname,
     entityId: '',
     signOnUrl: '',
     certificate: '',
     signOutUrl: '',
     spCertificate: '',
+    groupJsonPath: '',
 };
 
 export const SamlAuth = () => {
@@ -36,6 +38,7 @@ export const SamlAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('saml');
     const { updateSettings, errors, loading } = useAuthSettingsApi('saml');
+    const ssoSyncHidden = !uiConfig.flags.syncSSOGroups;
 
     useEffect(() => {
         if (config.entityId) {
@@ -53,6 +56,10 @@ export const SamlAuth = () => {
 
     const updateField = (event: React.ChangeEvent<HTMLInputElement>) => {
         setValue(event.target.name, event.target.value);
+    };
+
+    const updateGroupSyncing = () => {
+        setData({ ...data, enableGroupSyncing: !data.enableGroupSyncing });
     };
 
     const updateEnabled = () => {
@@ -243,6 +250,53 @@ export const SamlAuth = () => {
                             maxRows={14}
                             variant="outlined"
                             size="small"
+                        />
+                    </Grid>
+                </Grid>
+                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Enable Group Syncing</strong>
+                        <p>
+                            Enables automatically syncing of users from the SAML provider when a user logs in
+                        </p>
+                    </Grid>
+                    <Grid item md={6} style={{ padding: '20px' }}>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    onChange={updateGroupSyncing}
+                                    value={data.enableGroupSyncing}
+                                    disabled={!data.enabled}
+                                    name="enableGroupSyncing"
+                                    checked={data.enableGroupSyncing}
+                                />
+                            }
+                            label={
+                                data.enableGroupSyncing
+                                    ? 'Enabled'
+                                    : 'Disabled'
+                            }
+                        />
+                    </Grid>
+                </Grid>
+                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Group Field JSON Path</strong>
+                        <p>
+                            Specifies the path in the SAML token response from which to read the groups the user belongs to
+                        </p>
+                    </Grid>
+                    <Grid item md={6}>
+                        <TextField
+                            onChange={updateField}
+                            label="Group JSON Path"
+                            name="groupJsonPath"
+                            value={data.groupJsonPath}
+                            disabled={!data.enableGroupSyncing}
+                            style={{ width: '400px' }}
+                            variant="outlined"
+                            size="small"
+                            required
                         />
                     </Grid>
                 </Grid>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -257,7 +257,8 @@ export const SamlAuth = () => {
                     <Grid item md={5}>
                         <strong>Enable Group Syncing</strong>
                         <p>
-                            Enables automatically syncing of users from the SAML provider when a user logs in
+                            Enables automatically syncing of users from the SAML
+                            provider when a user logs in
                         </p>
                     </Grid>
                     <Grid item md={6} style={{ padding: '20px' }}>
@@ -272,9 +273,7 @@ export const SamlAuth = () => {
                                 />
                             }
                             label={
-                                data.enableGroupSyncing
-                                    ? 'Enabled'
-                                    : 'Disabled'
+                                data.enableGroupSyncing ? 'Enabled' : 'Disabled'
                             }
                         />
                     </Grid>
@@ -283,7 +282,8 @@ export const SamlAuth = () => {
                     <Grid item md={5}>
                         <strong>Group Field JSON Path</strong>
                         <p>
-                            Specifies the path in the SAML token response from which to read the groups the user belongs to
+                            Specifies the path in the SAML token response from
+                            which to read the groups the user belongs to
                         </p>
                     </Grid>
                     <Grid item md={6}>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -17,6 +17,8 @@ import useAuthSettings from 'hooks/api/getters/useAuthSettings/useAuthSettings';
 import useAuthSettingsApi from 'hooks/api/actions/useAuthSettingsApi/useAuthSettingsApi';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { removeEmptyStringFields } from 'utils/removeEmptyStringFields';
+import { SsoGroupSettings } from '../SsoGroupSettings';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const initialState = {
     enabled: false,
@@ -38,7 +40,7 @@ export const SamlAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('saml');
     const { updateSettings, errors, loading } = useAuthSettingsApi('saml');
-    const ssoSyncHidden = !uiConfig.flags.syncSSOGroups;
+    const ssoSyncShown = uiConfig.flags.syncSSOGroups || false;
 
     useEffect(() => {
         if (config.entityId) {
@@ -56,10 +58,6 @@ export const SamlAuth = () => {
 
     const updateField = (event: React.ChangeEvent<HTMLInputElement>) => {
         setValue(event.target.name, event.target.value);
-    };
-
-    const updateGroupSyncing = () => {
-        setData({ ...data, enableGroupSyncing: !data.enableGroupSyncing });
     };
 
     const updateEnabled = () => {
@@ -253,53 +251,17 @@ export const SamlAuth = () => {
                         />
                     </Grid>
                 </Grid>
-                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Enable Group Syncing</strong>
-                        <p>
-                            Enables automatically syncing of users from the SAML
-                            provider when a user logs in
-                        </p>
-                    </Grid>
-                    <Grid item md={6} style={{ padding: '20px' }}>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    onChange={updateGroupSyncing}
-                                    value={data.enableGroupSyncing}
-                                    disabled={!data.enabled}
-                                    name="enableGroupSyncing"
-                                    checked={data.enableGroupSyncing}
-                                />
-                            }
-                            label={
-                                data.enableGroupSyncing ? 'Enabled' : 'Disabled'
-                            }
-                        />
-                    </Grid>
-                </Grid>
-                <Grid hidden={ssoSyncHidden} container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Group Field JSON Path</strong>
-                        <p>
-                            Specifies the path in the SAML token response from
-                            which to read the groups the user belongs to
-                        </p>
-                    </Grid>
-                    <Grid item md={6}>
-                        <TextField
-                            onChange={updateField}
-                            label="Group JSON Path"
-                            name="groupJsonPath"
-                            value={data.groupJsonPath}
-                            disabled={!data.enableGroupSyncing}
-                            style={{ width: '400px' }}
-                            variant="outlined"
-                            size="small"
-                            required
-                        />
-                    </Grid>
-                </Grid>
+                <ConditionallyRender
+                    condition={ssoSyncShown}
+                    show={
+                        <SsoGroupSettings
+                            ssoType={'SAML'}
+                            data={data}
+                            setValue={setValue}
+                        ></SsoGroupSettings>
+                    }
+                />
+
                 <AutoCreateForm data={data} setValue={setValue} />
                 <Grid container spacing={3}>
                     <Grid item md={5}>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -40,7 +40,7 @@ export const SamlAuth = () => {
     const { hasAccess } = useContext(AccessContext);
     const { config } = useAuthSettings('saml');
     const { updateSettings, errors, loading } = useAuthSettingsApi('saml');
-    const ssoSyncShown = uiConfig.flags.syncSSOGroups || false;
+    const ssoSyncShown = Boolean(uiConfig.flags.syncSSOGroups);
 
     useEffect(() => {
         if (config.entityId) {
@@ -255,10 +255,10 @@ export const SamlAuth = () => {
                     condition={ssoSyncShown}
                     show={
                         <SsoGroupSettings
-                            ssoType={'SAML'}
+                            ssoType="SAML"
                             data={data}
                             setValue={setValue}
-                        ></SsoGroupSettings>
+                        />
                     }
                 />
 

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -1,0 +1,81 @@
+import React, { Fragment } from 'react';
+import { FormControlLabel, Grid, Switch, TextField } from '@mui/material';
+
+interface SsoGroupSettingsProps {
+    ssoType: string;
+    data?: {
+        enabled: boolean;
+        enableGroupSyncing: boolean;
+        groupJsonPath: string;
+    };
+    setValue: (name: string, value: string | boolean) => void;
+}
+
+export const SsoGroupSettings = ({
+    ssoType,
+    data = {
+        enabled: false,
+        enableGroupSyncing: false,
+        groupJsonPath: '',
+    },
+    setValue,
+}: SsoGroupSettingsProps) => {
+    const updateGroupSyncing = () => {
+        setValue('enableGroupSyncing', !data.enableGroupSyncing);
+    };
+
+    const updateField = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.name, event.target.value);
+    };
+
+    return (
+        <Fragment>
+            <Grid container spacing={3} mb={2}>
+                <Grid item md={5}>
+                    <strong>Enable Group Syncing</strong>
+                    <p>
+                        Enables automatically syncing of users from the{' '}
+                        {ssoType}
+                        provider when a user logs in.
+                    </p>
+                </Grid>
+                <Grid item md={6} style={{ padding: '20px' }}>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                onChange={updateGroupSyncing}
+                                value={data.enableGroupSyncing}
+                                name="enableGroupSyncing"
+                                checked={data.enableGroupSyncing}
+                                disabled={!data.enabled}
+                            />
+                        }
+                        label={data.enableGroupSyncing ? 'Enabled' : 'Disabled'}
+                    />
+                </Grid>
+            </Grid>
+            <Grid container spacing={3} mb={2}>
+                <Grid item md={5}>
+                    <strong>Group Field JSON Path</strong>
+                    <p>
+                        Specifies the path in the {ssoType} token response from
+                        which to read the groups the user belongs to.
+                    </p>
+                </Grid>
+                <Grid item md={6}>
+                    <TextField
+                        onChange={updateField}
+                        label="Group JSON Path"
+                        name="groupJsonPath"
+                        value={data.groupJsonPath}
+                        disabled={!data.enableGroupSyncing}
+                        style={{ width: '400px' }}
+                        variant="outlined"
+                        size="small"
+                        required
+                    />
+                </Grid>
+            </Grid>
+        </Fragment>
+    );
+};

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { FormControlLabel, Grid, Switch, TextField } from '@mui/material';
 
 interface SsoGroupSettingsProps {
-    ssoType: string;
+    ssoType: 'OIDC' | 'SAML';
     data?: {
         enabled: boolean;
         enableGroupSyncing: boolean;

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -76,6 +76,6 @@ export const SsoGroupSettings = ({
                     />
                 </Grid>
             </Grid>
-        </Fragment>
+        </>
     );
 };

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -29,7 +29,7 @@ export const SsoGroupSettings = ({
     };
 
     return (
-        <Fragment>
+        <>
             <Grid container spacing={3} mb={2}>
                 <Grid item md={5}>
                     <strong>Enable Group Syncing</strong>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -42,6 +42,7 @@ export interface IFlags {
     embedProxyFrontend?: boolean;
     publicSignup?: boolean;
     personalAccessTokens?: boolean;
+    syncSSOGroups?: boolean;
 }
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -74,6 +74,7 @@ exports[`should create default config 1`] = `
       "personalAccessTokens": false,
       "publicSignup": false,
       "responseTimeWithAppName": false,
+      "syncSSOGroups": false,
     },
   },
   "flagResolver": FlagResolver {
@@ -86,6 +87,7 @@ exports[`should create default config 1`] = `
       "personalAccessTokens": false,
       "publicSignup": false,
       "responseTimeWithAppName": false,
+      "syncSSOGroups": false,
     },
     "externalResolver": {
       "isEnabled": [Function],

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -14,6 +14,10 @@ export const defaultExperimentalOptions = {
             process.env.UNLEASH_EXPERIMENTAL_PERSONAL_ACCESS_TOKENS,
             false,
         ),
+        syncSSOGroups: parseEnvVarBoolean(
+            process.env.UNLEASH_EXPERIMENTAL_SYNC_SSO_GROUPS,
+            false,
+        ),
         embedProxyFrontend: parseEnvVarBoolean(
             process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY_FRONTEND,
             false,
@@ -43,6 +47,7 @@ export interface IExperimentalOptions {
         batchMetrics?: boolean;
         anonymiseEventLog?: boolean;
         personalAccessTokens?: boolean;
+        syncSSOGroups?: boolean;
     };
     externalResolver: IExternalFlagResolver;
 }

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -39,6 +39,7 @@ process.nextTick(async () => {
                         anonymiseEventLog: false,
                         responseTimeWithAppName: true,
                         personalAccessTokens: true,
+                        syncSSOGroups: true,
                     },
                 },
                 authentication: {

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -28,6 +28,7 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
                 embedProxyFrontend: true,
                 batchMetrics: true,
                 personalAccessTokens: true,
+                syncSSOGroups: true,
             },
         },
     };


### PR DESCRIPTION
Adds front end properties to the OIDC and SAML pages to allow group syncing to be turned on or off by the user. Requires related PR in enterprise to actually save the settings