### PR TITLE
chore: remove constraints announcements from readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="center">
 
-## 🚀 Unleash 4.16 brings powerful Constraints feature to OSS users. [Read more →](https://www.getunleash.io/blog/unleash-brings-powerful-constraints-feature-to-oss-users?utm_source=github&utm_medium=community&utm_campaign=constraints_04102026)
-
 <a href="https://getunleash.io" title="Unleash - Create with freedom. Release with confidence">
     <img src="./.github/github_header_opaque_landscape.svg" alt="The Unleash website">
 </a>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,12 +26,6 @@ module.exports = {
             apiKey: 'dc9c4491fcf9143ee34015f22d1dd9d6',
             indexName: 'getunleash',
         },
-        announcementBar: {
-            id: 'strategy-constraints-announcement',
-            content:
-                '🚀 Unleash brings powerful Constraints feature to OSS users. <a href=https://www.getunleash.io/blog/unleash-brings-powerful-constraints-feature-to-oss-users title="Unleash blog: Constraints are now available to open-source users">Read more</a> →',
-            isCloseable: true,
-        },
         navbar: {
             title: 'Unleash',
             logo: {


### PR DESCRIPTION
## What

This change removes the Unleash 4.16 constraints announcement from readme and from the docs.

## Why

It feels like 4.16 has been out for long enough now. Gearing up for version 4.19, it may be time to take this away.

## Discussion

However, open-sourcing constraints was (and still is) a big deal, so it might be worth keeping the banner around, but maybe in a more subdued format? Something like "did you know Unleash's constraints feature is open source, now?".