### PR TITLE
Remove link that's not necessary

### DIFF
--- a/src/migrations/20230306103400-remove-direct-link-from-segment-permissions-to-admin.js
+++ b/src/migrations/20230306103400-remove-direct-link-from-segment-permissions-to-admin.js
@@ -1,0 +1,35 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        DELETE FROM role_permission 
+        WHERE permission_id IN (
+                    SELECT id FROM permissions WHERE permission IN (
+                        'DELETE_SEGMENT',
+                        'UPDATE_SEGMENT',
+                        'CREATE_SEGMENT'
+                    )) 
+        AND role_id IN (SELECT id FROM roles r WHERE r.name = 'Admin');
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        insert into role_permission (role_id, permission_id)
+            select
+                r.id as role_id,
+                p.id as permission_id
+            from roles r
+            cross join permissions p
+            where r.name = 'Admin'
+            and p.permission in  (
+                'CREATE_SEGMENT',
+                'UPDATE_SEGMENT',
+                'DELETE_SEGMENT'
+            );
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
## About the changes
Tested manually as admin in enterprise:

![image](https://user-images.githubusercontent.com/455064/223457013-abd3a16c-5aff-427a-a8a9-32695073309b.png)

Admin should have a special permission that gives super-powers. There's no need to have specific permissions linked to it.

Based of: https://github.com/Unleash/unleash/blob/a077967760f39df2f0fd7adf1db64d14df039326/src/migrations/20220307130902-add-segments.js#L32-L46