### PR TITLE
fix: notifications tables drop order

### DIFF
--- a/src/migrations/20230222154915-create-notiications-table.js
+++ b/src/migrations/20230222154915-create-notiications-table.js
@@ -25,8 +25,9 @@ exports.up = function (db, cb) {
 exports.down = function (db, cb) {
     db.runSql(
         `
+        DROP TABLE IF EXISTS user_notifications;
         DROP TABLE IF EXISTS notifications;
-        DROP TABLE IF EXISTS user_notifications;`,
+        `,
         cb,
     );
 };


### PR DESCRIPTION
Since `user_notifications` references `notifications`, it makes sense to drop `user_notifications` before dropping `notifications` and not the other way around. This should fix the failing tests on Enterprise with latest main.

Thanks @gastonfournier for the help finding the bug 👍 