### PR TITLE
feat: upload main branch builds to cdn

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,9 @@ jobs:
           CI: true
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - name: Publish static assets to S3
+        run: |
+          aws s3 cp frontend/build s3://getunleash-static/unleash/main/$(git rev-parse HEAD) --recursive
 
   trigger-ci-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This enables us to run tip of main builds of enterprise pointing to the newest frontend builds.
