### PR TITLE
fix: small UI-centric suggestions

### DIFF
--- a/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
+++ b/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
@@ -7,7 +7,13 @@ const StyledHtmlTooltipBody = styled('div')(({ theme }) => ({
 }));
 
 const StyledHtmlTooltip = styled(
-    ({ className, maxWidth, maxHeight, ...props }: IHtmlTooltipProps) => (
+    ({
+        className,
+        maxWidth,
+        maxHeight,
+        fontSize,
+        ...props
+    }: IHtmlTooltipProps) => (
         <Tooltip
             {...props}
             title={<StyledHtmlTooltipBody>{props.title}</StyledHtmlTooltipBody>}
@@ -15,11 +21,21 @@ const StyledHtmlTooltip = styled(
         />
     ),
     {
-        shouldForwardProp: prop => prop !== 'maxWidth' && prop !== 'maxHeight',
+        shouldForwardProp: prop =>
+            prop !== 'maxWidth' && prop !== 'maxHeight' && prop !== 'fontSize',
     }
-)<{ maxWidth?: SpacingArgument; maxHeight?: SpacingArgument }>(
-    ({ theme, maxWidth, maxHeight }) => ({
-        maxWidth: maxWidth || theme.spacing(37.5),
+)<{
+    maxWidth?: SpacingArgument;
+    maxHeight?: SpacingArgument;
+    fontSize?: string;
+}>(
+    ({
+        theme,
+        maxWidth = theme.spacing(37.5),
+        maxHeight = theme.spacing(37.5),
+        fontSize = theme.fontSizes.smallerBody,
+    }) => ({
+        maxWidth,
         [`& .${tooltipClasses.tooltip}`]: {
             display: 'flex',
             flexDirection: 'column',
@@ -31,7 +47,8 @@ const StyledHtmlTooltip = styled(
             fontWeight: theme.fontWeight.medium,
             maxWidth: 'inherit',
             border: `1px solid ${theme.palette.lightBorder}`,
-            maxHeight: maxHeight || theme.spacing(37.5),
+            maxHeight,
+            fontSize,
         },
         [`& .${tooltipClasses.arrow}`]: {
             '&:before': {
@@ -45,6 +62,7 @@ const StyledHtmlTooltip = styled(
 export interface IHtmlTooltipProps extends TooltipProps {
     maxWidth?: SpacingArgument;
     maxHeight?: SpacingArgument;
+    fontSize?: string;
 }
 
 export const HtmlTooltip = (props: IHtmlTooltipProps) => (

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelEnvironmentSwitches/FeatureOverviewSidePanelEnvironmentSwitches.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelEnvironmentSwitches/FeatureOverviewSidePanelEnvironmentSwitches.tsx
@@ -34,6 +34,13 @@ const StyledSubLabel = styled('p')(({ theme }) => ({
     alignItems: 'center',
 }));
 
+const StyledSeparator = styled('span')(({ theme }) => ({
+    padding: theme.spacing(0, 0.5),
+    '::after': {
+        content: '"-"',
+    },
+}));
+
 const StyledLink = styled(Link<typeof RouterLink | 'a'>)(() => ({
     '&:hover, &:focus': {
         textDecoration: 'underline',
@@ -71,7 +78,7 @@ export const FeatureOverviewSidePanelEnvironmentSwitches = ({
 
                 const variantsLink = variants.length > 0 && (
                     <>
-                        {' - '}
+                        <StyledSeparator />
                         <Tooltip title="View variants" arrow describeChild>
                             <StyledLink
                                 component={RouterLink}
@@ -119,7 +126,10 @@ export const FeatureOverviewSidePanelEnvironmentSwitches = ({
                                                     variants in this
                                                     environment, you will get
                                                     the{' '}
-                                                    <a href="https://docs.getunleash.io/reference/feature-toggle-variants#the-disabled-variant">
+                                                    <a
+                                                        href="https://docs.getunleash.io/reference/feature-toggle-variants#the-disabled-variant"
+                                                        target="_blank"
+                                                    >
                                                         disabled variant
                                                     </a>
                                                     .


### PR DESCRIPTION
Small UI-centric suggestions for things I identified:

![image](https://user-images.githubusercontent.com/14320932/213725772-56ff24ea-3179-4f5d-9827-00db0c7d390b.png) (1)
![image](https://user-images.githubusercontent.com/14320932/213726102-ea5b599a-e868-47a7-9f61-284e0fb286e6.png) (2)

- Links now open on a new tab by default;
- Small refactoring opportunities;
- Improves the spacing in the feature overview toggles (1);
- Improves the alignment of the environment switch on the project overview (2);

Also includes some small `HtmlTooltip` changes - I noticed `fontSize` was different between tooltips so this aligns the default and includes some refactoring with the default values.