### PR TITLE
Update rootRole on login (#2243)

### DIFF
--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -330,6 +330,9 @@ class UserService {
             if (name && user.name !== name) {
                 user = await this.store.update(user.id, { name, email });
             }
+            if (rootRole) {
+                user = await this.store.update(user.id, { rootRole });
+            }
         } catch (e) {
             // User does not exists. Create if "autoCreate" is enabled
             if (autoCreate) {

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -1,3 +1,4 @@
+import { RoleName } from '../model';
 import { IUser } from '../user';
 import { Store } from './store';
 
@@ -17,6 +18,7 @@ export interface IUserLookup {
 export interface IUserUpdateFields {
     name?: string;
     email?: string;
+    rootRole?: number | RoleName;
 }
 
 export interface IUserStore extends Store<IUser, number> {


### PR DESCRIPTION
## About the changes
Don't think this needs much explanation. It will only update the user object on SSO authentication when a rootRole is present on the User object. This should solve the issues as mentioned in #2243 

<!-- Does it close an issue? Multiple? -->
Closes #2243 .
