### PR TITLE
fix: remove duplicate formatApiPath in userUiConfigApi hook

### DIFF
--- a/frontend/src/hooks/api/actions/useUiConfigApi/useUiConfigApi.ts
+++ b/frontend/src/hooks/api/actions/useUiConfigApi/useUiConfigApi.ts
@@ -1,5 +1,4 @@
 import useAPI from '../useApi/useApi';
-import { formatApiPath } from 'utils/formatPath';
 
 export const useUiConfigApi = () => {
     const { makeRequest, createRequest, errors, loading } = useAPI({
@@ -13,7 +12,7 @@ export const useUiConfigApi = () => {
             frontendSettings: { frontendApiOrigins },
         };
         const req = createRequest(
-            formatApiPath('api/admin/ui-config'),
+            'api/admin/ui-config',
             { method: 'POST', body: JSON.stringify(payload) },
             'setFrontendSettings'
         );


### PR DESCRIPTION
Fix a small UI bug that incorrectly formats the API url, making the CORS update fail when "baseUriPath" is configured. 