### PR TITLE
fix: fix sort order for environments

### DIFF
--- a/src/migrations/20230615122909-fix-env-sort-order.js
+++ b/src/migrations/20230615122909-fix-env-sort-order.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            WITH sorted_environments AS (
+                SELECT
+                    *,
+                    ROW_NUMBER() OVER (
+                        ORDER BY
+                            sort_order,
+                            created_at
+                        ) AS new_sort_order
+                FROM
+                    environments
+            )
+            UPDATE
+                environments
+            SET
+                sort_order = sorted_environments.new_sort_order
+            FROM
+                sorted_environments
+            WHERE
+                environments.name = sorted_environments.name;
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(``, callback);
+};


### PR DESCRIPTION
This query reorganizes the existing environments based on their current sort order and creation date, ensuring a unique and sequential order starting from 1. 