### PR TITLE
fix: validate min constraint values in openapi

### DIFF
--- a/src/lib/openapi/spec/constraint-schema.ts
+++ b/src/lib/openapi/spec/constraint-schema.ts
@@ -39,6 +39,7 @@ export const constraintSchemaBase = {
             items: {
                 type: 'string',
             },
+            minItems: 1,
             example: ['my-app', 'my-other-app'],
         },
         value: {

--- a/src/test/arbitraries.test.ts
+++ b/src/test/arbitraries.test.ts
@@ -37,7 +37,7 @@ export const strategyConstraint = (): Arbitrary<ConstraintSchema> =>
         operator: fc.constantFrom(...ALL_OPERATORS),
         caseInsensitive: fc.boolean(),
         inverted: fc.boolean(),
-        values: fc.array(fc.string()),
+        values: fc.array(fc.string(), { minLength: 1 }),
         value: fc.string(),
     });
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<img width="1073" alt="Screenshot 2023-07-07 at 11 32 45" src="https://github.com/Unleash/unleash/assets/1394682/ef869e96-8b3e-4084-86a2-74e4d12387d4">


Previously constraint values were validated inside the feature toggle service not in the openapi. What it means is that change requests that are using the same schema, don't get a validation since it's inside the feature service. So I'm moving the validation of values min length to the openapi schema. Since this field is optional the validation only kicks in when values are provided, not when single value is provided.

Solves: https://linear.app/unleash/issue/1-1095/cr-allows-0-values-for-constraints

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
