### PR TITLE
Add possibility to soft delete users

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -28,6 +28,8 @@ const T = {
     PERMISSIONS: 'permissions',
     PERMISSION_TYPES: 'permission_types',
     CHANGE_REQUEST_SETTINGS: 'change_request_settings',
+    PERSONAL_ACCESS_TOKENS: 'personal_access_tokens',
+    PUBLIC_SIGNUP_TOKENS_USER: 'public_signup_tokens_user',
 };
 
 interface IPermissionRow {
@@ -209,6 +211,30 @@ export class AccessStore implements IAccessStore {
 
     async unlinkUserRoles(userId: number): Promise<void> {
         return this.db(T.ROLE_USER)
+            .where({
+                user_id: userId,
+            })
+            .delete();
+    }
+
+    async unlinkUserGroups(userId: number): Promise<void> {
+        return this.db(T.GROUP_USER)
+            .where({
+                user_id: userId,
+            })
+            .delete();
+    }
+
+    async clearUserPersonalAccessTokens(userId: number): Promise<void> {
+        return this.db(T.PERSONAL_ACCESS_TOKENS)
+            .where({
+                user_id: userId,
+            })
+            .delete();
+    }
+
+    async clearPublicSignupUserTokens(userId: number): Promise<void> {
+        return this.db(T.PUBLIC_SIGNUP_TOKENS_USER)
             .where({
                 user_id: userId,
             })

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -85,7 +85,7 @@ class UserStore implements IUserStore {
 
     async insert(user: ICreateUser): Promise<User> {
         const rows = await this.db(TABLE)
-            .insert({ ...mapUserToColumns(user), deleted_at: null })
+            .insert(mapUserToColumns(user))
             .returning(USER_COLUMNS);
         return rowToUser(rows[0]);
     }
@@ -203,7 +203,7 @@ class UserStore implements IUserStore {
 
     async exists(id: number): Promise<boolean> {
         const result = await this.db.raw(
-            `SELECT EXISTS (SELECT 1 FROM ${TABLE} WHERE id = ? and is_deleted = false) AS present`,
+            `SELECT EXISTS (SELECT 1 FROM ${TABLE} WHERE id = ? and deleted_at = null) AS present`,
             [id],
         );
         const { present } = result.rows[0];

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -77,13 +77,15 @@ class UserStore implements IUserStore {
     }
 
     async update(id: number, fields: IUserUpdateFields): Promise<User> {
-        await this.db(TABLE).where('id', id).update(mapUserToColumns(fields));
+        await this.buildBaseQuery()
+            .where('id', id)
+            .update(mapUserToColumns(fields));
         return this.get(id);
     }
 
     async insert(user: ICreateUser): Promise<User> {
         const rows = await this.db(TABLE)
-            .insert(mapUserToColumns(user))
+            .insert({ ...mapUserToColumns(user), is_deleted: false })
             .returning(USER_COLUMNS);
         return rowToUser(rows[0]);
     }
@@ -98,7 +100,7 @@ class UserStore implements IUserStore {
     }
 
     buildSelectUser(q: IUserLookup): any {
-        const query = this.db(TABLE);
+        const query = this.buildBaseQuery();
         if (q.id) {
             return query.where('id', q.id);
         }
@@ -111,6 +113,10 @@ class UserStore implements IUserStore {
         throw new Error('Can only find users with id, username or email.');
     }
 
+    buildBaseQuery(): any {
+        return this.db(TABLE).where('is_deleted', false);
+    }
+
     async hasUser(idQuery: IUserLookup): Promise<number | undefined> {
         const query = this.buildSelectUser(idQuery);
         const item = await query.first('id');
@@ -118,14 +124,13 @@ class UserStore implements IUserStore {
     }
 
     async getAll(): Promise<User[]> {
-        const users = await this.db.select(USER_COLUMNS).from(TABLE);
+        const users = await this.buildBaseQuery().select(USER_COLUMNS);
         return users.map(rowToUser);
     }
 
     async search(query: string): Promise<User[]> {
-        const users = await this.db
+        const users = await this.buildBaseQuery()
             .select(USER_COLUMNS_PUBLIC)
-            .from(TABLE)
             .where('name', 'ILIKE', `%${query}%`)
             .orWhere('username', 'ILIKE', `${query}%`)
             .orWhere('email', 'ILIKE', `${query}%`);
@@ -133,9 +138,8 @@ class UserStore implements IUserStore {
     }
 
     async getAllWithId(userIdList: number[]): Promise<User[]> {
-        const users = await this.db
+        const users = await this.buildBaseQuery()
             .select(USER_COLUMNS_PUBLIC)
-            .from(TABLE)
             .whereIn('id', userIdList);
         return users.map(rowToUser);
     }
@@ -146,11 +150,18 @@ class UserStore implements IUserStore {
     }
 
     async delete(id: number): Promise<void> {
-        return this.db(TABLE).where({ id }).del();
+        return this.buildBaseQuery()
+            .where({ id })
+            .update({
+                is_deleted: true,
+                email: null,
+                username: null,
+                name: this.db.raw('name || ?', '(Deleted)'),
+            });
     }
 
     async getPasswordHash(userId: number): Promise<string> {
-        const item = await this.db(TABLE)
+        const item = await this.buildBaseQuery()
             .where('id', userId)
             .first('password_hash');
 
@@ -162,7 +173,7 @@ class UserStore implements IUserStore {
     }
 
     async setPasswordHash(userId: number, passwordHash: string): Promise<void> {
-        return this.db(TABLE).where('id', userId).update({
+        return this.buildBaseQuery().where('id', userId).update({
             password_hash: passwordHash,
         });
     }
@@ -179,12 +190,11 @@ class UserStore implements IUserStore {
     }
 
     async deleteAll(): Promise<void> {
-        await this.db(TABLE).del();
+        await this.buildBaseQuery().del();
     }
 
     async count(): Promise<number> {
-        return this.db
-            .from(TABLE)
+        return this.buildBaseQuery()
             .count('*')
             .then((res) => Number(res[0].count));
     }
@@ -193,7 +203,7 @@ class UserStore implements IUserStore {
 
     async exists(id: number): Promise<boolean> {
         const result = await this.db.raw(
-            `SELECT EXISTS (SELECT 1 FROM ${TABLE} WHERE id = ?) AS present`,
+            `SELECT EXISTS (SELECT 1 FROM ${TABLE} WHERE id = ? and is_deleted = false) AS present`,
             [id],
         );
         const { present } = result.rows[0];
@@ -201,14 +211,13 @@ class UserStore implements IUserStore {
     }
 
     async get(id: number): Promise<User> {
-        const row = await this.db(TABLE).where({ id }).first();
+        const row = await this.buildBaseQuery().where({ id }).first();
         return rowToUser(row);
     }
 
     async getUserByPersonalAccessToken(secret: string): Promise<User> {
-        const row = await this.db
+        const row = await this.buildBaseQuery()
             .select(USER_COLUMNS.map((column) => `${TABLE}.${column}`))
-            .from(TABLE)
             .leftJoin(
                 'personal_access_tokens',
                 'personal_access_tokens.user_id',

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -351,8 +351,12 @@ export class AccessService {
         return this.store.getRolesForUserId(userId);
     }
 
-    async unlinkUserRoles(userId: number): Promise<void> {
-        return this.store.unlinkUserRoles(userId);
+    async wipeUserPermissions(userId: number): Promise<void> {
+        await this.store.unlinkUserRoles(userId);
+        await this.store.unlinkUserGroups(userId);
+        await this.store.clearUserPersonalAccessTokens(userId);
+        await this.store.clearPublicSignupUserTokens(userId);
+        return Promise.resolve();
     }
 
     async getUsersForRole(roleId: number): Promise<IUser[]> {

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -351,12 +351,13 @@ export class AccessService {
         return this.store.getRolesForUserId(userId);
     }
 
-    async wipeUserPermissions(userId: number): Promise<void> {
-        await this.store.unlinkUserRoles(userId);
-        await this.store.unlinkUserGroups(userId);
-        await this.store.clearUserPersonalAccessTokens(userId);
-        await this.store.clearPublicSignupUserTokens(userId);
-        return Promise.resolve();
+    async wipeUserPermissions(userId: number): Promise<void[]> {
+        return Promise.all([
+            this.store.unlinkUserRoles(userId),
+            this.store.unlinkUserGroups(userId),
+            this.store.clearUserPersonalAccessTokens(userId),
+            this.store.clearPublicSignupUserTokens(userId),
+        ]);
     }
 
     async getUsersForRole(roleId: number): Promise<IUser[]> {

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -264,7 +264,7 @@ class UserService {
 
     async deleteUser(userId: number, updatedBy?: User): Promise<void> {
         const user = await this.store.get(userId);
-        await this.accessService.unlinkUserRoles(userId);
+        await this.accessService.wipeUserPermissions(userId);
         await this.sessionService.deleteSessionsForUser(userId);
 
         await this.store.delete(userId);

--- a/src/lib/types/stores/access-store.ts
+++ b/src/lib/types/stores/access-store.ts
@@ -53,6 +53,12 @@ export interface IAccessStore extends Store<IRole, number> {
 
     unlinkUserRoles(userId: number): Promise<void>;
 
+    unlinkUserGroups(userId: number): Promise<void>;
+
+    clearUserPersonalAccessTokens(userId: number): Promise<void>;
+
+    clearPublicSignupUserTokens(userId: number): Promise<void>;
+
     getRolesForUserId(userId: number): Promise<IRoleWithProject[]>;
 
     getProjectUsersForRole(

--- a/src/migrations/20221121133546-soft-delete-user.js
+++ b/src/migrations/20221121133546-soft-delete-user.js
@@ -3,7 +3,7 @@
 exports.up = function (db, callback) {
     db.runSql(
         `
-            ALTER TABLE users ADD COLUMN IF NOT EXISTS is_deleted boolean not null default false;
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;;
         `,
         callback,
     );
@@ -12,7 +12,7 @@ exports.up = function (db, callback) {
 exports.down = function (db, callback) {
     db.runSql(
         `
-            ALTER TABLE users DROP COLUMN IF EXISTS is_deleted;
+            ALTER TABLE users DROP COLUMN IF EXISTS deleted_at;
         `,
         callback,
     );

--- a/src/migrations/20221121133546-soft-delete-user.js
+++ b/src/migrations/20221121133546-soft-delete-user.js
@@ -3,7 +3,7 @@
 exports.up = function (db, callback) {
     db.runSql(
         `
-            ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;;
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
         `,
         callback,
     );

--- a/src/migrations/20221121133546-soft-delete-user.js
+++ b/src/migrations/20221121133546-soft-delete-user.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE users ADD COLUMN IF NOT EXISTS is_deleted boolean not null default false;
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE users DROP COLUMN IF EXISTS is_deleted;
+        `,
+        callback,
+    );
+};

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -215,7 +215,8 @@ test('get a single user', async () => {
 test('should delete user', async () => {
     const user = await userStore.insert({ email: 'some@mail.com' });
 
-    return app.request.delete(`/api/admin/user-admin/${user.id}`).expect(200);
+    await app.request.delete(`/api/admin/user-admin/${user.id}`).expect(200);
+    await app.request.get(`/api/admin/user-admin/${user.id}`).expect(404);
 });
 
 test('validator should require strong password', async () => {
@@ -341,7 +342,7 @@ test('generates USER_CREATED event', async () => {
 
 test('generates USER_DELETED event', async () => {
     const user = await userStore.insert({ email: 'some@mail.com' });
-    await app.request.delete(`/api/admin/user-admin/${user.id}`);
+    await app.request.delete(`/api/admin/user-admin/${user.id}`).expect(200);
 
     const events = await eventStore.getEvents();
     expect(events[0].type).toBe(USER_DELETED);

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -109,6 +109,7 @@ test('should not be able to login with deleted user', async () => {
         password: 'unleash4all',
         rootRole: adminRole.id,
     });
+
     await userService.deleteUser(user.id);
 
     await expect(

--- a/src/test/e2e/stores/user-store.e2e.test.ts
+++ b/src/test/e2e/stores/user-store.e2e.test.ts
@@ -27,6 +27,13 @@ test('should insert new user with email', async () => {
     expect(users[0].id).toBeTruthy();
 });
 
+test('should not allow two users with same email', async () => {
+    await expect(async () => {
+        await stores.userStore.insert({ email: 'me2@mail.com' });
+        await stores.userStore.insert({ email: 'me2@mail.com' });
+    }).rejects.toThrow(/duplicate key value violates unique constraint/);
+});
+
 test('should insert new user with email and return it', async () => {
     const user = { email: 'me2@mail.com' };
     const newUser = await stores.userStore.upsert(user);

--- a/src/test/e2e/stores/user-store.e2e.test.ts
+++ b/src/test/e2e/stores/user-store.e2e.test.ts
@@ -158,6 +158,7 @@ test('should delete user', async () => {
     const user = await stores.userStore.upsert({
         email: 'deleteuser@mail.com',
     });
+
     await stores.userStore.delete(user.id);
 
     await expect(() => stores.userStore.get(user.id)).rejects.toThrow(

--- a/src/test/e2e/stores/user-store.e2e.test.ts
+++ b/src/test/e2e/stores/user-store.e2e.test.ts
@@ -27,13 +27,6 @@ test('should insert new user with email', async () => {
     expect(users[0].id).toBeTruthy();
 });
 
-test('should not allow two users with same email', async () => {
-    await expect(async () => {
-        await stores.userStore.insert({ email: 'me2@mail.com' });
-        await stores.userStore.insert({ email: 'me2@mail.com' });
-    }).rejects.toThrow(/duplicate key value violates unique constraint/);
-});
-
 test('should insert new user with email and return it', async () => {
     const user = { email: 'me2@mail.com' };
     const newUser = await stores.userStore.upsert(user);
@@ -159,4 +152,15 @@ test('should always lowercase emails on updates', async () => {
 
     storedUser = await store.get(storedUser.id);
     expect(storedUser.email).toBe(updatedUser.email.toLowerCase());
+});
+
+test('should delete user', async () => {
+    const user = await stores.userStore.upsert({
+        email: 'deleteuser@mail.com',
+    });
+    await stores.userStore.delete(user.id);
+
+    await expect(() => stores.userStore.get(user.id)).rejects.toThrow(
+        new NotFoundError('No user found'),
+    );
 });

--- a/src/test/fixtures/fake-access-store.ts
+++ b/src/test/fixtures/fake-access-store.ts
@@ -199,6 +199,18 @@ class AccessStoreMock implements IAccessStore {
     ): Promise<void> {
         return Promise.resolve(undefined);
     }
+
+    clearUserPersonalAccessTokens(userId: number): Promise<void> {
+        return Promise.resolve(undefined);
+    }
+
+    unlinkUserGroups(userId: number): Promise<void> {
+        return Promise.resolve(undefined);
+    }
+
+    clearPublicSignupUserTokens(userId: number): Promise<void> {
+        return Promise.resolve(undefined);
+    }
 }
 
 module.exports = AccessStoreMock;


### PR DESCRIPTION
Previously we hard deleted the users, but due to change requests and possibly other features in future, we really want to hard-link user table and have meaningful relationships.

But this means, when user is deleted, all linked data is also deleted.
**Workaround is to soft delete users and just clear users data and keep the relationships alive for audit logs.**

This PR implements this feature.