### PR TITLE
fix: Updated event to include project

### DIFF
--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -221,9 +221,10 @@ export default class VariantsController extends Controller {
         req: IAuthRequest<FeatureEnvironmentParams, any, IVariant[], any>,
         res: Response<FeatureVariantsSchema>,
     ): Promise<void> {
-        const { featureName, environment } = req.params;
+        const { featureName, environment, projectId } = req.params;
         const userName = extractUsername(req);
         const variants = await this.featureService.saveVariantsOnEnv(
+            projectId,
             featureName,
             environment,
             req.body,

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1245,6 +1245,7 @@ class FeatureToggleService {
         );
         const { newDocument } = await applyPatch(oldVariants, newVariants);
         return this.saveVariantsOnEnv(
+            project,
             featureName,
             environment,
             newDocument,
@@ -1283,6 +1284,7 @@ class FeatureToggleService {
     }
 
     async saveVariantsOnEnv(
+        projectId: string,
         featureName: string,
         environment: string,
         newVariants: IVariant[],
@@ -1301,6 +1303,7 @@ class FeatureToggleService {
             new EnvironmentVariantEvent({
                 featureName,
                 environment,
+                project: projectId,
                 createdBy,
                 oldVariants,
                 newVariants: fixedVariants,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -195,6 +195,8 @@ export class FeatureVariantEvent extends BaseEvent {
 }
 
 export class EnvironmentVariantEvent extends BaseEvent {
+    readonly project: string;
+
     readonly environment: string;
 
     readonly featureName: string;
@@ -206,6 +208,7 @@ export class EnvironmentVariantEvent extends BaseEvent {
     constructor(p: {
         featureName: string;
         environment: string;
+        project: string;
         createdBy: string;
         newVariants: IVariant[];
         oldVariants: IVariant[];
@@ -213,6 +216,7 @@ export class EnvironmentVariantEvent extends BaseEvent {
         super(FEATURE_ENVIRONMENT_VARIANTS_UPDATED, p.createdBy);
         this.featureName = p.featureName;
         this.environment = p.environment;
+        this.project = p.project;
         this.data = { variants: p.newVariants };
         this.preData = { variants: p.oldVariants };
     }


### PR DESCRIPTION
### What
Our EnvironmentVariant needs project name so this PR makes sure our service accepts the project id as one of the arguments.