### PR TITLE
fix: hide change password when simple auth is disabled

### DIFF
--- a/frontend/src/component/user/Profile/Profile.tsx
+++ b/frontend/src/component/user/Profile/Profile.tsx
@@ -1,6 +1,7 @@
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { ITab, VerticalTabs } from 'component/common/VerticalTabs/VerticalTabs';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+import useAuthSettings from 'hooks/api/getters/useAuthSettings/useAuthSettings';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PasswordTab } from './PasswordTab/PasswordTab';
@@ -11,10 +12,16 @@ export const Profile = () => {
     const { user } = useAuthUser();
     const location = useLocation();
     const navigate = useNavigate();
+    const { config } = useAuthSettings('simple');
 
     const tabs = [
         { id: 'profile', label: 'Profile' },
-        { id: 'password', label: 'Change password', path: 'change-password' },
+        {
+            id: 'password',
+            label: 'Change password',
+            path: 'change-password',
+            hidden: config.disabled,
+        },
         {
             id: 'pat',
             label: 'Personal API tokens',

--- a/frontend/src/component/user/Profile/Profile.tsx
+++ b/frontend/src/component/user/Profile/Profile.tsx
@@ -12,7 +12,7 @@ export const Profile = () => {
     const { user } = useAuthUser();
     const location = useLocation();
     const navigate = useNavigate();
-    const { config } = useAuthSettings('simple');
+    const { config: simpleAuthConfig } = useAuthSettings('simple');
 
     const tabs = [
         { id: 'profile', label: 'Profile' },
@@ -20,7 +20,7 @@ export const Profile = () => {
             id: 'password',
             label: 'Change password',
             path: 'change-password',
-            hidden: config.disabled,
+            hidden: simpleAuthConfig.disabled,
         },
         {
             id: 'pat',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-764/change-password-should-be-disabled-when-password-login-is-disabled

Hides "Change password" option on the profile page when "Password based login" is disabled.

![image](https://user-images.githubusercontent.com/14320932/224018081-d866a17f-97a4-4e6e-8057-2f60a20e3d52.png)
