### PR TITLE
fix: Only show names as changed when titles have changed.

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -15,6 +15,7 @@ import { Typography, styled } from '@mui/material';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { textTruncated } from 'themes/themeStyles';
+import { useStrategies } from 'hooks/api/getters/useStrategies/useStrategies';
 
 const StyledCodeSection = styled('div')(({ theme }) => ({
     overflowX: 'auto',
@@ -73,37 +74,47 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
     change,
     previousTitle,
     children,
-}) => (
-    <StyledContainer>
-        <GetFeatureStrategyIcon strategyName={change.payload.name} />
-        <Truncated>
-            <ConditionallyRender
-                condition={Boolean(
-                    (previousTitle && previousTitle !== change.payload.title) ||
-                        (!previousTitle && change.payload.title)
-                )}
-                show={
-                    <Truncated>
-                        <Typography component="s" color="text.secondary">
-                            {previousTitle}
-                        </Typography>{' '}
-                    </Truncated>
-                }
-            />
+}) => {
+    const { strategies } = useStrategies();
+    const titleHasChanged = Boolean(
+        (previousTitle && previousTitle !== change.payload.title) ||
+            (!previousTitle && change.payload.title)
+    );
+    const previousTitleOrDefault = () =>
+        (previousTitle ||
+            strategies.find(strategy => strategy.name === change.payload.name)
+                ?.displayName) ??
+        '';
+
+    return (
+        <StyledContainer>
+            <GetFeatureStrategyIcon strategyName={change.payload.name} />
             <Truncated>
-                <TooltipLink
-                    tooltip={children}
-                    tooltipProps={{
-                        maxWidth: 500,
-                        maxHeight: 600,
-                    }}
-                >
-                    <Typography component="span">
-                        {change.payload.title ||
-                            formatStrategyName(change.payload.name)}
-                    </Typography>
-                </TooltipLink>
+                <ConditionallyRender
+                    condition={titleHasChanged}
+                    show={
+                        <Truncated>
+                            <Typography component="s" color="text.secondary">
+                                {previousTitleOrDefault()}
+                            </Typography>{' '}
+                        </Truncated>
+                    }
+                />
+                <Truncated>
+                    <TooltipLink
+                        tooltip={children}
+                        tooltipProps={{
+                            maxWidth: 500,
+                            maxHeight: 600,
+                        }}
+                    >
+                        <Typography component="span">
+                            {change.payload.title ||
+                                formatStrategyName(change.payload.name)}
+                        </Typography>
+                    </TooltipLink>
+                </Truncated>
             </Truncated>
-        </Truncated>
-    </StyledContainer>
-);
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -73,43 +73,38 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
     change,
     previousTitle,
     children,
-}) => {
-    const titleHasChanged = Boolean(
-        (previousTitle && previousTitle !== change.payload.title) ||
-            (!previousTitle && change.payload.title)
-    );
-    const previousTitleOrDefault = () =>
-        previousTitle || formatStrategyName(change.payload.name);
-
-    return (
-        <StyledContainer>
-            <GetFeatureStrategyIcon strategyName={change.payload.name} />
-            <Truncated>
-                <ConditionallyRender
-                    condition={titleHasChanged}
-                    show={
-                        <Truncated>
-                            <Typography component="s" color="text.secondary">
-                                {previousTitleOrDefault()}
-                            </Typography>{' '}
-                        </Truncated>
-                    }
-                />
-                <Truncated>
-                    <TooltipLink
-                        tooltip={children}
-                        tooltipProps={{
-                            maxWidth: 500,
-                            maxHeight: 600,
-                        }}
-                    >
-                        <Typography component="span">
-                            {change.payload.title ||
+}) => (
+    <StyledContainer>
+        <GetFeatureStrategyIcon strategyName={change.payload.name} />
+        <Truncated>
+            <ConditionallyRender
+                condition={Boolean(
+                    (previousTitle && previousTitle !== change.payload.title) ||
+                        (!previousTitle && change.payload.title)
+                )}
+                show={
+                    <Truncated>
+                        <Typography component="s" color="text.secondary">
+                            {previousTitle ||
                                 formatStrategyName(change.payload.name)}
-                        </Typography>
-                    </TooltipLink>
-                </Truncated>
+                        </Typography>{' '}
+                    </Truncated>
+                }
+            />
+            <Truncated>
+                <TooltipLink
+                    tooltip={children}
+                    tooltipProps={{
+                        maxWidth: 500,
+                        maxHeight: 600,
+                    }}
+                >
+                    <Typography component="span">
+                        {change.payload.title ||
+                            formatStrategyName(change.payload.name)}
+                    </Typography>
+                </TooltipLink>
             </Truncated>
-        </StyledContainer>
-    );
-};
+        </Truncated>
+    </StyledContainer>
+);

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -80,7 +80,7 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
             <ConditionallyRender
                 condition={Boolean(
                     (previousTitle && previousTitle !== change.payload.title) ||
-                        true
+                        (!previousTitle && change.payload.title)
                 )}
                 show={
                     <Truncated>

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -15,7 +15,6 @@ import { Typography, styled } from '@mui/material';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { textTruncated } from 'themes/themeStyles';
-import { useStrategies } from 'hooks/api/getters/useStrategies/useStrategies';
 
 const StyledCodeSection = styled('div')(({ theme }) => ({
     overflowX: 'auto',
@@ -75,16 +74,12 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
     previousTitle,
     children,
 }) => {
-    const { strategies } = useStrategies();
     const titleHasChanged = Boolean(
         (previousTitle && previousTitle !== change.payload.title) ||
             (!previousTitle && change.payload.title)
     );
     const previousTitleOrDefault = () =>
-        (previousTitle ||
-            strategies.find(strategy => strategy.name === change.payload.name)
-                ?.displayName) ??
-        '';
+        previousTitle || formatStrategyName(change.payload.name);
 
     return (
         <StyledContainer>


### PR DESCRIPTION
Related to [linear task 1-954](https://linear.app/unleash/issue/1-954/disabling-last-strategy-in-change-request-shows-strikethrough).

This PR changes the display logic for showing titles as changed: it previously fell back to always being `true` if there was a custom title set for a strategy. This PR makes it so that it only shows as changed if the title has actually changed, either from one custom title to another, or to and from the display name.

To accommodate the last bit, it also shows display names with a strikethrough if the strategy had no title previously, but now it does.


Here's a number of different examples: 

![image](https://github.com/Unleash/unleash/assets/17786332/034bcc01-8715-4052-afec-56caf7edea51)
