### PR TITLE
docs: not on latest unleash with openapi enabeld

### DIFF
--- a/website/docs/how-to/how-to-enable-openapi.mdx
+++ b/website/docs/how-to/how-to-enable-openapi.mdx
@@ -35,7 +35,7 @@ Similarly, if you're running the Unleash proxy locally at `http://localhost:3000
 
 The OpenAPI spec and the Swagger UI can be turned on either via environment variables or via configuration options. Configuration options take precedence over environment variables.
 
-If you are using Unleash v5.2.0, OpenAPI is enabled by default. You still need to enabled it for Unleash proxy.
+If you are using Unleash v5.2.0, OpenAPI is enabled by default. You still need to enable it for Unleash proxy.
 
 ### Enable OpenAPI via environment variables
 

--- a/website/docs/how-to/how-to-enable-openapi.mdx
+++ b/website/docs/how-to/how-to-enable-openapi.mdx
@@ -9,6 +9,7 @@ import TabItem from '@theme/TabItem';
 :::info Availability
 
 OpenAPI schemas were introduced in v4.13.0 of Unleash and v0.10.0 of the Unleash proxy.
+Since v5.2.0 Unleash has OpenAPI enabled by default.
 
 :::
 
@@ -33,6 +34,8 @@ Similarly, if you're running the Unleash proxy locally at `http://localhost:3000
 ## Step 1: enable OpenAPI
 
 The OpenAPI spec and the Swagger UI can be turned on either via environment variables or via configuration options. Configuration options take precedence over environment variables.
+
+If you are using Unleash v5.2.0, OpenAPI is enabled by default. You still need to enabled it for Unleash proxy.
 
 ### Enable OpenAPI via environment variables
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

**We need to merge it together with 5.2.0 release.**

Since 5.2.0 Unleash will have OpenAPI enabled by default. Docs should be updated accordingly. Since people are still running older versions I'd like to leave most of the docs for now. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Should we enabled OAS for proxy by default? My current stance is for OAS to be opt-in for proxy.