### PR TITLE
fix: demo flow with split strategy button by making step optional

### DIFF
--- a/frontend/src/component/demo/demo-topics.tsx
+++ b/frontend/src/component/demo/demo-topics.tsx
@@ -147,6 +147,7 @@ export const TOPICS: ITutorialTopic[] = [
                     </Description>
                 ),
                 placement: 'right',
+                optional: true,
                 backCloseModal: true,
             },
             {


### PR DESCRIPTION
This fixes the demo flow by making the strategy popup step optional. 

This way the demo works whether the flag is enabled or not. Once we make the split strategy button GA, we can remove this step entirely.

Feel free to re-enable the flag once this is deployed to demo.