### PR TITLE
fix: unexpected ligatures

### DIFF
--- a/frontend/src/themes/app.css
+++ b/frontend/src/themes/app.css
@@ -11,10 +11,13 @@ html {
 body {
     height: 100%;
     font-family: 'Sen', sans-serif;
+    font-size: 16px;
+    font-variant-ligatures: none;
 }
 
 button {
     font-family: 'Sen', sans-serif;
+    font-variant-ligatures: none;
 }
 
 .MuiAccordion-root.Mui-expanded {
@@ -112,10 +115,6 @@ button {
 
     /* BORDERS */
     --default-border: 1px solid #f1f1f1;
-}
-
-body {
-    font-size: 16px;
 }
 
 h1,


### PR DESCRIPTION
## About the changes
[`Sen` font](https://fonts.google.com/specimen/Sen) adds smiley for keywords like `:D`, `tantan`, `kosal` and `starlee`.

![image (8)](https://user-images.githubusercontent.com/2625371/212014881-173efe2b-ab05-4d90-b5f9-593242e4fe85.png)


## Discussion points
Downslide is we are loosing the `tt` ligature.