### PR TITLE
feat: filter segments by project on the strategy

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -213,6 +213,7 @@ export const FeatureStrategyForm = ({
                     <FeatureStrategySegment
                         segments={segments}
                         setSegments={setSegments}
+                        projectId={projectId}
                     />
                 }
             />

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
@@ -13,6 +13,7 @@ import { Divider, styled, Typography } from '@mui/material';
 interface IFeatureStrategySegmentProps {
     segments: ISegment[];
     setSegments: React.Dispatch<React.SetStateAction<ISegment[]>>;
+    projectId: string;
 }
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
@@ -22,6 +23,7 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
 export const FeatureStrategySegment = ({
     segments: selectedSegments,
     setSegments: setSelectedSegments,
+    projectId,
 }: IFeatureStrategySegmentProps) => {
     const { segments: allSegments } = useSegments();
     const { strategySegmentsLimit } = useSegmentLimits();
@@ -35,7 +37,11 @@ export const FeatureStrategySegment = ({
         return null;
     }
 
-    const unusedSegments = allSegments.filter(segment => {
+    const allSelectableSegments = allSegments.filter(
+        ({ project }) => !project || project === projectId
+    );
+
+    const unusedSegments = allSelectableSegments.filter(segment => {
         return !selectedSegments.find(selected => selected.id === segment.id);
     });
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-737/when-listing-segments-project-specific-segments-should-also-be-present

Simple filter on the UI for segments that are either global or for the specific project.