### PR TITLE
chore: make sure we run tsc on build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "tsc && vite build",
     "start": "vite",
     "start:prod": "vite build && vite preview",
     "start:sandbox": "UNLEASH_API=https://sandbox.getunleash.io/ospro yarn run start",


### PR DESCRIPTION
## About the changes
This helps give more visibility to errors in the frontend by running `tsc` before building the frontend.
