### PR TITLE
chore: remove sync to enterprise from release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,19 +41,3 @@ jobs:
       - name: Publish static assets to S3
         run: |
           aws s3 cp frontend/build s3://getunleash-static/unleash/${{ steps.get_version.outputs.VERSION }} --recursive
-      - name: Trigger sync
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.UNLEASH_CI_BUILDER_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'ivarconr',
-              repo: 'unleash-enterprise',
-              workflow_id: 'cicd.yaml',
-              ref: 'master',
-              inputs: {
-                 commit: "${{ github.event.head_commit.id }}",
-                 actor: "${{ github.actor }}",
-                 message: ${{ toJSON(github.event.head_commit.message) }},
-              }
-            })


### PR DESCRIPTION
## About the changes
When we do releases on the release branch we should not sync that back to master on unleash-enterprise repo. At most we can trigger a different process to automate the release of unleash-enterprise, but that'd be a different story.
