### PR TITLE
fix: reduce severity of api token middleware errors

### DIFF
--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -77,7 +77,7 @@ const apiAccessMiddleware = (
                 }
             }
         } catch (error) {
-            logger.error(error);
+            logger.warn(error);
         }
 
         next();


### PR DESCRIPTION
This isn't something our on-calls can do something about when it fails, so downgrading to WARN seems like the right level.