### PR TITLE
feat: limit the amount of results coming from Prometheus

### DIFF
--- a/frontend/src/component/admin/network/NetworkTraffic/NetworkTraffic.tsx
+++ b/frontend/src/component/admin/network/NetworkTraffic/NetworkTraffic.tsx
@@ -87,7 +87,7 @@ const createInstanceChartOptions = (
             },
         },
         title: {
-            text: 'Requests per second in the last 6 hours',
+            text: 'Top 10 requests per second in the last 6 hours',
             position: 'top',
             align: 'start',
             display: true,

--- a/src/lib/services/client-metrics/instance-service.ts
+++ b/src/lib/services/client-metrics/instance-service.ts
@@ -224,7 +224,7 @@ export default class ClientInstanceService {
         return (d.getTime() - d.getMilliseconds()) / 1000;
     }
 
-    async getRPS(hoursToQuery: number): Promise<any> {
+    async getRPS(hoursToQuery: number, limit = 10): Promise<any> {
         if (!this.prometheusApi) {
             this.logger.warn('Prometheus not configured');
             return;
@@ -233,7 +233,7 @@ export default class ClientInstanceService {
         const basePath = this.serverOption.baseUriPath.replace(/\/$/, '');
         const pathQuery = `${basePath}/api/.*`;
         const step = '5m';
-        const rpsQuery = `irate (http_request_duration_milliseconds_count{path=~"${pathQuery}"} [${step}])`;
+        const rpsQuery = `topk(${limit}, irate (http_request_duration_milliseconds_count{path=~"${pathQuery}"} [${step}]))`;
         const query = `sum by(appName, endpoint) (label_replace(${rpsQuery}, "endpoint", "$1", "path", "${basePath}(/api/(?:client/)?[^/\*]*).*"))`;
         const end = new Date();
         const start = new Date();


### PR DESCRIPTION
## About the changes
To avoid showing too much data in the traffic screen, limit the number of results to `topk`. 

## Discussion points
Top 10 is a rule of thumb, but maybe we could do top 25. Until we gather more data, I believe this should be good enough
