### PR TITLE
fix: seed setup and remove admin/features call

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:coverage": "NODE_ENV=test PORT=4243 jest --coverage --testLocationInResults --outputFile=\"coverage/report.json\" --forceExit --testTimeout=10000",
     "pretest:coverage:jest": "yarn build:frontend",
     "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000",
-    "seed:setup": "ts-node src/test/e2e/seed/segment.seed.ts",
+    "seed:setup": "ts-node --compilerOptions '{\"strictNullChecks\": false}' src/test/e2e/seed/segment.seed.ts",
     "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",
     "preversion": "./scripts/check-release.sh",


### PR DESCRIPTION
## About the changes
Seed setup fails because of compilation errors, we need to skip errors until we fix them. Also, this removes one usage of `/api/admin/features` that was used only for testing 