### PR TITLE
Fix/show tag events

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureLog/FeatureLog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureLog/FeatureLog.tsx
@@ -22,7 +22,6 @@ const FeatureLog = () => {
         <StyledContainer>
             <EventLog
                 title="Event log"
-                project={projectId}
                 feature={featureId}
                 displayInline
             />

--- a/frontend/src/component/feature/FeatureView/FeatureLog/FeatureLog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureLog/FeatureLog.tsx
@@ -20,11 +20,7 @@ const FeatureLog = () => {
 
     return (
         <StyledContainer>
-            <EventLog
-                title="Event log"
-                feature={featureId}
-                displayInline
-            />
+            <EventLog title="Event log" feature={featureId} displayInline />
         </StyledContainer>
     );
 };


### PR DESCRIPTION
This PR fixes two issues with events today:

1. Feature toggles "Event log" must include all events, regardless of the project. This is important as feature toggles may move between projects. (41bc22d304a1ca410800e40e4009338cce10fc83)
2. Add/remove tags on a feature toggle events should include project id in order to show up in the project specific event log. (5944b77e3bda8c014653e89384afdf21c78a0df3)
