### PR TITLE
fix: also export context fields used for stickiness

### DIFF
--- a/src/lib/services/export-import-service.ts
+++ b/src/lib/services/export-import-service.ts
@@ -107,10 +107,12 @@ export default class ExportImportService {
         ]);
         this.addSegmentsToStrategies(featureStrategies, strategySegments);
         const filteredContextFields = contextFields.filter((field) =>
-            featureStrategies.some((strategy) =>
-                strategy.constraints.some(
-                    (constraint) => constraint.contextName === field.name,
-                ),
+            featureStrategies.some(
+                (strategy) =>
+                    strategy.parameters.stickiness === field.name ||
+                    strategy.constraints.some(
+                        (constraint) => constraint.contextName === field.name,
+                    ),
             ),
         );
         const filteredSegments = segments.filter((segment) =>


### PR DESCRIPTION
Now context fields that are used for stickiness are also exported.