### PR TITLE
feat: display strategy title and type

### DIFF
--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
@@ -1,0 +1,34 @@
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { StrategyItemContainer } from './StrategyItemContainer';
+import { IFeatureStrategy } from 'interfaces/strategy';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { UIProviderContainer } from '../../providers/UIProvider/UIProviderContainer';
+
+const server = testServerSetup();
+testServerRoute(server, '/api/admin/ui-config', {
+    flags: { strategyImprovements: true },
+});
+
+test('should render authorization error on missing old password', async () => {
+    const strategy: IFeatureStrategy = {
+        id: 'irrelevant',
+        name: 'strategy name',
+        title: 'custom title',
+        constraints: [],
+        parameters: {},
+    };
+
+    render(
+        <UIProviderContainer>
+            <StrategyItemContainer
+                strategy={strategy}
+                description={'description'}
+            />
+        </UIProviderContainer>
+    );
+
+    expect(screen.getByText('strategy name')).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+    await screen.findByText('custom title'); // behind async flag
+});

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
@@ -10,7 +10,7 @@ testServerRoute(server, '/api/admin/ui-config', {
     flags: { strategyImprovements: true },
 });
 
-test('should render authorization error on missing old password', async () => {
+test('should render strategy name, custom title and description', async () => {
     const strategy: IFeatureStrategy = {
         id: 'irrelevant',
         name: 'strategy name',

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -50,6 +50,13 @@ const StyledDescription = styled('div')(({ theme }) => ({
         display: 'block',
     },
 }));
+const StyledCustomTitle = styled('div')(({ theme }) => ({
+    fontWeight: 'normal',
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+        display: 'block',
+    },
+}));
 const StyledHeaderContainer = styled('div')({
     flexDirection: 'column',
     justifyContent: 'center',
@@ -141,11 +148,19 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
                         <StringTruncator
                             maxWidth="400"
                             maxLength={15}
-                            text={formatStrategyName(
-                                uiConfig?.flags?.strategyImprovements
-                                    ? strategy.title || strategy.name
-                                    : strategy.name
-                            )}
+                            text={formatStrategyName(strategy.name)}
+                        />
+                        <ConditionallyRender
+                            condition={
+                                Boolean(
+                                    uiConfig?.flags?.strategyImprovements
+                                ) && Boolean(strategy.title)
+                            }
+                            show={
+                                <StyledCustomTitle>
+                                    {formatStrategyName(String(strategy.title))}
+                                </StyledCustomTitle>
+                            }
                         />
                         <ConditionallyRender
                             condition={Boolean(description)}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* displaying strategy name and type at the same time
<img width="664" alt="Screenshot 2023-06-06 at 11 29 04" src="https://github.com/Unleash/unleash/assets/1394682/2da5a4e9-bd71-41ab-834a-c1ffd63c2caa">

* when configuring default strategy also description is added as it was before
<img width="1231" alt="Screenshot 2023-06-06 at 11 29 31" src="https://github.com/Unleash/unleash/assets/1394682/04f600a7-232f-4a7f-b7dc-885fa34eb50c">

* added a test as this piece of code wasn't covered before

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
