### PR TITLE
fix: replace assert with error

### DIFF
--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -16,8 +16,7 @@ import {
     frontendSettingsKey,
 } from '../types/settings/frontend-settings';
 import { validateOrigins } from '../util';
-import { BadDataError } from '../error';
-import assert from 'assert';
+import { BadDataError, InvalidTokenError } from '../error';
 import { minutesToMilliseconds } from 'date-fns';
 
 type Config = Pick<
@@ -158,7 +157,9 @@ export class ProxyService {
     }
 
     private static assertExpectedTokenType({ type }: ApiUser) {
-        assert(type === ApiTokenType.FRONTEND || type === ApiTokenType.ADMIN);
+        if (!(type === ApiTokenType.FRONTEND || type === ApiTokenType.ADMIN)) {
+            throw new InvalidTokenError();
+        }
     }
 
     async setFrontendSettings(


### PR DESCRIPTION
This PR changes the behavior of checking the incoming token on the `/api/frontend` path. Instead of using assert resulting in a 500 error we are throwing an error that is caught by the default controller and emitted back to the user as JSON. 

<img width="486" alt="Skjermbilde 2023-02-09 kl  14 49 29" src="https://user-images.githubusercontent.com/16081982/217830726-347094aa-c9dc-43b6-a23f-0b15c298085f.png">

This should be the correct behaviour, since the endpoint can not give you any meaningful data without the environment that the API token holds.
