### PR TITLE
Suggest change - update status and get per project

### DIFF
--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -385,13 +385,12 @@ export interface ISuggestChange {
     createdAt?: Date;
 }
 
-export enum SuggestChangesetEvent {
-    CREATED = 'CREATED',
-    UPDATED = 'UPDATED',
-    SUBMITTED = 'SUBMITTED',
-    APPROVED = 'APPROVED',
-    REJECTED = 'REJECTED',
-    CLOSED = 'CLOSED',
+export enum SuggestChangesetState {
+    DRAFT = 'Draft',
+    APPROVED = 'Approved',
+    IN_REVIEW = 'In review',
+    APPLIED = 'Applied',
+    CANCELLED = 'Cancelled',
 }
 
 export enum SuggestChangeAction {
@@ -401,12 +400,6 @@ export enum SuggestChangeAction {
     DELETE_STRATEGY = 'strategyDelete',
 }
 
-export enum SuggestChangeEvent {
-    UPDATE_ENABLED = 'updateFeatureEnabledEvent',
-    ADD_STRATEGY = 'addStrategyEvent',
-    UPDATE_STRATEGY = 'updateStrategyEvent',
-    DELETE_STRATEGY = 'deleteStrategyEvent',
-}
 export interface ISuggestChangeEventData {
     feature: string;
     data: unknown;

--- a/src/lib/types/stores/suggest-change-store.ts
+++ b/src/lib/types/stores/suggest-change-store.ts
@@ -1,5 +1,9 @@
 import { Store } from './store';
-import { ISuggestChange, ISuggestChangeset } from '../model';
+import {
+    ISuggestChange,
+    ISuggestChangeset,
+    SuggestChangesetState,
+} from '../model';
 import { PartialSome } from '../partial';
 
 export interface ISuggestChangeStore extends Store<ISuggestChangeset, number> {
@@ -18,6 +22,11 @@ export interface ISuggestChangeStore extends Store<ISuggestChangeset, number> {
     ): Promise<void>;
 
     get(id: number): Promise<ISuggestChangeset>;
+
+    updateState(
+        id: number,
+        state: SuggestChangesetState,
+    ): Promise<ISuggestChangeset>;
 
     getAll(): Promise<ISuggestChangeset[]>;
 

--- a/src/test/fixtures/fake-suggest-change-store.ts
+++ b/src/test/fixtures/fake-suggest-change-store.ts
@@ -1,5 +1,9 @@
 import { ISuggestChangeStore } from '../../lib/types/stores/suggest-change-store';
-import { ISuggestChange, ISuggestChangeset } from '../../lib/types/model';
+import {
+    ISuggestChange,
+    ISuggestChangeset,
+    SuggestChangesetState,
+} from '../../lib/types/model';
 import { PartialSome } from '../../lib/types/partial';
 
 export default class FakeSuggestChangeStore implements ISuggestChangeStore {
@@ -85,5 +89,14 @@ export default class FakeSuggestChangeStore implements ISuggestChangeStore {
 
     exists(key: number): Promise<boolean> {
         return Promise.resolve(Boolean(key));
+    }
+
+    updateState(
+        id: number,
+        state: SuggestChangesetState,
+    ): Promise<ISuggestChangeset> {
+        const changeSet = this.suggestChanges.find((s) => s.id === id);
+        changeSet.state = state;
+        return Promise.resolve(undefined);
     }
 }


### PR DESCRIPTION
This PR adds two endpoints to suggest change

1. Update status of change set
2. Get all change sets per project that are not drafts