### PR TITLE
fix: use utc to compare time

### DIFF
--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -18,7 +18,7 @@ const StyledMermaid = styled(Mermaid)(({ theme }) => ({
 
 const isRecent = (value: ResultValue) => {
     const threshold = 60000; // ten minutes
-    return value[0] * 1000 > new Date().getTime() - threshold;
+    return value[0] * 1000 > new Date().getUTCMilliseconds() - threshold;
 };
 
 type ResultValue = [number, string];

--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -17,8 +17,8 @@ const StyledMermaid = styled(Mermaid)(({ theme }) => ({
 }));
 
 const isRecent = (value: ResultValue) => {
-    const threshold = 60000; // ten minutes
-    return value[0] * 1000 > new Date().getUTCMilliseconds() - threshold;
+    const threshold = 600000; // ten minutes
+    return value[0] * 1000 > new Date().getTime() - threshold;
 };
 
 type ResultValue = [number, string];
@@ -36,6 +36,7 @@ const toGraphData = (metrics?: RequestsPerSecondSchema) => {
             ?.map(result => {
                 const values = (result.values || []) as ResultValue[];
                 const data = values.filter(value => isRecent(value)) || [];
+                console.log('data', data);
                 let reqs = 0;
                 if (data.length) {
                     reqs = parseFloat(data[data.length - 1][1]);


### PR DESCRIPTION
## About the changes
We've found that 60000 was just 1 minute and we wanted it to be 10 minutes so we were missing 1 zero and sometimes in 1 minute we didn't have data. This is still an assumption we'll verify in sandbox

Co-authored-by: Nuno Góis <github@nunogois.com>