### PR TITLE
fix: disallow empty list of envs and invalid env names in advanced playground

### DIFF
--- a/src/lib/openapi/spec/advanced-playground-request-schema.ts
+++ b/src/lib/openapi/spec/advanced-playground-request-schema.ts
@@ -12,6 +12,7 @@ export const advancedPlaygroundRequestSchema = {
         environments: {
             type: 'array',
             items: { type: 'string' },
+            minItems: 1,
             example: ['development', 'production'],
             description: 'The environments to evaluate toggles in.',
         },

--- a/src/lib/openapi/spec/advanced-playground-request-schema.ts
+++ b/src/lib/openapi/spec/advanced-playground-request-schema.ts
@@ -11,7 +11,7 @@ export const advancedPlaygroundRequestSchema = {
     properties: {
         environments: {
             type: 'array',
-            items: { type: 'string' },
+            items: { type: 'string', minLength: 1, pattern: '^[^\\s]+$' },
             minItems: 1,
             example: ['development', 'production'],
             description: 'The environments to evaluate toggles in.',

--- a/src/lib/openapi/spec/advanced-playground-request-schema.ts
+++ b/src/lib/openapi/spec/advanced-playground-request-schema.ts
@@ -11,7 +11,11 @@ export const advancedPlaygroundRequestSchema = {
     properties: {
         environments: {
             type: 'array',
-            items: { type: 'string', minLength: 1, pattern: '^[^\\s]+$' },
+            items: {
+                type: 'string',
+                minLength: 1,
+                pattern: '^[a-zA-Z0-9~_.-]+$',
+            },
             minItems: 1,
             example: ['development', 'production'],
             description: 'The environments to evaluate toggles in.',

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -845,6 +845,7 @@ The provider you choose for your addon dictates what properties the \`parameters
             "items": {
               "type": "string",
             },
+            "minItems": 1,
             "type": "array",
           },
           "projects": {

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -844,7 +844,7 @@ The provider you choose for your addon dictates what properties the \`parameters
             ],
             "items": {
               "minLength": 1,
-              "pattern": "^[^\\s]+$",
+              "pattern": "^[a-zA-Z0-9~_.-]+$",
               "type": "string",
             },
             "minItems": 1,

--- a/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
+++ b/src/test/e2e/api/openapi/__snapshots__/openapi.e2e.test.ts.snap
@@ -843,6 +843,8 @@ The provider you choose for your addon dictates what properties the \`parameters
               "production",
             ],
             "items": {
+              "minLength": 1,
+              "pattern": "^[^\\s]+$",
               "type": "string",
             },
             "minItems": 1,


### PR DESCRIPTION
This PR changes the OpenAPI schema for the advanced playground to not accept empty lists of environments and to not accept environment names that don't match the env name pattern we use.

The pattern is the same as the one we use for controlling environment names on creation.

However, there is a (small) chance that these may get out of sync later, so we could do something to only define this pattern once (and import it in the enterprise package), but that may be more work than is necessary, and I'd suggest we do that later.

I've also added a minLength to the string items although it isn't strictly necessary. It's primarily to give the users better feedback if the name is empty.