### PR TITLE
fix: bulk tags will work now with project permissions

### DIFF
--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -59,7 +59,7 @@ export const ManageTags: VFC<IManageTagsProps> = ({ projectId, data }) => {
         const features = data.map(({ name }) => name);
         const payload = { features, tags: { addedTags, removedTags } };
         try {
-            await bulkUpdateTags(payload);
+            await bulkUpdateTags(payload, projectId);
             refetch();
             const added = addedTags.length
                 ? `Added tags: ${addedTags

--- a/frontend/src/hooks/api/actions/useTagApi/useTagApi.ts
+++ b/frontend/src/hooks/api/actions/useTagApi/useTagApi.ts
@@ -20,8 +20,11 @@ const useTagApi = () => {
         }
     };
 
-    const bulkUpdateTags = async (payload: TagsBulkAddSchema) => {
-        const path = `api/admin/tags/features`;
+    const bulkUpdateTags = async (
+        payload: TagsBulkAddSchema,
+        projectId: string
+    ) => {
+        const path = `api/admin/projects/${projectId}/tags`;
         const req = createRequest(path, {
             method: 'PUT',
             body: JSON.stringify(payload),

--- a/src/lib/routes/admin-api/tag.ts
+++ b/src/lib/routes/admin-api/tag.ts
@@ -23,7 +23,6 @@ import {
 } from '../../openapi/spec/tag-with-version-schema';
 import { emptyResponse } from '../../openapi/util/standard-responses';
 import FeatureTagService from 'lib/services/feature-tag-service';
-import { TagsBulkAddSchema } from '../../openapi/spec/tags-bulk-add-schema';
 import { IFlagResolver } from '../../types';
 
 const version = 1;
@@ -74,7 +73,7 @@ class TagController extends Controller {
             method: 'post',
             path: '',
             handler: this.createTag,
-            permission: UPDATE_FEATURE,
+            permission: NONE,
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
@@ -88,20 +87,7 @@ class TagController extends Controller {
                 }),
             ],
         });
-        this.route({
-            method: 'put',
-            path: '/features',
-            handler: this.updateFeaturesTags,
-            permission: UPDATE_FEATURE,
-            middleware: [
-                openApiService.validPath({
-                    tags: ['Tags'],
-                    operationId: 'addTagToFeatures',
-                    requestBody: createRequestSchema('tagsBulkAddSchema'),
-                    responses: { 200: emptyResponse },
-                }),
-            ],
-        });
+
         this.route({
             method: 'get',
             path: '/:type',
@@ -206,21 +192,6 @@ class TagController extends Controller {
         const { type, value } = req.params;
         const userName = extractUsername(req);
         await this.tagService.deleteTag({ type, value }, userName);
-        res.status(200).end();
-    }
-
-    async updateFeaturesTags(
-        req: IAuthRequest<void, void, TagsBulkAddSchema>,
-        res: Response<TagSchema>,
-    ): Promise<void> {
-        const { features, tags } = req.body;
-        const userName = extractUsername(req);
-        await this.featureTagService.updateTags(
-            features,
-            tags.addedTags,
-            tags.removedTags,
-            userName,
-        );
         res.status(200).end();
     }
 }

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -143,7 +143,7 @@ test('Can tag features', async () => {
         strategies: [{ name: 'default' }],
     });
 
-    await app.request.put('/api/admin/tags/features').send({
+    await app.request.put('/api/admin/projects/default/tags').send({
         features: [featureName, featureName2],
         tags: {
             addedTags: [addedTag],
@@ -185,7 +185,7 @@ test('Can bulk remove tags', async () => {
     });
 
     await app.request
-        .put('/api/admin/tags/features')
+        .put('/api/admin/projects/default/tags')
         .send({
             features: [featureName, featureName2],
             tags: {
@@ -196,7 +196,7 @@ test('Can bulk remove tags', async () => {
         .expect(200);
 
     await app.request
-        .put('/api/admin/tags/features')
+        .put('/api/admin/projects/default/tags')
         .send({
             features: [featureName, featureName2],
             tags: {


### PR DESCRIPTION
Previously creation of tags required UPDATE_FEATURE permission, but creating tags is not related to feature or project, so it was not able to work.
Also bulk update tags was missing projectId from url, so it also did not work properly.