### PR TITLE
fix: properly escaping app names

### DIFF
--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -94,7 +94,10 @@ export const NetworkOverview = () => {
             ${apps
                 .map(
                     ({ label, reqs, type }, i) =>
-                        `app-${i}(${label}) -- ${reqs} req/s<br>${type} --> Unleash`
+                        `app-${i}("${label.replaceAll(
+                            '"',
+                            '&quot;'
+                        )}") -- ${reqs} req/s<br>${type} --> Unleash`
                 )
                 .join('\n')}
         end


### PR DESCRIPTION
## About the changes
Network overview was not escaping square brackets from app names and that caused mermaid graph to break. We've also identified problems with quotes and some characters not showing properly when using utf-8 (but still no solution for this). We're going to be testing the utf-8 issue in our sandbox instances.
