### PR TITLE
feat: add support for node 18

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/build_frontend_prs.yml
+++ b/.github/workflows/build_frontend_prs.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: frontend
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build_prs.yaml
+++ b/.github/workflows/build_prs.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build_prs_jest_report.yaml
+++ b/.github/workflows/build_prs_jest_report.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     services:
       # Label used to access the service container
       postgres:

--- a/.github/workflows/docker_publish_main.yaml
+++ b/.github/workflows/docker_publish_main.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [14-alpine, 16-alpine]
+        version: [14-alpine, 16-alpine, 18-alpine]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR change default builds to run with node 16 and also adds node 18 as a build target for tests. 

It will also produce "main" builds of the docker image for node 18. Need to align with  @gardleopard and @chriswk on whether we should add build targets for the versioned docker images as well. 

- [ ] Add matrix build to [docker_publish_tags.yaml](https://github.com/Unleash/unleash/blob/main/.github/workflows/docker_publish_tags.yaml) to support both node v16 and 18