### PR TITLE
feat/enable_batch_metrics_for_all

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -69,7 +69,6 @@ exports[`should create default config 1`] = `
     "flags": {
       "ENABLE_DARK_MODE_SUPPORT": false,
       "anonymiseEventLog": false,
-      "batchMetrics": false,
       "caseInsensitiveInOperators": false,
       "crOnVariants": false,
       "embedProxy": true,
@@ -91,7 +90,6 @@ exports[`should create default config 1`] = `
     "experiments": {
       "ENABLE_DARK_MODE_SUPPORT": false,
       "anonymiseEventLog": false,
-      "batchMetrics": false,
       "caseInsensitiveInOperators": false,
       "crOnVariants": false,
       "embedProxy": true,

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -95,18 +95,11 @@ export default class ClientMetricsServiceV2 {
             no: value.bucket.toggles[name].no,
         }));
 
-        if (this.config.flagResolver.isEnabled('batchMetrics')) {
-            this.unsavedMetrics = collapseHourlyMetrics([
-                ...this.unsavedMetrics,
-                ...clientMetrics,
-            ]);
-            this.lastSeenService.updateLastSeen(clientMetrics);
-        } else {
-            if (toggleNames.length > 0) {
-                await this.featureToggleStore.setLastSeen(toggleNames);
-            }
-            await this.clientMetricsStoreV2.batchInsertMetrics(clientMetrics);
-        }
+        this.unsavedMetrics = collapseHourlyMetrics([
+            ...this.unsavedMetrics,
+            ...clientMetrics,
+        ]);
+        this.lastSeenService.updateLastSeen(clientMetrics);
 
         this.config.eventBus.emit(CLIENT_METRICS, value);
     }

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -22,10 +22,6 @@ const flags = {
         process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY_FRONTEND,
         true,
     ),
-    batchMetrics: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_BATCH_METRICS,
-        false,
-    ),
     responseTimeWithAppName: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_RESPONSE_TIME_WITH_APP_NAME,
         false,

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -36,7 +36,6 @@ process.nextTick(async () => {
                     flags: {
                         embedProxy: true,
                         embedProxyFrontend: true,
-                        batchMetrics: true,
                         anonymiseEventLog: false,
                         responseTimeWithAppName: true,
                         variantsPerEnvironment: true,

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -26,7 +26,6 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
             flags: {
                 embedProxy: true,
                 embedProxyFrontend: true,
-                batchMetrics: true,
                 variantsPerEnvironment: true,
             },
         },


### PR DESCRIPTION
Batch Metrics as a capability developed to support the frontend API to handle more metrics from SDKs without overloading the DB to much. It has been running in Unleash Cloud for months and has proven to work quite nice. 

This PR simply removes the flag to make the capability GA, also for self-hosted users. 