### PR TITLE
fix: build is not present in npm package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         run: |
           yarn install --frozen-lockfile
-          yarn --cwd ./frontend build
+          yarn build
       - name: Publish to npm
         run: |
           LATEST=$(npm show unleash-server version)


### PR DESCRIPTION
## About the changes
Before publishing we should build. Not sure how this was working before