### PR TITLE
refactor/clean-up-get-project

### DIFF
--- a/src/lib/routes/admin-api/project/health-report.ts
+++ b/src/lib/routes/admin-api/project/health-report.ts
@@ -4,20 +4,15 @@ import { IUnleashServices } from '../../../types/services';
 import { IUnleashConfig } from '../../../types/option';
 import ProjectHealthService from '../../../services/project-health-service';
 import { Logger } from '../../../logger';
-import { IArchivedQuery, IProjectParam } from '../../../types/model';
+import { IProjectParam } from '../../../types/model';
 import { NONE } from '../../../types/permissions';
 import { OpenApiService } from '../../../services/openapi-service';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
-import {
-    healthOverviewSchema,
-    HealthOverviewSchema,
-} from '../../../openapi/spec/health-overview-schema';
 import { serializeDates } from '../../../types/serialize-dates';
 import {
     healthReportSchema,
     HealthReportSchema,
 } from '../../../openapi/spec/health-report-schema';
-import { IAuthRequest } from '../../unleash-types';
 
 export default class ProjectHealthReport extends Controller {
     private projectHealthService: ProjectHealthService;
@@ -40,22 +35,6 @@ export default class ProjectHealthReport extends Controller {
 
         this.route({
             method: 'get',
-            path: '/:projectId',
-            handler: this.getProjectHealthOverview,
-            permission: NONE,
-            middleware: [
-                openApiService.validPath({
-                    tags: ['Projects'],
-                    operationId: 'getProjectHealthOverview',
-                    responses: {
-                        200: createResponseSchema('healthOverviewSchema'),
-                    },
-                }),
-            ],
-        });
-
-        this.route({
-            method: 'get',
             path: '/:projectId/health-report',
             handler: this.getProjectHealthReport,
             permission: NONE,
@@ -69,26 +48,6 @@ export default class ProjectHealthReport extends Controller {
                 }),
             ],
         });
-    }
-
-    async getProjectHealthOverview(
-        req: IAuthRequest<IProjectParam, unknown, unknown, IArchivedQuery>,
-        res: Response<HealthOverviewSchema>,
-    ): Promise<void> {
-        const { projectId } = req.params;
-        const { archived } = req.query;
-        const { user } = req;
-        const overview = await this.projectHealthService.getProjectOverview(
-            projectId,
-            archived,
-            user.id,
-        );
-        this.openApiService.respondWithValidation(
-            200,
-            res,
-            healthOverviewSchema.$id,
-            serializeDates(overview),
-        );
     }
 
     async getProjectHealthReport(

--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -16,6 +16,11 @@ import { OpenApiService } from '../../../services/openapi-service';
 import { serializeDates } from '../../../types/serialize-dates';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
 import { IAuthRequest } from '../../unleash-types';
+import {
+    HealthOverviewSchema,
+    healthOverviewSchema,
+} from '../../../../lib/openapi';
+import { IArchivedQuery, IProjectParam } from '../../../types/model';
 
 export default class ProjectApi extends Controller {
     private projectService: ProjectService;
@@ -38,6 +43,22 @@ export default class ProjectApi extends Controller {
                     operationId: 'getProjects',
                     responses: {
                         200: createResponseSchema('projectsSchema'),
+                    },
+                }),
+            ],
+        });
+
+        this.route({
+            method: 'get',
+            path: '/:projectId',
+            handler: this.getProjectOverview,
+            permission: NONE,
+            middleware: [
+                services.openApiService.validPath({
+                    tags: ['Projects'],
+                    operationId: 'getProjectOverview',
+                    responses: {
+                        200: createResponseSchema('healthOverviewSchema'),
                     },
                 }),
             ],
@@ -66,6 +87,26 @@ export default class ProjectApi extends Controller {
             res,
             projectsSchema.$id,
             { version: 1, projects: serializeDates(projects) },
+        );
+    }
+
+    async getProjectOverview(
+        req: IAuthRequest<IProjectParam, unknown, unknown, IArchivedQuery>,
+        res: Response<HealthOverviewSchema>,
+    ): Promise<void> {
+        const { projectId } = req.params;
+        const { archived } = req.query;
+        const { user } = req;
+        const overview = await this.projectService.getProjectOverview(
+            projectId,
+            archived,
+            user.id,
+        );
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            healthOverviewSchema.$id,
+            serializeDates(overview),
         );
     }
 }

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -92,12 +92,6 @@ export const createServices = (
     const environmentService = new EnvironmentService(stores, config);
     const featureTagService = new FeatureTagService(stores, config);
     const favoritesService = new FavoritesService(stores, config);
-    const projectHealthService = new ProjectHealthService(
-        stores,
-        config,
-        featureToggleServiceV2,
-        favoritesService,
-    );
     const projectService = new ProjectService(
         stores,
         config,
@@ -105,6 +99,11 @@ export const createServices = (
         featureToggleServiceV2,
         groupService,
         favoritesService,
+    );
+    const projectHealthService = new ProjectHealthService(
+        stores,
+        config,
+        projectService,
     );
     const userSplashService = new UserSplashService(stores, config);
     const openApiService = new OpenApiService(config);

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -104,6 +104,7 @@ export const createServices = (
         accessService,
         featureToggleServiceV2,
         groupService,
+        favoritesService,
     );
     const userSplashService = new UserSplashService(stores, config);
     const openApiService = new OpenApiService(config);

--- a/src/test/e2e/api/admin/feature.custom-auth.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.custom-auth.e2e.test.ts
@@ -23,7 +23,7 @@ test('should require authenticated user', async () => {
     const preHook = (app) => {
         app.use('/api/admin/', (req, res) =>
             res
-                .status('401')
+                .status(401)
                 .json(
                     new AuthenticationRequired({
                         path: '/auth/demo/login',

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -5288,7 +5288,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/api/admin/projects/{projectId}": {
       "get": {
-        "operationId": "getProjectHealthOverview",
+        "operationId": "getProjectOverview",
         "parameters": [
           {
             "in": "path",

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -14,12 +14,14 @@ import { DEFAULT_PROJECT } from '../../../lib/types/project';
 import { ALL_PROJECTS } from '../../../lib/util/constants';
 import { SegmentService } from '../../../lib/services/segment-service';
 import { GroupService } from '../../../lib/services/group-service';
+import { FavoritesService } from '../../../lib/services';
 
 let db: ITestDb;
 let stores: IUnleashStores;
 let accessService;
 let groupService;
 let featureToggleService;
+let favoritesService;
 let projectService;
 let editorUser;
 let superUser;
@@ -220,12 +222,14 @@ beforeAll(async () => {
         new SegmentService(stores, config),
         accessService,
     );
+    favoritesService = new FavoritesService(stores, config);
     projectService = new ProjectService(
         stores,
         config,
         accessService,
         featureToggleService,
         groupService,
+        favoritesService,
     );
 
     editorUser = await createUserEditorAccess('Bob Test', 'bob@getunleash.io');

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -10,11 +10,13 @@ import FeatureToggleService from '../../../lib/services/feature-toggle-service';
 import { AccessService } from '../../../lib/services/access-service';
 import { SegmentService } from '../../../lib/services/segment-service';
 import { GroupService } from '../../../lib/services/group-service';
+import { FavoritesService } from '../../../lib/services';
 
 let db;
 let stores;
 let apiTokenService: ApiTokenService;
 let projectService: ProjectService;
+let favoritesService: FavoritesService;
 
 beforeAll(async () => {
     const config = createTestConfig({
@@ -39,13 +41,14 @@ beforeAll(async () => {
         name: 'Some Name',
         email: 'test@getunleash.io',
     });
-
+    favoritesService = new FavoritesService(stores, config);
     projectService = new ProjectService(
         stores,
         config,
         accessService,
         featureToggleService,
         groupService,
+        favoritesService,
     );
 
     await projectService.createProject(project, user);

--- a/src/test/e2e/services/project-health-service.e2e.test.ts
+++ b/src/test/e2e/services/project-health-service.e2e.test.ts
@@ -50,8 +50,7 @@ beforeAll(async () => {
     projectHealthService = new ProjectHealthService(
         stores,
         config,
-        featureToggleService,
-        favoritesService,
+        projectService,
     );
 });
 

--- a/src/test/e2e/services/project-health-service.e2e.test.ts
+++ b/src/test/e2e/services/project-health-service.e2e.test.ts
@@ -37,14 +37,16 @@ beforeAll(async () => {
         new SegmentService(stores, config),
         accessService,
     );
+    favoritesService = new FavoritesService(stores, config);
+
     projectService = new ProjectService(
         stores,
         config,
         accessService,
         featureToggleService,
         groupService,
+        favoritesService,
     );
-    favoritesService = new FavoritesService(stores, config);
     projectHealthService = new ProjectHealthService(
         stores,
         config,

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -11,6 +11,7 @@ import EnvironmentService from '../../../lib/services/environment-service';
 import IncompatibleProjectError from '../../../lib/error/incompatible-project-error';
 import { SegmentService } from '../../../lib/services/segment-service';
 import { GroupService } from '../../../lib/services/group-service';
+import { FavoritesService } from '../../../lib/services';
 
 let stores;
 let db: ITestDb;
@@ -20,6 +21,7 @@ let groupService: GroupService;
 let accessService: AccessService;
 let environmentService: EnvironmentService;
 let featureToggleService: FeatureToggleService;
+let favoritesService: FavoritesService;
 let user;
 
 beforeAll(async () => {
@@ -42,6 +44,8 @@ beforeAll(async () => {
         new SegmentService(stores, config),
         accessService,
     );
+
+    favoritesService = new FavoritesService(stores, config);
     environmentService = new EnvironmentService(stores, config);
     projectService = new ProjectService(
         stores,
@@ -49,6 +53,7 @@ beforeAll(async () => {
         accessService,
         featureToggleService,
         groupService,
+        favoritesService,
     );
 });
 


### PR DESCRIPTION
This PR moves the getProjectOverview method out from the project health controller. It doesn't make sense that this method lives here anymore, as over time it has grown into method that relays all information about a single project. It makes more sense that this now lives on the root of the project api. Also removes unwanted duplication of getProjectOverview from the project-service and the project-health-service.