### PR TITLE
fix: make sure we have a user in event store

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1331,7 +1331,7 @@ class FeatureToggleService {
         featureName: string,
         environment: string,
         newVariants: IVariant[],
-        createdBy: string,
+        user: User,
         oldVariants?: IVariant[],
     ): Promise<IVariant[]> {
         await variantsArraySchema.validateAsync(newVariants);
@@ -1350,7 +1350,7 @@ class FeatureToggleService {
                 featureName,
                 environment,
                 project: projectId,
-                createdBy,
+                createdBy: user.email || user.username,
                 oldVariants: theOldVariants,
                 newVariants: fixedVariants,
             }),
@@ -1383,7 +1383,7 @@ class FeatureToggleService {
             featureName,
             environment,
             newVariants,
-            user.username,
+            user,
             oldVariants,
         );
     }
@@ -1405,7 +1405,7 @@ class FeatureToggleService {
             featureName,
             environments,
             newVariants,
-            user.username,
+            user,
         );
     }
 
@@ -1414,7 +1414,7 @@ class FeatureToggleService {
         featureName: string,
         environments: string[],
         newVariants: IVariant[],
-        createdBy: string,
+        user: User,
     ): Promise<IVariant[]> {
         await variantsArraySchema.validateAsync(newVariants);
         const fixedVariants = this.fixVariantWeights(newVariants);
@@ -1436,7 +1436,7 @@ class FeatureToggleService {
                         featureName,
                         environment,
                         project: projectId,
-                        createdBy,
+                        createdBy: user.email || user.username,
                         oldVariants: oldVariants[environment],
                         newVariants: fixedVariants,
                     }),

--- a/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
+++ b/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
@@ -433,6 +433,7 @@ test('If change requests are enabled, cannot change variants without going via C
 });
 
 test('If CRs are protected for any environment in the project stops bulk update of variants', async () => {
+    const user = { email: 'test@example.com', username: 'test-user' } as User;
     const project = await stores.projectStore.create({
         id: 'crOnVariantsProject',
         name: 'crOnVariantsProject',
@@ -476,7 +477,7 @@ test('If CRs are protected for any environment in the project stops bulk update 
     const toggle = await service.createFeatureToggle(
         project.id,
         { name: 'crOnVariantToggle' },
-        'test-user',
+        user.username,
     );
 
     const variant: IVariant = {
@@ -495,7 +496,7 @@ test('If CRs are protected for any environment in the project stops bulk update 
         toggle.name,
         [enabledEnv.name, disabledEnv.name],
         [variant],
-        'test-user',
+        user,
     );
 
     const newVariants = [


### PR DESCRIPTION
## About the changes
Spotted some issues in logs:
```json
{
  "level":"warn",
  "message":"Failed to store \"feature-environment-variants-updated\" event: error: insert into \"events\" (\"created_by\", \"data\", \"environment\", \"feature_name\", \"pre_data\", \"project\", \"tags\", \"type\") values (DEFAULT, $1, $2, $3, $4, $5, $6, $7) returning \"id\", \"type\", \"created_by\", \"created_at\", \"data\", \"pre_data\", \"tags\", \"feature_name\", \"project\", \"environment\" - null value in column \"created_by\" violates not-null constraint",
  "name":"lib/db/event-store.ts"
}
```

In all other events we're doing the following: https://github.com/Unleash/unleash/blob/b7fdcd36c08fcd9461fef930767606962e73d59c/src/lib/services/segment-service.ts#L80

So this is just mimicking that to quickly release a patch, but I'll look into a safer (type-checked) solution so this problem does not happen again