### PR TITLE
fix: isPro check on change request configuration

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
@@ -23,14 +23,11 @@ export const ChangeRequestConfiguration = () => {
     const projectId = useRequiredPathParam('projectId');
     const projectName = useProjectNameOrId(projectId);
     const { hasAccess } = useContext(AccessContext);
-    const { isOss, uiConfig } = useUiConfig();
-    const isPro = !(
-        Boolean(uiConfig.versionInfo?.current.oss) ||
-        Boolean(uiConfig.versionInfo?.current.enterprise)
-    );
+    const { isOss, isPro } = useUiConfig();
+
     usePageTitle(`Project change request – ${projectName}`);
 
-    if (isOss() || isPro) {
+    if (isOss() || isPro()) {
         return (
             <PageContent
                 header={<PageHeader title="Change request configuration" />}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-487/bug-change-request-badge-is-not-working-on-pro
Using the new `isPro()` from `useUiConfig()` seems to fix this in Pro, correctly showing the premium feature info:

![image](https://user-images.githubusercontent.com/14320932/205958034-f412471a-c732-425a-bb14-64b62ea1e665.png)

The errors described in the issue should be fixed by the new `useEnterpriseSWR`. See: https://unleash-internal.slack.com/archives/C046LV6HH6W/p1670337216187539?thread_ts=1670331887.521059&cid=C046LV6HH6W