### PR TITLE
docs: add link to the Unleash help center

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -115,6 +115,10 @@ module.exports = {
                             label: 'Roadmap',
                             href: 'https://github.com/orgs/Unleash/projects/10',
                         },
+                        {
+                            label: 'Unleash help center',
+                            href: 'https://getunleash.zendesk.com/hc/en-gb',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
## What

This change adds a link to the Unleash help center in the list of links.

## Why

To make it easier to get help for customers who require it.

## Notes

Signed off by Diego (@dsusa72) and Elise (@EliseBrevald).