### PR TITLE
task: Make keepalive configurable via an environment variable

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -171,7 +171,7 @@ exports[`should create default config 1`] = `
     "gracefulShutdownTimeout": 1000,
     "headersTimeout": 61000,
     "host": undefined,
-    "keepAliveTimeout": 60000,
+    "keepAliveTimeout": 15000,
     "pipe": undefined,
     "port": 4242,
     "secret": "super-secret",

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -22,11 +22,7 @@ import {
 import { getDefaultLogProvider, LogLevel, validateLogProvider } from './logger';
 import { defaultCustomAuthDenyAll } from './default-custom-auth-deny-all';
 import { formatBaseUri } from './util/format-base-uri';
-import {
-    hoursToMilliseconds,
-    minutesToMilliseconds,
-    secondsToMilliseconds,
-} from 'date-fns';
+import { hoursToMilliseconds, secondsToMilliseconds } from 'date-fns';
 import EventEmitter from 'events';
 import {
     ApiTokenType,
@@ -170,7 +166,10 @@ const defaultServerOption: IServerOption = {
         process.env.ENABLE_HEAP_SNAPSHOT_ENPOINT,
         false,
     ),
-    keepAliveTimeout: minutesToMilliseconds(1),
+    keepAliveTimeout: parseEnvVarNumber(
+        process.env.SERVER_KEEPALIVE_TIMEOUT,
+        secondsToMilliseconds(15),
+    ),
     headersTimeout: secondsToMilliseconds(61),
     enableRequestLogger: false,
     gracefulShutdownEnable: parseEnvVarBoolean(

--- a/website/docs/reference/deploy/configuring-unleash.md
+++ b/website/docs/reference/deploy/configuring-unleash.md
@@ -133,7 +133,7 @@ unleash.start(unleashOptions);
   - `refreshIntervalInMs` - how often (in milliseconds) front-end clients should refresh their data from the cache. Overridable with the `FRONTEND_API_REFRESH_INTERVAL_MS` environment variable.
 - **accessControlMaxAge** - You can configure the max-age of the Access-Control-Max-Age header. Defaults to 86400 seconds. Overridable with the `ACCESS_CONTROL_MAX_AGE` environment variable.
 - **responseTimeWithAppNameKillSwitch** - use this to disable metrics with app names. This is enabled by default but may increase the cardinality of metrics causing Unleash memory usage to grow if your app name is randomly generated (which is not recommended). Overridable with the `UNLEASH_RESPONSE_TIME_WITH_APP_NAME_KILL_SWITCH` environment variable.
-
+- **keepAliveTimeout** - Use this to tweak connection keepalive timeout in seconds. Useful for hosted situations where you need to make sure your connections are closed before terminating the instance. Defaults to `15`. Overridable with the `SERVER_KEEPALIVE_TIMEOUT` environment variable.
 You can also set the environment variable `ENABLED_ENVIRONMENTS` to a comma delimited string of environment names to override environments.
 
 ### Disabling Auto-Start {#disabling-auto-start}


### PR DESCRIPTION
As requested in [Linear](https://linear.app/unleash/issue/2-1147/unleash-cloud-make-keepalive-configurable) this PR makes the serverKeepAliveTimeout configurable via the SERVER_KEEPALIVE_TIMEOUT environment variable. This was already configurable when starting Unleash programmatically, but it's nice to have as an env variable as well