### PR TITLE
fix: add confirmation to disable password login

### DIFF
--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -94,7 +94,7 @@ export const OidcAuth = () => {
 
     return (
         <PageContent>
-            <Grid container style={{ marginBottom: '1rem' }}>
+            <Grid container sx={{ mb: 3 }}>
                 <Grid item md={12}>
                     <Alert severity="info">
                         Please read the{' '}

--- a/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
+++ b/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
@@ -84,7 +84,7 @@ export const PasswordAuth = () => {
                     <Link to="/admin/users">{adminCount?.password}</Link>
                     <br />
                     <strong>Other administrators: </strong>{' '}
-                    <Link to="/admin/users">{adminCount?.no_password}</Link>
+                    <Link to="/admin/users">{adminCount?.noPassword}</Link>
                     <br />
                     <strong>Admin service accounts: </strong>{' '}
                     <Link to="/admin/service-accounts">

--- a/frontend/src/component/admin/auth/PasswordAuth/PasswordAuthDialog.tsx
+++ b/frontend/src/component/admin/auth/PasswordAuth/PasswordAuthDialog.tsx
@@ -1,0 +1,53 @@
+import { Alert, Typography } from '@mui/material';
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+import { IAdminCount } from 'hooks/api/getters/useAdminCount/useAdminCount';
+import { IApiToken } from 'hooks/api/getters/useApiTokens/useApiTokens';
+
+interface IPasswordAuthDialogProps {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    onClick: () => void;
+    adminCount: IAdminCount;
+    tokens: IApiToken[];
+}
+
+export const PasswordAuthDialog = ({
+    open,
+    setOpen,
+    onClick,
+    adminCount,
+    tokens,
+}: IPasswordAuthDialogProps) => (
+    <Dialogue
+        open={open}
+        onClose={() => {
+            setOpen(false);
+        }}
+        onClick={onClick}
+        title="Disable password based login?"
+        primaryButtonText="Disable password based login"
+        secondaryButtonText="Cancel"
+    >
+        <Alert severity="warning">
+            <strong>Warning!</strong> Disabling password based login may lock
+            you out of the system permanently if you do not have any alternative
+            admin credentials (such as an admin SSO account or admin API token)
+            secured beforehand.
+            <br />
+            <br />
+            <strong>Password based administrators: </strong>{' '}
+            {adminCount?.password}
+            <br />
+            <strong>Other administrators: </strong> {adminCount?.no_password}
+            <br />
+            <strong>Admin service accounts: </strong> {adminCount?.service}
+            <br />
+            <strong>Admin API tokens: </strong>{' '}
+            {tokens.filter(({ type }) => type === 'admin').length}
+        </Alert>
+        <Typography sx={{ mt: 3 }}>
+            You are about to disable password based login. Are you sure you want
+            to proceed?
+        </Typography>
+    </Dialogue>
+);

--- a/frontend/src/component/admin/auth/PasswordAuth/PasswordAuthDialog.tsx
+++ b/frontend/src/component/admin/auth/PasswordAuth/PasswordAuthDialog.tsx
@@ -38,7 +38,7 @@ export const PasswordAuthDialog = ({
             <strong>Password based administrators: </strong>{' '}
             {adminCount?.password}
             <br />
-            <strong>Other administrators: </strong> {adminCount?.no_password}
+            <strong>Other administrators: </strong> {adminCount?.noPassword}
             <br />
             <strong>Admin service accounts: </strong> {adminCount?.service}
             <br />

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -85,7 +85,7 @@ export const SamlAuth = () => {
 
     return (
         <PageContent>
-            <Grid container style={{ marginBottom: '1rem' }}>
+            <Grid container sx={{ mb: 3 }}>
                 <Grid item md={12}>
                     <Alert severity="info">
                         Please read the{' '}

--- a/frontend/src/hooks/api/getters/useAdminCount/useAdminCount.ts
+++ b/frontend/src/hooks/api/getters/useAdminCount/useAdminCount.ts
@@ -4,7 +4,7 @@ import handleErrorResponses from '../httpErrorResponseHandler';
 
 export interface IAdminCount {
     password: number;
-    no_password: number;
+    noPassword: number;
     service: number;
 }
 

--- a/frontend/src/hooks/api/getters/useAdminCount/useAdminCount.ts
+++ b/frontend/src/hooks/api/getters/useAdminCount/useAdminCount.ts
@@ -1,0 +1,29 @@
+import useSWR from 'swr';
+import { formatApiPath } from 'utils/formatPath';
+import handleErrorResponses from '../httpErrorResponseHandler';
+
+export interface IAdminCount {
+    password: number;
+    no_password: number;
+    service: number;
+}
+
+export const useAdminCount = () => {
+    const { data, error, mutate } = useSWR<IAdminCount>(
+        formatApiPath(`api/admin/user-admin/admin-count`),
+        fetcher
+    );
+
+    return {
+        data,
+        loading: !error && !data,
+        refetch: () => mutate(),
+        error,
+    };
+};
+
+const fetcher = (path: string) => {
+    return fetch(path)
+        .then(handleErrorResponses('Admin count'))
+        .then(res => res.json());
+};

--- a/src/lib/db/account-store.ts
+++ b/src/lib/db/account-store.ts
@@ -191,6 +191,10 @@ export class AccountStore implements IAccountStore {
                 ),
             );
 
-        return adminCount[0];
+        return {
+            password: adminCount[0].password,
+            noPassword: adminCount[0].no_password,
+            service: adminCount[0].service,
+        };
     }
 }

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -5,6 +5,7 @@ import {
     addonSchema,
     addonsSchema,
     addonTypeSchema,
+    adminCountSchema,
     adminFeaturesQuerySchema,
     apiTokenSchema,
     apiTokensSchema,
@@ -182,6 +183,7 @@ interface OpenAPIV3DocumentWithServers extends OpenAPIV3.Document {
 
 // All schemas in `openapi/spec` should be listed here.
 export const schemas: UnleashSchemas = {
+    adminCountSchema,
     adminFeaturesQuerySchema,
     addonParameterSchema,
     addonSchema,

--- a/src/lib/openapi/meta-schema-rules.test.ts
+++ b/src/lib/openapi/meta-schema-rules.test.ts
@@ -79,6 +79,7 @@ const metaRules: Rule[] = [
             },
         },
         knownExceptions: [
+            'adminCountSchema',
             'batchFeaturesSchema',
             'batchStaleSchema',
             'changePasswordSchema',
@@ -181,6 +182,7 @@ const metaRules: Rule[] = [
             required: ['description'],
         },
         knownExceptions: [
+            'adminCountSchema',
             'adminFeaturesQuerySchema',
             'applicationSchema',
             'applicationsSchema',

--- a/src/lib/openapi/meta-schema-rules.test.ts
+++ b/src/lib/openapi/meta-schema-rules.test.ts
@@ -79,7 +79,6 @@ const metaRules: Rule[] = [
             },
         },
         knownExceptions: [
-            'adminCountSchema',
             'batchFeaturesSchema',
             'batchStaleSchema',
             'changePasswordSchema',
@@ -182,7 +181,6 @@ const metaRules: Rule[] = [
             required: ['description'],
         },
         knownExceptions: [
-            'adminCountSchema',
             'adminFeaturesQuerySchema',
             'applicationSchema',
             'applicationsSchema',

--- a/src/lib/openapi/spec/admin-count-schema.ts
+++ b/src/lib/openapi/spec/admin-count-schema.ts
@@ -4,16 +4,22 @@ export const adminCountSchema = {
     $id: '#/components/schemas/adminCountSchema',
     type: 'object',
     additionalProperties: false,
+    description: 'Contains total admin counts for an Unleash instance.',
     required: ['password', 'noPassword', 'service'],
     properties: {
         password: {
             type: 'number',
+            description: 'Total number of admins that have a password set.',
         },
         noPassword: {
             type: 'number',
+            description:
+                'Total number of admins that do not have a password set. May be SSO, but may also be users that did not set a password yet.',
         },
         service: {
             type: 'number',
+            description:
+                'Total number of service accounts that have the admin root role.',
         },
     },
     components: {},

--- a/src/lib/openapi/spec/admin-count-schema.ts
+++ b/src/lib/openapi/spec/admin-count-schema.ts
@@ -1,0 +1,22 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const adminCountSchema = {
+    $id: '#/components/schemas/adminCountSchema',
+    type: 'object',
+    additionalProperties: false,
+    required: ['password', 'no_password', 'service'],
+    properties: {
+        password: {
+            type: 'number',
+        },
+        no_password: {
+            type: 'number',
+        },
+        service: {
+            type: 'number',
+        },
+    },
+    components: {},
+} as const;
+
+export type AdminCountSchema = FromSchema<typeof adminCountSchema>;

--- a/src/lib/openapi/spec/admin-count-schema.ts
+++ b/src/lib/openapi/spec/admin-count-schema.ts
@@ -4,12 +4,12 @@ export const adminCountSchema = {
     $id: '#/components/schemas/adminCountSchema',
     type: 'object',
     additionalProperties: false,
-    required: ['password', 'no_password', 'service'],
+    required: ['password', 'noPassword', 'service'],
     properties: {
         password: {
             type: 'number',
         },
-        no_password: {
+        noPassword: {
             type: 'number',
         },
         service: {

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -136,3 +136,4 @@ export * from './upsert-segment-schema';
 export * from './batch-features-schema';
 export * from './token-string-list-schema';
 export * from './bulk-toggle-features-schema';
+export * from './admin-count-schema';

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -41,6 +41,10 @@ import { IGroup } from '../../types/group';
 import { IFlagResolver } from '../../types/experimental';
 import rateLimit from 'express-rate-limit';
 import { minutesToMilliseconds } from 'date-fns';
+import {
+    AdminCountSchema,
+    adminCountSchema,
+} from '../../openapi/spec/admin-count-schema';
 
 export default class UserAdminController extends Controller {
     private flagResolver: IFlagResolver;
@@ -187,6 +191,22 @@ export default class UserAdminController extends Controller {
                     operationId: 'getBaseUsersAndGroups',
                     responses: {
                         200: createResponseSchema('usersGroupsBaseSchema'),
+                    },
+                }),
+            ],
+        });
+
+        this.route({
+            method: 'get',
+            path: '/admin-count',
+            handler: this.getAdminCount,
+            permission: ADMIN,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Users'],
+                    operationId: 'getAdminCount',
+                    responses: {
+                        200: createResponseSchema('adminCountSchema'),
                     },
                 }),
             ],
@@ -497,5 +517,20 @@ export default class UserAdminController extends Controller {
 
         await this.userService.changePassword(+id, password);
         res.status(200).send();
+    }
+
+    async getAdminCount(
+        req: Request,
+        res: Response<AdminCountSchema>,
+    ): Promise<void> {
+        console.log('user-admin controller');
+        const adminCount = await this.accountService.getAdminCount();
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            adminCountSchema.$id,
+            adminCount,
+        );
     }
 }

--- a/src/lib/services/account-service.ts
+++ b/src/lib/services/account-service.ts
@@ -5,6 +5,7 @@ import { IAccountStore, IUnleashStores } from '../types/stores';
 import { minutesToMilliseconds } from 'date-fns';
 import { AccessService } from './access-service';
 import { RoleName } from '../types/model';
+import { IAdminCount } from 'lib/types/stores/account-store';
 
 interface IUserWithRole extends IUser {
     rootRole: number;
@@ -50,6 +51,10 @@ export class AccountService {
 
     async getAccountByPersonalAccessToken(secret: string): Promise<IUser> {
         return this.store.getAccountByPersonalAccessToken(secret);
+    }
+
+    async getAdminCount(): Promise<IAdminCount> {
+        return this.store.getAdminCount();
     }
 
     async updateLastSeen(): Promise<void> {

--- a/src/lib/types/stores/account-store.ts
+++ b/src/lib/types/stores/account-store.ts
@@ -7,6 +7,12 @@ export interface IUserLookup {
     email?: string;
 }
 
+export interface IAdminCount {
+    password: number;
+    no_password: number;
+    service: number;
+}
+
 export interface IAccountStore extends Store<IUser, number> {
     hasAccount(idQuery: IUserLookup): Promise<number | undefined>;
     search(query: string): Promise<IUser[]>;
@@ -15,4 +21,5 @@ export interface IAccountStore extends Store<IUser, number> {
     count(): Promise<number>;
     getAccountByPersonalAccessToken(secret: string): Promise<IUser>;
     markSeenAt(secrets: string[]): Promise<void>;
+    getAdminCount(): Promise<IAdminCount>;
 }

--- a/src/lib/types/stores/account-store.ts
+++ b/src/lib/types/stores/account-store.ts
@@ -9,7 +9,7 @@ export interface IUserLookup {
 
 export interface IAdminCount {
     password: number;
-    no_password: number;
+    noPassword: number;
     service: number;
 }
 

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -608,6 +608,26 @@ The provider you choose for your addon dictates what properties the \`parameters
         ],
         "type": "object",
       },
+      "adminCountSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "no_password": {
+            "type": "number",
+          },
+          "password": {
+            "type": "number",
+          },
+          "service": {
+            "type": "number",
+          },
+        },
+        "required": [
+          "password",
+          "no_password",
+          "service",
+        ],
+        "type": "object",
+      },
       "adminFeaturesQuerySchema": {
         "additionalProperties": false,
         "properties": {
@@ -12515,6 +12535,26 @@ If the provided project does not exist, the list of events will be empty.",
               },
             },
             "description": "usersGroupsBaseSchema",
+          },
+        },
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/api/admin/user-admin/admin-count": {
+      "get": {
+        "operationId": "getAdminCount",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/adminCountSchema",
+                },
+              },
+            },
+            "description": "adminCountSchema",
           },
         },
         "tags": [

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -610,14 +610,18 @@ The provider you choose for your addon dictates what properties the \`parameters
       },
       "adminCountSchema": {
         "additionalProperties": false,
+        "description": "Contains total admin counts for an Unleash instance.",
         "properties": {
           "noPassword": {
+            "description": "Total number of admins that do not have a password set. May be SSO, but may also be users that did not set a password yet.",
             "type": "number",
           },
           "password": {
+            "description": "Total number of admins that have a password set.",
             "type": "number",
           },
           "service": {
+            "description": "Total number of service accounts that have the admin root role.",
             "type": "number",
           },
         },

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -611,7 +611,7 @@ The provider you choose for your addon dictates what properties the \`parameters
       "adminCountSchema": {
         "additionalProperties": false,
         "properties": {
-          "no_password": {
+          "noPassword": {
             "type": "number",
           },
           "password": {
@@ -623,7 +623,7 @@ The provider you choose for your addon dictates what properties the \`parameters
         },
         "required": [
           "password",
-          "no_password",
+          "noPassword",
           "service",
         ],
         "type": "object",

--- a/src/test/fixtures/fake-account-store.ts
+++ b/src/test/fixtures/fake-account-store.ts
@@ -3,6 +3,7 @@ import {
     // ICreateUser,
     IUserLookup,
     IAccountStore,
+    IAdminCount,
 } from '../../lib/types/stores/account-store';
 
 export class FakeAccountStore implements IAccountStore {
@@ -91,6 +92,10 @@ export class FakeAccountStore implements IAccountStore {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async markSeenAt(secrets: string[]): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    async getAdminCount(): Promise<IAdminCount> {
         throw new Error('Not implemented');
     }
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1071/prevent-users-from-disabling-password-authentication-when-there-are-no

Improves the behavior of disabling password based login by adding some relevant information and a confirmation dialog with a warning. This felt better than trying to disable the toggle, by still allowing the end users to make the decision, except now it should be a properly informed decision with confirmation.

![image](https://github.com/Unleash/unleash/assets/14320932/2ca754d8-cfa2-4fda-984d-0c34b89750f3)

- **Password based administrators**: Admin accounts that have a password set;
- **Other administrators**: Other admin users that do not have a password. May be SSO, but may also be users that did not set a password yet;
- **Admin service accounts**: Service accounts that have the admin root role. Depending on how you're using the SA this may not necessarily mean locking yourself out of an admin account, especially if you secured its token beforehand;
- **Admin API tokens**: Similar to the above. If you secured an admin API token beforehand, you still have access to all features through the API;

Each one of them link to the respective page inside Unleash (e.g. users page, service accounts page, tokens page...);

If you try to disable and press "save", and only in that scenario, you are presented with the following confirmation dialog:

![image](https://github.com/Unleash/unleash/assets/14320932/5ad6d105-ad47-4d31-a1df-04737aed4e00)