### PR TITLE
Fix PATCH variants (old endpoint) when variants per environment are enabled

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -305,9 +305,11 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 }
 
                 // this code sets variants at the feature level (should be deprecated with variants per environment)
-                const currentVariants = new Set(acc.variants);
+                const currentVariants = new Map(
+                    acc.variants?.map((v) => [v.name, v]),
+                );
                 variants.forEach((variant) => {
-                    currentVariants.add(variant);
+                    currentVariants.set(variant.name, variant);
                 });
                 acc.variants = Array.from(currentVariants.values());
 

--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -303,7 +303,13 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 if (withEnvironmentVariants) {
                     env.variants = variants;
                 }
-                acc.variants = variants;
+
+                // this code sets variants at the feature level (should be deprecated with variants per environment)
+                const currentVariants = new Set(acc.variants);
+                variants.forEach((variant) => {
+                    currentVariants.add(variant);
+                });
+                acc.variants = Array.from(currentVariants.values());
 
                 env.enabled = r.enabled;
                 env.type = r.environment_type;

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -143,6 +143,11 @@ export default class VariantsController extends Controller {
         });
     }
 
+    /**
+     * @deprecated - Variants should be fetched from featureService.getVariantsForEnv (since variants are now; since 4.18, connected to environments)
+     * @param req
+     * @param res
+     */
     async getVariants(
         req: Request<FeatureParams, any, any, any>,
         res: Response<FeatureVariantsSchema>,
@@ -158,7 +163,6 @@ export default class VariantsController extends Controller {
     ): Promise<void> {
         const { projectId, featureName } = req.params;
         const userName = extractUsername(req);
-
         const updatedFeature = await this.featureService.updateVariants(
             featureName,
             projectId,

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -645,6 +645,7 @@ class FeatureToggleService {
 
     /**
      * GET /api/admin/projects/:project/features/:featureName/variants
+     * @deprecated - Variants should be fetched from FeatureEnvironmentStore (since variants are now; since 4.18, connected to environments)
      * @param featureName
      * @return The list of variants
      */
@@ -1247,9 +1248,26 @@ class FeatureToggleService {
         newVariants: Operation[],
         createdBy: string,
     ): Promise<FeatureToggle> {
-        const oldVariants = await this.getVariants(featureName);
-        const { newDocument } = applyPatch(oldVariants, newVariants);
-        return this.saveVariants(featureName, project, newDocument, createdBy);
+        // const oldVariants = await this.getVariants(featureName);
+        // const { newDocument } = applyPatch(oldVariants, newVariants);
+        // NOTE: saveVariants iterates over all feature_environments overriding the variants in all environments
+        // this.saveVariants(featureName, project, newDocument, createdBy);
+        const ft =
+            await this.featureStrategiesStore.getFeatureToggleWithVariantEnvs(
+                featureName,
+            );
+        const promises = ft.environments.map((env) =>
+            this.updateVariantsOnEnv(
+                featureName,
+                project,
+                env.name,
+                newVariants,
+                createdBy,
+            ).then((resultingVariants) => (env.variants = resultingVariants)),
+        );
+        await Promise.all(promises);
+        ft.variants = ft.environments[0].variants;
+        return ft;
     }
 
     async updateVariantsOnEnv(
@@ -1270,6 +1288,7 @@ class FeatureToggleService {
             environment,
             newDocument,
             createdBy,
+            oldVariants,
         );
     }
 
@@ -1309,15 +1328,18 @@ class FeatureToggleService {
         environment: string,
         newVariants: IVariant[],
         createdBy: string,
+        oldVariants?: IVariant[],
     ): Promise<IVariant[]> {
         await variantsArraySchema.validateAsync(newVariants);
         const fixedVariants = this.fixVariantWeights(newVariants);
-        const oldVariants = (
-            await this.featureEnvironmentStore.get({
-                featureName,
-                environment,
-            })
-        ).variants;
+        const theOldVariants: IVariant[] =
+            oldVariants ||
+            (
+                await this.featureEnvironmentStore.get({
+                    featureName,
+                    environment,
+                })
+            ).variants;
 
         await this.eventStore.store(
             new EnvironmentVariantEvent({
@@ -1325,7 +1347,7 @@ class FeatureToggleService {
                 environment,
                 project: projectId,
                 createdBy,
-                oldVariants,
+                oldVariants: theOldVariants,
                 newVariants: fixedVariants,
             }),
         );

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1248,10 +1248,6 @@ class FeatureToggleService {
         newVariants: Operation[],
         createdBy: string,
     ): Promise<FeatureToggle> {
-        // const oldVariants = await this.getVariants(featureName);
-        // const { newDocument } = applyPatch(oldVariants, newVariants);
-        // NOTE: saveVariants iterates over all feature_environments overriding the variants in all environments
-        // this.saveVariants(featureName, project, newDocument, createdBy);
         const ft =
             await this.featureStrategiesStore.getFeatureToggleWithVariantEnvs(
                 featureName,


### PR DESCRIPTION
## About the changes
This PR addresses some issues when working with variants after migrating to variants per environment.

**Problem:** since PATCH `/api/admin/projects/default/features/${featureName}/variants` does not take into account `featureEnvironments`, when variantsPerEnvironment gets enabled, this method will override the variants in other environments (i.e. not doing a patch). This method has to be maintained because of backward compatibility but it has to be adapted to deal with variants per environment

https://linear.app/unleash/issue/2-476/when-using-patch-for-variants-without-environments-it-wipes-out

