### PR TITLE
Fix/cors max age

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should create default config 1`] = `
 {
-  "accessControlMaxAge": 172800,
+  "accessControlMaxAge": 86400,
   "additionalCspAllowedDomains": {
     "defaultSrc": [],
     "fontSrc": [],

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -452,7 +452,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
 
     const accessControlMaxAge = options.accessControlMaxAge
         ? options.accessControlMaxAge
-        : parseEnvVarNumber(process.env.ACCESS_CONTROL_MAX_AGE, 172800);
+        : parseEnvVarNumber(process.env.ACCESS_CONTROL_MAX_AGE, 86400);
 
     const clientFeatureCaching = loadClientCachingOptions(options);
 

--- a/src/lib/middleware/cors-origin-middleware.ts
+++ b/src/lib/middleware/cors-origin-middleware.ts
@@ -27,6 +27,7 @@ export const corsOriginMiddleware = (
                     frontendApiOrigins,
                 ),
                 maxAge: config.accessControlMaxAge,
+                exposedHeaders: 'ETag',
             });
         } catch (error) {
             callback(error);

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -156,6 +156,9 @@ export default class ProxyController extends Controller {
                 ProxyController.createContext(req),
             );
         }
+
+        res.set('Cache-control', 'public, max-age=2');
+
         this.services.openApiService.respondWithValidation(
             200,
             res,

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -988,6 +988,6 @@ test('should return maxAge header on options call', async () => {
         .set('Origin', 'https://example.com')
         .expect(204)
         .expect((res) => {
-            expect(res.headers['access-control-max-age']).toBe('172800');
+            expect(res.headers['access-control-max-age']).toBe('86400');
         });
 });

--- a/website/docs/reference/deploy/configuring-unleash.md
+++ b/website/docs/reference/deploy/configuring-unleash.md
@@ -130,7 +130,7 @@ unleash.start(unleashOptions);
   - `maxAge` - the time to cache features, set to 600 milliseconds by default - Overridable with (`CLIENT_FEATURE_CACHING_MAXAGE`) ) (accepts milliseconds)
 - **frontendApi** - Configuration options for the [Unleash front-end API](../front-end-api.md).
   - `refreshIntervalInMs` - how often (in milliseconds) front-end clients should refresh their data from the cache. Overridable with the `FRONTEND_API_REFRESH_INTERVAL_MS` environment variable.
-- **accessControlMaxAge** - You can configure the max-age of the Access-Control-Max-Age header. Defaults to 172800 seconds. Overridable with the `ACCESS_CONTROL_MAX_AGE` environment variable.
+- **accessControlMaxAge** - You can configure the max-age of the Access-Control-Max-Age header. Defaults to 86400 seconds. Overridable with the `ACCESS_CONTROL_MAX_AGE` environment variable.
 
 You can also set the environment variable `ENABLED_ENVIRONMENTS` to a comma delimited string of environment names to override environments.
 


### PR DESCRIPTION
This PR fixes to issues with the frontend API

**1. fix: update cors max age to match chromium defaults**

**source**: https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/cpp/cors/preflight_result.cc;drc=49e7c0b4886cac1f3d09dc046bd528c9c811a0fa;l=31

Update: setting it to 24 hours.

**2. fix: expose ETage for cross-origin requests.**
without exposing the ETag headers SDKs cannot cache correctly.