### PR TITLE
fix: avoid expression injection

### DIFF
--- a/.github/workflows/notify_enterprise.yaml
+++ b/.github/workflows/notify_enterprise.yaml
@@ -38,7 +38,7 @@ jobs:
               ref: 'master',
               inputs: {
                  commit: "${{ github.event.head_commit.id }}",
-                 actor: "${{ env.COMMIT_ACTOR }}",
+                 actor: ${{ toJSON(env.COMMIT_ACTOR) }},
                  message: ${{ toJSON(github.event.head_commit.message) }},
               }
             })


### PR DESCRIPTION
## About the changes
Using toJSON should escape any potentially harmful content from the username and email input