### PR TITLE
chore: ignore Twitter link from being checked

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,6 +2,7 @@ dev-example-okta.com
 .*-dsn.algolia.net
 www.linkedin.com/company/getunleash
 www.instagram.com/getunleash
+twitter.com/getunleash
 
 .*.unleash.host.*.com.*
 unleash.*.com/api/


### PR DESCRIPTION
## About the changes
Removing perfect match on our Twitter account URL

Closes #2958
