### PR TITLE
fix: metrics performance patch

### DIFF
--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -174,9 +174,7 @@ export default class ClientMetricsServiceV2 {
                     const metric = applicationMetrics.find(
                         (item) =>
                             compareAsc(hourBucket.timestamp, item.timestamp) ===
-                                0 &&
-                            item.appName === appName &&
-                            item.environment === environment,
+                            0,
                     );
                     return (
                         metric || {

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -162,10 +162,16 @@ export default class ClientMetricsServiceV2 {
             100,
         );
 
-        const result = environments.flatMap((environment) =>
-            applications.flatMap((appName) =>
-                hours.flatMap((hourBucket) => {
-                    const metric = metrics.find(
+        const result = environments.flatMap((environment) => {
+            const environmentMetrics = metrics.filter(
+                (metric) => metric.environment === environment,
+            );
+            return applications.flatMap((appName) => {
+                const applicationMetrics = environmentMetrics.filter(
+                    (metric) => metric.appName === appName,
+                );
+                return hours.flatMap((hourBucket) => {
+                    const metric = applicationMetrics.find(
                         (item) =>
                             compareAsc(hourBucket.timestamp, item.timestamp) ===
                                 0 &&
@@ -182,10 +188,9 @@ export default class ClientMetricsServiceV2 {
                             featureName,
                         }
                     );
-                }),
-            ),
-        );
-
+                });
+            });
+        });
         return result.sort((a, b) => compareAsc(a.timestamp, b.timestamp));
     }
 


### PR DESCRIPTION
In our **hosted** instance, we faced issue of metrics loading 5-10 seconds. We had two environments, around 70 applications, and 48 hour buckets, resulting in ~7000 permutations.

The main issue arose when the metrics.filter function was called, which involved running the compare function on all metrics for each permutation. With 3000 metrics in total, this led to **over 20 million calls** to the compareAsc function worse case scenario, causing a delay of 5-10 seconds for metric loading.

To improve performance, I optimized the logic by prefiltering the metrics based on the environment and appName. This eliminated the need to run the same function on all metrics repeatedly. Now, the compareAsc function is expected to be called only around 5000 times, resulting in a significant **tenfold performance increase**.