### PR TITLE
Make single project endpoint also return all features favorites

### DIFF
--- a/src/lib/routes/admin-api/project/features.ts
+++ b/src/lib/routes/admin-api/project/features.ts
@@ -403,10 +403,8 @@ export default class ProjectFeaturesController extends Controller {
         res: Response<FeaturesSchema>,
     ): Promise<void> {
         const { projectId } = req.params;
-        const { user } = req;
         const features = await this.featureService.getFeatureOverview({
             projectId,
-            userId: user.id,
         });
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/services/project-health-service.ts
+++ b/src/lib/services/project-health-service.ts
@@ -72,6 +72,7 @@ export default class ProjectHealthService {
         const features = await this.featureToggleService.getFeatureOverview({
             projectId,
             archived,
+            userId,
         });
         const members = await this.projectStore.getMembersCountByProject(
             projectId,

--- a/src/test/e2e/api/admin/favorites.e2e.test.ts
+++ b/src/test/e2e/api/admin/favorites.e2e.test.ts
@@ -111,16 +111,21 @@ test('should be favorited in project endpoint', async () => {
     const featureName = 'test-feature';
     await createFeature(featureName);
     await favoriteFeature(featureName);
+    await favoriteProject();
 
     const { body } = await app.request
-        .get(`/api/admin/projects/default/features`)
+        .get(`/api/admin/projects/default`)
         .set('Content-Type', 'application/json')
         .expect(200);
 
-    expect(body.features).toHaveLength(1);
-    expect(body.features[0]).toMatchObject({
-        name: featureName,
+    expect(body).toMatchObject({
         favorite: true,
+        features: [
+            {
+                name: featureName,
+                favorite: true,
+            },
+        ],
     });
 });
 
@@ -129,12 +134,11 @@ test('feature should not be favorited by default', async () => {
     await createFeature(featureName);
 
     const { body } = await app.request
-        .get(`/api/admin/projects/default/features`)
+        .get(`/api/admin/projects/default/features/${featureName}`)
         .set('Content-Type', 'application/json')
         .expect(200);
 
-    expect(body.features).toHaveLength(1);
-    expect(body.features[0]).toMatchObject({
+    expect(body).toMatchObject({
         name: featureName,
         favorite: false,
     });


### PR DESCRIPTION
Small update, that single project endpoint would also return features with favorites.