### PR TITLE
chore: avoid building frontend twice

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: Build
         run: |
           yarn install --frozen-lockfile
-          yarn build
       - name: Publish to npm
         run: |
           LATEST=$(npm show unleash-server version)


### PR DESCRIPTION
## About the changes
Running `yarn install` without the `dist` folder will trigger a `yarn build` automatically as part of the `prepare script`

As we can see here: https://github.com/Unleash/unleash/actions/runs/5200272004/jobs/9378770279
```
[build:frontend] ✓ built in 41.10s
// more output
[build:frontend] ✓ built in 39.81s
```