### PR TITLE
feat: update strategy segments with edit / create strategy

### DIFF
--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -48,7 +48,7 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
     className,
 }) => {
     const { classes: styles } = useStyles();
-    const Icon = getFeatureStrategyIcon(strategy.name);
+    const Icon = getFeatureStrategyIcon(strategy.name || '');
 
     return (
         <Box sx={{ position: 'relative' }}>
@@ -85,7 +85,7 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
                     <StringTruncator
                         maxWidth="150"
                         maxLength={15}
-                        text={formatStrategyName(strategy.name)}
+                        text={formatStrategyName(strategy.name || '')}
                     />
                     <div className={styles.actions}>{actions}</div>
                 </div>

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -2,7 +2,7 @@ import { DragEventHandler, FC, ReactNode } from 'react';
 import { DragIndicator } from '@mui/icons-material';
 import { styled, IconButton, Box } from '@mui/material';
 import classNames from 'classnames';
-import { IFeatureStrategy } from 'interfaces/strategy';
+import { IFeatureStrategy, IFeatureStrategyPayload } from 'interfaces/strategy';
 import {
     getFeatureStrategyIcon,
     formatStrategyName,
@@ -12,7 +12,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { useStyles } from './StrategyItemContainer.styles';
 
 interface IStrategyItemContainerProps {
-    strategy: IFeatureStrategy;
+    strategy: IFeatureStrategyPayload;
     onDragStart?: DragEventHandler<HTMLButtonElement>;
     onDragEnd?: DragEventHandler<HTMLButtonElement>;
     actions?: ReactNode;

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -2,7 +2,7 @@ import { DragEventHandler, FC, ReactNode } from 'react';
 import { DragIndicator } from '@mui/icons-material';
 import { styled, IconButton, Box } from '@mui/material';
 import classNames from 'classnames';
-import { IFeatureStrategy, IFeatureStrategyPayload } from 'interfaces/strategy';
+import { IFeatureStrategyPayload } from 'interfaces/strategy';
 import {
     getFeatureStrategyIcon,
     formatStrategyName,
@@ -12,7 +12,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { useStyles } from './StrategyItemContainer.styles';
 
 interface IStrategyItemContainerProps {
-    strategy: IFeatureStrategyPayload;
+    strategy: IFeatureStrategy;
     onDragStart?: DragEventHandler<HTMLButtonElement>;
     onDragEnd?: DragEventHandler<HTMLButtonElement>;
     actions?: ReactNode;
@@ -48,7 +48,7 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
     className,
 }) => {
     const { classes: styles } = useStyles();
-    const Icon = getFeatureStrategyIcon(strategy.name || '');
+    const Icon = getFeatureStrategyIcon(strategy.name);
 
     return (
         <Box sx={{ position: 'relative' }}>
@@ -85,7 +85,7 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
                     <StringTruncator
                         maxWidth="150"
                         maxLength={15}
-                        text={formatStrategyName(strategy.name || '')}
+                        text={formatStrategyName(strategy.name)}
                     />
                     <div className={styles.actions}>{actions}</div>
                 </div>

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -10,9 +10,10 @@ import {
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useStyles } from './StrategyItemContainer.styles';
+import { PlaygroundStrategySchema } from 'component/playground/Playground/interfaces/playground.model';
 
 interface IStrategyItemContainerProps {
-    strategy: IFeatureStrategy;
+    strategy: IFeatureStrategy | PlaygroundStrategySchema;
     onDragStart?: DragEventHandler<HTMLButtonElement>;
     onDragEnd?: DragEventHandler<HTMLButtonElement>;
     actions?: ReactNode;

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -2,7 +2,7 @@ import { DragEventHandler, FC, ReactNode } from 'react';
 import { DragIndicator } from '@mui/icons-material';
 import { styled, IconButton, Box } from '@mui/material';
 import classNames from 'classnames';
-import { IFeatureStrategyPayload } from 'interfaces/strategy';
+import { IFeatureStrategy } from 'interfaces/strategy';
 import {
     getFeatureStrategyIcon,
     formatStrategyName,

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -90,14 +90,7 @@ export const FeatureStrategyCreate = () => {
             environmentId,
             payload
         );
-        // if (uiConfig.flags.SE) {
-        //     await setStrategySegments({
-        //         environmentId,
-        //         projectId,
-        //         strategyId: created.id,
-        //         segmentIds: segments.map(s => s.id),
-        //     });
-        // }
+
         setToastData({
             title: 'Strategy created',
             type: 'success',

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -90,14 +90,14 @@ export const FeatureStrategyCreate = () => {
             environmentId,
             payload
         );
-        if (uiConfig.flags.SE) {
-            await setStrategySegments({
-                environmentId,
-                projectId,
-                strategyId: created.id,
-                segmentIds: segments.map(s => s.id),
-            });
-        }
+        // if (uiConfig.flags.SE) {
+        //     await setStrategySegments({
+        //         environmentId,
+        //         projectId,
+        //         strategyId: created.id,
+        //         segmentIds: segments.map(s => s.id),
+        //     });
+        // }
         setToastData({
             title: 'Strategy created',
             type: 'success',
@@ -121,7 +121,7 @@ export const FeatureStrategyCreate = () => {
     };
 
     const onSubmit = async () => {
-        const payload = createStrategyPayload(strategy);
+        const payload = createStrategyPayload(strategy, segments);
 
         try {
             if (isChangeRequestConfigured(environmentId)) {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -133,7 +133,8 @@ export const FeatureStrategyEdit = () => {
     };
 
     const onSubmit = async () => {
-        const payload = createStrategyPayload(strategy);
+        const segmentsToSubmit = uiConfig?.flags.SE ? segments : [];
+        const payload = createStrategyPayload(strategy, segmentsToSubmit);
 
         try {
             if (isChangeRequestConfigured(environmentId)) {
@@ -191,11 +192,13 @@ export const FeatureStrategyEdit = () => {
 };
 
 export const createStrategyPayload = (
-    strategy: Partial<IFeatureStrategy>
+    strategy: Partial<IFeatureStrategy>,
+    segments: ISegment[]
 ): IFeatureStrategyPayload => ({
     name: strategy.name,
     constraints: strategy.constraints ?? [],
     parameters: strategy.parameters ?? {},
+    segments: segments.map(segment => segment.id),
 });
 
 export const formatFeaturePath = (

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -101,15 +101,8 @@ export const FeatureStrategyEdit = () => {
             strategyId,
             payload
         );
-        if (uiConfig.flags.SE) {
-            await setStrategySegments({
-                environmentId,
-                projectId,
-                strategyId,
-                segmentIds: segments.map(s => s.id),
-            });
-            await refetchSavedStrategySegments();
-        }
+
+        await refetchSavedStrategySegments();
         setToastData({
             title: 'Strategy updated',
             type: 'success',

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
@@ -86,7 +86,6 @@ export const FeatureStrategyEmpty = ({
                     const { id, ...strategyCopy } = {
                         ...strategy,
                         environment: environmentId,
-                        copyOf: strategy.id,
                     };
 
                     return addStrategyToFeature(

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -127,8 +127,6 @@ const EnvironmentAccordionBody = ({
         );
     };
 
-    console.log(strategies);
-
     return (
         <div className={styles.accordionBody}>
             <div className={styles.accordionBodyInnerContainer}>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -127,6 +127,8 @@ const EnvironmentAccordionBody = ({
         );
     };
 
+    console.log(strategies);
+
     return (
         <div className={styles.accordionBody}>
             <div className={styles.accordionBodyInnerContainer}>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -64,7 +64,6 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         const { id, ...strategyCopy } = {
             ...strategy,
             environment,
-            copyOf: strategy.id,
         };
         if (isChangeRequestConfigured(environmentId)) {
             await onChangeRequestAddStrategy(

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -8,7 +8,7 @@ import {
     Tooltip,
 } from '@mui/material';
 import { AddToPhotos as CopyIcon, Lock } from '@mui/icons-material';
-import { IFeatureStrategy } from 'interfaces/strategy';
+import { IFeatureStrategy, IFeatureStrategyPayload } from 'interfaces/strategy';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { IFeatureEnvironment } from 'interfaces/featureToggle';
 import AccessContext from 'contexts/AccessContext';
@@ -27,7 +27,7 @@ import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 interface ICopyStrategyIconMenuProps {
     environmentId: string;
     environments: IFeatureEnvironment['name'][];
-    strategy: IFeatureStrategy;
+    strategy: IFeatureStrategyPayload;
 }
 
 export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
@@ -60,14 +60,14 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         onChangeRequestAddStrategyConfirm,
     } = useChangeRequestAddStrategy(projectId, featureId, 'addStrategy');
 
-    const onCopyStrategy = async (environment: string) => {
+    const onCopyStrategy = async (targetEnvironment: string) => {
         const { id, ...strategyCopy } = {
             ...strategy,
-            environment,
+            targetEnvironment,
         };
-        if (isChangeRequestConfigured(environmentId)) {
+        if (isChangeRequestConfigured(targetEnvironment)) {
             await onChangeRequestAddStrategy(
-                environment,
+                targetEnvironment,
                 {
                     id,
                     ...strategyCopy,
@@ -81,14 +81,14 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
             await addStrategyToFeature(
                 projectId,
                 featureId,
-                environment,
+                targetEnvironment,
                 strategy
             );
             refetchFeature();
             refetchFeatureImmutable();
             setToastData({
                 title: `Strategy created`,
-                text: `Successfully copied a strategy to ${environment}`,
+                text: `Successfully copied a strategy to ${targetEnvironment}`,
                 type: 'success',
             });
         } catch (error) {

--- a/frontend/src/component/playground/Playground/PlaygroundResultsTable/FeatureResultInfoPopoverCell/FeatureStrategyList/StrategyList/StrategyItem/FeatureStrategyItem.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundResultsTable/FeatureResultInfoPopoverCell/FeatureStrategyList/StrategyList/StrategyItem/FeatureStrategyItem.tsx
@@ -8,6 +8,7 @@ import { StrategyExecution } from './StrategyExecution/StrategyExecution';
 import { useStyles } from './FeatureStrategyItem.styles';
 import { StrategyItemContainer } from 'component/common/StrategyItemContainer/StrategyItemContainer';
 import { objectId } from 'utils/objectId';
+import { IFeatureStrategy } from 'interfaces/strategy';
 
 interface IFeatureStrategyItemProps {
     strategy: PlaygroundStrategySchema;

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -9,7 +9,7 @@ export interface IFeatureStrategy {
     featureName?: string;
     projectId?: string;
     environment?: string;
-    segments: number[];
+    segments?: number[];
 }
 
 export interface IFeatureStrategyParameters {

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -21,7 +21,7 @@ export interface IFeatureStrategyPayload {
     name?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
-    segments?: [];
+    segments?: number[];
 }
 
 export interface IStrategy {

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -21,7 +21,7 @@ export interface IFeatureStrategyPayload {
     name?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
-    segments: [];
+    segments?: [];
 }
 
 export interface IStrategy {

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -20,7 +20,6 @@ export interface IFeatureStrategyPayload {
     name?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
-    copyOf?: string;
 }
 
 export interface IStrategy {

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -9,6 +9,7 @@ export interface IFeatureStrategy {
     featureName?: string;
     projectId?: string;
     environment?: string;
+    segments: number[];
 }
 
 export interface IFeatureStrategyParameters {
@@ -20,6 +21,7 @@ export interface IFeatureStrategyPayload {
     name?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
+    segments: [];
 }
 
 export interface IStrategy {

--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -298,9 +298,14 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     env.strategies = [];
                 }
                 if (r.strategy_id) {
-                    env.strategies.push(
-                        FeatureStrategiesStore.getAdminStrategy(r),
+                    const found = env.strategies.find(
+                        (strategy) => strategy.id === r.strategy_id,
                     );
+                    if (!found) {
+                        env.strategies.push(
+                            FeatureStrategiesStore.getAdminStrategy(r),
+                        );
+                    }
                 }
                 if (r.segments) {
                     this.addSegmentIdsToStrategy(env, r);

--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -11,11 +11,12 @@ import {
     IEnvironmentOverview,
     IFeatureOverview,
     IFeatureStrategy,
+    IFeatureToggleClient,
     IStrategyConfig,
     ITag,
 } from '../types/model';
 import { IFeatureStrategiesStore } from '../types/stores/feature-strategies-store';
-import { PartialSome } from '../types/partial';
+import { PartialDeep, PartialSome } from '../types/partial';
 import FeatureToggleStore from './feature-toggle-store';
 import { ensureStringValue } from '../util/ensureStringValue';
 import { mapValues } from '../util/map-values';
@@ -237,6 +238,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 'feature_strategies.parameters as parameters',
                 'feature_strategies.constraints as constraints',
                 'feature_strategies.sort_order as sort_order',
+                'fss.segment_id as segments',
             )
             .leftJoin(
                 'feature_environments',
@@ -259,6 +261,11 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 'feature_environments.environment',
                 'environments.name',
             )
+            .leftJoin(
+                'feature_strategy_segment as fss',
+                `fss.feature_strategy_id`,
+                `feature_strategies.id`,
+            )
             .where('features.name', featureName)
             .modify(FeatureToggleStore.filterByArchived, archived);
         stopTimer();
@@ -267,6 +274,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 if (acc.environments === undefined) {
                     acc.environments = {};
                 }
+
                 acc.name = r.name;
                 acc.impressionData = r.impression_data;
                 acc.description = r.description;
@@ -281,6 +289,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                         name: r.environment,
                     };
                 }
+
                 const env = acc.environments[r.environment];
                 env.enabled = r.enabled;
                 env.type = r.environment_type;
@@ -292,6 +301,9 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     env.strategies.push(
                         FeatureStrategiesStore.getAdminStrategy(r),
                     );
+                }
+                if (r.segments) {
+                    this.addSegmentIdsToStrategy(env, r);
                 }
                 acc.environments[r.environment] = env;
                 return acc;
@@ -316,6 +328,22 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         throw new NotFoundError(
             `Could not find feature toggle with name ${featureName}`,
         );
+    }
+
+    private addSegmentIdsToStrategy(
+        feature: PartialDeep<IFeatureToggleClient>,
+        row: Record<string, any>,
+    ) {
+        const strategy = feature.strategies.find(
+            (s) => s.id === row.strategy_id,
+        );
+        if (!strategy) {
+            return;
+        }
+        if (!strategy.segments) {
+            strategy.segments = [];
+        }
+        strategy.segments.push(row.segments);
     }
 
     private static getEnvironment(r: any): IEnvironmentOverview {

--- a/src/lib/openapi/spec/create-feature-strategy-schema.ts
+++ b/src/lib/openapi/spec/create-feature-strategy-schema.ts
@@ -19,9 +19,6 @@ export const createFeatureStrategySchema = {
                 $ref: '#/components/schemas/constraintSchema',
             },
         },
-        copyOf: {
-            type: 'string',
-        },
         parameters: {
             $ref: '#/components/schemas/parametersSchema',
         },

--- a/src/lib/routes/admin-api/project/features.ts
+++ b/src/lib/routes/admin-api/project/features.ts
@@ -598,7 +598,11 @@ export default class ProjectFeaturesController extends Controller {
         res: Response<FeatureStrategySchema>,
     ): Promise<void> {
         const { projectId, featureName, environment } = req.params;
-        const { copyOf, ...strategyConfig } = req.body;
+        const { ...strategyConfig } = req.body;
+
+        if (!strategyConfig.segmentIds) {
+            strategyConfig.segmentIds = [];
+        }
 
         const userName = extractUsername(req);
         const strategy = await this.featureService.createStrategy(
@@ -606,16 +610,6 @@ export default class ProjectFeaturesController extends Controller {
             { environment, projectId, featureName },
             userName,
         );
-
-        if (copyOf) {
-            this.logger.info(
-                `Cloning segments from: strategyId=${copyOf} to: strategyId=${strategy.id} `,
-            );
-            await this.segmentService.cloneStrategySegments(
-                copyOf,
-                strategy.id,
-            );
-        }
 
         const updatedStrategy = await this.featureService.getStrategy(
             strategy.id,
@@ -661,6 +655,11 @@ export default class ProjectFeaturesController extends Controller {
     ): Promise<void> {
         const { strategyId, environment, projectId, featureName } = req.params;
         const userName = extractUsername(req);
+
+        if (!req.body.segmentIds) {
+            req.body.segmentIds = [];
+        }
+
         const updatedStrategy = await this.featureService.updateStrategy(
             strategyId,
             req.body,

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -332,6 +332,11 @@ class FeatureToggleService {
                     environment,
                 });
 
+            await this.segmentService.updateStrategySegments(
+                newFeatureStrategy.id,
+                strategyConfig.segments,
+            );
+
             const tags = await this.tagStore.getAllTagsForFeature(featureName);
             const segments = await this.segmentService.getByStrategy(
                 newFeatureStrategy.id,
@@ -392,6 +397,11 @@ class FeatureToggleService {
             const strategy = await this.featureStrategiesStore.updateStrategy(
                 id,
                 updates,
+            );
+
+            await this.segmentService.updateStrategySegments(
+                strategy.id,
+                updates.segments || [],
             );
 
             const segments = await this.segmentService.getByStrategy(

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -332,10 +332,15 @@ class FeatureToggleService {
                     environment,
                 });
 
-            await this.segmentService.updateStrategySegments(
-                newFeatureStrategy.id,
-                strategyConfig.segments,
-            );
+            if (
+                strategyConfig.segments &&
+                Array.isArray(strategyConfig.segments)
+            ) {
+                await this.segmentService.updateStrategySegments(
+                    newFeatureStrategy.id,
+                    strategyConfig.segments,
+                );
+            }
 
             const tags = await this.tagStore.getAllTagsForFeature(featureName);
             const segments = await this.segmentService.getByStrategy(
@@ -399,10 +404,12 @@ class FeatureToggleService {
                 updates,
             );
 
-            await this.segmentService.updateStrategySegments(
-                strategy.id,
-                updates.segments || [],
-            );
+            if (updates.segments && Array.isArray(updates.segments)) {
+                await this.segmentService.updateStrategySegments(
+                    strategy.id,
+                    updates.segments,
+                );
+            }
 
             const segments = await this.segmentService.getByStrategy(
                 strategy.id,

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -36,6 +36,7 @@ export interface IFeatureStrategy {
     sortOrder?: number;
     constraints: IConstraint[];
     createdAt?: Date;
+    segments?: number[];
 }
 
 export interface FeatureToggleDTO {

--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -2661,6 +2661,7 @@ test.only('should create a strategy with segments', async () => {
         parameters: {
             userId: 'string',
         },
+        segments: [],
     });
 
     await app.request

--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -13,7 +13,12 @@ import {
 import ApiUser from '../../../../../lib/types/api-user';
 import { ApiTokenType } from '../../../../../lib/types/models/api-token';
 import IncompatibleProjectError from '../../../../../lib/error/incompatible-project-error';
-import { IVariant, RoleName, WeightType } from '../../../../../lib/types/model';
+import {
+    IStrategyConfig,
+    IVariant,
+    RoleName,
+    WeightType,
+} from '../../../../../lib/types/model';
 import { v4 as uuidv4 } from 'uuid';
 import supertest from 'supertest';
 import { randomId } from '../../../../../lib/util/random-id';
@@ -23,6 +28,60 @@ let db: ITestDb;
 const sortOrderFirst = 0;
 const sortOrderSecond = 10;
 const sortOrderDefault = 9999;
+
+const createFeatureToggle = (featureName: string, project = 'default') => {
+    return app.request.post(`/api/admin/projects/${project}/features`).send({
+        name: featureName,
+    });
+};
+
+const createSegment = async (segmentName: string) => {
+    const segment = await app.services.segmentService.create(
+        {
+            name: segmentName,
+            description: '',
+            constraints: [
+                {
+                    contextName: 'appName',
+                    operator: 'IN',
+                    values: ['test'],
+                    caseInsensitive: false,
+                    inverted: false,
+                },
+            ],
+        },
+        { username: 'testuser', email: 'test@test.com' },
+    );
+
+    return segment;
+};
+
+const createStrategy = async (
+    featureName: string,
+    payload: IStrategyConfig,
+) => {
+    return app.request
+        .post(
+            `/api/admin/projects/default/features/${featureName}/environments/default/strategies`,
+        )
+        .send(payload)
+        .expect(200);
+};
+
+const updateStrategy = async (
+    featureName: string,
+    strategyId: string,
+    payload: IStrategyConfig,
+) => {
+    const { body } = await app.request
+        .put(
+            `/api/admin/projects/default/features/${featureName}/environments/default/strategies/${strategyId}`,
+        )
+        .send(payload)
+        .expect(200);
+
+    return body;
+};
 
 beforeAll(async () => {
     db = await dbInit('feature_strategy_api_serial', getLogger);
@@ -2569,4 +2628,84 @@ test('should return strategies in correct order when new strategies are added', 
     expect(strategiesReOrdered[2].id).toBe(strategyOne.id);
     expect(strategiesReOrdered[3].sortOrder).toBe(9999);
     expect(strategiesReOrdered[3].id).toBe(strategyThree.id);
+});
+
+test.only('should create a strategy with segments', async () => {
+    const feature = { name: uuidv4(), impressionData: false };
+    await createFeatureToggle(feature.name);
+    const segment = await createSegment('segmentOne');
+    const { body: strategyOne } = await createStrategy(feature.name, {
+        name: 'default',
+        parameters: {
+            userId: 'string',
+        },
+        segments: [segment.id],
+    });
+
+    // Can get the strategy with segment ids
+    await app.request
+        .get(`/api/admin/projects/default/features/${feature.name}`)
+        .expect((res) => {
+            const defaultEnv = res.body.environments.find(
+                (env) => env.name === 'default',
+            );
+            const strategy = defaultEnv.strategies.find(
+                (strat) => strat.id === strategyOne.id,
+            );
+
+            expect(strategy.segments).toEqual([segment.id]);
+        });
+
+    await updateStrategy(feature.name, strategyOne.id, {
+        name: 'default',
+        parameters: {
+            userId: 'string',
+        },
+    });
+
+    await app.request
+        .get(`/api/admin/projects/default/features/${feature.name}`)
+        .expect((res) => {
+            const defaultEnv = res.body.environments.find(
+                (env) => env.name === 'default',
+            );
+            const strategy = defaultEnv.strategies.find(
+                (strat) => strat.id === strategyOne.id,
+            );
+
+            expect(strategy.segments).toBe(undefined);
+        });
+});
+
+test.only('should add multiple segments to a strategy', async () => {
+    const feature = { name: uuidv4(), impressionData: false };
+    await createFeatureToggle(feature.name);
+    const segment = await createSegment('seg1');
+    const segmentTwo = await createSegment('seg2');
+    const segmentThree = await createSegment('seg3');
+    const { body: strategyOne } = await createStrategy(feature.name, {
+        name: 'default',
+        parameters: {
+            userId: 'string',
+        },
+        segments: [segment.id, segmentTwo.id, segmentThree.id],
+    });
+
+    // Can get the strategy with segment ids
+    await app.request
+        .get(`/api/admin/projects/default/features/${feature.name}`)
+        .expect((res) => {
+            const defaultEnv = res.body.environments.find(
+                (env) => env.name === 'default',
+            );
+            const strategy = defaultEnv.strategies.find(
+                (strat) => strat.id === strategyOne.id,
+            );
+
+            expect(strategy.segments).toEqual([
+                segment.id,
+                segmentTwo.id,
+                segmentThree.id,
+            ]);
+        });
 });

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -709,9 +709,6 @@ exports[`should serve the OpenAPI spec 1`] = `
             },
             "type": "array",
           },
-          "copyOf": {
-            "type": "string",
-          },
           "name": {
             "type": "string",
           },


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

* This PR refactors segments to be directly added when creating or editing a strategy. Instead of making a separate call to the segments API, we directly accept a list of segment ids and apply them when we receive the edit / create call on the strategy. 

Discussion points: 
* To not break existing API, the segmentIds are optional. In the controller we default the segmentIds if they don't exist.
* There is some uglyness in this code, fixing it will be more invasive than I'd like in this PR. But something to look into for the future.
<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
