### PR TITLE
docs: add next.js docs

### DIFF
--- a/website/readme-fns.js
+++ b/website/readme-fns.js
@@ -14,8 +14,8 @@
 //
 // type ReadmeData = Readme & { repoUrl: string };
 
-const CLIENT_SIDE_SDK = "client-side"
-const SERVER_SIDE_SDK = "server-side"
+const CLIENT_SIDE_SDK = 'client-side';
+const SERVER_SIDE_SDK = 'server-side';
 
 const serverSideSdks = {
     'unleash-client-go': {
@@ -169,9 +169,10 @@ const modifyContent = (filename, content) => {
 This SDK **cannot** connect to the regular (server-side) \`client\` API.`
 
             case SERVER_SIDE_SDK:
-            default: return `To connect to Unleash, you'll need your Unleash API url (e.g. \`https://<your-unleash>/api\`) and a [server-side API token](/reference/api-tokens-and-client-keys.mdx#client-tokens) ([how do I create an API token?](/how-to/how-to-create-api-tokens.mdx)).`
+            default:
+                return `To connect to Unleash, you'll need your Unleash API url (e.g. \`https://<your-unleash>/api\`) and a [server-side API token](/reference/api-tokens-and-client-keys.mdx#client-tokens) ([how do I create an API token?](/how-to/how-to-create-api-tokens.mdx)).`;
         }
-    }
+    };
 
     return {
         filename: `${sdk.type}/${sdk.slugName}.md`,

--- a/website/readme-fns.js
+++ b/website/readme-fns.js
@@ -71,6 +71,10 @@ const clientSideSdks = {
     'proxy-client-vue': {
         sidebarName: 'Vue',
     },
+    'unleash-client-nextjs': {
+        sidebarName: 'Next.js',
+        slugName: 'next-js',
+    },
 };
 
 const allSdks = () => {

--- a/website/readme-fns.js
+++ b/website/readme-fns.js
@@ -162,11 +162,8 @@ const modifyContent = (filename, content) => {
 
     const getConnectionTip = (sdkType) => {
         switch (sdkType) {
-        case CLIENT_SIDE_SDK: return `To connect this SDK to Unleash, you'll need to use either
-- the [Unleash front-end API](/reference/front-end-api) (released in Unleash 4.16) ([how do I create an API token?](/how-to/how-to-create-api-tokens.mdx))
-- the [Unleash proxy](/reference/unleash-proxy) ([how do I create client keys?](/reference/api-tokens-and-client-keys#proxy-client-keys))
-
-This SDK **cannot** connect to the regular (server-side) \`client\` API.`
+            case CLIENT_SIDE_SDK:
+                return `To connect to Unleash from a client-side context, you'll need to use the [Unleash front-end API](/reference/front-end-api) ([how do I create an API token?](/how-to/how-to-create-api-tokens.mdx)) or the [Unleash proxy](/reference/unleash-proxy) ([how do I create client keys?](/reference/api-tokens-and-client-keys#proxy-client-keys)).`;
 
             case SERVER_SIDE_SDK:
             default:


### PR DESCRIPTION
## What

This change adds the next.js sdk's readme to the client-side SDKs section in the docs.

## Why

Because we have a new and official SDK 🙌🏼 