### PR TITLE
feat: adds the PAT_DELETE event

### DIFF
--- a/src/lib/routes/admin-api/user/pat.ts
+++ b/src/lib/routes/admin-api/user/pat.ts
@@ -103,7 +103,7 @@ export default class PatController extends Controller {
         res: Response,
     ): Promise<void> {
         const { id } = req.params;
-        await this.patService.deletePat(id, req.user.id);
+        await this.patService.deletePat(id, req.user.id, req.user);
         res.status(200).end();
     }
 }

--- a/src/lib/services/pat-service.ts
+++ b/src/lib/services/pat-service.ts
@@ -2,7 +2,7 @@ import { IUnleashConfig, IUnleashStores } from '../types';
 import { Logger } from '../logger';
 import { IPatStore } from '../types/stores/pat-store';
 import { IEventStore } from '../types/stores/event-store';
-import { PAT_CREATED } from '../types/events';
+import { PAT_CREATED, PAT_DELETED } from '../types/events';
 import { IPat } from '../types/models/pat';
 import crypto from 'crypto';
 import User from '../types/user';
@@ -33,11 +33,7 @@ export default class PatService {
         this.eventStore = eventStore;
     }
 
-    async createPat(
-        pat: IPat,
-        forUserId: number,
-        creator: User,
-    ): Promise<IPat> {
+    async createPat(pat: IPat, forUserId: number, editor: User): Promise<IPat> {
         await this.validatePat(pat, forUserId);
         pat.secret = this.generateSecretKey();
         pat.userId = forUserId;
@@ -46,7 +42,7 @@ export default class PatService {
         pat.secret = '***';
         await this.eventStore.store({
             type: PAT_CREATED,
-            createdBy: creator.email || creator.username,
+            createdBy: editor.email || editor.username,
             data: pat,
         });
 
@@ -57,8 +53,21 @@ export default class PatService {
         return this.patStore.getAllByUser(userId);
     }
 
-    async deletePat(id: number, userId: number): Promise<void> {
-        return this.patStore.deleteForUser(id, userId);
+    async deletePat(
+        id: number,
+        forUserId: number,
+        editor: User,
+    ): Promise<void> {
+        const pat = await this.patStore.get(id);
+
+        pat.secret = '***';
+        await this.eventStore.store({
+            type: PAT_DELETED,
+            createdBy: editor.email || editor.username,
+            data: pat,
+        });
+
+        return this.patStore.deleteForUser(id, forUserId);
     }
 
     async validatePat(

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -80,6 +80,7 @@ export const CLIENT_METRICS = 'client-metrics';
 export const CLIENT_REGISTER = 'client-register';
 
 export const PAT_CREATED = 'pat-created';
+export const PAT_DELETED = 'pat-deleted';
 
 export const PUBLIC_SIGNUP_TOKEN_CREATED = 'public-signup-token-created';
 export const PUBLIC_SIGNUP_TOKEN_USER_ADDED = 'public-signup-token-user-added';


### PR DESCRIPTION
Adds the `PAT_DELETE` event so we can log the relevant information when a PAT is deleted.

Should cover the following scenarios:

- User deletes their own PAT;
- Admin deletes another user's PAT;
- Admin deletes a Service Account token; 