### PR TITLE
docs: add `/docs` redirects to _all_ redirect paths

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -255,10 +255,7 @@ module.exports = {
                         to: '/reference/deploy/getting-started',
                     },
                     {
-                        from: [
-                            '/docs/deploy/configuring_unleash',
-                            '/deploy/configuring_unleash',
-                        ],
+                        from: '/deploy/configuring_unleash',
                         to: '/reference/deploy/configuring-unleash',
                     },
                     {
@@ -342,7 +339,6 @@ module.exports = {
                             '/sdks',
                             '/user_guide/client-sdk',
                             '/client-sdk',
-                            '/docs/user_guide/connect_sdk',
                             '/user_guide/connect_sdk',
                             '/sdks/community',
                         ],
@@ -482,7 +478,7 @@ module.exports = {
                         to: '/reference/api/legacy/unleash/admin/context',
                     },
                     {
-                        from: ['/api/admin/events', '/docs/api/admin/events'],
+                        from: '/api/admin/events',
                         to: '/reference/api/legacy/unleash/admin/events',
                     },
                     {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,10 +1,27 @@
 const { readmes } = require('./readme-fns');
 
-// add `/docs` redirect prefixes to all `from` paths
+// for a given redirect object, modify it's `from` property such that for every
+// path that doesn't start with `/docs/`, a corresponding path that _does_ start
+// with `/docs/` is added.
+//
+// For instance, given the object
+//
+// {
+//   to: '/new/path',
+//   from: ['/old/path', '/docs/other/old/path'],
+// }
+//
+// it will produce
+//
+// {
+//   to: '/new/path',
+//   from: ['/old/path', '/docs/old/path', '/docs/other/old/path'],
+// }
+//
 const addDocsRoutePrefix = ({ from, ...rest }) => {
     const addDocs = (from) => {
         if (Array.isArray(from)) {
-            // if `from` is a list, then add a an extra entry for every route
+            // if `from` is a list, then check each entry
             return from.flatMap(addDocs);
         } else {
             if (from.startsWith('/docs/')) {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -545,6 +545,10 @@ module.exports = {
                         from: '/api/internal/health',
                         to: '/reference/api/legacy/unleash/internal/health',
                     },
+                    {
+                        from: '/help',
+                        to: '/#getting-help',
+                    },
                 ].map(addDocsRoutePrefix), // add /docs prefixes
                 createRedirects: function (toPath) {
                     if (

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,21 @@
 const { readmes } = require('./readme-fns');
 
+// add `/docs` redirect prefixes to all `from` paths
+const addDocsRoutePrefix = ({ from, ...rest }) => {
+    const addDocs = (from) => {
+        if (Array.isArray(from)) {
+            // if `from` is a list, then add a an extra entry for every route
+            from.flat(addDocsRoutePrefix);
+        } else {
+            return [from, `/docs${from}`];
+        }
+    };
+
+    return {
+        ...rest,
+        from: addDocs(from),
+    };
+};
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
     title: 'Unleash',
@@ -529,7 +545,7 @@ module.exports = {
                         from: '/api/internal/health',
                         to: '/reference/api/legacy/unleash/internal/health',
                     },
-                ],
+                ].map(addDocsRoutePrefix), // add /docs prefixes
                 createRedirects: function (toPath) {
                     if (
                         toPath.indexOf('/docs/') === -1 &&

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,9 +5,13 @@ const addDocsRoutePrefix = ({ from, ...rest }) => {
     const addDocs = (from) => {
         if (Array.isArray(from)) {
             // if `from` is a list, then add a an extra entry for every route
-            from.flat(addDocs);
+            return from.flat(addDocs);
         } else {
-            return [from, `/docs${from}`];
+            if (from.startsWith('/docs/')) {
+                return [from];
+            } else {
+                return [from, `/docs${from}`];
+            }
         }
     };
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -547,7 +547,7 @@ module.exports = {
                     },
                     {
                         from: '/help',
-                        to: '/#getting-help',
+                        to: '/',
                     },
                 ].map(addDocsRoutePrefix), // add /docs prefixes
                 createRedirects: function (toPath) {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,7 +5,7 @@ const addDocsRoutePrefix = ({ from, ...rest }) => {
     const addDocs = (from) => {
         if (Array.isArray(from)) {
             // if `from` is a list, then add a an extra entry for every route
-            return from.flat(addDocs);
+            return from.flatMap(addDocs);
         } else {
             if (from.startsWith('/docs/')) {
                 return [from];

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,7 +5,7 @@ const addDocsRoutePrefix = ({ from, ...rest }) => {
     const addDocs = (from) => {
         if (Array.isArray(from)) {
             // if `from` is a list, then add a an extra entry for every route
-            from.flat(addDocsRoutePrefix);
+            from.flat(addDocs);
         } else {
             return [from, `/docs${from}`];
         }


### PR DESCRIPTION
## What

For each defined doc redirect path (that doesn't start with `/docs/`), this PR adds an additional redirect that starts with `/docs`. The rest of the path is otherwise identical.

For instance, if we have a redirect that goes from `/user_guide/x`, then this change will ensure that we also have redirect that goes from `/docs/user_guide/x`.

## Why

As reported by Roman, we've had some 404s recently when people have tried to access pages that used to exist (wayyyy back) and that used to redirect.

The reason these redirects stopped working is that we changed the url structure recently. Before then, the `createRedirects` function would go and create redirects that started with `/docs/` for all the paths that required it. However, now that we've changed the structure of the URLs, a blanket implementation like that won't work anymore.

Luckily, though, we already have all the redirects for pages we have moved (just not redirecting from the `/docs/...` paths), so we can map over the paths and add the missing redirects.