### PR TITLE
fix: broken feature.e2e test + make error message clearer

### DIFF
--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -301,7 +301,7 @@ export const fromOpenApiValidationErrors = (
     return new UnleashError({
         name: 'ValidationError',
         message:
-            "The request payload you provided doesn't conform to the schema. Check the `details` property for a list of errors that we found.",
+            "Request validation failed: the payload you provided doesn't conform to the schema. Check the `details` property for a list of errors that we found.",
         // @ts-expect-error We know that the list is non-empty
         details,
     });

--- a/src/test/e2e/api/admin/feature.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.e2e.test.ts
@@ -916,6 +916,7 @@ test('Should throw error when updating a flexibleRollout strategy with "" for st
         .expect((res) => {
             const result = res.body;
             expect(res.status).toBe(400);
-            expect(result.error).toBe('Request validation failed');
+            expect(result.message.includes('validation'));
+            expect(result.message.includes('failed'));
         });
 });


### PR DESCRIPTION
This PR fixes a broken e2e test by relaxing what it checks for. It must have been developed in parallel so that the test wasn't included before merging into main. 