### PR TITLE
fix: strategyId in edit strategy API command endpoint

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.test.tsx
@@ -37,7 +37,7 @@ test('formatUpdateStrategyApiCode', () => {
             'unleashUrl'
         )
     ).toMatchInlineSnapshot(`
-      "curl --location --request PUT 'unleashUrl/api/admin/projects/projectId/features/featureId/environments/environmentId/strategies/a' \\\\
+      "curl --location --request PUT 'unleashUrl/api/admin/projects/projectId/features/featureId/environments/environmentId/strategies/strategyId' \\\\
           --header 'Authorization: INSERT_API_KEY' \\\\
           --header 'Content-Type: application/json' \\\\
           --data-raw '{

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.test.tsx
@@ -31,6 +31,7 @@ test('formatUpdateStrategyApiCode', () => {
             'projectId',
             'featureId',
             'environmentId',
+            'strategyId',
             strategy,
             strategyDefinition,
             'unleashUrl'

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -213,6 +213,7 @@ export const FeatureStrategyEdit = () => {
                     projectId,
                     featureId,
                     environmentId,
+                    strategyId,
                     payload,
                     strategyDefinition,
                     unleashUrl
@@ -272,6 +273,7 @@ export const formatUpdateStrategyApiCode = (
     projectId: string,
     featureId: string,
     environmentId: string,
+    strategyId: string,
     strategy: Partial<IFeatureStrategy>,
     strategyDefinition: IStrategy,
     unleashUrl?: string
@@ -290,7 +292,7 @@ export const formatUpdateStrategyApiCode = (
         ),
     };
 
-    const url = `${unleashUrl}/api/admin/projects/${projectId}/features/${featureId}/environments/${environmentId}/strategies/${strategy.id}`;
+    const url = `${unleashUrl}/api/admin/projects/${projectId}/features/${featureId}/environments/${environmentId}/strategies/${strategyId}`;
     const payload = JSON.stringify(sortedStrategy, undefined, 2);
 
     return `curl --location --request PUT '${url}' \\


### PR DESCRIPTION
Fixes a small issue where the "API Command" for edit strategy was showing the strategyId as `undefined`:

`/api/admin/projects/demo-app/features/demoApp.step1/environments/dev/strategies/undefined'`

![image](https://github.com/Unleash/unleash/assets/14320932/19650a15-5cde-43c3-9d2b-a7e790bea0ac)
