### PR TITLE
OpenAPI(feat): add new 'Segments' tag

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -70,6 +70,11 @@ const OPENAPI_TAGS = [
             'Create, update, and delete [Unleash Public Signup tokens](https://docs.getunleash.io/reference/public-signup-tokens).',
     },
     {
+        name: 'Segments',
+        description:
+            'Create, update, delete, and manage [segments](https://docs.getunleash.io/reference/segments).',
+    },
+    {
         name: 'Strategies',
         description:
             'Create, update, delete, manage [custom strategies](https://docs.getunleash.io/advanced/custom_activation_strategy).',

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -7610,6 +7610,10 @@ If the provided project does not exist, the list of events will be empty.",
       "name": "Public signup tokens",
     },
     {
+      "description": "Create, update, delete, and manage [segments](https://docs.getunleash.io/reference/segments).",
+      "name": "Segments",
+    },
+    {
       "description": "Create, update, delete, manage [custom strategies](https://docs.getunleash.io/advanced/custom_activation_strategy).",
       "name": "Strategies",
     },


### PR DESCRIPTION
## What

This change adds a new Segments tag to the list of valid OpenAPI tags.

## Why

When updating tags for the enterprise version of Unleash, I realized we didn't have any tags that were appropriate for the segments endpoints.