### PR TITLE
fix: creating groups should work without users

### DIFF
--- a/src/lib/db/group-store.ts
+++ b/src/lib/db/group-store.ts
@@ -194,7 +194,7 @@ export default class GroupStore implements IGroupStore {
         userName: string,
         transaction?: Transaction,
     ): Promise<void> {
-        const rows = users.map((user) => {
+        const rows = (users || []).map((user) => {
             return {
                 group_id: groupId,
                 user_id: user.user.id,
@@ -219,7 +219,6 @@ export default class GroupStore implements IGroupStore {
     async updateGroupUsers(
         groupId: number,
         newUsers: IGroupUserModel[],
-        existingUsers: IGroupUserModel[],
         deletableUsers: IGroupUser[],
         userName: string,
     ): Promise<void> {

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -119,17 +119,11 @@ export class GroupService {
                     (groupUser) => groupUser.user.id == existingUser.userId,
                 ),
         );
-        const deletableUserIds = deletableUsers.map((g) => g.userId);
 
         await this.groupStore.updateGroupUsers(
             newGroup.id,
             group.users.filter(
                 (user) => !existingUserIds.includes(user.user.id),
-            ),
-            group.users.filter(
-                (user) =>
-                    existingUserIds.includes(user.user.id) &&
-                    !deletableUserIds.includes(user.user.id),
             ),
             deletableUsers,
             userName,

--- a/src/lib/types/stores/group-store.ts
+++ b/src/lib/types/stores/group-store.ts
@@ -39,7 +39,6 @@ export interface IGroupStore extends Store<IGroup, number> {
     updateGroupUsers(
         groupId: number,
         newUsers: IGroupUserModel[],
-        existingUsers: IGroupUserModel[],
         deletableUsers: IGroupUser[],
         userName: string,
     ): Promise<void>;

--- a/src/test/fixtures/fake-group-store.ts
+++ b/src/test/fixtures/fake-group-store.ts
@@ -69,7 +69,6 @@ export default class FakeGroupStore implements IGroupStore {
     updateGroupUsers(
         groupId: number,
         newUsers: IGroupUserModel[],
-        existingUsers: IGroupUserModel[],
         deletableUsers: IGroupUser[],
         userName: string,
     ): Promise<void> {


### PR DESCRIPTION
1. Now groups can be created without providing empty list of users
2. Some cleanup