### PR TITLE
fix: allow publish-new-version action to run from branch

### DIFF
--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: npm version
         run: |
           npm version ${{ github.event.inputs.version }} --ignore-scripts
-          git push origin main
+          git push origin ${{ github.ref_name }}
           git push --tags
         env:
           CI: true


### PR DESCRIPTION
We cannot hard code the branch to be "main" if we want to allow the release script to also run from branch (e.g. 4.18 maintenance branch)