### PR TITLE
disable change request overview actions when CR are disabled

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
@@ -19,6 +19,7 @@ import {
 } from 'utils/strategyNames';
 import { hasNameField } from '../changeRequest.types';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 
 interface IChangeRequestProps {
     changeRequest: IChangeRequest;
@@ -91,8 +92,15 @@ export const ChangeRequest: VFC<IChangeRequestProps> = ({
             setToastApiError(formatUnknownError(error));
         }
     };
+    const { isChangeRequestConfigured } = useChangeRequestsEnabled(
+        changeRequest.project
+    );
+    const allowChangeRequestActions = isChangeRequestConfigured(
+        changeRequest.environment
+    );
 
     const showDiscard =
+        allowChangeRequestActions &&
         !['Cancelled', 'Applied'].includes(changeRequest.state) &&
         changeRequest.features.flatMap(feature => feature.changes).length > 1;
 

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
@@ -11,9 +11,8 @@ const AddCommentWrapper = styled(Box)(({ theme }) => ({
 export const AddCommentField: FC<{
     imageUrl: string;
     commentText: string;
-    onAddComment: () => void;
     onTypeComment: (text: string) => void;
-}> = ({ imageUrl, commentText, onTypeComment, onAddComment }) => (
+}> = ({ imageUrl, commentText, onTypeComment, children }) => (
     <>
         <AddCommentWrapper>
             <StyledAvatar src={imageUrl} />
@@ -28,16 +27,7 @@ export const AddCommentField: FC<{
             />
         </AddCommentWrapper>
         <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Button
-                variant="outlined"
-                onClick={onAddComment}
-                disabled={
-                    commentText.trim().length === 0 ||
-                    commentText.trim().length > 1000
-                }
-            >
-                Comment
-            </Button>
+            {children}
         </Box>
     </>
 );

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -241,7 +241,6 @@ export const ChangeRequestOverview: FC = () => {
                                         sx={{ ml: 2 }}
                                         variant="outlined"
                                         onClick={onCancelChanges}
-                                        disabled={!allowChangeRequestActions}
                                     >
                                         Cancel changes
                                     </Button>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { FC, useContext } from 'react';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { useChangeRequest } from 'hooks/api/getters/useChangeRequest/useChangeRequest';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
@@ -22,7 +22,7 @@ import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import AccessContext from 'contexts/AccessContext';
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
 
-export const ReviewButton = () => {
+export const ReviewButton: FC<{ disabled: boolean }> = ({ disabled }) => {
     const { isAdmin } = useContext(AccessContext);
     const projectId = useRequiredPathParam('projectId');
     const id = useRequiredPathParam('id');
@@ -73,7 +73,9 @@ export const ReviewButton = () => {
         <React.Fragment>
             <PermissionButton
                 variant="contained"
-                disabled={data?.createdBy.id === user?.id && !isAdmin}
+                disabled={
+                    disabled || (data?.createdBy.id === user?.id && !isAdmin)
+                }
                 aria-controls={open ? 'review-options-menu' : undefined}
                 aria-expanded={open ? 'true' : undefined}
                 aria-label="review changes"

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -261,7 +261,7 @@ export const ProjectFeatureToggles = ({
                 disableSortBy: true,
             },
         ],
-        [projectId, environments, loading, isChangeRequestConfigured]
+        [projectId, environments, loading, onToggle]
     );
 
     const [searchValue, setSearchValue] = useState(

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -261,7 +261,7 @@ export const ProjectFeatureToggles = ({
                 disableSortBy: true,
             },
         ],
-        [projectId, environments, loading]
+        [projectId, environments, loading, isChangeRequestConfigured]
     );
 
     const [searchValue, setSearchValue] = useState(

--- a/frontend/src/hooks/useChangeRequestsEnabled.ts
+++ b/frontend/src/hooks/useChangeRequestsEnabled.ts
@@ -17,7 +17,7 @@ export const useChangeRequestsEnabled = (projectId: string) => {
 
             return Boolean(uiConfig?.flags.changeRequests) && enabled;
         },
-        [data]
+        [JSON.stringify(data)]
     );
 
     const isChangeRequestConfiguredInAnyEnv = React.useCallback((): boolean => {
@@ -25,7 +25,7 @@ export const useChangeRequestsEnabled = (projectId: string) => {
             Boolean(uiConfig?.flags.changeRequests) &&
             data.some(draft => draft.changeRequestEnabled)
         );
-    }, [data]);
+    }, [JSON.stringify(data)]);
 
     return {
         isChangeRequestFlagEnabled: Boolean(uiConfig?.flags.changeRequests),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

When ChangeRequests are disabled and we go to change request overview:
* disable review button
* disable approve button
* disabled add comment button
* disable cancel button
<img width="1342" alt="Screenshot 2022-11-24 at 13 59 04" src="https://user-images.githubusercontent.com/1394682/203790667-ac949886-1e8c-45d8-bd12-92ad40714abf.png">

Also: fixed hook deps so that change request config is picked on feature toggles project list

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
