### PR TITLE
fix: segment project null handling

### DIFF
--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -68,7 +68,7 @@ export default class SegmentStore implements ISegmentStore {
                 id: segment.id,
                 name: segment.name,
                 description: segment.description,
-                segment_project_id: segment.project,
+                segment_project_id: segment.project || null,
                 constraints: JSON.stringify(segment.constraints),
                 created_by: user.username || user.email,
             })
@@ -83,7 +83,7 @@ export default class SegmentStore implements ISegmentStore {
             .update({
                 name: segment.name,
                 description: segment.description,
-                segment_project_id: segment.project,
+                segment_project_id: segment.project || null,
                 constraints: JSON.stringify(segment.constraints),
             })
             .returning(COLUMNS);

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -73,7 +73,13 @@ export class SegmentService {
         const input = await segmentSchema.validateAsync(data);
         this.validateSegmentValuesLimit(input);
         await this.validateName(input.name);
-        const segment = await this.segmentStore.create(input, user);
+        const segment = await this.segmentStore.create(
+            {
+                ...input,
+                project: input.project || null,
+            },
+            user,
+        );
 
         await this.eventStore.store({
             type: SEGMENT_CREATED,
@@ -97,7 +103,10 @@ export class SegmentService {
             await this.validateName(input.name);
         }
 
-        const segment = await this.segmentStore.update(id, input);
+        const segment = await this.segmentStore.update(id, {
+            ...input,
+            project: input.project || null,
+        });
 
         await this.eventStore.store({
             type: SEGMENT_UPDATED,

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -73,13 +73,7 @@ export class SegmentService {
         const input = await segmentSchema.validateAsync(data);
         this.validateSegmentValuesLimit(input);
         await this.validateName(input.name);
-        const segment = await this.segmentStore.create(
-            {
-                ...input,
-                project: input.project || null,
-            },
-            user,
-        );
+        const segment = await this.segmentStore.create(input, user);
 
         await this.eventStore.store({
             type: SEGMENT_CREATED,
@@ -103,10 +97,7 @@ export class SegmentService {
             await this.validateName(input.name);
         }
 
-        const segment = await this.segmentStore.update(id, {
-            ...input,
-            project: input.project || null,
-        });
+        const segment = await this.segmentStore.update(id, input);
 
         await this.eventStore.store({
             type: SEGMENT_UPDATED,


### PR DESCRIPTION
~~Should we handle this on the store layer instead~~? 🤔
Fixing this on the store layer. Effectively, frontend is able to send `project: null` and even if that gets magically converted to `""` it's OK since we're covering that use case on the store layer. Backend response will be `project: null` as well, so it should be consistent.