### PR TITLE
fix: prevent margin collapsing

### DIFF
--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -25,7 +25,7 @@ const MainLayoutContainer = styled(Grid)(() => ({
 
 const MainLayoutContentWrapper = styled('main')(({ theme }) => ({
     margin: theme.spacing(0, 'auto'),
-    display: 'flex',
+    display: 'flex', // prevent margin collapsing
     flex: 1,
     width: '100%',
     backgroundColor: theme.palette.contentWrapper,

--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -25,6 +25,7 @@ const MainLayoutContainer = styled(Grid)(() => ({
 
 const MainLayoutContentWrapper = styled('main')(({ theme }) => ({
     margin: theme.spacing(0, 'auto'),
+    display: 'flex',
     flex: 1,
     width: '100%',
     backgroundColor: theme.palette.contentWrapper,


### PR DESCRIPTION
After styled component migration we broke the header. Grid element margin was going outside the main parent element and entering the area of the header (margin collapsing). Added display: flex to main element to prevent child elements escaping with their margins.

Fixed:
<img width="799" alt="Screenshot 2023-01-11 at 10 40 40" src="https://user-images.githubusercontent.com/1394682/211821051-95edd4e2-e66c-4d4e-b94d-0f3bb57d4051.png">

Before:
<img width="796" alt="Screenshot 2023-01-11 at 10 40 35" src="https://user-images.githubusercontent.com/1394682/211821058-775a3eef-ef30-41e4-bdcc-e5d0977d6c7e.png">


Solution: Added flex to parent of the element that was collapsing its margin.