### PR TITLE
feat: wait for deps to be somewhat stable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,9 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePatterns": ["*"],
-      "automerge": true
+      "automerge": true,
+      "stabilityDays": 7,
+      "internalChecksFilter": "strict"
     }
   ]
 }


### PR DESCRIPTION
## About the changes
Some dependency updates we receive are recent releases with a low adoption rate. It's fine to be early adopters but this can also introduce unintended bugs. This PR adds a 7 days grace period before we consider a dependency as ready to be upgraded. It doesn't guarantee its stability but it improves it.

Ideally, I'd like to also use adoption and confidence to automatically merge or delay the creation of the PR, but I haven't found a way of doing that

It also protects us from:
> npm packages less than 72 hours (3 days) old can be unpublished

Documentation: https://docs.renovatebot.com/configuration-options/#stabilitydays

### Examples
![image](https://user-images.githubusercontent.com/455064/209797881-6fb34546-9c76-44f6-a276-9d897daa1257.png)
![image](https://user-images.githubusercontent.com/455064/209797919-046bb577-4dc8-444e-8515-0b8e9a6cbcbf.png)

