### PR TITLE
disable approvers select when no access

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
@@ -25,10 +25,10 @@ import { UPDATE_PROJECT } from '@server/types/permissions';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { ChangeRequestProcessHelp } from './ChangeRequestProcessHelp/ChangeRequestProcessHelp';
-import GeneralSelect from '../../../../common/GeneralSelect/GeneralSelect';
+import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
 import { KeyboardArrowDownOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
-import AccessContext from '../../../../../contexts/AccessContext';
+import AccessContext from 'contexts/AccessContext';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(1),
@@ -57,7 +57,6 @@ export const ChangeRequestConfiguration: VFC = () => {
         useChangeRequestConfig(projectId);
     const { updateChangeRequestEnvironmentConfig } = useChangeRequestApi();
     const { setToastData, setToastApiError } = useToast();
-    const { hasAccess } = useContext(AccessContext);
 
     const onRowChange =
         (
@@ -143,28 +142,34 @@ export const ChangeRequestConfiguration: VFC = () => {
             {
                 Header: 'Required approvals',
                 align: 'center',
-                Cell: ({ row: { original } }: any) => (
-                    <ConditionallyRender
-                        condition={original.changeRequestEnabled}
-                        show={
-                            <StyledBox data-loading>
-                                <GeneralSelect
-                                    options={approvalOptions}
-                                    value={original.requiredApprovals || 1}
-                                    onChange={approvals => {
-                                        onRequiredApprovalsChange(
-                                            original,
-                                            approvals
-                                        );
-                                    }}
-                                    disabled={!hasAccess(UPDATE_PROJECT)}
-                                    IconComponent={KeyboardArrowDownOutlined}
-                                    fullWidth
-                                />
-                            </StyledBox>
-                        }
-                    />
-                ),
+                Cell: ({ row: { original } }: any) => {
+                    const { hasAccess } = useContext(AccessContext);
+
+                    return (
+                        <ConditionallyRender
+                            condition={original.changeRequestEnabled}
+                            show={
+                                <StyledBox data-loading>
+                                    <GeneralSelect
+                                        options={approvalOptions}
+                                        value={original.requiredApprovals || 1}
+                                        onChange={approvals => {
+                                            onRequiredApprovalsChange(
+                                                original,
+                                                approvals
+                                            );
+                                        }}
+                                        disabled={!hasAccess(UPDATE_PROJECT)}
+                                        IconComponent={
+                                            KeyboardArrowDownOutlined
+                                        }
+                                        fullWidth
+                                    />
+                                </StyledBox>
+                            }
+                        />
+                    );
+                },
                 width: 100,
                 disableGlobalFilter: true,
                 disableSortBy: true,

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, VFC } from 'react';
+import React, { useContext, useMemo, useState, VFC } from 'react';
 import { HeaderGroup, useGlobalFilter, useTable } from 'react-table';
 import { Alert, Box, styled, Typography } from '@mui/material';
 import {
@@ -28,6 +28,7 @@ import { ChangeRequestProcessHelp } from './ChangeRequestProcessHelp/ChangeReque
 import GeneralSelect from '../../../../common/GeneralSelect/GeneralSelect';
 import { KeyboardArrowDownOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
+import AccessContext from '../../../../../contexts/AccessContext';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(1),
@@ -56,6 +57,7 @@ export const ChangeRequestConfiguration: VFC = () => {
         useChangeRequestConfig(projectId);
     const { updateChangeRequestEnvironmentConfig } = useChangeRequestApi();
     const { setToastData, setToastApiError } = useToast();
+    const { hasAccess } = useContext(AccessContext);
 
     const onRowChange =
         (
@@ -155,6 +157,7 @@ export const ChangeRequestConfiguration: VFC = () => {
                                             approvals
                                         );
                                     }}
+                                    disabled={!hasAccess(UPDATE_PROJECT)}
                                     IconComponent={KeyboardArrowDownOutlined}
                                     fullWidth
                                 />


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Users w/o project update permission should not change number of approvers.
<img width="1041" alt="Screenshot 2022-11-21 at 13 32 15" src="https://user-images.githubusercontent.com/1394682/203056135-98108113-14c6-41ad-b58b-3e7ce7cc4c28.png">



<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
It was a tricky one. When I put the access context at the root level after page refresh it was broken.
The context has to be inside the cell component.