### PR TITLE
Support environment in API token even with auth disabled

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -103,25 +103,22 @@ export default async function getApp(
     );
 
     app.use(baseUriPath, patMiddleware(config, services));
+    app.use(baseUriPath, apiTokenMiddleware(config, services));
 
     switch (config.authentication.type) {
         case IAuthType.OPEN_SOURCE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             ossAuthentication(app, config.server.baseUriPath);
             break;
         }
         case IAuthType.ENTERPRISE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             config.authentication.customAuthHandler(app, config, services);
             break;
         }
         case IAuthType.HOSTED: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             config.authentication.customAuthHandler(app, config, services);
             break;
         }
         case IAuthType.DEMO: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,
@@ -131,7 +128,6 @@ export default async function getApp(
             break;
         }
         case IAuthType.CUSTOM: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             config.authentication.customAuthHandler(app, config, services);
             break;
         }
@@ -140,7 +136,6 @@ export default async function getApp(
             break;
         }
         default: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

The preferred method of providing the environment in API calls is implicitly in the API token. It is the [_only_ way to set it in the go client](https://github.com/Unleash/unleash-client-go/issues/95) since it does provide a way to add query parameters.

However, when using `AuthType.NONE`, the API Token middleware isn't included. Without the middleware, the environment isn't parsed from the API token in the authorization header and it always falls back to `default`.

After this change, when using `AuthType.NONE`, both of these provide a `200` with the expected results:

```
curl -H "Authorization: $API_TOKEN" http://localhost:4242/api/client/features
curl http://localhost:4242/api/client/features?environment=development
```

<!-- Does it close an issue? Multiple? -->
Closes #
https://github.com/Unleash/unleash/issues/2782
https://github.com/Unleash/unleash/issues/3005

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->

N/A

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

It wasn't clear if there was a specific reason the API Token middleware was omitted. The middleware calls [`next()` without error when no token was provided](https://github.com/Unleash/unleash/blob/627958d30f01a8124c6f25c76efb16befd815d2c/src/lib/middleware/api-token-middleware.ts#L50). Since it functioned nearly identical to before (continued providing API results without `401`) when no `Authorization` header was present, I chose to unconditionally include the middleware.
