### PR TITLE
docs: add notes to constraints and segment docs about large values

### DIFF
--- a/website/docs/reference/segments.mdx
+++ b/website/docs/reference/segments.mdx
@@ -45,3 +45,9 @@ Segments can be created, edited, and deleted from the segments page in the admin
 A segment that is in use **cannot** be deleted. If you'd like to delete a segment that is in use, you must first remove the segment from all the activation strategies that are currently using it.
 
 ![The Segments page, listing two existing segments: "Mobile users" and "Users in the APAC region". The navigation menu with the Segments page link is opened and highlighted to provide navigation help.](/img/segments-page.png)
+
+### A note on large segments and limits {#large-segments}
+
+In theory, you could you create segments with a thousand constraints, each with a million values. But this wouldn't scale well, so there are limitations in place to stop you from doing this. Segments are just constraints, so any limitations that apply to constraints also apply to segments.
+
+This means that if you want to add a hundred different user IDs to one of your constraints, you are most likely better off thinking about finding another way to solve this problem. That may be using a different abstraction or finding another pattern that you can use instead. Refer to the section on [constraint limitations](../reference/strategy-constraints.md#limitations) for a more thorough explanation.

--- a/website/docs/reference/strategy-constraints.md
+++ b/website/docs/reference/strategy-constraints.md
@@ -180,6 +180,16 @@ If you set a context field to a value that the SDKs cannot parse correctly for a
 In other words: if you have a strategy constraint operator that expects a number, such as `NUM_GT`, but you set the corresponding context field to a string value, then the expression will be false: `"some string"` is **not** greater than `5`.
 This value can still be negated as explained in [the section on negating values](#constraint-negation).
 
+## Constraint limitations (or "how many user IDs can I add to a constraint") {#limitations}
+
+When using a constraint operator that accepts a list of values, it might be tempting to add a large number of values to that list. However, we strongly advise you **not** to do that: Unleash is **not** a database, and is not intended to store large amounts of data. Instead you should try and find a different way to achieve what you want.
+
+Because Unleash's server-side SDKs fetch the full feature toggle configuration from Unleash, every value that you add to that constraint value list will increase the payload size. For small numbers, this isn't an issue, but as the list grows, so will the payload, and so will the time and processing power used by the SDK to evaluate the feature.
+
+If you find yourself in this situation, try and think about whether there is another way to do what you want. For instance, instead of adding hundreds of user ids to the constraint value list, think about what properties those users share. Are they beta testers? Are they premium members? Are they employees?
+
+Can you map their common feature into an [Unleash context](../reference/unleash-context) property instead and set the constraint on that? If they're beta testers, how about using a `betaTester` property? And likewise, for premium members, you could check to see if their `membership` is `premium`? And if they're employees, maybe you're better off checking whether their user ID ends with `@yourcompany.tld`?
+
 ## Incompatibilities and undefined behavior {#incompatibilities}
 
 It's important that you use an up-to-date client SDK if you're using the advanced constraint operators introduced in Unleash 4.9. If your client SDK does not support the new operators, we cannot guarantee how it'll react. As a result, you may see different behavior across applications.

--- a/website/docs/reference/strategy-constraints.md
+++ b/website/docs/reference/strategy-constraints.md
@@ -182,13 +182,13 @@ This value can still be negated as explained in [the section on negating values]
 
 ## Constraint limitations (or "how many user IDs can I add to a constraint") {#limitations}
 
-When using a constraint operator that accepts a list of values, it might be tempting to add a large number of values to that list. However, we strongly advise you **not** to do that: Unleash is **not** a database, and is not intended to store large amounts of data. Instead you should try and find a different way to achieve what you want.
+When using a constraint operator that accepts a list of values, it might be tempting to add a large number of values to that list. However, we advise you **not** to do that: Unleash is not a database, and is not intended to store large amounts of data. Instead you should try and find a different way to achieve what you want.
 
-Because Unleash's server-side SDKs fetch the full feature toggle configuration from Unleash, every value that you add to that constraint value list will increase the payload size. For small numbers, this isn't an issue, but as the list grows, so will the payload, and so will the time and processing power used by the SDK to evaluate the feature.
-
-If you find yourself in this situation, try and think about whether there is another way to do what you want. For instance, instead of adding hundreds of user ids to the constraint value list, think about what properties those users share. Are they beta testers? Are they premium members? Are they employees?
+For instance, instead of adding hundreds of user ids to the constraint value list, think about what properties those users share. Are they beta testers? Are they premium members? Are they employees?
 
 Can you map their common feature into an [Unleash context](../reference/unleash-context) property instead and set the constraint on that? If they're beta testers, how about using a `betaTester` property? And likewise, for premium members, you could check to see if their `membership` is `premium`? And if they're employees, maybe you're better off checking whether their user ID ends with `@yourcompany.tld`?
+
+The **reason** why you should try and keep value lists small has to do with Unleash's evaluation model: Because Unleash's server-side SDKs fetch the full feature toggle configuration from Unleash, every value that you add to that constraint value list will increase the payload size. For small numbers, this isn't an issue, but as the list grows, so will the payload, and so will the time and processing power used by the SDK to evaluate the feature.
 
 ## Incompatibilities and undefined behavior {#incompatibilities}
 


### PR DESCRIPTION
## What

This PR adds a note to the constraint and the segment docs about using a large number of constraint values.

## Why

This is a fairly common question in slack, and there is no clear documentation around this at the moment. As such, it's likely that people do this a fair bit without telling us. We don't think this is the right approach, so adding this bit of documentation should hopefully make it a little clearer.