### PR TITLE
1-1049 Emit events after db transaction is complete

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -97,29 +97,10 @@ class EventStore implements IEventStore {
     }
 
     async store(event: IBaseEvent): Promise<void> {
-        console.log('In src/lib/db/event-store.ts. Received event:', event);
-
         try {
-            const rows = await this.db(TABLE)
+            await this.db(TABLE)
                 .insert(this.eventToDbRow(event))
                 .returning(EVENT_COLUMNS);
-            const savedEvent = this.rowToEvent(rows[0]);
-            console.log('Finished db transaction');
-
-            console.log(
-                'in src/lib/db/event-store.ts. Stored event with id:',
-                savedEvent.id,
-                'base event:',
-                event,
-                'saved event',
-                savedEvent,
-            );
-
-            // use a separate db column to store announced/unannounced
-            // use the scheduler service to process events that haven't been announced yet
-            // process.nextTick(() =>
-            //     this.eventEmitter.emit(event.type, savedEvent),
-            // );
         } catch (error: unknown) {
             this.logger.warn(`Failed to store "${event.type}" event: ${error}`);
         }
@@ -163,14 +144,9 @@ class EventStore implements IEventStore {
 
     async batchStore(events: IBaseEvent[]): Promise<void> {
         try {
-            // const savedRows =
             await this.db(TABLE)
                 .insert(events.map(this.eventToDbRow))
                 .returning(EVENT_COLUMNS);
-            // const savedEvents = savedRows.map(this.rowToEvent);
-            // process.nextTick(() =>
-            //     savedEvents.forEach((e) => this.eventEmitter.emit(e.type, e)),
-            // );
         } catch (error: unknown) {
             this.logger.warn(`Failed to store events: ${error}`);
         }

--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -382,6 +382,28 @@ class EventStore implements IEventStore {
         };
     }
 
+    setMaxListeners(number: number): EventEmitter {
+        return this.eventEmitter.setMaxListeners(number);
+    }
+
+    on(
+        eventName: string | symbol,
+        listener: (...args: any[]) => void,
+    ): EventEmitter {
+        return this.eventEmitter.on(eventName, listener);
+    }
+
+    emit(eventName: string | symbol, ...args: any[]): boolean {
+        return this.eventEmitter.emit(eventName, ...args);
+    }
+
+    off(
+        eventName: string | symbol,
+        listener: (...args: any[]) => void,
+    ): EventEmitter {
+        return this.eventEmitter.off(eventName, listener);
+    }
+
     async setUnannouncedToAnnounced(): Promise<IEvent[]> {
         const rows = await this.db(TABLE)
             .update({ announced: true })

--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -434,6 +434,7 @@ class EventStore implements IEventStore {
             .where('announced', false)
             .whereNotNull('announced')
             .returning(EVENT_COLUMNS);
+
         return rows.map(this.rowToEvent);
     }
 }

--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -382,28 +382,6 @@ class EventStore implements IEventStore {
         };
     }
 
-    setMaxListeners(number: number): EventEmitter {
-        return this.eventEmitter.setMaxListeners(number);
-    }
-
-    on(
-        eventName: string | symbol,
-        listener: (...args: any[]) => void,
-    ): EventEmitter {
-        return this.eventEmitter.on(eventName, listener);
-    }
-
-    emit(eventName: string | symbol, ...args: any[]): boolean {
-        return this.eventEmitter.emit(eventName, ...args);
-    }
-
-    off(
-        eventName: string | symbol,
-        listener: (...args: any[]) => void,
-    ): EventEmitter {
-        return this.eventEmitter.off(eventName, listener);
-    }
-
     async setUnannouncedToAnnounced(): Promise<IEvent[]> {
         const rows = await this.db(TABLE)
             .update({ announced: true })

--- a/src/lib/services/event-announcer-service.ts
+++ b/src/lib/services/event-announcer-service.ts
@@ -23,9 +23,6 @@ export default class EventAnnouncer {
 
     async publishUnannouncedEvents(): Promise<void> {
         const events = await this.eventStore.setUnannouncedToAnnounced();
-        if (events.length) {
-            console.log('about to announce these events', events);
-        }
 
         events.forEach((e) => this.eventEmitter.emit(e.type, e));
     }

--- a/src/lib/services/event-announcer-service.ts
+++ b/src/lib/services/event-announcer-service.ts
@@ -1,16 +1,12 @@
 import { IUnleashConfig } from '../types/option';
 import { IUnleashStores } from '../types/stores';
-import { sharedEventEmitter } from '../util/anyEventEmitter';
 import { Logger } from '../logger';
 import { IEventStore } from '../types/stores/event-store';
-import EventEmitter from 'events';
 
 export default class EventAnnouncer {
     private logger: Logger;
 
     private eventStore: IEventStore;
-
-    private eventEmitter: EventEmitter;
 
     constructor(
         { eventStore }: Pick<IUnleashStores, 'eventStore'>,
@@ -18,7 +14,6 @@ export default class EventAnnouncer {
     ) {
         this.logger = getLogger('services/event-service.ts');
         this.eventStore = eventStore;
-        this.eventEmitter = sharedEventEmitter;
     }
 
     async publishUnannouncedEvents(): Promise<void> {

--- a/src/lib/services/event-announcer-service.ts
+++ b/src/lib/services/event-announcer-service.ts
@@ -1,0 +1,32 @@
+import { IUnleashConfig } from '../types/option';
+import { IUnleashStores } from '../types/stores';
+import { sharedEventEmitter } from '../util/anyEventEmitter';
+import { Logger } from '../logger';
+import { IEventStore } from '../types/stores/event-store';
+import EventEmitter from 'events';
+
+export default class EventAnnouncer {
+    private logger: Logger;
+
+    private eventStore: IEventStore;
+
+    private eventEmitter: EventEmitter;
+
+    constructor(
+        { eventStore }: Pick<IUnleashStores, 'eventStore'>,
+        { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
+    ) {
+        this.logger = getLogger('services/event-service.ts');
+        this.eventStore = eventStore;
+        this.eventEmitter = sharedEventEmitter;
+    }
+
+    async publishUnannouncedEvents(): Promise<void> {
+        const events = await this.eventStore.setUnannouncedToAnnounced();
+        if (events.length) {
+            console.log('about to announce these events', events);
+        }
+
+        events.forEach((e) => this.eventEmitter.emit(e.type, e));
+    }
+}

--- a/src/lib/services/event-announcer-service.ts
+++ b/src/lib/services/event-announcer-service.ts
@@ -22,8 +22,6 @@ export default class EventAnnouncer {
     }
 
     async publishUnannouncedEvents(): Promise<void> {
-        const events = await this.eventStore.setUnannouncedToAnnounced();
-
-        events.forEach((e) => this.eventEmitter.emit(e.type, e));
+        return this.eventStore.publishUnannouncedEvents();
     }
 }

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -58,6 +58,7 @@ import {
 } from '../features/change-request-access-service/createChangeRequestAccessReadModel';
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 import { createFeatureToggleService } from '../features';
+import EventAnnouncerService from './event-announcer-service';
 
 // TODO: will be moved to scheduler feature directory
 export const scheduleServices = async (
@@ -72,6 +73,7 @@ export const scheduleServices = async (
         projectHealthService,
         configurationRevisionService,
         maintenanceService,
+        eventAnnouncerService,
     } = services;
 
     if (await maintenanceService.isMaintenanceMode()) {
@@ -113,6 +115,13 @@ export const scheduleServices = async (
     schedulerService.schedule(
         configurationRevisionService.updateMaxRevisionId.bind(
             configurationRevisionService,
+        ),
+        secondsToMilliseconds(1),
+    );
+
+    schedulerService.schedule(
+        eventAnnouncerService.publishUnannouncedEvents.bind(
+            eventAnnouncerService,
         ),
         secondsToMilliseconds(1),
     );
@@ -240,10 +249,13 @@ export const createServices = (
         schedulerService,
     );
 
+    const eventAnnouncerService = new EventAnnouncerService(stores, config);
+
     return {
         accessService,
         accountService,
         addonService,
+        eventAnnouncerService,
         featureToggleService: featureToggleServiceV2,
         featureToggleServiceV2,
         featureTypeService,

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -42,6 +42,7 @@ import { Knex } from 'knex';
 import ExportImportService from '../features/export-import-toggles/export-import-service';
 import { ISegmentService } from '../segments/segment-service-interface';
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
+import EventAnnouncerService from 'lib/services/event-announcer-service';
 
 export interface IUnleashServices {
     accessService: AccessService;
@@ -88,6 +89,7 @@ export interface IUnleashServices {
     exportImportService: ExportImportService;
     configurationRevisionService: ConfigurationRevisionService;
     schedulerService: SchedulerService;
+    eventAnnouncerService: EventAnnouncerService;
     transactionalExportImportService: (
         db: Knex.Transaction,
     ) => ExportImportService;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -1,9 +1,12 @@
 import { IBaseEvent, IEvent } from '../events';
 import { Store } from './store';
 import { SearchEventsSchema } from '../../openapi/spec/search-events-schema';
+import EventEmitter from 'events';
 import { IQueryOperations } from 'lib/db/event-store';
 
-export interface IEventStore extends Store<IEvent, number> {
+export interface IEventStore
+    extends Store<IEvent, number>,
+        Pick<EventEmitter, 'on' | 'setMaxListeners' | 'emit' | 'off'> {
     setUnannouncedToAnnounced(): Promise<IEvent[]>;
     store(event: IBaseEvent): Promise<void>;
     batchStore(events: IBaseEvent[]): Promise<void>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -7,6 +7,7 @@ import { IQueryOperations } from 'lib/db/event-store';
 export interface IEventStore
     extends Store<IEvent, number>,
         Pick<EventEmitter, 'on' | 'setMaxListeners' | 'emit' | 'off'> {
+    setUnannouncedToAnnounced(): Promise<IEvent[]>;
     store(event: IBaseEvent): Promise<void>;
     batchStore(events: IBaseEvent[]): Promise<void>;
     getEvents(): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -1,12 +1,9 @@
 import { IBaseEvent, IEvent } from '../events';
 import { Store } from './store';
 import { SearchEventsSchema } from '../../openapi/spec/search-events-schema';
-import EventEmitter from 'events';
 import { IQueryOperations } from 'lib/db/event-store';
 
-export interface IEventStore
-    extends Store<IEvent, number>,
-        Pick<EventEmitter, 'on' | 'setMaxListeners' | 'emit' | 'off'> {
+export interface IEventStore extends Store<IEvent, number> {
     setUnannouncedToAnnounced(): Promise<IEvent[]>;
     store(event: IBaseEvent): Promise<void>;
     batchStore(events: IBaseEvent[]): Promise<void>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -7,7 +7,7 @@ import { IQueryOperations } from 'lib/db/event-store';
 export interface IEventStore
     extends Store<IEvent, number>,
         Pick<EventEmitter, 'on' | 'setMaxListeners' | 'emit' | 'off'> {
-    setUnannouncedToAnnounced(): Promise<IEvent[]>;
+    publishUnannouncedEvents(): Promise<void>;
     store(event: IBaseEvent): Promise<void>;
     batchStore(events: IBaseEvent[]): Promise<void>;
     getEvents(): Promise<IEvent[]>;

--- a/src/migrations/20230706123907-events-announced-column.js
+++ b/src/migrations/20230706123907-events-announced-column.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    // mark existing events as announced, set the default to false for future events.
+    db.runSql(
+        `
+        ALTER TABLE events
+            ADD COLUMN IF NOT EXISTS "announced" BOOLEAN DEFAULT TRUE,
+            ALTER COLUMN "announced" SET DEFAULT FALSE;
+        `,
+        cb(),
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE events DROP COLUMN IF EXISTS "announced";
+        `,
+        cb,
+    );
+};

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -43,7 +43,7 @@ test('Should include id and createdAt when saving', async () => {
     const seen: Array<IEvent> = [];
     eventStore.on(APPLICATION_CREATED, (e) => seen.push(e));
     await eventStore.store(event1);
-    jest.advanceTimersByTime(100);
+    await eventStore.publishUnannouncedEvents();
     expect(seen).toHaveLength(1);
     expect(seen[0].id).toBeTruthy();
     expect(seen[0].createdAt).toBeTruthy();
@@ -74,6 +74,7 @@ test('Should include empty tags array for new event', async () => {
 
     // Trigger
     await eventStore.store(event);
+    await eventStore.publishUnannouncedEvents();
 
     return promise;
 });
@@ -108,7 +109,7 @@ test('Should be able to store multiple events at once', async () => {
     const seen = [];
     eventStore.on(APPLICATION_CREATED, (e) => seen.push(e));
     await eventStore.batchStore([event1, event2, event3]);
-    jest.advanceTimersByTime(100);
+    await eventStore.publishUnannouncedEvents();
     expect(seen.length).toBe(3);
     seen.forEach((e) => {
         expect(e.id).toBeTruthy();

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -121,6 +121,10 @@ class FakeEventStore implements IEventStore {
     ): EventEmitter {
         return this.eventEmitter.off(eventName, listener);
     }
+
+    setUnannouncedToAnnounced(): Promise<IEvent[]> {
+        throw new Error('Method not implemented.');
+    }
 }
 
 module.exports = FakeEventStore;

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -122,7 +122,7 @@ class FakeEventStore implements IEventStore {
         return this.eventEmitter.off(eventName, listener);
     }
 
-    setUnannouncedToAnnounced(): Promise<IEvent[]> {
+    publishUnannouncedEvents(): Promise<void> {
         throw new Error('Method not implemented.');
     }
 }


### PR DESCRIPTION
This PR fixes an issue where events generated during a db transaction would get published before the transaction was complete. This caused errors in some of our services that expected the data to be stored before the transaction had been commited. Refer to [linear issue 1-1049](https://linear.app/unleash/issue/1-1049/event-emitter-should-emit-events-after-db-transaction-is-commited-not) for more info.

Fixes 1-1049.

## Changes

The most important change here is that the `eventStore` no longer emits events when they happen (because that can be in the middle of a transaction). Instead, events are stored with a new `announced` column. The new event announcer service runs on a schedule (every second) and publishes any new events that have not been published. 

Parts of the code have largely been lifted from the `client-application-store`, which uses a similar logic.

I have kept the emitting of the event within the event store because a lot of other services listen to events from this store, so removing that would require a large rewrite. It's something we could look into down the line, but it seems like too much of a change to do right now.

## Discussion

### Terminology:

Published vs announced? We should settle on one or the other. Announced is consistent with the client-application store, but published sounds more fitting for events.

### Publishing and marking events as published

The current implementation fetches all events that haven't been marked as announced, sets them as announced, and then emits them. It's possible that Unleash would crash in the interim or something else might happen, causing the events not to get published. Maybe it would make sense to just fetch the events and only mark them as published after the announcement? On the other hand, that might get us into other problems. Any thoughts on this would be much appreciated.