### PR TITLE
fix: client query should not include favorute

### DIFF
--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -211,7 +211,6 @@ export default class FeatureToggleClientStore
             feature.impressionData = r.impression_data;
             feature.enabled = !!r.enabled;
             feature.name = r.name;
-            feature.favorite = r.favorite;
             feature.description = r.description;
             feature.project = r.project;
             feature.stale = r.stale;
@@ -219,6 +218,7 @@ export default class FeatureToggleClientStore
             feature.variants = r.variants || [];
             feature.project = r.project;
             if (isAdmin) {
+                feature.favorite = r.favorite;
                 feature.lastSeenAt = r.last_seen_at;
                 feature.createdAt = r.created_at;
             }


### PR DESCRIPTION
Calls to /api/client/features should not return favorites 