### PR TITLE
feat: strategy variant schema openapi

### DIFF
--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -145,6 +145,8 @@ import {
     versionSchema,
     advancedPlaygroundFeatureSchema,
     telemetrySettingsSchema,
+    strategyVariantSchema,
+    createStrategyVariantSchema,
 } from './spec';
 import { IServerOption } from '../types';
 import { mapValues, omitKeys } from '../util';
@@ -347,6 +349,8 @@ export const schemas: UnleashSchemas = {
     importTogglesValidateItemSchema,
     contextFieldStrategiesSchema,
     telemetrySettingsSchema,
+    strategyVariantSchema,
+    createStrategyVariantSchema,
 };
 
 // Remove JSONSchema keys that would result in an invalid OpenAPI spec.

--- a/src/lib/openapi/spec/client-feature-schema.ts
+++ b/src/lib/openapi/spec/client-feature-schema.ts
@@ -4,6 +4,7 @@ import { parametersSchema } from './parameters-schema';
 import { featureStrategySchema } from './feature-strategy-schema';
 import { variantSchema } from './variant-schema';
 import { overrideSchema } from './override-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const clientFeatureSchema = {
     $id: '#/components/schemas/clientFeatureSchema',
@@ -78,6 +79,7 @@ export const clientFeatureSchema = {
             constraintSchema,
             parametersSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             variantSchema,
             overrideSchema,
         },

--- a/src/lib/openapi/spec/client-features-schema.ts
+++ b/src/lib/openapi/spec/client-features-schema.ts
@@ -8,6 +8,7 @@ import { parametersSchema } from './parameters-schema';
 import { featureStrategySchema } from './feature-strategy-schema';
 import { clientFeatureSchema } from './client-feature-schema';
 import { variantSchema } from './variant-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const clientFeaturesSchema = {
     $id: '#/components/schemas/clientFeaturesSchema',
@@ -54,6 +55,7 @@ export const clientFeaturesSchema = {
             overrideSchema,
             parametersSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             variantSchema,
         },
     },

--- a/src/lib/openapi/spec/create-feature-strategy-schema.ts
+++ b/src/lib/openapi/spec/create-feature-strategy-schema.ts
@@ -1,6 +1,7 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { parametersSchema } from './parameters-schema';
 import { constraintSchema } from './constraint-schema';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
 
 export const createFeatureStrategySchema = {
     $id: '#/components/schemas/createFeatureStrategySchema',
@@ -48,6 +49,13 @@ export const createFeatureStrategySchema = {
                 $ref: '#/components/schemas/constraintSchema',
             },
         },
+        variants: {
+            type: 'array',
+            description: 'Strategy level variants',
+            items: {
+                $ref: '#/components/schemas/createStrategyVariantSchema',
+            },
+        },
         parameters: {
             description: 'An object containing the parameters for the strategy',
             example: {
@@ -70,6 +78,7 @@ export const createFeatureStrategySchema = {
         schemas: {
             constraintSchema,
             parametersSchema,
+            createStrategyVariantSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/create-strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/create-strategy-variant-schema.ts
@@ -10,7 +10,8 @@ export const createStrategyVariantSchema = {
     properties: {
         name: {
             type: 'string',
-            description: 'The variant name. Must be unique for this feature toggle',
+            description:
+                'The variant name. Must be unique for this feature toggle',
             example: 'blue_group',
         },
         weight: {
@@ -38,9 +39,12 @@ export const createStrategyVariantSchema = {
             description: 'Extra data configured for this variant',
             properties: {
                 type: {
+                    description:
+                        'The type of the value. Commonly used types are string, json and csv.',
                     type: 'string',
                 },
                 value: {
+                    description: 'The actual value of payload',
                     type: 'string',
                 },
             },

--- a/src/lib/openapi/spec/create-strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/create-strategy-variant-schema.ts
@@ -5,7 +5,7 @@ export const createStrategyVariantSchema = {
     type: 'object',
     additionalProperties: true,
     description:
-        '[WIP] A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+        "This is an experimental property. It may change or be removed as we work on it. Please don't depend on it yet. A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.",
     required: ['name', 'weight', 'weightType', 'stickiness'],
     properties: {
         name: {

--- a/src/lib/openapi/spec/create-strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/create-strategy-variant-schema.ts
@@ -1,0 +1,55 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const createStrategyVariantSchema = {
+    $id: '#/components/schemas/createStrategyVariantSchema',
+    type: 'object',
+    additionalProperties: true,
+    description:
+        '[WIP] A strategy variant allows to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+    required: ['name', 'weight', 'weightType', 'stickiness'],
+    properties: {
+        name: {
+            type: 'string',
+            description: 'The variants name. Is unique for this feature toggle',
+            example: 'blue_group',
+        },
+        weight: {
+            type: 'number',
+            description:
+                'The weight is the likelihood of any one user getting this variant. It is a number between 0 and 1000. See the section on [variant weights](https://docs.getunleash.io/reference/feature-toggle-variants#variant-weight) for more information',
+            minimum: 0,
+            maximum: 1000,
+        },
+        weightType: {
+            description:
+                'Set to fix if this variant must have exactly the weight allocated to it. If the type is variable, the weight will adjust so that the total weight of all variants adds up to 1000',
+            type: 'string',
+            example: 'fix',
+        },
+        stickiness: {
+            type: 'string',
+            description:
+                '[Stickiness](https://docs.getunleash.io/reference/feature-toggle-variants#variant-stickiness) is how Unleash guarantees that the same user gets the same variant every time',
+            example: 'custom.context.field',
+        },
+        payload: {
+            type: 'object',
+            required: ['type', 'value'],
+            description: 'Extra data configured for this variant',
+            properties: {
+                type: {
+                    type: 'string',
+                },
+                value: {
+                    type: 'string',
+                },
+            },
+            example: { type: 'json', value: '{color: red}' },
+        },
+    },
+    components: {},
+} as const;
+
+export type CreateStrategyVariantSchema = FromSchema<
+    typeof createStrategyVariantSchema
+>;

--- a/src/lib/openapi/spec/create-strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/create-strategy-variant-schema.ts
@@ -5,31 +5,31 @@ export const createStrategyVariantSchema = {
     type: 'object',
     additionalProperties: true,
     description:
-        '[WIP] A strategy variant allows to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+        '[WIP] A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
     required: ['name', 'weight', 'weightType', 'stickiness'],
     properties: {
         name: {
             type: 'string',
-            description: 'The variants name. Is unique for this feature toggle',
+            description: 'The variant name. Must be unique for this feature toggle',
             example: 'blue_group',
         },
         weight: {
-            type: 'number',
+            type: 'integer',
             description:
-                'The weight is the likelihood of any one user getting this variant. It is a number between 0 and 1000. See the section on [variant weights](https://docs.getunleash.io/reference/feature-toggle-variants#variant-weight) for more information',
+                'The weight is the likelihood of any one user getting this variant. It is an integer between 0 and 1000. See the section on [variant weights](https://docs.getunleash.io/reference/feature-toggle-variants#variant-weight) for more information',
             minimum: 0,
             maximum: 1000,
         },
         weightType: {
             description:
-                'Set to fix if this variant must have exactly the weight allocated to it. If the type is variable, the weight will adjust so that the total weight of all variants adds up to 1000',
+                'Set to `fix` if this variant must have exactly the weight allocated to it. If the type is `variable`, the weight will adjust so that the total weight of all variants adds up to 1000. Refer to the [variant weight documentation](https://docs.getunleash.io/reference/feature-toggle-variants#variant-weight).',
             type: 'string',
             example: 'fix',
         },
         stickiness: {
             type: 'string',
             description:
-                '[Stickiness](https://docs.getunleash.io/reference/feature-toggle-variants#variant-stickiness) is how Unleash guarantees that the same user gets the same variant every time',
+                'The [stickiness](https://docs.getunleash.io/reference/feature-toggle-variants#variant-stickiness) to use for distribution of this variant. Stickiness is how Unleash guarantees that the same user gets the same variant every time',
             example: 'custom.context.field',
         },
         payload: {

--- a/src/lib/openapi/spec/environment-project-schema.ts
+++ b/src/lib/openapi/spec/environment-project-schema.ts
@@ -1,5 +1,6 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { createFeatureStrategySchema } from './create-feature-strategy-schema';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
 
 export const environmentProjectSchema = {
     $id: '#/components/schemas/environmentProjectSchema',
@@ -60,6 +61,7 @@ export const environmentProjectSchema = {
     components: {
         schemas: {
             createFeatureStrategySchema,
+            createStrategyVariantSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/export-result-schema.ts
+++ b/src/lib/openapi/spec/export-result-schema.ts
@@ -11,6 +11,7 @@ import { overrideSchema } from './override-schema';
 import { variantsSchema } from './variants-schema';
 import { constraintSchema } from './constraint-schema';
 import { tagTypeSchema } from './tag-type-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const exportResultSchema = {
     $id: '#/components/schemas/exportResultSchema',
@@ -170,6 +171,7 @@ export const exportResultSchema = {
         schemas: {
             featureSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             featureEnvironmentSchema,
             contextFieldSchema,
             featureTagSchema,

--- a/src/lib/openapi/spec/feature-environment-schema.ts
+++ b/src/lib/openapi/spec/feature-environment-schema.ts
@@ -3,6 +3,7 @@ import { constraintSchema } from './constraint-schema';
 import { parametersSchema } from './parameters-schema';
 import { featureStrategySchema } from './feature-strategy-schema';
 import { variantSchema } from './variant-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const featureEnvironmentSchema = {
     $id: '#/components/schemas/featureEnvironmentSchema',
@@ -65,6 +66,7 @@ export const featureEnvironmentSchema = {
             constraintSchema,
             parametersSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             variantSchema,
         },
     },

--- a/src/lib/openapi/spec/feature-schema.ts
+++ b/src/lib/openapi/spec/feature-schema.ts
@@ -6,6 +6,7 @@ import { parametersSchema } from './parameters-schema';
 import { featureStrategySchema } from './feature-strategy-schema';
 import { tagSchema } from './tag-schema';
 import { featureEnvironmentSchema } from './feature-environment-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const featureSchema = {
     $id: '#/components/schemas/featureSchema',
@@ -125,6 +126,7 @@ export const featureSchema = {
             constraintSchema,
             featureEnvironmentSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             overrideSchema,
             parametersSchema,
             variantSchema,

--- a/src/lib/openapi/spec/feature-strategy-schema.ts
+++ b/src/lib/openapi/spec/feature-strategy-schema.ts
@@ -1,6 +1,7 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { constraintSchema } from './constraint-schema';
 import { parametersSchema } from './parameters-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const featureStrategySchema = {
     $id: '#/components/schemas/featureStrategySchema',
@@ -59,6 +60,13 @@ export const featureStrategySchema = {
                 $ref: '#/components/schemas/constraintSchema',
             },
         },
+        variants: {
+            type: 'array',
+            description: 'Strategy level variants',
+            items: {
+                $ref: '#/components/schemas/strategyVariantSchema',
+            },
+        },
         parameters: {
             $ref: '#/components/schemas/parametersSchema',
         },
@@ -67,6 +75,7 @@ export const featureStrategySchema = {
         schemas: {
             constraintSchema,
             parametersSchema,
+            strategyVariantSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/features-schema.ts
+++ b/src/lib/openapi/spec/features-schema.ts
@@ -7,6 +7,7 @@ import { constraintSchema } from './constraint-schema';
 import { featureStrategySchema } from './feature-strategy-schema';
 import { environmentSchema } from './environment-schema';
 import { featureEnvironmentSchema } from './feature-environment-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const featuresSchema = {
     $id: '#/components/schemas/featuresSchema',
@@ -32,6 +33,7 @@ export const featuresSchema = {
             overrideSchema,
             featureEnvironmentSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             parametersSchema,
             variantSchema,
         },

--- a/src/lib/openapi/spec/health-overview-schema.ts
+++ b/src/lib/openapi/spec/health-overview-schema.ts
@@ -10,6 +10,8 @@ import { featureEnvironmentSchema } from './feature-environment-schema';
 import { projectStatsSchema } from './project-stats-schema';
 import { createFeatureStrategySchema } from './create-feature-strategy-schema';
 import { projectEnvironmentSchema } from './project-environment-schema';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const healthOverviewSchema = {
     $id: '#/components/schemas/healthOverviewSchema',
@@ -114,12 +116,14 @@ export const healthOverviewSchema = {
             environmentSchema,
             projectEnvironmentSchema,
             createFeatureStrategySchema,
+            createStrategyVariantSchema,
             constraintSchema,
             featureSchema,
             featureEnvironmentSchema,
             overrideSchema,
             parametersSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             variantSchema,
             projectStatsSchema,
         },

--- a/src/lib/openapi/spec/import-toggles-schema.ts
+++ b/src/lib/openapi/spec/import-toggles-schema.ts
@@ -13,6 +13,7 @@ import { parametersSchema } from './parameters-schema';
 import { legalValueSchema } from './legal-value-schema';
 import { tagTypeSchema } from './tag-type-schema';
 import { featureEnvironmentSchema } from './feature-environment-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const importTogglesSchema = {
     $id: '#/components/schemas/importTogglesSchema',
@@ -43,6 +44,7 @@ export const importTogglesSchema = {
             exportResultSchema,
             featureSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             featureEnvironmentSchema,
             contextFieldSchema,
             featureTagSchema,

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -144,3 +144,5 @@ export * from './advanced-playground-feature-schema';
 export * from './advanced-playground-response-schema';
 export * from './advanced-playground-request-schema';
 export * from './telemetry-settings-schema';
+export * from './create-strategy-variant-schema';
+export * from './strategy-variant-schema';

--- a/src/lib/openapi/spec/project-environment-schema.ts
+++ b/src/lib/openapi/spec/project-environment-schema.ts
@@ -1,5 +1,6 @@
 import { FromSchema } from 'json-schema-to-ts';
 import { createFeatureStrategySchema } from './create-feature-strategy-schema';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
 
 export const projectEnvironmentSchema = {
     $id: '#/components/schemas/projectEnvironmentSchema',
@@ -29,6 +30,7 @@ export const projectEnvironmentSchema = {
     components: {
         schemas: {
             createFeatureStrategySchema,
+            createStrategyVariantSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/project-overview-schema.ts
+++ b/src/lib/openapi/spec/project-overview-schema.ts
@@ -10,6 +10,8 @@ import { featureEnvironmentSchema } from './feature-environment-schema';
 import { projectStatsSchema } from './project-stats-schema';
 import { createFeatureStrategySchema } from './create-feature-strategy-schema';
 import { projectEnvironmentSchema } from './project-environment-schema';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const projectOverviewSchema = {
     $id: '#/components/schemas/projectOverviewSchema',
@@ -116,12 +118,14 @@ export const projectOverviewSchema = {
             environmentSchema,
             projectEnvironmentSchema,
             createFeatureStrategySchema,
+            createStrategyVariantSchema,
             constraintSchema,
             featureSchema,
             featureEnvironmentSchema,
             overrideSchema,
             parametersSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             variantSchema,
             projectStatsSchema,
         },

--- a/src/lib/openapi/spec/state-schema.ts
+++ b/src/lib/openapi/spec/state-schema.ts
@@ -10,6 +10,7 @@ import { environmentSchema } from './environment-schema';
 import { segmentSchema } from './segment-schema';
 import { featureStrategySegmentSchema } from './feature-strategy-segment-schema';
 import { strategySchema } from './strategy-schema';
+import { strategyVariantSchema } from './strategy-variant-schema';
 
 export const stateSchema = {
     $id: '#/components/schemas/stateSchema',
@@ -98,6 +99,7 @@ export const stateSchema = {
             featureTagSchema,
             projectSchema,
             featureStrategySchema,
+            strategyVariantSchema,
             featureEnvironmentSchema,
             environmentSchema,
             segmentSchema,

--- a/src/lib/openapi/spec/strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/strategy-variant-schema.ts
@@ -6,7 +6,7 @@ export const strategyVariantSchema = {
     type: 'object',
     additionalProperties: false,
     description:
-        '[WIP] A strategy variant allows to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+        '[WIP] A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
     required: ['name', 'weight', 'weightType', 'stickiness'],
     properties: {
         ...createStrategyVariantSchema.properties,

--- a/src/lib/openapi/spec/strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/strategy-variant-schema.ts
@@ -6,7 +6,7 @@ export const strategyVariantSchema = {
     type: 'object',
     additionalProperties: false,
     description:
-        '[WIP] A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+        "This is an experimental property. It may change or be removed as we work on it. Please don't depend on it yet. A strategy variant allows you to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.",
     required: ['name', 'weight', 'weightType', 'stickiness'],
     properties: {
         ...createStrategyVariantSchema.properties,

--- a/src/lib/openapi/spec/strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/strategy-variant-schema.ts
@@ -1,0 +1,17 @@
+import { FromSchema } from 'json-schema-to-ts';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema';
+
+export const strategyVariantSchema = {
+    $id: '#/components/schemas/strategyVariantSchema',
+    type: 'object',
+    additionalProperties: false,
+    description:
+        '[WIP] A strategy variant allows to attach any data to strategies instead of only returning `true`/`false`. Strategy variants take precedence over feature variants.',
+    required: ['name', 'weight', 'weightType', 'stickiness'],
+    properties: {
+        ...createStrategyVariantSchema.properties,
+    },
+    components: {},
+} as const;
+
+export type StrategyVariantSchema = FromSchema<typeof strategyVariantSchema>;

--- a/src/lib/openapi/spec/variant-schema.ts
+++ b/src/lib/openapi/spec/variant-schema.ts
@@ -39,9 +39,12 @@ export const variantSchema = {
             description: 'Extra data configured for this variant',
             properties: {
                 type: {
+                    description:
+                        'The type of the value. Commonly used types are string, json and csv.',
                     type: 'string',
                 },
                 value: {
+                    description: 'The actual value of payload',
                     type: 'string',
                 },
             },


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Introducing a new openapi concept for the strategy variant. It differs from the old variant in two ways:
* overrides are not supported
* ['name', 'weight', 'weightType', 'stickiness'] are required so weightType and stickiness were added. 

I don't know why weightType and stickiness were not required for the old variants but it makes types align with the application services (tested in a separate POC).

Added WIP in description so that people don't have expectations that it's already implemented.

Create and read variant differ by additionalProperties requirement.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
