### PR TITLE
refactor: clean up deprecated permissions

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -43,18 +43,6 @@ interface IPermissionRow {
 }
 
 export class AccessStore implements IAccessStore {
-    private readonly DEPRECATED_PERMISSIONS = [
-        'CREATE_API_TOKEN',
-        'UPDATE_API_TOKEN',
-        'DELETE_API_TOKEN',
-        'READ_API_TOKEN',
-        'UPDATE_ROLE',
-        'CREATE_ADMIN_API_TOKEN',
-        'UPDATE_ADMIN_API_TOKEN',
-        'DELETE_ADMIN_API_TOKEN',
-        'READ_ADMIN_API_TOKEN',
-    ];
-
     private logger: Logger;
 
     private timer: Function;
@@ -115,9 +103,7 @@ export class AccessStore implements IAccessStore {
             .orWhere('type', 'environment')
             .orWhere('type', 'root')
             .from(`${T.PERMISSIONS} as p`);
-        return rows
-            .map(this.mapPermission)
-            .filter((p) => !this.DEPRECATED_PERMISSIONS.includes(p.name));
+        return rows.map(this.mapPermission);
     }
 
     mapPermission(permission: IPermissionRow): IPermission {

--- a/src/migrations/20230630080126-delete-deprecated-permissions.js
+++ b/src/migrations/20230630080126-delete-deprecated-permissions.js
@@ -1,0 +1,20 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        DELETE FROM permissions WHERE permission IN ('CREATE_API_TOKEN', 'UPDATE_API_TOKEN', 'DELETE_API_TOKEN', 'READ_API_TOKEN');
+        DELETE FROM permissions WHERE permission = 'UPDATE_ROLE';
+        DELETE FROM permissions WHERE permission IN ('CREATE_ADMIN_API_TOKEN', 'UPDATE_ADMIN_API_TOKEN', 'DELETE_ADMIN_API_TOKEN', 'READ_ADMIN_API_TOKEN');
+
+        DELETE FROM role_permission rp where NOT EXISTS (SELECT * FROM permissions WHERE id = rp.permission_id);
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1158/add-delete-migration-to-clean-up-no-longer-used-permissions

Cleans up the filter in https://github.com/Unleash/unleash/pull/4083 and deletes the deprecated permissions from the database.