### PR TITLE
fix: existing stickiness value should be available in the dropdown 

### DIFF
--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/StickinessSelect/StickinessSelect.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/StickinessSelect/StickinessSelect.tsx
@@ -43,6 +43,11 @@ export const StickinessSelect = ({
             options.push({ key: 'random', label: 'random' });
         }
 
+        // Add existing value to the options
+        if (value && !options.find(option => option.key === value)) {
+            options.push({ key: value, label: value });
+        }
+
         return options;
     };
 


### PR DESCRIPTION
 existing stickiness value should be available in the dropdown even if the context field is no longer sticky

Closes # [1-1115](https://linear.app/unleash/issue/1-1115/current-gradual-rollout-stickiness-configurations-should-take-priority)
