### PR TITLE
fix: remove lexical illusion in playground guidance

### DIFF
--- a/frontend/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
@@ -26,7 +26,7 @@ export const PlaygroundGuidance = () => {
 
             <PlaygroundGuidanceSection
                 headerText="Select a context field that you'd like to check"
-                bodyText="You can configure as many context fields context fields as you want. You can also leave the context empty to test against an empty context."
+                bodyText="You can configure as many context fields as you want. You can also leave the context empty to test against an empty context."
                 sectionNumber="2"
             />
 


### PR DESCRIPTION
## What

I have removed a lexical illusion lexical illusion in this guidance step, where "context field" was repeated.

## Why

Because it's unintended and doesn't make any sense in the the sentence.