### PR TITLE
fix: correct escaping of ui flags for plausible

### DIFF
--- a/frontend/src/component/providers/PlausibleProvider/PlausibleProvider.tsx
+++ b/frontend/src/component/providers/PlausibleProvider/PlausibleProvider.tsx
@@ -20,7 +20,7 @@ export const PlausibleProvider: FC = ({ children }) => {
                         'meta[name="uiFlags"]'
                     ) as HTMLMetaElement
                 )?.content || '{}';
-            return JSON.parse(uiFlagsStr);
+            return JSON.parse(decodeURI(uiFlagsStr));
         } catch (e) {
             return {};
         }

--- a/src/lib/util/load-index-html.ts
+++ b/src/lib/util/load-index-html.ts
@@ -9,7 +9,7 @@ export async function loadIndexHTML(
     publicFolder: string,
 ): Promise<string> {
     const { cdnPrefix, baseUriPath = '' } = config.server;
-    const uiFlags = JSON.stringify(config.ui.flags);
+    const uiFlags = encodeURI(JSON.stringify(config.ui.flags || '{}'));
 
     let indexHTML: string;
     if (cdnPrefix) {


### PR DESCRIPTION
## About the changes
Stringified JSON still needs to be escaped before being placed in an HTML attribute.