### PR TITLE
fix: Add default stickiness if empty when creating or throw error whe…

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -224,6 +224,16 @@ class FeatureToggleService {
                 'You can not change the featureName for an activation strategy.',
             );
         }
+
+        if (
+            strategy.parameters &&
+            'stickiness' in strategy.parameters &&
+            strategy.parameters.stickiness === ''
+        ) {
+            throw new InvalidOperationError(
+                'You can not have an empty string for stickiness.',
+            );
+        }
     }
 
     async validateProjectCanAccessSegments(
@@ -408,6 +418,14 @@ class FeatureToggleService {
             strategyConfig.constraints = await this.validateConstraints(
                 strategyConfig.constraints,
             );
+        }
+
+        if (
+            strategyConfig.parameters &&
+            'stickinees' in strategyConfig.parameters &&
+            strategyConfig.parameters.stickinees === ''
+        ) {
+            strategyConfig.parameters.stickinees = 'default';
         }
 
         try {

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -17,8 +17,11 @@ let app: IUnleashTest;
 let db: ITestDb;
 
 const defaultStrategy = {
-    name: 'default',
-    parameters: {},
+    name: 'flexibleRollout',
+    parameters: {
+        rollout: '100',
+        stickiness: '',
+    },
     constraints: [],
 };
 


### PR DESCRIPTION
fix: Add 'default' when creating or throw error when updating a flexibleRollout strategy with empty stickiness
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
