### PR TITLE
[docs]: Update Prometheus docs with security info

### DIFF
--- a/website/docs/api/internal/internal-backstage-api.md
+++ b/website/docs/api/internal/internal-backstage-api.md
@@ -7,7 +7,9 @@ title: /internal-backstage/prometheus
 
 `GET http://unleash.host.com/internal-backstage/prometheus`
 
-Unleash uses prometheus internally to collect metrics. These are available on the given url if the `serverMetrics` option is enabled (default=true).
+Unleash uses Prometheus internally to collect metrics. These are available on the given url if the `serverMetrics` option is enabled (default=true).
+
+Note that it's not recomended to expose Prometheus metrics to the public. You should therefore drop all external access to `/internal-backstage/*` on the network layer to keep your instance secure. 
 
 [Read more about Prometheus](https://prometheus.io/)
 

--- a/website/docs/api/internal/internal-backstage-api.md
+++ b/website/docs/api/internal/internal-backstage-api.md
@@ -9,7 +9,7 @@ title: /internal-backstage/prometheus
 
 Unleash uses Prometheus internally to collect metrics. By default, the metrics are available at `/internal-backstage/prometheus`. You can disable this endpoint by setting the `serverMetrics` option to `false`.
 
-Note that it's not recommended to expose Prometheus metrics to the public. Thus, if you want to keep metrics enabled, you should block all external access to `/internal-backstage/*` on the network layer to keep your instance secure. 
+Note that it's not recommended to expose Prometheus metrics to the public as of the [Prometheus pentest-report](https://prometheus.io/assets/downloads/2018-06-11--cure53_security_audit.pdf) issue PRM-01-002. Thus, if you want to keep metrics enabled, you should block all external access to `/internal-backstage/*` on the network layer to keep your instance secure. 
 
 [Read more about Prometheus](https://prometheus.io/)
 

--- a/website/docs/api/internal/internal-backstage-api.md
+++ b/website/docs/api/internal/internal-backstage-api.md
@@ -7,9 +7,9 @@ title: /internal-backstage/prometheus
 
 `GET http://unleash.host.com/internal-backstage/prometheus`
 
-Unleash uses Prometheus internally to collect metrics. These are available on the given url if the `serverMetrics` option is enabled (default=true).
+Unleash uses Prometheus internally to collect metrics. By default, the metrics are available at `/internal-backstage/prometheus`. You can disable this endpoint by setting the `serverMetrics` option to `false`.
 
-Note that it's not recomended to expose Prometheus metrics to the public. You should therefore drop all external access to `/internal-backstage/*` on the network layer to keep your instance secure. 
+Note that it's not recommended to expose Prometheus metrics to the public. Thus, if you want to keep metrics enabled, you should block all external access to `/internal-backstage/*` on the network layer to keep your instance secure. 
 
 [Read more about Prometheus](https://prometheus.io/)
 


### PR DESCRIPTION
## About the changes
Prometheus metrics should not be exposed to the public. Added a note about this to inform people that internal endpoints should be dropped on external access. 

## Discussion points
https://unleash-community.slack.com/archives/CGP2MCHPF/p1666688295670459
