### PR TITLE
fix: sandbox codemirror/state 6.1.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,6 +96,9 @@
     "vitest": "0.22.1",
     "whatwg-fetch": "3.6.2"
   },
+  "resolutions": {
+    "@codemirror/state": "6.1.2"
+  },
   "jest": {
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/__mocks__/fileMock.js",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1514,12 +1514,7 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.0.tgz#c0f1d80f61908c9dcf5e2a3fe931e9dd78f3df8a"
-  integrity sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==
-
-"@codemirror/state@^6.1.1":
+"@codemirror/state@6.1.2", "@codemirror/state@^6.0.0", "@codemirror/state@^6.1.1":
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.2.tgz#182d46eabcc17c95508984d6add5a5a641dcd517"
   integrity sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==


### PR DESCRIPTION
Seems like some `codemirror` dependencies were requesting @codemirror/state v6.1.1 while others requested v6.1.2 - This PR adds a resolution so we use `6.1.2`, fixing the issue.