### PR TITLE
fix: application name link styling

### DIFF
--- a/frontend/src/component/common/common.module.scss
+++ b/frontend/src/component/common/common.module.scss
@@ -24,14 +24,13 @@
 }
 
 .listLink {
-    color: #212121;
     text-decoration: none;
     font-weight: normal;
     display: block;
 }
 
 .listLink:hover {
-    color: #000;
+    text-decoration: underline;
 }
 
 @media (max-width: 920px) {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1021/bug-dark-mode-application-screen-name-of-the-application-not-visible

Applies the styling changes mentioned in the task above, fixing the style in dark mode and making these links more consistent in general.

Closes https://github.com/Unleash/unleash/issues/3718

![image](https://github.com/Unleash/unleash/assets/14320932/f3a873c1-e25e-4137-8b74-8020ebde0493)