### PR TITLE
fix: fix bulk removal of tags

### DIFF
--- a/src/lib/db/feature-tag-store.ts
+++ b/src/lib/db/feature-tag-store.ts
@@ -187,13 +187,15 @@ class FeatureTagStore implements IFeatureTagStore {
     }
 
     async tagFeatures(featureTags: IFeatureTag[]): Promise<IFeatureAndTag[]> {
-        const rows = await this.db(TABLE)
-            .insert(featureTags.map(this.featureTagToRow))
-            .returning(COLUMNS)
-            .onConflict(COLUMNS)
-            .ignore();
-        if (rows) {
-            return rows.map(this.rowToFeatureAndTag);
+        if (featureTags.length !== 0) {
+            const rows = await this.db(TABLE)
+                .insert(featureTags.map(this.featureTagToRow))
+                .returning(COLUMNS)
+                .onConflict(COLUMNS)
+                .ignore();
+            if (rows) {
+                return rows.map(this.rowToFeatureAndTag);
+            }
         }
         return [];
     }

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -161,3 +161,48 @@ test('Can tag features', async () => {
     expect(res.body).toMatchObject({ tags: [addedTag] });
     expect(res2.body).toMatchObject({ tags: [addedTag] });
 });
+
+test('Can bulk remove tags', async () => {
+    const featureName = 'test.feature3';
+    const featureName2 = 'test.feature4';
+    const addedTag = {
+        value: 'TeamRed',
+        type: 'simple',
+    };
+
+    await app.request.post('/api/admin/projects/default/features').send({
+        name: featureName,
+        type: 'killswitch',
+        enabled: true,
+        strategies: [{ name: 'default' }],
+    });
+
+    await app.request.post('/api/admin/projects/default/features').send({
+        name: featureName2,
+        type: 'killswitch',
+        enabled: true,
+        strategies: [{ name: 'default' }],
+    });
+
+    await app.request
+        .put('/api/admin/tags/features')
+        .send({
+            features: [featureName, featureName2],
+            tags: {
+                addedTags: [addedTag],
+                removedTags: [],
+            },
+        })
+        .expect(200);
+
+    await app.request
+        .put('/api/admin/tags/features')
+        .send({
+            features: [featureName, featureName2],
+            tags: {
+                addedTags: [],
+                removedTags: [addedTag],
+            },
+        })
+        .expect(200);
+});


### PR DESCRIPTION
Currently if you had multiple tags and wanted to remove a tag from a batch of features, the request failed.
This PR fixes it.