### PR TITLE
fix: tags endpoint returning 404 when featureId is not set

### DIFF
--- a/frontend/src/hooks/api/getters/useTags/useTags.ts
+++ b/frontend/src/hooks/api/getters/useTags/useTags.ts
@@ -1,8 +1,9 @@
-import useSWR, { mutate, SWRConfiguration } from 'swr';
+import { mutate, SWRConfiguration } from 'swr';
 import { useState, useEffect } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import { ITag } from 'interfaces/tags';
 import handleErrorResponses from '../httpErrorResponseHandler';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 
 const useTags = (featureId: string, options: SWRConfiguration = {}) => {
     const fetcher = async () => {
@@ -15,7 +16,13 @@ const useTags = (featureId: string, options: SWRConfiguration = {}) => {
 
     const KEY = `api/admin/features/${featureId}/tags`;
 
-    const { data, error } = useSWR(KEY, fetcher, options);
+    const { data, error } = useConditionalSWR<{ tags: ITag[] }>(
+        Boolean(featureId),
+        { tags: [] },
+        KEY,
+        fetcher,
+        options
+    );
     const [loading, setLoading] = useState(!error && !data);
 
     const refetch = () => {


### PR DESCRIPTION
Leverages the new `useConditionalSWR` hook to fix the underlying issue in the `useTags` hook, preventing edge cases where we try to fetch when featureId is not correctly set.