### PR TITLE
Add collab mode docs to side bar + fix casing inconsistency in tooltip

### DIFF
--- a/frontend/src/component/project/Project/ProjectForm/CollaborationModeTooltip.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/CollaborationModeTooltip.tsx
@@ -25,7 +25,7 @@ export const CollaborationModeTooltip: FC = () => (
                 <Box sx={{ mt: 2 }}>
                     <StyledTitle>protected: </StyledTitle>
                     <StyledDescription>
-                        Only admins and project members can submit change
+                        only admins and project members can submit change
                         requests
                     </StyledDescription>
                 </Box>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -322,6 +322,7 @@ module.exports = {
                         'reference/playground',
                         'reference/public-signup',
                         'reference/projects',
+                        'reference/project-collaboration-mode',
                         'reference/rbac',
                         'reference/segments',
                         'reference/service-accounts',


### PR DESCRIPTION
This change does to things:

-   Adds project collaboration mode docs to the sidebar
-   Fixes a casing inconsistency in the collaboration mode tooltip: previously, one of the explanations started with a lowercase character and the other with an uppercase character. Now they both start with lowercase characters.