### PR TITLE
Feat lazy loading network

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "build": "vite build",
     "lint": "yarn fmt:check",
     "start": "vite",
+    "start:prod": "vite build && vite preview",
     "start:sandbox": "UNLEASH_API=https://sandbox.getunleash.io/ospro yarn run start",
     "start:enterprise": "UNLEASH_API=https://unleash4.herokuapp.com yarn run start",
     "start:demo": "UNLEASH_BASE_PATH=/demo/ yarn start",

--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -1,10 +1,12 @@
-import { NetworkOverview } from './NetworkOverview/NetworkOverview';
-import { NetworkTraffic } from './NetworkTraffic/NetworkTraffic';
+import { lazy } from 'react';
 import AdminMenu from '../menu/AdminMenu';
 import { styled, Tab, Tabs } from '@mui/material';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { CenteredNavLink } from '../menu/CenteredNavLink';
 import { PageContent } from 'component/common/PageContent/PageContent';
+
+const NetworkOverview = lazy(() => import('./NetworkOverview/NetworkOverview'));
+const NetworkTraffic = lazy(() => import('./NetworkTraffic/NetworkTraffic'));
 
 const StyledPageContent = styled(PageContent)(() => ({
     '.page-header': {


### PR DESCRIPTION
Adds lazy loading to the network routes, so we end up with smaller chunks in the build.

Also adds a `start:prod` script that can prove useful to test the chunk loading behaviour locally.