### PR TITLE
fix: add admin guard to groups

### DIFF
--- a/frontend/src/component/admin/groups/GroupsAdmin.tsx
+++ b/frontend/src/component/admin/groups/GroupsAdmin.tsx
@@ -1,9 +1,20 @@
+import { AdminAlert } from 'component/common/AdminAlert/AdminAlert';
 import { GroupsList } from './GroupsList/GroupsList';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useContext } from 'react';
+import AccessContext from 'contexts/AccessContext';
+import { ADMIN } from '@server/types/permissions';
 
 export const GroupsAdmin = () => {
+    const { hasAccess } = useContext(AccessContext);
+
     return (
         <div>
-            <GroupsList />
+            <ConditionallyRender
+                condition={hasAccess(ADMIN)}
+                show={<GroupsList />}
+                elseShow={<AdminAlert />}
+            />
         </div>
     );
 };


### PR DESCRIPTION
Adds an admin guard to groups: It is an admin feature and should be guarded on the UI the same way other admin features are.