### PR TITLE
docs: Add reference to Haskell SDK

### DIFF
--- a/website/docs/reference/sdks/index.md
+++ b/website/docs/reference/sdks/index.md
@@ -112,6 +112,7 @@ Here's some of the fantastic work our community has done to make Unleash work in
 - C++ ([aruizs/unleash-client-cpp](https://github.com/aruizs/unleash-client-cpp))
 - Dart ([uekoetter.dev/unleash-client-dart](https://pub.dev/packages/unleash))
 - Elixir ([afontaine/unleash_ex](https://gitlab.com/afontaine/unleash_ex))
+- Haskell ([finn-no/unleash-client-haskell](https://github.com/finn-no/unleash-client-haskell))
 - Kotlin ([silvercar/unleash-client-kotlin](https://github.com/silvercar/unleash-client-kotlin))
 - Laravel - PHP ([mikefrancis/laravel-unleash](https://github.com/mikefrancis/laravel-unleash))
 - NestJS - Node.js ([pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash))


### PR DESCRIPTION
Hi! Adding a link to a some-batteries-included Haskell Unleash SDK. It uses a "core" library underneath that adheres to your [Client Specifications](https://github.com/Unleash/client-specification). Could add a link to that too, but from what I can tell, it's overlapped by your Yggdrasil project. We have been using the SDK for a handful of months now and we're happy with how it works. Hope you'll have it :)