### PR TITLE
feat: add url/query sort/search to sign on log table

### DIFF
--- a/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
+++ b/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
@@ -27,7 +27,7 @@ import { useSearchParams } from 'react-router-dom';
 import { createLocalStorage } from 'utils/createLocalStorage';
 
 export type PageQueryType = Partial<
-    Record<'sort' | 'order' | 'search' | 'favorites', string>
+    Record<'sort' | 'order' | 'search', string>
 >;
 
 const defaultSort: SortingRule<string> = { id: 'created_at' };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-729/adapt-signontable-to-use-querystored-sortsearch-params

Adds the feature where the current sort + search are reflected in the URL.

![image](https://user-images.githubusercontent.com/14320932/221870486-22b7b0d5-1620-48f1-9d32-17a61cf11b52.png)
(notice the URL at the top)