### PR TITLE
docs: slight update to environment docs

### DIFF
--- a/website/docs/how-to/how-to-clone-environments.mdx
+++ b/website/docs/how-to/how-to-clone-environments.mdx
@@ -4,7 +4,7 @@ title: How to clone environments
 
 :::info availability
 
-Environment cloning is an upcoming feature, and is scheduled to become available in one of the next few releases.
+Environment cloning was made available in Unleash 4.19.
 
 :::
 

--- a/website/docs/reference/environments.md
+++ b/website/docs/reference/environments.md
@@ -3,10 +3,11 @@ id: environments
 title: Environments
 ---
 
-<div class="alert alert--info">
-  <em>Environments</em> are available in <i>Unleash v4.3.x</i> and later. They can also be enabled from <i>Unleash v4.2.x</i> with a feature toggle.
-</div>
-<br />
+:::info Availability
+
+Environments were released in Unleash v4.3.0.
+
+:::
 
 <div style={{position: 'relative', paddingBottom: '56.25%', height: '0'}}>
     <iframe src="https://www.loom.com/embed/95239e875bbc4e09a5c5833e1942e4b0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: 'absolute', top: '0', left: '0', width: '100%', height: '100%'}}></iframe>

--- a/website/docs/reference/environments.md
+++ b/website/docs/reference/environments.md
@@ -60,7 +60,7 @@ In order for the SDK to download the feature toggle configuration for the correc
 
 :::note Availability
 
-Environment cloning is an upcoming feature, and is scheduled to become available in one of the next few releases.
+Environment cloning was made available in Unleash 4.19.
 
 :::
 

--- a/website/docs/reference/environments.md
+++ b/website/docs/reference/environments.md
@@ -27,9 +27,17 @@ Despite this being a shift in how Unleash works, everything will continue to wor
 
 ## Environment types
 
-All environments in Unleash have a **type**. By default, Unleash uses the types "development" and "production", but you can assign any value you want. The environment type is used to ... What?
+All environments in Unleash have a **type**. When you create a new environment, you must also assign it a type.
 
-The **production** environment type is special, in that Unleash will show additional confirmation prompts when you do something that could impact users.
+The built-in environment types are:
+- Development
+- Test
+- Pre-production
+- Production
+
+The **production** environment type is special: Unleash will show additional confirmation prompts when you change something that could impact users in environments of this type. The built-in "production" environment is a production-type environment.
+
+The other environment types do not currently have any functionality associated with them. This may change in the future.
 
 ## Global and project-level environments
 

--- a/website/docs/reference/environments.md
+++ b/website/docs/reference/environments.md
@@ -25,6 +25,12 @@ Despite this being a shift in how Unleash works, everything will continue to wor
 
 ![A graph showing how environments work. Each project can have multiple features, and each feature can have different activation strategies in each of its environments.](/img/environments_overview.svg 'A feature toggle exists across all environments, but take different activation strategies per environment.')
 
+## Environment types
+
+All environments in Unleash have a **type**. By default, Unleash uses the types "development" and "production", but you can assign any value you want. The environment type is used to ... What?
+
+The **production** environment type is special, in that Unleash will show additional confirmation prompts when you do something that could impact users.
+
 ## Global and project-level environments
 
 Environments exist on a global level, so they are available to all projects within Unleash. However, every [project](./projects.md) might not need to use every environment. That's why you can also choose which of the global environments should be available within a project.


### PR DESCRIPTION
## What & why

This update does three things:

1. Adjusts the environment cloning feature availability notice: because this has been released.
2. Updates the availability notice for environments (to conform with the standard docusaurus way of doing things): for consistency
3. Add a brief explanation of environment types: because this isn't documented anywhere

## Sources

The note about how environment types work is sourced from this old [slack thread (internal to the team)](https://unleash-community.slack.com/archives/G01MU2Q49QC/p1659600175175769)