### PR TITLE
feat: improve frontend config freshness to < 1s

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -112,7 +112,7 @@ exports[`should create default config 1`] = `
     },
   },
   "frontendApi": {
-    "refreshIntervalInMs": 10000,
+    "refreshIntervalInMs": 20000,
   },
   "frontendApiOrigins": [
     "*",

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -431,7 +431,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const frontendApi = options.frontendApi || {
         refreshIntervalInMs: parseEnvVarNumber(
             process.env.FRONTEND_API_REFRESH_INTERVAL_MS,
-            10000,
+            20000,
         ),
     };
 

--- a/src/lib/features/feature-toggle/config-client/toggle-config-change-emitter.ts
+++ b/src/lib/features/feature-toggle/config-client/toggle-config-change-emitter.ts
@@ -1,0 +1,53 @@
+import { Logger } from 'lib/logger';
+import { IEventStore } from 'lib/types';
+
+export default class ToggleConfigChangeEmitter {
+    private logger: Logger;
+
+    private eventStore: IEventStore;
+
+    private revisionId: number;
+
+    constructor(
+        { eventStore }: Pick<IUnleashStores, 'eventStore'>,
+        { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
+    ) {
+        this.logger = getLogger(
+            'features/config-client/toggle-config-change-emitter',
+        );
+        this.eventStore = eventStore;
+    }
+
+    async getEvents(): Promise<IEventList> {
+        let totalEvents = await this.eventStore.count();
+        let events = await this.eventStore.getEvents();
+        return {
+            events,
+            totalEvents,
+        };
+    }
+
+    async searchEvents(search: SearchEventsSchema): Promise<IEventList> {
+        let totalEvents = await this.eventStore.filteredCount(search);
+        let events = await this.eventStore.searchEvents(search);
+        return {
+            events,
+            totalEvents,
+        };
+    }
+
+    async getMaxRevisionId(): Promise<number> {
+        if (this.revisionId) {
+            return this.revisionId;
+        } else {
+            return this.updateMaxRevisionId();
+        }
+    }
+
+    async updateMaxRevisionId(): Promise<number> {
+        this.revisionId = await this.eventStore.getMaxRevisionId(
+            this.revisionId,
+        );
+        return this.revisionId;
+    }
+}

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -17,7 +17,7 @@ export default class ConfigurationRevisionService extends EventEmitter {
     ) {
         super();
         this.logger = getLogger(
-            'features/config-client/toggle-config-change-emitter',
+            'configuration-revision-service.ts',
         );
         this.eventStore = eventStore;
     }

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -16,9 +16,7 @@ export default class ConfigurationRevisionService extends EventEmitter {
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
     ) {
         super();
-        this.logger = getLogger(
-            'configuration-revision-service.ts',
-        );
+        this.logger = getLogger('configuration-revision-service.ts');
         this.eventStore = eventStore;
     }
 

--- a/src/lib/routes/client-api/feature.test.ts
+++ b/src/lib/routes/client-api/feature.test.ts
@@ -82,7 +82,7 @@ test('if caching is enabled should memoize', async () => {
     const openApiService = { respondWithValidation, validPath };
     const featureToggleServiceV2 = { getClientFeatures };
     const segmentService = { getActive };
-    const eventService = { getMaxRevisionId: () => 1 };
+    const configurationRevisionService = { getMaxRevisionId: () => 1 };
 
     const controller = new FeatureController(
         {
@@ -94,7 +94,7 @@ test('if caching is enabled should memoize', async () => {
             // @ts-expect-error due to partial implementation
             segmentService,
             // @ts-expect-error due to partial implementation
-            eventService,
+            configurationRevisionService,
         },
         {
             getLogger,
@@ -120,7 +120,7 @@ test('if caching is not enabled all calls goes to service', async () => {
     const featureToggleServiceV2 = { getClientFeatures };
     const segmentService = { getActive };
     const openApiService = { respondWithValidation, validPath };
-    const eventService = { getMaxRevisionId: () => 1 };
+    const configurationRevisionService = { getMaxRevisionId: () => 1 };
 
     const controller = new FeatureController(
         {
@@ -132,7 +132,7 @@ test('if caching is not enabled all calls goes to service', async () => {
             // @ts-expect-error due to partial implementation
             segmentService,
             // @ts-expect-error due to partial implementation
-            eventService,
+            configurationRevisionService,
         },
         {
             getLogger,

--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -26,8 +26,8 @@ import {
     clientFeaturesSchema,
     ClientFeaturesSchema,
 } from '../../openapi/spec/client-features-schema';
-import { ISegmentService } from 'lib/segments/segment-service-interface';
-import { EventService } from 'lib/services';
+import { ISegmentService } from '../../segments/segment-service-interface';
+import ConfigurationRevisionService from '../../features/feature-toggle/configuration-revision-service';
 
 const version = 2;
 
@@ -53,7 +53,7 @@ export default class FeatureController extends Controller {
 
     private openApiService: OpenApiService;
 
-    private eventService: EventService;
+    private configurationRevisionService: ConfigurationRevisionService;
 
     private featuresAndSegments: (
         query: IFeatureToggleQuery,
@@ -66,14 +66,14 @@ export default class FeatureController extends Controller {
             segmentService,
             clientSpecService,
             openApiService,
-            eventService,
+            configurationRevisionService,
         }: Pick<
             IUnleashServices,
             | 'featureToggleServiceV2'
             | 'segmentService'
             | 'clientSpecService'
             | 'openApiService'
-            | 'eventService'
+            | 'configurationRevisionService'
         >,
         config: IUnleashConfig,
     ) {
@@ -83,7 +83,7 @@ export default class FeatureController extends Controller {
         this.segmentService = segmentService;
         this.clientSpecService = clientSpecService;
         this.openApiService = openApiService;
-        this.eventService = eventService;
+        this.configurationRevisionService = configurationRevisionService;
         this.logger = config.getLogger('client-api/feature.js');
 
         this.route({
@@ -265,7 +265,8 @@ export default class FeatureController extends Controller {
 
     async calculateMeta(query: IFeatureToggleQuery): Promise<IMeta> {
         // TODO: We will need to standardize this to be able to implement this a cross languages (Edge in Rust?).
-        const revisionId = await this.eventService.getMaxRevisionId();
+        const revisionId =
+            await this.configurationRevisionService.getMaxRevisionId();
 
         // TODO: We will need to standardize this to be able to implement this a cross languages (Edge in Rust?).
         const queryHash = hashSum(query);

--- a/src/lib/services/event-service.ts
+++ b/src/lib/services/event-service.ts
@@ -10,8 +10,6 @@ export default class EventService {
 
     private eventStore: IEventStore;
 
-    private revisionId: number;
-
     constructor(
         { eventStore }: Pick<IUnleashStores, 'eventStore'>,
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
@@ -37,21 +35,4 @@ export default class EventService {
             totalEvents,
         };
     }
-
-    async getMaxRevisionId(): Promise<number> {
-        if (this.revisionId) {
-            return this.revisionId;
-        } else {
-            return this.updateMaxRevisionId();
-        }
-    }
-
-    async updateMaxRevisionId(): Promise<number> {
-        this.revisionId = await this.eventStore.getMaxRevisionId(
-            this.revisionId,
-        );
-        return this.revisionId;
-    }
 }
-
-module.exports = EventService;

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -56,6 +56,7 @@ import {
     createChangeRequestAccessReadModel,
     createFakeChangeRequestAccessService,
 } from '../features/change-request-access-service/createChangeRequestAccessReadModel';
+import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 
 // TODO: will be moved to scheduler feature directory
 export const scheduleServices = (services: IUnleashServices): void => {
@@ -66,7 +67,7 @@ export const scheduleServices = (services: IUnleashServices): void => {
         clientInstanceService,
         projectService,
         projectHealthService,
-        eventService,
+        configurationRevisionService,
     } = services;
 
     schedulerService.schedule(
@@ -102,7 +103,9 @@ export const scheduleServices = (services: IUnleashServices): void => {
     );
 
     schedulerService.schedule(
-        eventService.updateMaxRevisionId.bind(eventService),
+        configurationRevisionService.updateMaxRevisionId.bind(
+            configurationRevisionService,
+        ),
         secondsToMilliseconds(1),
     );
 };
@@ -188,11 +191,18 @@ export const createServices = (
         featureToggleServiceV2,
         segmentService,
     });
+
+    const configurationRevisionService = new ConfigurationRevisionService(
+        stores,
+        config,
+    );
+
     const proxyService = new ProxyService(config, stores, {
         featureToggleServiceV2,
         clientMetricsServiceV2,
         segmentService,
         settingService,
+        configurationRevisionService,
     });
 
     const edgeService = new EdgeService(stores, config);
@@ -264,6 +274,7 @@ export const createServices = (
         exportImportService,
         transactionalExportImportService,
         schedulerService,
+        configurationRevisionService,
     };
 };
 

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -31,6 +31,7 @@ type Services = Pick<
     | 'segmentService'
     | 'clientMetricsServiceV2'
     | 'settingService'
+    | 'configurationRevisionService'
 >;
 
 export class ProxyService {

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -40,7 +40,8 @@ import { AccountService } from '../services/account-service';
 import { SchedulerService } from '../services/scheduler-service';
 import { Knex } from 'knex';
 import ExportImportService from '../features/export-import-toggles/export-import-service';
-import { ISegmentService } from 'lib/segments/segment-service-interface';
+import { ISegmentService } from '../segments/segment-service-interface';
+import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 
 export interface IUnleashServices {
     accessService: AccessService;
@@ -85,6 +86,7 @@ export interface IUnleashServices {
     favoritesService: FavoritesService;
     maintenanceService: MaintenanceService;
     exportImportService: ExportImportService;
+    configurationRevisionService: ConfigurationRevisionService;
     schedulerService: SchedulerService;
     transactionalExportImportService: (
         db: Knex.Transaction,

--- a/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
@@ -142,7 +142,7 @@ test('returns 200 when content updates and hash does not match anymore', async (
         },
         'test',
     );
-    await app.services.eventService.updateMaxRevisionId();
+    await app.services.configurationRevisionService.updateMaxRevisionId();
 
     const res = await app.request
         .get('/api/client/features')


### PR DESCRIPTION
This PR reuses the revision Id information from the "optimal 304 for server SDKs" to improve the freshness of the frontend API config data. 

In addition it allows us to reduce the polling (and eventually remove it when we are confident).  
