### PR TITLE
chore: increase max number of environments from 15 to 50

### DIFF
--- a/frontend/src/constants/values.ts
+++ b/frontend/src/constants/values.ts
@@ -1,1 +1,1 @@
-export const ENV_LIMIT = 15;
+export const ENV_LIMIT = 50;


### PR DESCRIPTION
Currently we have a soft limit of 15 environments, there's no technical or business reason for this, only that it's handled inelegantly in the UI. Users are asking for more