### PR TITLE
Fix(typo): Fix "login"/"log in", "logout"/"log out" issues

### DIFF
--- a/frontend/src/component/user/Login/Login.tsx
+++ b/frontend/src/component/user/Login/Login.tsx
@@ -48,7 +48,7 @@ const Login = () => {
                     condition={authDetails?.type !== DEMO_TYPE}
                     show={
                         <h2 className={styles.title}>
-                            Login to continue the great work
+                            Log in to continue the great work
                         </h2>
                     }
                 />

--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -128,7 +128,7 @@ export const UserProfileContent = ({
                     color="primary"
                     href={`${basePath}/logout`}
                 >
-                    Logout
+                    Log out
                 </StyledLogoutButton>
             </StyledPaper>
         }

--- a/website/docs/how-to/how-to-add-sso-google.md
+++ b/website/docs/how-to/how-to-add-sso-google.md
@@ -42,7 +42,7 @@ You will then get a `Client ID` and a `Client Secret` that you will need in the 
 
 ### Step 4: Configure Unleash {#step-4}
 
-Login to Unleash and navigate to `Admin menu -> Single-Sign-on -> Google`.
+Log in to Unleash and navigate to `Admin menu -> Single-Sign-on -> Google`.
 
 First insert the Client Id and Client Secret from step 3.
 
@@ -56,6 +56,6 @@ Remember to click “Save” to store your settings.
 
 ### Step 5: Verify {#step-5}
 
-Logout of Unleash and sign back in again. You should now be presented with the “SSO Authentication Option”. Click the button and follow the sign-in flow. If all goes well you should be successfully signed in to Unleash. If something is not working you can still sign-in with username and password.
+Log out of Unleash and sign back in again. You should now be presented with the “SSO Authentication Option”. Click the button and follow the sign-in flow. If all goes well you should be successfully signed in to Unleash. If something is not working you can still sign-in with username and password.
 
 ![Verify SSO](/img/sign-in-google.png)

--- a/website/docs/how-to/how-to-add-sso-open-id-connect.md
+++ b/website/docs/how-to/how-to-add-sso-open-id-connect.md
@@ -69,7 +69,7 @@ You may also choose to “Auto-create users”. This will make Unleash automatic
 
 ### Step 4: Verify {#step-4}
 
-Logout of Unleash and sign back in again. You should now be presented with the "Sign in with OpenID Connect" option. Click the button and follow the sign-in flow. If all goes well you should be successfully signed in to Unleash.
+Log out of Unleash and sign back in again. You should now be presented with the "Sign in with OpenID Connect" option. Click the button and follow the sign-in flow. If all goes well you should be successfully signed in to Unleash.
 
 (If something is not working you can still sign-in with username and password).
 


### PR DESCRIPTION
## What

This change updates some places in the docs where we use the terms "login" and "logout" incorrectly.

A "login" is a noun, typically referring to the set of credentials you need to _log in_ to a service. The verb form, the act of signing in, is written in two words: to "log in".

A similar logic applies to "logout" and "log out", although I don't find the term "logout" in my dictionary. However, I think it makes sense to talk about "logout requests" (and I see references to logout in other services and documentation), so I'm happy to use that as a noun. Regardless, the act of logging out is to "log out".