### PR TITLE
fix: tags highlight case sensitivity

### DIFF
--- a/frontend/src/component/common/Table/cells/FeatureTagCell/FeatureTagCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureTagCell/FeatureTagCell.tsx
@@ -47,7 +47,8 @@ export const FeatureTagCell: VFC<IFeatureTagCellProps> = ({ row, value }) => {
                 <StyledLink
                     underline="always"
                     highlighted={
-                        searchQuery.length > 0 && value.includes(searchQuery)
+                        searchQuery.length > 0 &&
+                        value.toLowerCase().includes(searchQuery.toLowerCase())
                     }
                 >
                     {row.original.tags?.length === 1


### PR DESCRIPTION
Search is already case insensitive, so it makes sense that the highlight style is as well.