### PR TITLE
docs: add google tag manager

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -177,6 +177,9 @@ module.exports = {
                 googleAnalytics: {
                     trackingID: 'UA-134882379-1',
                 },
+                googleTagManager: {
+                    containerId: 'GTM-KV5PRR2',
+                },
             },
         ],
     ],


### PR DESCRIPTION
This change adds google tag manager to docusaurus using the [plugin-google-tag-manager](https://www.docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-tag-manager) plugin.

## Why

The current analytics integration we've got in the docs is being sunset this year, so this is the replacement. It should only collect the same kind of data that we already collect. It does not require user consent, and it is used only for aggregation. The point is to help us understand our users' needs and usage patterns so that we can make a better product.