### PR TITLE
fix: PageContent bodyContainer overflowX

### DIFF
--- a/frontend/src/component/common/PageContent/PageContent.styles.ts
+++ b/frontend/src/component/common/PageContent/PageContent.styles.ts
@@ -9,9 +9,7 @@ export const useStyles = makeStyles()(theme => ({
         [theme.breakpoints.down('md')]: {
             padding: theme.spacing(2),
         },
-        [theme.breakpoints.down('sm')]: {
-            overflowX: 'auto',
-        },
+        overflowX: 'auto',
     },
     paddingDisabled: {
         padding: '0',

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`renders an empty list correctly 1`] = `
         </div>
       </div>
       <div
-        className="body css-142eaq1-bodyContainer"
+        className="body css-ccg7sp-bodyContainer"
       >
         <table
           className="MuiTable-root css-1h6dscb-MuiTable-root-table"


### PR DESCRIPTION
https://linear.app/unleash/issue/1-546/project-overview-table-is-missing-overflow-x-auto

Fixes an issue where the PageContent body doesn't scroll horizontally when needed.

This regression seems to have been included with https://github.com/Unleash/unleash/pull/2811, more specifically:
https://github.com/Unleash/unleash/pull/2811/files#diff-a1c10fdcd539d988f74d4c3742cc6b8844152999a6c7e509ed8b1765c604524fL491