### PR TITLE
fix: flaky tests on segments order

### DIFF
--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -2703,7 +2703,7 @@ test.only('should add multiple segments to a strategy', async () => {
                 (strat) => strat.id === strategyOne.id,
             );
 
-            expect(strategy.segments).toEqual([
+            expect(strategy.segments.sort()).toEqual([
                 segment.id,
                 segmentTwo.id,
                 segmentThree.id,


### PR DESCRIPTION
## About the changes
This test fails randomly, example: https://github.com/Unleash/unleash/actions/runs/3496006349/jobs/5853415518#step:5:376 

It's not so frequent but I tested locally one out of 4 or 8 runs fails because the rows returned are in the wrong order.

## Discussion points
If the order of segments is relevant, we should look into how we're fetching them or applying a `sort()` before returning from the query. I've validated on my machine that even if the segments are sent in order, when pulled from the db sometimes they are processed in a different order
