### PR TITLE
fix: small UI fixes to the clone environment modal

### DIFF
--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -320,7 +320,7 @@ export const EnvironmentCloneModal = ({
                                     <FormControlLabel
                                         value={APITokenGeneration.LATER}
                                         control={<Radio />}
-                                        label="Generate an API token later"
+                                        label="I want to generate an API token later"
                                     />
                                     <FormControlLabel
                                         value={APITokenGeneration.NOW}
@@ -329,35 +329,39 @@ export const EnvironmentCloneModal = ({
                                     />
                                 </RadioGroup>
                             </FormControl>
-                            <ConditionallyRender
-                                condition={
-                                    apiTokenGeneration ===
-                                    APITokenGeneration.NOW
-                                }
-                                show={
-                                    <StyledInlineContainer>
-                                        <StyledInputSecondaryDescription>
-                                            A new Server-side SDK (CLIENT) API
-                                            token will be generated for the
-                                            cloned environment, so you can get
-                                            started right away.
-                                        </StyledInputSecondaryDescription>
-                                        <StyledInputDescription>
-                                            Which projects do you want this
-                                            token to give access to?
-                                        </StyledInputDescription>
-                                        <SelectProjectInput
-                                            options={selectableProjects}
-                                            defaultValue={tokenProjects}
-                                            onChange={setTokenProjects}
-                                            error={errors.projects}
-                                            onFocus={() =>
-                                                clearError(ErrorField.PROJECTS)
-                                            }
-                                        />
-                                    </StyledInlineContainer>
-                                }
-                            />
+                            <StyledInlineContainer>
+                                <StyledInputSecondaryDescription>
+                                    A new Server-side SDK (CLIENT) API token
+                                    will be generated for the cloned
+                                    environment, so you can get started right
+                                    away.
+                                </StyledInputSecondaryDescription>
+                                <ConditionallyRender
+                                    condition={
+                                        apiTokenGeneration ===
+                                        APITokenGeneration.NOW
+                                    }
+                                    show={
+                                        <>
+                                            <StyledInputDescription>
+                                                Which projects do you want this
+                                                token to give access to?
+                                            </StyledInputDescription>
+                                            <SelectProjectInput
+                                                options={selectableProjects}
+                                                defaultValue={tokenProjects}
+                                                onChange={setTokenProjects}
+                                                error={errors.projects}
+                                                onFocus={() =>
+                                                    clearError(
+                                                        ErrorField.PROJECTS
+                                                    )
+                                                }
+                                            />
+                                        </>
+                                    }
+                                />
+                            </StyledInlineContainer>
                         </StyledSecondaryContainer>
                     </div>
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-371/small-ui-fixes-on-the-clone-environment-modal

UI/UX requests to make the flow a bit more understandable at a quick glance:
 - Change the "Generate an API token later" label to "I want to generate an API token later";
 - Show the "Generate an API token now" secondary description even if that option is not selected;
 
Goes against the change we made in https://github.com/Unleash/unleash/pull/2245#discussion_r1007697439 - But that's a conscious decision from UX to make the options more distinct at a quick glance.