### PR TITLE
feat(devenv): reproducible dev environment via https://devenv.sh

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ frontend/build
 # Generated docs
 website/docs/reference/api/**/sidebar.js
 website/docs/generated
+
+# Devenv
+.devenv*
+devenv.local.nix
+

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,138 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1683288106,
+        "narHash": "sha256-8/yuP6gWLhK8tRCtyqY5QnTq9GF7pCWpZyyZ08lXFwM=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "c4006ccba1b3e4533de462cee5933e0ccf5f1d6a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683392273,
+        "narHash": "sha256-pZTuxvcuDeBG+vvE1zczNyEUzlPbzXVh8Ed45Fzo+tQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16b3b0c53b1ee8936739f8c588544e7fcec3fc60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,41 @@
+{ pkgs, ... }:
+
+{
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.nodejs-18_x
+    pkgs.postgresql_14
+    pkgs.yarn
+  ];
+
+  # https://devenv.sh/processes/
+  processes = {
+    yarn-build-watch.exec = "yarn build:watch";
+    yarn-start-dev.exec = "yarn start:dev";
+  };
+
+  # https://devenv.sh/reference/options/#servicespostgresenable
+  services.postgres.enable = true;
+  services.postgres.listen_addresses = "127.0.0.1";
+
+  services.postgres.createDatabase = true;
+  services.postgres.initdbArgs = [
+    "--locale=C"
+    "--encoding=UTF8"
+  ];
+
+  services.postgres.initialDatabases = [{ name = "unleash"; }];
+  services.postgres.initialScript = ''
+    CREATE USER postgres SUPERUSER;
+    CREATE USER unleash_user;
+  '';
+
+  # https://devenv.sh/languages/  
+  languages.javascript.enable = true;
+  languages.nix.enable = true;
+
+  # https://devenv.sh/pre-commit-hooks/
+  # pre-commit.hooks.prettier.enable = true;
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable


### PR DESCRIPTION
## About the changes

The contributing/onboarding devloop can be simplified via https://devenv./sh (which is chrome around the Nix package manager). 

```bash
$ cd unleash
$ devenv up
```

![CleanShot 2023-05-07 at 13 17 43](https://user-images.githubusercontent.com/127353/236656022-83e88b2c-bc18-457c-8fe2-e00f0794c126.gif)

This will automatically:
- Install the correct version of nodejs, yarn and postgres in a sandbox (ie. no sudo, no changes to a developers computer)
- Create the Postgres database and the required users.
- Start the Postgres database
- Run the two yarn scripts and merge the output logs into a single console log where the process names are tagged.

### Important files

- Installation instructions: https://devenv.sh/getting-started/
- Configuration options: https://devenv.sh/reference/options/

## Discussion points

- Install https://devenv.sh/getting-started/ on your machine to test then run `$ devenv up`
- https://devenv./sh works on macOS, Linux and Windows (via WSL)
- https://devenv./sh is completely sandboxed meaning it does not mutate or make changes to a users computer (state is kept in `unleash/.devenv`)
