### PR TITLE
feat: unify error responses

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -184,27 +184,17 @@ export default async function getApp(
         res.send(indexHTML);
     });
 
-    // // handle all API 404s
-    // app.use(`${baseUriPath}/api`, (req, res) => {
-    //     const error = new UnleashError({
-    //         name: 'NotFoundError',
-    //         message: `The path you were looking for (${baseUriPath}/api${req.path}) is not available.`,
-    //         suggestion: 'Try using a path that does exist.',
-    //     });
-    //     res.status(error.statusCode).send(error);
-    //     return;
-    // });
+    // handle all API 404s
+    app.use(`${baseUriPath}/api`, (req, res) => {
+        const error = new UnleashError({
+            name: 'NotFoundError',
+            message: `The path you were looking for (${baseUriPath}/api${req.path}) is not available.`,
+        });
+        res.status(error.statusCode).send(error);
+        return;
+    });
 
     app.get(`${baseUriPath}/*`, (req, res) => {
-        if (req.path.startsWith(`${baseUriPath}/api`)) {
-            const error = new UnleashError({
-                name: 'NotFoundError',
-                message: `The path you were looking for (${req.path}) is not available.`,
-            });
-            res.status(error.statusCode).send(error);
-            return;
-        }
-
         res.send(indexHTML);
     });
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -28,7 +28,7 @@ import { Knex } from 'knex';
 import maintenanceMiddleware from './middleware/maintenance-middleware';
 import { unless } from './middleware/unless-middleware';
 import { catchAllErrorHandler } from './middleware/catch-all-error-handler';
-import { UnleashError } from './error/api-error';
+import NotFoundError from './error/notfound-error';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -174,6 +174,13 @@ export default async function getApp(
         services.openApiService.useErrorHandler(app);
     }
 
+    // handle all API 404s
+    app.use(`${baseUriPath}/api`, (req) => {
+        throw new NotFoundError(
+            `The path you were looking for (${baseUriPath}/api${req.path}) is not available.`,
+        );
+    });
+
     if (process.env.NODE_ENV !== 'production') {
         app.use(errorHandler());
     } else {
@@ -182,16 +189,6 @@ export default async function getApp(
 
     app.get(`${baseUriPath}`, (req, res) => {
         res.send(indexHTML);
-    });
-
-    // handle all API 404s
-    app.use(`${baseUriPath}/api`, (req, res) => {
-        const error = new UnleashError({
-            name: 'NotFoundError',
-            message: `The path you were looking for (${baseUriPath}/api${req.path}) is not available.`,
-        });
-        res.status(error.statusCode).send(error);
-        return;
     });
 
     app.get(`${baseUriPath}/*`, (req, res) => {

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -28,6 +28,7 @@ import { Knex } from 'knex';
 import maintenanceMiddleware from './middleware/maintenance-middleware';
 import { unless } from './middleware/unless-middleware';
 import { catchAllErrorHandler } from './middleware/catch-all-error-handler';
+import { UnleashError } from './error/api-error';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -183,9 +184,24 @@ export default async function getApp(
         res.send(indexHTML);
     });
 
+    // // handle all API 404s
+    // app.use(`${baseUriPath}/api`, (req, res) => {
+    //     const error = new UnleashError({
+    //         name: 'NotFoundError',
+    //         message: `The path you were looking for (${baseUriPath}/api${req.path}) is not available.`,
+    //         suggestion: 'Try using a path that does exist.',
+    //     });
+    //     res.status(error.statusCode).send(error);
+    //     return;
+    // });
+
     app.get(`${baseUriPath}/*`, (req, res) => {
         if (req.path.startsWith(`${baseUriPath}/api`)) {
-            res.status(404).send({ message: 'Not found' });
+            const error = new UnleashError({
+                name: 'NotFoundError',
+                message: `The path you were looking for (${req.path}) is not available.`,
+            });
+            res.status(error.statusCode).send(error);
             return;
         }
 

--- a/src/lib/error/api-error.test.ts
+++ b/src/lib/error/api-error.test.ts
@@ -1,0 +1,212 @@
+import {
+    fromOpenApiValidationError,
+    fromOpenApiValidationErrors,
+} from './api-error';
+
+describe('OpenAPI error conversion', () => {
+    it('Gives useful error messages for missing properties', () => {
+        const error = {
+            keyword: 'required',
+            instancePath: '',
+            dataPath: '.body',
+            schemaPath: '#/components/schemas/addonCreateUpdateSchema/required',
+            params: {
+                missingProperty: 'enabled',
+            },
+            message: "should have required property 'enabled'",
+        };
+
+        const { description } = fromOpenApiValidationError({})(error);
+
+        // it tells the user that the property is required
+        expect(description.includes('required'));
+        // it tells the user the name of the missing property
+        expect(description.includes(error.params.missingProperty));
+    });
+
+    it('Gives useful error messages for type errors', () => {
+        const error = {
+            keyword: 'type',
+            instancePath: '',
+            dataPath: '.body.parameters',
+            schemaPath:
+                '#/components/schemas/addonCreateUpdateSchema/properties/parameters/type',
+            params: {
+                type: 'object',
+            },
+            message: 'should be object',
+        };
+
+        const parameterValue = [];
+        const { description } = fromOpenApiValidationError({
+            parameters: parameterValue,
+        })(error);
+
+        // it provides the message
+        expect(description.includes(error.message));
+        // it tells the user what they provided
+        expect(description.includes(JSON.stringify(parameterValue)));
+    });
+
+    it('Gives useful pattern error messages', () => {
+        const error = {
+            instancePath: '',
+            keyword: 'pattern',
+            dataPath: '.body.description',
+            schemaPath:
+                '#/components/schemas/addonCreateUpdateSchema/properties/description/pattern',
+            params: {
+                pattern: '^this is',
+            },
+            message: 'should match pattern "^this is"',
+        };
+
+        const requestDescription = 'A pattern that does not match.';
+        const { description } = fromOpenApiValidationError({
+            description: requestDescription,
+        })(error);
+
+        // it tells the user what the pattern it should match is
+        expect(description.includes(error.params.pattern));
+        // it tells the user which property it pertains to
+        expect(description.includes('description'));
+        // it tells the user what they provided
+        expect(description.includes(requestDescription));
+    });
+
+    it('Gives useful min/maxlength error messages', () => {
+        const error = {
+            instancePath: '',
+            keyword: 'maxLength',
+            dataPath: '.body.description',
+            schemaPath:
+                '#/components/schemas/addonCreateUpdateSchema/properties/description/maxLength',
+            params: {
+                limit: 5,
+            },
+            message: 'should NOT be longer than 5 characters',
+        };
+
+        const requestDescription = 'Longer than the max length';
+        const { description } = fromOpenApiValidationError({
+            description: requestDescription,
+        })(error);
+
+        // it tells the user what the pattern it should match is
+        expect(description.includes(error.params.limit.toString()));
+        // it tells the user which property it pertains to
+        expect(description.includes('description'));
+        // it tells the user what they provided
+        expect(description.includes(requestDescription));
+    });
+
+    it('Handles numerical min/max errors', () => {
+        const error = {
+            keyword: 'maximum',
+            instancePath: '',
+            dataPath: '.body.newprop',
+            schemaPath:
+                '#/components/schemas/addonCreateUpdateSchema/properties/newprop/maximum',
+            params: {
+                comparison: '<=',
+                limit: 5,
+                exclusive: false,
+            },
+            message: 'should be <= 5',
+        };
+
+        const propertyValue = 6;
+        const { description } = fromOpenApiValidationError({
+            newprop: propertyValue,
+        })(error);
+
+        // it tells the user what the limit is
+        expect(description.includes(error.params.limit.toString()));
+        // it tells the user what kind of comparison it performed
+        expect(description.includes(error.params.comparison));
+        // it tells the user which property it pertains to
+        expect(description.includes('newprop'));
+        // it tells the user what they provided
+        expect(description.includes(propertyValue.toString()));
+    });
+
+    it('Handles multiple errors', () => {
+        const errors = [
+            {
+                keyword: 'maximum',
+                instancePath: '',
+                dataPath: '.body.newprop',
+                schemaPath:
+                    '#/components/schemas/addonCreateUpdateSchema/properties/newprop/maximum',
+                params: {
+                    comparison: '<=',
+                    limit: 5,
+                    exclusive: false,
+                },
+                message: 'should be <= 5',
+            },
+            {
+                keyword: 'required',
+                instancePath: '',
+                dataPath: '.body',
+                schemaPath:
+                    '#/components/schemas/addonCreateUpdateSchema/required',
+                params: {
+                    missingProperty: 'enabled',
+                },
+                message: "should have required property 'enabled'",
+            },
+        ];
+
+        const error = fromOpenApiValidationErrors({ newprop: 7 }, errors);
+
+        expect(error.name).toBe('ValidationError');
+        expect(error.message).toContain('`errors`');
+        // @ts-expect-error property exists on validation errors
+        expect(error.errors[0].description.includes('newprop'));
+        // @ts-expect-error property exists on validation errors
+        expect(error.errors[1].description.includes('enabled'));
+    });
+
+    it('Handles deeply nested properties gracefully', () => {
+        const error = {
+            keyword: 'type',
+            dataPath: '.body.nestedObject.a.b',
+            schemaPath:
+                '#/components/schemas/addonCreateUpdateSchema/properties/nestedObject/properties/a/properties/b/type',
+            params: { type: 'string' },
+            message: 'should be string',
+            instancePath: '',
+        };
+
+        const { description } = fromOpenApiValidationError({
+            nestedObject: { a: { b: [] } },
+        })(error);
+
+        // it should hold the full path to the error
+        expect(description.includes('nestedObject.a.b'));
+        // it should include the value that the user sent
+        expect(description.includes('[]'));
+    });
+
+    it('Handles deeply nested properties on referenced schemas', () => {
+        const error = {
+            keyword: 'type',
+            dataPath: '.body.nestedObject.a.b',
+            schemaPath: '#/components/schemas/parametersSchema/type',
+            params: { type: 'object' },
+            message: 'should be object',
+            instancePath: '',
+        };
+
+        const illegalValue = 'illegal string';
+        const { description } = fromOpenApiValidationError({
+            nestedObject: { a: { b: illegalValue } },
+        })(error);
+
+        // it should hold the full path to the error
+        expect(description.includes('nestedObject.a.b'));
+        // it should include the value that the user sent
+        expect(description.includes(illegalValue));
+    });
+});

--- a/src/lib/error/api-error.test.ts
+++ b/src/lib/error/api-error.test.ts
@@ -166,12 +166,12 @@ describe('OpenAPI error conversion', () => {
             fromOpenApiValidationErrors({ newprop: 7 }, errors).toJSON();
 
         expect(serializedUnleashError.name).toBe('ValidationError');
-        expect(serializedUnleashError.message).toContain('`errors`');
+        expect(serializedUnleashError.message).toContain('`details`');
         expect(
-            serializedUnleashError.errors!![0].description.includes('newprop'),
+            serializedUnleashError.details!![0].description.includes('newprop'),
         );
         expect(
-            serializedUnleashError.errors!![1].description.includes('enabled'),
+            serializedUnleashError.details!![1].description.includes('enabled'),
         );
     });
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -22,6 +22,7 @@ const UnleashApiErrorTypes = [
     'UnknownError',
     'PasswordMismatch',
     'DisabledError',
+    'ContentTypeError',
 
     // server errors; not the end user's fault
     'InternalError',
@@ -31,6 +32,8 @@ type UnleashApiErrorKind = typeof UnleashApiErrorTypes[number];
 
 export const statusCode = (errorKind: UnleashApiErrorKind): number => {
     switch (errorKind) {
+        case 'ContentTypeError':
+            return 415;
         case 'ValidationError':
             return 400;
         case 'BadDataError':

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidV4 } from 'uuid';
 import { FromSchema } from 'json-schema-to-ts';
+import { ErrorObject } from 'ajv';
 
 const UnleashApiErrorTypes = [
     'OwaspValidationError',
@@ -258,6 +259,22 @@ export const fromLegacyError = (e: Error): UnleashError => {
         message: e.message,
         errors: [{ description: 'whoops' }],
     });
+};
+
+export const fromOpenApiValidationError =
+    (requestBody: object) =>
+    (validationError: ErrorObject): ValidationErrorDescription => {
+        console.log(requestBody, validationError);
+
+        throw new Error();
+    };
+
+export const fromOpenApiValidationErrors = (
+    requestBody: object,
+    validationErrors: ErrorObject[],
+): UnleashError => {
+    console.log(requestBody, validationErrors);
+    throw new Error();
 };
 
 export type ApiErrorSchema = FromSchema<typeof apiErrorSchema>;

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -4,7 +4,6 @@ import { FromSchema } from 'json-schema-to-ts';
 const UnleashApiErrorTypes = [
     'OwaspValidationError',
     'PasswordUndefinedError',
-    'MinimumOneEnvironmentError',
     'InvalidTokenError',
     'NoAccessError',
     'UsedTokenError',
@@ -29,6 +28,7 @@ const UnleashApiErrorTypes = [
 
 // types that have extra data associated with them
 const UnleashApiErrorTypes2 = [
+    'MinimumOneEnvironmentError',
     'BadDataError',
     'BadRequestError',
     'ValidationError',
@@ -128,7 +128,11 @@ type UnleashErrorData =
                 type: string;
             }
           | {
-                name: 'ValidationError' | 'BadDataError' | 'BadRequestError';
+                name:
+                    | 'ValidationError'
+                    | 'BadDataError'
+                    | 'BadRequestError'
+                    | 'MinimumOneEnvironmentError';
                 errors: [
                     ValidationErrorDescription,
                     ...ValidationErrorDescription[],
@@ -229,7 +233,14 @@ export const fromLegacyError = (e: Error): UnleashError => {
         });
     }
 
-    if (['ValidationError', 'BadRequestError', 'BadDataError'].includes(name)) {
+    if (
+        [
+            'ValidationError',
+            'BadRequestError',
+            'BadDataError',
+            'MinimumOneEnvironmentError',
+        ].includes(name)
+    ) {
         return new UnleashError({
             name: name as
                 | 'ValidationError'
@@ -252,7 +263,7 @@ export const fromLegacyError = (e: Error): UnleashError => {
     return new UnleashError({
         name,
         message: e.message,
-        errors: [{ description: "this shouldn't be here" }],
+        errors: [{ description: 'whoops' }],
     });
 };
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -170,10 +170,6 @@ export class UnleashError implements Error {
             id: this.id,
             name: this.name,
             message: this.message,
-            documentationLink:
-                this.documentationLink ||
-                'There is no documentation link available for this or none was provided.',
-            help: this.help(),
             ...this.otherparams,
         };
     }
@@ -186,10 +182,9 @@ export class UnleashError implements Error {
 export const apiErrorSchema = {
     $id: '#/components/schemas/apiError',
     type: 'object',
-    additionalProperties: false,
-    required: ['id', 'name', 'message', 'documentationLink'],
+    required: ['id', 'name', 'message'],
     description:
-        'An Unleash API error. Contains information about what went wrong and suggests what you can do to fix your issue.',
+        'An Unleash API error. Contains information about what went wrong.',
     properties: {
         name: {
             type: 'string',
@@ -204,89 +199,15 @@ export const apiErrorSchema = {
                 'A unique identifier for this error instance. Can be used to search logs etc.',
             example: '0b84c7fd-5278-4087-832d-0b502c7929b3',
         },
-        documentationLink: {
-            type: 'string',
-            pattern: 'url',
-            description:
-                'A URL to where you can find more information about using this addon type.',
-            example: 'https://docs.getunleash.io/docs/addons/slack',
-        },
         message: {
             type: 'string',
             description: 'A human-readable explanation of what went wrong.',
             example:
                 "We couldn't find an addon provider with the name that you are trying to add ('bogus-addon')",
         },
-        help: {
-            type: 'string',
-            description: 'Where can you get more help?',
-            example:
-                'If you need help, you can ask a question on [GitHub discussions](https://github.com/orgs/Unleash/discussions) or on Slack (slack.unleash.run). Or ask your Unleash administrator to look up the error id 0b84c7fd-5278-4087-832d-0b502c7929b3.',
-        },
     },
     components: {},
 } as const;
-
-const authErrorSchema = {
-    type: 'object',
-    additionalProperties: false,
-    required: ['path', 'name'],
-    description: 'An API authorization error. Contains a path.',
-    properties: {
-        name: {
-            type: 'string',
-            enum: ['PasswordMismatchError'],
-            example: 'PasswordMismatchError',
-            description: 'The name of this authorization error type.',
-        },
-        path: {
-            type: 'string',
-            pattern: 'uri',
-            example: '/auth/simple/login',
-            description: 'Where you must go to log in.',
-        },
-        type: {
-            type: 'string',
-            example: 'password',
-            description: 'The kind of login that is required.',
-        },
-    },
-};
-
-const validationErrorSchema = {
-    type: 'object',
-    additionalProperties: false,
-    required: ['errors', 'name'],
-    description: 'An API authorization error. Contains a path.',
-    properties: {
-        name: {
-            type: 'string',
-            enum: ['ValidationError'],
-            example: 'ValidationError',
-            description: 'The name of this authorization error type.',
-        },
-        errors: {
-            type: 'array',
-            minLength: 1,
-            description:
-                'A list of errors on the request body with description and suggestions.',
-            example: [
-                {
-                    description: 'The x property is wrong.',
-                    suggestion: 'Try doing it right.',
-                },
-            ],
-            items: {
-                type: 'object',
-                required: ['description'],
-                properties: {
-                    description: { type: 'string' },
-                    path: { type: 'string' },
-                },
-            },
-        },
-    },
-};
 
 export const fromLegacyError = (e: Error): UnleashError => {
     const name = AllUnleashApiErrorTypes.includes(e.name as UnleashApiErrorKind)

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -175,6 +175,10 @@ export class UnleashError extends Error {
     toJSON(): ApiErrorSchema {
         return this.serialize();
     }
+
+    toString(): string {
+        return `${this.name}: ${this.message}.`;
+    }
 }
 
 export const apiErrorSchema = {

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -80,7 +80,7 @@ export const statusCode = (errorKind: UnleashApiErrorKind): number => {
 };
 
 type UnleashErrorData = {
-    type: UnleashApiErrorKind;
+    name: UnleashApiErrorKind;
     message: string;
     suggestion: string;
     documentationLink?: string;
@@ -98,26 +98,26 @@ export class UnleashError implements Error {
     documentationLink: string | null;
 
     constructor({
-        type,
+        name,
         message,
         suggestion,
         documentationLink,
     }: UnleashErrorData) {
         this.id = uuidV4();
-        this.name = type;
+        this.name = name;
         this.message = message;
         this.suggestion = suggestion;
         this.documentationLink = documentationLink ?? null;
     }
 
-    help() {
+    help(): string {
         return `Get help for id ${this.id}`;
     }
 
     serialize(): ApiErrorSchema {
         return {
             id: this.id,
-            type: this.name,
+            name: this.name,
             message: this.message,
             suggestion: this.suggestion,
             documentationLink:
@@ -127,7 +127,7 @@ export class UnleashError implements Error {
         };
     }
 
-    toJSON() {
+    toJSON(): ApiErrorSchema {
         return this.serialize();
     }
 }
@@ -136,11 +136,11 @@ export const apiErrorSchema = {
     $id: '#/components/schemas/apiError',
     type: 'object',
     additionalProperties: false,
-    required: ['id', 'type', 'message', 'documentationLink'],
+    required: ['id', 'name', 'message', 'documentationLink'],
     description:
         'An Unleash API error. Contains information about what went wrong and suggests what you can do to fix your issue.',
     properties: {
-        type: {
+        name: {
             type: 'string',
             enum: UnleashApiErrorTypes,
             description:
@@ -233,8 +233,6 @@ const validationErrorSchema = {
                     suggestion: { type: 'string' },
                 },
             },
-            example: '/auth/simple/login',
-            description: 'Where you must go to log in.',
         },
     },
 };
@@ -245,7 +243,7 @@ export const fromLegacyError = (e: Error): UnleashError => {
         : 'UnknownError';
 
     return new UnleashError({
-        type,
+        name: type,
         message: e.message,
         suggestion: 'Tell Unleash about this suggestion being missing',
     });

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -91,7 +91,6 @@ const statusCode = (errorKind: UnleashApiErrorKind): number => {
 type UnleashErrorData =
     | {
           message: string;
-          suggestion: string;
           documentationLink?: string;
       } & (
           | {
@@ -111,8 +110,6 @@ type UnleashErrorData =
 export class UnleashError implements Error {
     id: string;
 
-    suggestion: string;
-
     name: UnleashApiErrorKind;
 
     message: string;
@@ -126,14 +123,12 @@ export class UnleashError implements Error {
     constructor({
         name,
         message,
-        suggestion,
         documentationLink,
         ...rest
     }: UnleashErrorData) {
         this.id = uuidV4();
         this.name = name;
         this.message = message;
-        this.suggestion = suggestion;
         this.documentationLink = documentationLink ?? null;
 
         this.statusCode = statusCode(name);
@@ -150,7 +145,6 @@ export class UnleashError implements Error {
             id: this.id,
             name: this.name,
             message: this.message,
-            suggestion: this.suggestion,
             documentationLink:
                 this.documentationLink ||
                 'There is no documentation link available for this or none was provided.',
@@ -197,12 +191,6 @@ export const apiErrorSchema = {
             description: 'A human-readable explanation of what went wrong.',
             example:
                 "We couldn't find an addon provider with the name that you are trying to add ('bogus-addon')",
-        },
-        suggestion: {
-            type: 'string',
-            description: 'Suggestions to fix what might have gone wrong.',
-            example:
-                "You need to use the name of an existing addon provider (such as 'slack' or 'webhook') as the `provider` property value",
         },
         help: {
             type: 'string',
@@ -278,7 +266,6 @@ export const fromLegacyError = (e: Error): UnleashError => {
         return new UnleashError({
             name: type,
             message: e.message,
-            suggestion: 'Tell Unleash about this suggestion being missing',
             permission: 'unknown',
         });
     }
@@ -286,7 +273,6 @@ export const fromLegacyError = (e: Error): UnleashError => {
     return new UnleashError({
         name: type,
         message: e.message,
-        suggestion: 'Tell Unleash about this suggestion being missing',
     });
 };
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -141,7 +141,7 @@ export class UnleashError extends Error {
 
     statusCode: number;
 
-    otherparams: object;
+    additionalParameters: object;
 
     constructor({
         name,
@@ -149,14 +149,15 @@ export class UnleashError extends Error {
         documentationLink,
         ...rest
     }: UnleashErrorData) {
-        super(message);
+        super();
         this.id = uuidV4();
         this.documentationLink = documentationLink ?? null;
         this.name = name;
+        super.message = message;
 
         this.statusCode = statusCode(name);
 
-        this.otherparams = rest;
+        this.additionalParameters = rest;
     }
 
     help(): string {
@@ -168,7 +169,7 @@ export class UnleashError extends Error {
             id: this.id,
             name: this.name,
             message: this.message,
-            ...this.otherparams,
+            ...this.additionalParameters,
         };
     }
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -1,0 +1,166 @@
+import { v4 as uuidV4 } from 'uuid';
+import { FromSchema } from 'json-schema-to-ts';
+
+// const UnleashApiErrorTypes = {
+//     ValidationError: 400,
+//     BadDataError: 400,
+//     BadRequestError: 400,
+//     OwaspValidationError: 400,
+//     PasswordUndefinedError: 400,
+//     MinimumOneEnvironmentError: 400,
+//     InvalidTokenError: 401,
+//     NoAccessError: 403,
+//     UsedTokenError: 403,
+//     InvalidOperationError: 403,
+//     IncompatibleProjectError: 403,
+//     OperationDeniedError: 403,
+//     NotFoundError: 404,
+//     NameExistsError: 409,
+//     FeatureHasTagError: 409,
+//     RoleInUseError: 400,
+//     ProjectWithoutOwnerError: 409,
+//     TypeError: 400,
+//     UnknownError: 400,
+//     // server errors; not the end user's fault
+//     InternalError: 500,
+// } as const;
+
+const UnleashApiErrorTypes = [
+    'ValidationError',
+    'BadDataError',
+    'BadRequestError',
+    'OwaspValidationError',
+    'PasswordUndefinedError',
+    'MinimumOneEnvironmentError',
+    'InvalidTokenError',
+    'NoAccessError',
+    'UsedTokenError',
+    'InvalidOperationError',
+    'IncompatibleProjectError',
+    'OperationDeniedError',
+    'NotFoundError',
+    'NameExistsError',
+    'FeatureHasTagError',
+    'RoleInUseError',
+    'ProjectWithoutOwnerError',
+    'UnknownError',
+    // server errors; not the end user's fault
+    'InternalError',
+] as const;
+
+type UnleashApiErrorKind = typeof UnleashApiErrorTypes[number];
+
+const statusCode = (errorKind: UnleashApiErrorKind) => {};
+
+type UnleashErrorData = {
+    type: UnleashApiErrorKind;
+    message: string;
+    suggestion: string;
+    documentationLink?: string;
+};
+
+export class UnleashError implements Error {
+    id: string;
+    suggestion: string;
+    name: UnleashApiErrorKind;
+    message: string;
+    documentationLink: string | null;
+
+    constructor({
+        type,
+        message,
+        suggestion,
+        documentationLink,
+    }: UnleashErrorData) {
+        this.id = uuidV4();
+        this.name = type;
+        this.message = message;
+        this.suggestion = suggestion;
+        this.documentationLink = documentationLink ?? null;
+    }
+
+    help() {
+        return `Get help for id ${this.id}`;
+    }
+
+    serialize(): ApiErrorSchema {
+        return {
+            id: this.id,
+            type: this.name,
+            message: this.message,
+            suggestion: this.suggestion,
+            documentationLink:
+                this.documentationLink ||
+                'There is no documentation link available for this or none was provided.',
+            help: this.help(),
+        };
+    }
+
+    toJSON() {
+        return this.serialize();
+    }
+}
+
+export const apiErrorSchema = {
+    $id: '#/components/schemas/apiError',
+    type: 'object',
+    additionalProperties: false,
+    required: ['id', 'type', 'message', 'documentationLink'],
+    description:
+        'An Unleash API error. Contains information about what went wrong and suggests what you can do to fix your issue.',
+    properties: {
+        type: {
+            type: 'string',
+            enum: UnleashApiErrorTypes,
+            description:
+                'The kind of error that occurred. Meant for machine consumption.',
+            example: 'ValidationError',
+        },
+        id: {
+            type: 'string',
+            description:
+                'A unique identifier for this error instance. Can be used to search logs etc.',
+            example: '0b84c7fd-5278-4087-832d-0b502c7929b3',
+        },
+        documentationLink: {
+            type: 'string',
+            pattern: 'url',
+            description:
+                'A URL to where you can find more information about using this addon type.',
+            example: 'https://docs.getunleash.io/docs/addons/slack',
+        },
+        message: {
+            type: 'string',
+            description: 'A human-readable explanation of what went wrong.',
+            example:
+                "We couldn't find an addon provider with the name that you are trying to add ('bogus-addon')",
+        },
+        suggestion: {
+            type: 'string',
+            description: 'Suggestions to fix what might have gone wrong.',
+            example:
+                "You need to use the name of an existing addon provider (such as 'slack' or 'webhook') as the `provider` property value",
+        },
+        help: {
+            type: 'string',
+            description: 'Where can you get more help?',
+            example:
+                'If you need help, you can ask a question on [GitHub discussions](https://github.com/orgs/Unleash/discussions) or on Slack (slack.unleash.run). Or ask your Unleash administrator to look up the error id 0b84c7fd-5278-4087-832d-0b502c7929b3.',
+        },
+    },
+    components: {},
+} as const;
+
+export const fromLegacyError = (e: Error): ApiErrorSchema => {
+    const type = UnleashApiErrorTypes.includes(e.name as UnleashApiErrorKind)
+        ? (e.name as UnleashApiErrorKind)
+        : 'UnknownError';
+
+    return new UnleashError({
+        type,
+        message: e.message,
+        suggestion: 'Tell Unleash about this suggestion being missing',
+    }).serialize();
+};
+
+export type ApiErrorSchema = FromSchema<typeof apiErrorSchema>;

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -17,6 +17,7 @@ const UnleashApiErrorTypes = [
     'RoleInUseError',
     'ProjectWithoutOwnerError',
     'UnknownError',
+    'PasswordMismatch',
     'PasswordMismatchError',
     'DisabledError',
     'ContentTypeError',
@@ -86,6 +87,7 @@ const statusCode = (errorKind: UnleashApiErrorKind): number => {
             return 500;
         case 'InternalError':
             return 500;
+        case 'PasswordMismatch':
         case 'PasswordMismatchError':
             return 401;
         case 'DisabledError':

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -5,7 +5,6 @@ import { ErrorObject } from 'ajv';
 const UnleashApiErrorTypes = [
     'OwaspValidationError',
     'PasswordUndefinedError',
-    'InvalidTokenError',
     'NoAccessError',
     'UsedTokenError',
     'InvalidOperationError',
@@ -34,6 +33,7 @@ const UnleashApiErrorTypesWithExtraData = [
     'ValidationError',
     'AuthenticationRequired',
     'NoAccessError',
+    'InvalidTokenError',
 ] as const;
 
 const AllUnleashApiErrorTypes = [
@@ -131,7 +131,8 @@ type UnleashErrorData =
                     | 'ValidationError'
                     | 'BadDataError'
                     | 'BadRequestError'
-                    | 'MinimumOneEnvironmentError';
+                    | 'MinimumOneEnvironmentError'
+                    | 'InvalidTokenError';
                 details: [
                     ValidationErrorDescription,
                     ...ValidationErrorDescription[],
@@ -230,6 +231,7 @@ export const fromLegacyError = (e: Error): UnleashError => {
             'ValidationError',
             'BadRequestError',
             'BadDataError',
+            'InvalidTokenError',
             'MinimumOneEnvironmentError',
         ].includes(name)
     ) {
@@ -238,6 +240,7 @@ export const fromLegacyError = (e: Error): UnleashError => {
                 | 'ValidationError'
                 | 'BadRequestError'
                 | 'BadDataError'
+                | 'InvalidTokenError'
                 | 'MinimumOneEnvironmentError',
             message:
                 'Your request body failed to validate. Refer to the `details` list to see what happened.',

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -143,8 +143,6 @@ export class UnleashError extends Error {
 
     name: UnleashApiErrorName;
 
-    documentationLink: string | null;
-
     statusCode: number;
 
     additionalParameters: object;
@@ -157,7 +155,6 @@ export class UnleashError extends Error {
     }: UnleashErrorData) {
         super();
         this.id = uuidV4();
-        this.documentationLink = documentationLink ?? null;
         this.name = name;
         super.message = message;
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -20,7 +20,7 @@ const UnleashApiErrorTypes = [
     'RoleInUseError',
     'ProjectWithoutOwnerError',
     'UnknownError',
-    'PasswordMismatch',
+    'PasswordMismatchError',
     'DisabledError',
     'ContentTypeError',
 
@@ -72,7 +72,7 @@ export const statusCode = (errorKind: UnleashApiErrorKind): number => {
             return 400;
         case 'InternalError':
             return 500;
-        case 'PasswordMismatch':
+        case 'PasswordMismatchError':
             return 401;
         case 'DisabledError':
             return 422;
@@ -181,6 +181,63 @@ export const apiErrorSchema = {
     },
     components: {},
 } as const;
+
+const authErrorSchema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['path', 'name'],
+    description: 'An API authorization error. Contains a path.',
+    properties: {
+        name: {
+            type: 'string',
+            enum: ['PasswordMismatchError'],
+            example: 'PasswordMismatchError',
+            description: 'The name of this authorization error type.',
+        },
+        path: {
+            type: 'string',
+            pattern: 'uri',
+            example: '/auth/simple/login',
+            description: 'Where you must go to log in.',
+        },
+    },
+};
+
+const validationErrorSchema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['errors', 'name'],
+    description: 'An API authorization error. Contains a path.',
+    properties: {
+        name: {
+            type: 'string',
+            enum: ['ValidationError'],
+            example: 'ValidationError',
+            description: 'The name of this authorization error type.',
+        },
+        errors: {
+            type: 'array',
+            description:
+                'A list of errors on the request body with description and suggestions.',
+            example: [
+                {
+                    description: 'The x property is wrong.',
+                    suggestion: 'Try doing it right.',
+                },
+            ],
+            items: {
+                type: 'object',
+                required: ['description', 'suggestion'],
+                properties: {
+                    description: { type: 'string' },
+                    suggestion: { type: 'string' },
+                },
+            },
+            example: '/auth/simple/login',
+            description: 'Where you must go to log in.',
+        },
+    },
+};
 
 export const fromLegacyError = (e: Error): UnleashError => {
     const type = UnleashApiErrorTypes.includes(e.name as UnleashApiErrorKind)

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -1,30 +1,6 @@
 import { v4 as uuidV4 } from 'uuid';
 import { FromSchema } from 'json-schema-to-ts';
 
-// const UnleashApiErrorTypes = {
-//     ValidationError: 400,
-//     BadDataError: 400,
-//     BadRequestError: 400,
-//     OwaspValidationError: 400,
-//     PasswordUndefinedError: 400,
-//     MinimumOneEnvironmentError: 400,
-//     InvalidTokenError: 401,
-//     NoAccessError: 403,
-//     UsedTokenError: 403,
-//     InvalidOperationError: 403,
-//     IncompatibleProjectError: 403,
-//     OperationDeniedError: 403,
-//     NotFoundError: 404,
-//     NameExistsError: 409,
-//     FeatureHasTagError: 409,
-//     RoleInUseError: 400,
-//     ProjectWithoutOwnerError: 409,
-//     TypeError: 400,
-//     UnknownError: 400,
-//     // server errors; not the end user's fault
-//     InternalError: 500,
-// } as const;
-
 const UnleashApiErrorTypes = [
     'ValidationError',
     'BadDataError',
@@ -44,13 +20,61 @@ const UnleashApiErrorTypes = [
     'RoleInUseError',
     'ProjectWithoutOwnerError',
     'UnknownError',
+    'PasswordMismatch',
+    'DisabledError',
+
     // server errors; not the end user's fault
     'InternalError',
 ] as const;
 
 type UnleashApiErrorKind = typeof UnleashApiErrorTypes[number];
 
-const statusCode = (errorKind: UnleashApiErrorKind) => {};
+export const statusCode = (errorKind: UnleashApiErrorKind): number => {
+    switch (errorKind) {
+        case 'ValidationError':
+            return 400;
+        case 'BadDataError':
+            return 400;
+        case 'BadRequestError':
+            return 400;
+        case 'OwaspValidationError':
+            return 400;
+        case 'PasswordUndefinedError':
+            return 400;
+        case 'MinimumOneEnvironmentError':
+            return 400;
+        case 'InvalidTokenError':
+            return 401;
+        case 'NoAccessError':
+            return 403;
+        case 'UsedTokenError':
+            return 403;
+        case 'InvalidOperationError':
+            return 403;
+        case 'IncompatibleProjectError':
+            return 403;
+        case 'OperationDeniedError':
+            return 403;
+        case 'NotFoundError':
+            return 404;
+        case 'NameExistsError':
+            return 409;
+        case 'FeatureHasTagError':
+            return 409;
+        case 'RoleInUseError':
+            return 400;
+        case 'ProjectWithoutOwnerError':
+            return 409;
+        case 'UnknownError':
+            return 400;
+        case 'InternalError':
+            return 500;
+        case 'PasswordMismatch':
+            return 401;
+        case 'DisabledError':
+            return 422;
+    }
+};
 
 type UnleashErrorData = {
     type: UnleashApiErrorKind;
@@ -61,9 +85,13 @@ type UnleashErrorData = {
 
 export class UnleashError implements Error {
     id: string;
+
     suggestion: string;
+
     name: UnleashApiErrorKind;
+
     message: string;
+
     documentationLink: string | null;
 
     constructor({
@@ -151,7 +179,7 @@ export const apiErrorSchema = {
     components: {},
 } as const;
 
-export const fromLegacyError = (e: Error): ApiErrorSchema => {
+export const fromLegacyError = (e: Error): UnleashError => {
     const type = UnleashApiErrorTypes.includes(e.name as UnleashApiErrorKind)
         ? (e.name as UnleashApiErrorKind)
         : 'UnknownError';
@@ -160,7 +188,7 @@ export const fromLegacyError = (e: Error): ApiErrorSchema => {
         type,
         message: e.message,
         suggestion: 'Tell Unleash about this suggestion being missing',
-    }).serialize();
+    });
 };
 
 export type ApiErrorSchema = FromSchema<typeof apiErrorSchema>;

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -132,12 +132,10 @@ type UnleashErrorData =
             }
       );
 
-export class UnleashError implements Error {
+export class UnleashError extends Error {
     id: string;
 
     name: UnleashApiErrorKind;
-
-    message: string;
 
     documentationLink: string | null;
 
@@ -151,10 +149,10 @@ export class UnleashError implements Error {
         documentationLink,
         ...rest
     }: UnleashErrorData) {
+        super(message);
         this.id = uuidV4();
-        this.name = name;
-        this.message = message;
         this.documentationLink = documentationLink ?? null;
+        this.name = name;
 
         this.statusCode = statusCode(name);
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -42,6 +42,10 @@ const AllUnleashApiErrorTypes = [
 ] as const;
 
 type UnleashApiErrorName = typeof AllUnleashApiErrorTypes[number];
+type UnleashApiErrorNameWithoutExtraData = Exclude<
+    UnleashApiErrorName,
+    typeof UnleashApiErrorTypesWithExtraData[number]
+>;
 
 const statusCode = (errorName: UnleashApiErrorName): number => {
     switch (errorName) {
@@ -111,14 +115,7 @@ type UnleashErrorData =
           documentationLink?: string;
       } & (
           | {
-                name: Exclude<
-                    UnleashApiErrorName,
-                    | 'NoAccessError'
-                    | 'AuthenticationRequired'
-                    | 'ValidationError'
-                    | 'BadDataError'
-                    | 'BadRequestError'
-                >;
+                name: UnleashApiErrorNameWithoutExtraData;
             }
           | {
                 name: 'NoAccessError';
@@ -240,7 +237,8 @@ export const fromLegacyError = (e: Error): UnleashError => {
             name: name as
                 | 'ValidationError'
                 | 'BadRequestError'
-                | 'BadDataError',
+                | 'BadDataError'
+                | 'MinimumOneEnvironmentError',
             message:
                 'Your request body failed to validate. Refer to the `details` list to see what happened.',
             details: [{ description: e.message, message: e.message }],
@@ -255,10 +253,10 @@ export const fromLegacyError = (e: Error): UnleashError => {
             type: 'password',
         });
     }
+
     return new UnleashError({
-        name,
+        name: name as UnleashApiErrorNameWithoutExtraData,
         message: e.message,
-        details: [{ description: 'Ignore this list', message: '' }],
     });
 };
 

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -40,10 +40,10 @@ const AllUnleashApiErrorTypes = [
     ...UnleashApiErrorTypesWithExtraData,
 ] as const;
 
-type UnleashApiErrorType = typeof AllUnleashApiErrorTypes[number];
+type UnleashApiErrorName = typeof AllUnleashApiErrorTypes[number];
 
-const statusCode = (errorKind: UnleashApiErrorType): number => {
-    switch (errorKind) {
+const statusCode = (errorName: UnleashApiErrorName): number => {
+    switch (errorName) {
         case 'ContentTypeError':
             return 415;
         case 'ValidationError':
@@ -107,7 +107,7 @@ type UnleashErrorData =
       } & (
           | {
                 name: Exclude<
-                    UnleashApiErrorType,
+                    UnleashApiErrorName,
                     | 'NoAccessError'
                     | 'AuthenticationRequired'
                     | 'ValidationError'
@@ -140,7 +140,7 @@ type UnleashErrorData =
 export class UnleashError extends Error {
     id: string;
 
-    name: UnleashApiErrorType;
+    name: UnleashApiErrorName;
 
     documentationLink: string | null;
 
@@ -214,8 +214,8 @@ export const apiErrorSchema = {
 } as const;
 
 export const fromLegacyError = (e: Error): UnleashError => {
-    const name = AllUnleashApiErrorTypes.includes(e.name as UnleashApiErrorType)
-        ? (e.name as UnleashApiErrorType)
+    const name = AllUnleashApiErrorTypes.includes(e.name as UnleashApiErrorName)
+        ? (e.name as UnleashApiErrorName)
         : 'UnknownError';
 
     if (name === 'NoAccessError') {

--- a/src/lib/error/no-access-error.ts
+++ b/src/lib/error/no-access-error.ts
@@ -1,31 +1,25 @@
-class NoAccessError extends Error {
-    permission: string;
+import { UnleashError } from './api-error';
 
-    name: string;
+class NoAccessError extends UnleashError {
+    permission: string;
 
     message: string;
 
     environment?: string;
 
     constructor(permission: string, environment?: string) {
-        super();
+        const message =
+            "You don't have the required permissions to perform this operation." +
+            environment
+                ? `You need the "${permission}" permission to perform this action in the "${environment}" environment.`
+                : `You need the "${permission}" permission to perform this action`;
+
+        super({
+            name: 'NoAccessError',
+            message,
+            permission,
+        });
         Error.captureStackTrace(this, this.constructor);
-
-        this.name = this.constructor.name;
-        this.permission = permission;
-        this.environment = environment;
-        if (environment) {
-            this.message = `You need permission=${permission} to perform this action on environment=${environment}`;
-        } else {
-            this.message = `You need permission=${permission} to perform this action`;
-        }
-    }
-
-    toJSON(): any {
-        return {
-            permission: this.permission,
-            message: this.message,
-        };
     }
 }
 

--- a/src/lib/error/no-access-error.ts
+++ b/src/lib/error/no-access-error.ts
@@ -1,18 +1,10 @@
 import { UnleashError } from './api-error';
 
 class NoAccessError extends UnleashError {
-    permission: string;
-
-    message: string;
-
-    environment?: string;
-
     constructor(permission: string, environment?: string) {
         const message =
-            "You don't have the required permissions to perform this operation." +
-            environment
-                ? `You need the "${permission}" permission to perform this action in the "${environment}" environment.`
-                : `You need the "${permission}" permission to perform this action`;
+            `You don't have the required permissions to perform this operation. You need the "${permission}" permission to perform this action` +
+            (environment ? ` in the "${environment}" environment.` : `.`);
 
         super({
             name: 'NoAccessError',

--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -44,6 +44,7 @@ import { isValidField } from './import-context-validation';
 import { IImportTogglesStore } from './import-toggles-store-type';
 import { ImportPermissionsService } from './import-permissions-service';
 import { ImportValidationMessages } from './import-validation-messages';
+import { UnleashError } from '../../error/api-error';
 
 export default class ExportImportService {
     private logger: Logger;
@@ -365,11 +366,16 @@ export default class ExportImportService {
             Array.isArray(unsupportedContextFields) &&
             unsupportedContextFields.length > 0
         ) {
-            throw new BadDataError(
-                `Context fields with errors: ${unsupportedContextFields
-                    .map((field) => field.name)
-                    .join(', ')}`,
-            );
+            throw new UnleashError({
+                name: 'BadDataError',
+                message:
+                    'Some of the context fields you are trying to import are not supported.',
+                // @ts-ignore-error We know that the array contains at least one
+                // element here.
+                errors: unsupportedContextFields.map((field) => ({
+                    description: `${field.name} is not supported.`,
+                })),
+            });
         }
     }
 
@@ -441,11 +447,16 @@ export default class ExportImportService {
     private async verifyStrategies(dto: ImportTogglesSchema) {
         const unsupportedStrategies = await this.getUnsupportedStrategies(dto);
         if (unsupportedStrategies.length > 0) {
-            throw new BadDataError(
-                `Unsupported strategies: ${unsupportedStrategies
-                    .map((strategy) => strategy.name)
-                    .join(', ')}`,
-            );
+            throw new UnleashError({
+                name: 'BadDataError',
+                message:
+                    'Some of the strategies you are trying to import are not supported.',
+                // @ts-ignore-error We know that the array contains at least one
+                // element here.
+                errors: unsupportedStrategies.map((strategy) => ({
+                    description: `${strategy.name} is not supported.`,
+                })),
+            });
         }
     }
 

--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -671,13 +671,11 @@ test('reject import with unknown context fields', async () => {
         400,
     );
 
-    expect(body).toMatchObject({
-        details: [
-            {
-                message: 'Context fields with errors: ContextField1',
-            },
-        ],
-    });
+    expect(
+        body.errors.includes((error) =>
+            error.description.includes('ContextField1'),
+        ),
+    );
 });
 
 test('reject import with unsupported strategies', async () => {
@@ -697,13 +695,11 @@ test('reject import with unsupported strategies', async () => {
         400,
     );
 
-    expect(body).toMatchObject({
-        details: [
-            {
-                message: 'Unsupported strategies: customStrategy',
-            },
-        ],
-    });
+    expect(
+        body.errors.includes((error) =>
+            error.description.includes('customStrategy'),
+        ),
+    );
 });
 
 test('validate import data', async () => {

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -1,6 +1,5 @@
 import { IAuthRequest } from '../routes/unleash-types';
 import { NextFunction, Response } from 'express';
-import AuthenticationRequired from '../types/authentication-required';
 import { LogProvider } from '../logger';
 import { UnleashError } from '../error/api-error';
 

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -31,7 +31,7 @@ const authorizationMiddleware = (
             // API clients should get 401 without body
             return res.status(401).json(
                 new UnleashError({
-                    type: 'PasswordMismatchError',
+                    name: 'PasswordMismatchError',
                     message: 'You must log in to use Unleash.',
                     suggestion: 'Noh.',
                 }),
@@ -41,7 +41,7 @@ const authorizationMiddleware = (
         // const authRequired = await generateAuthResponse();
         return res.status(401).json(
             new UnleashError({
-                type: 'PasswordMismatchError',
+                name: 'PasswordMismatchError',
                 message:
                     'You must log in to use Unleash. Your request had no authorization header, so we could not authorize you.',
                 suggestion: `Log in using ${baseUriPath}/auth/simple/login.`,

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -37,22 +37,15 @@ const authorizationMiddleware = (
             );
         }
 
-        const newLogin = true;
-        if (newLogin) {
-            const path = `${baseUriPath}/auth/simple/login`;
-            const error = new UnleashError({
-                name: 'AuthenticationRequired',
-                message: `You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at ${baseUriPath}/auth/simple/login.`,
-                type: 'password',
-                path,
-            });
+        const path = `${baseUriPath}/auth/simple/login`;
+        const error = new UnleashError({
+            name: 'AuthenticationRequired',
+            message: `You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at ${baseUriPath}/auth/simple/login.`,
+            type: 'password',
+            path,
+        });
 
-            return res.status(error.statusCode).json(error);
-        } else {
-            // Admin UI users should get auth-response
-            const authRequired = await generateAuthResponse();
-            return res.status(401).json(authRequired);
-        }
+        return res.status(error.statusCode).json(error);
     };
 };
 

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -12,13 +12,6 @@ const authorizationMiddleware = (
     const logger = getLogger('/middleware/authorization-middleware.ts');
     logger.debug('Enabling Authorization middleware');
 
-    const generateAuthResponse = async () =>
-        new AuthenticationRequired({
-            type: 'password',
-            path: `${baseUriPath}/auth/simple/login`,
-            message: 'You must sign in order to use Unleash',
-        });
-
     return async (req: IAuthRequest, res: Response, next: NextFunction) => {
         if (req.session && req.session.user) {
             req.user = req.session.user;

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -33,20 +33,26 @@ const authorizationMiddleware = (
                 new UnleashError({
                     name: 'PasswordMismatchError',
                     message: 'You must log in to use Unleash.',
-                    suggestion: 'Noh.',
                 }),
             );
         }
-        // Admin UI users should get auth-response
-        // const authRequired = await generateAuthResponse();
-        return res.status(401).json(
-            new UnleashError({
-                name: 'PasswordMismatchError',
-                message:
-                    'You must log in to use Unleash. Your request had no authorization header, so we could not authorize you.',
-                suggestion: `Log in using ${baseUriPath}/auth/simple/login.`,
-            }),
-        );
+
+        const newLogin = true;
+        if (newLogin) {
+            const path = `${baseUriPath}/auth/simple/login`;
+            const error = new UnleashError({
+                name: 'AuthenticationRequired',
+                message: `You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at ${baseUriPath}/auth/simple/login.`,
+                type: 'password',
+                path,
+            });
+
+            return res.status(error.statusCode).json(error);
+        } else {
+            // Admin UI users should get auth-response
+            const authRequired = await generateAuthResponse();
+            return res.status(401).json(authRequired);
+        }
     };
 };
 

--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -2,6 +2,7 @@ import { IAuthRequest } from '../routes/unleash-types';
 import { NextFunction, Response } from 'express';
 import AuthenticationRequired from '../types/authentication-required';
 import { LogProvider } from '../logger';
+import { UnleashError } from '../error/api-error';
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 const authorizationMiddleware = (
@@ -28,11 +29,24 @@ const authorizationMiddleware = (
         }
         if (req.header('authorization')) {
             // API clients should get 401 without body
-            return res.sendStatus(401);
+            return res.status(401).json(
+                new UnleashError({
+                    type: 'PasswordMismatchError',
+                    message: 'You must log in to use Unleash.',
+                    suggestion: 'Noh.',
+                }),
+            );
         }
         // Admin UI users should get auth-response
-        const authRequired = await generateAuthResponse();
-        return res.status(401).json(authRequired);
+        // const authRequired = await generateAuthResponse();
+        return res.status(401).json(
+            new UnleashError({
+                type: 'PasswordMismatchError',
+                message:
+                    'You must log in to use Unleash. Your request had no authorization header, so we could not authorize you.',
+                suggestion: `Log in using ${baseUriPath}/auth/simple/login.`,
+            }),
+        );
     };
 };
 

--- a/src/lib/middleware/content_type_checker.test.ts
+++ b/src/lib/middleware/content_type_checker.test.ts
@@ -16,7 +16,10 @@ const returns415: (t: jest.Mock) => Response = (t) => ({
     status: (code) => {
         expect(415).toBe(code);
         return {
-            end: t,
+            json: () => ({
+                // @ts-ignore
+                end: t,
+            }),
         };
     },
 });
@@ -25,7 +28,10 @@ const expectNoCall: (t: jest.Mock) => Response = (t) => ({
     // @ts-ignore
     status: () => ({
         // @ts-ignore
-        end: () => expect(t).toHaveBeenCalledTimes(0),
+        json: () => ({
+            // @ts-ignore
+            end: () => expect(t).toHaveBeenCalledTimes(0),
+        }),
     }),
 });
 

--- a/src/lib/middleware/content_type_checker.ts
+++ b/src/lib/middleware/content_type_checker.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express';
-import { statusCode, UnleashError } from '../error/api-error';
+import { UnleashError } from '../error/api-error';
 import { is } from 'type-is';
 
 const DEFAULT_ACCEPTED_CONTENT_TYPE = 'application/json';
@@ -26,12 +26,11 @@ export default function requireContentType(
                 name: 'ContentTypeError',
                 message: `We do not accept the content-type you provided (${
                     contentType || "you didn't provide one"
-                }).`,
-                suggestion: `Try using one of the content-types we accept instead (${acceptedContentTypes.join(
+                }). Try using one of the content-types we do accept instead (${acceptedContentTypes.join(
                     ', ',
                 )}) and make sure the body is in the corresponding format.`,
             });
-            res.status(statusCode(error.name)).json(error).end();
+            res.status(error.statusCode).json(error).end();
         }
     };
 }

--- a/src/lib/middleware/content_type_checker.ts
+++ b/src/lib/middleware/content_type_checker.ts
@@ -23,7 +23,7 @@ export default function requireContentType(
             next();
         } else {
             const error = new UnleashError({
-                type: 'ContentTypeError',
+                name: 'ContentTypeError',
                 message: `We do not accept the content-type you provided (${
                     contentType || "you didn't provide one"
                 }).`,

--- a/src/lib/middleware/content_type_checker.ts
+++ b/src/lib/middleware/content_type_checker.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express';
+import { statusCode, UnleashError } from '../error/api-error';
 import { is } from 'type-is';
 
 const DEFAULT_ACCEPTED_CONTENT_TYPE = 'application/json';
@@ -21,7 +22,16 @@ export default function requireContentType(
         if (is(contentType, acceptedContentTypes)) {
             next();
         } else {
-            res.status(415).end();
+            const error = new UnleashError({
+                type: 'ContentTypeError',
+                message: `We do not accept the content-type you provided (${
+                    contentType || "you didn't provide one"
+                }).`,
+                suggestion: `Try using one of the content-types we accept instead (${acceptedContentTypes.join(
+                    ', ',
+                )}) and make sure the body is in the corresponding format.`,
+            });
+            res.status(statusCode(error.name)).json(error).end();
         }
     };
 }

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -5,33 +5,206 @@ export const emptyResponse = {
 const unauthorizedResponse = {
     description:
         'Authorization information is missing or invalid. Provide a valid API token as the `authorization` header, e.g. `authorization:*.*.my-admin-token`.',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'AuthenticationRequired',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example:
+                            'You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.',
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const forbiddenResponse = {
     description:
         'User credentials are valid but does not have enough privileges to execute this operation',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'NoAccessError',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example:
+                            'You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.',
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const badRequestResponse = {
     description: 'The request data does not match what we expect.',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'ValidationError',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example: `The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].`,
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const notFoundResponse = {
     description: 'The requested resource was not found.',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'NotFoundError',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example: `Could not find the addon with ID "12345".`,
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const conflictResponse = {
     description:
         'The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively.',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'NameExistsError',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example:
+                            'There is already a feature called "my-awesome-feature".',
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const contentTooLargeResponse = {
     description:
         'The request body is larger than what we accept. By default we only accept bodies of 100kB or less',
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'ContentTooLarge',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example:
+                            'You provided more data than we can handle. Unleash accepts at most X MB.',
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const unsupportedMediaTypeResponse = {
     description: `The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.`,
+    content: {
+        'application/json': {
+            schema: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        example: '9c40958a-daac-400e-98fb-3bb438567008',
+                        description: 'The ID of the error instance',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'ContentTypeerror',
+                        description: 'The name of the error kind',
+                    },
+                    message: {
+                        type: 'string',
+                        example:
+                            'We do not accept the content-type you provided (application/xml). Try using one of the content-types we do accept instead (application/json) and make sure the body is in the corresponding format.',
+                        description: 'A description of what went wrong.',
+                    },
+                },
+            },
+        },
+    },
 } as const;
 
 const standardResponses = {

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -27,7 +27,7 @@ const conflictResponse = {
 
 const contentTooLargeResponse = {
     description:
-        'The body request body is larger than what we accept. By default we only accept bodies of 100kB or less',
+        'The request body is larger than what we accept. By default we only accept bodies of 100kB or less',
 } as const;
 
 const unsupportedMediaTypeResponse = {

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -121,7 +121,7 @@ Note: passing \`null\` as a value for the description property will set it to an
                     requestBody: createRequestSchema('addonCreateUpdateSchema'),
                     responses: {
                         200: createResponseSchema('addonSchema'),
-                        ...getStandardResponses(400, 401, 403, 413, 415),
+                        ...getStandardResponses(400, 401, 403, 404, 413, 415),
                     },
                 }),
             ],
@@ -142,7 +142,7 @@ Note: passing \`null\` as a value for the description property will set it to an
                     operationId: 'deleteAddon',
                     responses: {
                         200: emptyResponse,
-                        ...getStandardResponses(401, 403),
+                        ...getStandardResponses(401, 403, 404),
                     },
                 }),
             ],

--- a/src/lib/routes/admin-api/strategy.test.ts
+++ b/src/lib/routes/admin-api/strategy.test.ts
@@ -53,8 +53,10 @@ test('require a name when creating a new strategy', async () => {
         .send({})
         .expect(400)
         .expect((res) => {
-            expect(res.body.validation[0].message).toEqual(
-                "should have required property 'name'",
+            expect(
+                ['name', 'property', 'required'].every((word) =>
+                    res.body.errors[0].description.includes(word),
+                ),
             );
         });
 });
@@ -66,7 +68,7 @@ test('require parameters array when creating a new strategy', async () => {
         .send({ name: 'TestStrat' })
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toEqual(
+            expect(res.body.errors[0].description).toEqual(
                 '"parameters" is required',
             );
         });

--- a/src/lib/routes/admin-api/strategy.test.ts
+++ b/src/lib/routes/admin-api/strategy.test.ts
@@ -55,7 +55,7 @@ test('require a name when creating a new strategy', async () => {
         .expect((res) => {
             expect(
                 ['name', 'property', 'required'].every((word) =>
-                    res.body.errors[0].description.includes(word),
+                    res.body.details[0].description.includes(word),
                 ),
             );
         });
@@ -68,7 +68,7 @@ test('require parameters array when creating a new strategy', async () => {
         .send({ name: 'TestStrat' })
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toEqual(
+            expect(res.body.details[0].description).toEqual(
                 '"parameters" is required',
             );
         });

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -20,6 +20,7 @@ import {
 import { Context } from 'unleash-client';
 import { enrichContextWithIp } from '../../proxy';
 import { corsOriginMiddleware } from '../../middleware';
+import { UnleashError } from '../../error/api-error';
 
 interface ApiUserRequest<
     PARAM = any,
@@ -135,9 +136,11 @@ export default class ProxyController extends Controller {
         req: ApiUserRequest,
         res: Response,
     ) {
-        res.status(405).json({
+        const error = new UnleashError({
+            name: 'NotImplementedError',
             message: 'The frontend API does not support this endpoint.',
         });
+        res.status(error.statusCode).json(error);
     }
 
     private async getProxyFeatures(

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import { Response } from 'express';
 import { Logger } from '../logger';
-import { fromLegacyError, statusCode } from '../error/api-error';
+import { fromLegacyError } from '../error/api-error';
 
 export const customJoi = joi.extend((j) => ({
     type: 'isUrlFriendly',
@@ -37,5 +37,5 @@ export const handleErrors: (
         logger.error('Server failed executing request', error);
     }
 
-    return res.status(statusCode(newError.name)).json(newError).end();
+    return res.status(newError.statusCode).json(newError).end();
 };

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import { Response } from 'express';
 import { Logger } from '../logger';
-import { fromLegacyError } from '../error/api-error';
+import { fromLegacyError, UnleashError } from '../error/api-error';
 
 export const customJoi = joi.extend((j) => ({
     type: 'isUrlFriendly',
@@ -31,11 +31,12 @@ export const handleErrors: (
     // eslint-disable-next-line no-param-reassign
     error.isJoi = true;
 
-    const newError = fromLegacyError(error);
+    const finalError =
+        error instanceof UnleashError ? error : fromLegacyError(error);
 
-    if (['InternalError', 'UnknownError'].includes(newError.name)) {
+    if (['InternalError', 'UnknownError'].includes(finalError.name)) {
         logger.error('Server failed executing request', error);
     }
 
-    return res.status(newError.statusCode).json(newError).end();
+    return res.status(finalError.statusCode).json(finalError).end();
 };

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -212,10 +212,11 @@ export default class AddonService {
         data: IAddonDto,
         userName: string,
     ): Promise<IAddon> {
+        const existingConfig = await this.addonStore.get(id); // because getting an early 404 here makes more sense
         const addonConfig = await addonSchema.validateAsync(data);
+        await this.validateKnownProvider(addonConfig);
         await this.validateRequiredParameters(addonConfig);
         if (this.sensitiveParams[addonConfig.provider].length > 0) {
-            const existingConfig = await this.addonStore.get(id);
             addonConfig.parameters = Object.keys(addonConfig.parameters).reduce(
                 (params, key) => {
                     const o = { ...params };

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -60,88 +60,6 @@ export class OpenApiService {
     useErrorHandler(app: Express): void {
         app.use((err, req, res, next) => {
             if (err && err.status && err.validationErrors) {
-                // const requiredError = {
-                //     error: 'Request validation failed',
-                //     validation: [
-                //         {
-                //             keyword: 'required',
-                //             dataPath: '.body',
-                //             schemaPath:
-                //                 '#/components/schemas/addonCreateUpdateSchema/required',
-                //             params: {
-                //                 missingProperty: 'enabled',
-                //             },
-                //             message: "should have required property 'enabled'",
-                //         },
-                //     ],
-                // };
-
-                // const typeError = {
-                //     error: 'Request validation failed',
-                //     validation: [
-                //         {
-                //             keyword: 'type',
-                //             dataPath: '.body.parameters',
-                //             schemaPath:
-                //                 '#/components/schemas/addonCreateUpdateSchema/properties/parameters/type',
-                //             params: {
-                //                 type: 'object',
-                //             },
-                //             message: 'should be object',
-                //         },
-                //     ],
-                // };
-                // const patternError = {
-                //     error: 'Request validation failed',
-                //     validation: [
-                //         {
-                //             keyword: 'pattern',
-                //             dataPath: '.body.description',
-                //             schemaPath:
-                //                 '#/components/schemas/addonCreateUpdateSchema/properties/description/pattern',
-                //             params: {
-                //                 pattern: '^this is',
-                //             },
-                //             message: 'should match pattern "^this is"',
-                //         },
-                //     ],
-                // };
-
-                // const maxLength = {
-                //     // minlength is equivalent
-                //     error: 'Request validation failed',
-                //     validation: [
-                //         {
-                //             keyword: 'maxLength',
-                //             dataPath: '.body.description',
-                //             schemaPath:
-                //                 '#/components/schemas/addonCreateUpdateSchema/properties/description/maxLength',
-                //             params: {
-                //                 limit: 5,
-                //             },
-                //             message: 'should NOT be longer than 5 characters',
-                //         },
-                //     ],
-                // };
-
-                // const integerMax = {
-                //     error: 'Request validation failed',
-                //     validation: [
-                //         {
-                //             keyword: 'maximum',
-                //             dataPath: '.body.newprop',
-                //             schemaPath:
-                //                 '#/components/schemas/addonCreateUpdateSchema/properties/newprop/maximum',
-                //             params: {
-                //                 comparison: '<=',
-                //                 limit: 5,
-                //                 exclusive: false,
-                //             },
-                //             message: 'should be <= 5',
-                //         },
-                //     ],
-                // };
-
                 const errors = err.validationErrors.map((validationError) => {
                     const propertyName = validationError.dataPath.substring(
                         '.body.'.length,
@@ -156,11 +74,7 @@ export class OpenApiService {
                             description: `The ${path} property is required. It was not present on the data you sent.`,
                         };
                     } else {
-                        console.log('the error is:', validationError);
-                        const youSent = JSON.stringify(
-                            // @ts-ignore-error it does exist
-                            req.body[propertyName],
-                        );
+                        const youSent = JSON.stringify(req.body[propertyName]);
                         return {
                             description: `The .${propertyName} property ${validationError.message}. You sent ${youSent}.`,
                             path: propertyName,

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -87,7 +87,7 @@ export class OpenApiService {
                         : regularText(err.validationErrors[0]);
 
                 const apiError = new UnleashError({
-                    type: 'BadRequestError',
+                    name: 'BadRequestError',
                     message:
                         "The request payload you provided doesn't conform to the schema.",
                     suggestion: description,

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -12,7 +12,7 @@ import { ApiOperation } from '../openapi/util/api-operation';
 import { Logger } from '../logger';
 import { validateSchema } from '../openapi/validate';
 import { IFlagResolver } from '../types';
-import { statusCode, UnleashError } from '../error/api-error';
+import { UnleashError } from '../error/api-error';
 
 export class OpenApiService {
     private readonly config: IUnleashConfig;
@@ -60,6 +60,88 @@ export class OpenApiService {
     useErrorHandler(app: Express): void {
         app.use((err, req, res, next) => {
             if (err && err.status && err.validationErrors) {
+                // const requiredError = {
+                //     error: 'Request validation failed',
+                //     validation: [
+                //         {
+                //             keyword: 'required',
+                //             dataPath: '.body',
+                //             schemaPath:
+                //                 '#/components/schemas/addonCreateUpdateSchema/required',
+                //             params: {
+                //                 missingProperty: 'enabled',
+                //             },
+                //             message: "should have required property 'enabled'",
+                //         },
+                //     ],
+                // };
+
+                // const typeError = {
+                //     error: 'Request validation failed',
+                //     validation: [
+                //         {
+                //             keyword: 'type',
+                //             dataPath: '.body.parameters',
+                //             schemaPath:
+                //                 '#/components/schemas/addonCreateUpdateSchema/properties/parameters/type',
+                //             params: {
+                //                 type: 'object',
+                //             },
+                //             message: 'should be object',
+                //         },
+                //     ],
+                // };
+                // const patternError = {
+                //     error: 'Request validation failed',
+                //     validation: [
+                //         {
+                //             keyword: 'pattern',
+                //             dataPath: '.body.description',
+                //             schemaPath:
+                //                 '#/components/schemas/addonCreateUpdateSchema/properties/description/pattern',
+                //             params: {
+                //                 pattern: '^this is',
+                //             },
+                //             message: 'should match pattern "^this is"',
+                //         },
+                //     ],
+                // };
+
+                // const maxLength = {
+                //     // minlength is equivalent
+                //     error: 'Request validation failed',
+                //     validation: [
+                //         {
+                //             keyword: 'maxLength',
+                //             dataPath: '.body.description',
+                //             schemaPath:
+                //                 '#/components/schemas/addonCreateUpdateSchema/properties/description/maxLength',
+                //             params: {
+                //                 limit: 5,
+                //             },
+                //             message: 'should NOT be longer than 5 characters',
+                //         },
+                //     ],
+                // };
+
+                // const integerMax = {
+                //     error: 'Request validation failed',
+                //     validation: [
+                //         {
+                //             keyword: 'maximum',
+                //             dataPath: '.body.newprop',
+                //             schemaPath:
+                //                 '#/components/schemas/addonCreateUpdateSchema/properties/newprop/maximum',
+                //             params: {
+                //                 comparison: '<=',
+                //                 limit: 5,
+                //                 exclusive: false,
+                //             },
+                //             message: 'should be <= 5',
+                //         },
+                //     ],
+                // };
+
                 const requiredText = (validationError: ErrorObject) => {
                     console.log('the error is:', validationError);
 
@@ -89,11 +171,11 @@ export class OpenApiService {
                 const apiError = new UnleashError({
                     name: 'BadRequestError',
                     message:
-                        "The request payload you provided doesn't conform to the schema.",
-                    suggestion: description,
+                        "The request payload you provided doesn't conform to the schema." +
+                        description,
                 });
 
-                res.status(statusCode(apiError.name)).json(apiError);
+                res.status(apiError.statusCode).json(apiError);
             } else {
                 next(err);
             }

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -1,6 +1,5 @@
 import openapi, { IExpressOpenApi } from '@unleash/express-openapi';
 import { Express, RequestHandler, Response } from 'express';
-import { ErrorObject } from 'ajv';
 import { IUnleashConfig } from '../types/option';
 import {
     createOpenApiSchema,

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -302,9 +302,8 @@ class UserService {
 
         throw new UnleashError({
             name: 'PasswordMismatchError',
-            message: 'The password you provided does not match the username.',
-            suggestion:
-                "Ensure that the password is correct for the username you're using and try again. If you have forgotten your password ... ",
+            message:
+                'The password you provided does not match the username. If you have forgotten your password ...',
         });
         // throw new PasswordMismatch();
     }

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -78,12 +78,15 @@ class UserService {
 
     private passwordResetTimeouts: { [key: string]: NodeJS.Timeout } = {};
 
+    private baseUriPath: string;
+
     constructor(
         stores: Pick<IUnleashStores, 'userStore' | 'eventStore'>,
         {
+            config,
             getLogger,
             authentication,
-        }: Pick<IUnleashConfig, 'getLogger' | 'authentication'>,
+        }: Pick<IUnleashConfig, 'getLogger' | 'authentication' | 'server'>,
         services: {
             accessService: AccessService;
             resetTokenService: ResetTokenService;
@@ -103,6 +106,8 @@ class UserService {
         if (authentication && authentication.createAdminUser) {
             process.nextTick(() => this.initAdminUser());
         }
+
+        this.baseUriPath = config.server.baseUriPath || '';
     }
 
     validatePassword(password: string): boolean {
@@ -301,8 +306,7 @@ class UserService {
 
         throw new UnleashError({
             name: 'PasswordMismatchError',
-            message:
-                'The password you provided does not match the username. If you have forgotten your password ...',
+            message: `The combination of password and username you provided is invalid. If you have forgotten your password, visit ${this.baseUriPath}/forgotten-password or get in touch with your instance administrator.`,
         });
     }
 

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -305,7 +305,6 @@ class UserService {
             message:
                 'The password you provided does not match the username. If you have forgotten your password ...',
         });
-        // throw new PasswordMismatch();
     }
 
     /**

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -83,7 +83,7 @@ class UserService {
     constructor(
         stores: Pick<IUnleashStores, 'userStore' | 'eventStore'>,
         {
-            config,
+            server,
             getLogger,
             authentication,
         }: Pick<IUnleashConfig, 'getLogger' | 'authentication' | 'server'>,
@@ -107,7 +107,7 @@ class UserService {
             process.nextTick(() => this.initAdminUser());
         }
 
-        this.baseUriPath = config.server.baseUriPath || '';
+        this.baseUriPath = server.baseUriPath || '';
     }
 
     validatePassword(password: string): boolean {

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -24,10 +24,11 @@ import SettingService from './setting-service';
 import { SimpleAuthSettings } from '../server-impl';
 import { simpleAuthSettingsKey } from '../types/settings/simple-auth-settings';
 import DisabledError from '../error/disabled-error';
-import PasswordMismatch from '../error/password-mismatch';
+// import PasswordMismatch from '../error/password-mismatch';
 import BadDataError from '../error/bad-data-error';
 import { isDefined } from '../util/isDefined';
 import { TokenUserSchema } from '../openapi/spec/token-user-schema';
+import { UnleashError } from '../error/api-error';
 
 const systemUser = new User({ id: -1, username: 'system' });
 
@@ -298,7 +299,14 @@ class UserService {
             await this.store.successfullyLogin(user);
             return user;
         }
-        throw new PasswordMismatch();
+
+        throw new UnleashError({
+            type: 'PasswordMismatchError',
+            message: 'The password you provided does not match the username.',
+            suggestion:
+                "Ensure that the password is correct for the username you're using and try again. If you have forgotten your password ... ",
+        });
+        // throw new PasswordMismatch();
     }
 
     /**

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -301,7 +301,7 @@ class UserService {
         }
 
         throw new UnleashError({
-            type: 'PasswordMismatchError',
+            name: 'PasswordMismatchError',
             message: 'The password you provided does not match the username.',
             suggestion:
                 "Ensure that the password is correct for the username you're using and try again. If you have forgotten your password ... ",

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -24,7 +24,6 @@ import SettingService from './setting-service';
 import { SimpleAuthSettings } from '../server-impl';
 import { simpleAuthSettingsKey } from '../types/settings/simple-auth-settings';
 import DisabledError from '../error/disabled-error';
-// import PasswordMismatch from '../error/password-mismatch';
 import BadDataError from '../error/bad-data-error';
 import { isDefined } from '../util/isDefined';
 import { TokenUserSchema } from '../openapi/spec/token-user-schema';

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -258,7 +258,7 @@ test('should not create token for invalid projectId', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details[0].description).toMatch(
                 /bogus-project-something/,
             );
         });
@@ -275,7 +275,7 @@ test('should not create token for invalid environment', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details[0].description).toMatch(
                 /bogus-environment-something/,
             );
         });

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -258,7 +258,7 @@ test('should not create token for invalid projectId', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors[0].description).toMatch(
                 /bogus-project-something/,
             );
         });
@@ -275,7 +275,7 @@ test('should not create token for invalid environment', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors[0].description).toMatch(
                 /bogus-environment-something/,
             );
         });

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -324,7 +324,6 @@ test('refuses to create a new feature toggle with variant when type is json but 
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].type).toBe('invalidJsonString');
             expect(res.body.errors[0].description).toBe(
                 `'value' must be a valid json string when 'type' is json`,
             );

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -324,9 +324,9 @@ test('refuses to create a new feature toggle with variant when type is json but 
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.isJoi).toBe(true);
-            expect(res.body.details[0].type).toBe('invalidJsonString');
-            expect(res.body.details[0].message).toBe(
+            console.log(res.body);
+            expect(res.body.errors[0].type).toBe('invalidJsonString');
+            expect(res.body.errors[0].description).toBe(
                 `'value' must be a valid json string when 'type' is json`,
             );
         });

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -324,7 +324,7 @@ test('refuses to create a new feature toggle with variant when type is json but 
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toBe(
+            expect(res.body.details[0].description).toBe(
                 `'value' must be a valid json string when 'type' is json`,
             );
         });

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -324,7 +324,6 @@ test('refuses to create a new feature toggle with variant when type is json but 
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            console.log(res.body);
             expect(res.body.errors[0].type).toBe('invalidJsonString');
             expect(res.body.errors[0].description).toBe(
                 `'value' must be a valid json string when 'type' is json`,

--- a/src/test/e2e/api/admin/project/environments.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/environments.e2e.test.ts
@@ -100,7 +100,7 @@ test('Should not remove environment from project if project only has one environ
         .delete(`/api/admin/projects/default/environments/default`)
         .expect(400)
         .expect((r) => {
-            expect(r.body.details[0].message).toBe(
+            expect(r.body.errors[0].description).toBe(
                 'You must always have one active environment',
             );
         });

--- a/src/test/e2e/api/admin/project/environments.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/environments.e2e.test.ts
@@ -100,7 +100,7 @@ test('Should not remove environment from project if project only has one environ
         .delete(`/api/admin/projects/default/environments/default`)
         .expect(400)
         .expect((r) => {
-            expect(r.body.errors[0].description).toBe(
+            expect(r.body.details[0].description).toBe(
                 'You must always have one active environment',
             );
         });

--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -184,7 +184,8 @@ test('Trying to add a strategy configuration to environment not connected to tog
         })
         .expect(400)
         .expect((r) => {
-            expect(r.body.message).toContain('environment', 'project');
+            expect(r.body.message.includes('environment'));
+            expect(r.body.message.includes('project'));
         });
 });
 
@@ -775,9 +776,11 @@ test('Trying to patch variants on a feature toggle should trigger an OperationDe
         ])
         .expect(403)
         .expect((res) => {
-            expect(res.body.message).toContain(
-                'PATCH',
-                '/api/admin/projects/:project/features/:feature/variants',
+            expect(res.body.message.includes('PATCH'));
+            expect(
+                res.body.message.includes(
+                    '/api/admin/projects/:project/features/:feature/variants',
+                ),
             );
         });
 });

--- a/src/test/e2e/api/admin/project/features.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/features.e2e.test.ts
@@ -184,9 +184,7 @@ test('Trying to add a strategy configuration to environment not connected to tog
         })
         .expect(400)
         .expect((r) => {
-            expect(r.body.details[0].message).toBe(
-                'You have not added the current environment to the project',
-            );
+            expect(r.body.message).toContain('environment', 'project');
         });
 });
 
@@ -777,8 +775,9 @@ test('Trying to patch variants on a feature toggle should trigger an OperationDe
         ])
         .expect(403)
         .expect((res) => {
-            expect(res.body.details[0].message).toEqual(
-                'Changing variants is done via PATCH operation to /api/admin/projects/:project/features/:feature/variants',
+            expect(res.body.message).toContain(
+                'PATCH',
+                '/api/admin/projects/:project/features/:feature/variants',
             );
         });
 });

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -848,8 +848,8 @@ test('If sum of fixed variant weight exceed 1000 fails with 400', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details).toHaveLength(1);
-            expect(res.body.details[0].message).toEqual(
+            expect(res.body.errors).toHaveLength(1);
+            expect(res.body.errors[0].description).toEqual(
                 'The traffic distribution total must equal 100%',
             );
         });
@@ -962,7 +962,7 @@ test('PATCH endpoint validates uniqueness of variant names', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors[0].description).toMatch(
                 /contains a duplicate value/,
             );
         });
@@ -998,7 +998,7 @@ test('PUT endpoint validates uniqueness of variant names', async () => {
         ])
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors[0].description).toMatch(
                 /contains a duplicate value/,
             );
         });

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -488,8 +488,8 @@ test('PUTing an invalid variant throws 400 exception', async () => {
         .send(invalidJson)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details).toHaveLength(1);
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors).toHaveLength(1);
+            expect(res.body.errors[0].description).toMatch(
                 /.*weightType" must be one of/,
             );
         });
@@ -523,8 +523,8 @@ test('Invalid variant in PATCH also throws 400 exception', async () => {
         .send(invalidPatch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details).toHaveLength(1);
-            expect(res.body.details[0].message).toMatch(
+            expect(res.body.errors).toHaveLength(1);
+            expect(res.body.errors[0].description).toMatch(
                 /.*weight" must be less than or equal to 1000/,
             );
         });
@@ -651,8 +651,10 @@ test('PATCHING with no variable variants fails with 400', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details).toHaveLength(1);
-            expect(res.body.details[0].message).toEqual(
+            console.log(res.body);
+
+            expect(res.body.errors).toHaveLength(1);
+            expect(res.body.errors[0].description).toEqual(
                 'There must be at least one "variable" variant',
             );
         });

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -651,8 +651,6 @@ test('PATCHING with no variable variants fails with 400', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            console.log(res.body);
-
             expect(res.body.errors).toHaveLength(1);
             expect(res.body.errors[0].description).toEqual(
                 'There must be at least one "variable" variant',

--- a/src/test/e2e/api/admin/project/variants.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/variants.e2e.test.ts
@@ -488,8 +488,8 @@ test('PUTing an invalid variant throws 400 exception', async () => {
         .send(invalidJson)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors).toHaveLength(1);
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details).toHaveLength(1);
+            expect(res.body.details[0].description).toMatch(
                 /.*weightType" must be one of/,
             );
         });
@@ -523,8 +523,8 @@ test('Invalid variant in PATCH also throws 400 exception', async () => {
         .send(invalidPatch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors).toHaveLength(1);
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details).toHaveLength(1);
+            expect(res.body.details[0].description).toMatch(
                 /.*weight" must be less than or equal to 1000/,
             );
         });
@@ -651,8 +651,8 @@ test('PATCHING with no variable variants fails with 400', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors).toHaveLength(1);
-            expect(res.body.errors[0].description).toEqual(
+            expect(res.body.details).toHaveLength(1);
+            expect(res.body.details[0].description).toEqual(
                 'There must be at least one "variable" variant',
             );
         });
@@ -846,8 +846,8 @@ test('If sum of fixed variant weight exceed 1000 fails with 400', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors).toHaveLength(1);
-            expect(res.body.errors[0].description).toEqual(
+            expect(res.body.details).toHaveLength(1);
+            expect(res.body.details[0].description).toEqual(
                 'The traffic distribution total must equal 100%',
             );
         });
@@ -960,7 +960,7 @@ test('PATCH endpoint validates uniqueness of variant names', async () => {
         .send(patch)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details[0].description).toMatch(
                 /contains a duplicate value/,
             );
         });
@@ -996,7 +996,7 @@ test('PUT endpoint validates uniqueness of variant names', async () => {
         ])
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toMatch(
+            expect(res.body.details[0].description).toMatch(
                 /contains a duplicate value/,
             );
         });

--- a/src/test/e2e/api/admin/tag-types.e2e.test.ts
+++ b/src/test/e2e/api/admin/tag-types.e2e.test.ts
@@ -77,7 +77,7 @@ test('Invalid tag types gets rejected', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toBe(
+            expect(res.body.details[0].description).toBe(
                 '"name" must be URL friendly',
             );
         });
@@ -151,7 +151,7 @@ test('Invalid tag-types get refused by validator', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toBe(
+            expect(res.body.details[0].description).toBe(
                 '"name" must be URL friendly',
             );
         });

--- a/src/test/e2e/api/admin/tag-types.e2e.test.ts
+++ b/src/test/e2e/api/admin/tag-types.e2e.test.ts
@@ -77,7 +77,7 @@ test('Invalid tag types gets rejected', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toBe(
+            expect(res.body.errors[0].description).toBe(
                 '"name" must be URL friendly',
             );
         });
@@ -151,7 +151,7 @@ test('Invalid tag-types get refused by validator', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toBe(
+            expect(res.body.errors[0].description).toBe(
                 '"name" must be URL friendly',
             );
         });

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -86,8 +86,8 @@ test('Can validate a tag', async () =>
         .expect('Content-Type', /json/)
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors.length).toBe(1);
-            expect(res.body.errors[0].description).toBe(
+            expect(res.body.details.length).toBe(1);
+            expect(res.body.details[0].description).toBe(
                 '"type" must be URL friendly',
             );
         }));

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -86,8 +86,8 @@ test('Can validate a tag', async () =>
         .expect('Content-Type', /json/)
         .expect(400)
         .expect((res) => {
-            expect(res.body.details.length).toBe(1);
-            expect(res.body.details[0].message).toBe(
+            expect(res.body.errors.length).toBe(1);
+            expect(res.body.errors[0].description).toBe(
                 '"type" must be URL friendly',
             );
         }));

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -145,7 +145,7 @@ test('should require username or email on create', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].message).toEqual(
+            expect(res.body.errors[0].description).toEqual(
                 'You must specify username or email',
             );
         });

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -145,7 +145,7 @@ test('should require username or email on create', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.errors[0].description).toEqual(
+            expect(res.body.details[0].description).toEqual(
                 'You must specify username or email',
             );
         });

--- a/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
+++ b/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
@@ -170,7 +170,7 @@ test('Trying to reset password with same token twice does not work', async () =>
         })
         .expect(401)
         .expect((res) => {
-            expect(res.body.errors[0].description).toBeTruthy();
+            expect(res.body.details[0].description).toBeTruthy();
         });
 });
 

--- a/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
+++ b/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
@@ -170,7 +170,7 @@ test('Trying to reset password with same token twice does not work', async () =>
         })
         .expect(401)
         .expect((res) => {
-            expect(res.body.details[0].message).toBeTruthy();
+            expect(res.body.errors[0].description).toBeTruthy();
         });
 });
 

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -5133,6 +5133,30 @@ Stats are divided into current and previous **windows**.
             "description": "addonsSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
         },
@@ -5167,18 +5191,138 @@ Stats are divided into current and previous **windows**.
             "description": "addonSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "413": {
-            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You provided more data than we can handle. Unleash accepts at most X MB.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTooLarge",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "We do not accept the content-type you provided (application/xml). Try using one of the content-types we do accept instead (application/json) and make sure the body is in the corresponding format.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTypeerror",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
@@ -5207,10 +5351,85 @@ Stats are divided into current and previous **windows**.
             "description": "This response has no body.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The requested resource was not found.",
           },
         },
         "summary": "Delete an addon",
@@ -5243,6 +5462,30 @@ Stats are divided into current and previous **windows**.
             "description": "addonSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
         },
@@ -5289,18 +5532,165 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "addonSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The requested resource was not found.",
+          },
           "413": {
-            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You provided more data than we can handle. Unleash accepts at most X MB.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTooLarge",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "We do not accept the content-type you provided (application/xml). Try using one of the content-types we do accept instead (application/json) and make sure the body is in the corresponding format.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTypeerror",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
@@ -5789,9 +6179,57 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "environmentsSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -5827,12 +6265,84 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "environmentsProjectSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -5862,12 +6372,84 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "This response has no body.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -5903,12 +6485,84 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "environmentSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -5937,12 +6591,84 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "This response has no body.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -5971,12 +6697,84 @@ Note: passing \`null\` as a value for the description property will set it to an
             "description": "This response has no body.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -6014,6 +6812,30 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "eventsSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
         },
@@ -6080,6 +6902,30 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "featureEventsSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
         },
@@ -6259,12 +7105,84 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "tagsSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -6318,15 +7236,111 @@ If the provided project does not exist, the list of events will be empty.",
             },
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -6380,15 +7394,111 @@ If the provided project does not exist, the list of events will be empty.",
             },
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -6433,6 +7543,30 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -6590,12 +7724,84 @@ If the provided project does not exist, the list of events will be empty.",
             },
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -6631,9 +7837,57 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "publicSignupTokenSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -6678,12 +7932,84 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "publicSignupTokenSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -6709,9 +8035,57 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "maintenanceSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -6739,12 +8113,84 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You need the "UPDATE_ADDON" permission to perform this action in the "development" environment.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NoAccessError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "User credentials are valid but does not have enough privileges to execute this operation",
           },
         },
@@ -6884,9 +8330,57 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "playgroundResponseSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
         },
@@ -7335,12 +8829,60 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
             "description": "You either do not have the required permissions or used an invalid URL.",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -7382,12 +8924,60 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "featureSchema",
           },
           "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You must log in to use Unleash. Your request had no authorization header, so we could not authorize you. Try logging in at /auth/simple/login.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "AuthenticationRequired",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "Authorization information is missing or invalid. Provide a valid API token as the \`authorization\` header, e.g. \`authorization:*.*.my-admin-token\`.",
           },
           "403": {
             "description": "You either do not have the required permissions or used an invalid URL.",
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "Could not find the addon with ID "12345".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NotFoundError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The requested resource was not found.",
           },
         },
@@ -9855,6 +11445,30 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
         },
@@ -10030,12 +11644,84 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "413": {
-            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You provided more data than we can handle. Unleash accepts at most X MB.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTooLarge",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "We do not accept the content-type you provided (application/xml). Try using one of the content-types we do accept instead (application/json) and make sure the body is in the corresponding format.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTypeerror",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
@@ -10072,12 +11758,84 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "validatedEdgeTokensSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "413": {
-            "description": "The body request body is larger than what we accept. By default we only accept bodies of 100kB or less",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "You provided more data than we can handle. Unleash accepts at most X MB.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTooLarge",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The request body is larger than what we accept. By default we only accept bodies of 100kB or less",
           },
           "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "We do not accept the content-type you provided (application/xml). Try using one of the content-types we do accept instead (application/json) and make sure the body is in the corresponding format.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ContentTypeerror",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The operation does not support request payloads of the provided type. Please ensure that you're using one of the listed payload types and that you have specified the right content type in the "content-type" header.",
           },
         },
@@ -10154,9 +11912,57 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "userSchema",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
           "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "There is already a feature called "my-awesome-feature".",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "NameExistsError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The provided resource can not be created or updated because it would conflict with the current state of the resource or with an already existing resource, respectively.",
           },
         },
@@ -10184,6 +11990,30 @@ If the provided project does not exist, the list of events will be empty.",
             "description": "This response has no body.",
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "description": "The ID of the error instance",
+                      "example": "9c40958a-daac-400e-98fb-3bb438567008",
+                      "type": "string",
+                    },
+                    "message": {
+                      "description": "A description of what went wrong.",
+                      "example": "The request payload you provided doesn't conform to the schema. The .parameters property should be object. You sent [].",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "The name of the error kind",
+                      "example": "ValidationError",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
             "description": "The request data does not match what we expect.",
           },
         },

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -777,10 +777,8 @@ test('Should be denied move feature toggle to project where the user does not ha
         );
     } catch (e) {
         expect(e.name).toContain('NoAccess');
-        expect(e.message).toContain(
-            'permission',
-            permissions.MOVE_FEATURE_TOGGLE,
-        );
+        expect(e.message.includes('permission'));
+        expect(e.message.includes(permissions.MOVE_FEATURE_TOGGLE));
     }
 });
 

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -776,8 +776,10 @@ test('Should be denied move feature toggle to project where the user does not ha
             projectOrigin.id,
         );
     } catch (e) {
-        expect(e.toString()).toBe(
-            'NoAccessError: You need permission=MOVE_FEATURE_TOGGLE to perform this action',
+        expect(e.name).toContain('NoAccess');
+        expect(e.message).toContain(
+            'permission',
+            permissions.MOVE_FEATURE_TOGGLE,
         );
     }
 });

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -604,9 +604,8 @@ test('should fail if user is not authorized', async () => {
             project.id,
         );
     } catch (err) {
-        expect(err.message).toBe(
-            `You need permission=${MOVE_FEATURE_TOGGLE} to perform this action`,
-        );
+        expect(err.message.toLowerCase().includes('permission'));
+        expect(err.message.includes(MOVE_FEATURE_TOGGLE));
     }
 });
 

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -538,9 +538,8 @@ test('should not change project if feature toggle project does not match current
             'wrong-project-id',
         );
     } catch (err) {
-        expect(err.message).toBe(
-            `You need permission=${MOVE_FEATURE_TOGGLE} to perform this action`,
-        );
+        expect(err.message.toLowerCase().includes('permission'));
+        expect(err.message.includes(MOVE_FEATURE_TOGGLE));
     }
 });
 


### PR DESCRIPTION
This PR implements the first version of a suggested unification (and documentation) of the errors that we return from the API today.

The goal is for this to be the first step towards the error type defined in this internal [linear task](https://linear.app/unleash/issue/1-629/define-the-error-type 'Define the new API error type').

## The state of things today

As things stand, we currently have no (or **very** little) documentation of the errors that are returned from the API. We mention error codes, but never what the errors may contain.

Second, there is no specified format for errors, so what they return is arbitrary, and based on ... Who knows? As a result, we have multiple different errors returned by the API depending on what operation you're trying to do. What's more, with OpenAPI validation in the mix, it's absolutely possible for you to get two completely different error objects for operations to the same endpoint.

Third, the errors we do return are usually pretty vague and don't really provide any real help to the user. "You don't have the right permissions". Great. Well what permissions do I need? And how would I know? "BadDataError". Sick. Why is it bad?

... You get it.

## What we want to achieve

The ultimate goal is for error messages to serve both humans and machines. When the user provides bad data, we should tell them what parts of the data are bad and what they can do to fix it. When they don't have the right permissions, we should tell them what permissions they need.

Additionally, it would be nice if we could provide an ID for each error instance, so that you (or an admin) can look through the logs and locate the incident.

## What's included in **this** PR?

This PR does not aim to implement everything above. It's not intended to magically fix everything. Its goal is to implement the necessary **breaking** changes, so that they can be included in v5. Changing error messages is a slightly grayer area than changing APIs directly, but changing the format is definitely something I'd consider breaking.

So this PR:

-   defines a minimal version of the error type defined in the [API error definition linear task](https://linear.app/unleash/issue/1-629/define-the-error-type).
-   aims to catch all errors we return today and wrap them in the error type
-   updates tests to match the new expectations.

An important point: because we are cutting v5 very soon and because work for this wasn't started until last week, the code here isn't necessarily very polished. But it doesn't need to be. The internals can be as messy as we want, as long as the API surface is stable.

That said, I'm very open to feedback about design and code completeness, etc, but this has intentionally been done quickly.

Please also see my inline comments on the changes for more specific details.

### Proposed follow-ups

As mentioned, this is the first step to implementing the error type. The public API error type only exposes `id`, `name`, and `message`. This is barely any more than most of the previous messages, but they are now all using the same format. Any additional properties, such as `suggestion`, `help`, `documentationLink` etc can be added as features without breaking the current format. This is an intentional limitation of this PR.

Regarding additional properties: there are some error responses that must contain extra properties. Some of these are documented in the types of the new error constructor, but not all. This includes `path` and `type` properties on 401 errors, `errors` on validation errors, and more.

Also, because it was put together quickly, I don't yet know exactly how we (as developers) would **prefer** to use these new error messages within the code, so the internal API (the new type, name, etc), is just a suggestion. This can evolve naturally over time if (based on feedback and experience) without changing the public API.

## Error types:

We have `ValidationError`, `BadDataError`, and `BadRequestError` today. Do we really need all of these? I think we all of these are essentially the same thing?

## Returning multiple errors

Most of the time when we return errors today, we only return a single error (even if many things are wrong). AJV, the OpenAPI integration we use does have a setting that allows it to return all errors in a request instead of a single one. I suggest we turn that on, but that we do it in a separate PR (because it updates a number of other snapshots).

I've suggested we use the following format as a base to work off of:
```ts
type: ErrorDesecription = { description: string }

{
  errors: [ErrorDescription, ...ErrorDescription[]] // a non-empty list of descriptors
}
``` 

That gives json that looks a bit like this:

```json
{
  "name": "BadDataError",
  "message": "Something went wrong. Check the `errors` property for more information."
  "errors": [{
    "description": "The .params property must be an object. You provided an array.",
  }]
}
```

However, we already have used `details` and `message` in some places, which would look like this.

```json
{
  "name": "BadDataError",
  "message": "Something went wrong. Check the `errors` property for more information."
  "details": [{
    "message": "The .params property must be an object. You provided an array.",
  }]
}
```

I propose changing that to `errors` and `descriptions`, but am willing to discuss it. I think the term `description` is a better descriptor of what's contained in each separate item, but I don't have very strong feelings regarding `errors` vs `details`. Let me know if you have any thoughts.

## Failing tests

As of right now, there are a number of failing tests. I'm working on fixing them, but would like to get this reviewed as soon as possible to agree on the direction.