### PR TITLE
fix: add missing options parameter back in

### DIFF
--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -369,6 +369,25 @@ describe('Error serialization special cases', () => {
         expect(json).toMatchObject({ path, type });
     });
 
+    it('AuthenticationRequired adds `options` if they are present', () => {
+        const config = {
+            type: 'password',
+            path: `base-path/auth/simple/login`,
+            message: 'You must sign in order to use Unleash',
+            options: [
+                {
+                    type: 'google',
+                    message: 'Sign in with Google',
+                    path: `base-path/auth/google/login`,
+                },
+            ],
+        };
+
+        const json = new AuthenticationRequired(config).toJSON();
+
+        expect(json).toMatchObject(config);
+    });
+
     it('NoAccessError: adds `permission`', () => {
         const permission = 'x';
         const error = new NoAccessError(permission);

--- a/src/lib/types/authentication-required.ts
+++ b/src/lib/types/authentication-required.ts
@@ -39,6 +39,7 @@ class AuthenticationRequired extends UnleashError {
             ...super.toJSON(),
             path: this.path,
             type: this.type,
+            ...(this.options ? { options: this.options } : {}),
         };
     }
 }


### PR DESCRIPTION
This PR adds the missing serialization of the AuthenticationRequired response back in. It was mistakenly removed in #3633.

This PR also adds another test to verify that it the options property is present.