### PR TITLE
fix: consider ADMIN in API tokens fetch permissions

### DIFF
--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -353,13 +353,16 @@ export class ApiTokenController extends Controller {
         const userPermissions = await this.accessService.getPermissionsForUser(
             user,
         );
-        let allowedTokenTypes = [
+
+        const allowedTokenTypes = [
             READ_ADMIN_API_TOKEN,
             READ_CLIENT_API_TOKEN,
             READ_FRONTEND_API_TOKEN,
         ]
             .filter((readPerm) =>
-                userPermissions.some((p) => p.permission === readPerm),
+                userPermissions.some(
+                    (p) => p.permission === readPerm || p.permission === ADMIN,
+                ),
             )
             .map(permissionToTokenType)
             .filter((t) => t);


### PR DESCRIPTION
https://github.com/Unleash/unleash/pull/4019 introduced a bug where API token filtering was not taking into account ADMIN permissions, which means the API tokens were not being displayed on the UI.