### PR TITLE
fix: use projectId from param

### DIFF
--- a/src/lib/middleware/rbac-middleware.test.ts
+++ b/src/lib/middleware/rbac-middleware.test.ts
@@ -332,3 +332,36 @@ test('DELETE_TAG_TYPE does not need projectId', async () => {
         undefined,
     );
 });
+
+test('should not expect featureName for UPDATE_FEATURE when projectId specified', async () => {
+    const projectId = 'some-project-33';
+
+    const accessService = {
+        hasPermission: jest.fn(),
+    };
+
+    const func = rbacMiddleware(config, { featureToggleStore }, accessService);
+
+    const cb = jest.fn();
+    const req: any = {
+        user: new User({
+            username: 'user',
+            id: 1,
+        }),
+        params: {},
+        body: {
+            project: projectId,
+        },
+    };
+
+    func(req, undefined, cb);
+
+    await req.checkRbac(perms.UPDATE_FEATURE);
+
+    expect(accessService.hasPermission).toHaveBeenCalledWith(
+        req.user,
+        perms.UPDATE_FEATURE,
+        projectId,
+        undefined,
+    );
+});

--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -63,7 +63,10 @@ const rbacMiddleware = (
 
             // Temporary workaround to figure out projectId for feature toggle updates.
             // will be removed in Unleash v5.0
-            if ([DELETE_FEATURE, UPDATE_FEATURE].includes(permission)) {
+            if (
+                !projectId &&
+                [DELETE_FEATURE, UPDATE_FEATURE].includes(permission)
+            ) {
                 const { featureName } = params;
                 projectId = await featureToggleStore.getProjectId(featureName);
             } else if (


### PR DESCRIPTION
Previously every time there was permission **DELETE_FEATURE** or **UPDATE_FEATURE** needed, it expected to have `featureName` in path parameters.

Now that we introduced batch operations, for example batch deletion of features, the `featureName` will not be in parameters, but instead the `projectId` is provided as path parameter.

This PR makes following change:  now `projectId` from path parameters will be used instead of making a database call to find the `projectId` from feature.