### PR TITLE
Docs(fix): fix broken link to sdk-generator ADR

### DIFF
--- a/website/docs/contributing/ADRs/ADRs.md
+++ b/website/docs/contributing/ADRs/ADRs.md
@@ -37,4 +37,4 @@ We have created a set of ADRs to help guide the development of the front end:
 * [Preferred data fetching method](./front-end/preferred-data-fetching-method.md)
 * [Preferred folder structure](./front-end/preferred-folder-structure.md)
 * [Preferred form architecture](./front-end/preferred-form-architecture.md)
-* [OpenAPI SDK generator](../front-end/sdk-generator.md)
+* [OpenAPI SDK generator](./front-end/sdk-generator.md)


### PR DESCRIPTION
This should have been caught by the build system (and it _is_ on this [unrelated docs PR](https://github.com/Unleash/unleash/actions/runs/3847684144/jobs/6554451234)). 

@Tymek , you're listed as the author of the commit that introduced it; can you link me to the PR? I'd like to try and figure out why this went through 🕵🏼 