### PR TITLE
chore: improve joi errors

### DIFF
--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -18,7 +18,7 @@ class BadDataError extends UnleashError {
         const topLevelMessage =
             'Request validation failed: your request body contains invalid data' +
             (errors
-                ? '. Refer to the `details` list to see what happened.'
+                ? '. Refer to the `details` list for more information.'
                 : `: ${message}`);
         super(topLevelMessage);
 

--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -1,4 +1,5 @@
 import { ErrorObject } from 'ajv';
+import { ValidationError } from 'joi';
 import getProp from 'lodash.get';
 import { ApiErrorSchema, UnleashError } from './unleash-error';
 
@@ -120,4 +121,30 @@ export const fromOpenApiValidationErrors = (
         "Request validation failed: the payload you provided doesn't conform to the schema. Check the `details` property for a list of errors that we found.",
         [firstDetail, ...remainingDetails],
     );
+};
+
+export const fromJoiError = (err: ValidationError): BadDataError => {
+    const details = err.details.map((detail) => {
+        const messageEnd = detail.context?.value
+            ? `. You provided ${JSON.stringify(detail.context.value)}.`
+            : '.';
+        const description = detail.message + messageEnd;
+        return {
+            description,
+            message: description,
+        };
+    });
+
+    const [first, ...rest] = details;
+
+    if (first) {
+        return new BadDataError(
+            'A validation error occurred while processing your request data. Refer to the `details` property for more information.',
+            [first, ...rest],
+        );
+    } else {
+        return new BadDataError(
+            'A validation error occurred while processing your request data. Please make sure it conforms to the request data schema.',
+        );
+    }
 };

--- a/src/lib/error/from-legacy-error.ts
+++ b/src/lib/error/from-legacy-error.ts
@@ -1,3 +1,5 @@
+import { fromJoiError } from './bad-data-error';
+import { ValidationError as JoiValidationError } from 'joi';
 import {
     GenericUnleashError,
     UnleashApiErrorName,
@@ -18,6 +20,10 @@ export const fromLegacyError = (e: Error): UnleashError => {
             name: 'NoAccessError',
             message: e.message,
         });
+    }
+
+    if (e instanceof JoiValidationError) {
+        return fromJoiError(e);
     }
 
     if (name === 'ValidationError' || name === 'BadDataError') {

--- a/src/lib/error/from-legacy-error.ts
+++ b/src/lib/error/from-legacy-error.ts
@@ -1,0 +1,48 @@
+import {
+    GenericUnleashError,
+    UnleashApiErrorName,
+    UnleashApiErrorTypes,
+    UnleashError,
+} from './unleash-error';
+
+export const fromLegacyError = (e: Error): UnleashError => {
+    if (e instanceof UnleashError) {
+        return e;
+    }
+    const name = UnleashApiErrorTypes.includes(e.name as UnleashApiErrorName)
+        ? (e.name as UnleashApiErrorName)
+        : 'UnknownError';
+
+    if (name === 'NoAccessError') {
+        return new GenericUnleashError({
+            name: 'NoAccessError',
+            message: e.message,
+        });
+    }
+
+    if (name === 'ValidationError' || name === 'BadDataError') {
+        return new GenericUnleashError({
+            name: 'BadDataError',
+            message: e.message,
+        });
+    }
+
+    if (name === 'OwaspValidationError') {
+        return new GenericUnleashError({
+            name: 'OwaspValidationError',
+            message: e.message,
+        });
+    }
+
+    if (name === 'AuthenticationRequired') {
+        return new GenericUnleashError({
+            name: 'AuthenticationRequired',
+            message: `You must be authenticated to view this content. Please log in.`,
+        });
+    }
+
+    return new GenericUnleashError({
+        name: name as UnleashApiErrorName,
+        message: e.message,
+    });
+};

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -361,28 +361,19 @@ describe('Error serialization special cases', () => {
             await validateString([]);
         } catch (e) {
             validationThrewAnError = true;
-            const ep = `
-[Error [ValidationError]: "value" must contain at least 1 items] {
-      _original: [],
-      details: [
-        {
-          message: '"value" must contain at least 1 items',
-          path: [],
-          type: 'array.min',
-          context: { limit: 1, value: [], label: 'value' }
-        }
-      ]
-    }
-`;
-            const expectedDetails = 'You provided ';
-            console.log(e, e.details[0].context, fromLegacyError(e));
+            const convertedError = fromLegacyError(e);
 
-            // expect(convertedError.toJSON()).toMatchObject({
-            //     message: expect.matches("invalid") && expect.containsan
-            //     details: [{
-            //         message: '"value" must contain at least 1 items'
-            //     }]
-            // })
+            expect(convertedError.toJSON()).toMatchObject({
+                message:
+                    expect.stringContaining('validation error') &&
+                    expect.stringContaining('details'),
+                details: [
+                    {
+                        description:
+                            '"value" must contain at least 1 items. You provided [].',
+                    },
+                ],
+            });
         }
 
         expect(validationThrewAnError).toBeTruthy();

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -356,6 +356,8 @@ describe('Error serialization special cases', () => {
     });
 
     it('Converts Joi errors in a sensible fashion', async () => {
+        // if the validation doesn't fail, this test does nothing, so ensure
+        // that an error is thrown.
         let validationThrewAnError = false;
         try {
             await validateString([]);

--- a/src/lib/error/unleash-error.ts
+++ b/src/lib/error/unleash-error.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidV4 } from 'uuid';
 import { FromSchema } from 'json-schema-to-ts';
 
-const UnleashApiErrorTypes = [
+export const UnleashApiErrorTypes = [
     'ContentTypeError',
     'DisabledError',
     'FeatureHasTagError',
@@ -32,7 +32,7 @@ const UnleashApiErrorTypes = [
     'InternalError',
 ] as const;
 
-type UnleashApiErrorName = typeof UnleashApiErrorTypes[number];
+export type UnleashApiErrorName = typeof UnleashApiErrorTypes[number];
 
 const statusCode = (errorName: string): number => {
     switch (errorName) {
@@ -127,7 +127,7 @@ export abstract class UnleashError extends Error {
     }
 }
 
-class GenericUnleashError extends UnleashError {
+export class GenericUnleashError extends UnleashError {
     constructor({
         name,
         message,
@@ -167,47 +167,5 @@ export const apiErrorSchema = {
     },
     components: {},
 } as const;
-
-export const fromLegacyError = (e: Error): UnleashError => {
-    if (e instanceof UnleashError) {
-        return e;
-    }
-    const name = UnleashApiErrorTypes.includes(e.name as UnleashApiErrorName)
-        ? (e.name as UnleashApiErrorName)
-        : 'UnknownError';
-
-    if (name === 'NoAccessError') {
-        return new GenericUnleashError({
-            name: 'NoAccessError',
-            message: e.message,
-        });
-    }
-
-    if (name === 'ValidationError' || name === 'BadDataError') {
-        return new GenericUnleashError({
-            name: 'BadDataError',
-            message: e.message,
-        });
-    }
-
-    if (name === 'OwaspValidationError') {
-        return new GenericUnleashError({
-            name: 'OwaspValidationError',
-            message: e.message,
-        });
-    }
-
-    if (name === 'AuthenticationRequired') {
-        return new GenericUnleashError({
-            name: 'AuthenticationRequired',
-            message: `You must be authenticated to view this content. Please log in.`,
-        });
-    }
-
-    return new GenericUnleashError({
-        name: name as UnleashApiErrorName,
-        message: e.message,
-    });
-};
 
 export type ApiErrorSchema = FromSchema<typeof apiErrorSchema>;

--- a/src/lib/routes/admin-api/strategy.test.ts
+++ b/src/lib/routes/admin-api/strategy.test.ts
@@ -68,7 +68,7 @@ test('require parameters array when creating a new strategy', async () => {
         .send({ name: 'TestStrat' })
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].description).toEqual(
+            expect(res.body.details[0].description).toMatch(
                 '"parameters" is required',
             );
         });

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -1,7 +1,8 @@
 import joi from 'joi';
 import { Response } from 'express';
 import { Logger } from '../logger';
-import { fromLegacyError, UnleashError } from '../error/unleash-error';
+import { UnleashError } from '../error/unleash-error';
+import { fromLegacyError } from '../error/from-legacy-error';
 
 export const customJoi = joi.extend((j) => ({
     type: 'isUrlFriendly',

--- a/src/test/e2e/api/admin/tag-types.e2e.test.ts
+++ b/src/test/e2e/api/admin/tag-types.e2e.test.ts
@@ -77,7 +77,7 @@ test('Invalid tag types gets rejected', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].description).toBe(
+            expect(res.body.details[0].description).toMatch(
                 '"name" must be URL friendly',
             );
         });
@@ -151,7 +151,7 @@ test('Invalid tag-types get refused by validator', async () => {
         .set('Content-Type', 'application/json')
         .expect(400)
         .expect((res) => {
-            expect(res.body.details[0].description).toBe(
+            expect(res.body.details[0].description).toMatch(
                 '"name" must be URL friendly',
             );
         });

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -86,7 +86,7 @@ test('Can validate a tag', async () =>
         .expect(400)
         .expect((res) => {
             expect(res.body.details.length).toBe(1);
-            expect(res.body.details[0].description).toBe(
+            expect(res.body.details[0].description).toMatch(
                 '"type" must be URL friendly',
             );
         }));


### PR DESCRIPTION
This PR improves our handling of internal Joi errors, to make them more sensible to the end user. It does that by providing a better description of the errors and by telling the user what they value they provided was.

Previous conversion:
```json
{
  "id": "705a8dc0-1198-4894-9015-f1e5b9992b48",
  "name": "BadDataError",
  "message": "\"value\" must contain at least 1 items",
  "details": [
    {
      "message": "\"value\" must contain at least 1 items",
      "description": "\"value\" must contain at least 1 items"
    }
  ]
}
```

New conversion:
```json
{
  "id": "87fb4715-cbdd-48bb-b4d7-d354e7d97380",
  "name": "BadDataError",
  "message": "Request validation failed: your request body contains invalid data. Refer to the `details` list for more information.",
  "details": [
    {
      "description": "\"value\" must contain at least 1 items. You provided [].",
      "message": "\"value\" must contain at least 1 items. You provided []."
    }
  ]
}
```

## Restructuring

This PR moves some code out of `unleash-error.ts` and into a new file. The purpose of this is twofold:
1. avoid circular dependencies (we need imports from both UnleashError and BadDataError)
2. carve out a clearer separation of concerns, keeping `unleash-error` a little more focused.