### PR TITLE
fix: hide password login when it's disabled

### DIFF
--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -374,6 +374,7 @@ describe('Error serialization special cases', () => {
             type: 'password',
             path: `base-path/auth/simple/login`,
             message: 'You must sign in order to use Unleash',
+            defaultHidden: true,
             options: [
                 {
                     type: 'google',

--- a/src/lib/types/authentication-required.ts
+++ b/src/lib/types/authentication-required.ts
@@ -39,6 +39,7 @@ class AuthenticationRequired extends UnleashError {
             ...super.toJSON(),
             path: this.path,
             type: this.type,
+            defaultHidden: this.defaultHidden,
             ...(this.options ? { options: this.options } : {}),
         };
     }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1085/bug-password-based-login-still-shows-on-the-login-page-even-if

Fixes a regression introduced with the changes related with #3633 where we still show the password login even though it's disabled.