### PR TITLE
fix: log missing user at warn level

### DIFF
--- a/src/lib/middleware/pat-middleware.ts
+++ b/src/lib/middleware/pat-middleware.ts
@@ -1,5 +1,6 @@
 import { IUnleashConfig } from '../types';
 import { IAuthRequest } from '../routes/unleash-types';
+import NotFoundError from '../error/notfound-error';
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 const patMiddleware = (
@@ -21,7 +22,14 @@ const patMiddleware = (
                 accountService.addPATSeen(apiToken);
             }
         } catch (error) {
-            logger.error(error);
+            if (error instanceof NotFoundError) {
+                logger.warn(
+                    'Tried to use a PAT token for user that no longer existed',
+                    error,
+                );
+            } else {
+                logger.error(error);
+            }
         }
         next();
     };


### PR DESCRIPTION
When using PATs if the user that the PAT is for has been removed, we currently log the missing user at ERROR level. Since this is not something our SREs can fix, this PR downgrades the NotFoundError to WARN, instead of ERROR.