### PR TITLE
fix: addon parameter validation on empty strings

### DIFF
--- a/frontend/src/component/addons/AddonForm/AddonForm.tsx
+++ b/frontend/src/component/addons/AddonForm/AddonForm.tsx
@@ -130,9 +130,13 @@ export const AddonForm: VFC<IAddonFormProps> = ({
         (param: string): ChangeEventHandler<HTMLInputElement> =>
         event => {
             event.preventDefault();
+            const value =
+                trim(event.target.value) === ''
+                    ? undefined
+                    : event.target.value;
             setFormValues(
                 produce(draft => {
-                    draft.parameters[param] = event.target.value;
+                    draft.parameters[param] = value;
                 })
             );
         };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-408/addon-parameter-validation