### PR TITLE
docs: update appId and apiKey to new DocSearch

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,8 +22,8 @@ module.exports = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
         algolia: {
-            appId: 'BH4D9OD16A',
-            apiKey: '9772249a7262b377ac876853d32bd760',
+            appId: '5U05JI5NE1',
+            apiKey: 'dc9c4491fcf9143ee34015f22d1dd9d6',
             indexName: 'getunleash',
         },
         announcementBar: {


### PR DESCRIPTION
## What

This change updates the details used for the doc search integration we use.

## Why

Algolia has migrated to a new doc search platform. The old credentials still work, but the crawlers stopped working months ago. This is why new articles don't show up in the search at all.

This update _should_ allow us to update our indices and get search working properly again.