### PR TITLE
docs: update footer links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -113,7 +113,7 @@ module.exports = {
                         },
                         {
                             label: 'Roadmap',
-                            href: 'https://github.com/orgs/Unleash/projects/5',
+                            href: 'https://github.com/orgs/Unleash/projects/10',
                         },
                     ],
                 },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -121,12 +121,16 @@ module.exports = {
                     title: 'Community',
                     items: [
                         {
-                            label: 'Stack Overflow',
-                            href: 'https://stackoverflow.com/questions/tagged/unleash',
+                            label: 'GitHub discussions',
+                            href: 'https://github.com/unleash/unleash/discussions/',
                         },
                         {
                             label: 'Slack',
                             href: 'https://slack.unleash.run/',
+                        },
+                        {
+                            label: 'Stack Overflow',
+                            href: 'https://stackoverflow.com/questions/tagged/unleash',
                         },
                         {
                             label: 'Twitter',


### PR DESCRIPTION
## What

This PR:

-   adds a footer link to GitHub discussions
-   updates the link to the public roadmap

## Why

Because we want more people to use discussions as a resource and because the old roadmap link leads to a deprecated roadmap.