### PR TITLE
fix: notifcations word break

### DIFF
--- a/frontend/src/component/common/Notifications/Notification.tsx
+++ b/frontend/src/component/common/Notifications/Notification.tsx
@@ -71,6 +71,7 @@ const StyledMessageTypography = styled(Typography, {
     fontWeight: readAt ? 'normal' : 'bold',
     textDecoration: 'none',
     color: 'inherit',
+    wordBreak: 'break-all',
 }));
 
 const StyledTimeAgoTypography = styled(Typography)(({ theme }) => ({

--- a/website/docs/reference/deploy/environment-import-export.mdx
+++ b/website/docs/reference/deploy/environment-import-export.mdx
@@ -18,7 +18,7 @@ Then, when you import, you must select **one** environment and **one** project t
 
 When you export features, the export will contain both feature-specific configuration and global configuration.
 
-On the project-level these  items are exported:
+On the project-level these items are exported:
 
 * [the feature itself](../feature-toggles.mdx)
 * [feature tags](../tags.md)
@@ -39,7 +39,7 @@ Importantly, while references to [segments](../segments.mdx)) are exported, the 
 
 You can export features either from a project search or the global feature search. Use the search functionality to narrow the results to the list of features you want to export and use the export button to select environment. All features included in your search results will be included in the export.
 
-<Figure caption='Feature toggle lists can be filtered using the search bar. Once filtered, you can use the "export current selection" button to export the configuration for those features.'  img="/img/export.png"/>
+<Figure caption='Feature toggle lists can be filtered using the search bar. Once filtered, you can use the "export current selection" button to export the configuration for those features.' img="/img/export.png"/>
 
 ## Import
 
@@ -117,7 +117,7 @@ Additionally, depending on the actions your import job would trigger, you may al
 
 If change requests are enabled for the target project and environment, the import will not be fully applied. Any new features will be created, but all feature configuration will be added to a new change request.
 
-If change requests are enabled, any permissions for  **Create activation strategies**, **Delete activation strategies** and **Update variants** are not required.
+If change requests are enabled, any permissions for **Create activation strategies**, **Delete activation strategies** and **Update variants** are not required.
 
 ## Environment import/export vs the [instance import/export API](import-export.md)
 


### PR DESCRIPTION
This PR fixes the issue that long feature names did not break line and created a horizontal scrollbar to notifications.