### PR TITLE
fix: fix transparancy of sticky component

### DIFF
--- a/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
+++ b/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
@@ -9,6 +9,7 @@ const StyledStickyContainer = styled('div')(() => ({
     position: 'sticky',
     marginTop: 'auto',
     bottom: 0,
+    zIndex: 1,
 }));
 
 const StyledContainer = styled(Box)(({ theme }) => ({

--- a/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
+++ b/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
@@ -5,11 +5,11 @@ interface IBatchSelectionActionsBarProps {
     count: number;
 }
 
-const StyledStickyContainer = styled('div')(() => ({
+const StyledStickyContainer = styled('div')(({ theme }) => ({
     position: 'sticky',
     marginTop: 'auto',
     bottom: 0,
-    zIndex: 1,
+    zIndex: theme.zIndex.mobileStepper,
 }));
 
 const StyledContainer = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
Currently the component was not on top of all elements in feature table. Can be seen in enterprise instance.

This PR fixes it.