### PR TITLE
fix: for hosted we want to limit the query to that instance

### DIFF
--- a/src/lib/routes/admin-api/metrics.ts
+++ b/src/lib/routes/admin-api/metrics.ts
@@ -21,6 +21,8 @@ class MetricsController extends Controller {
 
     private clientInstanceService: ClientInstanceService;
 
+    readonly baseUriPath: string;
+
     constructor(
         config: IUnleashConfig,
         {
@@ -31,6 +33,7 @@ class MetricsController extends Controller {
         super(config);
         this.logger = config.getLogger('/admin-api/metrics.ts');
         this.flagResolver = config.flagResolver;
+        this.baseUriPath = config.server.baseUriPath || '';
 
         this.clientInstanceService = clientInstanceService;
 
@@ -189,11 +192,11 @@ class MetricsController extends Controller {
             const hoursToQuery = 6;
             const [clientMetrics, adminMetrics] = await Promise.all([
                 this.clientInstanceService.getRPSForPath(
-                    '/api/client/.*',
+                    `${this.baseUriPath}/api/client/.*`,
                     hoursToQuery,
                 ),
                 this.clientInstanceService.getRPSForPath(
-                    '/api/admin/.*',
+                    `${this.baseUriPath}/api/admin/.*`,
                     hoursToQuery,
                 ),
             ]);


### PR DESCRIPTION
## About the changes
This follows up on the traffic UI, right now it shows no data because none of the metrics starts with /api (which is true for all hosted instances). We also want to limit the query to the instance querying the data.
