### PR TITLE
Hyperlink Injection in People Invitation Emails

### DIFF
--- a/src/lib/services/email-service.test.ts
+++ b/src/lib/services/email-service.test.ts
@@ -99,4 +99,5 @@ test('should strip special characters from email subject', async () => {
     expect(emailService.stripSpecialCharacters('http://ööbik.com')).toBe(
         'httpööbikcom',
     );
+    expect(emailService.stripSpecialCharacters('tom-jones')).toBe('tom-jones');
 });

--- a/src/lib/services/email-service.test.ts
+++ b/src/lib/services/email-service.test.ts
@@ -80,3 +80,23 @@ test('Can supply additional SMTP transport options', async () => {
         },
     });
 });
+
+test('should strip special characters from email subject', async () => {
+    const emailService = new EmailService(
+        {
+            host: 'test',
+            port: 9999,
+            secure: false,
+            sender: 'noreply@getunleash.ai',
+            smtpuser: '',
+            smtppass: '',
+        },
+        noLoggerProvider,
+    );
+    expect(emailService.stripSpecialCharacters('http://evil.com')).toBe(
+        'httpevilcom',
+    );
+    expect(emailService.stripSpecialCharacters('http://ööbik.com')).toBe(
+        'httpööbikcom',
+    );
+});

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -138,7 +138,12 @@ export class EmailService {
     ): Promise<IEmailEnvelope> {
         if (this.configured()) {
             const year = new Date().getFullYear();
-            const context = { passwordLink, name, year, unleashUrl };
+            const context = {
+                passwordLink,
+                name: this.stripSpecialCharacters(name),
+                year,
+                unleashUrl,
+            };
             const bodyHtml = await this.compileTemplate(
                 'getting-started',
                 TemplateFormat.HTML,
@@ -221,5 +226,9 @@ export class EmailService {
 
     configured(): boolean {
         return this.sender !== 'not-configured' && this.mailer !== undefined;
+    }
+
+    stripSpecialCharacters(str: string): string {
+        return str?.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
     }
 }

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -229,6 +229,6 @@ export class EmailService {
     }
 
     stripSpecialCharacters(str: string): string {
-        return str?.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
+        return str?.replace(/[`~!@#$%^&*()_|+=?;:'",.<>\{\}\[\]\\\/]/gi, '');
     }
 }


### PR DESCRIPTION
Currently it is possible to send links through emails to users during invitation.
As a workaround, we will start stripping special characters from name, but still leaving language specific letters.