### PR TITLE
fix: bug fix - `end` the response when projectScopedStickiness is disabled

### DIFF
--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -28,7 +28,7 @@ import { OpenApiService, SettingService } from '../../../services';
 import { IAuthRequest } from '../../unleash-types';
 import { ProjectApiTokenController } from './api-token';
 import ProjectArchiveController from './project-archive';
-import NotFoundError from 'lib/error/notfound-error';
+import NotFoundError from '../../../error/notfound-error';
 
 const STICKINESS_KEY = 'stickiness';
 const DEFAULT_STICKINESS = 'default';

--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -164,7 +164,7 @@ export default class ProjectApi extends Controller {
         res: Response<ProjectSettingsSchema>,
     ): Promise<void> {
         if (!this.config.flagResolver.isEnabled('projectScopedStickiness')) {
-            res.status(404);
+            res.status(404).end();
             return Promise.resolve();
         }
         const { projectId } = req.params;
@@ -192,7 +192,7 @@ export default class ProjectApi extends Controller {
         res: Response<ProjectSettingsSchema>,
     ): Promise<void> {
         if (!this.config.flagResolver.isEnabled('projectScopedStickiness')) {
-            res.status(404);
+            res.status(404).end();
             return Promise.resolve();
         }
         const { projectId } = req.params;

--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -28,6 +28,7 @@ import { OpenApiService, SettingService } from '../../../services';
 import { IAuthRequest } from '../../unleash-types';
 import { ProjectApiTokenController } from './api-token';
 import ProjectArchiveController from './project-archive';
+import NotFoundError from 'lib/error/notfound-error';
 
 const STICKINESS_KEY = 'stickiness';
 const DEFAULT_STICKINESS = 'default';
@@ -164,8 +165,7 @@ export default class ProjectApi extends Controller {
         res: Response<ProjectSettingsSchema>,
     ): Promise<void> {
         if (!this.config.flagResolver.isEnabled('projectScopedStickiness')) {
-            res.status(404).end();
-            return Promise.resolve();
+            throw new NotFoundError('Project scoped stickiness is not enabled');
         }
         const { projectId } = req.params;
         const stickinessSettings = await this.settingService.get<object>(
@@ -192,8 +192,7 @@ export default class ProjectApi extends Controller {
         res: Response<ProjectSettingsSchema>,
     ): Promise<void> {
         if (!this.config.flagResolver.isEnabled('projectScopedStickiness')) {
-            res.status(404).end();
-            return Promise.resolve();
+            throw new NotFoundError('Project scoped stickiness is not enabled');
         }
         const { projectId } = req.params;
         const { defaultStickiness } = req.body;


### PR DESCRIPTION
This PR fixes a bug where the api call to getProjectSettings was left hanging because no `end` was specified on the server

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
