### PR TITLE
refactor: flag resolver should use stricter types

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -121,7 +121,7 @@ exports[`should create default config 1`] = `
   },
   "preHook": undefined,
   "preRouterHook": undefined,
-  "prometheusApi": "http://localhost:9090",
+  "prometheusApi": undefined,
   "secureHeaders": false,
   "segmentValuesLimit": 100,
   "server": {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -67,6 +67,7 @@ exports[`should create default config 1`] = `
       "isEnabled": [Function],
     },
     "flags": {
+      "E": false,
       "ENABLE_DARK_MODE_SUPPORT": false,
       "anonymiseEventLog": false,
       "batchMetrics": false,
@@ -83,6 +84,7 @@ exports[`should create default config 1`] = `
   },
   "flagResolver": FlagResolver {
     "experiments": {
+      "E": false,
       "ENABLE_DARK_MODE_SUPPORT": false,
       "anonymiseEventLog": false,
       "batchMetrics": false,
@@ -119,7 +121,7 @@ exports[`should create default config 1`] = `
   },
   "preHook": undefined,
   "preRouterHook": undefined,
-  "prometheusApi": undefined,
+  "prometheusApi": "http://localhost:9090",
   "secureHeaders": false,
   "segmentValuesLimit": 100,
   "server": {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -1,73 +1,61 @@
 import { parseEnvVarBoolean } from '../util';
 
-export type IFlags = IExperimentalOptions['flags'];
+export type IFlags = Partial<typeof flags>;
 export type IFlagKey = keyof IFlags;
 
+const flags = {
+    E: false,
+    ENABLE_DARK_MODE_SUPPORT: false,
+    anonymiseEventLog: false,
+    embedProxy: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
+        true,
+    ),
+    changeRequests: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_CHANGE_REQUESTS,
+        false,
+    ),
+    embedProxyFrontend: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY_FRONTEND,
+        true,
+    ),
+    batchMetrics: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_BATCH_METRICS,
+        false,
+    ),
+    responseTimeWithAppName: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_RESPONSE_TIME_WITH_APP_NAME,
+        false,
+    ),
+    proxyReturnAllToggles: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PROXY_RETURN_ALL_TOGGLES,
+        false,
+    ),
+    variantsPerEnvironment: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_VARIANTS_PER_ENVIRONMENT,
+        false,
+    ),
+    favorites: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_FAVORITES,
+        false,
+    ),
+    networkView: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NETWORK_VIEW,
+        false,
+    ),
+    maintenance: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_MAINTENANCE,
+        false,
+    ),
+};
+
 export const defaultExperimentalOptions: IExperimentalOptions = {
-    flags: {
-        ENABLE_DARK_MODE_SUPPORT: false,
-        anonymiseEventLog: false,
-        embedProxy: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
-            true,
-        ),
-        changeRequests: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_CHANGE_REQUESTS,
-            false,
-        ),
-        embedProxyFrontend: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY_FRONTEND,
-            true,
-        ),
-        batchMetrics: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_BATCH_METRICS,
-            false,
-        ),
-        responseTimeWithAppName: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_RESPONSE_TIME_WITH_APP_NAME,
-            false,
-        ),
-        proxyReturnAllToggles: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_PROXY_RETURN_ALL_TOGGLES,
-            false,
-        ),
-        variantsPerEnvironment: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_VARIANTS_PER_ENVIRONMENT,
-            false,
-        ),
-        favorites: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_FAVORITES,
-            false,
-        ),
-        maintenance: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_MAINTENANCE,
-            false,
-        ),
-        networkView: parseEnvVarBoolean(
-            process.env.UNLEASH_EXPERIMENTAL_NETWORK_VIEW,
-            false,
-        ),
-    },
+    flags,
     externalResolver: { isEnabled: (): boolean => false },
 };
 
 export interface IExperimentalOptions {
-    flags: {
-        E?: boolean;
-        ENABLE_DARK_MODE_SUPPORT?: boolean;
-        embedProxy?: boolean;
-        embedProxyFrontend?: boolean;
-        batchMetrics?: boolean;
-        anonymiseEventLog?: boolean;
-        changeRequests?: boolean;
-        responseTimeWithAppName?: boolean;
-        toggleTagFiltering?: boolean;
-        proxyReturnAllToggles?: boolean;
-        variantsPerEnvironment?: boolean;
-        favorites?: boolean;
-        networkView?: boolean;
-        maintenance?: boolean;
-    };
+    flags: IFlags;
     externalResolver: IExternalFlagResolver;
 }
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -1,8 +1,9 @@
 import { parseEnvVarBoolean } from '../util';
 
-export type IFlags = Partial<Record<string, boolean>>;
+export type IFlags = IExperimentalOptions['flags'];
+export type IFlagKey = keyof IFlags;
 
-export const defaultExperimentalOptions = {
+export const defaultExperimentalOptions: IExperimentalOptions = {
     flags: {
         ENABLE_DARK_MODE_SUPPORT: false,
         anonymiseEventLog: false,
@@ -52,13 +53,15 @@ export const defaultExperimentalOptions = {
 
 export interface IExperimentalOptions {
     flags: {
-        [key: string]: boolean;
+        E?: boolean;
         ENABLE_DARK_MODE_SUPPORT?: boolean;
         embedProxy?: boolean;
         embedProxyFrontend?: boolean;
         batchMetrics?: boolean;
         anonymiseEventLog?: boolean;
         changeRequests?: boolean;
+        responseTimeWithAppName?: boolean;
+        toggleTagFiltering?: boolean;
         proxyReturnAllToggles?: boolean;
         variantsPerEnvironment?: boolean;
         favorites?: boolean;
@@ -74,9 +77,9 @@ export interface IFlagContext {
 
 export interface IFlagResolver {
     getAll: (context?: IFlagContext) => IFlags;
-    isEnabled: (expName: string, context?: IFlagContext) => boolean;
+    isEnabled: (expName: IFlagKey, context?: IFlagContext) => boolean;
 }
 
 export interface IExternalFlagResolver {
-    isEnabled: (flagName: string, context?: IFlagContext) => boolean;
+    isEnabled: (flagName: IFlagKey, context?: IFlagContext) => boolean;
 }

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -1,5 +1,6 @@
-import { defaultExperimentalOptions } from '../types/experimental';
+import { defaultExperimentalOptions, IFlagKey } from '../types/experimental';
 import FlagResolver from './flag-resolver';
+import { IExperimentalOptions } from '../../../dist/lib/types/experimental';
 
 test('should produce empty exposed flags', () => {
     const resolver = new FlagResolver(defaultExperimentalOptions);
@@ -14,11 +15,10 @@ test('should produce UI flags with extra dynamic flags', () => {
         ...defaultExperimentalOptions,
         flags: { extraFlag: false },
     };
-    // @ts-expect-error
-    const resolver = new FlagResolver(config);
-    const result = resolver.getAll();
 
-    // @ts-expect-error
+    const resolver = new FlagResolver(config as IExperimentalOptions);
+    const result = resolver.getAll() as typeof config.flags;
+
     expect(result.extraFlag).toBe(false);
 });
 
@@ -36,12 +36,10 @@ test('should use external resolver for dynamic flags', () => {
         externalResolver,
     };
 
-    // @ts-expect-error
-    const resolver = new FlagResolver(config);
+    const resolver = new FlagResolver(config as IExperimentalOptions);
 
-    const result = resolver.getAll();
+    const result = resolver.getAll() as typeof config.flags;
 
-    // @ts-expect-error
     expect(result.extraFlag).toBe(true);
 });
 
@@ -57,12 +55,10 @@ test('should not use external resolver for enabled experiments', () => {
         externalResolver,
     };
 
-    // @ts-expect-error
-    const resolver = new FlagResolver(config);
+    const resolver = new FlagResolver(config as IExperimentalOptions);
 
-    const result = resolver.getAll();
+    const result = resolver.getAll() as typeof config.flags;
 
-    // @ts-expect-error
     expect(result.should_be_enabled).toBe(true);
 });
 
@@ -78,13 +74,10 @@ test('should load experimental flags', () => {
         externalResolver,
     };
 
-    // @ts-expect-error
-    const resolver = new FlagResolver(config);
+    const resolver = new FlagResolver(config as IExperimentalOptions);
 
-    // @ts-expect-error
-    expect(resolver.isEnabled('someFlag')).toBe(true);
-    // @ts-expect-error
-    expect(resolver.isEnabled('extraFlag')).toBe(false);
+    expect(resolver.isEnabled('someFlag' as IFlagKey)).toBe(true);
+    expect(resolver.isEnabled('extraFlag' as IFlagKey)).toBe(false);
 });
 
 test('should load experimental flags from external provider', () => {
@@ -101,11 +94,8 @@ test('should load experimental flags from external provider', () => {
         externalResolver,
     };
 
-    // @ts-expect-error
-    const resolver = new FlagResolver(config);
+    const resolver = new FlagResolver(config as IExperimentalOptions);
 
-    // @ts-expect-error
-    expect(resolver.isEnabled('someFlag')).toBe(true);
-    // @ts-expect-error
-    expect(resolver.isEnabled('extraFlag')).toBe(true);
+    expect(resolver.isEnabled('someFlag' as IFlagKey)).toBe(true);
+    expect(resolver.isEnabled('extraFlag' as IFlagKey)).toBe(true);
 });

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -1,6 +1,6 @@
 import { defaultExperimentalOptions, IFlagKey } from '../types/experimental';
 import FlagResolver from './flag-resolver';
-import { IExperimentalOptions } from '../../../dist/lib/types/experimental';
+import { IExperimentalOptions } from '../types/experimental';
 
 test('should produce empty exposed flags', () => {
     const resolver = new FlagResolver(defaultExperimentalOptions);

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -14,9 +14,11 @@ test('should produce UI flags with extra dynamic flags', () => {
         ...defaultExperimentalOptions,
         flags: { extraFlag: false },
     };
+    // @ts-expect-error
     const resolver = new FlagResolver(config);
     const result = resolver.getAll();
 
+    // @ts-expect-error
     expect(result.extraFlag).toBe(false);
 });
 
@@ -29,15 +31,17 @@ test('should use external resolver for dynamic flags', () => {
         },
     };
 
-    const resolver = new FlagResolver({
-        flags: {
-            extraFlag: false,
-        },
+    const config = {
+        flags: { extraFlag: false },
         externalResolver,
-    });
+    };
+
+    // @ts-expect-error
+    const resolver = new FlagResolver(config);
 
     const result = resolver.getAll();
 
+    // @ts-expect-error
     expect(result.extraFlag).toBe(true);
 });
 
@@ -48,16 +52,17 @@ test('should not use external resolver for enabled experiments', () => {
         },
     };
 
-    const resolver = new FlagResolver({
-        flags: {
-            should_be_enabled: true,
-            extraFlag: false,
-        },
+    const config = {
+        flags: { should_be_enabled: true, extraFlag: false },
         externalResolver,
-    });
+    };
+
+    // @ts-expect-error
+    const resolver = new FlagResolver(config);
 
     const result = resolver.getAll();
 
+    // @ts-expect-error
     expect(result.should_be_enabled).toBe(true);
 });
 
@@ -67,15 +72,18 @@ test('should load experimental flags', () => {
             return false;
         },
     };
-    const resolver = new FlagResolver({
-        flags: {
-            extraFlag: false,
-            someFlag: true,
-        },
-        externalResolver,
-    });
 
+    const config = {
+        flags: { extraFlag: false, someFlag: true },
+        externalResolver,
+    };
+
+    // @ts-expect-error
+    const resolver = new FlagResolver(config);
+
+    // @ts-expect-error
     expect(resolver.isEnabled('someFlag')).toBe(true);
+    // @ts-expect-error
     expect(resolver.isEnabled('extraFlag')).toBe(false);
 });
 
@@ -88,14 +96,16 @@ test('should load experimental flags from external provider', () => {
         },
     };
 
-    const resolver = new FlagResolver({
-        flags: {
-            extraFlag: false,
-            someFlag: true,
-        },
+    const config = {
+        flags: { extraFlag: false, someFlag: true },
         externalResolver,
-    });
+    };
 
+    // @ts-expect-error
+    const resolver = new FlagResolver(config);
+
+    // @ts-expect-error
     expect(resolver.isEnabled('someFlag')).toBe(true);
+    // @ts-expect-error
     expect(resolver.isEnabled('extraFlag')).toBe(true);
 });

--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -4,6 +4,7 @@ import {
     IFlagContext,
     IFlags,
     IFlagResolver,
+    IFlagKey,
 } from '../types/experimental';
 export default class FlagResolver implements IFlagResolver {
     private experiments: IFlags;
@@ -18,7 +19,7 @@ export default class FlagResolver implements IFlagResolver {
     getAll(context?: IFlagContext): IFlags {
         const flags: IFlags = { ...this.experiments };
 
-        Object.keys(flags).forEach((flagName) => {
+        Object.keys(flags).forEach((flagName: IFlagKey) => {
             if (!this.experiments[flagName])
                 flags[flagName] = this.externalResolver.isEnabled(
                     flagName,
@@ -29,7 +30,7 @@ export default class FlagResolver implements IFlagResolver {
         return flags;
     }
 
-    isEnabled(expName: string, context?: IFlagContext): boolean {
+    isEnabled(expName: IFlagKey, context?: IFlagContext): boolean {
         if (this.experiments[expName]) {
             return true;
         }


### PR DESCRIPTION
Adding stricter types to `FlagResolver` can possibly help improve our DX - Help us prevent errors like typos, guide us to correctly add a flag when needed, and warn us of stray checks whenever we do a clean up at a later stage.