### PR TITLE
docs: add sidebar entry for project API tokens guide

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -69,6 +69,7 @@ module.exports = {
                     items: [
                         'how-to/how-to-create-api-tokens',
                         'how-to/how-to-create-personal-access-tokens',
+                        'how-to/how-to-create-project-api-tokens',
                         'how-to/how-to-create-service-accounts',
                         'how-to/how-to-download-login-history',
                         'how-to/how-to-use-the-admin-api',


### PR DESCRIPTION
It seems that we forgot to add this doc to the sidebar. This PR fixes that