### PR TITLE
chore: add auto-generated doc index to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ frontend/build
 
 # Generated docs
 website/docs/reference/api/**/sidebar.js
+website/docs/reference/api/**/**.info.mdx
 website/docs/generated
 reports/jest-junit.xml


### PR DESCRIPTION
I've seen this one pop up a couple times. It's part of our openapi docusaurus integration and should be ignored.