### PR TITLE
fix: flaky test on number of projects statistic

### DIFF
--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -32,7 +32,7 @@ test('should return instance statistics', async () => {
 });
 
 test('should return instance statistics with correct number of projects', async () => {
-    stores.projectStore.create({
+    await stores.projectStore.create({
         id: 'test',
         name: 'Test',
         description: 'lorem',


### PR DESCRIPTION
This test fails from time to time due to a race condition between the http statement and the creation of the new project.
Adding an await statement should fix this.