### PR TITLE
fix: resolve an issue where cloning a feature toggle with a segment

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -801,9 +801,7 @@ class FeatureToggleService {
                     featureName: newFeatureName,
                     environment: e.name,
                 };
-                return this.createStrategy(s, context, userName).then((s2) =>
-                    this.segmentService.cloneStrategySegments(s.id, s2.id),
-                );
+                return this.createStrategy(s, context, userName);
             }),
         );
 


### PR DESCRIPTION
Creating a strategy has been updated to also clone segments for Suggest Changes reasons, however, the code for cloning a toggle was not updated in tandem. This means that when cloning a feature toggle with a segment, the toggle would be created with a strategy and automatically get the segments copied across, then the promise chain would resolve and attempt to create the exact same segment a second time, which caused a write of a duplicate entry into the db on a set of columns that have a uniqueness constraint.

This PR removes the callback for handling the segment cloning, allowing the create strategy method to do it right the first time