### PR TITLE
Feat segments project safeguards

### DIFF
--- a/frontend/src/component/segments/SegmentFormStepOne.tsx
+++ b/frontend/src/component/segments/SegmentFormStepOne.tsx
@@ -13,6 +13,8 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
 import { GO_BACK } from 'constants/navigate';
+import { useStrategiesBySegment } from 'hooks/api/getters/useStrategiesBySegment/useStrategiesBySegment';
+import { SegmentProjectAlert } from './SegmentProjectAlert';
 
 interface ISegmentFormPartOneProps {
     name: string;
@@ -67,10 +69,24 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
     clearErrors,
     setCurrentStep,
 }) => {
+    const segmentId = useOptionalPathParam('segmentId');
     const projectId = useOptionalPathParam('projectId');
     const { uiConfig } = useUiConfig();
     const navigate = useNavigate();
-    const { projects } = useProjects();
+    const { projects, loading: loadingProjects } = useProjects();
+
+    const { strategies, loading: loadingStrategies } =
+        useStrategiesBySegment(segmentId);
+
+    const projectsUsed = new Set<string>(
+        strategies.map(({ projectId }) => projectId!).filter(Boolean)
+    );
+
+    const availableProjects = projects.filter(
+        ({ id }) =>
+            !projectsUsed.size ||
+            (projectsUsed.size === 1 && projectsUsed.has(id))
+    );
 
     const [selectedProject, setSelectedProject] = React.useState(
         projects.find(({ id }) => id === project) ?? null
@@ -79,6 +95,8 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
     useEffect(() => {
         setSelectedProject(projects.find(({ id }) => id === project) ?? null);
     }, [project, projects]);
+
+    const loading = loadingProjects && loadingStrategies;
 
     return (
         <StyledForm>
@@ -110,7 +128,8 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
                 <ConditionallyRender
                     condition={
                         Boolean(uiConfig.flags.projectScopedSegments) &&
-                        !projectId
+                        !projectId &&
+                        !loading
                     }
                     show={
                         <>
@@ -123,11 +142,18 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
                                 onChange={(_, newValue) => {
                                     setProject(newValue?.id);
                                 }}
-                                options={projects}
+                                options={availableProjects}
                                 getOptionLabel={option => option.name}
                                 renderInput={params => (
                                     <TextField {...params} label="Project" />
                                 )}
+                                disabled={projectsUsed.size > 1}
+                            />
+                            <SegmentProjectAlert
+                                projects={projects}
+                                strategies={strategies}
+                                projectsUsed={Array.from(projectsUsed)}
+                                availableProjects={availableProjects}
                             />
                         </>
                     }

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -72,7 +72,7 @@ export const SegmentProjectAlert = ({
             <StyledAlert severity="info">
                 You can't specify a project other than{' '}
                 <strong>{availableProjects[0].name}</strong> for this segment
-                because it is used in that project:
+                because it is used here:
                 {projectList}
             </StyledAlert>
         );

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -5,6 +5,11 @@ import { IFeatureStrategy } from 'interfaces/strategy';
 import { Link } from 'react-router-dom';
 import { formatStrategyName } from 'utils/strategyNames';
 
+const StyledUl = styled('ul')(({ theme }) => ({
+    listStyle: 'none',
+    paddingLeft: 0,
+}));
+
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginTop: theme.spacing(1),
 }));
@@ -23,7 +28,7 @@ export const SegmentProjectAlert = ({
     availableProjects,
 }: ISegmentProjectAlertProps) => {
     const projectList = (
-        <ul>
+        <StyledUl>
             {Array.from(projectsUsed).map(projectId => (
                 <li key={projectId}>
                     <Link to={`/projects/${projectId}`} target="_blank">
@@ -54,7 +59,7 @@ export const SegmentProjectAlert = ({
                     </ul>
                 </li>
             ))}
-        </ul>
+        </StyledUl>
     );
 
     if (projectsUsed.length > 1) {

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -1,0 +1,90 @@
+import { Alert, styled } from '@mui/material';
+import { formatEditStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit';
+import { IProjectCard } from 'interfaces/project';
+import { IFeatureStrategy } from 'interfaces/strategy';
+import { Link } from 'react-router-dom';
+import { formatStrategyName } from 'utils/strategyNames';
+
+const StyledAlert = styled(Alert)(({ theme }) => ({
+    marginTop: theme.spacing(1),
+}));
+
+interface ISegmentProjectAlertProps {
+    projects: IProjectCard[];
+    strategies: IFeatureStrategy[];
+    projectsUsed: string[];
+    availableProjects: IProjectCard[];
+}
+
+export const SegmentProjectAlert = ({
+    projects,
+    strategies,
+    projectsUsed,
+    availableProjects,
+}: ISegmentProjectAlertProps) => {
+    const projectList = (
+        <ul>
+            {Array.from(projectsUsed).map(projectId => (
+                <li key={projectId}>
+                    <Link to={`/projects/${projectId}`} target="_blank">
+                        {projects.find(({ id }) => id === projectId)?.name ??
+                            projectId}
+                    </Link>
+                    <ul>
+                        {strategies
+                            ?.filter(
+                                strategy => strategy.projectId === projectId
+                            )
+                            .map(strategy => (
+                                <li key={strategy.id}>
+                                    <Link
+                                        to={formatEditStrategyPath(
+                                            strategy.projectId!,
+                                            strategy.featureName!,
+                                            strategy.environment!,
+                                            strategy.id
+                                        )}
+                                        target="_blank"
+                                    >
+                                        {strategy.featureName!}{' '}
+                                        {formatStrategyNameParens(strategy)}
+                                    </Link>
+                                </li>
+                            ))}
+                    </ul>
+                </li>
+            ))}
+        </ul>
+    );
+
+    if (projectsUsed.length > 1) {
+        return (
+            <StyledAlert severity="info">
+                You can't specify a project for this segment because it is used
+                in multiple projects:
+                {projectList}
+            </StyledAlert>
+        );
+    }
+
+    if (availableProjects.length === 1) {
+        return (
+            <StyledAlert severity="info">
+                You can't specify a project other than{' '}
+                <strong>{availableProjects[0].name}</strong> for this segment
+                because it is used in that project:
+                {projectList}
+            </StyledAlert>
+        );
+    }
+
+    return null;
+};
+
+const formatStrategyNameParens = (strategy: IFeatureStrategy): string => {
+    if (!strategy.strategyName) {
+        return '';
+    }
+
+    return `(${formatStrategyName(strategy.strategyName)})`;
+};

--- a/frontend/src/hooks/api/getters/useStrategiesBySegment/useStrategiesBySegment.ts
+++ b/frontend/src/hooks/api/getters/useStrategiesBySegment/useStrategiesBySegment.ts
@@ -1,28 +1,31 @@
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
 import { useCallback } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { IFeatureStrategy } from 'interfaces/strategy';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 
 export interface IUseStrategiesBySegmentOutput {
-    strategies?: IFeatureStrategy[];
+    strategies: IFeatureStrategy[];
     refetchUsedSegments: () => void;
     loading: boolean;
     error?: Error;
 }
 
 export const useStrategiesBySegment = (
-    id: number
+    id?: string | number
 ): IUseStrategiesBySegmentOutput => {
     const path = formatApiPath(`api/admin/segments/${id}/strategies`);
-    const { data, error } = useSWR(path, () => fetchUsedSegment(path));
+    const { data, error } = useConditionalSWR(id, [], path, () =>
+        fetchUsedSegment(path)
+    );
 
     const refetchUsedSegments = useCallback(() => {
         mutate(path).catch(console.warn);
     }, [path]);
 
     return {
-        strategies: data?.strategies,
+        strategies: data?.strategies || [],
         refetchUsedSegments,
         loading: !error && !data,
         error,

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -22,6 +22,12 @@ export interface ISegmentService {
         user: Partial<Pick<IUser, 'username' | 'email'>>,
     ): Promise<ISegment>;
 
+    update(
+        id: number,
+        data: UpsertSegmentSchema,
+        user: Partial<Pick<IUser, 'username' | 'email'>>,
+    ): Promise<void>;
+
     delete(id: number, user: IUser): Promise<void>;
 
     cloneStrategySegments(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-811/ability-to-move-project-specific-segments

![image](https://user-images.githubusercontent.com/14320932/226572047-19ed225c-13d5-4f2e-b10f-e17a7f7e6ae7.png)

Provides some safeguards to project-specific segments when managing them on a global level (segments page):
- You can always promote a segment to global;
- You can't specify a project if the segment is currently in use in multiple projects;
- You can't specify a different project if the segment is currently already in use in a project;