### PR TITLE
fix: escape single quotes ' for curl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: Trigger CI build
         env:
           UNLEASH_CI_BUILDER_GITHUB_TOKEN: ${{ secrets.UNLEASH_CI_BUILDER_GITHUB_TOKEN }}
+          COMMITS: ${{ toJSON(github.event.commits) }}
         run: |
           curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${UNLEASH_CI_BUILDER_GITHUB_TOKEN}" \
             https://api.github.com/repos/bricks-software/unleash-ci-builder/dispatches \
-            -d '{"event_type":"trigger-unleash-cloud-build","client_payload":{"commits":${{toJSON(github.event.commits)}}}}'
+            -d '{"event_type":"trigger-unleash-cloud-build","client_payload":{"commits":$COMMITS}}'


### PR DESCRIPTION
## About the changes
When the commit message has a single quote `'`, it breaks our curl command that encloses the request body between single quotes. A similar issue was reported in https://github.com/actions/runner/issues/1656 and the suggestion is to use an environment variable that when used in bash will use bash's built-in escaping of env variables that should help us here as well.

For testing purposes the title of the PR includes also a single quote