### PR TITLE
fix: force clone feature to correctly copy variant environments

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -768,18 +768,30 @@ class FeatureToggleService {
         await this.validateName(newFeatureName);
 
         const cToggle =
-            await this.featureStrategiesStore.getFeatureToggleWithEnvs(
+            await this.featureStrategiesStore.getFeatureToggleWithVariantEnvs(
                 featureName,
             );
 
-        const newToggle = { ...cToggle, name: newFeatureName };
+        const newToggle = {
+            ...cToggle,
+            name: newFeatureName,
+            variants: undefined,
+        };
         const created = await this.createFeatureToggle(
             projectId,
             newToggle,
             userName,
         );
 
-        const tasks = newToggle.environments.flatMap((e) =>
+        const variantTasks = newToggle.environments.map((e) => {
+            return this.featureEnvironmentStore.addVariantsToFeatureEnvironment(
+                newToggle.name,
+                e.name,
+                e.variants,
+            );
+        });
+
+        const strategyTasks = newToggle.environments.flatMap((e) =>
             e.strategies.map((s) => {
                 if (replaceGroupId && s.parameters.hasOwnProperty('groupId')) {
                     s.parameters.groupId = newFeatureName;
@@ -795,7 +807,7 @@ class FeatureToggleService {
             }),
         );
 
-        await Promise.all(tasks);
+        await Promise.all([...strategyTasks, ...variantTasks]);
         return created;
     }
 


### PR DESCRIPTION
This patches an issue where cloning a feature would clone variants for it's last found environment in the db. This now will clone the feature environments correctly