### PR TITLE
fix: anonymise PII fields in user access if flag is set

### DIFF
--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -294,6 +294,8 @@ export default class UserAdminController extends Controller {
     anonymiseUsers(users: IUser[]): IUser[] {
         return users.map((u) => ({
             ...u,
+            name: anonymise(u.name),
+            username: anonymise(u.username),
             email: anonymise(u.email || 'random'),
             imageUrl:
                 'https://gravatar.com/avatar/21232f297a57a5a743894a0e4a801fc3?size=42&default=retro',
@@ -334,6 +336,9 @@ export default class UserAdminController extends Controller {
                 accountType: u.accountType,
             } as IUser;
         });
+        if (this.flagResolver.isEnabled('anonymiseEventLog')) {
+            users = this.anonymiseUsers(users);
+        }
 
         let allGroups = await this.groupService.getAll();
         let groups = allGroups.map((g) => {

--- a/src/lib/util/anonymise.ts
+++ b/src/lib/util/anonymise.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'crypto';
 
-export function anonymise(s: string): string {
+export function anonymise(s?: string): string {
+    if (!s) {
+        return '';
+    }
     const hash = createHash('sha256')
         .update(s, 'utf-8')
         .digest('hex')

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -372,3 +372,26 @@ test('generates USER_UPDATED event', async () => {
     expect(events[0].data.id).toBe(body.id);
     expect(events[0].data.name).toBe('New name');
 });
+
+test('Anonymises name, username and email fields if anonymiseEventLog flag is set', async () => {
+    let anonymisedApp = await setupAppWithCustomConfig(
+        stores,
+        { experimental: { flags: { anonymiseEventLog: true } } },
+        db,
+    );
+    await anonymisedApp.request
+        .post('/api/admin/user-admin')
+        .send({
+            email: 'some@getunleash.ai',
+            name: 'Some Name',
+            rootRole: editorRole.id,
+        })
+        .set('Content-Type', 'application/json');
+    let response = await anonymisedApp.request.get(
+        '/api/admin/user-admin/access',
+    );
+    let body = response.body;
+    expect(body.users[0].email).toEqual('aeb83743e@unleash.run');
+    expect(body.users[0].name).toEqual('3a8b17647@unleash.run');
+    expect(body.users[0].username).toEqual(''); // Not set, so anonymise should return the empty string.
+});


### PR DESCRIPTION
### What
In the demo when listing possible users to grant access to your project, we inadvertently expose emails when listing users you can grant access to. This PR anonymises the access list on the way out.