### PR TITLE
Fix OOM with eslint in migrations

### DIFF
--- a/src/migrations/.eslintrc
+++ b/src/migrations/.eslintrc
@@ -5,15 +5,10 @@
     "plugins": [],
     "rules": {},
     "settings": {},
-    "parserOptions": {
-        "project": "../../tsconfig.json"
-    },
+    "parserOptions": {},
     "overrides": [
         {
-            "files": "*.js",
-            "rules": {
-                "@typescript-eslint/indent": "off"
-            }
+            "files": "*.js"
         }
     ]
 }


### PR DESCRIPTION
## About the changes
When adding a new migration, we might run out of memory. Migrations have only JS files and we're running these through TS parser. Removing TS config reference from `.eslintrc` proved to solve the issue while running local manual tests

This still lint the migration files but using JS syntax

## Discussion points
Not sure if this is the best shape of our `.eslintrc` file