### PR TITLE
fix: remove playground results flip

### DIFF
--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -57,6 +57,7 @@ export const AdvancedPlayground: VFC<{
     const [searchParams, setSearchParams] = useSearchParams();
     const searchParamsLength = Array.from(searchParams.entries()).length;
     const { evaluateAdvancedPlayground, loading } = usePlaygroundApi();
+    const [hasFormBeenSubmitted, setHasFormBeenSubmitted] = useState(false);
 
     useEffect(() => {
         if (environments?.length === 0) {
@@ -167,6 +168,8 @@ export const AdvancedPlayground: VFC<{
     const onSubmit: FormEventHandler<HTMLFormElement> = async event => {
         event.preventDefault();
 
+        setHasFormBeenSubmitted(true);
+
         await evaluatePlaygroundContext(environments, projects, context, () => {
             setURLParameters();
             setValue({
@@ -272,17 +275,25 @@ export const AdvancedPlayground: VFC<{
                         condition={loading}
                         show={<Loader />}
                         elseShow={
-                            <ConditionallyRender
-                                condition={Boolean(results)}
-                                show={
-                                    <AdvancedPlaygroundResultsTable
-                                        loading={loading}
-                                        features={results?.features}
-                                        input={results?.input}
-                                    />
-                                }
-                                elseShow={<PlaygroundGuidance />}
-                            />
+                            <>
+                                <ConditionallyRender
+                                    condition={Boolean(results)}
+                                    show={
+                                        <AdvancedPlaygroundResultsTable
+                                            loading={loading}
+                                            features={results?.features}
+                                            input={results?.input}
+                                        />
+                                    }
+                                />
+                                <ConditionallyRender
+                                    condition={
+                                        !Boolean(results) &&
+                                        !hasFormBeenSubmitted
+                                    }
+                                    show={<PlaygroundGuidance />}
+                                />
+                            </>
                         }
                     />
                 </Box>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Before:
* when try configuration was clicked in playground and the results fetching was over there was a quick moment where playground guidance/instructions showed up before the result table was rendered

After:
* instruction if only shown before form submission
* after form submission loaded appears
* when loading finishes table starts rendering

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
