### PR TITLE
fixes 2-456: Preserve all data from strategy import

### DIFF
--- a/src/lib/db/strategy-store.ts
+++ b/src/lib/db/strategy-store.ts
@@ -6,6 +6,7 @@ import {
     IEditableStrategy,
     IMinimalStrategyRow,
     IStrategy,
+    IStrategyImport,
     IStrategyStore,
 } from '../types/stores/strategy-store';
 
@@ -157,8 +158,16 @@ export default class StrategyStore implements IStrategyStore {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async importStrategy(data): Promise<void> {
-        const rowData = this.eventDataToRow(data);
+    async importStrategy(data: IStrategyImport): Promise<void> {
+        const rowData = {
+            name: data.name,
+            description: data.description,
+            deprecated: data.deprecated || false,
+            parameters: JSON.stringify(data.parameters || []),
+            built_in: data.builtIn ? 1 : 0,
+            sort_order: data.sortOrder || 9999,
+            display_name: data.displayName,
+        };
         await this.db(TABLE).insert(rowData).onConflict(['name']).merge();
     }
 

--- a/src/lib/db/strategy-store.ts
+++ b/src/lib/db/strategy-store.ts
@@ -157,7 +157,6 @@ export default class StrategyStore implements IStrategyStore {
         await this.db(TABLE).where({ name }).del();
     }
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     async importStrategy(data: IStrategyImport): Promise<void> {
         const rowData = {
             name: data.name,

--- a/src/lib/types/stores/strategy-store.ts
+++ b/src/lib/types/stores/strategy-store.ts
@@ -23,6 +23,16 @@ export interface IMinimalStrategy {
     parameters?: any[];
 }
 
+export interface IStrategyImport {
+    name: string;
+    description?: string;
+    deprecated?: boolean;
+    parameters?: object[];
+    builtIn?: boolean;
+    sortOrder?: number;
+    displayName?: string;
+}
+
 export interface IMinimalStrategyRow {
     name: string;
     description?: string;
@@ -36,7 +46,7 @@ export interface IStrategyStore extends Store<IStrategy, string> {
     updateStrategy(update: IMinimalStrategy): Promise<void>;
     deprecateStrategy({ name }: Pick<IStrategy, 'name'>): Promise<void>;
     reactivateStrategy({ name }: Pick<IStrategy, 'name'>): Promise<void>;
-    importStrategy(data: IMinimalStrategy): Promise<void>;
+    importStrategy(data: IStrategyImport): Promise<void>;
     dropCustomStrategies(): Promise<void>;
     count(): Promise<number>;
 }

--- a/src/test/fixtures/fake-strategies-store.ts
+++ b/src/test/fixtures/fake-strategies-store.ts
@@ -2,6 +2,7 @@ import {
     IEditableStrategy,
     IMinimalStrategy,
     IStrategy,
+    IStrategyImport,
     IStrategyStore,
 } from '../../lib/types/stores/strategy-store';
 import NotFoundError from '../../lib/error/notfound-error';
@@ -104,7 +105,7 @@ export default class FakeStrategiesStore implements IStrategyStore {
         throw new NotFoundError(`Could not find strategy with name: ${name}`);
     }
 
-    async importStrategy(data: IMinimalStrategy): Promise<void> {
+    async importStrategy(data: IStrategyImport): Promise<void> {
         return this.createStrategy(data);
     }
 


### PR DESCRIPTION
## What
Previously when importing strategies we've used the same data type we've used for creating strategies (the minimal, a name, an optional description, optional parameters and an optional editable column). This meant that exporting strategies and then importing them would reactivate deprecated strategies. This PR changes to allow the import to preserve all the data coming in the export file.

## Tests
Added four new tests, two new unit tests using our fake stores and two new e2e tests. Interestingly the ones in the fake store ran green before this change as well, probably because we just insert the parsed json object in the fake store, whereas the real store actually converts the object from camelCasing to the postgresql snake_casing standard.  

## Discussion points:
### Mismatch between fake and real stores
This is inevitable since storing things in javascript arrays vs saving in a real database will have some differences, but this again shows the value of our e2e tests.

### Invariants
Should we see if we can add some invariants to our import/export so that we can write some proptests for it? One candidate is commutativity of import/export. On a fresh database importing and then exporting should yield the same file that was imported provided all flags are turned on. Candidate for Q1 improvement of import/export.