### PR TITLE
fix: Make api token environment selector accept environments

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenForm/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/EnvironmentSelector/EnvironmentSelector.tsx
@@ -5,19 +5,23 @@ import {
     StyledInputDescription,
     StyledSelectInput,
 } from '../ApiTokenForm.styles';
-import { useEnvironments } from '../../../../../hooks/api/getters/useEnvironments/useEnvironments';
+import {
+    IEnvironment,
+    IProjectEnvironment,
+} from '../../../../../interfaces/environments';
 
 interface IEnvironmentSelectorProps {
     type: string;
     environment?: string;
+    environments: IProjectEnvironment[] | IEnvironment[];
     setEnvironment: React.Dispatch<React.SetStateAction<string | undefined>>;
 }
 export const EnvironmentSelector = ({
     type,
     environment,
     setEnvironment,
+    environments,
 }: IEnvironmentSelectorProps) => {
-    const { environments } = useEnvironments();
     const selectableEnvs =
         type === TokenType.ADMIN
             ? [{ key: '*', label: 'ALL' }]

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/EnvironmentSelector/EnvironmentSelector.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/EnvironmentSelector/EnvironmentSelector.tsx
@@ -22,6 +22,11 @@ export const EnvironmentSelector = ({
     setEnvironment,
     environments,
 }: IEnvironmentSelectorProps) => {
+    const isProjectEnv = (
+        environment: IEnvironment | IProjectEnvironment
+    ): environment is IProjectEnvironment => {
+        return 'projectVisible' in environment;
+    };
     const selectableEnvs =
         type === TokenType.ADMIN
             ? [{ key: '*', label: 'ALL' }]
@@ -29,7 +34,9 @@ export const EnvironmentSelector = ({
                   key: environment.name,
                   label: environment.name,
                   title: environment.name,
-                  disabled: !environment.enabled,
+                  disabled: isProjectEnv(environment)
+                      ? !environment.projectVisible
+                      : !environment.enabled,
               }));
 
     return (

--- a/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
+++ b/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
@@ -18,6 +18,7 @@ import { TokenInfo } from '../ApiTokenForm/TokenInfo/TokenInfo';
 import { TokenTypeSelector } from '../ApiTokenForm/TokenTypeSelector/TokenTypeSelector';
 import { ProjectSelector } from '../ApiTokenForm/ProjectSelector/ProjectSelector';
 import { EnvironmentSelector } from '../ApiTokenForm/EnvironmentSelector/EnvironmentSelector';
+import { useEnvironments } from '../../../../hooks/api/getters/useEnvironments/useEnvironments';
 
 const pageTitle = 'Create API token';
 interface ICreateApiTokenProps {
@@ -29,6 +30,7 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
     const navigate = useNavigate();
     const [showConfirm, setShowConfirm] = useState(false);
     const [token, setToken] = useState('');
+    const { environments } = useEnvironments();
 
     const {
         getApiTokenPayload,
@@ -125,6 +127,7 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
                 />
                 <EnvironmentSelector
                     type={type}
+                    environments={environments}
                     environment={environment}
                     setEnvironment={setEnvironment}
                 />

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
@@ -21,6 +21,7 @@ import { TokenTypeSelector } from 'component/admin/apiToken/ApiTokenForm/TokenTy
 import { ConfirmToken } from 'component/admin/apiToken/ConfirmToken/ConfirmToken';
 import { useProjectApiTokens } from 'hooks/api/getters/useProjectApiTokens/useProjectApiTokens';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useProjectEnvironments } from '../../../../../hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
 
 const pageTitle = 'Create project API token';
 
@@ -49,6 +50,7 @@ export const CreateProjectApiTokenForm = () => {
         useProjectApiTokensApi();
     const { refetch: refetchProjectTokens } = useProjectApiTokens(project);
     const { trackEvent } = usePlausibleTracker();
+    const { environments } = useProjectEnvironments(project);
 
     usePageTitle(pageTitle);
 
@@ -131,6 +133,7 @@ export const CreateProjectApiTokenForm = () => {
                     type={type}
                     environment={environment}
                     setEnvironment={setEnvironment}
+                    environments={environments}
                 />
             </ApiTokenForm>
             <ConfirmToken

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
 
@@ -22,11 +22,13 @@ import { ConfirmToken } from 'component/admin/apiToken/ConfirmToken/ConfirmToken
 import { useProjectApiTokens } from 'hooks/api/getters/useProjectApiTokens/useProjectApiTokens';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useProjectEnvironments } from '../../../../../hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
+import { IProjectEnvironment } from '../../../../../interfaces/environments';
+import useProject from '../../../../../hooks/api/getters/useProject/useProject';
 
 const pageTitle = 'Create project API token';
 
 export const CreateProjectApiTokenForm = () => {
-    const project = useRequiredPathParam('projectId');
+    const projectId = useRequiredPathParam('projectId');
     const { setToastApiError } = useToast();
     const { uiConfig } = useUiConfig();
     const navigate = useNavigate();
@@ -44,17 +46,28 @@ export const CreateProjectApiTokenForm = () => {
         isValid,
         errors,
         clearErrors,
-    } = useApiTokenForm(project);
+    } = useApiTokenForm(projectId);
 
     const { createToken: createProjectToken, loading } =
         useProjectApiTokensApi();
-    const { refetch: refetchProjectTokens } = useProjectApiTokens(project);
+    const { refetch: refetchProjectTokens } = useProjectApiTokens(projectId);
     const { trackEvent } = usePlausibleTracker();
-    const { environments } = useProjectEnvironments(project);
+    const { environments } = useProjectEnvironments(projectId);
+    const { project } = useProject(projectId);
 
+    const projectEnvironments = useMemo<IProjectEnvironment[]>(
+        () =>
+            environments.map(environment => ({
+                ...environment,
+                projectVisible: project?.environments.includes(
+                    environment.name
+                ),
+            })),
+        [environments, project?.environments]
+    );
     usePageTitle(pageTitle);
 
-    const PATH = `api/admin/project/${project}/api-tokens`;
+    const PATH = `api/admin/project/${projectId}/api-tokens`;
     const permission = CREATE_PROJECT_API_TOKEN;
 
     const handleSubmit = async (e: Event) => {
@@ -65,7 +78,7 @@ export const CreateProjectApiTokenForm = () => {
         try {
             const payload = getApiTokenPayload();
 
-            await createProjectToken(payload, project)
+            await createProjectToken(payload, projectId)
                 .then(res => res.json())
                 .then(api => {
                     scrollToTop();
@@ -118,7 +131,7 @@ export const CreateProjectApiTokenForm = () => {
                     <CreateButton
                         name="token"
                         permission={permission}
-                        projectId={project}
+                        projectId={projectId}
                     />
                 }
             >
@@ -133,7 +146,7 @@ export const CreateProjectApiTokenForm = () => {
                     type={type}
                     environment={environment}
                     setEnvironment={setEnvironment}
-                    environments={environments}
+                    environments={projectEnvironments}
                 />
             </ApiTokenForm>
             <ConfirmToken


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->
Makes the api token environment selector accept options to allow different environment to be passed in according to the use case ie use all envs when creating api tokens and use project envs when creating project scoped tokens
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes [# 1-811](https://linear.app/unleash/issue/1-811/change-environment-dropdown-to-show-all-environments-enabled-for-the)

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
