### PR TITLE
change request tooltips

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
-import { Box, Button, styled, TextField } from '@mui/material';
+import { Box, styled, TextField, Tooltip } from '@mui/material';
 import { StyledAvatar } from './StyledAvatar';
+import { IUser } from 'interfaces/user';
 
 const AddCommentWrapper = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -9,13 +10,15 @@ const AddCommentWrapper = styled(Box)(({ theme }) => ({
 }));
 
 export const AddCommentField: FC<{
-    imageUrl: string;
+    user: IUser | undefined;
     commentText: string;
     onTypeComment: (text: string) => void;
-}> = ({ imageUrl, commentText, onTypeComment, children }) => (
+}> = ({ user, commentText, onTypeComment, children }) => (
     <>
         <AddCommentWrapper>
-            <StyledAvatar src={imageUrl} />
+            <Tooltip title={user?.name || user?.username}>
+                <StyledAvatar src={user?.imageUrl || ''} />
+            </Tooltip>
             <TextField
                 variant="outlined"
                 placeholder="Add your comment here"

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import Paper from '@mui/material/Paper';
-import { Box, styled, Typography } from '@mui/material';
+import { Box, styled, Typography, Tooltip } from '@mui/material';
 import TimeAgo from 'react-timeago';
 import { StyledAvatar } from './StyledAvatar';
 import { IChangeRequestComment } from '../../changeRequest.types';
@@ -26,7 +26,9 @@ export const ChangeRequestComment: FC<{ comment: IChangeRequestComment }> = ({
     comment,
 }) => (
     <ChangeRequestCommentWrapper>
-        <StyledAvatar src={comment.createdBy.imageUrl} />
+        <Tooltip title={comment.createdBy.username}>
+            <StyledAvatar src={comment.createdBy.imageUrl} />
+        </Tooltip>
         <CommentPaper variant="outlined">
             <CommentHeader>
                 <Box>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import { FC } from 'react';
-import { Typography } from '@mui/material';
+import { Typography, Tooltip } from '@mui/material';
 import TimeAgo from 'react-timeago';
 import { IChangeRequest } from 'component/changeRequest/changeRequest.types';
 import { ChangeRequestStatusBadge } from 'component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge';
@@ -29,7 +29,9 @@ export const ChangeRequestHeader: FC<{ changeRequest: IChangeRequest }> = ({
                     Created <TimeAgo date={new Date(changeRequest.createdAt)} />{' '}
                     by
                 </Typography>
-                <StyledAvatar src={changeRequest?.createdBy?.imageUrl} />
+                <Tooltip title={changeRequest?.createdBy?.username}>
+                    <StyledAvatar src={changeRequest?.createdBy?.imageUrl} />
+                </Tooltip>
                 <Box>
                     <StyledCard variant="outlined">
                         <Typography variant="body2">

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -167,7 +167,7 @@ export const ChangeRequestOverview: FC = () => {
                             />
                         ))}
                         <AddCommentField
-                            imageUrl={user?.imageUrl || ''}
+                            user={user}
                             commentText={commentText}
                             onTypeComment={setCommentText}
                         >

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -38,7 +38,6 @@ import { useMediaQuery } from '@mui/material';
 import { Search } from 'component/common/Search/Search';
 import { useChangeRequestToggle } from 'hooks/useChangeRequestToggle';
 import { ChangeRequestDialogue } from 'component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog';
-import { CopyStrategyMessage } from '../../../changeRequest/ChangeRequestConfirmDialog/ChangeRequestMessages/CopyStrategyMessage';
 import { UpdateEnabledMessage } from '../../../changeRequest/ChangeRequestConfirmDialog/ChangeRequestMessages/UpdateEnabledMessage';
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { IFeatureToggleListItem } from 'interfaces/featureToggle';


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding change request tooltips for all user avatarts. 
<img width="708" alt="Screenshot 2022-11-29 at 09 44 20" src="https://user-images.githubusercontent.com/1394682/204481592-960c6bdb-0b4a-4346-a7ed-e3f9d0560548.png">

<img width="704" alt="Screenshot 2022-11-29 at 09 44 28" src="https://user-images.githubusercontent.com/1394682/204481614-db25e070-6a62-483a-b9ba-5f2737e1357e.png">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->


There's an existing UserAvatar with native browser tooltip, but it's using some custom code instead of MUI tooltip and also makes too many assumptions about the user data structure.

<img width="492" alt="Screenshot 2022-11-29 at 09 44 45" src="https://user-images.githubusercontent.com/1394682/204481793-96e31d78-f7ad-483d-ab81-77eece934d57.png">

