### PR TITLE
fix: Default email sender to getunleash.io domain

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -48,7 +48,7 @@ exports[`should create default config 1`] = `
     "host": undefined,
     "port": 587,
     "secure": false,
-    "sender": "noreply@unleash-hosted.com",
+    "sender": "noreply@getunleash.io",
     "smtppass": undefined,
     "smtpuser": undefined,
   },

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -209,7 +209,7 @@ const defaultEmail: IEmailOption = {
     host: process.env.EMAIL_HOST,
     secure: parseEnvVarBoolean(process.env.EMAIL_SECURE, false),
     port: parseEnvVarNumber(process.env.EMAIL_PORT, 587),
-    sender: process.env.EMAIL_SENDER || 'noreply@unleash-hosted.com',
+    sender: process.env.EMAIL_SENDER || 'noreply@getunleash.io',
     smtpuser: process.env.EMAIL_USER,
     smtppass: process.env.EMAIL_PASSWORD,
 };


### PR DESCRIPTION
As part of the move to a unified domain this PR updates the default EMAIL_SENDER to noreply@getunleash.io . Should not be merged/deployed until we've verified DMARC, DKIM for the new domain.