### PR TITLE
docs: mark 'yes' and `no` as required, add more details to variants

### DIFF
--- a/src/lib/openapi/spec/__snapshots__/client-metrics-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/client-metrics-schema.test.ts.snap
@@ -12,6 +12,15 @@ exports[`clientMetricsSchema should fail when required field is missing 1`] = `
       },
       "schemaPath": "#/properties/bucket/required",
     },
+    {
+      "instancePath": "/bucket/toggles/someToggle",
+      "keyword": "required",
+      "message": "must have required property 'no'",
+      "params": {
+        "missingProperty": "no",
+      },
+      "schemaPath": "#/properties/bucket/properties/toggles/additionalProperties/required",
+    },
   ],
   "schema": "#/components/schemas/clientMetricsSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/client-metrics-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/client-metrics-schema.test.ts.snap
@@ -12,15 +12,6 @@ exports[`clientMetricsSchema should fail when required field is missing 1`] = `
       },
       "schemaPath": "#/properties/bucket/required",
     },
-    {
-      "instancePath": "/bucket/toggles/someToggle",
-      "keyword": "required",
-      "message": "must have required property 'no'",
-      "params": {
-        "missingProperty": "no",
-      },
-      "schemaPath": "#/properties/bucket/properties/toggles/additionalProperties/required",
-    },
   ],
   "schema": "#/components/schemas/clientMetricsSchema",
 }

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -64,6 +64,7 @@ export const clientMetricsSchema = {
                     },
                     additionalProperties: {
                         type: 'object',
+                        required: ['yes', 'no'],
                         properties: {
                             yes: {
                                 description:
@@ -81,7 +82,7 @@ export const clientMetricsSchema = {
                             },
                             variants: {
                                 description:
-                                    'How many times each variant was returned',
+                                    'An object describing many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. `{ [variantName]: number }`).',
                                 type: 'object',
                                 additionalProperties: {
                                     type: 'integer',

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -64,7 +64,6 @@ export const clientMetricsSchema = {
                     },
                     additionalProperties: {
                         type: 'object',
-                        required: ['yes', 'no'],
                         properties: {
                             yes: {
                                 description:

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -81,7 +81,7 @@ export const clientMetricsSchema = {
                             },
                             variants: {
                                 description:
-                                    'An object describing many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. `{ [variantName]: number }`).',
+                                    'An object describing how many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. `{ [variantName]: number }`).',
                                 type: 'object',
                                 additionalProperties: {
                                     type: 'integer',

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1540,7 +1540,7 @@ The provider you choose for your addon dictates what properties the \`parameters
                         "minimum": 0,
                         "type": "integer",
                       },
-                      "description": "An object describing how many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. \`{ [variantName]: number }\`).",
+                      "description": "An object describing many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. \`{ [variantName]: number }\`).",
                       "example": {
                         "variantA": 15,
                         "variantB": 25,

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1555,10 +1555,6 @@ The provider you choose for your addon dictates what properties the \`parameters
                       "type": "number",
                     },
                   },
-                  "required": [
-                    "yes",
-                    "no",
-                  ],
                   "type": "object",
                 },
                 "description": "an object containing feature names with yes/no plus variant usage",

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1540,7 +1540,7 @@ The provider you choose for your addon dictates what properties the \`parameters
                         "minimum": 0,
                         "type": "integer",
                       },
-                      "description": "An object describing many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. \`{ [variantName]: number }\`).",
+                      "description": "An object describing how many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. \`{ [variantName]: number }\`).",
                       "example": {
                         "variantA": 15,
                         "variantB": 25,

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -1540,7 +1540,7 @@ The provider you choose for your addon dictates what properties the \`parameters
                         "minimum": 0,
                         "type": "integer",
                       },
-                      "description": "How many times each variant was returned",
+                      "description": "An object describing many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. \`{ [variantName]: number }\`).",
                       "example": {
                         "variantA": 15,
                         "variantB": 25,
@@ -1555,6 +1555,10 @@ The provider you choose for your addon dictates what properties the \`parameters
                       "type": "number",
                     },
                   },
+                  "required": [
+                    "yes",
+                    "no",
+                  ],
                   "type": "object",
                 },
                 "description": "an object containing feature names with yes/no plus variant usage",


### PR DESCRIPTION
This change adds a little more detail to the client metrics schema. The description for variants felt a
little unclear.