### PR TITLE
feat: expose project members

### DIFF
--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -2,6 +2,7 @@ import NameExistsError from '../error/name-exists-error';
 import getLogger from '../../test/fixtures/no-logger';
 import createStores from '../../test/fixtures/store';
 import { AccessService, IRoleValidation } from './access-service';
+import { GroupService } from './group-service';
 
 function getSetup(withNameInUse: boolean) {
     const stores = createStores();
@@ -18,7 +19,7 @@ function getSetup(withNameInUse: boolean) {
             {
                 getLogger,
             },
-            undefined, // GroupService
+            {} as GroupService,
         ),
         stores,
     };

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -382,7 +382,7 @@ export class AccessService {
             const userIdList = userRoleList.map((u) => u.userId);
             const users = await this.accountStore.getAllWithId(userIdList);
             return users.map((user) => {
-                const role = userRoleList.find((role) => role.userId == user.id)!;
+                const role = userRoleList.find((r) => r.userId == user.id)!;
                 return {
                     ...user,
                     addedAt: role.addedAt!,

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -382,7 +382,7 @@ export class AccessService {
             const userIdList = userRoleList.map((u) => u.userId);
             const users = await this.accountStore.getAllWithId(userIdList);
             return users.map((user) => {
-                const role = userRoleList.find((r) => r.userId == user.id)!;
+                const role = userRoleList.find((role) => role.userId == user.id)!;
                 return {
                     ...user,
                     addedAt: role.addedAt!,

--- a/src/lib/types/stores/role-store.ts
+++ b/src/lib/types/stores/role-store.ts
@@ -27,6 +27,6 @@ export interface IRoleStore extends Store<ICustomRole, number> {
     getProjectRoles(): Promise<IRole[]>;
     getRootRoles(): Promise<IRole[]>;
     getRootRoleForAllUsers(): Promise<IUserRole[]>;
-    nameInUse(name: string, existingId: number): Promise<boolean>;
+    nameInUse(name: string, existingId?: number): Promise<boolean>;
     count(): Promise<number>;
 }

--- a/src/lib/util/unique.test.ts
+++ b/src/lib/util/unique.test.ts
@@ -1,0 +1,19 @@
+import { uniqueByKey } from './unique';
+
+test('should filter unique objects by key', () => {
+    expect(
+        uniqueByKey(
+            [
+                { name: 'name1', value: 'val1' },
+                { name: 'name1', value: 'val1' },
+                { name: 'name1', value: 'val2' },
+                { name: 'name1', value: 'val4' },
+                { name: 'name2', value: 'val5' },
+            ],
+            'name',
+        ),
+    ).toStrictEqual([
+        { name: 'name1', value: 'val4' },
+        { name: 'name2', value: 'val5' },
+    ]);
+});

--- a/src/lib/util/unique.ts
+++ b/src/lib/util/unique.ts
@@ -1,2 +1,7 @@
 export const unique = <T extends string | number>(items: T[]): T[] =>
     Array.from(new Set(items));
+
+export const uniqueByKey = <T extends Record<string, unknown>>(
+    items: T[],
+    key: keyof T,
+): T[] => [...new Map(items.map((item) => [item[key], item])).values()];

--- a/src/test/fixtures/fake-role-store.ts
+++ b/src/test/fixtures/fake-role-store.ts
@@ -18,7 +18,7 @@ export default class FakeRoleStore implements IRoleStore {
         throw new Error('Method not implemented.');
     }
 
-    nameInUse(name: string, existingId: number): Promise<boolean> {
+    nameInUse(name: string, existingId?: number): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Exposing project members and checking if a user is a member. We need this in the notifications service to send notifications to all project members. We also need this for checking who should be able to submit change requests in a protected model. Access service seems to be the holder of the core information so he owns the membership check.

Also fixed TS errors in all the files I touched.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
