### PR TITLE
task: Make operations on the API Token store auditable.

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -173,7 +173,10 @@ export class ApiTokenStore implements IApiTokenStore {
     }
 
     async get(key: string): Promise<IApiToken> {
-        const row = await this.makeTokenProjectQuery().where('secret', key);
+        const row = await this.makeTokenProjectQuery().where(
+            'tokens.secret',
+            key,
+        );
         return toTokens(row)[0];
     }
 

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { Logger } from '../logger';
 import { ADMIN, CLIENT, FRONTEND } from '../types/permissions';
-import { IUnleashStores } from '../types/stores';
+import { IEventStore, IUnleashStores } from '../types/stores';
 import { IUnleashConfig } from '../types/option';
 import ApiUser from '../types/api-user';
 import {
@@ -20,6 +20,12 @@ import BadDataError from '../error/bad-data-error';
 import { minutesToMilliseconds } from 'date-fns';
 import { IEnvironmentStore } from 'lib/types/stores/environment-store';
 import { constantTimeCompare } from '../util/constantTimeCompare';
+import {
+    ApiTokenCreatedEvent,
+    ApiTokenDeletedEvent,
+    ApiTokenUpdatedEvent,
+} from '../types';
+import { omitKeys } from '../util';
 
 const resolveTokenPermissions = (tokenType: string) => {
     if (tokenType === ApiTokenType.ADMIN) {
@@ -48,14 +54,21 @@ export class ApiTokenService {
 
     private activeTokens: IApiToken[] = [];
 
+    private eventStore: IEventStore;
+
     constructor(
         {
             apiTokenStore,
             environmentStore,
-        }: Pick<IUnleashStores, 'apiTokenStore' | 'environmentStore'>,
+            eventStore,
+        }: Pick<
+            IUnleashStores,
+            'apiTokenStore' | 'environmentStore' | 'eventStore'
+        >,
         config: Pick<IUnleashConfig, 'getLogger' | 'authentication'>,
     ) {
         this.store = apiTokenStore;
+        this.eventStore = eventStore;
         this.environmentStore = environmentStore;
         this.logger = config.getLogger('/services/api-token-service.ts');
         this.fetchActiveTokens();
@@ -95,7 +108,7 @@ export class ApiTokenService {
         try {
             const createAll = tokens
                 .map(mapLegacyTokenWithSecret)
-                .map((t) => this.insertNewApiToken(t));
+                .map((t) => this.insertNewApiToken(t, 'init-api-tokens'));
             await Promise.all(createAll);
         } catch (e) {
             this.logger.error('Unable to create initial Admin API tokens');
@@ -140,12 +153,31 @@ export class ApiTokenService {
     public async updateExpiry(
         secret: string,
         expiresAt: Date,
+        updatedBy: string,
     ): Promise<IApiToken> {
-        return this.store.setExpiry(secret, expiresAt);
+        const previous = await this.store.get(secret);
+        const token = await this.store.setExpiry(secret, expiresAt);
+        await this.eventStore.store(
+            new ApiTokenUpdatedEvent({
+                createdBy: updatedBy,
+                previousToken: omitKeys(previous, 'secret'),
+                apiToken: omitKeys(token, 'secret'),
+            }),
+        );
+        return token;
     }
 
-    public async delete(secret: string): Promise<void> {
-        return this.store.delete(secret);
+    public async delete(secret: string, deletedBy: string): Promise<void> {
+        if (await this.store.exists(secret)) {
+            const token = await this.store.get(secret);
+            await this.store.delete(secret);
+            await this.eventStore.store(
+                new ApiTokenDeletedEvent({
+                    createdBy: deletedBy,
+                    apiToken: omitKeys(token, 'secret'),
+                }),
+            );
+        }
     }
 
     /**
@@ -153,13 +185,15 @@ export class ApiTokenService {
      */
     public async createApiToken(
         newToken: Omit<ILegacyApiTokenCreate, 'secret'>,
+        createdBy: string = 'unleash-system',
     ): Promise<IApiToken> {
         const token = mapLegacyToken(newToken);
-        return this.createApiTokenWithProjects(token);
+        return this.createApiTokenWithProjects(token, createdBy);
     }
 
     public async createApiTokenWithProjects(
         newToken: Omit<IApiTokenCreate, 'secret'>,
+        createdBy: string = 'unleash-system',
     ): Promise<IApiToken> {
         validateApiToken(newToken);
 
@@ -168,7 +202,7 @@ export class ApiTokenService {
 
         const secret = this.generateSecretKey(newToken);
         const createNewToken = { ...newToken, secret };
-        return this.insertNewApiToken(createNewToken);
+        return this.insertNewApiToken(createNewToken, createdBy);
     }
 
     // TODO: Remove this service method after embedded proxy has been released in
@@ -180,15 +214,22 @@ export class ApiTokenService {
 
         const secret = this.generateSecretKey(newToken);
         const createNewToken = { ...newToken, secret };
-        return this.insertNewApiToken(createNewToken);
+        return this.insertNewApiToken(createNewToken, 'system-migration');
     }
 
     private async insertNewApiToken(
         newApiToken: IApiTokenCreate,
+        createdBy: string,
     ): Promise<IApiToken> {
         try {
             const token = await this.store.insert(newApiToken);
             this.activeTokens.push(token);
+            await this.eventStore.store(
+                new ApiTokenCreatedEvent({
+                    createdBy,
+                    apiToken: omitKeys(token, 'secret'),
+                }),
+            );
             return token;
         } catch (error) {
             if (error.code === FOREIGN_KEY_VIOLATION) {

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -94,6 +94,10 @@ export const CHANGE_REQUEST_CANCELLED = 'change-request-cancelled';
 export const CHANGE_REQUEST_SENT_TO_REVIEW = 'change-request-sent-to-review';
 export const CHANGE_REQUEST_APPLIED = 'change-request-applied';
 
+export const API_TOKEN_CREATED = 'api-token-created';
+export const API_TOKEN_UPDATED = 'api-token-updated';
+export const API_TOKEN_DELETED = 'api-token-deleted';
+
 export interface IBaseEvent {
     type: string;
     createdBy: string;
@@ -602,5 +606,63 @@ export class PublicSignupTokenUserAddedEvent extends BaseEvent {
     constructor(eventData: { createdBy: string; data: any }) {
         super(PUBLIC_SIGNUP_TOKEN_USER_ADDED, eventData.createdBy);
         this.data = eventData.data;
+    }
+}
+
+export class ApiTokenCreatedEvent extends BaseEvent {
+    readonly data: any;
+
+    readonly environment: string;
+
+    readonly project: string;
+
+    constructor(eventData: {
+        createdBy: string;
+        apiToken: Omit<IApiToken, 'secret'>;
+    }) {
+        super(API_TOKEN_CREATED, eventData.createdBy);
+        this.data = eventData.apiToken;
+        this.environment = eventData.apiToken.environment;
+        this.project = eventData.apiToken.project;
+    }
+}
+
+export class ApiTokenDeletedEvent extends BaseEvent {
+    readonly preData: any;
+
+    readonly environment: string;
+
+    readonly project: string;
+
+    constructor(eventData: {
+        createdBy: string;
+        apiToken: Omit<IApiToken, 'secret'>;
+    }) {
+        super(API_TOKEN_DELETED, eventData.createdBy);
+        this.preData = eventData.apiToken;
+        this.environment = eventData.apiToken.environment;
+        this.project = eventData.apiToken.project;
+    }
+}
+
+export class ApiTokenUpdatedEvent extends BaseEvent {
+    readonly preData: any;
+
+    readonly data: any;
+
+    readonly environment: string;
+
+    readonly project: string;
+
+    constructor(eventData: {
+        createdBy: string;
+        previousToken: Omit<IApiToken, 'secret'>;
+        apiToken: Omit<IApiToken, 'secret'>;
+    }) {
+        super(API_TOKEN_UPDATED, eventData.createdBy);
+        this.preData = eventData.previousToken;
+        this.data = eventData.apiToken;
+        this.environment = eventData.apiToken.environment;
+        this.project = eventData.apiToken.project;
     }
 }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -1,4 +1,5 @@
 import { FeatureToggle, IStrategyConfig, ITag, IVariant } from './model';
+import { IApiToken } from './models/api-token';
 
 export const APPLICATION_CREATED = 'application-created';
 

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -120,15 +120,18 @@ test('should update expiry of token', async () => {
     const time = new Date('2022-01-01');
     const newTime = new Date('2023-01-01');
 
-    const token = await apiTokenService.createApiToken({
-        username: 'default-client',
-        type: ApiTokenType.CLIENT,
-        expiresAt: time,
-        project: '*',
-        environment: DEFAULT_ENV,
-    });
+    const token = await apiTokenService.createApiToken(
+        {
+            username: 'default-client',
+            type: ApiTokenType.CLIENT,
+            expiresAt: time,
+            project: '*',
+            environment: DEFAULT_ENV,
+        },
+        'tester',
+    );
 
-    await apiTokenService.updateExpiry(token.secret, newTime);
+    await apiTokenService.updateExpiry(token.secret, newTime, 'tester');
 
     const [updatedToken] = await apiTokenService.getAllTokens();
 


### PR DESCRIPTION
## About the changes
We need a way to have an audit log for operations made on Api Tokens. These changes add three new event types, API_TOKEN_CREATED, API_TOKEN_UPDATED, API_TOKEN_DELETED and extends api-token-service to store these to our event store to reflect the action being taken.

## Discussion points
I'd love to have an discussion on the event format. 
I'm currently exporting the token (minus the secret) as data, and then using it as preData for deletion events and both preData and data in the update events.

Also, not too fond of the Omit use here, since if you pass in an object with the secret that will still be kept. Now I have tests in place for our current three places where we add these three events.