### PR TITLE
make prettify large number tests independent of locale

### DIFF
--- a/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.test.tsx
+++ b/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.test.tsx
@@ -11,7 +11,7 @@ describe('PrettifyLargeNumber', () => {
             LARGE_NUMBER_PRETTIFIED
         );
 
-        expect(prettifiedText.textContent).toBe('999,999');
+        expect(prettifiedText.textContent).toHaveLength('999,999'.length);
     });
 
     it('should render prettified number for value equal to the threshold', async () => {
@@ -41,7 +41,9 @@ describe('PrettifyLargeNumber', () => {
             LARGE_NUMBER_PRETTIFIED
         );
 
-        expect(prettifiedText.getAttribute('aria-label')).toBe('12,345,678');
+        expect(prettifiedText.getAttribute('aria-label')).toHaveLength(
+            '12,345,678'.length
+        );
     });
 
     it('should render prettified number with provided significant figures for value greater than threshold', async () => {


### PR DESCRIPTION
## What

We recently accepted a PR that includes some tests to prettify large numbers in the front end project. However, these tests are not locale independent and so fail on machines where the number separator is not a comma. This patches those tests to rather check that the length of the output string matches the expected length i.e. that the input strings have had a separator injected into them.

This doesn't touch the tests that use millify for the number formatting. Since we don't set any options on the millify function itself, this should be locale independent already (possibly something to talk about in future). 

I'm not 100% we actually want to keep these tests but if we do this is an option to preserve the logic while keeping them locale independent.