### PR TITLE
fix: allow import @server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -62,6 +62,9 @@ export default mergeConfig(
                     changeOrigin: true,
                 },
             },
+            fs: {
+                allow: ['..'],
+            },
         },
         plugins: [react(), tsconfigPaths(), svgr(), envCompatible()],
         esbuild: {


### PR DESCRIPTION
I noticed we had a Vite error when trying to run the front-end locally bound to `unleash-cloud` due to the new `@server` import. This fixes it by allowing serving fs from one level up.

Docs: https://vitejs.dev/config/server-options.html#server-fs-allow