### PR TITLE
Add passport-azure-ad

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -17,6 +17,7 @@
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "basic-auth": "^2.0.1",
     "passport": "^0.6.0",
+    "passport-azure-ad": "^4.3.3",
     "unleash-server": "file:../build"
   },
   "resolutions": {


### PR DESCRIPTION
## About the changes
Add passport-azure-ad to package.json used in docker build to make example https://github.com/Unleash/unleash-examples/tree/main/v4/securing-azure-auth work in Helm chart

<!-- Does it close an issue? Multiple? -->
Closes #2436 

