### PR TITLE
fix: add environment to event log card

### DIFF
--- a/frontend/src/component/events/EventCard/EventCard.tsx
+++ b/frontend/src/component/events/EventCard/EventCard.tsx
@@ -113,6 +113,17 @@ const EventCard = ({ entry }: IEventCardProps) => {
                         </>
                     }
                 />
+                <ConditionallyRender
+                    condition={Boolean(entry.environment)}
+                    show={
+                        <>
+                            <StyledDefinitionTerm>
+                                Environment:
+                            </StyledDefinitionTerm>
+                            <dd>{entry.environment}</dd>
+                        </>
+                    }
+                />
             </dl>
             <ConditionallyRender
                 condition={entry.data || entry.preData}


### PR DESCRIPTION
## About the changes
Some changes recorded in the event log apply only to one particular environment. This is currently not visible in the event log card, but it is present in the recorded event:

| Full event | Event card |
| --- | --- |
| ![Screenshot from 2023-01-17 14-22-55](https://user-images.githubusercontent.com/455064/212910227-77b5e81c-60fe-4891-bfad-e3358e5a0ba5.png) | ![image](https://user-images.githubusercontent.com/455064/212910207-7cae700b-3f50-4035-9bcd-897de62d76d2.png) |

This PR makes that information visible on the event card

## Discussion points
- **Should the environment name have a link?** I believe this depends on what resource we're modifying. Between linking to the resource (a link that already exists in the event card) and not adding a link I'm inclined to don't include a link
