### PR TITLE
Change request API draft to open

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -14,7 +14,7 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { HelpOutline } from '@mui/icons-material';
 import EnvironmentIcon from 'component/common/EnvironmentIcon/EnvironmentIcon';
 import { ChangeRequest } from '../ChangeRequest/ChangeRequest';
-import { useChangeRequestDraft } from 'hooks/api/getters/useChangeRequestDraft/useChangeRequestDraft';
+import { useChangeRequestOpen } from 'hooks/api/getters/useChangeRequestOpen/useChangeRequestOpen';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 import { ChangeRequestStatusBadge } from '../ChangeRequestStatusBadge/ChangeRequestStatusBadge';
 
@@ -65,7 +65,7 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
         draft,
         loading,
         refetch: refetchChangeRequest,
-    } = useChangeRequestDraft(project);
+    } = useChangeRequestOpen(project);
     const { changeState } = useChangeRequestApi();
 
     const onReview = async (draftId: number) => {

--- a/frontend/src/component/changeRequest/DraftBanner/DraftBanner.tsx
+++ b/frontend/src/component/changeRequest/DraftBanner/DraftBanner.tsx
@@ -4,7 +4,7 @@ import { useStyles as useAppStyles } from 'component/App.styles';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { ChangeRequestSidebar } from '../ChangeRequestSidebar/ChangeRequestSidebar';
-import { useChangeRequestDraft } from 'hooks/api/getters/useChangeRequestDraft/useChangeRequestDraft';
+import { useChangeRequestOpen } from 'hooks/api/getters/useChangeRequestOpen/useChangeRequestOpen';
 
 interface IDraftBannerProps {
     project: string;
@@ -13,7 +13,7 @@ interface IDraftBannerProps {
 export const DraftBanner: VFC<IDraftBannerProps> = ({ project }) => {
     const { classes } = useAppStyles();
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-    const { draft, loading } = useChangeRequestDraft(project);
+    const { draft, loading } = useChangeRequestOpen(project);
     const environment = '';
 
     if ((!loading && !draft) || draft?.length === 0) {

--- a/frontend/src/hooks/api/getters/useChangeRequestOpen/useChangeRequestOpen.ts
+++ b/frontend/src/hooks/api/getters/useChangeRequestOpen/useChangeRequestOpen.ts
@@ -13,9 +13,9 @@ const fetcher = (path: string) => {
         .then(res => res.json());
 };
 
-export const useChangeRequestDraft = (project: string) => {
+export const useChangeRequestOpen = (project: string) => {
     const { data, error, mutate } = useSWR<IChangeRequest[]>(
-        formatApiPath(`api/admin/projects/${project}/change-requests/draft`),
+        formatApiPath(`api/admin/projects/${project}/change-requests/open`),
         fetcher
     );
 

--- a/frontend/src/hooks/useChangeRequestToggle.ts
+++ b/frontend/src/hooks/useChangeRequestToggle.ts
@@ -2,12 +2,12 @@ import { useCallback, useState } from 'react';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useChangeRequestApi } from './api/actions/useChangeRequestApi/useChangeRequestApi';
-import { useChangeRequestDraft } from './api/getters/useChangeRequestDraft/useChangeRequestDraft';
+import { useChangeRequestOpen } from './api/getters/useChangeRequestOpen/useChangeRequestOpen';
 
 export const useChangeRequestToggle = (project: string) => {
     const { setToastData, setToastApiError } = useToast();
     const { addChangeRequest } = useChangeRequestApi();
-    const { refetch: refetchChangeRequests } = useChangeRequestDraft(project);
+    const { refetch: refetchChangeRequests } = useChangeRequestOpen(project);
 
     const [changeRequestDialogDetails, setChangeRequestDialogDetails] =
         useState<{


### PR DESCRIPTION
This is small PR that aligns with the latest API paths.

`/change-requests/draft` changed to` /change-requests/open`