### PR TITLE
fix: SERVER_KEEPALIVE_TIMEOUT env variable should be seconds

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -166,9 +166,8 @@ const defaultServerOption: IServerOption = {
         process.env.ENABLE_HEAP_SNAPSHOT_ENPOINT,
         false,
     ),
-    keepAliveTimeout: parseEnvVarNumber(
-        process.env.SERVER_KEEPALIVE_TIMEOUT,
-        secondsToMilliseconds(15),
+    keepAliveTimeout: secondsToMilliseconds(
+        parseEnvVarNumber(process.env.SERVER_KEEPALIVE_TIMEOUT, 15),
     ),
     headersTimeout: secondsToMilliseconds(61),
     enableRequestLogger: false,


### PR DESCRIPTION
This changes SERVER_KEEPALIVE_TIMEOUT to take in seconds instead of milliseconds.
