### PR TITLE
docs: Document the min and max lengths of a feature name.

### DIFF
--- a/website/docs/reference/feature-toggles.mdx
+++ b/website/docs/reference/feature-toggles.mdx
@@ -10,7 +10,7 @@ Each feature toggle has the following configuration options
 
 | Option | Required? | Default value | Description |
 | --- | --- | --- | --- |
-| name | Yes | N/A | The feature toggle's name. Must be URL-friendly according to [section 2.3 of RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.3) and must be unique within your Unleash instance. |
+| name | Yes | N/A | The feature toggle's name. Must be URL-friendly according to [section 2.3 of RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.3) and must be unique within your Unleash instance. Must be between 1 and 100 characters long, inclusive. |
 | feature toggle type | Yes | Release | The [feature toggle's type](../advanced/feature-toggle-types.md). |
 | project | Yes | The [default project](../user_guide/projects.md#the-default-project). When created from a project page in the admin UI, that project will be the default value instead. | The [project](../user_guide/projects.md) that should contain the feature toggle. |
 | description | No | N/A | A description of the feature toggle's purpose. |


### PR DESCRIPTION
## What

This change adds a the min and max lengths allowed for a feature toggle name to the feature toggle docs.

## Why

As was mentioned in #2185, this isn't documented anywhere as of today, making it a potentially surprising issue to come across.