### PR TITLE
docs: don't tell users to contact support for proxy hosting

### DIFF
--- a/website/docs/reference/unleash-proxy.md
+++ b/website/docs/reference/unleash-proxy.md
@@ -4,8 +4,6 @@ title: Unleash Proxy
 ---
 import Figure from '@site/src/components/Figure/Figure.tsx'
 
-> The unleash-proxy is compatible with all Unleash Enterprise versions and Unleash Open-Source v4. You should reach out to **support@getunleash.io** if you want the Unleash Team to host the Unleash Proxy for you.
-
 :::tip
 
 Looking for how to run the Unleash proxy? Check out the [_How to run the Unleash Proxy_ guide](../how-to/how-to-run-the-unleash-proxy.mdx)!


### PR DESCRIPTION
## What

This change removes a notice from the proxy documentation saying that users should reach out to support@getunleash.io if they want the Unleash team to host it.

## Why

Unleash ships with the front-end API now, so we don't want people reaching out to support for this anymore.