### PR TITLE
docs: highlight unleash edge

### DIFF
--- a/website/docs/topics/proxy-hosting.mdx
+++ b/website/docs/topics/proxy-hosting.mdx
@@ -2,7 +2,7 @@
 title: Proxy hosting strategies
 ---
 
-Because the [Unleash proxy](../generated/unleash-proxy.md) is a separate piece of the Unleash architecture and because it should sit close to your application, there are numerous ways of hosting it. Another important distinction is whether you're hosting Unleash yourself or you have a managed solution.
+Because the [Unleash proxy](../generated/unleash-proxy.md) (or alternatively [Unleash edge](../generated/unleash-edge.md)) is a separate piece of the Unleash architecture and because it should sit close to your application, there are numerous ways of hosting it. Another important distinction is whether you're hosting Unleash yourself or you have a managed solution.
 
 This document describes the two main ways of hosting the proxy alongside the Unleash API and the tradeoffs between hosting the proxy yourself and using the Frontend API that Unleash hosts for you.
 


### PR DESCRIPTION
Highlight edge in the first paragraph.

Not sure if we should suggest that it should be the preferred choice, but at least this helps to realize there's an alternative already in the first paragraph.