### PR TITLE
Remove uniqueness from change requests merging

### DIFF
--- a/src/migrations/20221103125732-change-request-remove-unique.js
+++ b/src/migrations/20221103125732-change-request-remove-unique.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE change_request_events
+                DROP CONSTRAINT change_request_events_feature_action_change_request_id_key
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE change_request_events
+                ADD CONSTRAINT change_request_events_feature_action_change_request_id_key
+                    UNIQUE (feature, action, change_request_id);
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
The unique constraint was too restrictive and we were not able to add multiple `addStrategy` or `editStrategy` actions.