### PR TITLE
Check assumption·

### DIFF
--- a/src/test/e2e/api/admin/state.e2e.test.ts
+++ b/src/test/e2e/api/admin/state.e2e.test.ts
@@ -463,4 +463,5 @@ test(`should not show environment on feature toggle, when environment is disable
 
     expect(body.environments).toHaveLength(1);
     expect(body.environments[0].name).toBe('state-visible-environment');
+    expect(body.environments[0].isEnabled).toBeTruthy();
 });


### PR DESCRIPTION
## About the changes
After importing we should have an enabled feature in the environment, but it seems we're not:
```
[
   {
      "enabled":false,
      "name":"state-visible-environment",
      "sortOrder":9999,
      "strategies":[
         {
            "constraints":[
               
            ],
            "id":"2ea91298-4565-4db2-8a23-50757001a076",
            "name":"gradualRolloutRandom",
            "parameters":{
               "percentage":"100"
            },
            "sortOrder":9999
         }
      ],
      "type":"production"
   }
]
```

Adding an extra check to validate that shows that the feature is not enabled in the environment.