### PR TITLE
test: try serving openapi.json from docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -590,16 +590,26 @@ module.exports = {
             },
         ],
         [
+            'docusaurus-plugin-remote-content',
+            {
+                name: 'openapi-schema',
+                sourceBaseUrl:
+                    process.env.OPENAPI_SOURCE === 'localhost'
+                        ? 'http://localhost:4242/docs/'
+                        : 'https://us.app.unleash-hosted.com/ushosted/docs/',
+                outDir: 'docs/generated',
+                documents: ['openapi.json'],
+                requestConfig: { responseType: 'text' },
+            },
+        ],
+        [
             'docusaurus-plugin-openapi-docs',
             {
                 id: 'api-operations',
                 docsPluginId: 'classic',
                 config: {
                     server: {
-                        specPath:
-                            process.env.OPENAPI_SOURCE === 'localhost'
-                                ? 'http://localhost:4242/docs/openapi.json'
-                                : 'https://us.app.unleash-hosted.com/ushosted/docs/openapi.json',
+                        specPath: 'docs/generated/openapi.json',
                         outputDir: 'docs/reference/api/unleash',
                         sidebarOptions: {
                             groupPathsBy: 'tag',
@@ -647,7 +657,5 @@ module.exports = {
             async: true,
         },
     ],
-    clientModules: [
-        require.resolve('./global.js'),
-      ],
+    clientModules: [require.resolve('./global.js')],
 };


### PR DESCRIPTION
## About the changes
It'd be nice to have our openapi.json (maybe openapi.yaml as well) being part of our docs. This can help auto-generate clients.

The problem is having the only available version under https://us.app.unleash-hosted.com/ushosted/docs/openapi.json that can run out of sync with the generated documentation. Having it as a static asset of the current version of our documentation can be helpful.

Also, the documentation https://us.app.unleash-hosted.com/ushosted/docs/openapi/ allows you to download the raw spec (under the title) but the page generated by docusaurus does not

![image](https://github.com/Unleash/unleash/assets/455064/71bca482-d057-4567-b843-2d3e8613dd60)
