### PR TITLE
fix: respect environment if set on context

### DIFF
--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -1,6 +1,6 @@
 // Copy of https://github.com/Unleash/unleash-proxy/blob/main/src/test/create-context.test.ts.
 
-import { createContext } from './create-context';
+import { createContext, enrichContextWithIp } from './create-context';
 
 test('should remove undefined properties', () => {
     const context = createContext({
@@ -81,6 +81,16 @@ test('will not set environment to be development if not set in context', () => {
     });
 
     expect(context.environment).toBe(undefined);
+});
+
+test('will only enrich context with ip', () => {
+    const query = {};
+    const ip = '192.168.10.0';
+    const result = enrichContextWithIp(query, ip);
+
+    expect(result.environment).toBe(undefined);
+    expect(result.remoteAddress).toBe(ip);
+    expect(result.properties).toStrictEqual({});
 });
 
 test.skip('will not blow up if userId is an array', () => {

--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -72,6 +72,17 @@ test('will respect environment set in context', () => {
     expect(context.environment).toBe('development');
 });
 
+test('will not set environment to be development if not set in context', () => {
+    const context = createContext({
+        userId: '123',
+        tenantId: 'some-tenant',
+        region: 'eu',
+        properties: ['some'],
+    });
+
+    expect(context.environment).toBe(undefined);
+});
+
 test.skip('will not blow up if userId is an array', () => {
     const context = createContext({
         userId: ['123'],

--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -83,14 +83,20 @@ test('will not set environment to be development if not set in context', () => {
     expect(context.environment).toBe(undefined);
 });
 
-test('will only enrich context with ip', () => {
+test('will enrich context with ip', () => {
     const query = {};
     const ip = '192.168.10.0';
     const result = enrichContextWithIp(query, ip);
 
-    expect(result.environment).toBe(undefined);
     expect(result.remoteAddress).toBe(ip);
-    expect(result.properties).toStrictEqual({});
+});
+
+test('will not change environment when enriching', () => {
+    const query = { environment: 'production' };
+    const ip = '192.168.10.0';
+    const result = enrichContextWithIp(query, ip);
+
+    expect(result.environment).toBe('production');
 });
 
 test.skip('will not blow up if userId is an array', () => {

--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -55,11 +55,23 @@ test('will not blow up if properties is an array', () => {
         properties: ['some'],
     });
 
-    // console.log(context);
-
     expect(context.userId).toBe('123');
     expect(context).not.toHaveProperty('tenantId');
     expect(context).not.toHaveProperty('region');
+});
+
+test('will respect environment set in context', () => {
+    const context = createContext({
+        userId: '123',
+        tenantId: 'some-tenant',
+        environment: 'development',
+        region: 'eu',
+        properties: ['some'],
+    });
+
+    // console.log(context);
+
+    expect(context.environment).toBe('development');
 });
 
 test.skip('will not blow up if userId is an array', () => {

--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -69,8 +69,6 @@ test('will respect environment set in context', () => {
         properties: ['some'],
     });
 
-    // console.log(context);
-
     expect(context.environment).toBe('development');
 });
 

--- a/src/lib/proxy/create-context.ts
+++ b/src/lib/proxy/create-context.ts
@@ -32,3 +32,9 @@ export function createContext(value: any): Context {
 
     return cleanContext;
 }
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const enrichContextWithIp = (query: any, ip: string): Context => {
+    query.remoteAddress = query.remoteAddress || ip;
+    return createContext(query);
+};

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -169,7 +169,7 @@ export default class ProxyController extends Controller {
     private static createContext(req: ApiUserRequest): Context {
         const { query } = req;
         query.remoteAddress = query.remoteAddress || req.ip;
-        query.environment = req.user.environment;
+        query.environment = query.environment || req.user.environment;
         return createContext(query);
     }
 }

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -9,7 +9,7 @@ import {
     ProxyFeaturesSchema,
 } from '../../openapi/spec/proxy-features-schema';
 import { Context } from 'unleash-client';
-import { createContext } from '../../proxy/create-context';
+import { enrichContextWithIp } from '../../proxy/create-context';
 import { ProxyMetricsSchema } from '../../openapi/spec/proxy-metrics-schema';
 import { ProxyClientSchema } from '../../openapi/spec/proxy-client-schema';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
@@ -168,7 +168,6 @@ export default class ProxyController extends Controller {
 
     private static createContext(req: ApiUserRequest): Context {
         const { query } = req;
-        query.remoteAddress = query.remoteAddress || req.ip;
-        return createContext(query);
+        return enrichContextWithIp(query, req.ip);
     }
 }

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -169,7 +169,6 @@ export default class ProxyController extends Controller {
     private static createContext(req: ApiUserRequest): Context {
         const { query } = req;
         query.remoteAddress = query.remoteAddress || req.ip;
-        query.environment = query.environment || req.user.environment;
         return createContext(query);
     }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

This PR fixes an issue with the new frontend API where we would override environment set on the context to what the environment of the API key was. This will break feature toggles for older users of unleash because some might still be using the deprecated environment field on the SDKs.

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes # .

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
