### PR TITLE
fix: return 404 when gettings tags for a non existing feature

### DIFF
--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -120,7 +120,7 @@ class FeatureController extends Controller {
                     operationId: 'listTags',
                     responses: {
                         200: createResponseSchema('tagsSchema'),
-                        ...getStandardResponses(401),
+                        ...getStandardResponses(401, 403, 404),
                     },
                 }),
             ],

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -6182,6 +6182,12 @@ If the provided project does not exist, the list of events will be empty.",
           "401": {
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
+          "403": {
+            "description": "User credentials are valid but does not have enough privileges to execute this operation",
+          },
+          "404": {
+            "description": "The requested resource was not found.",
+          },
         },
         "summary": "Get all tags for a feature.",
         "tags": [

--- a/src/test/e2e/stores/feature-tag-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-tag-store.e2e.test.ts
@@ -2,6 +2,7 @@ import { IFeatureTagStore } from 'lib/types/stores/feature-tag-store';
 import { IFeatureToggleStore } from 'lib/types/stores/feature-toggle-store';
 import dbInit from '../helpers/database-init';
 import getLogger from '../../fixtures/no-logger';
+import NotFoundError from '../../../lib/error/notfound-error';
 
 let stores;
 let db;
@@ -43,7 +44,7 @@ test('should tag feature', async () => {
     expect(featureTag.tagValue).toBe(tag.value);
 });
 
-test('feature tag exits', async () => {
+test('feature tag exists', async () => {
     await featureTagStore.tagFeature(featureName, tag);
     const exists = await featureTagStore.exists({
         featureName,
@@ -96,4 +97,21 @@ test('should import feature tags', async () => {
 
     const all = await featureTagStore.getAll();
     expect(all).toHaveLength(2);
+});
+
+test('should throw not found error if feature does not exist', async () => {
+    await expect(async () =>
+        featureTagStore.getAllTagsForFeature('non.existing.toggle'),
+    ).rejects.toThrow(
+        new NotFoundError(
+            `Could not find feature with name non.existing.toggle`,
+        ),
+    );
+});
+
+test('Returns empty tag list for existing feature with no tags', async () => {
+    const name = 'feature.with.no.tags';
+    await featureToggleStore.create('default', { name });
+    let tags = await featureTagStore.getAllTagsForFeature(name);
+    expect(tags).toHaveLength(0);
 });


### PR DESCRIPTION
From the discussion here https://github.com/Unleash/unleash/pull/3496#discussion_r1163745860

This PR checks the existence of the feature before trying to get tags for the feature. Doing so by stealing the exists method from the feature store, since that's what we need to know exists, and avoiding having the feature store as a dependency to the featureTagStore seemed reasonable.
