### PR TITLE
chore: rename version to reflect next candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
-  "version": "5.1.0-beta.54",
+  "version": "5.2.0-main",
   "keywords": [
     "unleash",
     "feature toggle",


### PR DESCRIPTION
## About the changes
Rationale: we're doing continuous deployment of every commit. We don't want to bump versions with every deployment because it doesn't add value. 

Having a `-beta.xx` is also not relevant now, as any commit is deployed, but the repository on itself is not published on npm as a different version

We discussed some options: `rc` for release candidate, `beta`, but we thought main reflects better that this version does not change unless there's a reason for changing it (i.e. we're preparing the next version)
