### PR TITLE
fix: Remove repository which is no longer needed

### DIFF
--- a/.github/workflows/notify_enterprise.yaml
+++ b/.github/workflows/notify_enterprise.yaml
@@ -32,7 +32,6 @@ jobs:
               workflow_id: 'cicd.yaml',
               ref: 'master',
               inputs: {
-                 repository: "${{ github.repository }}",
                  commit: "${{ github.event.head_commit.id }}",
                  actor: "${{ github.event.head_commit.committer.name || github.actor }} <${{ github.event.head_commit.committer.email }}>",
                  message: ${{ toJSON(github.event.head_commit.message) }},

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,6 @@ jobs:
               workflow_id: 'cicd.yaml',
               ref: 'master',
               inputs: {
-                 repository: "${{ github.repository }}",
                  commit: "${{ github.event.head_commit.id }}",
                  actor: "${{ github.actor }}",
                  message: ${{ toJSON(github.event.head_commit.message) }},


### PR DESCRIPTION
## About the changes
Sync fails https://github.com/Unleash/unleash/actions/runs/5174602051/jobs/9321118800#step:3:23 due to https://github.com/ivarconr/unleash-enterprise/pull/562 because we now assume the repository is Unleash/unleash

This removes the repository from the payload