### PR TITLE
docs: clarify node sdk instructions wrt envs and tokens

### DIFF
--- a/website/docs/reference/sdks/node.md
+++ b/website/docs/reference/sdks/node.md
@@ -37,7 +37,6 @@ const unleash = require('unleash-client');
 unleash.initialize({
   url: 'https://YOUR-API-URL',
   appName: 'my-node-name',
-  environment: process.env.APP_ENV,
   customHeaders: { Authorization: 'SOME-SECRET' },
 });
 ```
@@ -51,7 +50,6 @@ const { startUnleash } = require('unleash-client');
 const unleash = await startUnleash({
   url: 'https://YOUR-API-URL',
   appName: 'my-node-name',
-  environment: process.env.APP_ENV,
   customHeaders: { Authorization: 'SOME-SECRET' },
 });
 ```
@@ -59,7 +57,7 @@ const unleash = await startUnleash({
   </TabItem>
 </Tabs>
 
-The example code above will initialize the client SDK, and connect to the Unleash-hosted demo instance. It also uses the API token for the demo instance. You should change the URL and the Authorization header (API token) with the correct values for your instance, which you may locate under “Instance admin” in the menu.
+The example code above will initialize the client SDK, and try to the Unleash instance you point it to. You will need to use your own Unleash instance URL and a [server-side API token](../api-tokens-and-client-keys.mdx#client-tokens) to connect. For steps on how to create an API token, refer to the [_how to create API tokens_](../../how-to/how-to-create-api-tokens.mdx) guide.
 
 ## Step 3: Use the feature toggle {#step-3-use-the-feature-toggle}
 


### PR DESCRIPTION
## What

This change does two things:

It **removes the `environment` option** from the initialization examples. This option is deprecated and only causes confusion. There's no good reason to have it lying around in the examples.

It also **updates the explanation of the code samples**, telling you that you need to generate an API key and linking you to the reference doc and how to guide.

Relates to: #2782.