### PR TITLE
fix: make the tags column have a fixed width

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -65,6 +65,7 @@ const columns = [
             row.tags?.map(({ type, value }) => `${type}:${value}`).join('\n') ||
             '',
         Cell: FeatureTagCell,
+        width: 80,
         searchable: true,
     },
     {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -202,6 +202,7 @@ export const ProjectFeatureToggles = ({
                         ?.map(({ type, value }) => `${type}:${value}`)
                         .join('\n') || '',
                 Cell: FeatureTagCell,
+                width: 80,
                 hideInMenu: true,
                 searchable: true,
             },


### PR DESCRIPTION
By setting a fixed width in the tags column we can save some extra space.