### PR TITLE
chore: set unleash version to be either the enterprise version or OSS

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -39,7 +39,7 @@ async function createApp(
 ): Promise<IUnleash> {
     // Database dependencies (stateful)
     const logger = config.getLogger('server-impl.js');
-    const serverVersion = version;
+    const serverVersion = config.enterpriseVersion ?? version;
     const db = createDb(config);
     const stores = createStores(config, db);
     const services = createServices(stores, config, db);
@@ -83,7 +83,7 @@ async function createApp(
         services,
         app,
         config,
-        version: config.enterpriseVersion ?? serverVersion,
+        version: serverVersion,
     };
 
     if (config.import.file) {


### PR DESCRIPTION
## About the changes
Unleash version should be the one best representing its runtime. In this regard, enterpriseVersion trumps unleash-server version.

This version is the one that's sent as part of our metrics.
