### PR TITLE
fix: hide users list extra searchable columns

### DIFF
--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -197,7 +197,9 @@ const UsersList = () => {
     const initialState = useMemo(() => {
         return {
             sortBy: [{ id: 'createdAt' }],
-            hiddenColumns: isBillingUsers ? [] : ['type'],
+            hiddenColumns: isBillingUsers
+                ? ['username', 'email']
+                : ['type', 'username', 'email'],
         };
     }, [isBillingUsers]);
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1187/fix-two-extra-columns-in-users-list

This fixes a regression introduced in https://github.com/Unleash/unleash/pull/4131 where two extra columns were added for search only but were not properly hidden.

Thanks @nicolaesocaciu for the heads up!

Before:
![image](https://github.com/Unleash/unleash/assets/14320932/09db9078-7804-448a-b889-bd0c58cb2013)

After:
![image](https://github.com/Unleash/unleash/assets/14320932/f099cf42-811c-4a9b-b34a-482fd2bae478)
