### PR TITLE
chore: Use last version of @unleash/express-openapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     ]
   },
   "dependencies": {
-    "@unleash/express-openapi": "^0.2.1-beta.0",
+    "@unleash/express-openapi": "^0.2.1",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
     "async": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,10 +1773,10 @@
     "@typescript-eslint/types" "5.40.1"
     eslint-visitor-keys "^3.3.0"
 
-"@unleash/express-openapi@^0.2.1-beta.0":
-  version "0.2.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@unleash/express-openapi/-/express-openapi-0.2.1-beta.0.tgz#1f5f43c6eb46c490990dc3e4709ab23a48a24e9a"
-  integrity sha512-72pNESnWyIvsLZaYjaBHwPXzO361up/A1tA/Mv+eG1MkntRJMNhRSgPzPvoP5j7pCxKeXqu1FRfXTXLRzGo+HA==
+"@unleash/express-openapi@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@unleash/express-openapi/-/express-openapi-0.2.1.tgz#ecbba742dad0a05c1563f35e3272ee3671dc478d"
+  integrity sha512-wvwgSrzMGo3khB2E/xPLXlB/uT6FruszIsUDThJpttILtxBmj1SDWb0L6SG1CQ2tlnC786/6+0iSBwcz0fViOg==
   dependencies:
     ajv "^6.10.2"
     http-errors "^1.7.3"


### PR DESCRIPTION
## About the changes
Just to use a non-beta version https://www.npmjs.com/package/@unleash/express-openapi?activeTab=versions no changes from v0.2.1-beta.0 meaning that the [change we were testing](https://github.com/Unleash/express-openapi/pull/5) is stable now