### PR TITLE
fix: show profile projects correctly

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -391,14 +391,12 @@ class ProjectStore implements IProjectStore {
     }
 
     async getProjectsByUser(userId: number): Promise<string[]> {
-        const members = await this.db
+        const projects = await this.db
             .from((db) => {
                 db.select('project')
                     .from('role_user')
                     .leftJoin('roles', 'role_user.role_id', 'roles.id')
-                    .where('type', 'root')
-                    .andWhere('name', 'Editor')
-                    .andWhere('user_id', userId)
+                    .where('user_id', userId)
                     .union((queryBuilder) => {
                         queryBuilder
                             .select('project')
@@ -413,7 +411,7 @@ class ProjectStore implements IProjectStore {
                     .as('query');
             })
             .pluck('project');
-        return members;
+        return projects;
     }
 
     async getMembersCountByProject(projectId: string): Promise<number> {


### PR DESCRIPTION
Profile projects were not showing correctly in most cases. This fixes the query to only take into consider whether you have access to the project (either directly or through a group).
![image](https://user-images.githubusercontent.com/14320932/228598175-874f0daa-8d33-49a8-b6f8-072942876138.png)
