### PR TITLE
chore: PoC test API helper (DRY)

### DIFF
--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -128,15 +128,15 @@ const createSegment = (postData: UpsertSegmentSchema): Promise<ISegment> => {
 };
 
 const createContextField = async (contextField: IContextFieldDto) => {
-    await app.api.createContextField(contextField).expect(201);
+    await app.createContextField(contextField).expect(201);
 };
 
 const createFeature = async (featureName: string) => {
-    await app.api.createFeature(featureName).expect(201);
+    await app.createFeature(featureName).expect(201);
 };
 
 const archiveFeature = async (featureName: string) => {
-    await app.api.archiveFeature(featureName).expect(202);
+    await app.archiveFeature(featureName).expect(202);
 };
 
 const unArchiveFeature = async (featureName: string) => {

--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -128,15 +128,15 @@ const createSegment = (postData: UpsertSegmentSchema): Promise<ISegment> => {
 };
 
 const createContextField = async (contextField: IContextFieldDto) => {
-    await app.createContextField(contextField).expect(201);
+    await app.createContextField(contextField);
 };
 
 const createFeature = async (featureName: string) => {
-    await app.createFeature(featureName).expect(201);
+    await app.createFeature(featureName);
 };
 
 const archiveFeature = async (featureName: string) => {
-    await app.archiveFeature(featureName).expect(202);
+    await app.archiveFeature(featureName);
 };
 
 const unArchiveFeature = async (featureName: string) => {

--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -128,26 +128,15 @@ const createSegment = (postData: UpsertSegmentSchema): Promise<ISegment> => {
 };
 
 const createContextField = async (contextField: IContextFieldDto) => {
-    await app.request.post(`/api/admin/context`).send(contextField).expect(201);
+    await app.api.createContextField(contextField).expect(201);
 };
 
 const createFeature = async (featureName: string) => {
-    await app.request
-        .post(`/api/admin/projects/${DEFAULT_PROJECT}/features`)
-        .send({
-            name: featureName,
-        })
-        .set('Content-Type', 'application/json')
-        .expect(201);
+    await app.api.createFeature(featureName).expect(201);
 };
 
 const archiveFeature = async (featureName: string) => {
-    await app.request
-        .delete(
-            `/api/admin/projects/${DEFAULT_PROJECT}/features/${featureName}`,
-        )
-        .set('Content-Type', 'application/json')
-        .expect(202);
+    await app.api.archiveFeature(featureName).expect(202);
 };
 
 const unArchiveFeature = async (featureName: string) => {

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -34,7 +34,7 @@ function httpApis(
     const base = config.server.baseUriPath || '';
 
     return {
-        createFeature: (name: string, project?: string) => {
+        createFeature: (name: string, project: string = DEFAULT_PROJECT) => {
             return request
                 .post(`${base}/api/admin/projects/${project}/features`)
                 .send({

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -13,12 +13,11 @@ import { IContextFieldDto } from 'lib/types/stores/context-field-store';
 
 process.env.NODE_ENV = 'test';
 
-export interface IUnleashTest {
+export interface IUnleashTest extends IUnleashHttpAPI {
     request: supertest.SuperAgentTest;
     destroy: () => Promise<void>;
     services: IUnleashServices;
     config: IUnleashConfig;
-    api: IUnleashHttpAPI;
 }
 
 export interface IUnleashHttpAPI {
@@ -97,7 +96,7 @@ async function createApp(
         destroy,
         services,
         config,
-        api: httpApis(request, config),
+        ...httpApis(request, config),
     };
 }
 

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -21,9 +21,20 @@ export interface IUnleashTest extends IUnleashHttpAPI {
 }
 
 export interface IUnleashHttpAPI {
-    createFeature(name: string, project?: string): supertest.Test;
-    archiveFeature(name: string, project?: string): supertest.Test;
-    createContextField(contextField: IContextFieldDto): supertest.Test;
+    createFeature(
+        name: string,
+        project?: string,
+        expectedResponseCode?: number,
+    ): supertest.Test;
+    archiveFeature(
+        name: string,
+        project?: string,
+        expectedResponseCode?: number,
+    ): supertest.Test;
+    createContextField(
+        contextField: IContextFieldDto,
+        expectedResponseCode?: number,
+    ): supertest.Test;
 }
 
 function httpApis(
@@ -33,28 +44,41 @@ function httpApis(
     const base = config.server.baseUriPath || '';
 
     return {
-        createFeature: (name: string, project: string = DEFAULT_PROJECT) => {
+        createFeature: (
+            name: string,
+            project: string = DEFAULT_PROJECT,
+            expectedResponseCode: number = 201,
+        ) => {
             return request
                 .post(`${base}/api/admin/projects/${project}/features`)
                 .send({
                     name,
                 })
-                .set('Content-Type', 'application/json');
+                .set('Content-Type', 'application/json')
+                .expect(expectedResponseCode);
         },
 
         archiveFeature(
             name: string,
             project: string = DEFAULT_PROJECT,
+            expectedResponseCode: number = 202,
         ): supertest.Test {
             return request
                 .delete(
                     `${base}/api/admin/projects/${project}/features/${name}`,
                 )
-                .set('Content-Type', 'application/json');
+                .set('Content-Type', 'application/json')
+                .expect(expectedResponseCode);
         },
 
-        createContextField(contextField: IContextFieldDto): supertest.Test {
-            return request.post(`${base}/api/admin/context`).send(contextField);
+        createContextField(
+            contextField: IContextFieldDto,
+            expectedResponseCode: number = 201,
+        ): supertest.Test {
+            return request
+                .post(`${base}/api/admin/context`)
+                .send(contextField)
+                .expect(expectedResponseCode);
         },
     };
 }


### PR DESCRIPTION
## About the changes
The idea of this PR is to propose a way of centralizing API calls while doing E2E tests to avoid repeating ourselves. 

In many places in our e2e tests, we end up doing the same thing over and over. I.e. to create features:
https://github.com/Unleash/unleash/blob/bc011e987673fa44cd72776bbc3d456eb03dfcb5/src/lib/features/export-import-toggles/export-import-permissions.e2e.test.ts#L47-L55
https://github.com/Unleash/unleash/blob/bc011e987673fa44cd72776bbc3d456eb03dfcb5/src/lib/features/export-import-toggles/export-import.e2e.test.ts#L134-L142
https://github.com/Unleash/unleash/blob/bc011e987673fa44cd72776bbc3d456eb03dfcb5/src/test/e2e/api/admin/project/project.health.e2e.test.ts#L36-L51

This PR is using the new API showing how it'd look like.