### PR TITLE
fix: log project access events

### DIFF
--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -5,7 +5,7 @@ import EventService from '../../services/event-service';
 import { ADMIN, NONE } from '../../types/permissions';
 import { IEvent, IEventList } from '../../types/events';
 import Controller from '../controller';
-import { anonymise } from '../../util/anonymise';
+import { anonymiseKeys } from '../../util/anonymise';
 import { OpenApiService } from '../../services/openapi-service';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import { endpointDescriptions } from '../../openapi/endpoint-descriptions';
@@ -23,6 +23,7 @@ import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { SearchEventsSchema } from '../../openapi/spec/search-events-schema';
 import { IFlagResolver } from '../../types/experimental';
 
+const ANON_KEYS = ['email', 'username', 'createdBy'];
 const version = 1;
 export default class EventController extends Controller {
     private eventService: EventService;
@@ -108,24 +109,7 @@ export default class EventController extends Controller {
 
     maybeAnonymiseEvents(events: IEvent[]): IEvent[] {
         if (this.flagResolver.isEnabled('anonymiseEventLog')) {
-            return events.map((e: IEvent) => ({
-                ...e,
-                createdBy: anonymise(e.createdBy),
-                data:
-                    e.data && 'email' in e.data
-                        ? {
-                              ...e.data,
-                              email: anonymise(e.data.email),
-                          }
-                        : e.data,
-                preData:
-                    e.preData && 'email' in e.preData
-                        ? {
-                              ...e.preData,
-                              email: anonymise(e.preData.email),
-                          }
-                        : e.preData,
-            }));
+            return anonymiseKeys(events, ANON_KEYS);
         }
         return events;
     }

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -7,6 +7,7 @@ import createStores from '../../../test/fixtures/store';
 import getApp from '../../app';
 import {
     FeatureCreatedEvent,
+    ProjectAccessAddedEvent,
     ProjectUserAddedEvent,
     ProjectUserRemovedEvent,
 } from '../../types/events';
@@ -103,4 +104,28 @@ test('should also anonymise email fields in data and preData properties', async 
     expect(body.events.length).toBe(2);
     expect(body.events[0].data.email).not.toBe(email1);
     expect(body.events[1].preData.email).not.toBe(email2);
+});
+
+test('should anonymise any PII fields, no matter the depth', async () => {
+    const username = 'test-username';
+
+    const { request, base, eventStore } = await getSetup(true);
+    eventStore.store(
+        new ProjectAccessAddedEvent({
+            createdBy: 'some@email.com',
+            data: {
+                groups: [
+                    { name: 'test', project: 'default', users: [{ username }] },
+                ],
+            },
+            project: 'default',
+        }),
+    );
+    const { body } = await request
+        .get(`${base}/api/admin/events`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+    expect(body.events.length).toBe(1);
+    expect(body.events[0].data.groups[0].users[0].username).not.toBe(username);
 });

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -107,7 +107,7 @@ test('should also anonymise email fields in data and preData properties', async 
 });
 
 test('should anonymise any PII fields, no matter the depth', async () => {
-    const username = 'test-username';
+    const testUsername = 'test-username';
 
     const { request, base, eventStore } = await getSetup(true);
     eventStore.store(
@@ -115,7 +115,11 @@ test('should anonymise any PII fields, no matter the depth', async () => {
             createdBy: 'some@email.com',
             data: {
                 groups: [
-                    { name: 'test', project: 'default', users: [{ username }] },
+                    {
+                        name: 'test',
+                        project: 'default',
+                        users: [{ username: testUsername }],
+                    },
                 ],
             },
             project: 'default',
@@ -127,5 +131,7 @@ test('should anonymise any PII fields, no matter the depth', async () => {
         .expect(200);
 
     expect(body.events.length).toBe(1);
-    expect(body.events[0].data.groups[0].users[0].username).not.toBe(username);
+    expect(body.events[0].data.groups[0].users[0].username).not.toBe(
+        testUsername,
+    );
 });

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -521,14 +521,12 @@ export default class ProjectService {
                     roleId,
                     roleName: role.name,
                     groups: addedGroups.map(
-                        ({ id, name, users: groupUsers }) => ({
-                            id,
+                        ({ id: groupId, name, users: groupUsers }) => ({
+                            id: groupId,
                             name,
                             users: groupUsers.map(
-                                ({
-                                    user: { id: userId, email, username },
-                                }) => ({
-                                    id: userId,
+                                ({ user: { id, email, username } }) => ({
+                                    id,
                                     email,
                                     username,
                                 }),

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -520,19 +520,10 @@ export default class ProjectService {
                 data: {
                     roleId,
                     roleName: role.name,
-                    groups: addedGroups.map(
-                        ({ id: groupId, name, users: groupUsers }) => ({
-                            id: groupId,
-                            name,
-                            users: groupUsers.map(
-                                ({ user: { id, email, username } }) => ({
-                                    id,
-                                    email,
-                                    username,
-                                }),
-                            ),
-                        }),
-                    ),
+                    groups: addedGroups.map(({ id: groupId, name }) => ({
+                        id: groupId,
+                        name,
+                    })),
                     users: addedUsers.map(({ id, email, username }) => ({
                         id,
                         email,

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -502,33 +502,14 @@ export default class ProjectService {
             createdBy,
         );
 
-        const role = await this.accessService.getRole(roleId);
-        const { users, groups } = await this.getAccessToProject(projectId);
-
-        const addedUsers = users.filter(({ id }) =>
-            usersAndGroups.users.some(({ id: userId }) => userId === id),
-        );
-
-        const addedGroups = groups.filter(({ id }) =>
-            usersAndGroups.groups.some(({ id: groupId }) => groupId === id),
-        );
-
         await this.eventStore.store(
             new ProjectAccessAddedEvent({
                 project: projectId,
                 createdBy,
                 data: {
                     roleId,
-                    roleName: role.name,
-                    groups: addedGroups.map(({ id: groupId, name }) => ({
-                        id: groupId,
-                        name,
-                    })),
-                    users: addedUsers.map(({ id, email, username }) => ({
-                        id,
-                        email,
-                        username,
-                    })),
+                    groups: usersAndGroups.groups.map(({ id }) => id),
+                    users: usersAndGroups.users.map(({ id }) => id),
                 },
             }),
         );

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -40,6 +40,7 @@ export const DROP_STRATEGIES = 'drop-strategies';
 export const CONTEXT_FIELD_CREATED = 'context-field-created';
 export const CONTEXT_FIELD_UPDATED = 'context-field-updated';
 export const CONTEXT_FIELD_DELETED = 'context-field-deleted';
+export const PROJECT_ACCESS_ADDED = 'project-access-added';
 export const PROJECT_CREATED = 'project-created';
 export const PROJECT_UPDATED = 'project-updated';
 export const PROJECT_DELETED = 'project-deleted';
@@ -634,6 +635,25 @@ export class ProjectGroupUpdateRoleEvent extends BaseEvent {
         this.project = project;
         this.data = data;
         this.preData = preData;
+    }
+}
+
+export class ProjectAccessAddedEvent extends BaseEvent {
+    readonly project: string;
+
+    readonly data: any;
+
+    readonly preData: any;
+
+    /**
+     * @param createdBy accepts a string for backward compatibility. Prefer using IUser for standardization
+     */
+    constructor(p: { project: string; createdBy: string | IUser; data: any }) {
+        super(PROJECT_ACCESS_ADDED, p.createdBy);
+        const { project, data } = p;
+        this.project = project;
+        this.data = data;
+        this.preData = null;
     }
 }
 

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -564,7 +564,7 @@ export class ProjectUserUpdateRoleEvent extends BaseEvent {
         data: any;
         preData: any;
     }) {
-        super(PROJECT_USER_REMOVED, eventData.createdBy);
+        super(PROJECT_USER_ROLE_CHANGED, eventData.createdBy);
         const { project, data, preData } = eventData;
         this.project = project;
         this.data = data;

--- a/src/lib/util/anonymise.ts
+++ b/src/lib/util/anonymise.ts
@@ -7,3 +7,26 @@ export function anonymise(s: string): string {
         .slice(0, 9);
     return `${hash}@unleash.run`;
 }
+
+export function anonymiseKeys<T>(object: T, keys: string[]): T {
+    if (typeof object !== 'object' || object === null) {
+        return object;
+    }
+
+    if (Array.isArray(object)) {
+        return object.map((item) => anonymiseKeys(item, keys)) as unknown as T;
+    } else {
+        return Object.keys(object).reduce((result, key) => {
+            if (
+                keys.includes(key) &&
+                result[key] !== undefined &&
+                result[key] !== null
+            ) {
+                result[key] = anonymise(result[key]);
+            } else if (typeof result[key] === 'object') {
+                result[key] = anonymiseKeys(result[key], keys);
+            }
+            return result;
+        }, object);
+    }
+}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-992/register-event-when-granting-access-to-a-project

 - Correctly registers a new `project-access-added` event;
 - Adds an anonymization method that supports anonymizing objects, recursively searching for keys to anonymize;
 - Fixes the event label used by `ProjectUserUpdateRoleEvent` to be `PROJECT_USER_ROLE_CHANGED`;

![image](https://user-images.githubusercontent.com/14320932/236216227-bf6e5dff-f509-48a4-ba7c-9f37e23e87c0.png)