### PR TITLE
Make it possible to validate enterprise schema with respondWithValidation

### DIFF
--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -2,7 +2,7 @@ import Ajv, { ErrorObject } from 'ajv';
 import { SchemaId, schemas } from './index';
 import { omitKeys } from '../util/omit-keys';
 
-interface ISchemaValidationErrors<S = SchemaId> {
+export interface ISchemaValidationErrors<S = SchemaId> {
     schema: S;
     errors: ErrorObject[];
 }

--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -2,8 +2,8 @@ import Ajv, { ErrorObject } from 'ajv';
 import { SchemaId, schemas } from './index';
 import { omitKeys } from '../util/omit-keys';
 
-interface ISchemaValidationErrors {
-    schema: SchemaId;
+interface ISchemaValidationErrors<S = SchemaId> {
+    schema: S;
     errors: ErrorObject[];
 }
 
@@ -21,10 +21,10 @@ const ajv = new Ajv({
     },
 });
 
-export const validateSchema = (
-    schema: SchemaId,
+export const validateSchema = <S = SchemaId>(
+    schema: S,
     data: unknown,
-): ISchemaValidationErrors | undefined => {
+): ISchemaValidationErrors<S> | undefined => {
     if (!ajv.validate(schema, data)) {
         return {
             schema,

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -64,14 +64,14 @@ export class OpenApiService {
         });
     }
 
-    respondWithValidation<T>(
+    respondWithValidation<T, S extends SchemaId = SchemaId>(
         status: number,
         res: Response<T>,
-        schema: SchemaId,
+        schema: S,
         data: T,
         headers: { [header: string]: string } = {},
     ): void {
-        const errors = validateSchema(schema, data);
+        const errors = validateSchema<S>(schema, data);
 
         if (errors) {
             this.logger.debug('Invalid response:', errors);

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -64,7 +64,7 @@ export class OpenApiService {
         });
     }
 
-    respondWithValidation<T, S extends SchemaId = SchemaId>(
+    respondWithValidation<T, S = SchemaId>(
         status: number,
         res: Response<T>,
         schema: S,


### PR DESCRIPTION
Now respondWithValidation<T, S = SchemaId> can be called in oss and enterprise to validate against needed schema.