### PR TITLE
feat: add capability to write heap snapshot.

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -126,6 +126,7 @@ exports[`should create default config 1`] = `
   "server": {
     "baseUriPath": "",
     "cdnPrefix": undefined,
+    "enableHeapSnapshotEnpoint": false,
     "enableRequestLogger": false,
     "gracefulShutdownEnable": true,
     "gracefulShutdownTimeout": 1000,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -165,6 +165,10 @@ const defaultServerOption: IServerOption = {
     cdnPrefix: process.env.CDN_PREFIX,
     unleashUrl: process.env.UNLEASH_URL || 'http://localhost:4242',
     serverMetrics: true,
+    enableHeapSnapshotEnpoint: parseEnvVarBoolean(
+        process.env.ENABLE_HEAP_SNAPSHOT_ENPOINT,
+        false,
+    ),
     keepAliveTimeout: minutesToMilliseconds(1),
     headersTimeout: secondsToMilliseconds(61),
     enableRequestLogger: false,

--- a/src/lib/routes/backstage.ts
+++ b/src/lib/routes/backstage.ts
@@ -19,7 +19,7 @@ class BackstageController extends Controller {
         }
 
         if (config.server.enableHeapSnapshotEnpoint) {
-            this.get('/heapSnapshot', async (req, res) => {
+            this.get('/heap-snapshot', async (req, res) => {
                 writeHeapSnapshot();
                 res.status(200);
                 res.end('Snapshot written');

--- a/src/lib/routes/backstage.ts
+++ b/src/lib/routes/backstage.ts
@@ -1,3 +1,4 @@
+import { writeHeapSnapshot } from 'v8';
 import { register as prometheusRegister } from 'prom-client';
 import Controller from './controller';
 import { IUnleashConfig } from '../types/option';
@@ -14,6 +15,14 @@ class BackstageController extends Controller {
             this.get('/prometheus', async (req, res) => {
                 res.set('Content-Type', prometheusRegister.contentType);
                 res.end(await prometheusRegister.metrics());
+            });
+        }
+
+        if (config.server.enableHeapSnapshotEnpoint) {
+            this.get('/heapSnapshot', async (req, res) => {
+                writeHeapSnapshot();
+                res.status(200);
+                res.end('Snapshot written');
             });
         }
     }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -79,6 +79,7 @@ export interface IServerOption {
     cdnPrefix?: string;
     unleashUrl: string;
     serverMetrics: boolean;
+    enableHeapSnapshotEnpoint: boolean;
     enableRequestLogger: boolean;
     gracefulShutdownEnable: boolean;
     gracefulShutdownTimeout: number;

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -23,6 +23,7 @@ process.nextTick(async () => {
                     // keepAliveTimeout: 1,
                     gracefulShutdownEnable: true,
                     // cdnPrefix: 'https://cdn.getunleash.io/unleash/v4.4.1',
+                    enableHeapSnapshotEnpoint: true,
                 },
                 logLevel: LogLevel.debug,
                 enableOAS: true,


### PR DESCRIPTION
Is protected behind a config option called `enableHeapSnapshotEnpoint`. When API endpoint is triggered it will write a heapSnapshot to disk. 

Steps to create heap snapshot:

1. Add env variable `ENABLE_HEAP_SNAPSHOT_ENPOINT=true`. 
2. Call this endpoint: `/internal-backstage/heapSnapshot`
3. Download the created heapdump from the server. 

The snapshot can be loaded in the chrome dev-tool to analysis. 