### PR TITLE
makes the 'Should update last seen for known toggles test' no longer …

### DIFF
--- a/src/test/e2e/services/last-seen-service.e2e.test.ts
+++ b/src/test/e2e/services/last-seen-service.e2e.test.ts
@@ -22,7 +22,7 @@ afterAll(async () => {
 
 test('Should update last seen for known toggles', async () => {
     const service = new LastSeenService(stores, config);
-    const time = Date.now();
+    const time = Date.now() - 100;
     await stores.featureToggleStore.create('default', { name: 'ta1' });
 
     const metrics: IClientMetricsEnv[] = [


### PR DESCRIPTION
The patched test is currently depending on runtime to take more than a millisecond to update the tested property. That's not always true and more so on a fast machine, which makes this test flakey. This forces the old timestamp to be 100 ms in the past so that the checked property must be at least 100 ms different if the update occured