### PR TITLE
fix: concurrency issue when running multiple requests

### DIFF
--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -200,7 +200,7 @@ export class ApiTokenController extends Controller {
         const { token } = req.params;
 
         await this.apiTokenService.delete(token, extractUsername(req));
-        this.proxyService.deleteClientForProxyToken(token);
+        await this.proxyService.deleteClientForProxyToken(token);
         res.status(200).end();
     }
 

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -187,7 +187,7 @@ export class ProjectApiTokenController extends Controller {
                     storedToken.project[0] === projectId))
         ) {
             await this.apiTokenService.delete(token, extractUsername(req));
-            this.proxyService.deleteClientForProxyToken(token);
+            await this.proxyService.deleteClientForProxyToken(token);
             res.status(200).end();
         }
     }

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -42,7 +42,8 @@ export class ProxyService {
 
     private readonly services: Services;
 
-    private readonly clients: Map<ApiUser['secret'], Unleash> = new Map();
+    private readonly clients: Map<ApiUser['secret'], Promise<Unleash>> =
+        new Map();
 
     private cachedFrontendSettings?: FrontendSettings;
 
@@ -99,14 +100,13 @@ export class ProxyService {
     private async clientForProxyToken(token: ApiUser): Promise<Unleash> {
         ProxyService.assertExpectedTokenType(token);
 
-        if (!this.clients.has(token.secret)) {
-            this.clients.set(
-                token.secret,
-                await this.createClientForProxyToken(token),
-            );
+        let client = this.clients.get(token.secret);
+        if (!client) {
+            client = this.createClientForProxyToken(token);
+            this.clients.set(token.secret, client);
         }
 
-        return this.clients.get(token.secret);
+        return client;
     }
 
     private async createClientForProxyToken(token: ApiUser): Promise<Unleash> {
@@ -134,13 +134,17 @@ export class ProxyService {
         return client;
     }
 
-    deleteClientForProxyToken(secret: string): void {
-        this.clients.get(secret)?.destroy();
-        this.clients.delete(secret);
+    async deleteClientForProxyToken(secret: string): Promise<void> {
+        let clientPromise = this.clients.get(secret);
+        if (clientPromise) {
+            const client = await clientPromise;
+            client.destroy();
+            this.clients.delete(secret);
+        }
     }
 
     stopAll(): void {
-        this.clients.forEach((client) => client.destroy());
+        this.clients.forEach((promise) => promise.then((c) => c.destroy()));
     }
 
     private static assertExpectedTokenType({ type }: ApiUser) {

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -42,6 +42,11 @@ export class ProxyService {
 
     private readonly services: Services;
 
+    /**
+     * This is intentionally a Promise becasue we want to be able to await
+     * until the client (which might be being created by a different request) is ready
+     * Check this test that fails if we don't use a Promise: src/test/e2e/api/proxy/proxy.concurrency.e2e.test.ts
+     */
     private readonly clients: Map<ApiUser['secret'], Promise<Unleash>> =
         new Map();
 

--- a/src/test/e2e/api/proxy/proxy.concurrency.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.concurrency.e2e.test.ts
@@ -1,0 +1,64 @@
+import { IUnleashTest, setupAppWithAuth } from '../../helpers/test-helper';
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import { randomId } from '../../../../lib/util';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
+
+let app: IUnleashTest;
+let db: ITestDb;
+let appErrorLogs: string[] = [];
+
+beforeAll(async () => {
+    db = await dbInit(`proxy_concurrency`, getLogger);
+    const baseLogger = getLogger();
+    const appLogger = {
+        ...baseLogger,
+        error: (msg: string, ...args: any[]) => {
+            appErrorLogs.push(msg);
+            baseLogger.error(msg, ...args);
+        },
+    };
+    app = await setupAppWithAuth(db.stores, {
+        frontendApiOrigins: ['https://example.com'],
+        getLogger: () => appLogger,
+    });
+});
+
+afterEach(() => {
+    app.services.proxyService.stopAll();
+    jest.clearAllMocks();
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+beforeEach(async () => {
+    appErrorLogs = [];
+});
+
+/**
+ * This test needs to run on a new instance of the application and a clean DB
+ * which is why it should be the only test of this file
+ */
+test('multiple parallel calls to api/frontend should not create multiple instances', async () => {
+    const frontendTokenDefault =
+        await app.services.apiTokenService.createApiTokenWithProjects({
+            type: ApiTokenType.FRONTEND,
+            projects: ['default'],
+            environment: 'default',
+            username: `test-token-${randomId()}`,
+        });
+
+    await Promise.all(
+        Array.from(Array(15).keys()).map(() =>
+            app.request
+                .get('/api/frontend')
+                .set('Authorization', frontendTokenDefault.secret)
+                .expect('Content-Type', /json/)
+                .expect(200),
+        ),
+    );
+    expect(appErrorLogs).toHaveLength(0);
+});


### PR DESCRIPTION
## About the changes

Running multiple calls to the frontend concurrently creates many instances of unleash SDK client.

The test added in commit 34004b5be5f41d5cad646ce9e18cd1e307119ceb is to verify we can reproduce the issue with a test case, and we can see the error [here](https://github.com/Unleash/unleash/actions/runs/4596689332/jobs/8118467530?pr=3442#step:5:571)

The next commit introduces a fix for the issue

### How to reproduce manually
1. Start Unleash (it has to be a fresh application: to retry the test, first restart Unleash)
2. Run: 
```shell
#!/usr/bin/env bash

i=0
while [ $i -ne 15 ]
do
  curl http://localhost:4242/api/frontend -H 'Authorization: *:development.5487836a72f472d3494d92134fab6b4e07fcffe84c6c81a1d78448d0' &

  echo $i
  (( i=i+1 ));
done
```
You should see some errors, such as: 
```shell
[2023-04-03T10:48:49.818] [ERROR] services/proxy-service.ts - Error: The unleash SDK has been initialized more than 10 times
    at /home/ivar/code/unleash/node_modules/unleash-client/lib/unleash.js:96:29
```
