### PR TITLE
ux: return better error message if a segment doesn't exist

### DIFF
--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -23,7 +23,6 @@ describe('unexpected input handling for get segment', () => {
         try {
             await segmentStore.get(id);
         } catch (e) {
-            console.log(e.message);
             expect(e instanceof NotFoundError).toBeTruthy();
             expect(e.message).toEqual(expect.stringMatching(id.toString()));
         }

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -1,4 +1,3 @@
-import { BadDataError } from '../error';
 import { ISegmentStore } from '../types/stores/segment-store';
 import dbInit from '../../test/e2e/helpers/database-init';
 import getLogger from '../../test/fixtures/no-logger';
@@ -19,24 +18,6 @@ afterAll(async () => {
 });
 
 describe('unexpected input handling for get segment', () => {
-    test('gives bad data error if the id is a floating point number', async () => {
-        const id = 42.5;
-        try {
-            await segmentStore.get(id);
-        } catch (e) {
-            expect(e instanceof BadDataError).toBeTruthy();
-            expect(e.message).toEqual(expect.stringMatching(id.toString()));
-        }
-    });
-    test("gives bad data error if the id is a value greater than Postgres's max integer", async () => {
-        const id = 123456789456;
-        try {
-            await segmentStore.get(id);
-        } catch (e) {
-            expect(e instanceof BadDataError).toBeTruthy();
-            expect(e.message).toEqual(expect.stringMatching(id.toString()));
-        }
-    });
     test("gives a NotFoundError with the ID of the segment if it doesn't exist", async () => {
         const id = 123;
         try {

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -1,0 +1,50 @@
+import { BadDataError } from '../error';
+import { ISegmentStore } from '../types/stores/segment-store';
+import dbInit from '../../test/e2e/helpers/database-init';
+import getLogger from '../../test/fixtures/no-logger';
+import NotFoundError from '../error/notfound-error';
+
+let stores;
+let db;
+let segmentStore: ISegmentStore;
+
+beforeAll(async () => {
+    db = await dbInit('segment_store_serial', getLogger);
+    stores = db.stores;
+    segmentStore = stores.segmentStore;
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+describe('unexpected input handling for get segment', () => {
+    test('gives bad data error if the id is a floating point number', async () => {
+        const id = 42.5;
+        try {
+            await segmentStore.get(id);
+        } catch (e) {
+            expect(e instanceof BadDataError).toBeTruthy();
+            expect(e.message).toEqual(expect.stringMatching(id.toString()));
+        }
+    });
+    test("gives bad data error if the id is a value greater than Postgres's max integer", async () => {
+        const id = 123456789456;
+        try {
+            await segmentStore.get(id);
+        } catch (e) {
+            expect(e instanceof BadDataError).toBeTruthy();
+            expect(e.message).toEqual(expect.stringMatching(id.toString()));
+        }
+    });
+    test("gives a NotFoundError with the ID of the segment if it doesn't exist", async () => {
+        const id = 123;
+        try {
+            await segmentStore.get(id);
+        } catch (e) {
+            console.log(e.message);
+            expect(e instanceof NotFoundError).toBeTruthy();
+            expect(e.message).toEqual(expect.stringMatching(id.toString()));
+        }
+    });
+});

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -7,7 +7,6 @@ import { PartialSome } from '../types/partial';
 import User from '../types/user';
 import { Db } from './db';
 import { IFlagResolver } from '../types';
-import { BadDataError } from '../error';
 
 const T = {
     segments: 'segments',
@@ -194,12 +193,7 @@ export default class SegmentStore implements ISegmentStore {
         const rows: ISegmentRow[] = await this.db
             .select(this.prefixColumns())
             .from(T.segments)
-            .where({ id })
-            .catch((error) => {
-                const errorParts = error.message.split(' - ');
-                const message = errorParts[errorParts.length - 1];
-                throw new BadDataError(message);
-            });
+            .where({ id });
 
         const row = rows[0];
         if (!row) {


### PR DESCRIPTION
Catch cases where the segment doesn't exist and populate that error message with more info: it now says that a segment
with <id> doesn't exist instead of just 'No row'.