### PR TITLE
fix: revert overflow hidden in section, unset in modal

### DIFF
--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -36,6 +36,7 @@ const StyledContainer = styled('section', {
     width: '100%',
     display: 'flex',
     margin: '0 auto',
+    overflow: modal ? 'unset' : 'hidden',
     [theme.breakpoints.down(1100)]: {
         flexDirection: 'column',
         minHeight: 0,


### PR DESCRIPTION
This reverts and adapts https://github.com/Unleash/unleash/pull/3307/files#r1135784293 - Apparently it broke the form border radius when not in modal mode.

This change makes it so that we have `overflow: hidden` in most cases but `overflow: unset` when using `FormTemplate` as a modal, effectively covering both use cases.

Normal:
![image](https://user-images.githubusercontent.com/14320932/226637777-cc8dba05-4447-4bee-b517-59d4e1dc1923.png)

Modal (`position: sticky` header in variants still works correctly):
![image](https://user-images.githubusercontent.com/14320932/226637986-bb744c3f-822b-454b-b058-450e7263bf5f.png)
