### PR TITLE
fix: update roles permission guard

### DIFF
--- a/frontend/src/component/admin/roles/Roles.tsx
+++ b/frontend/src/component/admin/roles/Roles.tsx
@@ -17,6 +17,7 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Add } from '@mui/icons-material';
 import ResponsiveButton from 'component/common/ResponsiveButton/ResponsiveButton';
 import { IRole } from 'interfaces/role';
+import { READ_ROLE } from '@server/types/permissions';
 
 const StyledPageContent = styled(PageContent)(({ theme }) => ({
     '& .page-header': {
@@ -84,7 +85,7 @@ export const Roles = () => {
     return (
         <div>
             <ConditionallyRender
-                condition={hasAccess(ADMIN)}
+                condition={hasAccess(READ_ROLE)}
                 show={
                     <StyledPageContent
                         headerClass="page-header"


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1162/read-roles-permissions-should-give-you-access-to-read-roles

This updates the roles page permission guard to be the `READ_ROLES` permission instead of `ADMIN`, which better reflects on the UI the real permissions of the user.

Our current `AdminAlert` component is pretty limited however, and I plan to improve it in https://linear.app/unleash/issue/2-1165/improve-adminalert-usage-to-be-more-generic-accept-non-admin to better reflect the permission we're missing (instead of alerting that you need to be an admin).