### PR TITLE
Remove full width access tab

### DIFF
--- a/frontend/cypress/integration/projects/access.spec.ts
+++ b/frontend/cypress/integration/projects/access.spec.ts
@@ -69,7 +69,7 @@ describe('project-access', () => {
 
     beforeEach(() => {
         cy.login();
-        cy.visit(`/projects/${groupAndProjectName}/access`);
+        cy.visit(`/projects/${groupAndProjectName}/settings/access`);
         if (document.querySelector("[data-testid='CLOSE_SPLASH']")) {
             cy.get("[data-testid='CLOSE_SPLASH']").click();
         }

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCard.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCard.tsx
@@ -126,7 +126,7 @@ export const GroupCard = ({ group }: IGroupCardProps) => {
                                             onClick={e => {
                                                 e.preventDefault();
                                                 navigate(
-                                                    `/projects/${project}/access`
+                                                    `/projects/${project}/settings/access`
                                                 );
                                             }}
                                             color="secondary"

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -19,13 +19,7 @@ import {
 } from 'component/providers/AccessProvider/permissions';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import {
-    Navigate,
-    redirect,
-    Route,
-    Routes,
-    useLocation,
-} from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { DeleteProjectDialogue } from './DeleteProject/DeleteProjectDialogue';
 import { ProjectLog } from './ProjectLog/ProjectLog';
 import { ChangeRequestOverview } from 'component/changeRequest/ChangeRequestOverview/ChangeRequestOverview';

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -8,7 +8,6 @@ import { Delete, Edit } from '@mui/icons-material';
 import useToast from 'hooks/useToast';
 import useQueryParams from 'hooks/useQueryParams';
 import React, { useEffect, useMemo, useState } from 'react';
-import { ProjectAccess } from '../ProjectAccess/ProjectAccess';
 import ProjectEnvironment from '../ProjectEnvironment/ProjectEnvironment';
 import { ProjectFeaturesArchive } from './ProjectFeaturesArchive/ProjectFeaturesArchive';
 import ProjectOverview from './ProjectOverview';
@@ -20,7 +19,13 @@ import {
 } from 'component/providers/AccessProvider/permissions';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import {
+    Navigate,
+    redirect,
+    Route,
+    Routes,
+    useLocation,
+} from 'react-router-dom';
 import { DeleteProjectDialogue } from './DeleteProject/DeleteProjectDialogue';
 import { ProjectLog } from './ProjectLog/ProjectLog';
 import { ChangeRequestOverview } from 'component/changeRequest/ChangeRequestOverview/ChangeRequestOverview';
@@ -270,6 +275,15 @@ const Project = () => {
             />
             <Routes>
                 <Route path="health" element={<ProjectHealth />} />
+                <Route
+                    path="access/*"
+                    element={
+                        <Navigate
+                            replace
+                            to={`/projects/${projectId}/settings/access`}
+                        />
+                    }
+                />
                 <Route path="environments" element={<ProjectEnvironment />} />
                 <Route path="archive" element={<ProjectFeaturesArchive />} />
                 <Route path="logs" element={<ProjectLog />} />

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -93,20 +93,6 @@ const Project = () => {
                 path: `${basePath}/health`,
                 name: 'health',
             },
-            ...(!isChangeRequestFlagEnabled
-                ? [
-                      {
-                          title: 'Access',
-                          path: `${basePath}/access`,
-                          name: 'access',
-                      },
-                      {
-                          title: 'Environments',
-                          path: `${basePath}/environments`,
-                          name: 'environments',
-                      },
-                  ]
-                : []),
             {
                 title: 'Archive',
                 path: `${basePath}/archive`,
@@ -115,28 +101,23 @@ const Project = () => {
             ...(isChangeRequestFlagEnabled
                 ? [
                       {
-                          title: 'Project settings',
-                          path: `${basePath}/settings`,
-                          name: 'settings',
+                          title: 'Change requests',
+                          path: `${basePath}/change-requests`,
+                          name: 'change-request',
                       },
                   ]
                 : []),
+            {
+                title: 'Project settings',
+                path: `${basePath}/settings`,
+                name: 'settings',
+            },
             {
                 title: 'Event log',
                 path: `${basePath}/logs`,
                 name: 'logs',
             },
         ];
-
-        const changeRequestTab = {
-            title: 'Change requests',
-            path: `${basePath}/change-requests`,
-            name: 'change-request',
-        };
-
-        if (isChangeRequestFlagEnabled) {
-            tabArray.splice(tabArray.length - 2, 0, changeRequestTab);
-        }
         return tabArray;
     }, [isChangeRequestFlagEnabled]);
 
@@ -155,7 +136,6 @@ const Project = () => {
                 title: text,
             });
         }
-
         /* eslint-disable-next-line */
     }, []);
 
@@ -290,7 +270,6 @@ const Project = () => {
             />
             <Routes>
                 <Route path="health" element={<ProjectHealth />} />
-                <Route path="access/*" element={<ProjectAccess />} />
                 <Route path="environments" element={<ProjectEnvironment />} />
                 <Route path="archive" element={<ProjectFeaturesArchive />} />
                 <Route path="logs" element={<ProjectLog />} />

--- a/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
@@ -18,12 +18,7 @@ interface IProjectInfoProps {
     description?: string;
 }
 
-const ProjectInfo = ({
-    id,
-    memberCount,
-    health,
-    description,
-}: IProjectInfoProps) => {
+const ProjectInfo = ({ id, memberCount, health }: IProjectInfoProps) => {
     const { classes: themeStyles } = useThemeStyles();
     const { classes: styles } = useStyles();
     const { uiConfig } = useUiConfig();
@@ -31,7 +26,7 @@ const ProjectInfo = ({
     let link = `/admin/users`;
 
     if (uiConfig?.versionInfo?.current?.enterprise) {
-        link = `/projects/${id}/access`;
+        link = `/projects/${id}/settings/access`;
     }
 
     return (


### PR DESCRIPTION
1. Now all redirect to access tab are going to narrow access tab
2. Remove wide access tab completely, so now it is not possible to access it via url
3. Project settings tab is visible by default now for **ALL USERS**