### PR TITLE
fix: variant weight display when decimals

### DIFF
--- a/frontend/src/component/common/util.ts
+++ b/frontend/src/component/common/util.ts
@@ -45,6 +45,15 @@ export const parseValidDate = (value: string): Date | undefined => {
 };
 
 export const calculateVariantWeight = (weight: number) => {
+    if (!Number.isInteger(weight)) {
+        const parts = String(weight).split('.');
+        return parseFloat(
+            `${parts[0].slice(0, -1)}.${parts[0][parts[0].length - 1]}${
+                parts[1]
+            }`
+        );
+    }
+
     return weight / 10.0;
 };
 

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
@@ -27,6 +27,7 @@ import cloneDeep from 'lodash.clonedeep';
 import { CloudCircle } from '@mui/icons-material';
 import PermissionSwitch from 'component/common/PermissionSwitch/PermissionSwitch';
 import { UPDATE_FEATURE_VARIANTS } from 'component/providers/AccessProvider/permissions';
+import { calculateVariantWeight } from 'component/common/util';
 
 const StyledFormSubtitle = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -193,7 +194,7 @@ export const EnvironmentVariantModal = ({
         if (variant) {
             setName(variant.name);
             setCustomPercentage(variant.weightType === WeightType.FIX);
-            setPercentage(String(variant.weight / 10));
+            setPercentage(String(calculateVariantWeight(variant.weight)));
             setPayload(variant.payload || EMPTY_PAYLOAD);
             overridesDispatch(
                 variant.overrides

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureVariantsList/AddFeatureVariant/AddFeatureVariant.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureVariantsList/AddFeatureVariant/AddFeatureVariant.tsx
@@ -11,7 +11,11 @@ import { OverrideConfig } from './OverrideConfig/OverrideConfig';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useThemeStyles } from 'themes/themeStyles';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
-import { modalStyles, trim } from 'component/common/util';
+import {
+    calculateVariantWeight,
+    modalStyles,
+    trim,
+} from 'component/common/util';
 import PermissionSwitch from 'component/common/PermissionSwitch/PermissionSwitch';
 import { UPDATE_FEATURE_VARIANTS } from 'component/providers/AccessProvider/permissions';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
@@ -83,7 +87,7 @@ export const AddVariant = ({
         if (editVariant) {
             setData({
                 name: editVariant.name,
-                weight: String(editVariant.weight / 10),
+                weight: String(calculateVariantWeight(editVariant.weight)),
                 weightType: editVariant.weightType || weightTypes.VARIABLE,
                 stickiness: editVariant.stickiness,
             });


### PR DESCRIPTION
## About the changes
When displaying decimal values for variants fixed percentages, we divide the value by `10.0` which causes some fix point imprecision:
![Screenshot from 2022-12-26 12-14-24](https://user-images.githubusercontent.com/455064/209543771-376c79c0-27e0-465d-9b16-bfed0635ee68.png)

To avoid rounding issues, we're manually shifting the comma.

After this change the numbers should show correctly:
![Screenshot from 2022-12-26 12-14-10](https://user-images.githubusercontent.com/455064/209543846-c50d1b3f-c53a-49ab-a146-19bdb85f1b4f.png)


Closes #2222 


## Discussion points
If there's a better way to avoid precision issues with float divisions I'm happy to change the implementation. The only alternative I found is using `toFixed`:
`(weight / 10.0).toFixed(precision)`

But the challenge with this approach is finding what `precision` is (because we don't impose a limit on the precision). The solution is to find the precision of `weight` and subtract 1 from it, but the method I've found to get the precision of a float implies converting it to a string, so instead I decided to use the string to shift the comma. 
