### PR TITLE
Query complexity validation

### DIFF
--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -261,7 +261,7 @@ export const AdvancedPlayground: VFC<{
                     <ConditionallyRender
                         condition={Boolean(configurationError)}
                         show={
-                            <StyledAlert severity="info">
+                            <StyledAlert severity="warning">
                                 {configurationError}
                             </StyledAlert>
                         }

--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -45,9 +45,11 @@ export const AdvancedPlayground: VFC<{
     const matches = true;
 
     const [configurationError, setConfigurationError] = useState<string>();
-    const [environments, setEnvironments] = useState<string[]>([]);
-    const [projects, setProjects] = useState<string[]>([]);
-    const [context, setContext] = useState<string>();
+    const [environments, setEnvironments] = useState<string[]>(
+        value.environments
+    );
+    const [projects, setProjects] = useState<string[]>(value.projects);
+    const [context, setContext] = useState<string | undefined>(value.context);
     const [results, setResults] = useState<
         AdvancedPlaygroundResponseSchema | undefined
     >();

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -15,6 +15,7 @@ import groupBy from 'lodash.groupby';
 import { omitKeys } from '../../util';
 import { AdvancedPlaygroundFeatureSchema } from '../../openapi/spec/advanced-playground-feature-schema';
 import { AdvancedPlaygroundEnvironmentFeatureSchema } from '../../openapi/spec/advanced-playground-environment-feature-schema';
+import { validateQueryComplexity } from './validateQueryComplexity';
 
 type EvaluationInput = {
     features: FeatureConfigurationClient[];
@@ -53,6 +54,12 @@ export class PlaygroundService {
             environments.map((env) => this.resolveFeatures(projects, env)),
         );
         const contexts = generateObjectCombinations(context);
+
+        validateQueryComplexity(
+            environments.length,
+            environmentFeatures[0]?.features.length ?? 0,
+            contexts.length,
+        );
 
         const results = await Promise.all(
             environmentFeatures.flatMap(

--- a/src/lib/features/playground/validateQueryComplexity.test.ts
+++ b/src/lib/features/playground/validateQueryComplexity.test.ts
@@ -6,7 +6,6 @@ test('should not throw error when total combinations are under MAX_COMPLEXITY', 
     const featuresCount = 10;
     const contextCombinationsCount = 10;
 
-    // Should not throw an error
     expect(() =>
         validateQueryComplexity(
             environmentsCount,
@@ -23,7 +22,6 @@ test('should throw BadDataError when total combinations are over MAX_COMPLEXITY'
 
     const expectedMessage = `Rejecting evaluation as it would generate 4000000 combinations exceeding 30000 limit. Please reduce the number of selected environments (2), features (200), context field combinations (10000).`;
 
-    // Expect a BadDataError to be thrown
     expect(() =>
         validateQueryComplexity(
             environmentsCount,

--- a/src/lib/features/playground/validateQueryComplexity.test.ts
+++ b/src/lib/features/playground/validateQueryComplexity.test.ts
@@ -1,0 +1,41 @@
+import { validateQueryComplexity } from './validateQueryComplexity';
+import { BadDataError } from '../../error';
+
+test('should not throw error when total combinations are under MAX_COMPLEXITY', () => {
+    const environmentsCount = 10;
+    const featuresCount = 10;
+    const contextCombinationsCount = 10;
+
+    // Should not throw an error
+    expect(() =>
+        validateQueryComplexity(
+            environmentsCount,
+            featuresCount,
+            contextCombinationsCount,
+        ),
+    ).not.toThrow();
+});
+
+test('should throw BadDataError when total combinations are over MAX_COMPLEXITY', () => {
+    const environmentsCount = 2;
+    const featuresCount = 200;
+    const contextCombinationsCount = 10000;
+
+    const expectedMessage = `Rejecting evaluation as it would generate 4000000 combinations exceeding 30000 limit. Please reduce the number of selected environments (2), features (200), context field combinations (10000).`;
+
+    // Expect a BadDataError to be thrown
+    expect(() =>
+        validateQueryComplexity(
+            environmentsCount,
+            featuresCount,
+            contextCombinationsCount,
+        ),
+    ).toThrow(BadDataError);
+    expect(() =>
+        validateQueryComplexity(
+            environmentsCount,
+            featuresCount,
+            contextCombinationsCount,
+        ),
+    ).toThrow(expectedMessage);
+});

--- a/src/lib/features/playground/validateQueryComplexity.ts
+++ b/src/lib/features/playground/validateQueryComplexity.ts
@@ -1,0 +1,19 @@
+import { BadDataError } from '../../error';
+
+const MAX_COMPLEXITY = 30000;
+
+export const validateQueryComplexity = (
+    environmentsCount: number,
+    featuresCount: number,
+    contextCombinationsCount: number,
+): void => {
+    const totalCount =
+        environmentsCount * featuresCount * contextCombinationsCount;
+
+    const reason = `Rejecting evaluation as it would generate ${totalCount} combinations exceeding ${MAX_COMPLEXITY} limit. `;
+    const action = `Please reduce the number of selected environments (${environmentsCount}), features (${featuresCount}), context field combinations (${contextCombinationsCount}).`;
+
+    if (totalCount > MAX_COMPLEXITY) {
+        throw new BadDataError(reason + action);
+    }
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

This PR adds capability to reject playground queries that are too complex (over 30k results)
<img width="1288" alt="Screenshot 2023-06-20 at 13 10 01" src="https://github.com/Unleash/unleash/assets/1394682/a8b78bc3-57cb-4b09-b607-12e8e859862f">


Details:
* complexity calculated by multiplying number of features, envs, context combinations
* complexity is calculated in the backend code and results are returned to UI
* UI alert box is reset after another form resubmission, not when the input data is changed. You may want to see the error for some time and not have it disappear instantly after the first change

Next PR:
* UI tests for failed form submission


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
