### PR TITLE
fix: project stats

### DIFF
--- a/frontend/src/component/project/Project/ProjectStats/ProjectStats.tsx
+++ b/frontend/src/component/project/Project/ProjectStats/ProjectStats.tsx
@@ -71,9 +71,7 @@ export const ProjectStats = ({ stats }: IProjectStatsProps) => {
                     title="Total changes"
                     boxText={String(projectActivityCurrentWindow)}
                     change={
-                        projectActivityCurrentWindow -
-                        projectActivityPastWindow -
-                        20
+                        projectActivityCurrentWindow - projectActivityPastWindow
                     }
                 >
                     <HelpPopper id="total-changes">


### PR DESCRIPTION
Display total changes correctly.

https://linear.app/unleash/issue/1-747/project-stats-displays-wrong-number-for-freshly-created-project