### PR TITLE
fix: ensure that the owaspvalidationerrors always contain all errors

### DIFF
--- a/src/lib/error/api-error.test.ts
+++ b/src/lib/error/api-error.test.ts
@@ -1,3 +1,4 @@
+import owasp from 'owasp-password-strength-test';
 import { ErrorObject } from 'ajv';
 import {
     ApiErrorSchema,
@@ -9,6 +10,7 @@ import {
     UnleashError,
 } from './api-error';
 import BadDataError from './bad-data-error';
+import OwaspValidationError from './owasp-validation-error';
 
 describe('v5 deprecation: backwards compatibility', () => {
     it.each(UnleashApiErrorTypes)(
@@ -318,5 +320,16 @@ describe('OpenAPI error conversion', () => {
         expect(description).toMatch(/\bnestedObject.a.b\b/);
         // it should include the value that the user sent
         expect(description.includes(illegalValue)).toBeTruthy();
+    });
+});
+
+describe('Error serialization special cases', () => {
+    it('OwaspValidationErrors: adds `validationErrors` to `details`', () => {
+        const results = owasp.test('123');
+        const error = new OwaspValidationError(results);
+        const json = fromLegacyError(error).toJSON();
+
+        expect(json.details!![0].message).toBe(results.errors[0]);
+        expect(json.details!![0].validationErrors).toBe(results.errors);
     });
 });

--- a/src/lib/error/api-error.ts
+++ b/src/lib/error/api-error.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidV4 } from 'uuid';
 import { FromSchema } from 'json-schema-to-ts';
 import { ErrorObject } from 'ajv';
+import OwaspValidationError from './owasp-validation-error';
 
 export const UnleashApiErrorTypes = [
     'ContentTypeError',
@@ -14,7 +15,6 @@ export const UnleashApiErrorTypes = [
     'NotFoundError',
     'NotImplementedError',
     'OperationDeniedError',
-    'OwaspValidationError',
     'PasswordMismatch',
     'PasswordMismatchError',
     'PasswordUndefinedError',
@@ -34,6 +34,7 @@ const UnleashApiErrorTypesWithExtraData = [
     'AuthenticationRequired',
     'NoAccessError',
     'InvalidTokenError',
+    'OwaspValidationError',
 ] as const;
 
 const AllUnleashApiErrorTypes = [
@@ -134,6 +135,15 @@ type UnleashErrorData =
                 details: [
                     ValidationErrorDescription,
                     ...ValidationErrorDescription[],
+                ];
+            }
+          | {
+                name: 'OwaspValidationError';
+                details: [
+                    {
+                        validationErrors: string[];
+                        message: string;
+                    },
                 ];
             }
       );
@@ -242,6 +252,15 @@ export const fromLegacyError = (e: Error): UnleashError => {
             message:
                 'Request validation failed: your request body failed to validate. Refer to the `details` list to see what happened.',
             details: [{ description: e.message, message: e.message }],
+        });
+    }
+
+    if (name === 'OwaspValidationError') {
+        return new UnleashError({
+            name,
+            message:
+                'Password validation failed. Refer to the `details` property.',
+            details: (e as OwaspValidationError).toJSON().details,
         });
     }
 


### PR DESCRIPTION
## What

This fixes a bug where the owasp validation response that came back from the server no longer contained all its validation errors. This caused the UI to slightly break and for the password validation box not to update correctly.

This is a quick fix (but with tests!). I'm working on a better design for this on the side, but it seemed pertinent to get this out ASAP.