### PR TITLE
chore: filter out deprecated permissions

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -43,6 +43,18 @@ interface IPermissionRow {
 }
 
 export class AccessStore implements IAccessStore {
+    private readonly DEPRECATED_PERMISSIONS = [
+        'CREATE_API_TOKEN',
+        'UPDATE_API_TOKEN',
+        'DELETE_API_TOKEN',
+        'READ_API_TOKEN',
+        'UPDATE_ROLE',
+        'CREATE_ADMIN_API_TOKEN',
+        'UPDATE_ADMIN_API_TOKEN',
+        'DELETE_ADMIN_API_TOKEN',
+        'READ_ADMIN_API_TOKEN',
+    ];
+
     private logger: Logger;
 
     private timer: Function;
@@ -103,7 +115,9 @@ export class AccessStore implements IAccessStore {
             .orWhere('type', 'environment')
             .orWhere('type', 'root')
             .from(`${T.PERMISSIONS} as p`);
-        return rows.map(this.mapPermission);
+        return rows
+            .map(this.mapPermission)
+            .filter((p) => !this.DEPRECATED_PERMISSIONS.includes(p.name));
     }
 
     mapPermission(permission: IPermissionRow): IPermission {


### PR DESCRIPTION
## About the changes
This makes these permissions not available for selection. In particular `UPDATE_ROLE`, `CREATE_API_TOKEN`, `UPDATE_API_TOKEN`, `DELETE_API_TOKEN`, `READ_API_TOKEN` are long-lived and should be taken out with special care which is why we have https://linear.app/unleash/issue/2-1158/add-delete-migration-to-clean-up-no-longer-used-permissions

## Discussion points
If a role has this permission assigned, it will be displayed but will not be able to remove it. Because the application code does not rely on these permissions, this shouldn't be a problem. Later when we remove them from the DB, the permission will be removed as well from the role by the migration
