### PR TITLE
fix: project tokens can now be created with the correct permissions

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -7,6 +7,7 @@ import {
     ADMIN,
     CREATE_FRONTEND_API_TOKEN,
     CREATE_CLIENT_API_TOKEN,
+    CREATE_PROJECT_API_TOKEN,
 } from '@server/types/permissions';
 import { useHasRootAccess } from 'hooks/useHasAccess';
 import { SelectOption } from './TokenTypeSelector/TokenTypeSelector';
@@ -17,17 +18,21 @@ export const useApiTokenForm = (project?: string) => {
     const { uiConfig } = useUiConfig();
     const initialEnvironment = environments?.find(e => e.enabled)?.name;
 
+    const hasCreateTokenPermission = useHasRootAccess(CREATE_CLIENT_API_TOKEN);
+    const hasCreateProjectTokenPermission = useHasRootAccess(CREATE_PROJECT_API_TOKEN, project);
+
     const apiTokenTypes: SelectOption[] = [
         {
             key: TokenType.CLIENT,
             label: `Server-side SDK (${TokenType.CLIENT})`,
             title: 'Connect server-side SDK or Unleash Proxy',
-            enabled: useHasRootAccess(CREATE_CLIENT_API_TOKEN),
+            enabled: hasCreateTokenPermission || hasCreateProjectTokenPermission,
         },
     ];
 
     const hasAdminAccess = useHasRootAccess(ADMIN);
     const hasCreateFrontendAccess = useHasRootAccess(CREATE_FRONTEND_API_TOKEN);
+    const hasCreateFrontendTokenAccess = useHasRootAccess(CREATE_PROJECT_API_TOKEN, project);
     if (!project) {
         apiTokenTypes.push({
             key: TokenType.ADMIN,
@@ -42,7 +47,7 @@ export const useApiTokenForm = (project?: string) => {
             key: TokenType.FRONTEND,
             label: `Client-side SDK (${TokenType.FRONTEND})`,
             title: 'Connect web and mobile SDK directly to Unleash',
-            enabled: hasCreateFrontendAccess,
+            enabled: hasCreateFrontendAccess || hasCreateFrontendTokenAccess,
         });
     }
 

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -19,20 +19,27 @@ export const useApiTokenForm = (project?: string) => {
     const initialEnvironment = environments?.find(e => e.enabled)?.name;
 
     const hasCreateTokenPermission = useHasRootAccess(CREATE_CLIENT_API_TOKEN);
-    const hasCreateProjectTokenPermission = useHasRootAccess(CREATE_PROJECT_API_TOKEN, project);
+    const hasCreateProjectTokenPermission = useHasRootAccess(
+        CREATE_PROJECT_API_TOKEN,
+        project
+    );
 
     const apiTokenTypes: SelectOption[] = [
         {
             key: TokenType.CLIENT,
             label: `Server-side SDK (${TokenType.CLIENT})`,
             title: 'Connect server-side SDK or Unleash Proxy',
-            enabled: hasCreateTokenPermission || hasCreateProjectTokenPermission,
+            enabled:
+                hasCreateTokenPermission || hasCreateProjectTokenPermission,
         },
     ];
 
     const hasAdminAccess = useHasRootAccess(ADMIN);
     const hasCreateFrontendAccess = useHasRootAccess(CREATE_FRONTEND_API_TOKEN);
-    const hasCreateFrontendTokenAccess = useHasRootAccess(CREATE_PROJECT_API_TOKEN, project);
+    const hasCreateFrontendTokenAccess = useHasRootAccess(
+        CREATE_PROJECT_API_TOKEN,
+        project
+    );
     if (!project) {
         apiTokenTypes.push({
             key: TokenType.ADMIN,

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -34,7 +34,6 @@ import { Response } from 'express';
 import { timingSafeEqual } from 'crypto';
 import { createApiToken } from '../../../schema/api-token-schema';
 import { OperationDeniedError } from '../../../error';
-import { tokenTypeToCreatePermission } from '../api-token';
 
 interface ProjectTokenParam {
     token: string;
@@ -159,9 +158,7 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<any> {
         const createToken = await createApiToken.validateAsync(req.body);
         const { projectId } = req.params;
-        const permissionRequired = tokenTypeToCreatePermission(
-            createToken.type,
-        );
+        const permissionRequired = CREATE_PROJECT_API_TOKEN;
         const hasPermission = await this.accessService.hasPermission(
             req.user,
             permissionRequired,

--- a/src/test/e2e/api/admin/api-token.auth.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.auth.e2e.test.ts
@@ -184,7 +184,7 @@ test('A role with only CREATE_PROJECT_API_TOKEN can create project tokens', asyn
             });
             req.user = user;
             const createClientApiTokenRole = await accessService.createRole({
-                name: 'client_token_creator',
+                name: 'project_client_token_creator',
                 description: 'Can create client tokens',
                 permissions: [],
                 type: 'root-custom',
@@ -199,7 +199,7 @@ test('A role with only CREATE_PROJECT_API_TOKEN can create project tokens', asyn
                 'default',
             );
             req.user = await userService.createUser({
-                email: 'admin@example.com',
+                email: 'someguyinplaces@example.com',
                 rootRole: role.id,
             });
             next();


### PR DESCRIPTION
This fixes the creation of project only tokens (done through the project settings). When we redesigned the way tokens are created, we missed project specific tokens, which have their own permission set that wasn't respected. This forces only the project api for token creation to use the CREATE_PROJECT_API_TOKEN instead of the global CREATE_CLIENT_API_TOKEN or CREATE_FRONTEND_API_TOKEN