### PR TITLE
perf: remove indexes covered by pks

### DIFF
--- a/src/migrations/20221125164718-remove-duplicated-indexes.js
+++ b/src/migrations/20221125164718-remove-duplicated-indexes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+export function up(db, callback) {
+    db.runSql(
+        `DROP INDEX idx_client_metrics_f_name;
+         DROP INDEX user_feedback_user_id_idx;
+         DROP INDEX user_splash_user_id_idx;
+        `,
+        callback,
+    );
+}
+
+export function down(db, callback) {
+    db.runSql(
+        `CREATE INDEX idx_client_metrics_f_name ON client_metrics_env(feature_name);
+         CREATE INDEX user_feedback_user_id_idx ON user_feedback (user_id);
+         CREATE INDEX user_splash_user_id_idx ON user_splash (user_id);
+        `,
+        callback,
+    );
+}


### PR DESCRIPTION
## About the changes
While experimenting with https://github.com/ankane/pghero it reported some indexes that can be removed:

![Screenshot from 2022-11-25 17-22-49](https://user-images.githubusercontent.com/455064/204260724-1ff27429-4e3d-4ed8-b06d-694f20c83603.png)

This can improve write performance and disk usage but in both cases, the impact might be rather low (except maybe for metrics).

## Discussion points
This is not a must do, but because the potential impact on metrics performance I opened this PR as a conversation opener