### PR TITLE
fix: segment delete confirmation double dialog flash

### DIFF
--- a/frontend/src/component/segments/SegmentDelete/SegmentDelete.tsx
+++ b/frontend/src/component/segments/SegmentDelete/SegmentDelete.tsx
@@ -1,7 +1,7 @@
+import React from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useStrategiesBySegment } from 'hooks/api/getters/useStrategiesBySegment/useStrategiesBySegment';
 import { ISegment } from 'interfaces/segment';
-import React from 'react';
 import { SegmentDeleteConfirm } from './SegmentDeleteConfirm/SegmentDeleteConfirm';
 import { SegmentDeleteUsedSegment } from './SegmentDeleteUsedSegment/SegmentDeleteUsedSegment';
 
@@ -11,14 +11,20 @@ interface ISegmentDeleteProps {
     onClose: () => void;
     onRemove: () => void;
 }
+
 export const SegmentDelete = ({
     segment,
     open,
     onClose,
     onRemove,
 }: ISegmentDeleteProps) => {
-    const { strategies } = useStrategiesBySegment(segment.id);
+    const { strategies, loading } = useStrategiesBySegment(segment.id);
     const canDeleteSegment = strategies?.length === 0;
+
+    if (loading) {
+        return null;
+    }
+
     return (
         <ConditionallyRender
             condition={canDeleteSegment}


### PR DESCRIPTION
## About the changes
Prevent flashing of another dialog when deleting a segment.

Closes [1-501/delete-segment-double-dialog](https://linear.app/unleash/issue/1-501/delete-segment-double-dialog)
