### PR TITLE
Middleware mode middlware

### DIFF
--- a/frontend/src/component/maintenance/Maintenance.tsx
+++ b/frontend/src/component/maintenance/Maintenance.tsx
@@ -25,8 +25,9 @@ const Maintenance = () => {
             <StyledErrorRoundedIcon />
             <b>Maintenance Mode! </b>
             <p>
-                Any changes you make during maintenance mode will not be saved.
-                We apologize for any inconvenience this may cause.
+                During maintenance mode, any changes made will not be saved and
+                you may receive an error. We apologize for any inconvenience
+                this may cause.
             </p>
         </StyledDiv>
     );

--- a/frontend/src/hooks/api/getters/useAuth/useAuthPermissions.ts
+++ b/frontend/src/hooks/api/getters/useAuth/useAuthPermissions.ts
@@ -15,9 +15,14 @@ const getPermissions = (
     uiConfig: IUiConfig
 ): IPermission[] | undefined => {
     let permissions =
-        auth.data && 'permissions' in auth.data && !uiConfig?.flags?.maintenance
+        auth.data && 'permissions' in auth.data
             ? auth.data.permissions
             : undefined;
+    if (permissions && uiConfig?.flags?.maintenance) {
+        permissions = permissions.filter(
+            permission => permission.permission === 'ADMIN'
+        );
+    }
 
     return permissions;
 };

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -25,6 +25,7 @@ import { findPublicFolder } from './util/findPublicFolder';
 import { conditionalMiddleware } from './middleware/conditional-middleware';
 import patMiddleware from './middleware/pat-middleware';
 import { Knex } from 'knex';
+import maintenanceMiddleware from './middleware/maintenance-middleware';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -137,6 +138,8 @@ export default async function getApp(
         baseUriPath,
         rbacMiddleware(config, stores, services.accessService),
     );
+
+    app.use('/api/admin', maintenanceMiddleware(config));
 
     if (typeof config.preRouterHook === 'function') {
         config.preRouterHook(app, config, services, stores, db);

--- a/src/lib/middleware/maintenance-middleware.ts
+++ b/src/lib/middleware/maintenance-middleware.ts
@@ -1,0 +1,24 @@
+import { IUnleashConfig } from '../types';
+import { Request } from 'express';
+
+const maintenanceMiddleware = ({
+    getLogger,
+    flagResolver,
+}: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>): any => {
+    const logger = getLogger('/middleware/maintenance-middleware.ts');
+    logger.debug('Enabling Maintenance middleware');
+
+    return async (req: Request, res, next) => {
+        try {
+            const writeMethod = ['POST', 'PUT', 'DELETE'].includes(req.method);
+            if (writeMethod && flagResolver.isEnabled('maintenance')) {
+                res.status(503).send({});
+            }
+        } catch (error) {
+            logger.error(error);
+        }
+        next();
+    };
+};
+
+export default maintenanceMiddleware;

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -13,7 +13,6 @@ import ProxyController from './proxy-api';
 import { conditionalMiddleware } from '../middleware';
 import EdgeController from './edge-api';
 import { PublicInviteController } from './public-invite';
-import maintenanceMiddleware from '../middleware/maintenance-middleware';
 
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
@@ -42,7 +41,6 @@ class IndexRouter extends Controller {
         );
 
         this.use('/api/admin', new AdminApi(config, services).router);
-        this.use('/api/admin', maintenanceMiddleware(config));
         this.use('/api/client', new ClientApi(config, services).router);
 
         this.use(

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -13,6 +13,7 @@ import ProxyController from './proxy-api';
 import { conditionalMiddleware } from '../middleware';
 import EdgeController from './edge-api';
 import { PublicInviteController } from './public-invite';
+import maintenanceMiddleware from '../middleware/maintenance-middleware';
 
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
@@ -41,6 +42,7 @@ class IndexRouter extends Controller {
         );
 
         this.use('/api/admin', new AdminApi(config, services).router);
+        this.use('/api/admin', maintenanceMiddleware(config));
         this.use('/api/client', new ClientApi(config, services).router);
 
         this.use(

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -837,3 +837,21 @@ test('should have access to the get all features endpoint even if api is disable
         .get('/api/admin/features')
         .expect(200);
 });
+
+test('should not allow creation of feature toggle in maintenance mode', async () => {
+    const appWithMaintenanceMode = await setupAppWithCustomConfig(db.stores, {
+        experimental: {
+            flags: {
+                maintenance: true,
+            },
+        },
+    });
+
+    return appWithMaintenanceMode.request
+        .post('/api/admin/features')
+        .send({
+            name: 'maintenance-feature',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(503);
+});


### PR DESCRIPTION
Related to #2699 

1. Added middleware to block all requests to /api/admin during maintenance mode
2. Normal users permissions will be wiped, which means they will see most things locked in UI
3. Admin users will keep their ADMIN permission, so they still see admin panel and can turn off maintenance mode in future