### PR TITLE
feat: visualize adding a default strategy

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
@@ -33,6 +33,7 @@ test('Display default strategy', async () => {
                     },
                 ],
                 defaultChange: {
+                    id: 0,
                     action: 'addStrategy',
                     payload: {
                         name: 'flexibleRollout',

--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { ChangeRequest } from './ChangeRequest';
+import { IChangeRequest } from '../changeRequest.types';
+
+test('Display default strategy', async () => {
+    const changeRequest: IChangeRequest = {
+        approvals: [],
+        comments: [],
+        createdAt: new Date(),
+        createdBy: {
+            id: 1,
+            username: 'author',
+            imageUrl: '',
+        },
+        features: [
+            {
+                name: 'Feature Toggle Name',
+                changes: [
+                    {
+                        id: 67,
+                        action: 'updateEnabled',
+                        payload: {
+                            enabled: true,
+                        },
+                        createdAt: new Date(),
+                        createdBy: {
+                            id: 1,
+                            username: 'admin',
+                            imageUrl:
+                                'https://gravatar.com/avatar/21232f297a57a5a743894a0e4a801fc3?size=42&default=retro',
+                        },
+                    },
+                ],
+                defaultChange: {
+                    action: 'addStrategy',
+                    payload: {
+                        name: 'flexibleRollout',
+                        constraints: [],
+                        parameters: {
+                            rollout: '100',
+                            stickiness: 'default',
+                            groupId: 'test123',
+                        },
+                    },
+                },
+            },
+        ],
+        id: 0,
+        minApprovals: 1,
+        state: 'Draft',
+        title: 'My change request',
+        project: 'project',
+        environment: 'production',
+    };
+
+    render(<ChangeRequest changeRequest={changeRequest} />);
+
+    expect(screen.getByText('Feature Toggle Name')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    expect(
+        screen.getByText('Default strategy will be added')
+    ).toBeInTheDocument();
+});

--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.test.tsx
@@ -1,9 +1,15 @@
 import { screen } from '@testing-library/react';
 import { render } from 'utils/testRenderer';
 import { ChangeRequest } from './ChangeRequest';
-import { IChangeRequest } from '../changeRequest.types';
+import {
+    IChangeRequest,
+    IChangeRequestAddStrategy,
+    IChangeRequestEnabled,
+} from '../changeRequest.types';
 
-test('Display default strategy', async () => {
+const changeRequestWithDefaultChange = (
+    defaultChange: IChangeRequestEnabled | IChangeRequestAddStrategy
+) => {
     const changeRequest: IChangeRequest = {
         approvals: [],
         comments: [],
@@ -32,19 +38,7 @@ test('Display default strategy', async () => {
                         },
                     },
                 ],
-                defaultChange: {
-                    id: 0,
-                    action: 'addStrategy',
-                    payload: {
-                        name: 'flexibleRollout',
-                        constraints: [],
-                        parameters: {
-                            rollout: '100',
-                            stickiness: 'default',
-                            groupId: 'test123',
-                        },
-                    },
-                },
+                defaultChange,
             },
         ],
         id: 0,
@@ -54,12 +48,49 @@ test('Display default strategy', async () => {
         project: 'project',
         environment: 'production',
     };
+    return changeRequest;
+};
 
-    render(<ChangeRequest changeRequest={changeRequest} />);
+test('Display default add strategy', async () => {
+    render(
+        <ChangeRequest
+            changeRequest={changeRequestWithDefaultChange({
+                id: 0,
+                action: 'addStrategy',
+                payload: {
+                    name: 'flexibleRollout',
+                    constraints: [],
+                    parameters: {
+                        rollout: '100',
+                        stickiness: 'default',
+                        groupId: 'test123',
+                    },
+                },
+            })}
+        />
+    );
 
     expect(screen.getByText('Feature Toggle Name')).toBeInTheDocument();
     expect(screen.getByText('Enabled')).toBeInTheDocument();
     expect(
         screen.getByText('Default strategy will be added')
     ).toBeInTheDocument();
+});
+
+test('Display default disable feature', async () => {
+    render(
+        <ChangeRequest
+            changeRequest={changeRequestWithDefaultChange({
+                id: 0,
+                action: 'updateEnabled',
+                payload: {
+                    enabled: false,
+                },
+            })}
+        />
+    );
+
+    expect(screen.getByText('Feature Toggle Name')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByText('Feature status will change')).toBeInTheDocument();
 });

--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
@@ -49,7 +49,10 @@ export const ChangeRequest: VFC<IChangeRequestProps> = ({
                                     variant="body2"
                                     color="text.secondary"
                                 >
-                                    Default strategy will be added
+                                    {feature.defaultChange.action ===
+                                    'addStrategy'
+                                        ? 'Default strategy will be added'
+                                        : 'Feature status will change'}
                                 </Typography>
                             }
                             index={feature.changes.length}

--- a/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/ChangeRequest.tsx
@@ -1,5 +1,5 @@
 import React, { VFC } from 'react';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { IChangeRequest } from '../changeRequest.types';
 import { FeatureToggleChanges } from './Changes/FeatureToggleChanges';
 import { Change } from './Changes/Change/Change';
@@ -42,6 +42,22 @@ export const ChangeRequest: VFC<IChangeRequestProps> = ({
                             feature={feature}
                         />
                     ))}
+                    {feature.defaultChange ? (
+                        <Change
+                            discard={
+                                <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                >
+                                    Default strategy will be added
+                                </Typography>
+                            }
+                            index={feature.changes.length}
+                            changeRequest={changeRequest}
+                            change={feature.defaultChange}
+                            feature={feature}
+                        />
+                    ) : null}
                 </FeatureToggleChanges>
             ))}
         </Box>

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
@@ -71,13 +71,16 @@ export const Change: FC<{
     change: IChange;
     feature: IChangeRequestFeature;
 }> = ({ index, change, feature, changeRequest, discard }) => {
+    const lastIndex = feature.defaultChange
+        ? feature.changes.length + 1
+        : feature.changes.length;
     return (
         <StyledSingleChangeBox
             key={objectId(change)}
             $hasConflict={Boolean(change.conflict)}
             $isInConflictFeature={Boolean(feature.conflict)}
             $isAfterWarning={Boolean(feature.changes[index - 1]?.conflict)}
-            $isLast={index + 1 === feature.changes.length}
+            $isLast={index + 1 === lastIndex}
         >
             <ConditionallyRender
                 condition={Boolean(change.conflict) && !feature.conflict}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
@@ -68,7 +68,7 @@ export const Change: FC<{
     discard: ReactNode;
     index: number;
     changeRequest: IChangeRequest;
-    change: IChange;
+    change: Omit<IChange, 'id'>;
     feature: IChangeRequestFeature;
 }> = ({ index, change, feature, changeRequest, discard }) => {
     const lastIndex = feature.defaultChange

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Change.tsx
@@ -68,7 +68,7 @@ export const Change: FC<{
     discard: ReactNode;
     index: number;
     changeRequest: IChangeRequest;
-    change: Omit<IChange, 'id'>;
+    change: IChange;
     feature: IChangeRequestFeature;
 }> = ({ index, change, feature, changeRequest, discard }) => {
     const lastIndex = feature.defaultChange

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -28,6 +28,7 @@ export interface IChangeRequestFeature {
     name: string;
     conflict?: string;
     changes: IChange[];
+    defaultChange?: Omit<IChangeRequestAddStrategy, 'id'>;
 }
 
 export interface IChangeRequestApproval {

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -28,7 +28,7 @@ export interface IChangeRequestFeature {
     name: string;
     conflict?: string;
     changes: IChange[];
-    defaultChange?: IChangeRequestAddStrategy;
+    defaultChange?: IChangeRequestAddStrategy | IChangeRequestEnabled;
 }
 
 export interface IChangeRequestApproval {

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -28,7 +28,7 @@ export interface IChangeRequestFeature {
     name: string;
     conflict?: string;
     changes: IChange[];
-    defaultChange?: Omit<IChangeRequestAddStrategy, 'id'>;
+    defaultChange?: IChangeRequestAddStrategy;
 }
 
 export interface IChangeRequestApproval {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When CR is not applied we show a default strategy that will be added:
<img width="916" alt="Screenshot 2023-04-14 at 08 59 53" src="https://user-images.githubusercontent.com/1394682/231979754-51deb9b8-c9b2-441a-b122-e7e804de2e8d.png">
The default one doesn't count into all the changes count since it's not something a user added.

After applying the default one goes away:

<img width="855" alt="Screenshot 2023-04-14 at 09 02 05" src="https://user-images.githubusercontent.com/1394682/231980087-4a3f5c7a-c8e4-4096-ba6e-7b891c82cfb1.png">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
