### PR TITLE
fix: show environment reorder handle

### DIFF
--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -134,7 +134,7 @@ export const StrategyItemContainer: FC<IStrategyItemContainerProps> = ({
                                 <DragIndicator
                                     titleAccess="Drag to reorder"
                                     cursor="grab"
-                                    sx={{ color: 'neutral.main' }}
+                                    sx={{ color: 'action.active' }}
                                 />
                             </DragIcon>
                         )}

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentIconCell/EnvironmentIconCell.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentIconCell/EnvironmentIconCell.tsx
@@ -10,14 +10,14 @@ const StyledCell = styled(Box)(({ theme }) => ({
     justifyContent: 'flex-end',
     paddingLeft: theme.spacing(0.5),
     minWidth: theme.spacing(6.5),
+    cursor: 'grab',
 }));
 
 const DragIcon = styled(IconButton)(({ theme }) => ({
     padding: theme.spacing(1.5, 0),
     cursor: 'inherit',
     transition: 'color 0.2s ease-in-out',
-    display: 'none',
-    color: theme.palette.neutral.main,
+    color: theme.palette.action.active,
 }));
 
 const StyledCloudCircle = styled(CloudCircle, {


### PR DESCRIPTION
## About the changes
Handle icon for reordering environments was not showing up.

**Before:**
![image](https://github.com/Unleash/unleash/assets/2625371/977cdda4-6cf2-4acf-affc-f812907bb543)

**After**
![image](https://github.com/Unleash/unleash/assets/2625371/ce495682-5366-4d31-8f5d-1601949d5089)
