### PR TITLE
fix sidebar width

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -10,7 +10,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
+import { DynamicSidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { CheckCircle, HelpOutline } from '@mui/icons-material';
@@ -31,6 +31,7 @@ interface IChangeRequestSidebarProps {
 const StyledPageContent = styled(PageContent)(({ theme }) => ({
     height: '100vh',
     overflow: 'auto',
+    minWidth: '50vw',
     padding: theme.spacing(7.5, 6),
     [theme.breakpoints.down('md')]: {
         padding: theme.spacing(4, 2),
@@ -147,7 +148,11 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
 
     if (!loading && !draft) {
         return (
-            <SidebarModal open={open} onClose={onClose} label="Review changes">
+            <DynamicSidebarModal
+                open={open}
+                onClose={onClose}
+                label="Review changes"
+            >
                 <StyledPageContent
                     header={
                         <PageHeader
@@ -160,12 +165,16 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
                     {/* FIXME: empty state */}
                     <BackButton onClick={onClose}>Close</BackButton>
                 </StyledPageContent>
-            </SidebarModal>
+            </DynamicSidebarModal>
         );
     }
 
     return (
-        <SidebarModal open={open} onClose={onClose} label="Review changes">
+        <DynamicSidebarModal
+            open={open}
+            onClose={onClose}
+            label="Review changes"
+        >
             <StyledPageContent
                 header={
                     <PageHeader
@@ -343,6 +352,6 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
                     </Box>
                 ))}
             </StyledPageContent>
-        </SidebarModal>
+        </DynamicSidebarModal>
     );
 };

--- a/frontend/src/component/common/SidebarModal/SidebarModal.tsx
+++ b/frontend/src/component/common/SidebarModal/SidebarModal.tsx
@@ -1,13 +1,14 @@
-import { ReactNode } from 'react';
+import { ReactNode, FC } from 'react';
 import { Modal, Backdrop, styled } from '@mui/material';
 import Fade from '@mui/material/Fade';
 import { SIDEBAR_MODAL_ID } from 'utils/testIds';
+import * as React from 'react';
 
 interface ISidebarModalProps {
     open: boolean;
     onClose: () => void;
     label: string;
-    children: ReactNode;
+    children: React.ReactElement<any, any>;
 }
 
 const TRANSITION_DURATION = 250;
@@ -19,17 +20,20 @@ const ModalContentWrapper = styled('div')({
     bottom: 0,
     height: '100vh',
     maxWidth: '98vw',
-    width: 1300,
     overflow: 'auto',
     boxShadow: '0 0 1rem rgba(0, 0, 0, 0.25)',
 });
 
-export const SidebarModal = ({
+const FixedWidthContentWrapper = styled(ModalContentWrapper)({
+    width: 1300,
+});
+
+export const BaseModal: FC<ISidebarModalProps> = ({
     open,
     onClose,
     label,
     children,
-}: ISidebarModalProps) => {
+}) => {
     return (
         <Modal
             open={open}
@@ -41,8 +45,26 @@ export const SidebarModal = ({
             data-testid={SIDEBAR_MODAL_ID}
         >
             <Fade timeout={TRANSITION_DURATION} in={open}>
-                <ModalContentWrapper>{children}</ModalContentWrapper>
+                {children}
             </Fade>
         </Modal>
+    );
+};
+
+export const SidebarModal: FC<ISidebarModalProps> = props => {
+    return (
+        <BaseModal {...props}>
+            <FixedWidthContentWrapper>
+                {props.children}
+            </FixedWidthContentWrapper>
+        </BaseModal>
+    );
+};
+
+export const DynamicSidebarModal: FC<ISidebarModalProps> = props => {
+    return (
+        <BaseModal {...props}>
+            <ModalContentWrapper>{props.children}</ModalContentWrapper>
+        </BaseModal>
     );
 };


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
<img width="1074" alt="Screenshot 2022-11-09 at 14 04 36" src="https://user-images.githubusercontent.com/1394682/200837845-e201236d-c2ae-41c4-bb1e-819ddc4c19ab.png">

Sidebar was stretched too wide. Not it's 50% of the screen.


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Existing SidebarModal has a fixed width of 1300. It's not good for reusability. Since I don't want to touch all usages of the existing sidebar I added DynamicSidebarModal that has a width affected by its children. Both modals share most of the code.