### PR TITLE
fix: filter out usage for export

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -587,27 +587,32 @@ export default class ExportImportService {
             this.tagTypeStore.getAll(),
         ]);
         this.addSegmentsToStrategies(featureStrategies, strategySegments);
-        const filteredContextFields = contextFields.filter(
-            (field) =>
-                featureEnvironments.some((featureEnv) =>
-                    featureEnv.variants?.some(
-                        (variant) =>
-                            variant.stickiness === field.name ||
-                            variant.overrides?.some(
-                                (override) =>
-                                    override.contextName === field.name,
+        const filteredContextFields = contextFields
+            .filter(
+                (field) =>
+                    featureEnvironments.some((featureEnv) =>
+                        featureEnv.variants?.some(
+                            (variant) =>
+                                variant.stickiness === field.name ||
+                                variant.overrides?.some(
+                                    (override) =>
+                                        override.contextName === field.name,
+                                ),
+                        ),
+                    ) ||
+                    featureStrategies.some(
+                        (strategy) =>
+                            strategy.parameters.stickiness === field.name ||
+                            strategy.constraints.some(
+                                (constraint) =>
+                                    constraint.contextName === field.name,
                             ),
                     ),
-                ) ||
-                featureStrategies.some(
-                    (strategy) =>
-                        strategy.parameters.stickiness === field.name ||
-                        strategy.constraints.some(
-                            (constraint) =>
-                                constraint.contextName === field.name,
-                        ),
-                ),
-        );
+            )
+            .map((item) => {
+                const { usedInFeatures, usedInProjects, ...rest } = item;
+                return rest;
+            });
         const filteredSegments = segments.filter((segment) =>
             featureStrategies.some((strategy) =>
                 strategy.segments?.includes(segment.id),


### PR DESCRIPTION
Will be filtering out usage counts for export, because:

1. This is the same pattern we are doing for other objects. Filtering out not needed fields.
2. Reducing the payload. This data is not needed for importing.