### PR TITLE
fix: default strategy screen not loading

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectDefaultStrategySettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectDefaultStrategySettings.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useProject, {
     useProjectNameOrId,
@@ -10,6 +10,9 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { UPDATE_PROJECT } from 'component/providers/AccessProvider/permissions';
 import { Alert, styled } from '@mui/material';
 import ProjectEnvironment from './ProjectEnvironment/ProjectEnvironment';
+import { Route, Routes, useNavigate } from 'react-router-dom';
+import { SidebarModal } from '../../../../common/SidebarModal/SidebarModal';
+import EditDefaultStrategy from './ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(4),
@@ -19,6 +22,7 @@ export const ProjectDefaultStrategySettings = () => {
     const projectName = useProjectNameOrId(projectId);
     const { hasAccess } = useContext(AccessContext);
     const { project } = useProject(projectId);
+    const navigate = useNavigate();
     usePageTitle(`Project default strategy configuration – ${projectName}`);
 
     if (!hasAccess(UPDATE_PROJECT, projectId)) {
@@ -33,19 +37,38 @@ export const ProjectDefaultStrategySettings = () => {
         );
     }
 
+    const path = `/projects/${projectId}/settings/default-strategy`;
+    const onSidebarClose = () => navigate(path);
+
     return (
-        <PageContent header={<PageHeader title={`Default Strategy`} />}>
-            <StyledAlert severity="info">
-                Here you can customize your default strategy for each specific
-                environment. These will be used when you enable a toggle
-                environment that has no strategies defined
-            </StyledAlert>
-            {project?.environments.map(environment => (
-                <ProjectEnvironment
-                    environment={environment}
-                    key={environment.environment}
+        <>
+            <PageContent header={<PageHeader title={`Default Strategy`} />}>
+                <StyledAlert severity="info">
+                    Here you can customize your default strategy for each
+                    specific environment. These will be used when you enable a
+                    toggle environment that has no strategies defined
+                </StyledAlert>
+                {project?.environments.map(environment => (
+                    <ProjectEnvironment
+                        environment={environment}
+                        key={environment.environment}
+                    />
+                ))}
+            </PageContent>
+            <Routes>
+                <Route
+                    path="edit"
+                    element={
+                        <SidebarModal
+                            label="Edit feature strategy"
+                            onClose={onSidebarClose}
+                            open
+                        >
+                            <EditDefaultStrategy />
+                        </SidebarModal>
+                    }
                 />
-            ))}
-        </PageContent>
+            </Routes>
+        </>
     );
 };

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectDefaultStrategyForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectDefaultStrategyForm.tsx
@@ -20,7 +20,6 @@ import { useHasProjectEnvironmentAccess } from 'hooks/useHasAccess';
 import { FeatureStrategyConstraints } from 'component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints';
 import { FeatureStrategyType } from 'component/feature/FeatureStrategy/FeatureStrategyType/FeatureStrategyType';
 import { FeatureStrategyTitle } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyTitle/FeatureStrategyTitle';
-import { CreateFeatureStrategySchema } from 'openapi';
 
 interface IProjectDefaultStrategyFormProps {
     projectId: string;
@@ -30,7 +29,7 @@ interface IProjectDefaultStrategyFormProps {
     onCancel?: () => void;
     loading: boolean;
     isChangeRequest?: boolean;
-    strategy: IFeatureStrategy | CreateFeatureStrategySchema;
+    strategy: Partial<IFeatureStrategy>;
     setStrategy: React.Dispatch<
         React.SetStateAction<Partial<IFeatureStrategy>>
     >;

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
@@ -2,13 +2,11 @@ import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { StrategyItemContainer } from 'component/common/StrategyItemContainer/StrategyItemContainer';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
-import { Link, Route, Routes, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Edit } from '@mui/icons-material';
 import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution';
 import { ProjectEnvironmentType } from 'interfaces/environments';
 import React, { useMemo } from 'react';
-import EditDefaultStrategy from './EditDefaultStrategy';
-import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { CreateFeatureStrategySchema } from 'openapi';
 
 interface ProjectEnvironmentDefaultStrategyProps {
@@ -41,7 +39,6 @@ const ProjectEnvironmentDefaultStrategy = ({
     environment,
     description,
 }: ProjectEnvironmentDefaultStrategyProps) => {
-    const navigate = useNavigate();
     const projectId = useRequiredPathParam('projectId');
     const { environment: environmentId, defaultStrategy } = environment;
 
@@ -50,13 +47,9 @@ const ProjectEnvironmentDefaultStrategy = ({
         environmentId
     );
 
-    const path = `/projects/${projectId}/settings/default-strategy`;
-
     const strategy: CreateFeatureStrategySchema = useMemo(() => {
         return defaultStrategy ? defaultStrategy : DEFAULT_STRATEGY;
     }, [JSON.stringify(defaultStrategy)]);
-
-    const onSidebarClose = () => navigate(path);
 
     return (
         <>
@@ -83,20 +76,6 @@ const ProjectEnvironmentDefaultStrategy = ({
             >
                 <StrategyExecution strategy={strategy} />
             </StrategyItemContainer>
-            <Routes>
-                <Route
-                    path="edit"
-                    element={
-                        <SidebarModal
-                            label="Edit feature strategy"
-                            onClose={onSidebarClose}
-                            open
-                        >
-                            <EditDefaultStrategy />
-                        </SidebarModal>
-                    }
-                />
-            </Routes>
         </>
     );
 };


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

Fixes the default strategy modal.  

The bug was the placement of the route component to `edit`

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes # https://linear.app/unleash/issue/1-965/fix-default-strategy-modal-re-render

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
