### PR TITLE
chore: add another migration that remigrates the proper way

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -39,7 +39,7 @@ const tokenRowReducer = (acc, tokenRow) => {
     if (!acc[tokenRow.secret]) {
         acc[tokenRow.secret] = {
             secret: token.secret,
-            tokenName: token.token_name,
+            tokenName: token.token_name ? token.token_name : token.username,
             type: token.type,
             project: ALL,
             projects: [ALL],
@@ -48,7 +48,7 @@ const tokenRowReducer = (acc, tokenRow) => {
             createdAt: token.created_at,
             alias: token.alias,
             seenAt: token.seen_at,
-            username: token.token_name,
+            username: token.token_name ? token.token_name : token.username,
         };
     }
     const currentToken = acc[tokenRow.secret];
@@ -63,6 +63,7 @@ const tokenRowReducer = (acc, tokenRow) => {
 };
 
 const toRow = (newToken: IApiTokenCreate) => ({
+    username: newToken.tokenName ?? newToken.username,
     token_name: newToken.tokenName ?? newToken.username,
     secret: newToken.secret,
     type: newToken.type,
@@ -125,6 +126,7 @@ export class ApiTokenStore implements IApiTokenStore {
             )
             .select(
                 'tokens.secret',
+                'username',
                 'token_name',
                 'type',
                 'expires_at',

--- a/src/migrations/20230509065107-recreate-username-field.js
+++ b/src/migrations/20230509065107-recreate-username-field.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        'ALTER TABLE api_tokens RENAME COLUMN token_name TO username;',
+        callback,
+    );
+    db.runSql('ALTER TABLE api_tokens ADD COLUMN "token_name" text;', callback);
+};
+
+exports.down = function (db, callback) {
+    db.runSql('ALTER TABLE api_tokens DROP COLUMN "token_name";', callback);
+    db.runSql(
+        'ALTER TABLE api_tokens RENAME COLUMN username TO token_name;',
+        callback,
+    );
+};


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Adds a migration that renames `token_name` back to `username`, then adds a new optional column named `token_name`

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

I've added fallbacks for resolving username/tokenname on insert and on making rows from results.
But this adds another column renaming, which is worth discussing properly