### PR TITLE
fix: add strategy bug when strategySplittedButton flag is on

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -33,7 +33,7 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import useQueryParams from 'hooks/useQueryParams';
 import useProject from 'hooks/api/getters/useProject/useProject';
 import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
-import { DEFAULT_STRATEGY } from '../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
+import { DEFAULT_STRATEGY } from 'component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
 
 export const FeatureStrategyCreate = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -101,11 +101,24 @@ export const FeatureStrategyCreate = () => {
 
     useEffect(() => {
         if (shouldUseDefaultStrategy) {
-            setStrategy((defaultStrategy as any) || DEFAULT_STRATEGY);
+            const strategyTemplate = defaultStrategy || DEFAULT_STRATEGY;
+            if (
+                strategyTemplate.parameters &&
+                'groupId' in strategyTemplate.parameters &&
+                strategyTemplate.parameters.groupId === '' &&
+                featureId
+            ) {
+                strategyTemplate.parameters.groupId = featureId;
+            }
+            setStrategy(strategyTemplate as any);
         } else if (strategyDefinition) {
             setStrategy(createFeatureStrategy(featureId, strategyDefinition));
         }
-    }, [featureId, strategyDefinition, shouldUseDefaultStrategy]);
+    }, [
+        featureId,
+        JSON.stringify(strategyDefinition),
+        shouldUseDefaultStrategy,
+    ]);
 
     const onAddStrategy = async (payload: IFeatureStrategyPayload) => {
         await addStrategyToFeature(

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -105,7 +105,7 @@ export const FeatureStrategyCreate = () => {
             if (strategyTemplate.parameters?.groupId === '' && featureId) {
                 strategyTemplate.parameters.groupId = featureId;
             }
-            setStrategy(strategyTemplate);
+            setStrategy(strategyTemplate as any);
         } else if (strategyDefinition) {
             setStrategy(createFeatureStrategy(featureId, strategyDefinition));
         }

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -102,15 +102,10 @@ export const FeatureStrategyCreate = () => {
     useEffect(() => {
         if (shouldUseDefaultStrategy) {
             const strategyTemplate = defaultStrategy || DEFAULT_STRATEGY;
-            if (
-                strategyTemplate.parameters &&
-                'groupId' in strategyTemplate.parameters &&
-                strategyTemplate.parameters.groupId === '' &&
-                featureId
-            ) {
+            if (strategyTemplate.parameters?.groupId === '' && featureId) {
                 strategyTemplate.parameters.groupId = featureId;
             }
-            setStrategy(strategyTemplate as any);
+            setStrategy(strategyTemplate);
         } else if (strategyDefinition) {
             setStrategy(createFeatureStrategy(featureId, strategyDefinition));
         }

--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
@@ -14,8 +14,9 @@ import {
 import { StickinessSelect } from './StickinessSelect/StickinessSelect';
 import { useDefaultProjectSettings } from 'hooks/useDefaultProjectSettings';
 import Loader from '../../../common/Loader/Loader';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useLocation } from 'react-router';
 
 interface IFlexibleStrategyProps {
     parameters: IFeatureStrategyParameters;
@@ -31,7 +32,9 @@ const FlexibleStrategy = ({
 }: IFlexibleStrategyProps) => {
     const projectId = useRequiredPathParam('projectId');
     const { defaultStickiness, loading } = useDefaultProjectSettings(projectId);
+    const { pathname } = useLocation();
 
+    const isDefaultStrategyEdit = pathname.includes('default-strategy');
     const onUpdate = (field: string) => (newValue: string) => {
         updateParameter(field, newValue);
     };
@@ -56,6 +59,12 @@ const FlexibleStrategy = ({
     if (parameters.stickiness === '') {
         onUpdate('stickiness')(stickiness);
     }
+
+    useEffect(() => {
+        if (isDefaultStrategyEdit) {
+            onUpdate('groupId')('');
+        }
+    }, [isDefaultStrategyEdit]);
 
     if (loading) {
         return <Loader />;

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -4,14 +4,14 @@ export interface IFeatureStrategy {
     id: string;
     strategyName?: string;
     name: string;
-    title?: string | null;
+    title?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
     featureName?: string;
     projectId?: string;
     environment?: string;
     segments?: number[];
-    disabled?: boolean | null;
+    disabled?: boolean;
 }
 
 export interface IFeatureStrategyParameters {

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -4,14 +4,14 @@ export interface IFeatureStrategy {
     id: string;
     strategyName?: string;
     name: string;
-    title?: string;
+    title?: string | null;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
     featureName?: string;
     projectId?: string;
     environment?: string;
     segments?: number[];
-    disabled?: boolean;
+    disabled?: boolean | null;
 }
 
 export interface IFeatureStrategyParameters {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

Fixes 2 bugs after the recent strategy improvements v2 changes:
- When creating a strategy the `groupId` param of the Gradual Rollout strategy now populates the groupId (when using default strategy, the groupId will only be overwritten when it is an empty string ) with the feature name (as it was before)

- When editing/setting a default strategy for an environment the `groupId` param should be an empty string, but editable.

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
