### PR TITLE
fix: list projects with all archived toggles

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -95,7 +95,7 @@ class ProjectStore implements IProjectStore {
         }
         let selectColumns = [
             this.db.raw(
-                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, count(case when features.archived_at is null then features.name end) AS number_of_features',
+                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, count(features.name) FILTER (WHERE features.archived_at is null) AS number_of_features',
             ),
         ] as (string | Raw<any>)[];
 

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -89,14 +89,13 @@ class ProjectStore implements IProjectStore {
         const projectTimer = this.timer('getProjectsWithCount');
         let projects = this.db(TABLE)
             .leftJoin('features', 'features.project', 'projects.id')
-            .where('features.archived_at', null)
             .orderBy('projects.name', 'asc');
         if (query) {
             projects = projects.where(query);
         }
         let selectColumns = [
             this.db.raw(
-                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, count(features.name) AS number_of_features',
+                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, count(case when features.archived_at is null then features.name end) AS number_of_features',
             ),
         ] as (string | Raw<any>)[];
 

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1057,6 +1057,28 @@ test('should only count active feature toggles for project', async () => {
     expect(theProject?.featureCount).toBe(1);
 });
 
+test('should list projects with all features archived', async () => {
+    const project = {
+        id: 'only-archived',
+        name: 'Listed project',
+        description: 'Blah',
+    };
+
+    await projectService.createProject(project, user);
+
+    await stores.featureToggleStore.create(project.id, {
+        name: 'archived-toggle',
+        project: project.id,
+        enabled: false,
+    });
+
+    await featureToggleService.archiveToggle('archived-toggle', 'me');
+
+    const projects = await projectService.getProjects();
+    const theProject = projects.find((p) => p.id === project.id);
+    expect(theProject?.featureCount).toBe(0);
+});
+
 const updateEventCreatedAt = async (date: Date, featureName: string) => {
     return db.rawDatabase
         .table('events')


### PR DESCRIPTION
## About the changes
While trying to count only features that are not archived to display the amount of features of a project, accidentally we filtered out projects with all features archived (they should show up in the list but with count of features zero)

Improves: #2923