### PR TITLE
fix: cr permission actions

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
@@ -161,7 +161,12 @@ export const ChangeRequestConfiguration: VFC = () => {
                                                 approvals
                                             );
                                         }}
-                                        disabled={!hasAccess(UPDATE_PROJECT)}
+                                        disabled={
+                                            !hasAccess(
+                                                UPDATE_PROJECT,
+                                                projectId
+                                            )
+                                        }
                                         IconComponent={
                                             KeyboardArrowDownOutlined
                                         }
@@ -186,7 +191,6 @@ export const ChangeRequestConfiguration: VFC = () => {
                     <StyledBox data-loading>
                         <PermissionSwitch
                             checked={value}
-                            environmentId={original.environment}
                             projectId={projectId}
                             permission={UPDATE_PROJECT}
                             inputProps={{ 'aria-label': original.environment }}


### PR DESCRIPTION
Fixes an issue where `PermissionSwitch` would not update because we passed in environmentId and the UPDATE_PROJECT permission is only project specific. Also fixes an issue where hasAccess didn't take in projectId for UPDATE_PROJECT which is a project specific permission.