### PR TITLE
docs: various fixes

### DIFF
--- a/website/docs/reference/front-end-api.md
+++ b/website/docs/reference/front-end-api.md
@@ -2,13 +2,14 @@
 title: Front-end API access
 ---
 
-<!-- TODO: link blog post with release notes -->
+:::info Availability
+
+The Unleash front-end API was released in Unleash 4.18. You can read more in the [Unleash 4.18 release blog post](https://www.getunleash.io/blog/new-features-direct-client-side-front-end-api-access-sync-user-groups-and-clone-environments).
 
 :::
 
 The **Unleash front-end API** offers a simplified workflow for connecting a client-side (front-end) applications to Unleash. It provides the exact same API as the [Unleash proxy](../reference/unleash-proxy.md). The front-end API is a quick and easy way to add Unleash to single-page applications and mobile apps.
 
-<!-- TODO: image illustrating connection -->
 
 Compared to using the Unleash proxy, using the Unleash front-end API has both benefits and drawbacks. The benefits are:
 

--- a/website/docs/reference/impression-data.md
+++ b/website/docs/reference/impression-data.md
@@ -2,9 +2,9 @@
 title: Impression data
 ---
 
-:::info
+:::info Availability
 
-Availability The impression data feature was introduced in **Unleash 4.7**. It is available in the JavaScript-based proxy clients and in some server-side SDKs. Please refer to the [SDK compatibility table](../reference/sdks/index.md#server-side-sdk-compatibility-table) for an overview of server-side SDKs that support it.
+The impression data feature was introduced in **Unleash 4.7**. It is available in the JavaScript-based proxy clients and in some server-side SDKs. Please refer to the [SDK compatibility table](../reference/sdks/index.md#server-side-sdk-compatibility-table) for an overview of server-side SDKs that support it.
 
 :::
 

--- a/website/docs/reference/unleash-proxy.md
+++ b/website/docs/reference/unleash-proxy.md
@@ -143,9 +143,9 @@ The Unleash Proxy has a very simple API. It takes the [Unleash Context](../refer
 
 ### OpenAPI integration and API documentation {#openapi}
 
-:::info
+:::info Availability
 
-Availability The OpenAPI integration is available in versions 0.9 and later of the Unleash proxy.
+The OpenAPI integration is available in versions 0.9 and later of the Unleash proxy.
 
 :::
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -172,7 +172,10 @@ module.exports = {
                         to: '/reference/archived-toggles',
                     },
                     {
-                        from: '/advanced/custom-activation-strategy',
+                        from: [
+                            '/advanced/custom-activation-strategy',
+                            '/advanced/custom_activation_strategy',
+                        ],
                         to: '/reference/custom-activation-strategies',
                     },
                     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -365,7 +365,7 @@ module.exports = {
                         to: '/reference/sdks/javascript-browser',
                     },
                     {
-                        from: '/sdks/react',
+                        from: ['/sdks/proxy-react', '/sdks/react'],
                         to: '/reference/sdks/react',
                     },
                     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -238,7 +238,10 @@ module.exports = {
                         to: '/reference/deploy/getting-started',
                     },
                     {
-                        from: '/deploy/configuring_unleash',
+                        from: [
+                            '/docs/deploy/configuring_unleash',
+                            '/deploy/configuring_unleash',
+                        ],
                         to: '/reference/deploy/configuring-unleash',
                     },
                     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -440,7 +440,7 @@ module.exports = {
                     {
                         from: [
                             '/user_guide/quickstart',
-                            'docs/getting_started',
+                            '/docs/getting_started',
                         ],
                         to: '/tutorials/quickstart',
                     },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -438,7 +438,10 @@ module.exports = {
                         to: '/tutorials/important-concepts',
                     },
                     {
-                        from: '/user_guide/quickstart',
+                        from: [
+                            '/user_guide/quickstart',
+                            'docs/getting_started',
+                        ],
                         to: '/tutorials/quickstart',
                     },
                     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -325,6 +325,7 @@ module.exports = {
                             '/sdks',
                             '/user_guide/client-sdk',
                             '/client-sdk',
+                            '/docs/user_guide/connect_sdk',
                             '/user_guide/connect_sdk',
                             '/sdks/community',
                         ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -368,7 +368,10 @@ module.exports = {
                         to: '/reference/sdks/ios-proxy',
                     },
                     {
-                        from: '/sdks/javascript-browser',
+                        from: [
+                            '/sdks/proxy-javascript',
+                            '/sdks/javascript-browser',
+                        ],
                         to: '/reference/sdks/javascript-browser',
                     },
                     {


### PR DESCRIPTION
## What

This PR contains a number of minor fixes to the docs in terms of formatting and redirects. The changes are:

-   Adding an availability notice for the front-end API reference docs (with links to the release blog post).

-   Fix malformed admonition headers in the Unleash proxy docs and impression data docs.

-   Add missing redirects:

    -   `/advanced/custom_activation_strategy` -> `/reference/custom-activation-strategies`
    -   `/docs/deploy/configuring_unleash` -> `/reference/deploy/configuring-unleash`
    -   `/docs/user_guide/connect_sdk` -> `/reference/sdks`(this one goes to the SDKs doc instead of the quickstart because there's more comprehensive information there and because `/user_guide/connect_sdk` already goes there)
    -   `/sdks/proxy-javascript` -> `/reference/sdks/javascript-browser`
    -   `/sdks/proxy-react`-> `/reference/sdks/react`
    -   `/docs/getting_started` -> `/tutorials/quickstart` (this does not go to "Deploy: getting started" because that is its own link)

## Why

Because keeping the docs up to date and accessible is important.