### PR TITLE
chore: test requirements for openapi

### DIFF
--- a/src/lib/openapi/index.test.ts
+++ b/src/lib/openapi/index.test.ts
@@ -17,15 +17,6 @@ test('all schema files should be added to the schemas object', () => {
     expect(expectedSchemaNames.sort()).toEqual(addedSchemaNames.sort());
 });
 
-test('all schema $id attributes should have the expected format', () => {
-    const schemaIds = Object.values(schemas).map((schema) => schema.$id);
-    const schemaIdRegExp = new RegExp(`^#/components/schemas/[a-z][a-zA-Z]+$`);
-
-    schemaIds.forEach((schemaId) => {
-        expect(schemaId).toMatch(schemaIdRegExp);
-    });
-});
-
 test('removeJsonSchemaProps', () => {
     expect(removeJsonSchemaProps({ a: 'b', $id: 'c', components: {} }))
         .toMatchInlineSnapshot(`

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -171,9 +171,9 @@ interface UnleashSchemas {
     [name: string]: SchemaWithMandatoryFields;
 }
 
-type OpenAPIV3DocumentWithServers = Omit<OpenAPIV3.Document, 'servers'> & {
+interface OpenAPIV3DocumentWithServers extends OpenAPIV3.Document {
     servers: OpenAPIV3.ServerObject[];
-};
+}
 
 // All schemas in `openapi/spec` should be listed here.
 export const schemas: UnleashSchemas = {

--- a/src/lib/openapi/meta-schema-rules.test.ts
+++ b/src/lib/openapi/meta-schema-rules.test.ts
@@ -1,5 +1,5 @@
-import { schemas } from '..';
 import Ajv, { Schema } from 'ajv';
+import { schemas } from '.';
 
 const ajv = new Ajv();
 
@@ -27,11 +27,14 @@ const metaRules: Rule[] = [
         knownExceptions: ['dateSchema'],
     },
     {
-        name: 'should have an $id',
+        name: 'should have an $id with the expected format',
         metaSchema: {
             type: 'object',
             properties: {
-                $id: { type: 'string' },
+                $id: {
+                    type: 'string',
+                    pattern: '^#/components/schemas/[a-z][a-zA-Z]+$',
+                },
             },
             required: ['$id'],
         },
@@ -143,6 +146,7 @@ const metaRules: Rule[] = [
             'strategySchema',
             'tagsBulkAddSchema',
             'tagSchema',
+            'tagsSchema',
             'tagTypeSchema',
             'tagTypesSchema',
             'tagWithVersionSchema',

--- a/src/lib/openapi/spec/meta-schema.test.ts
+++ b/src/lib/openapi/spec/meta-schema.test.ts
@@ -1,0 +1,33 @@
+import { schemas } from '..';
+import Ajv from 'ajv';
+
+const ajv = new Ajv();
+
+const openApiMetaSchema = {
+    type: 'object',
+    properties: {
+        description: { type: 'string' },
+    },
+    required: ['description'],
+};
+
+describe('OpenAPI schemas meta validation', () => {
+    let countErrors = 0;
+    Object.entries(schemas).forEach(([name, schema]) => {
+        it(`${name} should be valid`, () => {
+            const validateMetaSchema = ajv.compile(openApiMetaSchema);
+            validateMetaSchema(schema);
+            countErrors += validateMetaSchema.errors?.length ?? 0;
+            // expect(validateMetaSchema.errors).toBeNull(); // commented until we fix all schemas
+            if (validateMetaSchema.errors?.length) {
+                // this function outputs instead of failing the test
+                console.error(
+                    `${name} has the following errors: ${JSON.stringify(
+                        validateMetaSchema.errors,
+                    )}`,
+                );
+            }
+        });
+    });
+    expect(countErrors).toBeLessThanOrEqual(125); // current number of schema errors
+});


### PR DESCRIPTION
## About the changes
This enables us to validate the shape of our OpenAPI schemas by defining specific json-schema rules that will be evaluated against all our open API schemas.

Because we know there are things we need to improve, we've added a list of `knownExceptions`. When fixing some of the known exceptions the tests will force us to remove the exception from the list, that way contributing to reducing the number of violations to our own rules.

Co-authored-by: Mateusz Kwasniewski <kwasniewski.mateusz@gmail.com>
Co-authored-by: Thomas Heartman <thomas@getunleash.io>
