### PR TITLE
fix: added service-account events

### DIFF
--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -117,6 +117,10 @@ export const PROJECT_UNFAVORITED = 'project-unfavorited' as const;
 export const FEATURES_EXPORTED = 'features-exported' as const;
 export const FEATURES_IMPORTED = 'features-imported' as const;
 
+export const SERVICE_ACCOUNT_CREATED = 'service-account-created' as const;
+export const SERVICE_ACCOUNT_UPDATED = 'service-account-updated' as const;
+export const SERVICE_ACCOUNT_DELETED = 'service-account-deleted' as const;
+
 export const IEventTypes = [
     APPLICATION_CREATED,
     FEATURE_CREATED,
@@ -214,6 +218,9 @@ export const IEventTypes = [
     PROJECT_UNFAVORITED,
     FEATURES_EXPORTED,
     FEATURES_IMPORTED,
+    SERVICE_ACCOUNT_CREATED,
+    SERVICE_ACCOUNT_DELETED,
+    SERVICE_ACCOUNT_UPDATED,
 ] as const;
 export type IEventType = typeof IEventTypes[number];
 


### PR DESCRIPTION
We're using this in enterprise as well, so we need to add events that could happen there as well.