### PR TITLE
fix: make close button visible on small devices

### DIFF
--- a/frontend/src/component/common/SidebarModal/SidebarModal.tsx
+++ b/frontend/src/component/common/SidebarModal/SidebarModal.tsx
@@ -29,6 +29,13 @@ const FixedWidthContentWrapper = styled(ModalContentWrapper)({
     width: 1300,
 });
 
+const StyledIconButton = styled(IconButton)(({ theme }) => ({
+    zIndex: 1,
+    position: 'absolute',
+    top: theme.spacing(3),
+    right: theme.spacing(3),
+}));
+
 export const BaseModal: FC<ISidebarModalProps> = ({
     open,
     onClose,
@@ -67,16 +74,9 @@ export const DynamicSidebarModal: FC<ISidebarModalProps> = props => {
         <BaseModal {...props}>
             <ModalContentWrapper>
                 <Tooltip title="Close" arrow describeChild>
-                    <IconButton
-                        sx={theme => ({
-                            position: 'absolute',
-                            top: theme.spacing(3),
-                            right: theme.spacing(3),
-                        })}
-                        onClick={props.onClose}
-                    >
+                    <StyledIconButton onClick={props.onClose}>
                         <CloseIcon />
-                    </IconButton>
+                    </StyledIconButton>
                 </Tooltip>
                 {props.children}
             </ModalContentWrapper>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Make close button visible in sidebar when a device screen is small
<img width="924" alt="Screenshot 2023-01-11 at 15 02 48" src="https://user-images.githubusercontent.com/1394682/211825782-9ee772b5-be59-4a40-a968-b0efcfb5e7e0.png">

Changes:
* increase zIndex to 1
* extracted styled component (cleanup)


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
