### PR TITLE
Fix strategy screen 404

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -128,7 +128,9 @@ export const FeatureStrategyCreate = () => {
         }
     };
 
-    if (!data) return null;
+    const emptyFeature = !data || !data.project;
+
+    if (emptyFeature) return null;
 
     return (
         <FormTemplate


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Bug description: 
Add strategy screen has a concept of empty feature. 
Empty string projectId is propagated and ends up in usePendingChangeRequest: `api/admin/projects/${project}/change-requests/pending`.
Since project is empty we get `api/admin/projects/change-requests/pending` and this one hits the health overview endpoint.

This PR basically stops rendering when feature is empty

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
