### PR TITLE
chore: lower log-level for unexpected errors

### DIFF
--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -31,7 +31,7 @@ export const handleErrors: (
 
     if (!(error instanceof UnleashError)) {
         logger.debug(
-            `I encountered an error that wasn't an instance of the \`UnleashError\` type. This probably means that we had an unexpected crash. The original error and what it was mapped to are:`,
+            `I encountered an error that wasn't an instance of the \`UnleashError\` type. The original error and what it was mapped to are:`,
             error,
             finalError,
         );

--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -30,7 +30,7 @@ export const handleErrors: (
         error instanceof UnleashError ? error : fromLegacyError(error);
 
     if (!(error instanceof UnleashError)) {
-        logger.warn(
+        logger.debug(
             `I encountered an error that wasn't an instance of the \`UnleashError\` type. This probably means that we had an unexpected crash. The original error and what it was mapped to are:`,
             error,
             finalError,


### PR DESCRIPTION
This change lowers the log level from warning to debug for when we see unexpected error types.

Right now this triggers for Joi errors, which we still rely on pretty heavily. Lowering this should clear up logs for most users.