### PR TITLE
refactor: read project ids in memory

### DIFF
--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -68,37 +68,31 @@ export class PlaygroundService {
                     ? new Date(context.currentTime)
                     : undefined,
             };
-            const output: PlaygroundFeatureSchema[] = await Promise.all(
-                client
-                    .getFeatureToggleDefinitions()
-                    .map(async (feature: FeatureInterface) => {
-                        const strategyEvaluationResult: FeatureStrategiesEvaluationResult =
-                            client.isEnabled(feature.name, clientContext);
+            const output: PlaygroundFeatureSchema[] = client
+                .getFeatureToggleDefinitions()
+                .map((feature: FeatureInterface) => {
+                    const strategyEvaluationResult: FeatureStrategiesEvaluationResult =
+                        client.isEnabled(feature.name, clientContext);
 
-                        const isEnabled =
-                            strategyEvaluationResult.result === true &&
-                            feature.enabled;
+                    const isEnabled =
+                        strategyEvaluationResult.result === true &&
+                        feature.enabled;
 
-                        return {
-                            isEnabled,
-                            isEnabledInCurrentEnvironment: feature.enabled,
-                            strategies: {
-                                result: strategyEvaluationResult.result,
-                                data: strategyEvaluationResult.strategies,
-                            },
-                            projectId:
-                                await this.featureToggleService.getProjectId(
-                                    feature.name,
-                                ),
-                            variant: client.getVariant(
-                                feature.name,
-                                clientContext,
-                            ),
-                            name: feature.name,
-                            variants: variantsMap[feature.name] || [],
-                        };
-                    }),
-            );
+                    return {
+                        isEnabled,
+                        isEnabledInCurrentEnvironment: feature.enabled,
+                        strategies: {
+                            result: strategyEvaluationResult.result,
+                            data: strategyEvaluationResult.strategies,
+                        },
+                        projectId:
+                            features.find((f) => f.name === feature.name)
+                                ?.project || 'unknown',
+                        variant: client.getVariant(feature.name, clientContext),
+                        name: feature.name,
+                        variants: variantsMap[feature.name] || [],
+                    };
+                });
 
             return output;
         }

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -45,6 +45,13 @@ export class PlaygroundService {
             ),
             this.segmentService.getActive(),
         ]);
+        const featureProject: Record<string, string> = features.reduce(
+            (obj, feature) => {
+                obj[feature.name] = feature.project;
+                return obj;
+            },
+            {},
+        );
 
         const [head, ...rest] = features;
         if (!head) {
@@ -85,9 +92,7 @@ export class PlaygroundService {
                             result: strategyEvaluationResult.result,
                             data: strategyEvaluationResult.strategies,
                         },
-                        projectId:
-                            features.find((f) => f.name === feature.name)
-                                ?.project || 'unknown',
+                        projectId: featureProject[feature.name],
                         variant: client.getVariant(feature.name, clientContext),
                         name: feature.name,
                         variants: variantsMap[feature.name] || [],


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* instead of making hundreds of DB calls in parallel to fetch project id for every feature we can look it up in memory

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
* we could make it even faster if we stored input bootstrap data with project and returned it as part of the getFeatureToggleDefinitions output interface
