### PR TITLE
feat: smarter auth type labels on sign-on log table

### DIFF
--- a/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
+++ b/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogTable.tsx
@@ -37,6 +37,13 @@ const { value: storedParams, setValue: setStoredParams } = createLocalStorage(
     defaultSort
 );
 
+const AUTH_TYPE_LABEL: { [key: string]: string } = {
+    simple: 'Password',
+    oidc: 'OIDC',
+    saml: 'SAML',
+    google: 'Google',
+};
+
 export const SignOnLogTable = () => {
     const { setToastData, setToastApiError } = useToast();
 
@@ -99,9 +106,7 @@ export const SignOnLogTable = () => {
             {
                 Header: 'Authentication',
                 accessor: (event: ISignOnEvent) =>
-                    event.auth_type === 'simple'
-                        ? 'Password'
-                        : event.auth_type.toUpperCase(),
+                    AUTH_TYPE_LABEL[event.auth_type] || event.auth_type,
                 width: 150,
                 maxWidth: 150,
                 Cell: HighlightCell,


### PR DESCRIPTION
Small change to make the `Authentication` column in the Sign-on Log table display nice-to-read labels for the multiple authentication types.

![image](https://user-images.githubusercontent.com/14320932/221917306-d115f447-bfda-4d18-9bc7-545d76c03c22.png)