### PR TITLE
docs: switch order of api doc sidebar items; put legacy docs under legacy header

### DIFF
--- a/website/docs/reference/api/legacy/unleash/index.md
+++ b/website/docs/reference/api/legacy/unleash/index.md
@@ -1,7 +1,13 @@
 ---
 id: index
-title: API Documentation
+title: Legacy API Documentation
 ---
+
+:::caution
+
+The docs in this category are legacy documentation. You should prefer to use the [Unleash OpenAPI docs](/reference/api/unleash) instead whenever possible.
+
+:::
 
 ## Client API {#client-api}
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -188,6 +188,19 @@ module.exports = {
                     label: 'APIs',
                     items: [
                         {
+                            label: 'OpenAPI docs',
+                            collapsed: true,
+                            type: 'category',
+                            link: {
+                                title: 'Unleash Server APIs',
+                                type: 'generated-index',
+                                description:
+                                    'Generated API docs based on the Unleash OpenAPI schema. For the time being, some additional info can also be found in the older API docs.',
+                                slug: '/reference/api/unleash',
+                            },
+                            items: require('./docs/reference/api/unleash/sidebar.js'),
+                        },
+                        {
                             'Admin API': [
                                 'reference/api/legacy/unleash/admin/addons',
                                 'reference/api/legacy/unleash/admin/context',
@@ -213,19 +226,6 @@ module.exports = {
                                 'reference/api/legacy/unleash/internal/prometheus',
                                 'reference/api/legacy/unleash/internal/health',
                             ],
-                        },
-                        {
-                            label: 'OpenAPI docs',
-                            collapsed: true,
-                            type: 'category',
-                            link: {
-                                title: 'Unleash Server APIs',
-                                type: 'generated-index',
-                                description:
-                                    'Generated API docs based on the Unleash OpenAPI schema. For the time being, some additional info can also be found in the older API docs.',
-                                slug: '/reference/api/unleash',
-                            },
-                            items: require('./docs/reference/api/unleash/sidebar.js'),
                         },
                     ],
                 },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -181,10 +181,6 @@ module.exports = {
                 },
                 {
                     type: 'category',
-                    link: {
-                        type: 'doc',
-                        id: 'reference/api/legacy/unleash/index',
-                    },
                     label: 'APIs',
                     items: [
                         {
@@ -201,30 +197,40 @@ module.exports = {
                             items: require('./docs/reference/api/unleash/sidebar.js'),
                         },
                         {
-                            'Admin API': [
-                                'reference/api/legacy/unleash/admin/addons',
-                                'reference/api/legacy/unleash/admin/context',
-                                'reference/api/legacy/unleash/admin/events',
-                                'reference/api/legacy/unleash/admin/features-v2',
-                                'reference/api/legacy/unleash/admin/feature-types',
-                                'reference/api/legacy/unleash/admin/features',
-                                'reference/api/legacy/unleash/admin/archive',
-                                'reference/api/legacy/unleash/admin/metrics',
-                                'reference/api/legacy/unleash/admin/projects',
-                                'reference/api/legacy/unleash/admin/segments',
-                                'reference/api/legacy/unleash/admin/state',
-                                'reference/api/legacy/unleash/admin/strategies',
-                                'reference/api/legacy/unleash/admin/tags',
-                                'reference/api/legacy/unleash/admin/user-admin',
-                            ],
-                            'Client API': [
-                                'reference/api/legacy/unleash/client/features',
-                                'reference/api/legacy/unleash/client/metrics',
-                                'reference/api/legacy/unleash/client/register',
-                            ],
-                            'System API': [
-                                'reference/api/legacy/unleash/internal/prometheus',
-                                'reference/api/legacy/unleash/internal/health',
+                            type: 'category',
+                            label: 'Legacy API docs',
+                            link: {
+                                type: 'doc',
+                                id: 'reference/api/legacy/unleash/index',
+                            },
+                            items: [
+                                {
+                                    'Admin API': [
+                                        'reference/api/legacy/unleash/admin/addons',
+                                        'reference/api/legacy/unleash/admin/context',
+                                        'reference/api/legacy/unleash/admin/events',
+                                        'reference/api/legacy/unleash/admin/features-v2',
+                                        'reference/api/legacy/unleash/admin/feature-types',
+                                        'reference/api/legacy/unleash/admin/features',
+                                        'reference/api/legacy/unleash/admin/archive',
+                                        'reference/api/legacy/unleash/admin/metrics',
+                                        'reference/api/legacy/unleash/admin/projects',
+                                        'reference/api/legacy/unleash/admin/segments',
+                                        'reference/api/legacy/unleash/admin/state',
+                                        'reference/api/legacy/unleash/admin/strategies',
+                                        'reference/api/legacy/unleash/admin/tags',
+                                        'reference/api/legacy/unleash/admin/user-admin',
+                                    ],
+                                    'Client API': [
+                                        'reference/api/legacy/unleash/client/features',
+                                        'reference/api/legacy/unleash/client/metrics',
+                                        'reference/api/legacy/unleash/client/register',
+                                    ],
+                                    'System API': [
+                                        'reference/api/legacy/unleash/internal/prometheus',
+                                        'reference/api/legacy/unleash/internal/health',
+                                    ],
+                                },
                             ],
                         },
                     ],


### PR DESCRIPTION
Also adds a caution admonition to the legacy doc index page