### PR TITLE
WIP: working but hacky

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "@types/react-table": "7.7.14",
     "@types/react-test-renderer": "17.0.2",
     "@types/react-timeago": "4.1.3",
+    "@types/react-window": "^1.8.5",
     "@types/semver": "7.3.13",
     "@types/uuid": "^9.0.0",
     "@uiw/codemirror-theme-duotone": "4.19.10",
@@ -65,8 +66,10 @@
     "chartjs-adapter-date-fns": "3.0.0",
     "classnames": "2.3.2",
     "copy-to-clipboard": "3.3.3",
+    "countries-and-timezones": "^3.4.0",
     "cypress": "9.7.0",
     "date-fns": "2.29.3",
+    "date-fns-tz": "^2.0.0",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",
     "dequal": "2.0.3",
@@ -96,6 +99,7 @@
     "react-table": "7.8.0",
     "react-test-renderer": "17.0.2",
     "react-timeago": "7.1.0",
+    "react-window": "^1.8.8",
     "sass": "1.58.3",
     "semver": "7.3.8",
     "swr": "2.0.4",
@@ -106,9 +110,7 @@
     "vite-plugin-svgr": "2.4.0",
     "vite-tsconfig-paths": "4.0.5",
     "vitest": "0.28.5",
-    "whatwg-fetch": "3.6.2",
-    "countries-and-timezones": "^3.4.0",
-    "date-fns-tz": "^2.0.0"
+    "whatwg-fetch": "3.6.2"
   },
   "optionalDependencies": {
     "orval": "^6.10.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1050,6 +1050,13 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-transform-typescript" "^7.18.6"
 
+"@babel/runtime@^7.0.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
@@ -2560,6 +2567,13 @@
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
   integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-window@^1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
+  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
   dependencies:
     "@types/react" "*"
 
@@ -6466,6 +6480,11 @@ mdast-util-to-string@^3.1.0:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz#56c506d065fbf769515235e577b5a261552d56e9"
   integrity sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -7579,6 +7598,14 @@ react-transition-group@^4.4.5:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-window@^1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.8.tgz#1b52919f009ddf91970cbdb2050a6c7be44df243"
+  integrity sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
## About the changes
This PR is an attempt to do virtualized Autocomplete by using react-window as mentioned in MUI documentation: https://mui.com/material-ui/react-autocomplete/#virtualization

To implement this we need to write our own ListboxComponent which is what's used to render the listbox. 

By doing this the list is much more responsive but we lose the group name stickiness.

The implementation should be considered a proof of concept. I kept the older implementation that can be used to compare the behavior.

To create 1k users you can use the following script (just specify your token)
```bash
#!/usr/bin/env bash
ITERATIONS=${1:-1000}  # use first parameter as number of iterations
START=${START:-1}      # env variable to tweak the initial number
ROOT_ROLE=${ROLE:-2}   # default to editor role (1: admin, 2: editor, 3: viewer)
PREFIX=${PREFIX:-test} # prefix for name and email
TOKEN=${TOKEN:-*:*.secret-123}

set -x
for i in $( seq ${START} ${ITERATIONS} ); do
    curl --location --request POST 'http://localhost:4242/api/admin/user-admin' \
            --header "Authorization: ${TOKEN}" \
            --header 'Content-Type: application/json' \
            --data-raw "{ \"name\": \"${PREFIX} ${i}\", \"email\": \"${PREFIX}${i}@getunleash.io\", \"sendEmail\": false, \"rootRole\": ${ROOT_ROLE} }"
done
```