### PR TITLE
docs: remove instagram url from link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,7 @@
 dev-example-okta.com
 .*-dsn.algolia.net
 www.linkedin.com/company/getunleash
+www.instagram.com/getunleash
 
 .*.unleash.host.*.com.*
 unleash.*.com/api/


### PR DESCRIPTION
Instagram started to throttle us (i.e. #2248). Links that are well known such as our Instagram page, don't need to be checked every time. By explicitly ignoring the correct link we reduce noise but at the same time we continue checking other Instagram links that may help us identify a typo

<!-- Does it close an issue? Multiple? -->
Closes #2248 