### PR TITLE
fix: fix variant metrics

### DIFF
--- a/src/lib/util/collapseHourlyMetrics.test.ts
+++ b/src/lib/util/collapseHourlyMetrics.test.ts
@@ -108,3 +108,48 @@ test('collapseHourlyMetrics', () => {
         },
     ]);
 });
+
+test('collapseHourlyMetrics variants', () => {
+    const timestamp = startOfHour(new Date());
+
+    const metricAX1: IClientMetricsEnv = {
+        featureName: 'a',
+        appName: 'x',
+        environment: 'x',
+        timestamp: addMinutes(timestamp, 1),
+        yes: 1,
+        no: 11,
+    };
+
+    const metricAX2: IClientMetricsEnv = {
+        featureName: 'a',
+        appName: 'x',
+        environment: 'x',
+        timestamp: addMinutes(timestamp, 2),
+        yes: 2,
+        no: 12,
+        variants: { disabled: 3, red: 2 },
+    };
+
+    const metricAX3: IClientMetricsEnv = {
+        featureName: 'a',
+        appName: 'x',
+        environment: 'x',
+        timestamp: addMinutes(timestamp, 2),
+        yes: 2,
+        no: 12,
+        variants: { disabled: 1, red: 3 },
+    };
+
+    expect(collapseHourlyMetrics([metricAX1, metricAX2, metricAX3])).toEqual([
+        {
+            featureName: 'a',
+            appName: 'x',
+            environment: 'x',
+            timestamp,
+            yes: 5,
+            no: 35,
+            variants: { disabled: 4, red: 5 },
+        },
+    ]);
+});

--- a/src/lib/util/collapseHourlyMetrics.test.ts
+++ b/src/lib/util/collapseHourlyMetrics.test.ts
@@ -112,7 +112,7 @@ test('collapseHourlyMetrics', () => {
 test('collapseHourlyMetrics variants', () => {
     const timestamp = startOfHour(new Date());
 
-    const metricAX1: IClientMetricsEnv = {
+    const metricsWithoutVariant: IClientMetricsEnv = {
         featureName: 'a',
         appName: 'x',
         environment: 'x',
@@ -121,7 +121,7 @@ test('collapseHourlyMetrics variants', () => {
         no: 11,
     };
 
-    const metricAX2: IClientMetricsEnv = {
+    const metricsWithVariant1: IClientMetricsEnv = {
         featureName: 'a',
         appName: 'x',
         environment: 'x',
@@ -131,7 +131,7 @@ test('collapseHourlyMetrics variants', () => {
         variants: { disabled: 3, red: 2 },
     };
 
-    const metricAX3: IClientMetricsEnv = {
+    const metricsWithVariant2: IClientMetricsEnv = {
         featureName: 'a',
         appName: 'x',
         environment: 'x',
@@ -141,7 +141,13 @@ test('collapseHourlyMetrics variants', () => {
         variants: { disabled: 1, red: 3 },
     };
 
-    expect(collapseHourlyMetrics([metricAX1, metricAX2, metricAX3])).toEqual([
+    expect(
+        collapseHourlyMetrics([
+            metricsWithoutVariant,
+            metricsWithVariant1,
+            metricsWithVariant2,
+        ]),
+    ).toEqual([
         {
             featureName: 'a',
             appName: 'x',

--- a/src/lib/util/collapseHourlyMetrics.ts
+++ b/src/lib/util/collapseHourlyMetrics.ts
@@ -51,7 +51,7 @@ export const collapseHourlyMetrics = (
             if (metric.variants) {
                 grouped[key].variants = mergeRecords(
                     metric.variants,
-                    grouped[key].variants,
+                    grouped[key].variants ?? {},
                 );
             }
         }


### PR DESCRIPTION
Currently, Unleash is storing metrics every 5 seconds. However, a problem arises when multiple SDKs query the same feature flag, and one of them sends variants data while the other does not. If the SDK that does not send variants data is registered first, it leads to a error in the system.

This PR fixes the issue, by always storing variants object.