### PR TITLE
formatApiPath / formatAssetPath - Implement smart functionality to detect double subpath

### DIFF
--- a/frontend/src/utils/formatPath.test.ts
+++ b/frontend/src/utils/formatPath.test.ts
@@ -28,6 +28,7 @@ test('formatAssetPath', () => {
     expect(formatAssetPath('/a', '/x')).toEqual('/x/a');
     expect(formatAssetPath('/a/', '/x/')).toEqual('/x/a');
     expect(formatAssetPath('a/b/', 'x/y/')).toEqual('/x/y/a/b');
+    expect(formatAssetPath('x/y/', 'x/y/')).toEqual('/x/y');
     expect(formatAssetPath('//a//b//', '//x//y//')).toEqual('/x/y/a/b');
 });
 
@@ -42,6 +43,7 @@ test('formatApiPath', () => {
     expect(formatApiPath('/', '/')).toEqual('');
     expect(formatApiPath('a', 'x')).toEqual('/x/a');
     expect(formatApiPath('/a', '/x')).toEqual('/x/a');
+    expect(formatApiPath('/a', '/x/a')).toEqual('/x/a');
     expect(formatApiPath('/a/', '/x/')).toEqual('/x/a');
     expect(formatApiPath('a/b/', 'x/y/')).toEqual('/x/y/a/b');
     expect(formatApiPath('//a//b//', '//x//y//')).toEqual('/x/y/a/b');

--- a/frontend/src/utils/formatPath.ts
+++ b/frontend/src/utils/formatPath.ts
@@ -24,7 +24,9 @@ export const parseBasePath = (value = basePathMetaTagContent()): string => {
 // Join paths with a leading separator and without a trailing separator.
 const joinPaths = (...paths: string[]): string => {
     const filteredPaths = paths.filter(path => {
-        return !paths.some(i => i !== path && i.includes(path));
+        return !paths.some(
+            currentPath => currentPath !== path && currentPath.includes(path)
+        );
     });
     const uniquePaths = [...new Set(filteredPaths)];
 

--- a/frontend/src/utils/formatPath.ts
+++ b/frontend/src/utils/formatPath.ts
@@ -23,7 +23,12 @@ export const parseBasePath = (value = basePathMetaTagContent()): string => {
 
 // Join paths with a leading separator and without a trailing separator.
 const joinPaths = (...paths: string[]): string => {
-    return ['', ...paths]
+    const filteredPaths = paths.filter(path => {
+        return !paths.some(i => i !== path && i.includes(path));
+    });
+    const uniquePaths = [...new Set(filteredPaths)];
+
+    return ['', ...uniquePaths]
         .join('/')
         .replace(/\/+$/g, '') // Remove trailing separators.
         .replace(/\/+/g, '/'); // Collapse repeated separators.


### PR DESCRIPTION
Today we have two functions that wrap our paths with the subpath. Since all of our customers are hosted on a subpath, such as /eubb1001, we need to account for this path when building API paths and asset paths. 

These functions could be smarter, we could, for example detect if we have already added the base path and ignore it if it already exists.

**This PR implements this and adds 2 capabilities:**

1. If there is list of paths that need to be joined and one is subset of another, it is removed.
2. All duplicate paths in the list are removed