### PR TITLE
feat: shared event emitter

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -337,8 +337,8 @@ class EventStore implements IEventStore {
         };
     }
 
-    setMaxListeners(n: number): EventEmitter {
-        return this.eventEmitter.setMaxListeners(n);
+    setMaxListeners(number: number): EventEmitter {
+        return this.eventEmitter.setMaxListeners(number);
     }
 
     on(

--- a/src/lib/event-hook.ts
+++ b/src/lib/event-hook.ts
@@ -9,7 +9,7 @@ import {
 
 export const addEventHook = (
     eventHook: EventHook,
-    eventStore: EventEmitter,
+    eventStore: Pick<EventEmitter, 'on'>,
 ): void => {
     eventStore.on(FEATURE_CREATED, (data) => {
         eventHook(FEATURE_CREATED, data);

--- a/src/lib/features/export-import-toggles/createExportImportService.ts
+++ b/src/lib/features/export-import-toggles/createExportImportService.ts
@@ -1,5 +1,5 @@
 import { Db } from '../../db/db';
-import { IEventStore, IUnleashConfig } from '../../types';
+import { IUnleashConfig } from '../../types';
 import ExportImportService from './export-import-service';
 import { ImportTogglesStore } from './import-toggles-store';
 import FeatureToggleStore from '../../db/feature-toggle-store';
@@ -37,6 +37,7 @@ import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import FakeFeatureStrategiesStore from '../../../test/fixtures/fake-feature-strategies-store';
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
 import FakeStrategiesStore from '../../../test/fixtures/fake-strategies-store';
+import EventStore from '../../db/event-store';
 
 export const createFakeExportImportTogglesService = (
     config: IUnleashConfig,
@@ -111,7 +112,6 @@ export const createFakeExportImportTogglesService = (
 export const createExportImportTogglesService = (
     db: Db,
     config: IUnleashConfig,
-    eventStore: IEventStore,
 ): ExportImportService => {
     const { eventBus, getLogger, flagResolver } = config;
     const importTogglesStore = new ImportTogglesStore(db);
@@ -139,12 +139,9 @@ export const createExportImportTogglesService = (
         eventBus,
         getLogger,
     );
+    const eventStore = new EventStore(db, getLogger);
     const accessService = createAccessService(db, config);
-    const featureToggleService = createFeatureToggleService(
-        db,
-        config,
-        eventStore,
-    );
+    const featureToggleService = createFeatureToggleService(db, config);
 
     const featureTagService = new FeatureTagService(
         {

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -18,7 +18,7 @@ import { AccessStore } from '../../db/access-store';
 import RoleStore from '../../db/role-store';
 import EnvironmentStore from '../../db/environment-store';
 import { Db } from '../../db/db';
-import { IEventStore, IUnleashConfig } from '../../types';
+import { IUnleashConfig } from '../../types';
 import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import FakeFeatureStrategiesStore from '../../../test/fixtures/fake-feature-strategies-store';
 import FakeFeatureToggleStore from '../../../test/fixtures/fake-feature-toggle-store';
@@ -33,11 +33,11 @@ import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
 import FakeRoleStore from '../../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../../../test/fixtures/fake-environment-store';
+import EventStore from '../../db/event-store';
 
 export const createFeatureToggleService = (
     db: Db,
     config: IUnleashConfig,
-    eventStore: IEventStore,
 ): FeatureToggleService => {
     const { getLogger, eventBus, flagResolver } = config;
     const featureStrategiesStore = new FeatureStrategiesStore(
@@ -73,6 +73,7 @@ export const createFeatureToggleService = (
     const accessStore = new AccessStore(db, eventBus, getLogger);
     const roleStore = new RoleStore(db, eventBus, getLogger);
     const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
+    const eventStore = new EventStore(db, getLogger);
     const groupService = new GroupService(
         { groupStore, eventStore, accountStore },
         { getLogger },

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -164,10 +164,10 @@ export const createServices = (
 
     // TODO: this is a temporary seam to enable packaging by feature
     const exportImportService = db
-        ? createExportImportTogglesService(db, config, stores.eventStore)
+        ? createExportImportTogglesService(db, config)
         : createFakeExportImportTogglesService(config);
     const transactionalExportImportService = (txDb: Knex.Transaction) =>
-        createExportImportTogglesService(txDb, config, stores.eventStore);
+        createExportImportTogglesService(txDb, config);
     const userSplashService = new UserSplashService(stores, config);
     const openApiService = new OpenApiService(config);
     const clientSpecService = new ClientSpecService(config);

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -4,7 +4,9 @@ import { SearchEventsSchema } from '../../openapi/spec/search-events-schema';
 import EventEmitter from 'events';
 import { IQueryOperations } from 'lib/db/event-store';
 
-export interface IEventStore extends Store<IEvent, number>, EventEmitter {
+export interface IEventStore
+    extends Store<IEvent, number>,
+        Pick<EventEmitter, 'on' | 'setMaxListeners' | 'emit' | 'off'> {
     store(event: IBaseEvent): Promise<void>;
     batchStore(events: IBaseEvent[]): Promise<void>;
     getEvents(): Promise<IEvent[]>;

--- a/src/lib/util/anyEventEmitter.ts
+++ b/src/lib/util/anyEventEmitter.ts
@@ -10,3 +10,5 @@ export class AnyEventEmitter extends EventEmitter {
         return super.emit(type, ...args) || super.emit('', ...args);
     }
 }
+
+export const sharedEventEmitter = new AnyEventEmitter();

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -91,8 +91,8 @@ class FakeEventStore implements IEventStore {
         return [];
     }
 
-    setMaxListeners(n: number): EventEmitter {
-        return this.eventEmitter.setMaxListeners(n);
+    setMaxListeners(number: number): EventEmitter {
+        return this.eventEmitter.setMaxListeners(number);
     }
 
     on(


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

EventStore is used as part of DB transactions (events should be stored when business operations succeed) and EventStores are used as EventEmitters to notify other modules (including notifications module).
We want to have correctness of DB transactions (impossible to store event after failed business operation) and correctness of notifications (impossible not to get a notification). This PR combines those 2 architectural drivers. 

Problem in a diagram:
<img width="1037" alt="Screenshot 2023-03-02 at 09 19 05" src="https://user-images.githubusercontent.com/1394682/222371245-58412dea-ac19-42ca-80a2-273737edbafe.png">

Solution in code:

Composition over inheritance. Each EventEmitter should have HAS-A relationship to a shared EventEmitter. Previously it was IS-A relationship so we were getting a new emitter per EventStore instance. By making this dependency a singleton we make it impossible not to be notified about events no matter if we have one EventStore of many EventStores.


<img width="563" alt="Screenshot 2023-03-02 at 09 26 20" src="https://user-images.githubusercontent.com/1394682/222372911-6569312e-85a7-4d90-90af-655f759d99ba.png">



### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
