### PR TITLE
feat: add authentication as a table filter

### DIFF
--- a/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
+++ b/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
@@ -88,7 +88,7 @@ export const SignOnLogTable = () => {
                 searchable: true,
             },
             {
-                Header: 'Successful',
+                Header: 'Success',
                 accessor: 'successful',
                 align: 'center',
                 Cell: SignOnLogSuccessfulCell,

--- a/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
+++ b/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
@@ -79,6 +79,7 @@ export const SignOnLogTable = () => {
                 maxWidth: 150,
                 Cell: HighlightCell,
                 searchable: true,
+                filterName: 'auth',
             },
             {
                 Header: 'IP address',
@@ -91,7 +92,7 @@ export const SignOnLogTable = () => {
                 accessor: 'successful',
                 align: 'center',
                 Cell: SignOnLogSuccessfulCell,
-                filterName: 'successful',
+                filterName: 'success',
                 filterParsing: (value: boolean) => value.toString(),
             },
             {

--- a/frontend/src/hooks/api/getters/useSignOnLog/useSignOnLog.ts
+++ b/frontend/src/hooks/api/getters/useSignOnLog/useSignOnLog.ts
@@ -12,14 +12,14 @@ export const useSignOnLog = () => {
 
     const { data, error, mutate } = useConditionalSWR(
         signOnLog && isEnterprise(),
-        [],
+        { events: [] },
         formatApiPath(`api/admin/signons`),
         fetcher
     );
 
     return useMemo(
         () => ({
-            events: (data ?? []) as ISignOnEvent[],
+            events: (data?.events ?? []) as ISignOnEvent[],
             loading: !error && !data,
             refetch: () => mutate(),
             error,


### PR DESCRIPTION
Adds `auth` as a table filter.
Also fixes the hook to correctly fetch the events based on the new return type.

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/14320932/221603312-a40055a8-4c23-4f1f-9a87-7fbd03e7b49e.png">
