### PR TITLE
chore: Renames login_events to sign_on_log

### DIFF
--- a/src/migrations/20230227115320-rename-login-events-table-to-sign-on-log.js
+++ b/src/migrations/20230227115320-rename-login-events-table-to-sign-on-log.js
@@ -1,0 +1,7 @@
+exports.up = function (db, cb) {
+    db.runSql(`ALTER TABLE login_events RENAME TO sign_on_log`, cb);
+};
+
+exports.down = function (db, cb) {
+    db.runSql(`ALTER TABLE sign_on_log RENAME TO login_events`, cb);
+};


### PR DESCRIPTION
This makes the distinction from the event services clearer.

In enterprise we'll also rename LoginEventService etc to reflect this rename.