### PR TITLE
Change to preferred export format

### DIFF
--- a/website/docs/contributing/ADRs/front-end/preferred-data-mutation-method.md
+++ b/website/docs/contributing/ADRs/front-end/preferred-data-mutation-method.md
@@ -17,7 +17,7 @@ Example:
 import { ITagPayload } from 'interfaces/tags';
 import useAPI from '../useApi/useApi';
 
-const useTagTypesApi = () => {
+export const useTagTypesApi = () => {
     const { makeRequest, createRequest, errors, loading } = useAPI({
         propagateErrors: true,
     });
@@ -87,6 +87,4 @@ const useTagTypesApi = () => {
         loading,
     };
 };
-
-export default useTagTypesApi;
 ```


### PR DESCRIPTION
### What
This PR updates the example for the hook to use the export format that is recommended in the ADR we've written on export types.