### PR TITLE
fix: only show simple tag type if there are no tag types in the server

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
@@ -51,11 +51,15 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
     const { updateFeatureTags, loading: featureLoading } = useFeatureApi();
     const { tags, refetch, loading: tagsLoading } = useFeatureTags(featureId);
     const { setToastData } = useToast();
-    const [tagType, setTagType] = useState<ITagType>({
-        name: 'simple',
-        description: 'Simple tag to get you started',
-        icon: '',
-    });
+    const initialTagType =
+        tagTypes && tagTypes.length > 0
+            ? tagTypes[0]
+            : {
+                  name: 'simple',
+                  description: 'Simple tag to get you started',
+                  icon: '',
+              };
+    const [tagType, setTagType] = useState<ITagType>(initialTagType);
 
     const loading = featureLoading || tagsLoading;
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->
Fixes `simple` tag type still visible in dropdown even after deleted
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes # [1-997](https://linear.app/unleash/issue/1-997/simple-tag-type-still-visible-in-dropdown-after-deletion)

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
