### PR TITLE
Import of feature still showing env on feature, when environment is disabled on project

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1006,7 +1006,6 @@ class FeatureToggleService {
         const defaultEnv = environments.find((e) => e.name === DEFAULT_ENV);
         const strategies = defaultEnv?.strategies || [];
         const enabled = defaultEnv?.enabled || false;
-
         return { ...legacyFeature, enabled, strategies };
     }
 

--- a/src/lib/types/stores/project-store.ts
+++ b/src/lib/types/stores/project-store.ts
@@ -2,7 +2,7 @@ import {
     IEnvironmentProjectLink,
     IProjectMembersCount,
 } from '../../db/project-store';
-import { IProject, IProjectWithCount } from '../model';
+import { IEnvironment, IProject, IProjectWithCount } from '../model';
 import { Store } from './store';
 
 export interface IProjectInsert {
@@ -31,7 +31,10 @@ export interface IProjectStore extends Store<IProject, string> {
     updateHealth(healthUpdate: IProjectHealthUpdate): Promise<void>;
     create(project: IProjectInsert): Promise<IProject>;
     update(update: IProjectInsert): Promise<void>;
-    importProjects(projects: IProjectInsert[]): Promise<IProject[]>;
+    importProjects(
+        projects: IProjectInsert[],
+        environments?: IEnvironment[],
+    ): Promise<IProject[]>;
     addEnvironmentToProject(id: string, environment: string): Promise<void>;
     deleteEnvironmentForProject(id: string, environment: string): Promise<void>;
     getEnvironmentsForProject(id: string): Promise<string[]>;

--- a/src/test/e2e/api/admin/state.e2e.test.ts
+++ b/src/test/e2e/api/admin/state.e2e.test.ts
@@ -437,3 +437,25 @@ test(`should clean apitokens for not existing environment after import with drop
     const apiTokens = await app.services.apiTokenService.getAllTokens();
     expect(apiTokens.length).toEqual(0);
 });
+
+test(`should not show environment on feature toggle, when environment is disabled`, async () => {
+    await app.request
+        .post('/api/admin/state/import?drop=true')
+        .attach('file', 'src/test/examples/import-state.json')
+        .expect(202);
+
+    const { body } = await app.request.get(
+        '/api/admin/projects/default/features/my-feature',
+    );
+
+    expect(body.environments).toHaveLength(2);
+
+    const hiddenEnvironment = body.environments.find(
+        (env) => env.name === 'state-hidden-environment',
+    );
+    const visibleEnvironment = body.environments.find(
+        (env) => env.name === 'state-visible-environment',
+    );
+    expect(hiddenEnvironment.enabled).toBe(false);
+    expect(visibleEnvironment.enabled).toBe(true);
+});

--- a/src/test/examples/import-state.json
+++ b/src/test/examples/import-state.json
@@ -1,0 +1,53 @@
+{
+  "version": 2,
+  "features": [
+    {
+      "name": "my-feature",
+      "description": "",
+      "type": "release",
+      "project": "default",
+      "stale": false,
+      "variants": [],
+      "createdAt": "2021-09-17T07:06:40.925Z",
+      "lastSeenAt": null
+    }
+  ],
+  "featureStrategies": [
+    {
+      "id": "2ea91298-4565-4db2-8a23-50757001a076",
+      "featureName": "my-feature",
+      "projectId": "default",
+      "environment": "state-visible-environment",
+      "strategyName": "gradualRolloutRandom",
+      "parameters": {
+        "percentage": "100"
+      },
+      "constraints": [],
+      "createdAt": "2021-09-17T07:23:39.374Z"
+    }
+  ],
+  "environments": [
+    {
+      "name": "state-visible-environment",
+      "type": "production",
+      "displayName": "Visible"
+    },
+    {
+      "name": "state-hidden-environment",
+      "type": "production",
+      "displayName": "Hidden"
+    }
+  ],
+  "featureEnvironments": [
+    {
+      "enabled": true,
+      "featureName": "my-feature",
+      "environment": "state-visible-environment"
+    },
+    {
+      "enabled": false,
+      "featureName": "my-feature",
+      "environment": "state-hidden-environment"
+    }
+  ]
+}

--- a/src/test/fixtures/fake-feature-environment-store.ts
+++ b/src/test/fixtures/fake-feature-environment-store.ts
@@ -150,7 +150,7 @@ export default class FakeFeatureEnvironmentStore
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         projectId: string,
     ): Promise<void> {
-        return Promise.reject(new Error('Not implemented'));
+        return Promise.resolve();
     }
 
     disableEnvironmentIfNoStrategies(

--- a/src/test/fixtures/fake-project-store.ts
+++ b/src/test/fixtures/fake-project-store.ts
@@ -3,7 +3,11 @@ import {
     IProjectInsert,
     IProjectStore,
 } from '../../lib/types/stores/project-store';
-import { IProject, IProjectWithCount } from '../../lib/types/model';
+import {
+    IEnvironment,
+    IProject,
+    IProjectWithCount,
+} from '../../lib/types/model';
 import NotFoundError from '../../lib/error/notfound-error';
 import {
     IEnvironmentProjectLink,
@@ -110,7 +114,12 @@ export default class FakeProjectStore implements IProjectStore {
         return this.exists(id);
     }
 
-    async importProjects(projects: IProjectInsert[]): Promise<IProject[]> {
+    async importProjects(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        projects: IProjectInsert[],
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        environments?: IEnvironment[],
+    ): Promise<IProject[]> {
         return projects.map((p) => this.createInternal(p));
     }
 


### PR DESCRIPTION
Should fix the issue https://github.com/Unleash/unleash/issues/2186.

Changes:

1. When importing **featureEnvironments**, it created `feature_environments` always, now only if `project_environments` exists(is enabled).
2. When importing **projects**, it created a `project_environment` only for default project, now creates a `project_environment` for each new project and environment that is new. 