### PR TITLE
feat: set timezone to utc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ FROM node:$NODE_VERSION
 
 ENV NODE_ENV production
 
+ENV TZ UTC
+
 WORKDIR /unleash
 
 COPY --from=builder /unleash/docker /unleash

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "license": "Apache-2.0",
   "main": "./dist/lib/server-impl.js",
   "scripts": {
-    "start": "node ./dist/server.js",
+    "start": "TZ=UTC node ./dist/server.js",
     "prestart:dev": "yarn run clean",
-    "start:dev": "NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",
+    "start:dev": "TZ=UTC NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",
     "copy-templates": "copyfiles -u 1 src/mailtemplates/**/*.mustache dist/",
     "db-migrate": "db-migrate --migrations-dir ./src/migrations",
     "lint": "eslint ./src",


### PR DESCRIPTION
If Unleash is running in a timezone other than UTC, the metrics bucket values will be incorrect by the corresponding number of hours. We need to decide whether we should allow Unleash to run in other timezones or if we should modify the code to enforce UTC.


We decided to set timezone to UTC. There are two ways to do it, during runtime and before starting node. We decided to go with environment variable, because setting at runtime produces non-deterministic behaviour. Source https://github.com/nodejs/node-v0.x-archive/issues/3286. 


An example, metrics was posted at 13:00+3, and was stored in database 13:00+0. After setting application timezone, it is now stored 10:00+0
