### PR TITLE
docs: enable "remote content" plugin, add Rust SDK readme

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,3 +1,27 @@
+// all SDK repos and what they map to for the sidebar.
+//
+// Each key should return an object that contains *at least* the
+// `sidebarSdkName` property. This is the name that is placed before "SDK" in
+// the sidebar. An object can also optionally define a `slugName`. This will be
+// used to construct the slug. If no "slugName" is defined, the `sidebarSdkName`
+// should be used to create the slug.
+const readmeRepos = {
+    'unleash-client-rust': {
+        sidebarSdkName: 'Rust',
+    },
+    // as an example of when you'd use both
+    // 'unleash-android-proxy-sdk': {
+    //     sidebarSdkName: 'Android',
+    //     slugName: 'android-proxy',
+    // },
+};
+
+function getReadmeRepoData(filename) {
+    const repoName = filename.split('/')[0];
+
+    return readmeRepos[repoName] ?? { sdkName: repoName };
+}
+
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
     title: 'Unleash',
@@ -554,6 +578,32 @@ module.exports = {
                             categoryLinkSource: 'tag',
                         },
                     },
+                },
+            },
+        ],
+        [
+            'docusaurus-plugin-remote-content',
+            {
+                // more info at https://github.com/rdilweb/docusaurus-plugin-remote-content#options
+                name: 'content-sdks',
+                sourceBaseUrl: 'https://raw.githubusercontent.com/Unleash/', // gets prepended to all of the documents when fetching
+                outDir: 'docs/reference/sdks', // the base directory to output to.
+                documents: Object.keys(readmeRepos).map(
+                    (repo) => `${repo}/main/README.md`,
+                ), // the file names to download
+                modifyContent: (filename, content) => {
+                    const data = getReadmeRepoData(filename);
+                    return {
+                        filename: `${(
+                            data.slugName ?? data.sidebarSdkName
+                        ).toLowerCase()}.md`,
+                        content: `---
+title: ${data.sidebarSdkName} SDK
+---
+
+${content}
+`,
+                    };
                 },
             },
         ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -88,6 +88,7 @@ module.exports = {
                 'kotlin',
                 'php',
                 'ruby',
+                'rust',
                 'swift',
             ],
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -604,6 +604,9 @@ module.exports = {
                 ), // the file names to download
                 modifyContent: (filename, content) => {
                     const sdk = getReadmeRepoData(filename);
+
+                    const generationTime = new Date();
+
                     return {
                         filename: `${sdk.slugName}.md`,
                         content: `---
@@ -615,6 +618,13 @@ This document was generated from the README in the [${sdk.sidebarName} SDK's Git
 :::
 
 ${content}
+
+---
+
+This content was generated on <time datetime="${generationTime.toISOString()}">${generationTime.toLocaleString(
+                            'en-gb',
+                            { dateStyle: 'long', timeStyle: 'full' },
+                        )}</time>
 `,
                     };
                 },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -609,6 +609,10 @@ module.exports = {
 title: ${sdk.sidebarName} SDK
 ---
 
+:::info Generated content
+This document was generated from the README in the [${sdk.sidebarName} SDK's GitHub repository](${sdk.repoUrl}).
+:::
+
 ${content}
 `,
                     };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,11 +7,11 @@
 // should be used to create the slug.
 const readmeRepos = {
     'unleash-client-rust': {
-        sidebarSdkName: 'Rust',
+        sidebarName: 'Rust',
     },
     // as an example of when you'd use both
     // 'unleash-android-proxy-sdk': {
-    //     sidebarSdkName: 'Android',
+    //     sidebarName: 'Android',
     //     slugName: 'android-proxy',
     // },
 };
@@ -19,7 +19,17 @@ const readmeRepos = {
 function getReadmeRepoData(filename) {
     const repoName = filename.split('/')[0];
 
-    return readmeRepos[repoName] ?? { sdkName: repoName };
+    const repoData = readmeRepos[repoName];
+
+    const repoUrl = `https://github.com/Unleash/${repoName}`;
+
+    if (repoData) {
+        return {
+            repoUrl,
+            ...repoData,
+            slugName: (repoData.slugName ?? repoData.sidebarName).toLowerCase(),
+        };
+    } else return { sidebarName: repoName, repoUrl };
 }
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
@@ -592,13 +602,11 @@ module.exports = {
                     (repo) => `${repo}/main/README.md`,
                 ), // the file names to download
                 modifyContent: (filename, content) => {
-                    const data = getReadmeRepoData(filename);
+                    const sdk = getReadmeRepoData(filename);
                     return {
-                        filename: `${(
-                            data.slugName ?? data.sidebarSdkName
-                        ).toLowerCase()}.md`,
+                        filename: `${sdk.slugName}.md`,
                         content: `---
-title: ${data.sidebarSdkName} SDK
+title: ${sdk.sidebarName} SDK
 ---
 
 ${content}

--- a/website/package.json
+++ b/website/package.json
@@ -30,6 +30,7 @@
     "browserslist": "^4.16.5",
     "clsx": "1.2.1",
     "docusaurus-plugin-openapi-docs": "1.5.0",
+    "docusaurus-plugin-remote-content": "^3.1.0",
     "docusaurus-theme-openapi-docs": "1.5.0",
     "file-loader": "6.2.0",
     "immer": "^9.0.6",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -237,11 +237,7 @@ module.exports = {
                                 'reference/sdks/php',
                                 'reference/sdks/python',
                                 'reference/sdks/ruby',
-                                {
-                                    type: 'link',
-                                    href: 'https://github.com/unleash/unleash-client-rust',
-                                    label: 'Rust SDK',
-                                },
+                                'reference/sdks/rust',
                                 'reference/sdks/dotnet',
                             ],
                         },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4626,6 +4626,13 @@ axios@^0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-loader@9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
@@ -6386,6 +6393,16 @@ docusaurus-plugin-openapi-docs@1.5.0, docusaurus-plugin-openapi-docs@^1.5.0:
     webpack "^5.61.0"
     xml-formatter "^2.6.1"
 
+docusaurus-plugin-remote-content@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-remote-content/-/docusaurus-plugin-remote-content-3.1.0.tgz#d9349da5e098ba65050c5e00ef2425f3edb5e837"
+  integrity sha512-859WYmC75l9hRYa1f/2FNF+FLcKbkHCM/0dehN1Wl1fIuoFzEPf3tcWs4jcEobRHYnoMjyupqAhmu0q5j3JoIg==
+  dependencies:
+    axios "^0.26.1"
+    picocolors "^1.0.0"
+    pretty-ms "^7.0.1"
+    rimraf "^3.0.2"
+
 docusaurus-theme-openapi-docs@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/docusaurus-theme-openapi-docs/-/docusaurus-theme-openapi-docs-1.5.0.tgz#dfcfb2df92c3b87692e047b5f182688d570d75f0"
@@ -7257,7 +7274,7 @@ focus-lock@^0.8.0:
   dependencies:
     tslib "^1.9.3"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -10745,6 +10762,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-numeric-range@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz#7c63b61190d61e4d53a1197f0c83c47bb670ffa3"
@@ -11399,6 +11421,13 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
+
+pretty-ms@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 pretty-time@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## What

This PR does a few connected things:

1. It adds the ["docusaurus-plugin-remote-content" package](https://github.com/rdilweb/docusaurus-plugin-remote-content).

2. It adds configuration to make it work with Readmes found on GitHub.

3. It adds the Rust SDK's readme (replacing the link we used to have) as a proof of concept on how to do it.

## Why

With documentation split between GitHub readmes and the official docs, it's hard to keep everything up to date and in sync. It's also quite confusing that some information is only available in some places, but not in others. 

We've talked about auto-including readmes from GitHub for a while, so here's a proof of concept (finally) 🥳 

The intention is to get this merged and then to migrate the other SDK docs one by one, ensuring that everything in the documentation is also in the readme (so that no info is lost). 

## Discussion points

### Generation directory

The current generation method generates the files into `/reference/sdks/<sdk name>`. I think this works for now, but it means it adds auto-generated files into a directory that you can't ignore (at least not yet). 

We could instead generate them into `/generated/sdks` and update the slugs so that they still match the expected pattern. 

However, this would make the sidebar a little harder to work with (for now). That said, there may be ways around it. It's worth exploring.

### Generation method

By default, this plugin will generate files whenever you build. That (probably) means that you need an internet connection _and_ that you'll end up with a bunch of untracked files.

An option is to only generate the files "manually" and commit them to the repo. That would allow you to build the project without an internet connection and would also remove the need for ignoring the files. We could automate the generation if we wanted to. 

## Preview / Screenies

Visit [/reference/sdks/rust](https://unleash-docs-git-docs-include-sdk-readmes-unleash-team.vercel.app/reference/sdks/rust) in the preview to see what it looks like live. 

![image](https://user-images.githubusercontent.com/17786332/210373446-784b7e69-0f36-4e9e-874a-2b06b863b603.png)
