### PR TITLE
Permission guards in existing endpoints interacting with feature toggle configuration

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -27,6 +27,7 @@ const T = {
     ROLE_PERMISSION: 'role_permission',
     PERMISSIONS: 'permissions',
     PERMISSION_TYPES: 'permission_types',
+    CHANGE_REQUEST_SETTINGS: 'change_request_settings',
 };
 
 interface IPermissionRow {
@@ -447,5 +448,18 @@ export class AccessStore implements IAccessStore {
                 from ${T.ROLE_PERMISSION} where environment = ?)`,
             [destinationEnvironment, sourceEnvironment],
         );
+    }
+
+    async isChangeRequestsEnabled(
+        project: string,
+        environment: string,
+    ): Promise<boolean> {
+        const result = await this.db.raw(
+            `SELECT EXISTS(SELECT 1 FROM ${T.CHANGE_REQUEST_SETTINGS}
+                       WHERE environment = ? and project = ?) AS present`,
+            [environment, project],
+        );
+        const { present } = result.rows[0];
+        return present;
     }
 }

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -542,4 +542,11 @@ export class AccessService {
         await this.validateRoleIsUnique(role.name, existingId);
         return cleanedRole;
     }
+
+    async isChangeRequestsEnabled(
+        project: string,
+        environment: string,
+    ): Promise<boolean> {
+        return this.store.isChangeRequestsEnabled(project, environment);
+    }
 }

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -519,10 +519,11 @@ class FeatureToggleService {
                 featureName,
                 environment,
             );
+        } else {
+            throw new Error(
+                `Strategies can only deleted updated through change requests for ${environment} environment`,
+            );
         }
-        throw new Error(
-            `Strategies can only deleted updated through change requests for ${environment} environment`,
-        );
     }
 
     async getStrategiesForEnvironment(

--- a/src/lib/types/stores/access-store.ts
+++ b/src/lib/types/stores/access-store.ts
@@ -132,4 +132,9 @@ export interface IAccessStore extends Store<IRole, number> {
         sourceEnvironment: string,
         destinationEnvironment: string,
     ): Promise<void>;
+
+    isChangeRequestsEnabled(
+        project: string,
+        environment: string,
+    ): Promise<boolean>;
 }

--- a/src/test/fixtures/fake-access-store.ts
+++ b/src/test/fixtures/fake-access-store.ts
@@ -11,6 +11,13 @@ import {
 import { IPermission } from 'lib/types/model';
 
 class AccessStoreMock implements IAccessStore {
+    isChangeRequestsEnabled(
+        project: string,
+        environment: string,
+    ): Promise<boolean> {
+        throw new Error('Method not implemented.');
+    }
+
     addAccessToProject(
         users: IAccessInfo[],
         groups: IAccessInfo[],


### PR DESCRIPTION
This PR adds permission guards for operations.

1. Toggling feature flag
2. Adding a strategy
3. Updating a strategy
4. Deleting a strategy