### PR TITLE
fix: make area behind bulk actions clickable

### DIFF
--- a/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
+++ b/frontend/src/component/common/BatchSelectionActionsBar/BatchSelectionActionsBar.tsx
@@ -11,6 +11,7 @@ const StyledStickyContainer = styled('div')(({ theme }) => ({
     marginTop: 'auto',
     bottom: 0,
     zIndex: theme.zIndex.mobileStepper,
+    pointerEvents: 'none'
 }));
 
 const StyledContainer = styled(Box)(({ theme }) => ({
@@ -34,6 +35,7 @@ const StyledBar = styled(Paper)(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusLarge,
     gap: theme.spacing(1),
     flexWrap: 'wrap',
+    pointerEvents: 'auto'
 }));
 
 const StyledCount = styled('span')(({ theme }) => ({


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Make area behind bulk actions clickable on the left and right hand side.

<img width="999" alt="Screenshot 2023-05-23 at 10 14 48" src="https://github.com/Unleash/unleash/assets/1394682/9c641679-4a0e-4f83-ab2e-12d814a3becc">

Solution:
* parent container spanning outside the buttons has pointer events set to none
* while the child/narrower container with actions brings the pointer events back for itself and its children
