### PR TITLE
docs: point link to unleash/unleash instead of unleash-docker

### DIFF
--- a/website/docs/reference/deploy/getting-started.md
+++ b/website/docs/reference/deploy/getting-started.md
@@ -63,7 +63,7 @@ docker run -p 4242:4242 \
 
 **Steps:**
 
-1. Clone the [Unleash repository](https://github.com/Unleash/unleash-docker).
+1. Clone the [Unleash repository](https://github.com/Unleash/unleash).
 2. Run `docker compose up -d` in repository root folder.
 
 ### Option 3 - from Node.js {#option-three---from-nodejs}


### PR DESCRIPTION
## why

This link used to post to the now-outdated unleash-docker repo. They should instead go directly to the unleash repo now.
