### PR TITLE
fix: add createdAt in projects API response

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -107,7 +107,7 @@ class ProjectStore implements IProjectStore {
         }
         let selectColumns = [
             this.db.raw(
-                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, count(features.name) FILTER (WHERE features.archived_at is null) AS number_of_features',
+                'projects.id, projects.name, projects.description, projects.health, projects.updated_at, projects.created_at, count(features.name) FILTER (WHERE features.archived_at is null) AS number_of_features',
             ),
         ] as (string | Raw<any>)[];
 
@@ -164,6 +164,7 @@ class ProjectStore implements IProjectStore {
             featureCount: Number(row.number_of_features) || 0,
             memberCount: Number(row.number_of_users) || 0,
             updatedAt: row.updated_at,
+            createdAt: row.created_at,
             mode: 'open',
             defaultStickiness: 'default',
         };

--- a/src/lib/openapi/spec/project-overview-schema.ts
+++ b/src/lib/openapi/spec/project-overview-schema.ts
@@ -98,6 +98,12 @@ export const projectOverviewSchema = {
             nullable: true,
             example: '2023-02-10T08:36:35.262Z',
         },
+        createdAt: {
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+            example: '2023-02-10T08:36:35.262Z',
+        },
         favorite: {
             type: 'boolean',
             example: true,

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -840,6 +840,7 @@ export default class ProjectService {
             health: project.health || 0,
             favorite: favorite,
             updatedAt: project.updatedAt,
+            createdAt: project.createdAt,
             environments,
             features,
             members,

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -193,6 +193,7 @@ export interface IProjectOverview {
     health: number;
     favorite?: boolean;
     updatedAt?: Date;
+    createdAt: Date;
     stats?: IProjectStats;
     mode: ProjectMode;
 

--- a/src/test/e2e/api/admin/projects.e2e.test.ts
+++ b/src/test/e2e/api/admin/projects.e2e.test.ts
@@ -1,0 +1,31 @@
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import { IUnleashTest, setupApp } from '../../helpers/test-helper';
+import getLogger from '../../../fixtures/no-logger';
+let db: ITestDb;
+let app: IUnleashTest;
+
+beforeAll(async () => {
+    db = await dbInit('projects_api_serial', getLogger);
+    app = await setupApp(db.stores);
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+test('response should include created_at', async () => {
+    const { body } = await app.request
+        .get('/api/admin/projects')
+        .expect('Content-Type', /json/)
+        .expect(200);
+    expect(body.projects[0].createdAt).toBeDefined();
+});
+
+test('response for default project should include created_at', async () => {
+    const { body } = await app.request
+        .get('/api/admin/projects/default')
+        .expect('Content-Type', /json/)
+        .expect(200);
+    expect(body.createdAt).toBeDefined();
+});


### PR DESCRIPTION
This PR adds the "createdAt" field to the /api/projects response, so that we are compliant with the schema. 