### PR TITLE
feat: expose number of registered applications metric

### DIFF
--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -182,14 +182,16 @@ export default class ClientInstanceStore implements IClientInstanceStore {
         return rows.map((r) => r.app_name);
     }
 
-    async getDistinctApplicationsCount(): Promise<number> {
-        return this.db
-            .from(TABLE)
+    async getDistinctApplicationsCount(daysBefore?: number): Promise<number> {
+        let query = this.db.from(TABLE);
+        if (daysBefore) {
+            const after = new Date();
+            after.setDate(after.getDate() - daysBefore);
+            query = query.where('last_seen', '>', after);
+        }
+        return query
             .countDistinct('app_name')
-            .then((res) => {
-                console.log(res);
-                return Number(res[0].count);
-            });
+            .then((res) => Number(res[0].count));
     }
 
     async deleteForApplication(appName: string): Promise<void> {

--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -6,7 +6,7 @@ import {
     IClientInstanceStore,
     INewClientInstance,
 } from '../types/stores/client-instance-store';
-import { hoursToMilliseconds } from 'date-fns';
+import { hoursToMilliseconds, subDays } from 'date-fns';
 import Timeout = NodeJS.Timeout;
 
 const metricsHelper = require('../util/metrics-helper');
@@ -185,9 +185,11 @@ export default class ClientInstanceStore implements IClientInstanceStore {
     async getDistinctApplicationsCount(daysBefore?: number): Promise<number> {
         let query = this.db.from(TABLE);
         if (daysBefore) {
-            const after = new Date();
-            after.setDate(after.getDate() - daysBefore);
-            query = query.where('last_seen', '>', after);
+            query = query.where(
+                'last_seen',
+                '>',
+                subDays(new Date(), daysBefore),
+            );
         }
         return query
             .countDistinct('app_name')

--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -182,6 +182,16 @@ export default class ClientInstanceStore implements IClientInstanceStore {
         return rows.map((r) => r.app_name);
     }
 
+    async getDistinctApplicationsCount(): Promise<number> {
+        return this.db
+            .from(TABLE)
+            .countDistinct('app_name')
+            .then((res) => {
+                console.log(res);
+                return Number(res[0].count);
+            });
+    }
+
     async deleteForApplication(appName: string): Promise<void> {
         return this.db(TABLE).where('app_name', appName).del();
     }

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -127,7 +127,7 @@ test('should collect metrics for feature toggle size', async () => {
         setTimeout(done, 10);
     });
     const metrics = await prometheusRegister.metrics();
-    expect(metrics).toMatch(/client_apps_total 0/);
+    expect(metrics).toMatch(/client_apps_total{range="(.*)"} 0/);
 });
 
 test('Should collect metrics for database', async () => {

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -122,6 +122,14 @@ test('should collect metrics for feature toggle size', async () => {
     expect(metrics).toMatch(/feature_toggles_total{version="(.*)"} 0/);
 });
 
+test('should collect metrics for feature toggle size', async () => {
+    await new Promise((done) => {
+        setTimeout(done, 10);
+    });
+    const metrics = await prometheusRegister.metrics();
+    expect(metrics).toMatch(/client_apps_total 0/);
+});
+
 test('Should collect metrics for database', async () => {
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/db_pool_max/);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -118,6 +118,11 @@ export default class MetricsMonitor {
             help: 'Number of strategies',
         });
 
+        const clientAppsTotal = new client.Gauge({
+            name: 'client_apps_total',
+            help: 'Number of registered client apps',
+        });
+
         const samlEnabled = new client.Gauge({
             name: 'saml_enabled',
             help: 'Whether SAML is enabled',
@@ -170,6 +175,9 @@ export default class MetricsMonitor {
 
                 oidcEnabled.reset();
                 oidcEnabled.set(stats.OIDCenabled ? 1 : 0);
+
+                clientAppsTotal.reset();
+                clientAppsTotal.set(stats.clientApps);
             } catch (e) {}
         }
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -120,7 +120,8 @@ export default class MetricsMonitor {
 
         const clientAppsTotal = new client.Gauge({
             name: 'client_apps_total',
-            help: 'Number of registered client apps',
+            help: 'Number of registered client apps aggregated by range by last seen',
+            labelNames: ['range'],
         });
 
         const samlEnabled = new client.Gauge({
@@ -177,7 +178,11 @@ export default class MetricsMonitor {
                 oidcEnabled.set(stats.OIDCenabled ? 1 : 0);
 
                 clientAppsTotal.reset();
-                clientAppsTotal.set(stats.clientApps);
+                stats.clientApps.forEach((clientStat) =>
+                    clientAppsTotal
+                        .labels({ range: clientStat.range })
+                        .set(clientStat.count),
+                );
             } catch (e) {}
         }
 

--- a/src/lib/services/instance-stats-service.ts
+++ b/src/lib/services/instance-stats-service.ts
@@ -1,7 +1,7 @@
 import { sha256 } from 'js-sha256';
 import { Logger } from '../logger';
 import { IUnleashConfig } from '../types/option';
-import { IUnleashStores } from '../types/stores';
+import { IClientInstanceStore, IUnleashStores } from '../types/stores';
 import { IContextFieldStore } from '../types/stores/context-field-store';
 import { IEnvironmentStore } from '../types/stores/environment-store';
 import { IFeatureToggleStore } from '../types/stores/feature-toggle-store';
@@ -31,6 +31,7 @@ export interface InstanceStats {
     strategies: number;
     SAMLenabled: boolean;
     OIDCenabled: boolean;
+    clientApps: number;
 }
 
 interface InstanceStatsSigned extends InstanceStats {
@@ -62,6 +63,8 @@ export class InstanceStatsService {
 
     private settingStore: ISettingStore;
 
+    private clientInstanceStore: IClientInstanceStore;
+
     constructor(
         {
             featureToggleStore,
@@ -74,6 +77,7 @@ export class InstanceStatsService {
             segmentStore,
             roleStore,
             settingStore,
+            clientInstanceStore,
         }: Pick<
             IUnleashStores,
             | 'featureToggleStore'
@@ -86,6 +90,7 @@ export class InstanceStatsService {
             | 'segmentStore'
             | 'roleStore'
             | 'settingStore'
+            | 'clientInstanceStore'
         >,
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
         versionService: VersionService,
@@ -101,6 +106,7 @@ export class InstanceStatsService {
         this.roleStore = roleStore;
         this.versionService = versionService;
         this.settingStore = settingStore;
+        this.clientInstanceStore = clientInstanceStore;
         this.logger = getLogger('services/stats-service.js');
     }
 
@@ -141,6 +147,7 @@ export class InstanceStatsService {
             strategies,
             SAMLenabled,
             OIDCenabled,
+            clientApps,
         ] = await Promise.all([
             this.getToggleCount(),
             this.userStore.count(),
@@ -153,6 +160,7 @@ export class InstanceStatsService {
             this.strategyStore.count(),
             this.hasSAML(),
             this.hasOIDC(),
+            this.clientInstanceStore.getDistinctApplicationsCount(),
         ]);
 
         return {
@@ -171,6 +179,7 @@ export class InstanceStatsService {
             strategies,
             SAMLenabled,
             OIDCenabled,
+            clientApps,
         };
     }
 

--- a/src/lib/types/stores/client-instance-store.ts
+++ b/src/lib/types/stores/client-instance-store.ts
@@ -22,5 +22,6 @@ export interface IClientInstanceStore
     insert(details: INewClientInstance): Promise<void>;
     getByAppName(appName: string): Promise<IClientInstance[]>;
     getDistinctApplications(): Promise<string[]>;
+    getDistinctApplicationsCount(): Promise<number>;
     deleteForApplication(appName: string): Promise<void>;
 }

--- a/src/lib/types/stores/client-instance-store.ts
+++ b/src/lib/types/stores/client-instance-store.ts
@@ -22,6 +22,6 @@ export interface IClientInstanceStore
     insert(details: INewClientInstance): Promise<void>;
     getByAppName(appName: string): Promise<IClientInstance[]>;
     getDistinctApplications(): Promise<string[]>;
-    getDistinctApplicationsCount(): Promise<number>;
+    getDistinctApplicationsCount(daysBefore?: number): Promise<number>;
     deleteForApplication(appName: string): Promise<void>;
 }

--- a/src/test/fixtures/fake-client-instance-store.ts
+++ b/src/test/fixtures/fake-client-instance-store.ts
@@ -75,6 +75,10 @@ export default class FakeClientInstanceStore implements IClientInstanceStore {
         return Array.from(apps.values());
     }
 
+    async getDistinctApplicationsCount(): Promise<number> {
+        return this.getDistinctApplications().then((apps) => apps.length);
+    }
+
     async insert(details: INewClientInstance): Promise<void> {
         this.instances.push({ createdAt: new Date(), ...details });
     }


### PR DESCRIPTION
## About the changes
This metric will expose an aggregated view of how many client applications are registered in Unleash. Since applications are ephemeral we are exposing this metric in different time windows based on when the application was last seen. 

The caveat is that we issue a database query for each new range we want to add. Hopefully, this should not be a problem because:
a) the amount of ranges we'd expose is small and unlikely to grow
b) this is currently updated at startup time and even if we update it on a scheduled basis the refresh rate will be rather sparse

## Sample data
This is how metrics will look like
```
# HELP client_apps_total Number of registered client apps aggregated by range by last seen
# TYPE client_apps_total gauge
client_apps_total{range="allTime"} 3
client_apps_total{range="30d"} 3
client_apps_total{range="7d"} 2
```