### PR TITLE
feat: add download and delete all buttons to sign-on log UI

### DIFF
--- a/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogDeleteAllDialog/SignOnLogDeleteAllDialog.tsx
+++ b/frontend/src/component/signOnLog/SignOnLogTable/SignOnLogDeleteAllDialog/SignOnLogDeleteAllDialog.tsx
@@ -1,0 +1,28 @@
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+
+interface IServiceAccountDeleteAllDialogProps {
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    onConfirm: () => void;
+}
+
+export const SignOnLogDeleteAllDialog = ({
+    open,
+    setOpen,
+    onConfirm,
+}: IServiceAccountDeleteAllDialogProps) => (
+    <Dialogue
+        title="Clear sign-on log?"
+        open={open}
+        primaryButtonText="Clear sign-on log"
+        secondaryButtonText="Cancel"
+        onClick={onConfirm}
+        onClose={() => {
+            setOpen(false);
+        }}
+    >
+        You are about to clear the sign-on log.
+        <br />
+        This will delete all the sign-on events.
+    </Dialogue>
+);

--- a/frontend/src/hooks/api/actions/useSignOnLogApi/useSignOnLogApi.ts
+++ b/frontend/src/hooks/api/actions/useSignOnLogApi/useSignOnLogApi.ts
@@ -5,6 +5,23 @@ export const useSignOnLogApi = () => {
         propagateErrors: true,
     });
 
+    const downloadCSV = async () => {
+        const requestId = 'downloadCSV';
+        const req = createRequest(
+            'api/admin/signons',
+            {
+                method: 'GET',
+                responseType: 'blob',
+                headers: { Accept: 'text/csv' },
+            },
+            requestId
+        );
+
+        const file = await (await makeRequest(req.caller, req.id)).blob();
+        const url = window.URL.createObjectURL(file);
+        window.location.assign(url);
+    };
+
     const removeEvent = async (eventId: number) => {
         const requestId = 'removeEvent';
         const req = createRequest(
@@ -16,8 +33,21 @@ export const useSignOnLogApi = () => {
         await makeRequest(req.caller, req.id);
     };
 
+    const removeAllEvents = async () => {
+        const requestId = 'removeAllEvents';
+        const req = createRequest(
+            'api/admin/signons',
+            { method: 'DELETE' },
+            requestId
+        );
+
+        await makeRequest(req.caller, req.id);
+    };
+
     return {
+        downloadCSV,
         removeEvent,
+        removeAllEvents,
         errors,
         loading,
     };


### PR DESCRIPTION
Adds `Download sign-on log` and `Clear sign-on log` buttons to the UI, making it easy for admins to manage their sign-on log.

![image](https://user-images.githubusercontent.com/14320932/222138757-284c3f79-142f-4e25-847d-666938d4c12c.png)
![image](https://user-images.githubusercontent.com/14320932/222138863-bccf6343-41dd-4068-95b0-fac3ce37313f.png)
