### PR TITLE
Fix: Conditionally hide Change Requests tab

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -8,7 +8,7 @@ import { styled, Tab, Tabs } from '@mui/material';
 import { Delete, Edit } from '@mui/icons-material';
 import useToast from 'hooks/useToast';
 import useQueryParams from 'hooks/useQueryParams';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ProjectAccess } from '../ProjectAccess/ProjectAccess';
 import ProjectEnvironment from '../ProjectEnvironment/ProjectEnvironment';
 import { ProjectFeaturesArchive } from './ProjectFeaturesArchive/ProjectFeaturesArchive';
@@ -63,43 +63,53 @@ const Project = () => {
 
     const [showDelDialog, setShowDelDialog] = useState(false);
 
-    const tabs = [
-        {
-            title: 'Overview',
-            path: basePath,
-            name: 'overview',
-        },
-        {
-            title: 'Health',
-            path: `${basePath}/health`,
-            name: 'health',
-        },
-        {
-            title: 'Access',
-            path: `${basePath}/access`,
-            name: 'access',
-        },
-        {
-            title: 'Environments',
-            path: `${basePath}/environments`,
-            name: 'environments',
-        },
-        {
-            title: 'Archive',
-            path: `${basePath}/archive`,
-            name: 'archive',
-        },
-        {
+    const changeRequestsEnabled = uiConfig?.flags?.changeRequests;
+
+    const tabs = useMemo(() => {
+        const tabArray = [
+            {
+                title: 'Overview',
+                path: basePath,
+                name: 'overview',
+            },
+            {
+                title: 'Health',
+                path: `${basePath}/health`,
+                name: 'health',
+            },
+            {
+                title: 'Access',
+                path: `${basePath}/access`,
+                name: 'access',
+            },
+            {
+                title: 'Environments',
+                path: `${basePath}/environments`,
+                name: 'environments',
+            },
+            {
+                title: 'Archive',
+                path: `${basePath}/archive`,
+                name: 'archive',
+            },
+            {
+                title: 'Event log',
+                path: `${basePath}/logs`,
+                name: 'logs',
+            },
+        ];
+
+        const changeRequestTab = {
             title: 'Change requests',
             path: `${basePath}/change-requests`,
             name: 'change-request' + '',
-        },
-        {
-            title: 'Event log',
-            path: `${basePath}/logs`,
-            name: 'logs',
-        },
-    ];
+        };
+
+        if (changeRequestsEnabled) {
+            tabArray.splice(tabArray.length - 2, 0, changeRequestTab);
+        }
+        return tabArray;
+    }, [changeRequestsEnabled]);
 
     const activeTab = [...tabs]
         .reverse()


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->
This PR adds a conditional to the Change Request Tab in Project so that it can be hidden when not enterprise

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
