### PR TITLE
feat: report app names metric dimension only below a threshold

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -45,7 +45,13 @@ export default async function getApp(
     app.set('port', config.server.port);
     app.locals.baseUriPath = baseUriPath;
     if (config.server.serverMetrics && config.eventBus) {
-        app.use(responseTimeMetrics(config.eventBus, config.flagResolver));
+        app.use(
+            responseTimeMetrics(
+                config.eventBus,
+                config.flagResolver,
+                services.instanceStatsService,
+            ),
+        );
     }
 
     app.use(requestLogger(config));

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -2,21 +2,36 @@ import * as responseTime from 'response-time';
 import EventEmitter from 'events';
 import { REQUEST_TIME } from '../metric-events';
 import { IFlagResolver } from '../types/experimental';
+import { InstanceStatsService } from 'lib/services';
+import memoizee from 'memoizee';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _responseTime = responseTime.default;
 
+const countAppNames = async (instanceStatsService: InstanceStatsService) => {
+    const response = await instanceStatsService.getLabeledAppCounts();
+    return response.find((c) => c.range === '7d').count;
+};
 export function responseTimeMetrics(
     eventBus: EventEmitter,
     flagResolver: IFlagResolver,
+    instanceStatsService: InstanceStatsService,
 ): any {
-    return _responseTime((req, res, time) => {
+    const appNameReportingThreshold = 100;
+    let appNameCount = memoizee(() => countAppNames(instanceStatsService), {
+        promise: true,
+        maxAge: 30000, // milliseconds
+    });
+    return _responseTime(async (req, res, time) => {
         const { statusCode } = res;
 
         const pathname = req.route ? req.baseUrl + req.route.path : '(hidden)';
 
         let appName;
-        if (flagResolver.isEnabled('responseTimeWithAppName')) {
+        if (
+            flagResolver.isEnabled('responseTimeWithAppName') &&
+            (await appNameCount()) < appNameReportingThreshold
+        ) {
             appName = req.headers['unleash-appname'] ?? req.query.appName;
         }
 


### PR DESCRIPTION
## About the changes
Only adds appName dimension in response time metrics when the total number of app names is below a threshold. This reduces the risk of high cardinality

## Discussion points
1. This will apply to every request, so caching properly is really important to avoid impacting latency.
2. Alternatively to memoizee, we could use a fixed interval updating a value in memory that will be used in the comparison.
3. The previous point can also be extended to some properties inside InstantceStatsService that are only calculated at startup time, which would give us a more up-to-date view of the systems
