### PR TITLE
feat: changing password will expire reset password tokens

### DIFF
--- a/src/lib/services/reset-token-service.ts
+++ b/src/lib/services/reset-token-service.ts
@@ -61,6 +61,10 @@ export default class ResetTokenService {
         }
     }
 
+    expireExistingTokensForUser = async (userId: number): Promise<void> => {
+        return this.store.expireExistingTokensForUser(userId);
+    };
+
     async isValid(token: string): Promise<IResetToken> {
         let t;
         try {
@@ -109,7 +113,7 @@ export default class ResetTokenService {
     ): Promise<IResetToken> {
         const token = await this.generateToken();
         const expiry = new Date(Date.now() + expiryDelta);
-        await this.store.expireExistingTokensForUser(tokenUser);
+        await this.expireExistingTokensForUser(tokenUser);
         return this.store.insert({
             reset_token: token,
             user_id: tokenUser,

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -389,7 +389,6 @@ class UserService {
         });
         if (allowed) {
             await this.changePassword(user.id, password);
-            await this.sessionService.deleteSessionsForUser(user.id);
         } else {
             throw new InvalidTokenError();
         }

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -351,6 +351,7 @@ class UserService {
         const passwordHash = await bcrypt.hash(password, saltRounds);
         await this.store.setPasswordHash(userId, passwordHash);
         await this.sessionService.deleteSessionsForUser(userId);
+        await this.resetTokenService.expireExistingTokensForUser(userId);
     }
 
     async getUserForToken(token: string): Promise<TokenUserSchema> {

--- a/src/lib/types/stores/reset-token-store.ts
+++ b/src/lib/types/stores/reset-token-store.ts
@@ -33,5 +33,5 @@ export interface IResetTokenStore extends Store<IResetToken, string> {
     useToken(token: IResetQuery): Promise<boolean>;
     deleteFromQuery(query: IResetTokenQuery): Promise<void>;
     deleteExpired(): Promise<void>;
-    expireExistingTokensForUser(user_id: number): Promise<void>;
+    expireExistingTokensForUser(userId: number): Promise<void>;
 }

--- a/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
+++ b/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
@@ -168,7 +168,7 @@ test('Trying to reset password with same token twice does not work', async () =>
             token,
             password,
         })
-        .expect(403)
+        .expect(401)
         .expect((res) => {
             expect(res.body.details[0].message).toBeTruthy();
         });
@@ -191,7 +191,7 @@ test('Calling validate endpoint with already existing session should destroy ses
     await request.get('/api/admin/features').expect(200);
     const url = await resetTokenService.createResetPasswordUrl(
         user.id,
-        adminUser.username,
+        adminUser.username!,
     );
     const relative = getBackendResetUrl(url);
 
@@ -275,14 +275,12 @@ test('changing password should expire all active tokens', async () => {
     );
     const relative = getBackendResetUrl(url);
 
-    let token;
-    await app.request
+    const {
+        body: { token },
+    } = await app.request
         .get(relative)
         .expect(200)
-        .expect('Content-Type', /json/)
-        .expect((res) => {
-            token = res.body.token;
-        });
+        .expect('Content-Type', /json/);
 
     await app.request
         .post(`/api/admin/user-admin/${user.id}/change-password`)


### PR DESCRIPTION
Usecase:

1. User requests a forgot password link
2. User changes password normally
3. User can still reset password through the link

This is a security risk and now reset password tokens are invalidated.