### PR TITLE
feat: aggregate by label and type

### DIFF
--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -34,7 +34,7 @@ interface INetworkApp {
 
 const asNetworkAppData = (result: RequestsPerSecondSchemaDataResultItem) => {
     const values = (result.values || []) as ResultValue[];
-    const data = values.filter(value => isRecent(value)) || [];
+    const data = values.filter(value => isRecent(value));
     const reqs = data.length ? parseFloat(data[data.length - 1][1]) : 0;
     return {
         label: unknownify(result.metric?.appName),

--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -38,7 +38,7 @@ const asNetworkAppData = (result: RequestsPerSecondSchemaDataResultItem) => {
     const reqs = data.length ? parseFloat(data[data.length - 1][1]) : 0;
     return {
         label: unknownify(result.metric?.appName),
-        reqs: reqs,
+        reqs,
         type: unknownify(result.metric?.endpoint?.split('/')[2]),
     };
 };


### PR DESCRIPTION
## About the changes
We noticed in our instance that when we have same label it shows duplicated in the overview:
![image](https://user-images.githubusercontent.com/455064/216580261-91b09446-9f96-430f-8373-6a9dc7a3e623.png)


We're changing to this way of displaying info:
![Screenshot from 2023-02-03 11-35-26](https://user-images.githubusercontent.com/455064/216580027-ada82e24-a3f3-4985-acef-4754e6177b13.png)
when the data in traffic looks like this:
![Screenshot from 2023-02-03 11-35-35](https://user-images.githubusercontent.com/455064/216580065-0125f792-24af-4a96-bce6-584b70c7efbb.png)

