### PR TITLE
fix: prevent deleting the last variable variant on the ui

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
@@ -27,6 +27,7 @@ import cloneDeep from 'lodash.clonedeep';
 import { CloudCircle } from '@mui/icons-material';
 import PermissionSwitch from 'component/common/PermissionSwitch/PermissionSwitch';
 import { UPDATE_FEATURE_VARIANTS } from 'component/providers/AccessProvider/permissions';
+import { WeightType } from 'constants/variantTypes';
 
 const StyledFormSubtitle = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -120,11 +121,6 @@ const payloadOptions = [
     { key: 'json', label: 'json' },
     { key: 'csv', label: 'csv' },
 ];
-
-enum WeightType {
-    FIX = 'fix',
-    VARIABLE = 'variable',
-}
 
 const EMPTY_PAYLOAD = { type: 'string', value: '' };
 

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
@@ -112,6 +112,9 @@ export const EnvironmentVariantsTable = ({
                     <VariantsActionCell
                         variant={original}
                         projectId={projectId}
+                        isLastVariableVariant={isProtectedVariant(
+                            original
+                        )}
                         environmentId={environment.name}
                         editVariant={onEditVariant}
                         deleteVariant={onDeleteVariant}
@@ -129,6 +132,23 @@ export const EnvironmentVariantsTable = ({
         }),
         []
     );
+
+    const isProtectedVariant = (variant: IFeatureVariant): boolean => {
+        const isVariable = variant.weightType === 'variable';
+
+        const atLeastOneFixedVariant = variants.some(variant => {
+            return variant.weightType === 'fix';
+        });
+
+        const hasOnlyOneVariableVariant =
+            variants.filter(variant => {
+                return variant.weightType === 'variable';
+            }).length == 1;
+
+        return (
+            atLeastOneFixedVariant && hasOnlyOneVariableVariant && isVariable
+        );
+    };
 
     const { data, getSearchText } = useSearch(columns, searchValue, variants);
 

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
@@ -20,6 +20,7 @@ import { PayloadCell } from './PayloadCell/PayloadCell';
 import { OverridesCell } from './OverridesCell/OverridesCell';
 import { VariantsActionCell } from './VariantsActionsCell/VariantsActionsCell';
 import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { WeightType } from 'constants/variantTypes';
 
 const StyledTableContainer = styled('div')(({ theme }) => ({
     margin: theme.spacing(3, 0),
@@ -132,15 +133,15 @@ export const EnvironmentVariantsTable = ({
     );
 
     const isProtectedVariant = (variant: IFeatureVariant): boolean => {
-        const isVariable = variant.weightType === 'variable';
+        const isVariable = variant.weightType === WeightType.VARIABLE;
 
         const atLeastOneFixedVariant = variants.some(variant => {
-            return variant.weightType === 'fix';
+            return variant.weightType === WeightType.FIX;
         });
 
         const hasOnlyOneVariableVariant =
             variants.filter(variant => {
-                return variant.weightType === 'variable';
+                return variant.weightType === WeightType.VARIABLE;
             }).length == 1;
 
         return (

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
@@ -112,9 +112,7 @@ export const EnvironmentVariantsTable = ({
                     <VariantsActionCell
                         variant={original}
                         projectId={projectId}
-                        isLastVariableVariant={isProtectedVariant(
-                            original
-                        )}
+                        isLastVariableVariant={isProtectedVariant(original)}
                         environmentId={environment.name}
                         editVariant={onEditVariant}
                         deleteVariant={onDeleteVariant}

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/VariantsActionsCell/VariantsActionsCell.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/VariantsActionsCell/VariantsActionsCell.tsx
@@ -45,7 +45,9 @@ export const VariantsActionCell = ({
                 environmentId={environmentId}
                 onClick={() => deleteVariant(variant)}
                 tooltipProps={{
-                    title: isLastVariableVariant ? 'You need to have at least one variable variant' : 'Delete variant',
+                    title: isLastVariableVariant
+                        ? 'You need to have at least one variable variant'
+                        : 'Delete variant',
                 }}
             >
                 <Delete />

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/VariantsActionsCell/VariantsActionsCell.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/VariantsActionsCell/VariantsActionsCell.tsx
@@ -4,10 +4,11 @@ import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from 'component/providers/AccessProvider/permissions';
 import { IFeatureVariant } from 'interfaces/featureToggle';
 
-interface IVarintsActionCellProps {
+interface IVariantsActionCellProps {
     projectId: string;
     environmentId: string;
     variant: IFeatureVariant;
+    isLastVariableVariant: boolean;
     editVariant: (variant: IFeatureVariant) => void;
     deleteVariant: (variant: IFeatureVariant) => void;
 }
@@ -16,9 +17,10 @@ export const VariantsActionCell = ({
     projectId,
     environmentId,
     variant,
+    isLastVariableVariant,
     editVariant,
     deleteVariant,
-}: IVarintsActionCellProps) => {
+}: IVariantsActionCellProps) => {
     return (
         <ActionCell>
             <PermissionIconButton
@@ -39,10 +41,11 @@ export const VariantsActionCell = ({
                 permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
                 data-testid={`VARIANT_DELETE_BUTTON_${variant.name}`}
                 projectId={projectId}
+                disabled={isLastVariableVariant}
                 environmentId={environmentId}
                 onClick={() => deleteVariant(variant)}
                 tooltipProps={{
-                    title: 'Delete variant',
+                    title: isLastVariableVariant ? 'You need to have at least one variable variant' : 'Delete variant',
                 }}
             >
                 <Delete />

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
@@ -66,12 +66,8 @@ export const FeatureEnvironmentVariants = () => {
         patch: jsonpatch.Operation[];
         error?: string;
     } => {
-        try {
-            const updatedNewVariants = updateWeight(newVariants, 1000);
-            return { patch: createPatch(variants, updatedNewVariants) };
-        } catch (error: unknown) {
-            return { patch: [], error: formatUnknownError(error) };
-        }
+        const updatedNewVariants = updateWeight(newVariants, 1000);
+        return { patch: createPatch(variants, updatedNewVariants) };
     };
 
     const updateVariants = async (

--- a/frontend/src/constants/variantTypes.ts
+++ b/frontend/src/constants/variantTypes.ts
@@ -1,0 +1,4 @@
+export enum WeightType {
+    FIX = 'fix',
+    VARIABLE = 'variable',
+}


### PR DESCRIPTION
This blocks the UI from allowing you to attempt to delete the last fixed variant in environment variants, this was previously possible, but the UI catch an error and then never make a request. For bonus points this removes the problematic try catch, which allows the error message to bubble correctly to the handler