### PR TITLE
fix: favorite tooltip topleft flash

### DIFF
--- a/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTable.styles.ts
+++ b/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTable.styles.ts
@@ -6,7 +6,7 @@ export const useStyles = makeStyles()(() => ({
         width: '100%',
         '&:hover': {
             '.show-row-hover': {
-                display: 'inherit',
+                opacity: 1,
             },
         },
     },

--- a/frontend/src/component/common/Table/cells/FavoriteIconCell/FavoriteIconCell.tsx
+++ b/frontend/src/component/common/Table/cells/FavoriteIconCell/FavoriteIconCell.tsx
@@ -14,7 +14,7 @@ interface IFavoriteIconCellProps {
 
 const InactiveIconButton = styled(IconButton)(({ theme }) => ({
     color: theme.palette.primary.main,
-    display: 'none',
+    opacity: 0,
 }));
 
 export const FavoriteIconCell: VFC<IFavoriteIconCellProps> = ({


### PR DESCRIPTION
Fixes an issue where the tooltip would flash on the top left when going through the rows.