### PR TITLE
docs: Added docs for edge endpoints

### DIFF
--- a/src/lib/openapi/index.test.ts
+++ b/src/lib/openapi/index.test.ts
@@ -41,7 +41,7 @@ describe('createOpenApiSchema', () => {
             createOpenApiSchema({
                 unleashUrl: 'https://example.com',
                 baseUriPath: '',
-            }).servers[0].url,
+            }).servers![0].url,
         ).toEqual('https://example.com');
     });
 
@@ -50,7 +50,7 @@ describe('createOpenApiSchema', () => {
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/demo2',
                 baseUriPath: '/demo2',
-            }).servers[0].url,
+            }).servers![0].url,
         ).toEqual('https://example.com');
     });
 
@@ -59,7 +59,7 @@ describe('createOpenApiSchema', () => {
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/demo2',
                 baseUriPath: 'example',
-            }).servers[0].url,
+            }).servers![0].url,
         ).toEqual('https://example.com/demo2');
     });
 
@@ -68,13 +68,13 @@ describe('createOpenApiSchema', () => {
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/example/',
                 baseUriPath: 'example',
-            }).servers[0].url,
+            }).servers![0].url,
         ).toEqual('https://example.com');
         expect(
             createOpenApiSchema({
                 unleashUrl: 'https://example.com/example/',
                 baseUriPath: '/example',
-            }).servers[0].url,
+            }).servers![0].url,
         ).toEqual('https://example.com');
     });
 });

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -109,6 +109,7 @@ import {
     tagTypeSchema,
     tagTypesSchema,
     tagWithVersionSchema,
+    tokenStringListSchema,
     tokenUserSchema,
     uiConfigSchema,
     updateApiTokenSchema,
@@ -123,7 +124,7 @@ import {
     usersGroupsBaseSchema,
     usersSchema,
     usersSearchSchema,
-    validateEdgeTokensSchema,
+    validatedEdgeTokensSchema,
     validatePasswordSchema,
     validateTagTypeSchema,
     variantSchema,
@@ -133,7 +134,6 @@ import {
     importTogglesSchema,
     importTogglesValidateSchema,
     importTogglesValidateItemSchema,
-    tokenStringListSchema,
 } from './spec';
 import { IServerOption } from '../types';
 import { mapValues, omitKeys } from '../util';
@@ -281,7 +281,7 @@ export const schemas = {
     usersGroupsBaseSchema,
     usersSchema,
     usersSearchSchema,
-    validateEdgeTokensSchema,
+    validatedEdgeTokensSchema,
     validatePasswordSchema,
     validateTagTypeSchema,
     variantSchema,

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -133,6 +133,7 @@ import {
     importTogglesSchema,
     importTogglesValidateSchema,
     importTogglesValidateItemSchema,
+    tokenStringListSchema,
 } from './spec';
 import { IServerOption } from '../types';
 import { mapValues, omitKeys } from '../util';
@@ -265,6 +266,7 @@ export const schemas = {
     tagTypesSchema,
     tagWithVersionSchema,
     tokenUserSchema,
+    tokenStringListSchema,
     uiConfigSchema,
     updateApiTokenSchema,
     updateFeatureSchema,

--- a/src/lib/openapi/spec/bulk-metrics-schema.ts
+++ b/src/lib/openapi/spec/bulk-metrics-schema.ts
@@ -7,6 +7,8 @@ export const bulkMetricsSchema = {
     $id: '#/components/schemas/bulkMetricsSchema',
     type: 'object',
     required: ['applications', 'metrics'],
+    description:
+        'A batch of metrics accumulated by Edge (or other compatible applications). Includes both application registrations as well usage metrics from clients',
     properties: {
         applications: {
             type: 'array',

--- a/src/lib/openapi/spec/bulk-metrics-schema.ts
+++ b/src/lib/openapi/spec/bulk-metrics-schema.ts
@@ -6,6 +6,7 @@ import { clientMetricsEnvSchema } from './client-metrics-env-schema';
 export const bulkMetricsSchema = {
     $id: '#/components/schemas/bulkMetricsSchema',
     type: 'object',
+    required: ['applications', 'metrics'],
     properties: {
         applications: {
             type: 'array',

--- a/src/lib/openapi/spec/bulk-registration-schema.ts
+++ b/src/lib/openapi/spec/bulk-registration-schema.ts
@@ -9,7 +9,7 @@ export const bulkRegistrationSchema = {
         connectVia: {
             type: 'array',
             description:
-                'a list of applications this app registration has been registered through',
+                'A list of applications this app registration has been registered through or empty',
             items: {
                 type: 'object',
                 required: ['appName', 'instanceId'],

--- a/src/lib/openapi/spec/bulk-registration-schema.ts
+++ b/src/lib/openapi/spec/bulk-registration-schema.ts
@@ -8,6 +8,8 @@ export const bulkRegistrationSchema = {
     properties: {
         connectVia: {
             type: 'array',
+            description:
+                'a list of applications this app registration has been registered through',
             items: {
                 type: 'object',
                 required: ['appName', 'instanceId'],
@@ -20,29 +22,48 @@ export const bulkRegistrationSchema = {
                     },
                 },
             },
+            example: ['unleash-edge'],
         },
         appName: {
+            description:
+                'The name of the application that is evaluating toggles',
             type: 'string',
+            example: 'Ingress load balancer',
         },
         environment: {
+            description: 'Which environment is the application running in',
             type: 'string',
+            example: 'development',
         },
         instanceId: {
+            description: 'A unique identifier for the application',
             type: 'string',
+            example: 'Random UUID',
         },
         interval: {
+            description:
+                'How often (in seconds) does the application refresh its features',
             type: 'number',
+            example: 10,
         },
         started: {
+            description: 'When did the application start',
+            example: '1952-03-11T12:00:00.000Z', //GNU Douglas Adams
             $ref: '#/components/schemas/dateSchema',
         },
         strategies: {
+            description:
+                'Which [strategies](https://docs.getunleash.io/reference/activation-strategies) are enabled in the application',
             type: 'array',
+            example: ['standard', 'gradualRollout'],
             items: {
                 type: 'string',
             },
         },
         sdkVersion: {
+            summary: 'Version identifier for the SDK used',
+            description: 'Typically <client>:<version>',
+            example: 'unleash-client-java:8.0.0',
             type: 'string',
         },
     },

--- a/src/lib/openapi/spec/bulk-registration-schema.ts
+++ b/src/lib/openapi/spec/bulk-registration-schema.ts
@@ -10,7 +10,7 @@ export const bulkRegistrationSchema = {
         connectVia: {
             type: 'array',
             description:
-                'A list of applications this app registration has been registered through or empty',
+                'A list of applications this app registration has been registered through. If connected directly to Unleash, this is an empty list. \n This can be used in later visualizations to tell how many levels of proxy or Edge instances our SDKs have connected through',
             items: {
                 type: 'object',
                 required: ['appName', 'instanceId'],
@@ -23,7 +23,9 @@ export const bulkRegistrationSchema = {
                     },
                 },
             },
-            example: ['unleash-edge'],
+            example: [
+                { appName: 'unleash-edge', instanceId: 'edge-pod-bghzv5' },
+            ],
         },
         appName: {
             description:
@@ -63,8 +65,8 @@ export const bulkRegistrationSchema = {
             },
         },
         sdkVersion: {
-            summary: 'Version identifier for the SDK used',
-            description: 'Typically <client>:<version>',
+            description:
+                'The version the sdk is running. Typically <client>:<version>',
             example: 'unleash-client-java:8.0.0',
             type: 'string',
         },

--- a/src/lib/openapi/spec/bulk-registration-schema.ts
+++ b/src/lib/openapi/spec/bulk-registration-schema.ts
@@ -4,7 +4,8 @@ import { dateSchema } from './date-schema';
 export const bulkRegistrationSchema = {
     $id: '#/components/schemas/bulkRegistrationSchema',
     type: 'object',
-    required: ['appName', 'instanceId'],
+    required: ['appName', 'instanceId', 'environment'],
+    description: `An application registration. Defines the format POSTed by our server-side SDKs when they're starting up`,
     properties: {
         connectVia: {
             type: 'array',
@@ -31,29 +32,30 @@ export const bulkRegistrationSchema = {
             example: 'Ingress load balancer',
         },
         environment: {
-            description: 'Which environment is the application running in',
+            description: 'Which environment the application is running in',
             type: 'string',
             example: 'development',
         },
         instanceId: {
-            description: 'A unique identifier for the application',
+            description:
+                'A [(somewhat) unique identifier](https://docs.getunleash.io/reference/sdks/node#advanced-usage) for the application',
             type: 'string',
-            example: 'Random UUID',
+            example: 'application-name-dacb1234',
         },
         interval: {
             description:
-                'How often (in seconds) does the application refresh its features',
+                'How often (in seconds) the application refreshes its features',
             type: 'number',
             example: 10,
         },
         started: {
-            description: 'When did the application start',
+            description: 'The application started at',
             example: '1952-03-11T12:00:00.000Z', //GNU Douglas Adams
             $ref: '#/components/schemas/dateSchema',
         },
         strategies: {
             description:
-                'Which [strategies](https://docs.getunleash.io/reference/activation-strategies) are enabled in the application',
+                'Enabled [strategies](https://docs.getunleash.io/reference/activation-strategies) in the application',
             type: 'array',
             example: ['standard', 'gradualRollout'],
             items: {

--- a/src/lib/openapi/spec/client-metrics-env-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-env-schema.ts
@@ -9,27 +9,45 @@ export const clientMetricsEnvSchema = {
     properties: {
         featureName: {
             type: 'string',
+            description: 'Name of the feature checked by the SDK',
+            example: 'my.special.feature',
         },
         appName: {
+            description: 'The name of the application the SDK is being used in',
             type: 'string',
+            example: 'accounting',
         },
         environment: {
+            description: 'Which environment the SDK is being used in',
             type: 'string',
+            example: 'development',
         },
         timestamp: {
+            description: 'The time window these metrics are valid for',
+            example: '1926-05-08T12:00:00.000Z',
             $ref: '#/components/schemas/dateSchema',
         },
         yes: {
+            description: 'How many times the toggle evaluated to true',
             type: 'number',
+            example: 974,
         },
         no: {
+            description: 'How many times the toggle evaluated to false',
             type: 'number',
+            example: 50,
         },
         variants: {
+            description: 'How many times each variant was returned',
             type: 'object',
             additionalProperties: {
                 type: 'integer',
                 minimum: 0,
+            },
+            example: {
+                variantA: 15,
+                variantB: 25,
+                variantC: 5,
             },
         },
     },

--- a/src/lib/openapi/spec/client-metrics-env-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-env-schema.ts
@@ -4,8 +4,9 @@ import { FromSchema } from 'json-schema-to-ts';
 export const clientMetricsEnvSchema = {
     $id: '#/components/schemas/clientMetricsEnvSchema',
     type: 'object',
-    required: ['featureName', 'appName'],
+    required: ['featureName', 'appName', 'environment'],
     additionalProperties: true,
+    description: 'Used for reporting feature evaluation results from SDKs',
     properties: {
         featureName: {
             type: 'string',
@@ -23,7 +24,8 @@ export const clientMetricsEnvSchema = {
             example: 'development',
         },
         timestamp: {
-            description: 'The time window these metrics are valid for',
+            description:
+                'The start of the time window these metrics are valid for. The window is 1 hour wide',
             example: '1926-05-08T12:00:00.000Z',
             $ref: '#/components/schemas/dateSchema',
         },

--- a/src/lib/openapi/spec/edge-token-schema.ts
+++ b/src/lib/openapi/spec/edge-token-schema.ts
@@ -26,7 +26,7 @@ export const edgeTokenSchema = {
         },
         token: {
             description:
-                '[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters',
+                'The actual token value. [Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters',
             type: 'string',
             example:
                 '*:development.5c806b5320c88cf27e81f3e9b97dab298a77d5879316e3c2d806206b',

--- a/src/lib/openapi/spec/edge-token-schema.ts
+++ b/src/lib/openapi/spec/edge-token-schema.ts
@@ -10,7 +10,6 @@ export const edgeTokenSchema = {
         'A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) (used by proxy SDKs)',
     properties: {
         projects: {
-            summary: 'A list of projects this token can access',
             description:
                 'Since a token can have access to multiple projects, but that is represented with a `[]` in the token, this can be used to expand the []',
             type: 'array',
@@ -20,14 +19,12 @@ export const edgeTokenSchema = {
             example: ['developerexperience', 'enterprisegrowth'],
         },
         type: {
-            summary: 'Type of token',
             description: `Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with`,
             type: 'string',
             enum: Object.values(ApiTokenType),
             example: 'client',
         },
         token: {
-            summary: 'The actual token',
             description:
                 '[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters',
             type: 'string',

--- a/src/lib/openapi/spec/edge-token-schema.ts
+++ b/src/lib/openapi/spec/edge-token-schema.ts
@@ -6,19 +6,33 @@ export const edgeTokenSchema = {
     type: 'object',
     additionalProperties: false,
     required: ['token', 'projects', 'type'],
+    description:
+        'A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) (used by proxy SDKs)',
     properties: {
         projects: {
+            summary: 'A list of projects this token can access',
+            description:
+                'Since a token can have access to multiple projects, but that is represented with a `[]` in the token, this can be used to expand the []',
             type: 'array',
             items: {
                 type: 'string',
             },
+            example: ['developerexperience', 'enterprisegrowth'],
         },
         type: {
+            summary: 'Type of token',
+            description: `Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with`,
             type: 'string',
             enum: Object.values(ApiTokenType),
+            example: 'client',
         },
         token: {
+            summary: 'The actual token',
+            description:
+                '[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters',
             type: 'string',
+            example:
+                '*:development.5c806b5320c88cf27e81f3e9b97dab298a77d5879316e3c2d806206b',
         },
     },
     components: {},

--- a/src/lib/openapi/spec/edge-token-schema.ts
+++ b/src/lib/openapi/spec/edge-token-schema.ts
@@ -11,7 +11,7 @@ export const edgeTokenSchema = {
     properties: {
         projects: {
             description:
-                'Since a token can have access to multiple projects, but that is represented with a `[]` in the token, this can be used to expand the []',
+                'The list of projects this token has access to. If the token has access to specific projects they will be listed here. If the token has access to all projects it will be represented as [`*`]',
             type: 'array',
             items: {
                 type: 'string',
@@ -19,7 +19,7 @@ export const edgeTokenSchema = {
             example: ['developerexperience', 'enterprisegrowth'],
         },
         type: {
-            description: `Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with`,
+            description: `The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#api-tokens)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with`,
             type: 'string',
             enum: Object.values(ApiTokenType),
             example: 'client',

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -132,3 +132,4 @@ export * from './import-toggles-schema';
 export * from './tags-bulk-add-schema';
 export * from './upsert-segment-schema';
 export * from './batch-features-schema';
+export * from './token-string-list-schema';

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -108,7 +108,7 @@ export * from './environments-project-schema';
 export * from './instance-admin-stats-schema';
 export * from './public-signup-tokens-schema';
 export * from './upsert-context-field-schema';
-export * from './validate-edge-tokens-schema';
+export * from './validated-edge-tokens-schema';
 export * from './client-features-query-schema';
 export * from './admin-features-query-schema';
 export * from './playground-constraint-schema';

--- a/src/lib/openapi/spec/token-string-list-schema.ts
+++ b/src/lib/openapi/spec/token-string-list-schema.ts
@@ -1,0 +1,23 @@
+import { edgeTokenSchema } from './edge-token-schema';
+import { FromSchema } from 'json-schema-to-ts';
+
+export const tokenStringListSchema = {
+    $id: '#/components/schemas/tokenStringListSchema',
+    type: 'object',
+    additionalProperties: false,
+    required: ['tokens'],
+    properties: {
+        tokens: {
+            description: 'Tokens used to authenticate against Unleash',
+            type: 'array',
+            items: { type: 'string' },
+        },
+    },
+    components: {
+        schemas: {
+            edgeTokenSchema,
+        },
+    },
+} as const;
+
+export type TokenStringListSchema = FromSchema<typeof tokenStringListSchema>;

--- a/src/lib/openapi/spec/token-string-list-schema.ts
+++ b/src/lib/openapi/spec/token-string-list-schema.ts
@@ -1,23 +1,24 @@
-import { edgeTokenSchema } from './edge-token-schema';
 import { FromSchema } from 'json-schema-to-ts';
 
 export const tokenStringListSchema = {
     $id: '#/components/schemas/tokenStringListSchema',
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
+    description: 'A list of unleash tokens to validate against known tokens',
     required: ['tokens'],
     properties: {
         tokens: {
-            description: 'Tokens used to authenticate against Unleash',
+            summary: 'List of tokens',
+            description: 'Tokens that we want to get access information about',
             type: 'array',
             items: { type: 'string' },
+            example: [
+                'aproject:development.randomstring',
+                '[]:production.randomstring',
+            ],
         },
     },
-    components: {
-        schemas: {
-            edgeTokenSchema,
-        },
-    },
+    components: {},
 } as const;
 
 export type TokenStringListSchema = FromSchema<typeof tokenStringListSchema>;

--- a/src/lib/openapi/spec/token-string-list-schema.ts
+++ b/src/lib/openapi/spec/token-string-list-schema.ts
@@ -8,7 +8,6 @@ export const tokenStringListSchema = {
     required: ['tokens'],
     properties: {
         tokens: {
-            summary: 'List of tokens',
             description: 'Tokens that we want to get access information about',
             type: 'array',
             items: { type: 'string' },

--- a/src/lib/openapi/spec/validate-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validate-edge-tokens-schema.ts
@@ -6,8 +6,12 @@ export const validateEdgeTokensSchema = {
     type: 'object',
     additionalProperties: false,
     required: ['tokens'],
+    description: `A list of Unleash client tokens with what projects they can access included`,
     properties: {
         tokens: {
+            summary: 'A list of Unleash client tokens',
+            description:
+                'Includes which projects the client tokens can access as well as the token itself',
             type: 'array',
             items: { $ref: '#/components/schemas/edgeTokenSchema' },
         },

--- a/src/lib/openapi/spec/validate-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validate-edge-tokens-schema.ts
@@ -9,12 +9,7 @@ export const validateEdgeTokensSchema = {
     properties: {
         tokens: {
             type: 'array',
-            items: {
-                anyOf: [
-                    { $ref: '#/components/schemas/edgeTokenSchema' },
-                    { type: 'string' },
-                ],
-            },
+            items: { $ref: '#/components/schemas/edgeTokenSchema' },
         },
     },
     components: {

--- a/src/lib/openapi/spec/validated-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validated-edge-tokens-schema.ts
@@ -1,8 +1,8 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { edgeTokenSchema } from './edge-token-schema';
 
-export const validateEdgeTokensSchema = {
-    $id: '#/components/schemas/validateEdgeTokensSchema',
+export const validatedEdgeTokensSchema = {
+    $id: '#/components/schemas/validatedEdgeTokensSchema',
     type: 'object',
     additionalProperties: false,
     required: ['tokens'],
@@ -23,6 +23,6 @@ export const validateEdgeTokensSchema = {
     },
 } as const;
 
-export type ValidateEdgeTokensSchema = FromSchema<
-    typeof validateEdgeTokensSchema
+export type ValidatedEdgeTokensSchema = FromSchema<
+    typeof validatedEdgeTokensSchema
 >;

--- a/src/lib/openapi/spec/validated-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validated-edge-tokens-schema.ts
@@ -9,7 +9,6 @@ export const validatedEdgeTokensSchema = {
     description: `A list of Unleash client tokens with what projects they can access included`,
     properties: {
         tokens: {
-            summary: 'A list of Unleash client tokens',
             description:
                 'Includes which projects the client tokens can access as well as the token itself',
             type: 'array',

--- a/src/lib/openapi/spec/validated-edge-tokens-schema.ts
+++ b/src/lib/openapi/spec/validated-edge-tokens-schema.ts
@@ -6,11 +6,11 @@ export const validatedEdgeTokensSchema = {
     type: 'object',
     additionalProperties: false,
     required: ['tokens'],
-    description: `A list of Unleash client tokens with what projects they can access included`,
+    description: `A object containing a list of valid Unleash tokens.`,
     properties: {
         tokens: {
             description:
-                'Includes which projects the client tokens can access as well as the token itself',
+                'The list of Unleash token objects. Each object contains the token itself and some additional metadata.',
             type: 'array',
             items: { $ref: '#/components/schemas/edgeTokenSchema' },
         },

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -25,9 +25,9 @@ const conflictResponse = {
         'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively.',
 } as const;
 
-const tooBigResponse = {
+const contentTooLargeResponse = {
     description:
-        'The body POSTed was too large. By default we only accept bodies of 100kB or less',
+        'The body request body is larger than what we accept. By default we only accept bodies of 100kB or less',
 } as const;
 
 const unsupportedMediaTypeResponse = {

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -25,12 +25,24 @@ const conflictResponse = {
         'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively.',
 } as const;
 
+const tooBigResponse = {
+    description:
+        'The body POSTed was too large. By default we only accept bodies of 100kB or less',
+} as const;
+
+const wrongContentTypeResponse = {
+    description:
+        'The provided resource does not accept requests with this content-type',
+} as const;
+
 const standardResponses = {
     400: badRequestResponse,
     401: unauthorizedResponse,
     403: forbiddenResponse,
     404: notFoundResponse,
     409: conflictResponse,
+    413: tooBigResponse,
+    415: wrongContentTypeResponse,
 } as const;
 
 type StandardResponses = typeof standardResponses;

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -40,8 +40,8 @@ const standardResponses = {
     403: forbiddenResponse,
     404: notFoundResponse,
     409: conflictResponse,
-    413: tooBigResponse,
-    415: wrongContentTypeResponse,
+    413: contentTooLargeResponse,
+    415: unsupportedMediaTypeResponse,
 } as const;
 
 type StandardResponses = typeof standardResponses;

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -30,9 +30,8 @@ const tooBigResponse = {
         'The body POSTed was too large. By default we only accept bodies of 100kB or less',
 } as const;
 
-const wrongContentTypeResponse = {
-    description:
-        'The provided resource does not accept requests with this content-type',
+const unsupportedMediaTypeResponse = {
+    description: `The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.`,
 } as const;
 
 const standardResponses = {

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -64,9 +64,9 @@ export default class EdgeController extends Controller {
                 this.openApiService.validPath({
                     tags: ['Edge'],
                     summary:
-                        'Filter a list of tokens returning only the valid ones',
+                        'Check which tokens are valid',
                     description:
-                        'Accepts a list of tokens, and returns those that are valid with the projects they can access',
+                        'This operation accepts a list of tokens to validate. Unleash will validate each token you provide. For each valid token you provide, Unleash will return the token along with its type and which projects it has access to.',
                     operationId: 'getValidTokens',
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -17,6 +17,7 @@ import { emptyResponse } from '../../openapi/util/standard-responses';
 import { BulkMetricsSchema } from '../../openapi/spec/bulk-metrics-schema';
 import ClientMetricsServiceV2 from '../../services/client-metrics/metrics-service-v2';
 import { clientMetricsEnvBulkSchema } from '../../services/client-metrics/schema';
+import { TokenStringListSchema } from '../../openapi';
 
 export default class EdgeController extends Controller {
     private readonly logger: Logger;
@@ -59,10 +60,12 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
+                    summary:
+                        'Accepts a list of tokens, returns tokens that are valid and which projects they can access',
+                    description:
+                        'Send a list of tokens, only returns the valid ones',
                     operationId: 'getValidTokens',
-                    requestBody: createRequestSchema(
-                        'validateEdgeTokensSchema',
-                    ),
+                    requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {
                         200: createResponseSchema('validateEdgeTokensSchema'),
                     },
@@ -78,6 +81,8 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
+                    summary:
+                        'Accepts batched metrics from Edge, for insertion into our metrics storage',
                     operationId: 'bulkMetrics',
                     requestBody: createRequestSchema('bulkMetricsSchema'),
                     responses: {
@@ -89,12 +94,10 @@ export default class EdgeController extends Controller {
     }
 
     async getValidTokens(
-        req: RequestBody<ValidateEdgeTokensSchema>,
+        req: RequestBody<TokenStringListSchema>,
         res: Response<ValidateEdgeTokensSchema>,
     ): Promise<void> {
-        const tokens = await this.edgeService.getValidTokens(
-            req.body.tokens as string[],
-        );
+        const tokens = await this.edgeService.getValidTokens(req.body.tokens);
         this.openApiService.respondWithValidation<ValidateEdgeTokensSchema>(
             200,
             res,

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -7,9 +7,9 @@ import { createResponseSchema } from '../../openapi/util/create-response-schema'
 import { IAuthRequest, RequestBody } from '../unleash-types';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import {
-    validateEdgeTokensSchema,
-    ValidateEdgeTokensSchema,
-} from '../../openapi/spec/validate-edge-tokens-schema';
+    validatedEdgeTokensSchema,
+    ValidatedEdgeTokensSchema,
+} from '../../openapi/spec/validated-edge-tokens-schema';
 import ClientInstanceService from '../../services/client-metrics/instance-service';
 import EdgeService from '../../services/edge-service';
 import { OpenApiService } from '../../services/openapi-service';
@@ -70,7 +70,7 @@ export default class EdgeController extends Controller {
                     operationId: 'getValidTokens',
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {
-                        200: createResponseSchema('validateEdgeTokensSchema'),
+                        200: createResponseSchema('validatedEdgeTokensSchema'),
                         ...getStandardResponses(400, 413, 415),
                     },
                 }),
@@ -100,13 +100,13 @@ export default class EdgeController extends Controller {
 
     async getValidTokens(
         req: RequestBody<TokenStringListSchema>,
-        res: Response<ValidateEdgeTokensSchema>,
+        res: Response<ValidatedEdgeTokensSchema>,
     ): Promise<void> {
         const tokens = await this.edgeService.getValidTokens(req.body.tokens);
-        this.openApiService.respondWithValidation<ValidateEdgeTokensSchema>(
+        this.openApiService.respondWithValidation<ValidatedEdgeTokensSchema>(
             200,
             res,
-            validateEdgeTokensSchema.$id,
+            validatedEdgeTokensSchema.$id,
             tokens,
         );
     }

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -85,7 +85,7 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
-                    summary: 'Receive metrics from Edge',
+                    summary: 'Send metrics from Edge',
                     description: `This operation accepts batched metrics from Edge. Metrics will be inserted into Unleash's metrics storage`,
                     operationId: 'bulkMetrics',
                     requestBody: createRequestSchema('bulkMetricsSchema'),

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -63,8 +63,7 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
-                    summary:
-                        'Check which tokens are valid',
+                    summary: 'Check which tokens are valid',
                     description:
                         'This operation accepts a list of tokens to validate. Unleash will validate each token you provide. For each valid token you provide, Unleash will return the token along with its type and which projects it has access to.',
                     operationId: 'getValidTokens',

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -63,10 +63,9 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
-                    summary:
-                        'Accepts a list of tokens, returns tokens that are valid and which projects they can access',
+                    summary: 'Filter a list of tokens returning only the valid ones',
                     description:
-                        'Send a list of tokens, only returns the valid ones',
+                        'Accepts a list of tokens, and returns those that are valid with the projects they can access',
                     operationId: 'getValidTokens',
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -63,14 +63,15 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
-                    summary: 'Filter a list of tokens returning only the valid ones',
+                    summary:
+                        'Filter a list of tokens returning only the valid ones',
                     description:
                         'Accepts a list of tokens, and returns those that are valid with the projects they can access',
                     operationId: 'getValidTokens',
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {
                         200: createResponseSchema('validateEdgeTokensSchema'),
-                        ...getStandardResponses(400),
+                        ...getStandardResponses(400, 413, 415),
                     },
                 }),
             ],
@@ -84,13 +85,13 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
-                    summary:
-                        'Accepts batched metrics from Edge, for insertion into our metrics storage',
+                    summary: 'Receive metrics from Edge',
+                    description: `This operation accepts batched metrics from Edge. Metrics will be inserted into Unleash's metrics storage`,
                     operationId: 'bulkMetrics',
                     requestBody: createRequestSchema('bulkMetricsSchema'),
                     responses: {
                         202: emptyResponse,
-                        ...getStandardResponses(400),
+                        ...getStandardResponses(400, 413, 415),
                     },
                 }),
             ],

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -13,7 +13,10 @@ import {
 import ClientInstanceService from '../../services/client-metrics/instance-service';
 import EdgeService from '../../services/edge-service';
 import { OpenApiService } from '../../services/openapi-service';
-import { emptyResponse } from '../../openapi/util/standard-responses';
+import {
+    emptyResponse,
+    getStandardResponses,
+} from '../../openapi/util/standard-responses';
 import { BulkMetricsSchema } from '../../openapi/spec/bulk-metrics-schema';
 import ClientMetricsServiceV2 from '../../services/client-metrics/metrics-service-v2';
 import { clientMetricsEnvBulkSchema } from '../../services/client-metrics/schema';
@@ -68,6 +71,7 @@ export default class EdgeController extends Controller {
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {
                         200: createResponseSchema('validateEdgeTokensSchema'),
+                        ...getStandardResponses(400),
                     },
                 }),
             ],
@@ -87,6 +91,7 @@ export default class EdgeController extends Controller {
                     requestBody: createRequestSchema('bulkMetricsSchema'),
                     responses: {
                         202: emptyResponse,
+                        ...getStandardResponses(400),
                     },
                 }),
             ],

--- a/src/lib/services/edge-service.ts
+++ b/src/lib/services/edge-service.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { IApiTokenStore } from '../types/stores/api-token-store';
 import { EdgeTokenSchema } from '../openapi/spec/edge-token-schema';
 import { constantTimeCompare } from '../util/constantTimeCompare';
-import { ValidateEdgeTokensSchema } from '../openapi/spec/validate-edge-tokens-schema';
+import { ValidateEdgeTokensSchema } from '../openapi/spec/validated-edge-tokens-schema';
 
 export default class EdgeService {
     private logger: Logger;

--- a/src/lib/services/edge-service.ts
+++ b/src/lib/services/edge-service.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { IApiTokenStore } from '../types/stores/api-token-store';
 import { EdgeTokenSchema } from '../openapi/spec/edge-token-schema';
 import { constantTimeCompare } from '../util/constantTimeCompare';
-import { ValidateEdgeTokensSchema } from '../openapi/spec/validated-edge-tokens-schema';
+import { ValidatedEdgeTokensSchema } from '../openapi/spec/validated-edge-tokens-schema';
 
 export default class EdgeService {
     private logger: Logger;
@@ -18,7 +18,7 @@ export default class EdgeService {
         this.apiTokenStore = apiTokenStore;
     }
 
-    async getValidTokens(tokens: string[]): Promise<ValidateEdgeTokensSchema> {
+    async getValidTokens(tokens: string[]): Promise<ValidatedEdgeTokensSchema> {
         const activeTokens = await this.apiTokenStore.getAllActive();
         const edgeTokens = tokens.reduce((result: EdgeTokenSchema[], token) => {
             const dbToken = activeTokens.find((activeToken) =>

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1023,7 +1023,7 @@ exports[`should serve the OpenAPI spec 1`] = `
         "description": "A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) (used by proxy SDKs)",
         "properties": {
           "projects": {
-            "description": "Since a token can have access to multiple projects, but that is represented with a \`[]\` in the token, this can be used to expand the []",
+            "description": "The list of projects this token has access to. If the token has access to specific projects they will be listed here. If the token has access to all projects it will be represented as [\`*\`]",
             "example": [
               "developerexperience",
               "enterprisegrowth",
@@ -1034,12 +1034,12 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "array",
           },
           "token": {
-            "description": "[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters",
+            "description": "The actual token value. [Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters",
             "example": "*:development.5c806b5320c88cf27e81f3e9b97dab298a77d5879316e3c2d806206b",
             "type": "string",
           },
           "type": {
-            "description": "Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with",
+            "description": "The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#api-tokens)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with",
             "enum": [
               "client",
               "admin",
@@ -9244,13 +9244,13 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "The request data does not match what we expect.",
           },
           "413": {
-            "description": "The body POSTed was too large. By default we only accept bodies of 100kB or less",
+            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
-            "description": "The provided resource does not accept requests with this content-type",
+            "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
-        "summary": "Receive metrics from Edge",
+        "summary": "Send metrics from Edge",
         "tags": [
           "Edge",
         ],
@@ -9258,7 +9258,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/edge/validate": {
       "post": {
-        "description": "Accepts a list of tokens, and returns those that are valid with the projects they can access",
+        "description": "This operation accepts a list of tokens to validate. Unleash will validate each token you provide. For each valid token you provide, Unleash will return the token along with its type and which projects it has access to.",
         "operationId": "getValidTokens",
         "requestBody": {
           "content": {
@@ -9286,13 +9286,13 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "The request data does not match what we expect.",
           },
           "413": {
-            "description": "The body POSTed was too large. By default we only accept bodies of 100kB or less",
+            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
-            "description": "The provided resource does not accept requests with this content-type",
+            "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
-        "summary": "Filter a list of tokens returning only the valid ones",
+        "summary": "Check which tokens are valid",
         "tags": [
           "Edge",
         ],

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -4338,10 +4338,10 @@ Stats are divided into current and previous **windows**.
       },
       "validatedEdgeTokensSchema": {
         "additionalProperties": false,
-        "description": "A list of Unleash client tokens with what projects they can access included",
+        "description": "A object containing a list of valid Unleash tokens.",
         "properties": {
           "tokens": {
-            "description": "Includes which projects the client tokens can access as well as the token itself",
+            "description": "The list of Unleash token objects. Each object contains the token itself and some additional metadata.",
             "items": {
               "$ref": "#/components/schemas/edgeTokenSchema",
             },

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -361,6 +361,7 @@ exports[`should serve the OpenAPI spec 1`] = `
         "type": "object",
       },
       "bulkMetricsSchema": {
+        "description": "A batch of metrics accumulated by Edge (or other compatible applications). Includes both application registrations as well usage metrics from clients",
         "properties": {
           "applications": {
             "items": {
@@ -375,14 +376,25 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "array",
           },
         },
+        "required": [
+          "applications",
+          "metrics",
+        ],
         "type": "object",
       },
       "bulkRegistrationSchema": {
+        "description": "An application registration. Defines the format POSTed by our server-side SDKs when they're starting up",
         "properties": {
           "appName": {
+            "description": "The name of the application that is evaluating toggles",
+            "example": "Ingress load balancer",
             "type": "string",
           },
           "connectVia": {
+            "description": "A list of applications this app registration has been registered through or empty",
+            "example": [
+              "unleash-edge",
+            ],
             "items": {
               "properties": {
                 "appName": {
@@ -401,21 +413,37 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "array",
           },
           "environment": {
+            "description": "Which environment the application is running in",
+            "example": "development",
             "type": "string",
           },
           "instanceId": {
+            "description": "A [(somewhat) unique identifier](https://docs.getunleash.io/reference/sdks/node#advanced-usage) for the application",
+            "example": "application-name-dacb1234",
             "type": "string",
           },
           "interval": {
+            "description": "How often (in seconds) the application refreshes its features",
+            "example": 10,
             "type": "number",
           },
           "sdkVersion": {
+            "description": "Typically <client>:<version>",
+            "example": "unleash-client-java:8.0.0",
+            "summary": "Version identifier for the SDK used",
             "type": "string",
           },
           "started": {
             "$ref": "#/components/schemas/dateSchema",
+            "description": "The application started at",
+            "example": "1952-03-11T12:00:00.000Z",
           },
           "strategies": {
+            "description": "Enabled [strategies](https://docs.getunleash.io/reference/activation-strategies) in the application",
+            "example": [
+              "standard",
+              "gradualRollout",
+            ],
             "items": {
               "type": "string",
             },
@@ -425,6 +453,7 @@ exports[`should serve the OpenAPI spec 1`] = `
         "required": [
           "appName",
           "instanceId",
+          "environment",
         ],
         "type": "object",
       },
@@ -604,36 +633,56 @@ exports[`should serve the OpenAPI spec 1`] = `
       },
       "clientMetricsEnvSchema": {
         "additionalProperties": true,
+        "description": "Used for reporting feature evaluation results from SDKs",
         "properties": {
           "appName": {
+            "description": "The name of the application the SDK is being used in",
+            "example": "accounting",
             "type": "string",
           },
           "environment": {
+            "description": "Which environment the SDK is being used in",
+            "example": "development",
             "type": "string",
           },
           "featureName": {
+            "description": "Name of the feature checked by the SDK",
+            "example": "my.special.feature",
             "type": "string",
           },
           "no": {
+            "description": "How many times the toggle evaluated to false",
+            "example": 50,
             "type": "number",
           },
           "timestamp": {
             "$ref": "#/components/schemas/dateSchema",
+            "description": "The start of the time window these metrics are valid for. The window is 1 hour wide",
+            "example": "1926-05-08T12:00:00.000Z",
           },
           "variants": {
             "additionalProperties": {
               "minimum": 0,
               "type": "integer",
             },
+            "description": "How many times each variant was returned",
+            "example": {
+              "variantA": 15,
+              "variantB": 25,
+              "variantC": 5,
+            },
             "type": "object",
           },
           "yes": {
+            "description": "How many times the toggle evaluated to true",
+            "example": 974,
             "type": "number",
           },
         },
         "required": [
           "featureName",
           "appName",
+          "environment",
         ],
         "type": "object",
       },
@@ -968,22 +1017,35 @@ exports[`should serve the OpenAPI spec 1`] = `
       },
       "edgeTokenSchema": {
         "additionalProperties": false,
+        "description": "A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) (used by proxy SDKs)",
         "properties": {
           "projects": {
+            "description": "Since a token can have access to multiple projects, but that is represented with a \`[]\` in the token, this can be used to expand the []",
+            "example": [
+              "developerexperience",
+              "enterprisegrowth",
+            ],
             "items": {
               "type": "string",
             },
+            "summary": "A list of projects this token can access",
             "type": "array",
           },
           "token": {
+            "description": "[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters",
+            "example": "*:development.5c806b5320c88cf27e81f3e9b97dab298a77d5879316e3c2d806206b",
+            "summary": "The actual token",
             "type": "string",
           },
           "type": {
+            "description": "Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with",
             "enum": [
               "client",
               "admin",
               "frontend",
             ],
+            "example": "client",
+            "summary": "Type of token",
             "type": "string",
           },
         },
@@ -3812,6 +3874,28 @@ Stats are divided into current and previous **windows**.
         ],
         "type": "object",
       },
+      "tokenStringListSchema": {
+        "additionalProperties": true,
+        "description": "A list of unleash tokens to validate against known tokens",
+        "properties": {
+          "tokens": {
+            "description": "Tokens that we want to get access information about",
+            "example": [
+              "aproject:development.randomstring",
+              "[]:production.randomstring",
+            ],
+            "items": {
+              "type": "string",
+            },
+            "summary": "List of tokens",
+            "type": "array",
+          },
+        },
+        "required": [
+          "tokens",
+        ],
+        "type": "object",
+      },
       "tokenUserSchema": {
         "additionalProperties": false,
         "properties": {
@@ -4226,28 +4310,6 @@ Stats are divided into current and previous **windows**.
         },
         "type": "array",
       },
-      "validateEdgeTokensSchema": {
-        "additionalProperties": false,
-        "properties": {
-          "tokens": {
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/edgeTokenSchema",
-                },
-                {
-                  "type": "string",
-                },
-              ],
-            },
-            "type": "array",
-          },
-        },
-        "required": [
-          "tokens",
-        ],
-        "type": "object",
-      },
       "validatePasswordSchema": {
         "additionalProperties": false,
         "properties": {
@@ -4272,6 +4334,23 @@ Stats are divided into current and previous **windows**.
         "required": [
           "valid",
           "tagType",
+        ],
+        "type": "object",
+      },
+      "validatedEdgeTokensSchema": {
+        "additionalProperties": false,
+        "description": "A list of Unleash client tokens with what projects they can access included",
+        "properties": {
+          "tokens": {
+            "description": "Includes which projects the client tokens can access as well as the token itself",
+            "items": {
+              "$ref": "#/components/schemas/edgeTokenSchema",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "tokens",
         ],
         "type": "object",
       },
@@ -9145,6 +9224,7 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/edge/metrics": {
       "post": {
+        "description": "This operation accepts batched metrics from Edge. Metrics will be inserted into Unleash's metrics storage",
         "operationId": "bulkMetrics",
         "requestBody": {
           "content": {
@@ -9161,7 +9241,17 @@ If the provided project does not exist, the list of events will be empty.",
           "202": {
             "description": "This response has no body.",
           },
+          "400": {
+            "description": "The request data does not match what we expect.",
+          },
+          "413": {
+            "description": "The body POSTed was too large. By default we only accept bodies of 100kB or less",
+          },
+          "415": {
+            "description": "The provided resource does not accept requests with this content-type",
+          },
         },
+        "summary": "Receive metrics from Edge",
         "tags": [
           "Edge",
         ],
@@ -9169,16 +9259,17 @@ If the provided project does not exist, the list of events will be empty.",
     },
     "/edge/validate": {
       "post": {
+        "description": "Accepts a list of tokens, and returns those that are valid with the projects they can access",
         "operationId": "getValidTokens",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/validateEdgeTokensSchema",
+                "$ref": "#/components/schemas/tokenStringListSchema",
               },
             },
           },
-          "description": "validateEdgeTokensSchema",
+          "description": "tokenStringListSchema",
           "required": true,
         },
         "responses": {
@@ -9186,13 +9277,23 @@ If the provided project does not exist, the list of events will be empty.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/validateEdgeTokensSchema",
+                  "$ref": "#/components/schemas/validatedEdgeTokensSchema",
                 },
               },
             },
-            "description": "validateEdgeTokensSchema",
+            "description": "validatedEdgeTokensSchema",
+          },
+          "400": {
+            "description": "The request data does not match what we expect.",
+          },
+          "413": {
+            "description": "The body POSTed was too large. By default we only accept bodies of 100kB or less",
+          },
+          "415": {
+            "description": "The provided resource does not accept requests with this content-type",
           },
         },
+        "summary": "Filter a list of tokens returning only the valid ones",
         "tags": [
           "Edge",
         ],

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -391,9 +391,13 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "string",
           },
           "connectVia": {
-            "description": "A list of applications this app registration has been registered through or empty",
+            "description": "A list of applications this app registration has been registered through. If connected directly to Unleash, this is an empty list. 
+ This can be used in later visualizations to tell how many levels of proxy or Edge instances our SDKs have connected through",
             "example": [
-              "unleash-edge",
+              {
+                "appName": "unleash-edge",
+                "instanceId": "edge-pod-bghzv5",
+              },
             ],
             "items": {
               "properties": {
@@ -428,9 +432,8 @@ exports[`should serve the OpenAPI spec 1`] = `
             "type": "number",
           },
           "sdkVersion": {
-            "description": "Typically <client>:<version>",
+            "description": "The version the sdk is running. Typically <client>:<version>",
             "example": "unleash-client-java:8.0.0",
-            "summary": "Version identifier for the SDK used",
             "type": "string",
           },
           "started": {
@@ -1028,13 +1031,11 @@ exports[`should serve the OpenAPI spec 1`] = `
             "items": {
               "type": "string",
             },
-            "summary": "A list of projects this token can access",
             "type": "array",
           },
           "token": {
             "description": "[Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters",
             "example": "*:development.5c806b5320c88cf27e81f3e9b97dab298a77d5879316e3c2d806206b",
-            "summary": "The actual token",
             "type": "string",
           },
           "type": {
@@ -1045,7 +1046,6 @@ exports[`should serve the OpenAPI spec 1`] = `
               "frontend",
             ],
             "example": "client",
-            "summary": "Type of token",
             "type": "string",
           },
         },
@@ -3887,7 +3887,6 @@ Stats are divided into current and previous **windows**.
             "items": {
               "type": "string",
             },
-            "summary": "List of tokens",
             "type": "array",
           },
         },


### PR DESCRIPTION
Adding documentation for the edge endpoints. Also separating request and response schema for our validate endpoint to make clear that we expect a list of strings as input, but yield tokens as output.