### PR TITLE
feat: save memory on reading stats

### DIFF
--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -110,16 +110,16 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         return rows.map(this.rowToFeature);
     }
 
-    async getByDate(queryModifiers: {
+    async countByDate(queryModifiers: {
         archived?: boolean;
         project?: string;
         date?: string;
         range?: string[];
         dateAccessor: string;
-    }): Promise<FeatureToggle[]> {
+    }): Promise<number> {
         const { project, archived, dateAccessor } = queryModifiers;
         let query = this.db
-            .select(FEATURE_COLUMNS)
+            .count()
             .from(TABLE)
             .where({ project })
             .modify(FeatureToggleStore.filterByArchived, archived);
@@ -135,8 +135,8 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             ]);
         }
 
-        const rows = await query;
-        return rows.map(this.rowToFeature);
+        const queryResult = await query.first();
+        return parseInt(queryResult.count || 0);
     }
 
     /**

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -704,12 +704,12 @@ export default class ProjectService {
         const dateMinusSixtyDays = subDays(new Date(), 60).toISOString();
 
         const [createdCurrentWindow, createdPastWindow] = await Promise.all([
-            await this.featureToggleStore.getByDate({
+            await this.featureToggleStore.countByDate({
                 project: projectId,
                 dateAccessor: 'created_at',
                 date: dateMinusThirtyDays,
             }),
-            await this.featureToggleStore.getByDate({
+            await this.featureToggleStore.countByDate({
                 project: projectId,
                 dateAccessor: 'created_at',
                 range: [dateMinusSixtyDays, dateMinusThirtyDays],
@@ -717,13 +717,13 @@ export default class ProjectService {
         ]);
 
         const [archivedCurrentWindow, archivedPastWindow] = await Promise.all([
-            await this.featureToggleStore.getByDate({
+            await this.featureToggleStore.countByDate({
                 project: projectId,
                 archived: true,
                 dateAccessor: 'archived_at',
                 date: dateMinusThirtyDays,
             }),
-            await this.featureToggleStore.getByDate({
+            await this.featureToggleStore.countByDate({
                 project: projectId,
                 archived: true,
                 dateAccessor: 'archived_at',
@@ -795,10 +795,10 @@ export default class ProjectService {
             updates: {
                 avgTimeToProdCurrentWindow:
                     currentWindowTimeToProdReadModel.calculateAverageTimeToProd(),
-                createdCurrentWindow: createdCurrentWindow.length,
-                createdPastWindow: createdPastWindow.length,
-                archivedCurrentWindow: archivedCurrentWindow.length,
-                archivedPastWindow: archivedPastWindow.length,
+                createdCurrentWindow: createdCurrentWindow,
+                createdPastWindow: createdPastWindow,
+                archivedCurrentWindow: archivedCurrentWindow,
+                archivedPastWindow: archivedPastWindow,
                 projectActivityCurrentWindow: projectActivityCurrentWindow,
                 projectActivityPastWindow: projectActivityPastWindow,
                 projectMembersAddedCurrentWindow:

--- a/src/lib/types/stores/feature-toggle-store.ts
+++ b/src/lib/types/stores/feature-toggle-store.ts
@@ -25,13 +25,13 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
     revive(featureName: string): Promise<FeatureToggle>;
     getAll(query?: Partial<IFeatureToggleQuery>): Promise<FeatureToggle[]>;
     getAllByNames(names: string[]): Promise<FeatureToggle[]>;
-    getByDate(queryModifiers: {
+    countByDate(queryModifiers: {
         archived?: boolean;
         project?: string;
         date?: string;
         range?: string[];
         dateAccessor: string;
-    }): Promise<FeatureToggle[]>;
+    }): Promise<number>;
     /**
      * @deprecated - Variants should be fetched from FeatureEnvironmentStore (since variants are now; since 4.18, connected to environments)
      * @param featureName

--- a/src/test/fixtures/fake-feature-toggle-store.ts
+++ b/src/test/fixtures/fake-feature-toggle-store.ts
@@ -213,13 +213,13 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
         return Promise.resolve(newVariants);
     }
 
-    async getByDate(queryModifiers: {
+    async countByDate(queryModifiers: {
         archived?: boolean;
         project?: string;
         date?: string;
         range?: string[];
         dateAccessor: string;
-    }): Promise<FeatureToggle[]> {
+    }): Promise<number> {
         return this.features.filter((feature) => {
             if (feature.archived === queryModifiers.archived) {
                 return true;
@@ -245,7 +245,7 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
             ) {
                 return true;
             }
-        });
+        }).length;
     }
 
     dropAllVariants(): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Counting stats at the DB level instead of loading whole features into memory. Result: less memory used.

Potential next steps:
* more savings in other queries (I started with the lowest hanging fruit)
* extract project stats store/read model

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
