### PR TITLE
fix: profile should wait for loaded state before rendering

### DIFF
--- a/frontend/src/component/user/Profile/Profile.tsx
+++ b/frontend/src/component/user/Profile/Profile.tsx
@@ -13,7 +13,7 @@ export const Profile = () => {
     const { user } = useAuthUser();
     const location = useLocation();
     const navigate = useNavigate();
-    const { config: simpleAuthConfig } = useAuthSettings('simple');
+    const { config: simpleAuthConfig, loading } = useAuthSettings('simple');
 
     const { uiConfig } = useUiConfig();
 
@@ -51,6 +51,8 @@ export const Profile = () => {
     useEffect(() => {
         setTab(tabFromUrl());
     }, [location]);
+
+    if (loading) return null;
 
     return (
         <VerticalTabs tabs={tabs} value={tab} onChange={onChange}>


### PR DESCRIPTION
Small change that makes it so that the profile page waits for the loaded state before rendering.

E.g. Before this, there was a flash of the "change password" tab being visible for a very short time before the auth settings loaded.