### PR TITLE
fix: set suggested min value to 0

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.ts
@@ -65,6 +65,8 @@ export const createChartOptions = (
                     display: true,
                     text: 'Number of requests',
                 },
+                // min: 0,
+                suggestedMin: 0,
                 ticks: { precision: 0 },
             },
             x: {

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -33,7 +33,7 @@ export const FeatureMetricsHours = ({
 const parseFeatureMetricsHour = (value: unknown) => {
     switch (value) {
         case '1':
-            return 1;
+            return 2;
         case '24':
             return 24;
         default:


### PR DESCRIPTION
This PR does one thing, it sets the y-axis to start at "0" when showing request counts over time. 

![image](https://user-images.githubusercontent.com/158948/200946347-b3e803c6-6ace-4ecc-b5cf-aa92a5505331.png)

fixes #2107
