### PR TITLE
fix: anonymize email in event payload

### DIFF
--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -111,6 +111,20 @@ export default class EventController extends Controller {
             return events.map((e: IEvent) => ({
                 ...e,
                 createdBy: anonymise(e.createdBy),
+                data:
+                    e.data && 'email' in e.data
+                        ? {
+                              ...e.data,
+                              email: anonymise(e.data.email),
+                          }
+                        : e.data,
+                preData:
+                    e.preData && 'email' in e.preData
+                        ? {
+                              ...e.preData,
+                              email: anonymise(e.preData.email),
+                          }
+                        : e.preData,
             }));
         }
         return events;

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -5,7 +5,11 @@ import { createTestConfig } from '../../../test/config/test-config';
 import createStores from '../../../test/fixtures/store';
 
 import getApp from '../../app';
-import { FeatureCreatedEvent } from '../../types/events';
+import {
+    FeatureCreatedEvent,
+    ProjectUserAddedEvent,
+    ProjectUserRemovedEvent,
+} from '../../types/events';
 
 async function getSetup(anonymise: boolean = false) {
     const base = `/random${Math.round(Math.random() * 1000)}`;
@@ -70,4 +74,33 @@ test('should anonymise events list via admin', async () => {
 
     expect(body.events.length).toBe(1);
     expect(body.events[0].createdBy).toBe('676212ff7@unleash.run');
+});
+
+test('should also anonymise email fields in data and preData properties', async () => {
+    const email1 = 'test1@email.com';
+    const email2 = 'test2@email.com';
+
+    const { request, base, eventStore } = await getSetup(true);
+    eventStore.store(
+        new ProjectUserAddedEvent({
+            createdBy: 'some@email.com',
+            data: { name: 'test', project: 'default', email: email1 },
+            project: 'default',
+        }),
+    );
+    eventStore.store(
+        new ProjectUserRemovedEvent({
+            createdBy: 'some@email.com',
+            preData: { name: 'test', project: 'default', email: email2 },
+            project: 'default',
+        }),
+    );
+    const { body } = await request
+        .get(`${base}/api/admin/events`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+    expect(body.events.length).toBe(2);
+    expect(body.events[0].data.email).not.toBe(email1);
+    expect(body.events[1].preData.email).not.toBe(email2);
 });


### PR DESCRIPTION
https://linear.app/unleash/issue/2-987/unleash-is-not-correctly-anonymizing-emails-in-the-project-events

Context: https://unleash-internal.slack.com/archives/C048ELND3QD/p1683097636083299

We should also anonymize email fields in `data` and `preData` of event objects when `anonymiseEventLog` is enabled.

![image](https://user-images.githubusercontent.com/14320932/235862643-b59a3f8d-9bc6-4b22-816b-9bc7a0577bfc.png)
