### PR TITLE
feat: move createdAt col on users

### DIFF
--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -106,15 +106,6 @@ const UsersList = () => {
                 sortType: 'boolean',
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                disableGlobalFilter: true,
-                sortType: 'date',
-                width: 120,
-                maxWidth: 120,
-            },
-            {
                 Header: 'Avatar',
                 accessor: 'imageUrl',
                 Cell: ({ row: { original: user } }: any) => (
@@ -145,6 +136,15 @@ const UsersList = () => {
                     roles.find((role: IRole) => role.id === row.rootRole)
                         ?.name || '',
                 disableGlobalFilter: true,
+                maxWidth: 120,
+            },
+            {
+                Header: 'Created',
+                accessor: 'createdAt',
+                Cell: DateCell,
+                disableGlobalFilter: true,
+                sortType: 'date',
+                width: 120,
                 maxWidth: 120,
             },
             {


### PR DESCRIPTION
Small UI/UX change. 

After discussing with @NicolaeUnleash we decided that moving this column in the users table over to the right next to "last login" would improve readability and consistency.

![image](https://user-images.githubusercontent.com/14320932/211355575-bd9cbf87-baa5-4133-9fb4-14882d58dd07.png)
