### PR TITLE
task: enclose ETag in double quotes.

### DIFF
--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -1,7 +1,7 @@
 import memoizee from 'memoizee';
 import { Response } from 'express';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import hasSum from 'hash-sum';
+import hashSum from 'hash-sum';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { diff } from 'deep-object-diff';
 import Controller from '../controller';
@@ -318,7 +318,7 @@ export default class FeatureController extends Controller {
         const revisionId = await this.eventService.getMaxRevisionId();
 
         // TODO: We will need to standardize this to be able to implement this a cross languages (Edge in Rust?).
-        const queryHash = hasSum(query);
+        const queryHash = hashSum(query);
         const etag = `"${queryHash}:${revisionId}"`;
         return { revisionId, etag, queryHash };
     }

--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -319,7 +319,7 @@ export default class FeatureController extends Controller {
 
         // TODO: We will need to standardize this to be able to implement this a cross languages (Edge in Rust?).
         const queryHash = hasSum(query);
-        const etag = `${queryHash}:${revisionId}`;
+        const etag = `"${queryHash}:${revisionId}"`;
         return { revisionId, etag, queryHash };
     }
 

--- a/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
@@ -122,14 +122,14 @@ test('returns calculated hash', async () => {
         .get('/api/client/features')
         .expect('Content-Type', /json/)
         .expect(200);
-    expect(res.headers.etag).toBe('ae443048:19');
-    expect(res.body.meta.etag).toBe('ae443048:19');
+    expect(res.headers.etag).toBe('"ae443048:19"');
+    expect(res.body.meta.etag).toBe('"ae443048:19"');
 });
 
 test('returns 304 for pre-calculated hash', async () => {
     return app.request
         .get('/api/client/features')
-        .set('if-none-match', 'ae443048:19')
+        .set('if-none-match', '"ae443048:19"')
         .expect(304);
 });
 
@@ -149,6 +149,6 @@ test('returns 200 when content updates and hash does not match anymore', async (
         .set('if-none-match', 'ae443048:19')
         .expect(200);
 
-    expect(res.headers.etag).toBe('ae443048:20');
-    expect(res.body.meta.etag).toBe('ae443048:20');
+    expect(res.headers.etag).toBe('"ae443048:20"');
+    expect(res.body.meta.etag).toBe('"ae443048:20"');
 });


### PR DESCRIPTION
According to the
[RFC](https://www.rfc-editor.org/rfc/rfc7232#section-2.3) Etags should be enclosed in double quotes. This PR makes sure we do actually wrap it in double quotes

