### PR TITLE
fix: @server/openapi import breaking tsc

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,8 +65,10 @@
     "chartjs-adapter-date-fns": "3.0.0",
     "classnames": "2.3.2",
     "copy-to-clipboard": "3.3.3",
+    "countries-and-timezones": "^3.4.0",
     "cypress": "9.7.0",
     "date-fns": "2.29.3",
+    "date-fns-tz": "^1.3.7",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",
     "dequal": "2.0.3",
@@ -76,6 +78,7 @@
     "http-proxy-middleware": "2.0.6",
     "immer": "9.0.17",
     "jsdom": "21.0.0",
+    "json-schema-to-ts": "^2.6.2",
     "lodash.clonedeep": "4.5.0",
     "lodash.omit": "4.5.0",
     "mermaid": "^9.3.0",
@@ -106,9 +109,7 @@
     "vite-plugin-svgr": "2.4.0",
     "vite-tsconfig-paths": "4.0.3",
     "vitest": "0.27.1",
-    "whatwg-fetch": "3.6.2",
-    "countries-and-timezones": "^3.4.0",
-    "date-fns-tz": "^1.3.7"
+    "whatwg-fetch": "3.6.2"
   },
   "optionalDependencies": {
     "orval": "^6.10.3"

--- a/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/ProjectInfo.tsx
@@ -7,7 +7,7 @@ import { ToggleTypesWidget } from './ToggleTypesWidget';
 import { MetaWidget } from './MetaWidget';
 import { ProjectMembersWidget } from './ProjectMembersWidget';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { ProjectStatsSchema } from '@server/openapi';
+import { ProjectStatsSchema } from '@server/openapi/spec/project-stats-schema';
 import { ChangeRequestsWidget } from './ChangeRequestsWidget';
 
 interface IProjectInfoProps {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6037,6 +6037,16 @@ json-schema-ref-parser@^5.1.3:
     js-yaml "^3.12.0"
     ono "^4.0.6"
 
+json-schema-to-ts@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-2.6.2.tgz#15d79875d3277fa2ec17854d97e83502801b3335"
+  integrity sha512-RrcvhZUcTAtfMVSvHIq3h/tELToha68V/1kGeQ2ggBv/4Bv31Zjbqis+b+Hiwibj6GO5WLA9PE4X93C8VTJ1TA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@types/json-schema" "^7.0.9"
+    ts-algebra "^1.1.1"
+    ts-toolbelt "^9.6.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -8342,6 +8352,18 @@ trough@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
+
+ts-algebra@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-1.1.1.tgz#f7593cabcfd64f9d7211fa4f16ea9719e02461bc"
+  integrity sha512-W43a3/BN0Tp4SgRNERQF/QPVuY1rnHkgCr/fISLY0Ycu05P0NWPYRuViU8JFn+pFZuY6/zp9TgET1fxMzppR/Q==
+  dependencies:
+    ts-toolbelt "^9.6.0"
+
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
 
 tsconfck@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Seems like a `@server/openapi` import introduced with https://github.com/Unleash/unleash/pull/3013 was breaking `tsc`. Using a more explicit/extensive path to the schema seems to fix the issue for now.

See: https://unleash-internal.slack.com/archives/C048ELND3QD/p1675269006875629