### PR TITLE
fix: simplify OAS for state service

### DIFF
--- a/src/lib/openapi/spec/export-query-parameters.ts
+++ b/src/lib/openapi/spec/export-query-parameters.ts
@@ -15,18 +15,7 @@ export const exportQueryParameters = [
         name: 'download',
         schema: {
             default: false,
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
         },
         description: 'Whether exported data should be downloaded as a file.',
         in: 'query',
@@ -35,18 +24,7 @@ export const exportQueryParameters = [
         name: 'strategies',
         schema: {
             default: true,
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
         },
         description:
             'Whether strategies should be included in the exported data.',
@@ -55,18 +33,7 @@ export const exportQueryParameters = [
     {
         name: 'featureToggles',
         schema: {
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
             default: true,
         },
         description:
@@ -76,18 +43,7 @@ export const exportQueryParameters = [
     {
         name: 'projects',
         schema: {
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
             default: true,
         },
         description:
@@ -97,18 +53,7 @@ export const exportQueryParameters = [
     {
         name: 'tags',
         schema: {
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
             default: true,
         },
         description:
@@ -118,18 +63,7 @@ export const exportQueryParameters = [
     {
         name: 'environments',
         schema: {
-            anyOf: [
-                {
-                    type: 'boolean',
-                },
-                {
-                    type: 'string',
-                    minLength: 1,
-                },
-                {
-                    type: 'number',
-                },
-            ],
+            type: 'boolean',
             default: true,
         },
         description:

--- a/src/test/e2e/api/admin/state.e2e.test.ts
+++ b/src/test/e2e/api/admin/state.e2e.test.ts
@@ -44,14 +44,14 @@ test('exports strategies and features as yaml', async () => {
 
 test('exports only features as yaml', async () => {
     return app.request
-        .get('/api/admin/state/export?format=yaml&featureToggles=1')
+        .get('/api/admin/state/export?format=yaml&featureToggles=true')
         .expect('Content-Type', /yaml/)
         .expect(200);
 });
 
 test('exports strategies and features as attachment', async () => {
     return app.request
-        .get('/api/admin/state/export?download=1')
+        .get('/api/admin/state/export?download=true')
         .expect('Content-Type', /json/)
         .expect('Content-Disposition', /attachment/)
         .expect(200);

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -6622,19 +6622,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "download",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": false,
+              "type": "boolean",
             },
           },
           {
@@ -6642,19 +6631,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "strategies",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": true,
+              "type": "boolean",
             },
           },
           {
@@ -6662,19 +6640,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "featureToggles",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": true,
+              "type": "boolean",
             },
           },
           {
@@ -6682,19 +6649,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "projects",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": true,
+              "type": "boolean",
             },
           },
           {
@@ -6702,19 +6658,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "tags",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": true,
+              "type": "boolean",
             },
           },
           {
@@ -6722,19 +6667,8 @@ If the provided project does not exist, the list of events will be empty.",
             "in": "query",
             "name": "environments",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                },
-                {
-                  "minLength": 1,
-                  "type": "string",
-                },
-                {
-                  "type": "number",
-                },
-              ],
               "default": true,
+              "type": "boolean",
             },
           },
         ],


### PR DESCRIPTION
It feels unnecessary to define support for boolean, string and number to define a bool value. The API will accepts all, but the specification should push the user in to use the most appropriate type.

This also ease the down-conversion to Swagger 2.0.

