### PR TITLE
feat: adds CR to variants per env UI

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
@@ -54,7 +54,7 @@ export const ChangeRequestDialogue: FC<IChangeRequestDialogueProps> = ({
                 show={
                     <Alert severity="info" sx={{ mb: 2 }}>
                         Change requests feature is enabled for {environment}.
-                        Your changes needs to be approved before they will be
+                        Your changes need to be approved before they will be
                         live. All the changes you do now will be added into a
                         draft that you can submit for review.
                     </Alert>

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantModal/EnvironmentVariantModal.tsx
@@ -400,7 +400,7 @@ export const EnvironmentVariantModal = ({
                                             {environment
                                                 ? ` for ${environment.name}`
                                                 : ''}
-                                            . Your changes needs to be approved
+                                            . Your changes need to be approved
                                             before they will be live. All the
                                             changes you do now will be added
                                             into a draft that you can submit for

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
@@ -14,7 +14,7 @@ import {
     IFeatureEnvironmentWithCrEnabled,
     IFeatureVariant,
 } from 'interfaces/featureToggle';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { EnvironmentVariantModal } from './EnvironmentVariantModal/EnvironmentVariantModal';
 import { EnvironmentVariantsCard } from './EnvironmentVariantsCard/EnvironmentVariantsCard';
 import { VariantDeleteDialog } from './VariantDeleteDialog/VariantDeleteDialog';
@@ -66,13 +66,16 @@ export const FeatureEnvironmentVariants = () => {
     const [modalOpen, setModalOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
 
-    const environments: IFeatureEnvironmentWithCrEnabled[] =
-        feature?.environments?.map(environment => ({
-            ...environment,
-            crEnabled:
-                uiConfig.flags.crOnVariants &&
-                isChangeRequestConfigured(environment.name),
-        })) || [];
+    const environments: IFeatureEnvironmentWithCrEnabled[] = useMemo(
+        () =>
+            feature?.environments?.map(environment => ({
+                ...environment,
+                crEnabled:
+                    uiConfig.flags.crOnVariants &&
+                    isChangeRequestConfigured(environment.name),
+            })) || [],
+        [feature.environments, uiConfig.flags.crOnVariants]
+    );
 
     const createPatch = (
         variants: IFeatureVariant[],

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/PushVariantsButton/PushVariantsButton.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/PushVariantsButton/PushVariantsButton.tsx
@@ -8,7 +8,7 @@ import {
     styled,
 } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { IFeatureEnvironment } from 'interfaces/featureToggle';
+import { IFeatureEnvironmentWithCrEnabled } from 'interfaces/featureToggle';
 import { useState } from 'react';
 import { useCheckProjectAccess } from 'hooks/useHasAccess';
 
@@ -30,10 +30,10 @@ const StyledButton = styled(Button)(({ theme }) => ({
 
 interface IPushVariantsButtonProps {
     current: string;
-    environments: IFeatureEnvironment[];
+    environments: IFeatureEnvironmentWithCrEnabled[];
     permission: string;
     projectId: string;
-    onSubmit: (selected: string[]) => void;
+    onSubmit: (selected: IFeatureEnvironmentWithCrEnabled[]) => void;
 }
 
 export const PushVariantsButton = ({
@@ -48,9 +48,9 @@ export const PushVariantsButton = ({
     );
     const pushToOpen = Boolean(pushToAnchorEl);
 
-    const [selectedEnvironments, setSelectedEnvironments] = useState<string[]>(
-        []
-    );
+    const [selectedEnvironments, setSelectedEnvironments] = useState<
+        IFeatureEnvironmentWithCrEnabled[]
+    >([]);
 
     const hasAccess = useCheckProjectAccess(projectId);
     const hasAccessTo = environments.reduce((acc, env) => {
@@ -58,16 +58,22 @@ export const PushVariantsButton = ({
         return acc;
     }, {} as Record<string, boolean>);
 
-    const addSelectedEnvironment = (name: string) => {
+    const addSelectedEnvironment = (
+        environment: IFeatureEnvironmentWithCrEnabled
+    ) => {
         setSelectedEnvironments(prevSelectedEnvironments => [
             ...prevSelectedEnvironments,
-            name,
+            environment,
         ]);
     };
 
-    const removeSelectedEnvironment = (name: string) => {
+    const removeSelectedEnvironment = (
+        environment: IFeatureEnvironmentWithCrEnabled
+    ) => {
         setSelectedEnvironments(prevSelectedEnvironments =>
-            prevSelectedEnvironments.filter(env => env !== name)
+            prevSelectedEnvironments.filter(
+                ({ name }) => name !== environment.name
+            )
         );
     };
 
@@ -121,16 +127,16 @@ export const PushVariantsButton = ({
                                                 onChange={event => {
                                                     if (event.target.checked) {
                                                         addSelectedEnvironment(
-                                                            otherEnvironment.name
+                                                            otherEnvironment
                                                         );
                                                     } else {
                                                         removeSelectedEnvironment(
-                                                            otherEnvironment.name
+                                                            otherEnvironment
                                                         );
                                                     }
                                                 }}
                                                 checked={selectedEnvironments.includes(
-                                                    otherEnvironment.name
+                                                    otherEnvironment
                                                 )}
                                                 value={otherEnvironment.name}
                                             />

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -7,7 +7,8 @@ export interface IChangeSchema {
         | 'updateEnabled'
         | 'addStrategy'
         | 'updateStrategy'
-        | 'deleteStrategy';
+        | 'deleteStrategy'
+        | 'patchVariant';
     payload: string | boolean | object | number;
 }
 

--- a/frontend/src/interfaces/featureToggle.ts
+++ b/frontend/src/interfaces/featureToggle.ts
@@ -44,6 +44,10 @@ export interface IFeatureEnvironment {
     variants?: IFeatureVariant[];
 }
 
+export interface IFeatureEnvironmentWithCrEnabled extends IFeatureEnvironment {
+    crEnabled?: boolean;
+}
+
 export interface IFeatureVariant {
     name: string;
     stickiness: string;

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -47,6 +47,7 @@ export interface IFlags {
     featuresExportImport?: boolean;
     newProjectOverview?: boolean;
     caseInsensitiveInOperators?: boolean;
+    crOnVariants?: boolean;
 }
 
 export interface IVersionInfo {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-585/add-cr-to-variants-per-environment-ui

Adds CR to the variants per environment UI. This is basically the point where we have CRs integrated but can e.g. only update the weight once per CR. Adapting the UI to better fit CR logic will come next.

![image](https://user-images.githubusercontent.com/14320932/214563512-664a432f-f2eb-49f7-9721-cbd6785a9320.png)
