### PR TITLE
feature: add query support to features endpoint

### DIFF
--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIV3 } from 'openapi-types';
 import {
+    adminFeaturesQuerySchema,
     addonParameterSchema,
     addonSchema,
     addonsSchema,
@@ -131,6 +132,7 @@ import apiVersion from '../util/version';
 
 // All schemas in `openapi/spec` should be listed here.
 export const schemas = {
+    adminFeaturesQuerySchema,
     addonParameterSchema,
     addonSchema,
     addonsSchema,

--- a/src/lib/openapi/spec/admin-features-query-schema.test.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.test.ts
@@ -1,0 +1,21 @@
+import { validateSchema } from '../validate';
+import { AdminFeaturesQuerySchema } from './admin-features-query-schema';
+
+test('adminFeaturesQuerySchema empty', () => {
+    const data: AdminFeaturesQuerySchema = {};
+
+    expect(
+        validateSchema('#/components/schemas/adminFeaturesQuerySchema', data),
+    ).toBeUndefined();
+});
+
+test('adminFeatureQuerySchema all fields', () => {
+    const data: AdminFeaturesQuerySchema = {
+        tag: [['some-tag', 'some-other-tag']],
+        namePrefix: 'some-prefix',
+    };
+
+    expect(
+        validateSchema('#/components/schemas/adminFeaturesQuerySchema', data),
+    ).toBeUndefined();
+});

--- a/src/lib/openapi/spec/admin-features-query-schema.test.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.test.ts
@@ -11,11 +11,21 @@ test('adminFeaturesQuerySchema empty', () => {
 
 test('adminFeatureQuerySchema all fields', () => {
     const data: AdminFeaturesQuerySchema = {
-        tag: ['some-tag', 'some-other-tag'],
+        tag: ['simple:some-tag', 'simple:some-other-tag'],
         namePrefix: 'some-prefix',
     };
 
     expect(
         validateSchema('#/components/schemas/adminFeaturesQuerySchema', data),
     ).toBeUndefined();
+});
+
+test('pattern validation should deny invalid tags', () => {
+    const data: AdminFeaturesQuerySchema = {
+        tag: ['something', 'somethingelse'],
+    };
+
+    expect(
+        validateSchema('#/components/schemas/adminFeaturesQuerySchema', data),
+    ).toBeDefined();
 });

--- a/src/lib/openapi/spec/admin-features-query-schema.test.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.test.ts
@@ -11,7 +11,7 @@ test('adminFeaturesQuerySchema empty', () => {
 
 test('adminFeatureQuerySchema all fields', () => {
     const data: AdminFeaturesQuerySchema = {
-        tag: [['some-tag', 'some-other-tag']],
+        tag: ['some-tag', 'some-other-tag'],
         namePrefix: 'some-prefix',
     };
 

--- a/src/lib/openapi/spec/admin-features-query-schema.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.ts
@@ -4,18 +4,20 @@ export const adminFeaturesQuerySchema = {
     $id: '#/components/schemas/adminFeaturesQuerySchema',
     type: 'object',
     additionalProperties: true,
+    description: 'Used to filter feature toggles from the admin-api',
     properties: {
         tag: {
             type: 'array',
             items: {
-                type: 'array',
-                items: {
-                    type: 'string',
-                },
+                type: 'string',
             },
+            description:
+                'Used to filter by tags. For each entry, a TAGTYPE:TAGVALUE is expected',
         },
         namePrefix: {
             type: 'string',
+            description:
+                'A case-insensitive prefix filter for the names of feature toggles',
         },
     },
     components: {},

--- a/src/lib/openapi/spec/admin-features-query-schema.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.ts
@@ -1,0 +1,26 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const adminFeaturesQuerySchema = {
+    $id: '#/components/schemas/adminFeaturesQuerySchema',
+    type: 'object',
+    additionalProperties: true,
+    properties: {
+        tag: {
+            type: 'array',
+            items: {
+                type: 'array',
+                items: {
+                    type: 'string',
+                },
+            },
+        },
+        namePrefix: {
+            type: 'string',
+        },
+    },
+    components: {},
+} as const;
+
+export type AdminFeaturesQuerySchema = FromSchema<
+    typeof adminFeaturesQuerySchema
+>;

--- a/src/lib/openapi/spec/admin-features-query-schema.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.ts
@@ -4,7 +4,6 @@ export const adminFeaturesQuerySchema = {
     $id: '#/components/schemas/adminFeaturesQuerySchema',
     type: 'object',
     additionalProperties: false,
-    description: 'Used to filter feature toggles from the admin-api',
     properties: {
         tag: {
             type: 'array',

--- a/src/lib/openapi/spec/admin-features-query-schema.ts
+++ b/src/lib/openapi/spec/admin-features-query-schema.ts
@@ -3,21 +3,24 @@ import { FromSchema } from 'json-schema-to-ts';
 export const adminFeaturesQuerySchema = {
     $id: '#/components/schemas/adminFeaturesQuerySchema',
     type: 'object',
-    additionalProperties: true,
+    additionalProperties: false,
     description: 'Used to filter feature toggles from the admin-api',
     properties: {
         tag: {
             type: 'array',
             items: {
                 type: 'string',
+                pattern: '\\w+:\\w+',
             },
             description:
                 'Used to filter by tags. For each entry, a TAGTYPE:TAGVALUE is expected',
+            example: ['simple:mytag'],
         },
         namePrefix: {
             type: 'string',
             description:
                 'A case-insensitive prefix filter for the names of feature toggles',
+            example: 'demo.part1',
         },
     },
     components: {},

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -111,6 +111,7 @@ export * from './public-signup-tokens-schema';
 export * from './upsert-context-field-schema';
 export * from './validate-edge-tokens-schema';
 export * from './client-features-query-schema';
+export * from './admin-features-query-schema';
 export * from './playground-constraint-schema';
 export * from './create-feature-strategy-schema';
 export * from './set-strategy-sort-order-schema';

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -191,7 +191,6 @@ exports[`should serve the OpenAPI spec 1`] = `
       },
       "adminFeaturesQuerySchema": {
         "additionalProperties": false,
-        "description": "Used to filter feature toggles from the admin-api",
         "properties": {
           "namePrefix": {
             "description": "A case-insensitive prefix filter for the names of feature toggles",

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -189,6 +189,24 @@ exports[`should serve the OpenAPI spec 1`] = `
         ],
         "type": "object",
       },
+      "adminFeaturesQuerySchema": {
+        "additionalProperties": true,
+        "properties": {
+          "namePrefix": {
+            "type": "string",
+          },
+          "tag": {
+            "items": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      },
       "apiTokenSchema": {
         "additionalProperties": false,
         "properties": {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -191,16 +191,16 @@ exports[`should serve the OpenAPI spec 1`] = `
       },
       "adminFeaturesQuerySchema": {
         "additionalProperties": true,
+        "description": "Used to filter feature toggles from the admin-api",
         "properties": {
           "namePrefix": {
+            "description": "A case-insensitive prefix filter for the names of feature toggles",
             "type": "string",
           },
           "tag": {
+            "description": "Used to filter by tags. For each entry, a TAGTYPE:TAGVALUE is expected",
             "items": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
+              "type": "string",
             },
             "type": "array",
           },

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -190,16 +190,21 @@ exports[`should serve the OpenAPI spec 1`] = `
         "type": "object",
       },
       "adminFeaturesQuerySchema": {
-        "additionalProperties": true,
+        "additionalProperties": false,
         "description": "Used to filter feature toggles from the admin-api",
         "properties": {
           "namePrefix": {
             "description": "A case-insensitive prefix filter for the names of feature toggles",
+            "example": "demo.part1",
             "type": "string",
           },
           "tag": {
             "description": "Used to filter by tags. For each entry, a TAGTYPE:TAGVALUE is expected",
+            "example": [
+              "simple:mytag",
+            ],
             "items": {
+              "pattern": "\\w+:\\w+",
               "type": "string",
             },
             "type": "array",

--- a/src/test/e2e/stores/feature-strategies-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-strategies-store.e2e.test.ts
@@ -70,3 +70,58 @@ test('Can successfully update project for all strategies belonging to feature', 
         );
     return expect(oldProjectStrats).toHaveLength(0);
 });
+
+test('Can query for features with tags', async () => {
+    const tag = { type: 'simple', value: 'hello-tags' };
+    await stores.tagStore.createTag(tag);
+    await featureToggleStore.create('default', { name: 'to-be-tagged' });
+    await featureToggleStore.create('default', { name: 'not-tagged' });
+    await stores.featureTagStore.tagFeature('to-be-tagged', tag);
+    const features = await featureStrategiesStore.getFeatureOverview({
+        projectId: 'default',
+        tag: [[tag.type, tag.value]],
+    });
+    expect(features).toHaveLength(1);
+});
+
+test('Can query for features with namePrefix', async () => {
+    await featureToggleStore.create('default', {
+        name: 'nameprefix-to-be-hit',
+    });
+    await featureToggleStore.create('default', {
+        name: 'nameprefix-not-be-hit',
+    });
+    const features = await featureStrategiesStore.getFeatureOverview({
+        projectId: 'default',
+        namePrefix: 'nameprefix-to',
+    });
+    expect(features).toHaveLength(1);
+});
+
+test('Can query for features with namePrefix and tags', async () => {
+    const tag = { type: 'simple', value: 'hello-nameprefix-and-tags' };
+    await stores.tagStore.createTag(tag);
+    await featureToggleStore.create('default', {
+        name: 'to-be-tagged-nameprefix-and-tags',
+    });
+    await featureToggleStore.create('default', {
+        name: 'not-tagged-nameprefix-and-tags',
+    });
+    await featureToggleStore.create('default', {
+        name: 'tagged-but-not-hit-nameprefix-and-tags',
+    });
+    await stores.featureTagStore.tagFeature(
+        'to-be-tagged-nameprefix-and-tags',
+        tag,
+    );
+    await stores.featureTagStore.tagFeature(
+        'tagged-but-not-hit-nameprefix-and-tags',
+        tag,
+    );
+    const features = await featureStrategiesStore.getFeatureOverview({
+        projectId: 'default',
+        tag: [[tag.type, tag.value]],
+        namePrefix: 'to',
+    });
+    expect(features).toHaveLength(1);
+});


### PR DESCRIPTION
## About the changes
The deprecated /api/admin/features endpoint supported querying with tag and namePrefix parameters. 

This PR adds this functionality to /api/admin/projects/<project>/features as well, allowing to replicate queries that used to work.

Closes #2306

### Important files
src/lib/db/feature-strategy-store.ts
src/test/e2e/stores/feature-strategies-store.e2e.test.ts

## Discussion points
I'm extending our query parameters support for /api/admin/projects/<projectId>/features endpoint. This will be reflected in our open-api spec, so I also made an adminFeaturesQuerySchema for this.

Also, very open for something similar to what we did for the modifyQuery for the archived parameter, but couldn't come up with a good way to support subselects using the query builder, it just ended up blowing the stack. If anyone has a suggestion, I'm all ears.
