### PR TITLE
fix: proper check for billing seats on user creation

### DIFF
--- a/frontend/src/component/admin/users/CreateUser/SeatCostWarning/SeatCostWarning.tsx
+++ b/frontend/src/component/admin/users/CreateUser/SeatCostWarning/SeatCostWarning.tsx
@@ -7,7 +7,7 @@ export const SeatCostWarning: VFC = () => {
     const { users } = useUsers();
     const { isBillingUsers, seats, planUsers } = useUsersPlan(users);
 
-    if (!isBillingUsers) {
+    if (!isBillingUsers || planUsers.length < seats) {
         return null;
     }
 


### PR DESCRIPTION
https://unleash-community.slack.com/archives/C033ES94QMT/p1680236503981349
Fixes the user creation extra seat billing alert to only show when the total users exceed the number of free seats.