### PR TITLE
Ability to add AJV schemas runtime

### DIFF
--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -21,6 +21,13 @@ const ajv = new Ajv({
     },
 });
 
+export const addAjvSchema = (schemaObjects: any[]): any => {
+    const newSchemas = schemaObjects.filter(
+        (schema) => !ajv.getSchema(schema.$id),
+    );
+    return ajv.addSchema(newSchemas);
+};
+
 export const validateSchema = <S = SchemaId>(
     schema: S,
     data: unknown,


### PR DESCRIPTION
Previously there was no way to add AJV schemas in runtime. This PR adds to availability.