### PR TITLE
fix: when health is 0 we should not show 100

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -419,7 +419,7 @@ class ProjectStore implements IProjectStore {
             name: row.name,
             description: row.description,
             createdAt: row.created_at,
-            health: row.health || 100,
+            health: row.health ?? 100,
             updatedAt: row.updated_at || new Date(),
         };
     }


### PR DESCRIPTION
When health report is 0% we should report 0%. Previously we were reporting 100%.

<img width="1046" alt="Screenshot 2023-01-05 at 14 48 04" src="https://user-images.githubusercontent.com/1394682/210795057-4cdae6f5-59a8-4f89-b6a9-80cbbb784f1e.png">
