### PR TITLE
fix: remove toggles using this strategy

### DIFF
--- a/frontend/src/component/strategies/StrategyView/StrategyDetails/StrategyDetails.tsx
+++ b/frontend/src/component/strategies/StrategyView/StrategyDetails/StrategyDetails.tsx
@@ -84,17 +84,22 @@ export const StrategyDetails = ({
                     <List>{renderParameters(parameters)}</List>
                 </Grid>
 
-                <Grid item sm={12} md={6}>
+                <Grid item sm={12} md={toggles.length > 0 ? 6 : 12}>
                     <h6>Applications using this strategy</h6>
                     <hr />
                     <AppsLinkList apps={applications} />
                 </Grid>
 
-                <Grid item sm={12} md={6}>
-                    <h6>Toggles using this strategy</h6>
-                    <hr />
-                    <TogglesLinkList toggles={toggles} />
-                </Grid>
+                <ConditionallyRender
+                    condition={toggles.length > 0}
+                    show={() => (
+                        <Grid item sm={12} md={6}>
+                            <h6>Toggles using this strategy</h6>
+                            <hr />
+                            <TogglesLinkList toggles={toggles} />
+                        </Grid>
+                    )}
+                />
             </Grid>
         </div>
     );


### PR DESCRIPTION
## About the changes
Hide "toggles using this strategy" since it was not not working for a while.

Closes https://linear.app/unleash/issue/1-570/toggles-using-this-strategy-table-in-the-strategy-types-view-is-empty
