### PR TITLE
docs: update Anatomy doc with variants per environment notice

### DIFF
--- a/website/docs/topics/the-anatomy-of-unleash.mdx
+++ b/website/docs/topics/the-anatomy-of-unleash.mdx
@@ -132,7 +132,13 @@ When you create new variants for a feature, they must be given a name and a **we
 
 You can use the variant payload to attach arbitrary data to a variant. Variants can have different kinds of payloads.
 
-A feature toggle can have as many variants as you want. Importantly, variants are independent of [environments](../reference/environments.md). In other words: you’ll always have the exact same variants with the exact same weightings and the exact same payloads in all environments.
+A feature toggle can have as many variants as you want.
+
+### Variants and environments
+
+Prior to 4.21, variants were independent of [environments](../reference/environments.md). In other words: if you're on 4.19 or lower, you’ll always have the exact same variants with the exact same weightings and the exact same payloads in all environments.
+
+As of version 4.21, a feature can have different variants in different environments. For instance, a development environment might have no variants, while a production environment has 2 variants. Payloads, weightings and anything else can also differ between environments.
 
 <Figure img="/img/anatomy-of-unleash-variants.png" caption="Feature toggle variants are the same for all environments."/>
 


### PR DESCRIPTION
## What

This change updates the "variants" section of the Anatomy of Unleash document with more information about how variants work with multiple environments.

At the moment, it states that variants per env are GA from 4.21, but that might need to be changed.

## Why

With the upcoming release of variants per environment, the doc should reflect the current state of things. However, it should also still contain info for those not yet on v4.21