### PR TITLE
docs: remove "under construction" message for edge

### DIFF
--- a/website/remote-content/edge-proxy.js
+++ b/website/remote-content/edge-proxy.js
@@ -23,15 +23,11 @@ const getAdmonitions = (data) => {
 
 Looking for how to run the Unleash proxy? Check out the [_how to run the Unleash proxy_ guide](../how-to/how-to-run-the-unleash-proxy.mdx)!
 
-:::`, 'unleash-edge': `:::caution 🏗️ Under construction!
-Unleash Edge is currently considered very experimental. Use it at your own risk.
+:::`,
+        'unleash-edge': ``,
+    };
 
-
-Share your comments in [🗣️ GitHub Discussions](https://github.com/Unleash/unleash/discussions) or the [💬 Unleash community Slack](https://slack.unleash.run/).
-:::`
-    }
-
-    return [admonitions[data.slugName]]
+    return [admonitions[data.slugName]];
 };
 
 const modifyContent2 = modifyContent({


### PR DESCRIPTION
In preparation for Edge's stabilization, this PR removes the "under construction" admonition that was placed on the edge docs.