### PR TITLE
chore: name and email convention

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
               inputs: {
                  repository: "${{ github.repository }}",
                  commit: "${{ github.event.head_commit.id }}",
-                 actor: "${{ github.event.head_commit.committer.username }}",
+                 actor: "${{ github.event.head_commit.committer.name }} <${{ github.event.head_commit.committer.email }}>",
                  message: ${{ toJSON(github.event.head_commit.message) }},
               }
             })


### PR DESCRIPTION
## About the changes
Minor improvement to communicate the author of a commit as `Name <Email>`

Another option is to send email and name in different fields but we're only using it here https://github.com/ivarconr/unleash-enterprise/blob/master/.github/update_dependency_version.sh#L39 so this should be fine