### PR TITLE
fix: improve drag behaviour when using handle

### DIFF
--- a/frontend/src/hooks/useDragItem.ts
+++ b/frontend/src/hooks/useDragItem.ts
@@ -74,6 +74,9 @@ const addEventListeners = (
 
     handleEl.addEventListener('mouseenter', onMouseEnter);
     handleEl.addEventListener('mouseleave', onMouseLeave);
+    if (handle) {
+        el.addEventListener('mouseenter', onMouseLeave);
+    }
     el.addEventListener('dragstart', onDragStart);
     el.addEventListener('dragenter', onDragEnter);
     el.addEventListener('dragover', onDragOver);
@@ -82,6 +85,9 @@ const addEventListeners = (
     return () => {
         handleEl.removeEventListener('mouseenter', onMouseEnter);
         handleEl.removeEventListener('mouseleave', onMouseLeave);
+        if (handle) {
+            el.removeEventListener('mouseenter', onMouseLeave);
+        }
         el.removeEventListener('dragstart', onDragStart);
         el.removeEventListener('dragenter', onDragEnter);
         el.removeEventListener('dragover', onDragOver);


### PR DESCRIPTION
Fixes a small bug that caused the item to be draggable when clicking outside of the handle, when using a handle. Basically resets the draggable state when (re)entering the container.