### PR TITLE
fix: when app count is zero because it just started

### DIFF
--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -4,6 +4,8 @@ import { useInstanceMetrics } from 'hooks/api/getters/useInstanceMetrics/useInst
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Alert, styled } from '@mui/material';
 import { unknownify } from 'utils/unknownify';
+import logoIcon from 'assets/icons/logoBg.svg';
+import { formatAssetPath } from 'utils/formatPath';
 
 const StyledMermaid = styled(Mermaid)(({ theme }) => ({
     '#mermaid .node rect': {
@@ -61,7 +63,9 @@ export const NetworkOverview = () => {
     graph TD
         subgraph _[ ]
         direction BT
-            Unleash(<img src='https://www.getunleash.io/logos/unleash_glyph_pos.svg' width='60' height='60' /><br/>Unleash)
+            Unleash(<img src='${formatAssetPath(
+                logoIcon
+            )}' width='60' height='60' /><br/>Unleash)
             ${apps
                 .map(
                     ({ label, reqs, type }, i) =>

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -21,7 +21,7 @@ export function responseTimeMetrics(
         let appName;
         if (
             flagResolver.isEnabled('responseTimeWithAppName') &&
-            (instanceStatsService.getAppCountSnapshot('7d') ||
+            (instanceStatsService.getAppCountSnapshot('7d') ??
                 appNameReportingThreshold) < appNameReportingThreshold
         ) {
             appName = req.headers['unleash-appname'] ?? req.query.appName;


### PR DESCRIPTION
## About the changes
This fixes response time metrics with app names when the app just starts and has zero which is falsy. We want to compare against undefined (which means the snapshot is not yet ready)