### PR TITLE
fix: enterprise types not recognized

### DIFF
--- a/src/lib/openapi/spec/event-schema.ts
+++ b/src/lib/openapi/spec/event-schema.ts
@@ -1,6 +1,5 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { tagSchema } from './tag-schema';
-import { IEventTypes } from '../../types';
 import { variantSchema } from './variant-schema';
 
 const eventDataSchema = {
@@ -99,7 +98,6 @@ export const eventSchema = {
             type: 'string',
             description:
                 'What [type](https://docs.getunleash.io/reference/api/legacy/unleash/admin/events#event-type-description) of event this is',
-            enum: IEventTypes,
             example: 'feature-created',
         },
         createdBy: {

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -218,7 +218,7 @@ export const IEventTypes = [
 export type IEventType = typeof IEventTypes[number];
 
 export interface IBaseEvent {
-    type: IEventType;
+    type: string;
     createdBy: string;
     project?: string;
     environment?: string;

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -218,7 +218,7 @@ export const IEventTypes = [
 export type IEventType = typeof IEventTypes[number];
 
 export interface IBaseEvent {
-    type: string;
+    type: IEventType | string;
     createdBy: string;
     project?: string;
     environment?: string;


### PR DESCRIPTION
## About the changes
Allow extending event type, something that's needed on enterprise where we have additional event types: https://github.com/ivarconr/unleash-enterprise/actions/runs/5473805611/jobs/9967754171#step:10:473

This is a workaround to unblock the CI/CD pipeline, we might have to think this a bit further