### PR TITLE
chore: remove unnecessary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /unleash
 
 RUN yarn config set network-timeout 300000
 
-RUN yarn install --frozen-lockfile && yarn run build && yarn run local:package
+RUN yarn install --frozen-lockfile && yarn local:package
 
 RUN mkdir /unleash/build/frontend && cp -r /unleash/frontend/build /unleash/build/frontend/build
 


### PR DESCRIPTION
## About the changes
This removes unnecessary build that's already triggered as part of the prepare script https://github.com/Unleash/unleash/blob/0efaa346c45b1d8aea064c7649ad617c9da1f499/package.json#L41

This should reduce the build time of this action: https://github.com/Unleash/unleash/actions/workflows/docker_publish.yaml (currently at 30m)

We can see the double execution from the log files of one execution:
```shell
$ grep " #14 " 1_build\ \(18-alpine\).txt  | grep "build:frontend" | grep built
2023-06-06T11:20:25.6513037Z #14 1198.7 [build:frontend] ✓ built in 7m 48s
2023-06-06T11:28:35.0518703Z #14 1688.1 [build:frontend] ✓ built in 7m 34s
```
_That is step 14 executing build:frontend twice_