### PR TITLE
Fix/remove settings cache

### DIFF
--- a/frontend/src/component/admin/cors/CorsForm.tsx
+++ b/frontend/src/component/admin/cors/CorsForm.tsx
@@ -36,14 +36,18 @@ export const CorsForm = ({ frontendApiOrigins }: ICorsFormProps) => {
             <Box sx={{ display: 'grid', gap: 1 }}>
                 <label htmlFor={inputFieldId}>
                     Which origins should be allowed to call the Frontend API?
-                    Add only one origin per line. The CORS specification does not support wildcard for subdomains, it needs to be a fully qualified domain, including the protocol.
-                    <br /><br />
-                    If you specify "*" it will be the chosen origin. 
-                    <br /><br />
+                    Add only one origin per line. The CORS specification does
+                    not support wildcard for subdomains, it needs to be a fully
+                    qualified domain, including the protocol.
+                    <br />
+                    <br />
+                    If you specify "*" it will be the chosen origin.
+                    <br />
+                    <br />
                     Example:
                 </label>
 
-                <code style={{fontSize: "0.7em"}}>
+                <code style={{ fontSize: '0.7em' }}>
                     https://www.example.com
                     <br />
                     https://www.example2.com

--- a/frontend/src/component/admin/cors/CorsForm.tsx
+++ b/frontend/src/component/admin/cors/CorsForm.tsx
@@ -6,6 +6,7 @@ import { useUiConfigApi } from 'hooks/api/actions/useUiConfigApi/useUiConfigApi'
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useId } from 'hooks/useId';
+import { fontSize } from '@mui/system';
 
 interface ICorsFormProps {
     frontendApiOrigins: string[] | undefined;
@@ -35,8 +36,19 @@ export const CorsForm = ({ frontendApiOrigins }: ICorsFormProps) => {
             <Box sx={{ display: 'grid', gap: 1 }}>
                 <label htmlFor={inputFieldId}>
                     Which origins should be allowed to call the Frontend API?
-                    Add only one origin per line.
+                    Add only one origin per line. The CORS specification does not support wildcard for subdomains, it needs to be a fully qualified domain, including the protocol.
+                    <br /><br />
+                    If you specify "*" it will be the chosen origin. 
+                    <br /><br />
+                    Example:
                 </label>
+
+                <code style={{fontSize: "0.7em"}}>
+                    https://www.example.com
+                    <br />
+                    https://www.example2.com
+                </code>
+
                 <TextField
                     id={inputFieldId}
                     aria-describedby={helpTextId}

--- a/frontend/src/component/admin/cors/CorsHelpAlert.tsx
+++ b/frontend/src/component/admin/cors/CorsHelpAlert.tsx
@@ -17,6 +17,15 @@ export const CorsHelpAlert = () => {
                 An asterisk (<code>*</code>) may be used to allow API calls from
                 any origin.
             </p>
+            <br />
+            <p>
+                Be aware that changes here will take up to two minutes to be
+                updated. In addition, there is a maxAge on the
+                Access-Control-Allow-Origin header that will instruct browsers
+                to cache this header for some time. The cache period is set to
+                the maxium that the browser allows (2h for Chrome, 24h for
+                Firefox).
+            </p>
         </Alert>
     );
 };

--- a/src/lib/middleware/cors-origin-middleware.test.ts
+++ b/src/lib/middleware/cors-origin-middleware.test.ts
@@ -1,4 +1,4 @@
-import { allowRequestOrigin } from './cors-origin-middleware';
+import { resolveOrigin } from './cors-origin-middleware';
 import FakeSettingStore from '../../test/fixtures/fake-setting-store';
 import { createTestConfig } from '../../test/config/test-config';
 import FakeEventStore from '../../test/fixtures/fake-event-store';
@@ -31,21 +31,15 @@ const createSettingService = (
     };
 };
 
-test('allowRequestOrigin', () => {
+test('resolveOrigin', () => {
     const dotCom = 'https://example.com';
     const dotOrg = 'https://example.org';
 
-    expect(allowRequestOrigin('', [])).toEqual(false);
-    expect(allowRequestOrigin(dotCom, [])).toEqual(false);
-    expect(allowRequestOrigin(dotCom, [dotOrg])).toEqual(false);
-
-    expect(allowRequestOrigin(dotCom, [dotCom, dotOrg])).toEqual(true);
-    expect(allowRequestOrigin(dotCom, [dotOrg, dotCom])).toEqual(true);
-    expect(allowRequestOrigin(dotCom, [dotCom, dotCom])).toEqual(true);
-
-    expect(allowRequestOrigin(dotCom, ['*'])).toEqual(true);
-    expect(allowRequestOrigin(dotCom, [dotOrg, '*'])).toEqual(true);
-    expect(allowRequestOrigin(dotCom, [dotCom, dotOrg, '*'])).toEqual(true);
+    expect(resolveOrigin([])).toEqual('*');
+    expect(resolveOrigin(['*'])).toEqual('*');
+    expect(resolveOrigin([dotOrg])).toEqual([dotOrg]);
+    expect(resolveOrigin([dotCom, dotOrg])).toEqual([dotCom, dotOrg]);
+    expect(resolveOrigin([dotOrg, '*'])).toEqual('*');
 });
 
 test('corsOriginMiddleware origin validation', async () => {

--- a/src/lib/middleware/cors-origin-middleware.ts
+++ b/src/lib/middleware/cors-origin-middleware.ts
@@ -27,6 +27,7 @@ export const corsOriginMiddleware = (
                 origin: resolveOrigin(frontendApiOrigins),
                 maxAge: config.accessControlMaxAge,
                 exposedHeaders: 'ETag',
+                credentials: true,
             });
         } catch (error) {
             callback(error);

--- a/src/lib/middleware/cors-origin-middleware.ts
+++ b/src/lib/middleware/cors-origin-middleware.ts
@@ -14,13 +14,13 @@ export const allowRequestOrigin = (
 // Check the request's Origin header against a list of allowed origins.
 // The list may include '*', which `cors` does not support natively.
 export const corsOriginMiddleware = (
-    { settingService }: Pick<IUnleashServices, 'settingService'>,
+    { proxyService }: Pick<IUnleashServices, 'proxyService'>,
     config: IUnleashConfig,
 ): RequestHandler => {
     return cors(async (req, callback) => {
         try {
             const { frontendApiOrigins = [] } =
-                await settingService.getFrontendSettings();
+                await proxyService.getFrontendSettings();
             callback(null, {
                 origin: allowRequestOrigin(
                     req.header('Origin'),

--- a/src/lib/middleware/cors-origin-middleware.ts
+++ b/src/lib/middleware/cors-origin-middleware.ts
@@ -2,13 +2,15 @@ import { RequestHandler } from 'express';
 import cors from 'cors';
 import { IUnleashConfig, IUnleashServices } from '../types';
 
-export const allowRequestOrigin = (
-    requestOrigin: string,
-    allowedOrigins: string[],
-): boolean => {
-    return allowedOrigins.some((allowedOrigin) => {
-        return allowedOrigin === requestOrigin || allowedOrigin === '*';
-    });
+export const resolveOrigin = (allowedOrigins: string[]): string | string[] => {
+    if (allowedOrigins.length === 0) {
+        return '*';
+    }
+    if (allowedOrigins.some((origin: string) => origin === '*')) {
+        return '*';
+    } else {
+        return allowedOrigins;
+    }
 };
 
 // Check the request's Origin header against a list of allowed origins.
@@ -22,10 +24,7 @@ export const corsOriginMiddleware = (
             const { frontendApiOrigins = [] } =
                 await proxyService.getFrontendSettings();
             callback(null, {
-                origin: allowRequestOrigin(
-                    req.header('Origin'),
-                    frontendApiOrigins,
-                ),
+                origin: resolveOrigin(frontendApiOrigins),
                 maxAge: config.accessControlMaxAge,
                 exposedHeaders: 'ETag',
             });

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -98,7 +98,7 @@ class ConfigController extends Controller {
         res: Response<UiConfigSchema>,
     ): Promise<void> {
         const [frontendSettings, simpleAuthSettings] = await Promise.all([
-            this.proxyService.getFrontendSettings(),
+            this.proxyService.getFrontendSettings(false),
             this.settingService.get<SimpleAuthSettings>(simpleAuthSettingsKey),
         ]);
 

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -24,11 +24,14 @@ import { extractUsername } from '../../util/extract-user';
 import NotFoundError from '../../error/notfound-error';
 import { SetUiConfigSchema } from '../../openapi/spec/set-ui-config-schema';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
+import { ProxyService } from 'lib/services';
 
 class ConfigController extends Controller {
     private versionService: VersionService;
 
     private settingService: SettingService;
+
+    private proxyService: ProxyService;
 
     private emailService: EmailService;
 
@@ -41,12 +44,14 @@ class ConfigController extends Controller {
             settingService,
             emailService,
             openApiService,
+            proxyService,
         }: Pick<
             IUnleashServices,
             | 'versionService'
             | 'settingService'
             | 'emailService'
             | 'openApiService'
+            | 'proxyService'
         >,
     ) {
         super(config);
@@ -54,6 +59,7 @@ class ConfigController extends Controller {
         this.settingService = settingService;
         this.emailService = emailService;
         this.openApiService = openApiService;
+        this.proxyService = proxyService;
 
         this.route({
             method: 'get',
@@ -92,7 +98,7 @@ class ConfigController extends Controller {
         res: Response<UiConfigSchema>,
     ): Promise<void> {
         const [frontendSettings, simpleAuthSettings] = await Promise.all([
-            this.settingService.getFrontendSettings(),
+            this.proxyService.getFrontendSettings(),
             this.settingService.get<SimpleAuthSettings>(simpleAuthSettingsKey),
         ]);
 
@@ -133,7 +139,7 @@ class ConfigController extends Controller {
         res: Response<string>,
     ): Promise<void> {
         if (req.body.frontendSettings) {
-            await this.settingService.setFrontendSettings(
+            await this.proxyService.setFrontendSettings(
                 req.body.frontendSettings,
                 extractUsername(req),
             );

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -55,6 +55,7 @@ async function createApp(
         metricsMonitor.stopMonitoring();
         stores.clientInstanceStore.destroy();
         services.clientMetricsServiceV2.destroy();
+        services.proxyService.destroy();
         await db.destroy();
     };
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -109,6 +109,7 @@ export const createServices = (
         featureToggleServiceV2,
         clientMetricsServiceV2,
         segmentService,
+        settingService,
     });
 
     const edgeService = new EdgeService(stores, config);

--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -8,12 +8,6 @@ import {
     SettingDeletedEvent,
     SettingUpdatedEvent,
 } from '../types/events';
-import { validateOrigins } from '../util/validateOrigin';
-import {
-    FrontendSettings,
-    frontendSettingsKey,
-} from '../types/settings/frontend-settings';
-import BadDataError from '../error/bad-data-error';
 
 export default class SettingService {
     private config: IUnleashConfig;
@@ -77,22 +71,5 @@ export default class SettingService {
 
     async deleteAll(): Promise<void> {
         await this.settingStore.deleteAll();
-    }
-
-    async setFrontendSettings(
-        value: FrontendSettings,
-        createdBy: string,
-    ): Promise<void> {
-        const error = validateOrigins(value.frontendApiOrigins);
-        if (error) {
-            throw new BadDataError(error);
-        }
-        await this.insert(frontendSettingsKey, value, createdBy);
-    }
-
-    async getFrontendSettings(): Promise<FrontendSettings> {
-        return this.get(frontendSettingsKey, {
-            frontendApiOrigins: this.config.frontendApiOrigins,
-        });
     }
 }

--- a/src/test/e2e/api/admin/config.e2e.test.ts
+++ b/src/test/e2e/api/admin/config.e2e.test.ts
@@ -44,7 +44,7 @@ test('gets ui config with disablePasswordAuth', async () => {
 
 test('gets ui config with frontendSettings', async () => {
     const frontendApiOrigins = ['https://example.net'];
-    await app.services.settingService.setFrontendSettings(
+    await app.services.proxyService.setFrontendSettings(
         { frontendApiOrigins },
         randomId(),
     );

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -47,6 +47,7 @@ async function createApp(
         services.clientInstanceService.destroy();
         services.clientMetricsServiceV2.destroy();
         services.apiTokenService.destroy();
+        services.proxyService.destroy();
     };
 
     // TODO: use create from server-impl instead?


### PR DESCRIPTION
In this PR we remove the general SettingService cache, as it will not work across multiple horizontal unleash instances, events are not published across. 

We also fix the CORS origin to: 
- Access-Control-Allow-Origin set to "*" if no Origin is configured
- Access-Control-Allow-Origin set to "*" if any Origin is configured to "*"
- - Access-Control-Allow-Origin set to array and have the "cors" middleware to return an exact match on the user provided Origin. 