### PR TITLE
docs: update old docker compose instructions

### DIFF
--- a/website/docs/reference/deploy/getting-started.md
+++ b/website/docs/reference/deploy/getting-started.md
@@ -63,9 +63,8 @@ docker run -p 4242:4242 \
 
 **Steps:**
 
-1. Clone the [unleash-docker](https://github.com/Unleash/unleash-docker) repository.
-2. Run `docker-compose build` in repository root folder.
-3. Run `docker-compose up` in repository root folder.
+1. Clone the [Unleash repository](https://github.com/Unleash/unleash-docker).
+2. Run `docker compose up -d` in repository root folder.
 
 ### Option 3 - from Node.js {#option-three---from-nodejs}
 


### PR DESCRIPTION
## What

This change updates the docker compose instructions to match what is currently in the Unleash/unleash repo itself.

## Why

Because the old version was out of date.