### PR TITLE
fix: exclude favorites from the client api

### DIFF
--- a/src/lib/db/feature-toggle-client-store.ts
+++ b/src/lib/db/feature-toggle-client-store.ts
@@ -198,7 +198,6 @@ export default class FeatureToggleClientStore
             feature.impressionData = r.impression_data;
             feature.enabled = !!r.enabled;
             feature.name = r.name;
-            feature.favorite = r.favorite;
             feature.description = r.description;
             feature.project = r.project;
             feature.stale = r.stale;
@@ -206,6 +205,7 @@ export default class FeatureToggleClientStore
             feature.variants = r.variants || [];
             feature.project = r.project;
             if (isAdmin) {
+                feature.favorite = r.favorite;
                 feature.lastSeenAt = r.last_seen_at;
                 feature.createdAt = r.created_at;
             }

--- a/src/test/e2e/api/client/feature.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.e2e.test.ts
@@ -1,4 +1,7 @@
-import { IUnleashTest, setupApp } from '../../helpers/test-helper';
+import {
+    IUnleashTest,
+    setupAppWithCustomConfig,
+} from '../../helpers/test-helper';
 import dbInit, { ITestDb } from '../../helpers/database-init';
 import getLogger from '../../../fixtures/no-logger';
 import { DEFAULT_ENV } from '../../../../lib/util/constants';
@@ -8,7 +11,13 @@ let db: ITestDb;
 
 beforeAll(async () => {
     db = await dbInit('feature_api_client', getLogger);
-    app = await setupApp(db.stores);
+    app = await setupAppWithCustomConfig(db.stores, {
+        experimental: {
+            flags: {
+                strictSchemaValidation: true,
+            },
+        },
+    });
     await app.services.featureToggleServiceV2.createFeatureToggle(
         'default',
         {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Client API should not return favorites.
Enabling check in tests so that we don't make the same mistake again.
For now moved favorites inclusion in the admin if path. Separate PR may split the store into client and admin if this turns out to be a viable strategy.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
