### PR TITLE
fix: max revision query order

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -158,8 +158,11 @@ class EventStore implements IEventStore {
     async getMaxRevisionId(largerThan: number = 0): Promise<number> {
         const row = await this.db(TABLE)
             .max('id')
-            .whereNotNull('feature_name')
-            .orWhere('type', SEGMENT_UPDATED)
+            .where((builder) =>
+                builder
+                    .whereNotNull('feature_name')
+                    .orWhere('type', SEGMENT_UPDATED),
+            )
             .andWhere('id', '>=', largerThan)
             .first();
         return row ? row.max : -1;


### PR DESCRIPTION
The previous query utilized an ID limit for the "type" condition but not for the "feature_name" condition.

The improved query now correctly handles both conditions by ensuring that the "feature_name" is not null or the "type" matches the specified value, and then checking if the ID is greater than or equal to the provided value.
```
OLD: select max("id") from "events" where "feature_name" is not null or "type" = $1 and "id" >= $2 limit $3
NEW: select max("id") from "events" where ("feature_name" is not null or "type" = $1) and "id" >= $2 limit $3
```