### PR TITLE
refactor: address custom root roles PR comments

### DIFF
--- a/frontend/src/component/admin/projectRoles/ProjectRoleForm/PermissionAccordion/PermissionAccordion.tsx
+++ b/frontend/src/component/admin/projectRoles/ProjectRoleForm/PermissionAccordion/PermissionAccordion.tsx
@@ -48,7 +48,7 @@ export const PermissionAccordion: VFC<IEnvironmentPermissionAccordionProps> = ({
     permissions,
     checkedPermissions,
     Icon,
-    isInitiallyExpanded,
+    isInitiallyExpanded = false,
     context,
     onPermissionChange,
     onCheckAll,

--- a/frontend/src/component/admin/roles/RoleForm/RoleForm.tsx
+++ b/frontend/src/component/admin/roles/RoleForm/RoleForm.tsx
@@ -5,7 +5,7 @@ import { Person as UserIcon } from '@mui/icons-material';
 import { ICheckedPermissions, IPermission } from 'interfaces/permissions';
 import { IRoleFormErrors } from './useRoleForm';
 import { ROOT_PERMISSION_CATEGORIES } from '@server/types/permissions';
-import cloneDeep from 'lodash.clonedeep';
+import { toggleAllPermissions, togglePermission } from 'utils/permissions';
 
 const StyledInputDescription = styled('p')(({ theme }) => ({
     display: 'flex',
@@ -30,7 +30,6 @@ interface IRoleFormProps {
     setCheckedPermissions: React.Dispatch<
         React.SetStateAction<ICheckedPermissions>
     >;
-    handlePermissionChange: (permission: IPermission) => void;
     permissions: IPermission[];
     errors: IRoleFormErrors;
 }
@@ -42,7 +41,6 @@ export const RoleForm = ({
     setDescription,
     checkedPermissions,
     setCheckedPermissions,
-    handlePermissionChange,
     permissions,
     errors,
 }: IRoleFormProps) => {
@@ -61,30 +59,25 @@ export const RoleForm = ({
         categorizedPermissions.map(({ category }) => category).sort()
     );
 
-    const onToggleAllPermissions = (category: string) => {
-        let checkedPermissionsCopy = cloneDeep(checkedPermissions);
+    const onPermissionChange = (permission: IPermission) => {
+        const newCheckedPermissions = togglePermission(
+            checkedPermissions,
+            permission
+        );
+        setCheckedPermissions(newCheckedPermissions);
+    };
 
+    const onCheckAll = (category: string) => {
         const categoryPermissions = categorizedPermissions
             .filter(({ category: pCategory }) => pCategory === category)
             .map(({ permission }) => permission);
 
-        const allChecked = categoryPermissions.every(
-            (permission: IPermission) => checkedPermissionsCopy[permission.id]
+        const newCheckedPermissions = toggleAllPermissions(
+            checkedPermissions,
+            categoryPermissions
         );
 
-        if (allChecked) {
-            categoryPermissions.forEach((permission: IPermission) => {
-                delete checkedPermissionsCopy[permission.id];
-            });
-        } else {
-            categoryPermissions.forEach((permission: IPermission) => {
-                checkedPermissionsCopy[permission.id] = {
-                    ...permission,
-                };
-            });
-        }
-
-        setCheckedPermissions(checkedPermissionsCopy);
+        setCheckedPermissions(newCheckedPermissions);
     };
 
     return (
@@ -128,9 +121,9 @@ export const RoleForm = ({
                         .map(({ permission }) => permission)}
                     checkedPermissions={checkedPermissions}
                     onPermissionChange={(permission: IPermission) =>
-                        handlePermissionChange(permission)
+                        onPermissionChange(permission)
                     }
-                    onCheckAll={() => onToggleAllPermissions(category)}
+                    onCheckAll={() => onCheckAll(category)}
                 />
             ))}
         </div>

--- a/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
+++ b/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { IPermission, ICheckedPermissions } from 'interfaces/permissions';
 import IRole from 'interfaces/role';
 import { useRoles } from 'hooks/api/getters/useRoles/useRoles';
+import { permissionsToCheckedPermissions } from 'utils/permissions';
 
 enum ErrorField {
     NAME = 'name',
@@ -33,15 +34,9 @@ export const useRoleForm = (
     }, [initialDescription]);
 
     useEffect(() => {
-        setCheckedPermissions(
-            initialPermissions.reduce(
-                (acc: { [key: string]: IPermission }, curr: IPermission) => {
-                    acc[curr.id] = curr;
-                    return acc;
-                },
-                {}
-            )
-        );
+        const newCheckedPermissions =
+            permissionsToCheckedPermissions(initialPermissions);
+        setCheckedPermissions(newCheckedPermissions);
     }, [initialPermissions.length]);
 
     const getRolePayload = (type: 'root-custom' | 'custom' = 'custom') => ({

--- a/frontend/src/component/common/RoleBadge/RoleBadge.tsx
+++ b/frontend/src/component/common/RoleBadge/RoleBadge.tsx
@@ -14,7 +14,7 @@ export const RoleBadge = ({ roleId }: IRoleBadgeProps) => {
     if (!role) return null;
 
     return (
-        <HtmlTooltip title={<RoleDescription roleId={roleId} tooltip />}>
+        <HtmlTooltip title={<RoleDescription roleId={roleId} tooltip />} arrow>
             <Badge
                 color="success"
                 icon={<UserIcon />}

--- a/frontend/src/hooks/api/getters/usePermissions/usePermissions.ts
+++ b/frontend/src/hooks/api/getters/usePermissions/usePermissions.ts
@@ -2,21 +2,11 @@ import useSWR, { mutate, SWRConfiguration } from 'swr';
 import { useState, useEffect } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 
-import {
-    IProjectEnvironmentPermissions,
-    IPermissions,
-    IPermission,
-} from 'interfaces/permissions';
+import { IPermissions } from 'interfaces/permissions';
 import handleErrorResponses from '../httpErrorResponseHandler';
 
 interface IUsePermissions {
-    permissions:
-        | IPermissions
-        | {
-              root: IPermission[];
-              project: IPermission[];
-              environments: IProjectEnvironmentPermissions[];
-          };
+    permissions: IPermissions;
     loading: boolean;
     refetch: () => void;
     error: any;

--- a/frontend/src/hooks/api/getters/useRole/useRole.ts
+++ b/frontend/src/hooks/api/getters/useRole/useRole.ts
@@ -2,12 +2,12 @@ import { SWRConfiguration } from 'swr';
 import { useMemo } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
-import IRole from 'interfaces/role';
+import IRole, { IRoleWithPermissions } from 'interfaces/role';
 import useUiConfig from '../useUiConfig/useUiConfig';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 
 export interface IUseRoleOutput {
-    role?: IRole;
+    role?: IRoleWithPermissions;
     refetch: () => void;
     loading: boolean;
     error?: Error;
@@ -42,16 +42,19 @@ export const useRole = (
     return useMemo(() => {
         if (!isEnterprise()) {
             return {
-                role: ((ossData?.rootRoles ?? []) as IRole[]).find(
-                    ({ id: rId }) => rId === +id!
-                ),
+                role: {
+                    ...((ossData?.rootRoles ?? []) as IRole[]).find(
+                        ({ id: rId }) => rId === +id!
+                    ),
+                    permissions: [],
+                } as IRoleWithPermissions,
                 loading: !ossError && !ossData,
                 refetch: () => ossMutate(),
                 error: ossError,
             };
         } else {
             return {
-                role: data as IRole,
+                role: data as IRoleWithPermissions,
                 loading: !error && !data,
                 refetch: () => mutate(),
                 error,

--- a/frontend/src/interfaces/role.ts
+++ b/frontend/src/interfaces/role.ts
@@ -6,7 +6,10 @@ interface IRole {
     project: string | null;
     description: string;
     type: string;
-    permissions?: IPermission[];
+}
+
+export interface IRoleWithPermissions extends IRole {
+    permissions: IPermission[];
 }
 
 export interface IProjectRole {

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -1,16 +1,30 @@
 import { IPermission, ICheckedPermissions } from 'interfaces/permissions';
 import cloneDeep from 'lodash.clonedeep';
 
-export const getRoleKey = (permission: IPermission): string => {
+const getRoleKey = (permission: IPermission): string => {
     return permission.environment
         ? `${permission.id}-${permission.environment}`
         : `${permission.id}`;
 };
 
+export const permissionsToCheckedPermissions = (
+    permissions: IPermission[]
+): ICheckedPermissions =>
+    permissions.reduce(
+        (
+            checkedPermissions: { [key: string]: IPermission },
+            permission: IPermission
+        ) => {
+            checkedPermissions[getRoleKey(permission)] = permission;
+            return checkedPermissions;
+        },
+        {}
+    );
+
 export const togglePermission = (
     checkedPermissions: ICheckedPermissions,
     permission: IPermission
-) => {
+): ICheckedPermissions => {
     let checkedPermissionsCopy = cloneDeep(checkedPermissions);
 
     if (checkedPermissionsCopy[getRoleKey(permission)]) {
@@ -25,7 +39,7 @@ export const togglePermission = (
 export const toggleAllPermissions = (
     checkedPermissions: ICheckedPermissions,
     toggledPermissions: IPermission[]
-) => {
+): ICheckedPermissions => {
     let checkedPermissionsCopy = cloneDeep(checkedPermissions);
 
     const allChecked = toggledPermissions.every(

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -1,0 +1,49 @@
+import { IPermission, ICheckedPermissions } from 'interfaces/permissions';
+import cloneDeep from 'lodash.clonedeep';
+
+export const getRoleKey = (permission: IPermission): string => {
+    return permission.environment
+        ? `${permission.id}-${permission.environment}`
+        : `${permission.id}`;
+};
+
+export const togglePermission = (
+    checkedPermissions: ICheckedPermissions,
+    permission: IPermission
+) => {
+    let checkedPermissionsCopy = cloneDeep(checkedPermissions);
+
+    if (checkedPermissionsCopy[getRoleKey(permission)]) {
+        delete checkedPermissionsCopy[getRoleKey(permission)];
+    } else {
+        checkedPermissionsCopy[getRoleKey(permission)] = { ...permission };
+    }
+
+    return checkedPermissionsCopy;
+};
+
+export const toggleAllPermissions = (
+    checkedPermissions: ICheckedPermissions,
+    toggledPermissions: IPermission[]
+) => {
+    let checkedPermissionsCopy = cloneDeep(checkedPermissions);
+
+    const allChecked = toggledPermissions.every(
+        (permission: IPermission) =>
+            checkedPermissionsCopy[getRoleKey(permission)]
+    );
+
+    if (allChecked) {
+        toggledPermissions.forEach((permission: IPermission) => {
+            delete checkedPermissionsCopy[getRoleKey(permission)];
+        });
+    } else {
+        toggledPermissions.forEach((permission: IPermission) => {
+            checkedPermissionsCopy[getRoleKey(permission)] = {
+                ...permission,
+            };
+        });
+    }
+
+    return checkedPermissionsCopy;
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1135/address-3975-pr-comments-by-refactoring-some-of-the-new-custom-root

This pull request addresses the majority of the comments raised in issue #3975 and lays the groundwork for unifying roles. The idea is for project roles to also be managed in the "Roles" tab, and several components, such as `RoleForm` and the `useRoleForm` can potentially be reused.

I'll leave the further investigation and implementation of unifying roles to be addressed in a separate task.

As a mostly unrelated UI fix, this also adds an arrow to the tooltip in the `RoleBadge` component.