### PR TITLE
fix: ensure rel=noreferrer on target=_blank

### DIFF
--- a/frontend/src/component/admin/apiToken/ConfirmToken/ConfirmToken.tsx
+++ b/frontend/src/component/admin/apiToken/ConfirmToken/ConfirmToken.tsx
@@ -36,7 +36,7 @@ export const ConfirmToken = ({
                         By default, all {TokenType.FRONTEND} tokens may be used
                         from any CORS origin. If you'd like to configure a
                         strict set of origins, please use the{' '}
-                        <Link to="/admin/cors" target="_blank">
+                        <Link to="/admin/cors" target="_blank" rel="noreferrer">
                             CORS origins configuration page
                         </Link>
                         .

--- a/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
+++ b/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
@@ -78,6 +78,7 @@ export const InstanceStats: VFC = () => {
                         color="primary"
                         variant="contained"
                         target="_blank"
+                        rel="noreferrer"
                         href={formatApiPath(
                             '/api/admin/instance-admin/statistics/csv'
                         )}

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountModal.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountModal.tsx
@@ -352,6 +352,7 @@ export const ServiceAccountModal = ({
                                         <Link
                                             href="https://docs.getunleash.io/reference/api-tokens-and-client-keys"
                                             target="_blank"
+                                            rel="noreferrer"
                                         >
                                             Read more about API tokens
                                         </Link>

--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__snapshots__/DateSingleValue.test.tsx.snap
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__snapshots__/DateSingleValue.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Date component - snapshot matching 1`] = `
 {

--- a/frontend/src/component/common/InstanceStatus/__snapshots__/InstanceStatusBar.test.tsx.snap
+++ b/frontend/src/component/common/InstanceStatus/__snapshots__/InstanceStatusBar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`InstanceStatusBar should warn when the trial has churned 1`] = `
 <aside

--- a/frontend/src/component/common/MessageBanner/MessageBanner.tsx
+++ b/frontend/src/component/common/MessageBanner/MessageBanner.tsx
@@ -202,7 +202,7 @@ const BannerButton = ({
         );
 
     return (
-        <Link href={link} target="_blank" onClick={trackEvent}>
+        <Link href={link} target="_blank" rel="noreferrer" onClick={trackEvent}>
             {children}
         </Link>
     );

--- a/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
+++ b/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
@@ -93,7 +93,7 @@ export const PremiumFeature = ({ feature, tooltip }: PremiumFeatureProps) => {
     };
 
     const featureLabel = Boolean(url) ? (
-        <StyledLink href={url} target="_blank">
+        <StyledLink href={url} target="_blank" rel="noreferrer">
             {label}
         </StyledLink>
     ) : (
@@ -133,6 +133,7 @@ export const PremiumFeature = ({ feature, tooltip }: PremiumFeatureProps) => {
                             <StyledLink
                                 href={upgradeUrl}
                                 target="_blank"
+                                rel="noreferrer"
                                 onClick={handleClick}
                             >
                                 Upgrade now
@@ -156,6 +157,7 @@ export const PremiumFeature = ({ feature, tooltip }: PremiumFeatureProps) => {
                                 variant="outlined"
                                 href={upgradeUrl}
                                 target="_blank"
+                                rel="noreferrer"
                                 onClick={handleClick}
                             >
                                 Upgrade now

--- a/frontend/src/component/demo/DemoBanner/DemoBanner.tsx
+++ b/frontend/src/component/demo/DemoBanner/DemoBanner.tsx
@@ -45,6 +45,7 @@ export const DemoBanner = ({ onPlans }: IDemoBannerProps) => {
                 sx={{ ml: 1 }}
                 href="https://slack.unleash.run/"
                 target="_blank"
+                rel="noreferrer"
                 onClick={() => {
                     trackEvent('demo', {
                         props: {

--- a/frontend/src/component/demo/DemoDialog/DemoDialogPlans/DemoDialogPlans.tsx
+++ b/frontend/src/component/demo/DemoDialog/DemoDialogPlans/DemoDialogPlans.tsx
@@ -77,6 +77,7 @@ export const DemoDialogPlans = ({ open, onClose }: IDemoDialogPlansProps) => {
                         startIcon={<GitHub />}
                         href="https://github.com/unleash/unleash"
                         target="_blank"
+                        rel="noreferrer"
                         onClick={() => {
                             trackEvent('demo', {
                                 props: {
@@ -110,6 +111,7 @@ export const DemoDialogPlans = ({ open, onClose }: IDemoDialogPlansProps) => {
                         color="primary"
                         href="https://www.getunleash.io/plans/pro"
                         target="_blank"
+                        rel="noreferrer"
                         onClick={() => {
                             trackEvent('demo', {
                                 props: {
@@ -141,6 +143,7 @@ export const DemoDialogPlans = ({ open, onClose }: IDemoDialogPlansProps) => {
                         color="web"
                         href="https://www.getunleash.io/plans/enterprise"
                         target="_blank"
+                        rel="noreferrer"
                         onClick={() => {
                             trackEvent('demo', {
                                 props: {
@@ -157,6 +160,7 @@ export const DemoDialogPlans = ({ open, onClose }: IDemoDialogPlansProps) => {
             <StyledCompareLink
                 href="https://www.getunleash.io/plans"
                 target="_blank"
+                rel="noreferrer"
                 onClick={() => {
                     trackEvent('demo', {
                         props: {

--- a/frontend/src/component/demo/demo-topics.tsx
+++ b/frontend/src/component/demo/demo-topics.tsx
@@ -49,6 +49,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/feature-toggles"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Feature toggles
                             </a>{' '}
@@ -59,6 +60,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/projects"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 projects
                             </a>
@@ -99,6 +101,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/activation-strategies"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Activation strategies
                             </a>{' '}
@@ -154,6 +157,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/strategy-constraints"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Strategy constraints
                             </a>{' '}
@@ -161,6 +165,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/activation-strategies"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 activation strategy
                             </a>{' '}
@@ -181,6 +186,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/unleash-context"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Unleash context
                             </a>{' '}
@@ -301,6 +307,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/activation-strategies#gradual-rollout"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Gradual rollout
                             </a>{' '}
@@ -308,6 +315,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/activation-strategies"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 activation strategies
                             </a>
@@ -421,6 +429,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://docs.getunleash.io/reference/feature-toggle-variants"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 Feature toggle variants
                             </a>{' '}
@@ -496,6 +505,7 @@ export const TOPICS: ITutorialTopic[] = [
                             <a
                                 href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color"
                                 target="_blank"
+                                rel="noreferrer"
                             >
                                 color
                             </a>{' '}

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -303,6 +303,7 @@ export const EnvironmentCloneModal = ({
                                 <Link
                                     href="https://docs.getunleash.io/reference/api-tokens-and-client-keys"
                                     target="_blank"
+                                    rel="noreferrer"
                                 >
                                     Read more about API tokens
                                 </Link>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentChip.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentChip.tsx
@@ -76,7 +76,11 @@ export const FeatureStrategySegmentChip = ({
 
     return (
         <StyledChip>
-            <StyledLink to={`/segments/edit/${segment.id}`} target="_blank">
+            <StyledLink
+                to={`/segments/edit/${segment.id}`}
+                target="_blank"
+                rel="noreferrer"
+            >
                 {segment.name}
             </StyledLink>
             <Tooltip title={previewIconTooltip} arrow>

--- a/frontend/src/component/feedback/FeedbackCES/__snapshots__/FeedbackCESForm.test.tsx.snap
+++ b/frontend/src/component/feedback/FeedbackCES/__snapshots__/FeedbackCESForm.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FeedbackCESForm 1`] = `
 <body>

--- a/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`renders correctly with empty version 1`] = `
 <body>

--- a/frontend/src/component/menu/Footer/Footer.tsx
+++ b/frontend/src/component/menu/Footer/Footer.tsx
@@ -59,6 +59,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/node"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Node.js
                                                 </a>
@@ -71,6 +72,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/java"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Java
                                                 </a>
@@ -83,6 +85,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/go"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Go
                                                 </a>
@@ -95,6 +98,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/rust"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Rust
                                                 </a>
@@ -107,6 +111,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/ruby"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Ruby
                                                 </a>
@@ -119,6 +124,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/python"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Python
                                                 </a>
@@ -131,6 +137,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/dotnet"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     .NET
                                                 </a>
@@ -143,6 +150,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/php"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     PHP
                                                 </a>
@@ -155,6 +163,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     All SDKs
                                                 </a>
@@ -174,6 +183,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/unleash-proxy"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Unleash Proxy
                                                 </a>
@@ -186,6 +196,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/javascript-browser"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     JavaScript
                                                 </a>
@@ -198,6 +209,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/react"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     React
                                                 </a>
@@ -210,6 +222,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/next-js"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Next.js
                                                 </a>
@@ -222,6 +235,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/vue"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Vue
                                                 </a>
@@ -234,6 +248,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/ios-proxy"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     iOS
                                                 </a>
@@ -246,6 +261,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/android-proxy"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Android
                                                 </a>
@@ -258,6 +274,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://docs.getunleash.io/reference/sdks/flutter"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Flutter
                                                 </a>
@@ -277,6 +294,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://www.getunleash.io/"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     getunleash.io
                                                 </a>
@@ -289,6 +307,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://twitter.com/getunleash"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Twitter
                                                 </a>
@@ -301,6 +320,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://www.linkedin.com/company/getunleash"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     LinkedIn
                                                 </a>
@@ -313,6 +333,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://github.com/Unleash/unleash"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     GitHub
                                                 </a>
@@ -325,6 +346,7 @@ export const Footer: VFC = () => {
                                                 <a
                                                     href="https://slack.unleash.run"
                                                     target="_blank"
+                                                    rel="noreferrer"
                                                 >
                                                     Slack Community
                                                 </a>

--- a/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should render DrawerMenu 1`] = `
 [
@@ -64,6 +64,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/node"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Node.js
@@ -83,6 +84,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/java"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Java
@@ -102,6 +104,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/go"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Go
@@ -122,6 +125,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/rust"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Rust
@@ -142,6 +146,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/ruby"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Ruby
@@ -162,6 +167,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/python"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Python
@@ -181,6 +187,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/dotnet"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         .NET
@@ -200,6 +207,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/php"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         PHP
@@ -219,6 +227,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         All SDKs
@@ -255,6 +264,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/unleash-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Unleash Proxy
@@ -274,6 +284,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/javascript-browser"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         JavaScript
@@ -293,6 +304,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/react"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         React
@@ -312,6 +324,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/next-js"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Next.js
@@ -331,6 +344,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/vue"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Vue
@@ -350,6 +364,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/ios-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         iOS
@@ -369,6 +384,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/android-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Android
@@ -388,6 +404,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/flutter"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Flutter
@@ -422,6 +439,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://www.getunleash.io/"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         getunleash.io
@@ -441,6 +459,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://twitter.com/getunleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Twitter
@@ -460,6 +479,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://www.linkedin.com/company/getunleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         LinkedIn
@@ -479,6 +499,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://github.com/Unleash/unleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         GitHub
@@ -498,6 +519,7 @@ exports[`should render DrawerMenu 1`] = `
                     >
                       <a
                         href="https://slack.unleash.run"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Slack Community
@@ -586,6 +608,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/node"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Node.js
@@ -605,6 +628,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/java"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Java
@@ -624,6 +648,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/go"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Go
@@ -644,6 +669,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/rust"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Rust
@@ -664,6 +690,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/ruby"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Ruby
@@ -684,6 +711,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/python"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Python
@@ -703,6 +731,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/dotnet"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         .NET
@@ -722,6 +751,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/php"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         PHP
@@ -741,6 +771,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         All SDKs
@@ -777,6 +808,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/unleash-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Unleash Proxy
@@ -796,6 +828,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/javascript-browser"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         JavaScript
@@ -815,6 +848,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/react"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         React
@@ -834,6 +868,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/next-js"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Next.js
@@ -853,6 +888,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/vue"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Vue
@@ -872,6 +908,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/ios-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         iOS
@@ -891,6 +928,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/android-proxy"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Android
@@ -910,6 +948,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://docs.getunleash.io/reference/sdks/flutter"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Flutter
@@ -944,6 +983,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://www.getunleash.io/"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         getunleash.io
@@ -963,6 +1003,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://twitter.com/getunleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Twitter
@@ -982,6 +1023,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://www.linkedin.com/company/getunleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         LinkedIn
@@ -1001,6 +1043,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://github.com/Unleash/unleash"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         GitHub
@@ -1020,6 +1063,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
                     >
                       <a
                         href="https://slack.unleash.run"
+                        rel="noreferrer"
                         target="_blank"
                       >
                         Slack Community

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`returns all baseRoutes 1`] = `
 [

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -31,7 +31,11 @@ export const SegmentProjectAlert = ({
         <StyledUl>
             {Array.from(projectsUsed).map(projectId => (
                 <li key={projectId}>
-                    <Link to={`/projects/${projectId}`} target="_blank">
+                    <Link
+                        to={`/projects/${projectId}`}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
                         {projects.find(({ id }) => id === projectId)?.name ??
                             projectId}
                     </Link>
@@ -50,6 +54,7 @@ export const SegmentProjectAlert = ({
                                             strategy.id
                                         )}
                                         target="_blank"
+                                        rel="noreferrer"
                                     >
                                         {strategy.featureName!}{' '}
                                         {formatStrategyNameParens(strategy)}

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`renders an empty list correctly 1`] = `
 [


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1043/ensure-that-links-with-target=-blank-include-rel=noreferrer-to-prevent

Ensures that links with `target="_blank"` include `rel="noreferrer"` to prevent warnings such as:

![image](https://github.com/Unleash/unleash/assets/14320932/9e64df53-b4b9-4346-9394-edb0c2d2d555)
https://mathiasbynens.github.io/rel-noopener/#recommendations