### PR TITLE
feat: continuous beta version npm release

### DIFF
--- a/.github/workflows/continuous-publish-new-version.yaml
+++ b/.github/workflows/continuous-publish-new-version.yaml
@@ -13,7 +13,7 @@ on:
       - main
 
 # To trigger auto version publish name your squashed commits using conventional notation
-# We support: feat:, fix: and :refactor
+# We support: feat:, fix:m :refactor and :chore
 jobs:
   build:
     if: ${{ startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'refactor:') || startsWith(github.event.head_commit.message, 'chore:') }}

--- a/.github/workflows/continuous-publish-new-version.yaml
+++ b/.github/workflows/continuous-publish-new-version.yaml
@@ -16,7 +16,7 @@ on:
 # We support: feat:, fix: and :refactor
 jobs:
   build:
-    if: ${{ startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'refactor:') }}
+    if: ${{ startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'refactor:') || startsWith(github.event.head_commit.message, 'chore:') }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/continuous-publish-new-version.yaml
+++ b/.github/workflows/continuous-publish-new-version.yaml
@@ -1,0 +1,52 @@
+name: Continuous beta version publish to npm
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+
+# To trigger auto version publish name your squashed commits using conventional notation
+# We support: feat:, fix: and :refactor
+jobs:
+  build:
+    if: ${{ startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:') || startsWith(github.event.head_commit.message, 'refactor:') }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # using GITHUB_TOKEN prevents the commits from this action to trigger recursively
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: setup git config
+        # GitHub bot will be the author of the auto commits
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: update package version
+        # This step always creates beta version
+        # sample transition after official release: 4.20.0 -> 4.21.0-beta.0
+        # sample transition after previous beta release: 4.21.0-beta.0 -> 4.21.0-beta.1
+        #
+        # The new version is pushed back to master and to npm
+        run: |
+          npm version prerelease --preid=beta --ignore-scripts
+          git push origin ${{ github.ref_name }}
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Introducing **continuous npm version release**. Every conventional commit to main triggers a new version automatically.

Consequences: 
* for day to day beta releases we don't need to take any manual actions
* for official releases you can still use https://github.com/Unleash/unleash/actions/workflows/publish-new-version.yaml

How it works?
* you squash your commit with a conventional commit **feat:** or **fix:** or **refactor:**
* this action bumps up the beta version
* this action pushes the bumped up version back to the **github repo** and to **npm registry**

Corner cases:
* how will it work after official release of e.g. 4.22.0? new version: 4.23.0-beta.0
* how will it work after previous beta release e.g. 4.23.0-beta.0? new version 4.23.0-beta.1

Why is it using beta.0, beta.1? 
* because `npm version prerelease --preid=beta` gives us the version upgrade logic for free
* in future we may consider adding a timestamp instead of simple version upgrade (cc: @gardleopard )

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
