### PR TITLE
docs: update community sdk links

### DIFF
--- a/website/docs/reference/sdks/index.md
+++ b/website/docs/reference/sdks/index.md
@@ -114,7 +114,6 @@ Here's some of the fantastic work our community has done to make Unleash work in
 - Elixir ([afontaine/unleash_ex](https://gitlab.com/afontaine/unleash_ex))
 - Kotlin ([silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin))
 - Laravel - PHP ([mikefrancis/laravel-unleash](https://github.com/mikefrancis/laravel-unleash))
-- NestJS - Node.js ([pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash))
 - PHP ([minds/unleash-client-php](https://gitlab.com/minds/unleash-client-php))
 - PHP - Symfony ([Stogon/unleash-bundle](https://github.com/Stogon/unleash-bundle))
 - React Native / Expo ([nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native))


### PR DESCRIPTION
## About the changes
Removed the nestjs unleash link
https://github.com/pmb0/nestjs-unleash

**Reason:**
- The nestjs-unleash project is very old and not being updated. There are lot of issues with the context values and custom strategy.


## Discussion points
The given repository [NestJS-Unleash] (https://github.com/pmb0/nestjs-unleash)
The nestjs-unleash project is very old and not being updated. There are lot of issues with the context values and custom strategy.
