### PR TITLE
docs: update documentation and dev server use of passord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ You'll need:
    ```bash
    docker run \
        -e POSTGRES_USER=unleash_user \
-       -e POSTGRES_PASSWORD=passord \
+       -e POSTGRES_PASSWORD=password \
        -e POSTGRES_DB=unleash \
        --name postgres \
        -p 5432:5432 \
@@ -119,7 +119,7 @@ You'll need:
 3. Start a Postgres database. Make sure to use the network you created in step 2.
 
 ```sh
-docker run -e POSTGRES_PASSWORD=passord \
+docker run -e POSTGRES_PASSWORD=password \
   -e POSTGRES_USER=unleash_user -e POSTGRES_DB=unleash \
   --network unleash --name postgres postgres
 ```
@@ -129,7 +129,7 @@ docker run -e POSTGRES_PASSWORD=passord \
 ```sh
 docker run -p 4242:4242 \
   -e DATABASE_HOST=postgres -e DATABASE_NAME=unleash \
-  -e DATABASE_USERNAME=unleash_user -e DATABASE_PASSWORD=passord \
+  -e DATABASE_USERNAME=unleash_user -e DATABASE_PASSWORD=password \
   -e DATABASE_SSL=false \
   --network unleash unleash:local
 ```

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:alpine3.15
     environment:
       POSTGRES_USER: unleash_user
-      POSTGRES_PASSWORD: passord
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: unleash
     ports:
       - 5432:5432

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -9,7 +9,7 @@ process.nextTick(async () => {
             createConfig({
                 db: {
                     user: 'unleash_user',
-                    password: 'passord',
+                    password: 'password',
                     host: 'localhost',
                     port: 5432,
                     database: process.env.UNLEASH_DATABASE_NAME || 'unleash',

--- a/src/test/e2e/helpers/database-config.ts
+++ b/src/test/e2e/helpers/database-config.ts
@@ -3,6 +3,6 @@ import parseDbUrl from 'parse-database-url';
 export const getDbConfig = (): object => {
     const url =
         process.env.TEST_DATABASE_URL ||
-        'postgres://unleash_user:passord@localhost:5432/unleash_test';
+        'postgres://unleash_user:password@localhost:5432/unleash_test';
     return parseDbUrl(url);
 };

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -33,7 +33,7 @@ Unleash currently also work with PostgreSQL v12+, but this might change in a fut
 
 ```bash
 $ psql postgres <<SQL
-CREATE USER unleash_user WITH PASSWORD 'passord';
+CREATE USER unleash_user WITH PASSWORD 'password';
 CREATE DATABASE unleash;
 GRANT ALL PRIVILEGES ON DATABASE unleash to unleash_user;
 CREATE DATABASE unleash_test;
@@ -42,15 +42,15 @@ ALTER DATABASE unleash_test SET timezone TO 'UTC';
 SQL
 ```
 
-> Password is intentionally set to 'passord', which is the Norwegian word for password.
+> Password is intentionally set to 'password', which is the Norwegian word for password.
 
 Then set env vars:
 
 (Optional as unleash will assume these as default values).
 
 ```
-export DATABASE_URL=postgres://unleash_user:passord@localhost:5432/unleash
-export TEST_DATABASE_URL=postgres://unleash_user:passord@localhost:5432/unleash_test
+export DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash
+export TEST_DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash_test
 ```
 
 ## PostgreSQL with docker {#postgresql-with-docker}
@@ -86,7 +86,7 @@ We use database migrations to track database changes. Never change a migration t
 
 To run migrations, you will set the environment variable for DATABASE_URL
 
-`export DATABASE_URL=postgres://unleash_user:passord@localhost:5432/unleash`
+`export DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash`
 
 Use db-migrate to create new migrations file.
 

--- a/website/docs/reference/deploy/configuring-unleash.md
+++ b/website/docs/reference/deploy/configuring-unleash.md
@@ -38,7 +38,7 @@ const unleash = require('unleash-server');
 const unleashOptions = {
   db: {
     user: 'unleash_user',
-    password: 'passord',
+    password: 'password',
     host: 'localhost',
     port: 5432,
     database: 'unleash',
@@ -231,7 +231,7 @@ The available options are listed in the table below. Options can be specified ei
 | Property name | Environment variable | Default value | Description |
 | --- | --- | --- | --- |
 | `user` | `DATABASE_USERNAME` | `unleash_user` | The database username. |
-| `password` | `DATABASE_PASSWORD` | `passord` | The database password. |
+| `password` | `DATABASE_PASSWORD` | `password` | The database password. |
 | `host` | `DATABASE_HOST` | `localhost` | The database hostname. |
 | `port` | `DATABASE_PORT` | `5432` | The database port. |
 | `database` | `DATABASE_NAME` | `unleash` | The name of the database. |

--- a/website/docs/reference/deploy/securing-unleash.md
+++ b/website/docs/reference/deploy/securing-unleash.md
@@ -29,7 +29,7 @@ const myCustomAdminAuth = require('./auth-hook');
 
 unleash
   .start({
-    databaseUrl: 'postgres://unleash_user:passord@localhost:5432/unleash',
+    databaseUrl: 'postgres://unleash_user:password@localhost:5432/unleash',
     authentication: {
       type: 'custom',
       customAuthHandler: myCustomAdminAuth,


### PR DESCRIPTION
## About the changes
Update `passord` documentation with `password`. Note this was not a typo but just Norwegian: https://dictionary.cambridge.org/dictionary/english-norwegian/password
```shell
grep passord * -R -l | grep -v .git | grep -v dist | grep -v v3 | xargs sed -i 's/passord/password/g'
```
The script above avoids updating v3 because of legacy reasons

Related to #1265 