### PR TITLE
fix: clone environment creating token everytime

### DIFF
--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -177,8 +177,8 @@ export const EnvironmentCloneModal = ({
                 environment.name,
                 getCloneEnvironmentPayload()
             );
-            const response = await createToken(getApiTokenCreatePayload());
             if (apiTokenGeneration === APITokenGeneration.NOW) {
+                const response = await createToken(getApiTokenCreatePayload());
                 const token = await response.json();
                 newToken(token);
             }


### PR DESCRIPTION
Cloning an environment was creating a token every time, even when not choosing the respective option.