### PR TITLE
Fix crashing search bars

### DIFF
--- a/frontend/src/component/application/ApplicationList/ApplicationList.tsx
+++ b/frontend/src/component/application/ApplicationList/ApplicationList.tsx
@@ -8,6 +8,7 @@ import useApplications from 'hooks/api/getters/useApplications/useApplications';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useSearchParams } from 'react-router-dom';
 import { Search } from 'component/common/Search/Search';
+import { safeRegExp } from '@server/util/escape-regex';
 
 type PageQueryType = Partial<Record<'search', string>>;
 
@@ -30,7 +31,7 @@ export const ApplicationList = () => {
     }, [searchValue, setSearchParams]);
 
     const filteredApplications = useMemo(() => {
-        const regExp = new RegExp(searchValue, 'i');
+        const regExp = safeRegExp(searchValue, 'i');
         return searchValue
             ? applications?.filter(a => regExp.test(a.appName))
             : applications;

--- a/frontend/src/component/common/Highlighter/Highlighter.tsx
+++ b/frontend/src/component/common/Highlighter/Highlighter.tsx
@@ -1,13 +1,12 @@
 import { VFC } from 'react';
 import { useStyles } from './Highlighter.styles';
+import { safeRegExp } from '@server/util/escape-regex';
 
 interface IHighlighterProps {
     search?: string;
     children?: string;
     caseSensitive?: boolean;
 }
-
-const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export const Highlighter: VFC<IHighlighterProps> = ({
     search,
@@ -23,7 +22,7 @@ export const Highlighter: VFC<IHighlighterProps> = ({
         return <>{children}</>;
     }
 
-    const regex = new RegExp(escapeRegex(search), caseSensitive ? 'g' : 'gi');
+    const regex = safeRegExp(search, caseSensitive ? 'g' : 'gi');
 
     return (
         <span

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -23,6 +23,7 @@ import { Search } from 'component/common/Search/Search';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { ITooltipResolverProps } from 'component/common/TooltipResolver/TooltipResolver';
 import { ReactComponent as ProPlanIcon } from 'assets/icons/pro-enterprise-feature-badge.svg';
+import { safeRegExp } from '@server/util/escape-regex';
 
 type PageQueryType = Partial<Record<'search', string>>;
 
@@ -93,7 +94,7 @@ export const ProjectListNew = () => {
     }, [searchValue, setSearchParams]);
 
     const filteredProjects = useMemo(() => {
-        const regExp = new RegExp(searchValue, 'i');
+        const regExp = safeRegExp(searchValue, 'i');
         return (
             searchValue
                 ? projects.filter(project => regExp.test(project.name))

--- a/frontend/src/hooks/useFeaturesFilter.ts
+++ b/frontend/src/hooks/useFeaturesFilter.ts
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { createGlobalStateHook } from 'hooks/useGlobalState';
 import { FeatureSchema } from 'openapi';
+import { safeRegExp } from '@server/util/escape-regex';
 
 export interface IFeaturesFilter {
     query?: string;
@@ -66,7 +67,7 @@ const filterFeaturesByQuery = (
     // Try to parse the search query as a RegExp.
     // Return all features if it can't be parsed.
     try {
-        const regExp = new RegExp(filter.query, 'i');
+        const regExp = safeRegExp(filter.query, 'i');
         return features.filter(f => filterFeatureByRegExp(f, filter, regExp));
     } catch (err) {
         if (err instanceof SyntaxError) {

--- a/src/lib/proxy/create-context.test.ts
+++ b/src/lib/proxy/create-context.test.ts
@@ -107,8 +107,6 @@ test.skip('will not blow up if userId is an array', () => {
         properties: ['some'],
     });
 
-    // console.log(context);
-
     expect(context.userId).toBe('123');
     expect(context).not.toHaveProperty('tenantId');
     expect(context).not.toHaveProperty('region');

--- a/src/lib/util/escape-regex.ts
+++ b/src/lib/util/escape-regex.ts
@@ -1,0 +1,3 @@
+export function safeRegExp(pattern: string, flags?: string): RegExp {
+    return new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), flags);
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/964450/209789571-dc4d1832-a494-4898-8a6c-e8870bf4d130.png)
If you enter characters like ()[] in the search, following error occurs:
![image](https://user-images.githubusercontent.com/964450/209789597-712a5737-1a0a-4cf3-af6d-81bc87cf8f34.png)

**This PR escapes regex characters and makes the app not crash.**