### PR TITLE
Adapted code and added tests suggesting memoizee is not behaving

### DIFF
--- a/src/lib/middleware/response-time-metrics.test.ts
+++ b/src/lib/middleware/response-time-metrics.test.ts
@@ -1,0 +1,63 @@
+import { IUnleashConfig } from '../types/option';
+import { createTestConfig } from '../../test/config/test-config';
+import { InstanceStatsService } from 'lib/services';
+import { responseTimeMetrics } from './response-time-metrics';
+
+let config: IUnleashConfig;
+let instanceStatsService: Pick<InstanceStatsService, 'getLabeledAppCounts'>;
+const cb = jest.fn();
+
+const req = {
+    headers: {
+        'unleash-appname': 'test',
+    },
+};
+
+const res = {
+    statusCode: 200,
+    writeHead: (status: number) => console.log('Mocked write head ' + status),
+    find: jest.fn(),
+};
+// attempt to mock response-time to directly call our function
+jest.mock('response-time', () => (fn: any) => {
+    console.log('=Pre fn=');
+    fn(req, res, cb);
+    console.log('=Post fn=');
+});
+
+beforeEach(() => {
+    config = createTestConfig();
+    instanceStatsService = {
+        getLabeledAppCounts: jest
+            .fn()
+            .mockReturnValue([{ range: '7d', count: 5 }]),
+    };
+});
+
+test('getLabeledAppCounts', async () => {
+    const flagResolver = {
+        getAll: jest.fn(),
+        isEnabled: jest.fn().mockReturnValue(true),
+    };
+
+    await responseTimeMetrics(
+        config.eventBus,
+        flagResolver,
+        instanceStatsService,
+    );
+
+    await responseTimeMetrics(
+        config.eventBus,
+        flagResolver,
+        instanceStatsService,
+    );
+
+    // console.log(middleware);
+    // await middleware(req, res, cb);
+    // res.writeHead(200); // this executes the function
+    // // await middleware(req, res, cb);
+    // res.writeHead(200); // this executes the function twice
+
+    expect(flagResolver.isEnabled).toBeCalledTimes(2);
+    expect(instanceStatsService.getLabeledAppCounts).toBeCalledTimes(1);
+});

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -8,14 +8,16 @@ import memoizee from 'memoizee';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _responseTime = responseTime.default;
 
-const countAppNames = async (instanceStatsService: InstanceStatsService) => {
+const countAppNames = async (
+    instanceStatsService: Pick<InstanceStatsService, 'getLabeledAppCounts'>,
+) => {
     const response = await instanceStatsService.getLabeledAppCounts();
     return response.find((c) => c.range === '7d').count;
 };
 export function responseTimeMetrics(
     eventBus: EventEmitter,
     flagResolver: IFlagResolver,
-    instanceStatsService: InstanceStatsService,
+    instanceStatsService: Pick<InstanceStatsService, 'getLabeledAppCounts'>,
 ): any {
     const appNameReportingThreshold = 100;
     let appNameCount = memoizee(() => countAppNames(instanceStatsService), {
@@ -24,7 +26,6 @@ export function responseTimeMetrics(
     });
     return _responseTime(async (req, res, time) => {
         const { statusCode } = res;
-
         const pathname = req.route ? req.baseUrl + req.route.path : '(hidden)';
 
         let appName;


### PR DESCRIPTION
Adapted code and added tests suggesting memoizee is not working as expected: https://github.com/Unleash/unleash/actions/runs/3760626776/jobs/6391542763#step:5:370

```
Summary of all failing tests
FAIL src/lib/middleware/response-time-metrics.test.ts
  ● getLabeledAppCounts

    expect(jest.fn()).toBeCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 2

      60 |
      61 |     expect(flagResolver.isEnabled).toBeCalledTimes(2);
    > 62 |     expect(instanceStatsService.getLabeledAppCounts).toBeCalledTimes(1);
         |                                                      ^
      63 | });
      64 |

      at Object.toBeCalledTimes (src/lib/middleware/response-time-metrics.test.ts:62:54)
          at runMicrotasks (<anonymous>)


Test Suites: 1 failed, 206 passed, 207 total
Tests:       1 failed, 2 skipped, 1287 passed, 1290 total
Snapshots:   43 passed, 43 total
Time:        237.016 s
```

It can also be something else I'm not seeing but a I'll try a simpler path
