### PR TITLE
fix: add focus style to vertical tabs

### DIFF
--- a/frontend/src/component/common/VerticalTabs/VerticalTab/VerticalTab.tsx
+++ b/frontend/src/component/common/VerticalTabs/VerticalTab/VerticalTab.tsx
@@ -30,7 +30,14 @@ const StyledTab = styled(Button)<{ selected: boolean }>(
         '&.Mui-disabled': {
             pointerEvents: 'auto',
         },
+        '&:focus-visible': {
+            outline: `2px solid ${theme.palette.primary.main}`,
+        },
         justifyContent: 'space-between',
+        '& > span': {
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+        },
     })
 );
 
@@ -48,10 +55,8 @@ export const VerticalTab = ({
     <StyledTab
         selected={Boolean(selected)}
         onClick={onClick}
-        disableRipple
         disableElevation
         disableFocusRipple
-        disableTouchRipple
         fullWidth
     >
         {label}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1206/we-need-focus-state-for-vertical-menu

Adds a `focus-visible` style to vertical tabs in order to improve keyboard navigation.

![image](https://github.com/Unleash/unleash/assets/14320932/e07a1b69-2134-4d76-bafe-1c87a0384e64)
