### PR TITLE
fix: metrics one hour select label

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -33,7 +33,7 @@ export const FeatureMetricsHours = ({
 const parseFeatureMetricsHour = (value: unknown) => {
     switch (value) {
         case '1':
-            return 2;
+            return 1;
         case '24':
             return 24;
         default:


### PR DESCRIPTION
## About the changes

Fix missing label.

<img width="416" alt="image" src="https://user-images.githubusercontent.com/2625371/208456107-e78e855d-ad23-4e05-938b-d72ab42e89aa.png">

Closes [1-511](https://linear.app/unleash/issue/1-511/small-bug-with-the-dropdown-from-metrics-when-we-pick-last-hour-option)