### PR TITLE
fix: export failing because stream closed

### DIFF
--- a/src/lib/routes/admin-api/export-import.ts
+++ b/src/lib/routes/admin-api/export-import.ts
@@ -66,13 +66,6 @@ class ExportImportController extends Controller {
             exportResultSchema.$id,
             serializeDates(data),
         );
-
-        const timestamp = this.getFormattedDate(Date.now());
-        if (query.downloadFile) {
-            res.attachment(`export-${timestamp}.json`);
-        }
-
-        res.json(data);
     }
 
     private getFormattedDate(millis: number): string {


### PR DESCRIPTION
We are not using downloadFile flag. Frontend is generating the json file from payload and handling the naming.
Removed the issue that stream was accessed when closed.