### PR TITLE
docs: generate docs daily

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - website/**
 
+  workflow_dispatch:
+
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -7,9 +7,8 @@ on:
     paths:
       - website/**
 
-  workflow_dispatch:
-    schedule:
-      - cron: '@daily'
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
## What

This change fixes the `generate-docs` workflow, so that they'll run daily as a cron job. The `schedule` property had been erroneously listed as a sub-property of the `workflow_dispatch` property.

## Why

The way the docs are set up at the moment, they source a lot of their content from external repos. As it stands, we don't listen for update events in all of those external dependencies, so we don't know when they update. We do still want the docs to be reasonably fresh, though.

So to achieve this, we can run this workflow once a day to make sure that no docs are more than 24 hours old.