### PR TITLE
fix: ignore null check on tsc-watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "start": "node ./dist/server.js",
     "prestart:dev": "yarn run clean",
-    "start:dev": "NODE_ENV=development tsc-watch --onSuccess \"node dist/server-dev.js\"",
+    "start:dev": "NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",
     "copy-templates": "copyfiles -u 1 src/mailtemplates/**/*.mustache dist/",
     "db-migrate": "db-migrate --migrations-dir ./src/migrations",
     "lint": "eslint ./src",


### PR DESCRIPTION
## About the changes
This allows us to run start:dev