### PR TITLE
fix: SA duplicate autoResetHiddenColumns

### DIFF
--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
@@ -172,7 +172,6 @@ export const ServiceAccountsTable = () => {
             autoResetSortBy: false,
             disableSortRemove: true,
             disableMultiSort: true,
-            autoResetHiddenColumns: false,
             defaultColumn: {
                 Cell: TextCell,
             },


### PR DESCRIPTION
Seems like merging both https://github.com/Unleash/unleash/pull/2851 and https://github.com/Unleash/unleash/pull/2848 made us end up with a duplicate `autoResetHiddenColumns` option in the `ServiceAccountsTable` table component.