### PR TITLE
fix: assume undefined instead of null on segment project

### DIFF
--- a/frontend/src/component/segments/SegmentForm.tsx
+++ b/frontend/src/component/segments/SegmentForm.tsx
@@ -12,11 +12,11 @@ export type SegmentFormMode = 'create' | 'edit';
 interface ISegmentProps {
     name: string;
     description: string;
-    project: string | null;
+    project?: string;
     constraints: IConstraint[];
     setName: React.Dispatch<React.SetStateAction<string>>;
     setDescription: React.Dispatch<React.SetStateAction<string>>;
-    setProject: React.Dispatch<React.SetStateAction<string | null>>;
+    setProject: React.Dispatch<React.SetStateAction<string | undefined>>;
     setConstraints: React.Dispatch<React.SetStateAction<IConstraint[]>>;
     handleSubmit: (e: any) => void;
     errors: { [key: string]: string };

--- a/frontend/src/component/segments/SegmentFormStepOne.tsx
+++ b/frontend/src/component/segments/SegmentFormStepOne.tsx
@@ -15,10 +15,10 @@ import useProjects from 'hooks/api/getters/useProjects/useProjects';
 interface ISegmentFormPartOneProps {
     name: string;
     description: string;
-    project: string | null;
+    project?: string;
     setName: React.Dispatch<React.SetStateAction<string>>;
     setDescription: React.Dispatch<React.SetStateAction<string>>;
-    setProject: React.Dispatch<React.SetStateAction<string | null>>;
+    setProject: React.Dispatch<React.SetStateAction<string | undefined>>;
     errors: { [key: string]: string };
     clearErrors: () => void;
     setCurrentStep: React.Dispatch<React.SetStateAction<SegmentFormStep>>;
@@ -115,7 +115,7 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
                                 size="small"
                                 value={selectedProject}
                                 onChange={(_, newValue) => {
-                                    setProject(newValue?.id ?? null);
+                                    setProject(newValue?.id);
                                 }}
                                 options={projects}
                                 getOptionLabel={option => option.name}

--- a/frontend/src/component/segments/hooks/useSegmentForm.ts
+++ b/frontend/src/component/segments/hooks/useSegmentForm.ts
@@ -5,12 +5,12 @@ import { useSegmentValidation } from 'hooks/api/getters/useSegmentValidation/use
 export const useSegmentForm = (
     initialName = '',
     initialDescription = '',
-    initialProject: string | null = null,
+    initialProject?: string,
     initialConstraints: IConstraint[] = []
 ) => {
     const [name, setName] = useState(initialName);
     const [description, setDescription] = useState(initialDescription);
-    const [project, setProject] = useState<string | null>(initialProject);
+    const [project, setProject] = useState<string | undefined>(initialProject);
     const [constraints, setConstraints] =
         useState<IConstraint[]>(initialConstraints);
     const [errors, setErrors] = useState({});

--- a/frontend/src/interfaces/segment.ts
+++ b/frontend/src/interfaces/segment.ts
@@ -4,7 +4,7 @@ export interface ISegment {
     id: number;
     name: string;
     description: string;
-    project: string | null;
+    project?: string;
     createdAt: string;
     createdBy: string;
     constraints: IConstraint[];

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -203,7 +203,7 @@ export default class SegmentStore implements ISegmentStore {
             id: row.id,
             name: row.name,
             description: row.description,
-            project: row.segment_project_id,
+            project: row.segment_project_id || undefined,
             constraints: row.constraints,
             createdBy: row.created_by,
             createdAt: row.created_at,


### PR DESCRIPTION
Assume `undefined` instead of `null` for project in terms of interfacing with segments: If the `project` field is not present, that means that it is not set, which means we're dealing with a "global" segment. If we want to unset `project` and make a segment global, we simply don't send the `project` property on our PUT method.