### PR TITLE
openapi: add routeWithOpenApi

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-controller.ts
+++ b/src/lib/features/export-import-toggles/export-import-controller.ts
@@ -2,7 +2,6 @@ import { Response } from 'express';
 import Controller from '../../routes/controller';
 import { Logger } from '../../logger';
 import ExportImportService from './export-import-service';
-import { OpenApiService } from '../../services';
 import { TransactionCreator, UnleashTransaction } from '../../db/transaction';
 import {
     IUnleashConfig,
@@ -34,8 +33,6 @@ class ExportImportController extends Controller {
         db: UnleashTransaction,
     ) => ExportImportService;
 
-    private openApiService: OpenApiService;
-
     private readonly startTransaction: TransactionCreator<UnleashTransaction>;
 
     constructor(
@@ -52,13 +49,12 @@ class ExportImportController extends Controller {
         >,
         startTransaction: TransactionCreator<UnleashTransaction>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/export-import.ts');
         this.exportImportService = exportImportService;
         this.transactionalExportImportService =
             transactionalExportImportService;
         this.startTransaction = startTransaction;
-        this.openApiService = openApiService;
         this.route({
             method: 'post',
             path: '/export',

--- a/src/lib/features/playground/playground.ts
+++ b/src/lib/features/playground/playground.ts
@@ -3,7 +3,6 @@ import { IUnleashConfig } from '../../types/option';
 import { IUnleashServices } from '../../types/services';
 import { NONE } from '../../types/permissions';
 import Controller from '../../routes/controller';
-import { OpenApiService } from '../../services/openapi-service';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import { getStandardResponses } from '../../openapi/util/standard-responses';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
@@ -22,8 +21,6 @@ import {
 } from './playground-view-model';
 
 export default class PlaygroundController extends Controller {
-    private openApiService: OpenApiService;
-
     private playgroundService: PlaygroundService;
 
     private flagResolver: IFlagResolver;
@@ -35,8 +32,7 @@ export default class PlaygroundController extends Controller {
             playgroundService,
         }: Pick<IUnleashServices, 'openApiService' | 'playgroundService'>,
     ) {
-        super(config);
-        this.openApiService = openApiService;
+        super(config, { openApiService });
         this.playgroundService = playgroundService;
         this.flagResolver = config.flagResolver;
 

--- a/src/lib/openapi/util/standard-responses.ts
+++ b/src/lib/openapi/util/standard-responses.ts
@@ -218,6 +218,7 @@ const standardResponses = {
 } as const;
 
 type StandardResponses = typeof standardResponses;
+export type StandardResponseCodes = keyof StandardResponses;
 
 export const getStandardResponses = (
     ...statusCodes: (keyof StandardResponses)[]

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -14,7 +14,6 @@ import {
 import { IAuthRequest } from '../unleash-types';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import { AddonSchema, addonSchema } from '../../openapi/spec/addon-schema';
 import { serializeDates } from '../../types/serialize-dates';
 import { AddonsSchema, addonsSchema } from '../../openapi/spec/addons-schema';
@@ -30,17 +29,13 @@ class AddonController extends Controller {
 
     private addonService: AddonService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         { addonService, openApiService }: AddonServices,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/addon.ts');
         this.addonService = addonService;
-        this.openApiService = openApiService;
-
         this.routeWithOpenApi(this.openApiService)({
             method: 'get',
             path: '',

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -18,10 +18,7 @@ import { OpenApiService } from '../../services/openapi-service';
 import { AddonSchema, addonSchema } from '../../openapi/spec/addon-schema';
 import { serializeDates } from '../../types/serialize-dates';
 import { AddonsSchema, addonsSchema } from '../../openapi/spec/addons-schema';
-import {
-    emptyResponse,
-    getStandardResponses,
-} from '../../openapi/util/standard-responses';
+import { emptyResponse } from '../../openapi/util/standard-responses';
 import { AddonCreateUpdateSchema } from 'lib/openapi/spec/addon-create-update-schema';
 
 type AddonServices = Pick<IUnleashServices, 'addonService' | 'openApiService'>;
@@ -56,7 +53,6 @@ class AddonController extends Controller {
                 tags: ['Addons'],
                 operationId: 'getAddons',
                 responses: {
-                    ...getStandardResponses(401),
                     200: createResponseSchema('addonsSchema'),
                 },
             },
@@ -112,7 +108,6 @@ Note: passing \`null\` as a value for the description property will set it to an
                 requestBody: createRequestSchema('addonCreateUpdateSchema'),
                 responses: {
                     200: createResponseSchema('addonSchema'),
-                    ...getStandardResponses(404),
                 },
             },
         });
@@ -131,7 +126,6 @@ Note: passing \`null\` as a value for the description property will set it to an
                 operationId: 'deleteAddon',
                 responses: {
                     200: emptyResponse,
-                    ...getStandardResponses(404),
                 },
             },
         });

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -44,108 +44,96 @@ class AddonController extends Controller {
         this.addonService = addonService;
         this.openApiService = openApiService;
 
-        this.route({
+        this.routeWithOpenApi(this.openApiService)({
             method: 'get',
             path: '',
             permission: NONE,
             handler: this.getAddons,
-            middleware: [
-                openApiService.validPath({
-                    summary: 'Get all addons and providers',
-                    description:
-                        'Retrieve all addons and providers that are defined on this Unleash instance.',
-                    tags: ['Addons'],
-                    operationId: 'getAddons',
-                    responses: {
-                        ...getStandardResponses(401),
-                        200: createResponseSchema('addonsSchema'),
-                    },
-                }),
-            ],
+            openApi: {
+                summary: 'Get all addons and providers',
+                description:
+                    'Retrieve all addons and providers that are defined on this Unleash instance.',
+                tags: ['Addons'],
+                operationId: 'getAddons',
+                responses: {
+                    ...getStandardResponses(401),
+                    200: createResponseSchema('addonsSchema'),
+                },
+            },
         });
 
-        this.route({
+        this.routeWithOpenApi(this.openApiService)({
             method: 'post',
             path: '',
             handler: this.createAddon,
             permission: CREATE_ADDON,
-            middleware: [
-                openApiService.validPath({
-                    summary: 'Create a new addon',
-                    description:
-                        'Create an addon instance. The addon must use one of the providers available on this Unleash instance.',
-                    tags: ['Addons'],
-                    operationId: 'createAddon',
-                    requestBody: createRequestSchema('addonCreateUpdateSchema'),
-                    responses: {
-                        200: createResponseSchema('addonSchema'),
-                        ...getStandardResponses(400, 401, 403, 413, 415),
-                    },
-                }),
-            ],
+            openApi: {
+                summary: 'Create a new addon',
+                description:
+                    'Create an addon instance. The addon must use one of the providers available on this Unleash instance.',
+                tags: ['Addons'],
+                operationId: 'createAddon',
+                requestBody: createRequestSchema('addonCreateUpdateSchema'),
+                responses: {
+                    200: createResponseSchema('addonSchema'),
+                },
+            },
         });
 
-        this.route({
+        this.routeWithOpenApi(this.openApiService)({
             method: 'get',
             path: `${PATH}:id`,
             handler: this.getAddon,
             permission: NONE,
-            middleware: [
-                openApiService.validPath({
-                    summary: 'Get a specific addon',
-                    description:
-                        'Retrieve information about the addon whose ID matches the ID in the request URL.',
-                    tags: ['Addons'],
-                    operationId: 'getAddon',
-                    responses: {
-                        200: createResponseSchema('addonSchema'),
-                        ...getStandardResponses(401),
-                    },
-                }),
-            ],
+            openApi: {
+                summary: 'Get a specific addon',
+                description:
+                    'Retrieve information about the addon whose ID matches the ID in the request URL.',
+                tags: ['Addons'],
+                operationId: 'getAddon',
+                responses: {
+                    200: createResponseSchema('addonSchema'),
+                },
+            },
         });
 
-        this.route({
+        this.routeWithOpenApi(this.openApiService)({
             method: 'put',
             path: `${PATH}:id`,
             handler: this.updateAddon,
             permission: UPDATE_ADDON,
-            middleware: [
-                openApiService.validPath({
-                    summary: 'Update an addon',
-                    description: `Update the addon with a specific ID. Any fields in the update object will be updated. Properties that are not included in the update object will not be affected. To empty a property, pass \`null\` as that property's value.
+            openApi: {
+                summary: 'Update an addon',
+                description: `Update the addon with a specific ID. Any fields in the update object will be updated. Properties that are not included in the update object will not be affected. To empty a property, pass \`null\` as that property's value.
 
 Note: passing \`null\` as a value for the description property will set it to an empty string.`,
-                    tags: ['Addons'],
-                    operationId: 'updateAddon',
-                    requestBody: createRequestSchema('addonCreateUpdateSchema'),
-                    responses: {
-                        200: createResponseSchema('addonSchema'),
-                        ...getStandardResponses(400, 401, 403, 404, 413, 415),
-                    },
-                }),
-            ],
+                tags: ['Addons'],
+                operationId: 'updateAddon',
+                requestBody: createRequestSchema('addonCreateUpdateSchema'),
+                responses: {
+                    200: createResponseSchema('addonSchema'),
+                    ...getStandardResponses(404),
+                },
+            },
         });
 
-        this.route({
+        this.routeWithOpenApi(this.openApiService)({
             method: 'delete',
             path: `${PATH}:id`,
             handler: this.deleteAddon,
             acceptAnyContentType: true,
             permission: DELETE_ADDON,
-            middleware: [
-                openApiService.validPath({
-                    summary: 'Delete an addon',
-                    description:
-                        'Delete the addon specified by the ID in the request path.',
-                    tags: ['Addons'],
-                    operationId: 'deleteAddon',
-                    responses: {
-                        200: emptyResponse,
-                        ...getStandardResponses(401, 403, 404),
-                    },
-                }),
-            ],
+            openApi: {
+                summary: 'Delete an addon',
+                description:
+                    'Delete the addon specified by the ID in the request path.',
+                tags: ['Addons'],
+                operationId: 'deleteAddon',
+                responses: {
+                    200: emptyResponse,
+                    ...getStandardResponses(404),
+                },
+            },
         });
     }
 

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -36,7 +36,7 @@ class AddonController extends Controller {
         super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/addon.ts');
         this.addonService = addonService;
-        this.routeWithOpenApi(this.openApiService)({
+        this.routeWithOpenApi({
             method: 'get',
             path: '',
             permission: NONE,
@@ -53,7 +53,7 @@ class AddonController extends Controller {
             },
         });
 
-        this.routeWithOpenApi(this.openApiService)({
+        this.routeWithOpenApi({
             method: 'post',
             path: '',
             handler: this.createAddon,
@@ -71,7 +71,7 @@ class AddonController extends Controller {
             },
         });
 
-        this.routeWithOpenApi(this.openApiService)({
+        this.routeWithOpenApi({
             method: 'get',
             path: `${PATH}:id`,
             handler: this.getAddon,
@@ -88,7 +88,7 @@ class AddonController extends Controller {
             },
         });
 
-        this.routeWithOpenApi(this.openApiService)({
+        this.routeWithOpenApi({
             method: 'put',
             path: `${PATH}:id`,
             handler: this.updateAddon,
@@ -107,7 +107,7 @@ Note: passing \`null\` as a value for the description property will set it to an
             },
         });
 
-        this.routeWithOpenApi(this.openApiService)({
+        this.routeWithOpenApi({
             method: 'delete',
             path: `${PATH}:id`,
             handler: this.deleteAddon,

--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -20,7 +20,6 @@ import User from '../../types/user';
 import { IUnleashConfig } from '../../types/option';
 import { ApiTokenType, IApiToken } from '../../types/models/api-token';
 import { createApiToken } from '../../schema/api-token-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import { IUnleashServices } from '../../types';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import {
@@ -125,8 +124,6 @@ export class ApiTokenController extends Controller {
 
     private proxyService: ProxyService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -144,11 +141,10 @@ export class ApiTokenController extends Controller {
             | 'openApiService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.apiTokenService = apiTokenService;
         this.accessService = accessService;
         this.proxyService = proxyService;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('api-token-controller.js');
 
         this.route({

--- a/src/lib/routes/admin-api/archive.ts
+++ b/src/lib/routes/admin-api/archive.ts
@@ -11,7 +11,6 @@ import {
     FeaturesSchema,
 } from '../../openapi/spec/features-schema';
 import { serializeDates } from '../../types/serialize-dates';
-import { OpenApiService } from '../../services/openapi-service';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import {
     emptyResponse,
@@ -21,8 +20,6 @@ import {
 export default class ArchiveController extends Controller {
     private featureService: FeatureToggleService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -30,9 +27,8 @@ export default class ArchiveController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'featureToggleServiceV2' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.featureService = featureToggleServiceV2;
-        this.openApiService = openApiService;
 
         this.route({
             method: 'get',

--- a/src/lib/routes/admin-api/client-metrics.ts
+++ b/src/lib/routes/admin-api/client-metrics.ts
@@ -6,7 +6,6 @@ import { Logger } from '../../logger';
 import ClientMetricsServiceV2 from '../../services/client-metrics/metrics-service-v2';
 import { NONE } from '../../types/permissions';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import { serializeDates } from '../../types/serialize-dates';
 import {
     FeatureUsageSchema,
@@ -31,8 +30,6 @@ class ClientMetricsController extends Controller {
 
     private metrics: ClientMetricsServiceV2;
 
-    private openApiService: OpenApiService;
-
     private static HOURS_BACK_MIN = 1;
 
     private static HOURS_BACK_MAX = 48;
@@ -44,12 +41,10 @@ class ClientMetricsController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'clientMetricsServiceV2' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/client-metrics.ts');
 
         this.metrics = clientMetricsServiceV2;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'get',
             path: '/features/:name/raw',

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -16,7 +16,6 @@ import {
     uiConfigSchema,
     UiConfigSchema,
 } from '../../openapi/spec/ui-config-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import { EmailService } from '../../services/email-service';
 import { emptyResponse } from '../../openapi/util/standard-responses';
 import { IAuthRequest } from '../unleash-types';
@@ -38,8 +37,6 @@ class ConfigController extends Controller {
 
     private maintenanceService: MaintenanceService;
 
-    private readonly openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -59,11 +56,10 @@ class ConfigController extends Controller {
             | 'maintenanceService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.versionService = versionService;
         this.settingService = settingService;
         this.emailService = emailService;
-        this.openApiService = openApiService;
         this.proxyService = proxyService;
         this.maintenanceService = maintenanceService;
 

--- a/src/lib/routes/admin-api/constraints.ts
+++ b/src/lib/routes/admin-api/constraints.ts
@@ -5,14 +5,11 @@ import { IUnleashServices } from '../../types';
 import { NONE } from '../../types/permissions';
 import Controller from '../controller';
 import { Logger } from '../../logger';
-import { OpenApiService } from '../../services/openapi-service';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { ConstraintSchema, getStandardResponses } from '../../openapi';
 
 export default class ConstraintController extends Controller {
     private featureService: FeatureToggleService;
-
-    private openApiService: OpenApiService;
 
     private readonly logger: Logger;
 
@@ -23,9 +20,8 @@ export default class ConstraintController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'featureToggleServiceV2' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.featureService = featureToggleServiceV2;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('/admin-api/validation.ts');
 
         this.route({

--- a/src/lib/routes/admin-api/context.ts
+++ b/src/lib/routes/admin-api/context.ts
@@ -16,7 +16,6 @@ import ContextService from '../../services/context-service';
 import { Logger } from '../../logger';
 import { IAuthRequest } from '../unleash-types';
 
-import { OpenApiService } from '../../services/openapi-service';
 import {
     contextFieldSchema,
     ContextFieldSchema,
@@ -48,8 +47,6 @@ interface ContextParam {
 export class ContextController extends Controller {
     private contextService: ContextService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -59,8 +56,7 @@ export class ContextController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'contextService' | 'openApiService'>,
     ) {
-        super(config);
-        this.openApiService = openApiService;
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/context.ts');
         this.contextService = contextService;
 

--- a/src/lib/routes/admin-api/email.ts
+++ b/src/lib/routes/admin-api/email.ts
@@ -14,9 +14,12 @@ export default class EmailController extends Controller {
 
     constructor(
         config: IUnleashConfig,
-        { emailService }: Pick<IUnleashServices, 'emailService'>,
+        {
+            emailService,
+            openApiService,
+        }: Pick<IUnleashServices, 'emailService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.emailService = emailService;
         this.logger = config.getLogger('routes/admin-api/email');
         this.get('/preview/html/:template', this.getHtmlPreview, ADMIN);

--- a/src/lib/routes/admin-api/environments.ts
+++ b/src/lib/routes/admin-api/environments.ts
@@ -5,7 +5,6 @@ import { IUnleashConfig } from '../../types/option';
 import EnvironmentService from '../../services/environment-service';
 import { Logger } from '../../logger';
 import { ADMIN, NONE } from '../../types/permissions';
-import { OpenApiService } from '../../services/openapi-service';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import {
@@ -37,8 +36,6 @@ interface ProjectParam {
 export class EnvironmentsController extends Controller {
     private logger: Logger;
 
-    private openApiService: OpenApiService;
-
     private service: EnvironmentService;
 
     constructor(
@@ -48,9 +45,8 @@ export class EnvironmentsController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'environmentService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('admin-api/environments-controller.ts');
-        this.openApiService = openApiService;
         this.service = environmentService;
 
         this.route({

--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -6,7 +6,6 @@ import { ADMIN, NONE } from '../../types/permissions';
 import { IEvent, IEventList } from '../../types/events';
 import Controller from '../controller';
 import { anonymiseKeys } from '../../util/anonymise';
-import { OpenApiService } from '../../services/openapi-service';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import {
     eventsSchema,
@@ -29,8 +28,6 @@ export default class EventController extends Controller {
 
     private flagResolver: IFlagResolver;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -38,11 +35,9 @@ export default class EventController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'eventService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.eventService = eventService;
         this.flagResolver = config.flagResolver;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'get',
             path: '',

--- a/src/lib/routes/admin-api/favorites.ts
+++ b/src/lib/routes/admin-api/favorites.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import Controller from '../controller';
-import { FavoritesService, OpenApiService } from '../../services';
+import { FavoritesService } from '../../services';
 import { Logger } from '../../logger';
 import { IUnleashConfig, IUnleashServices, NONE } from '../../types';
 import { emptyResponse, getStandardResponses } from '../../openapi';
@@ -11,8 +11,6 @@ export default class FavoritesController extends Controller {
 
     private logger: Logger;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -20,11 +18,9 @@ export default class FavoritesController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'favoritesService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/routes/favorites-controller');
         this.favoritesService = favoritesService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'post',
             path: '/:projectId/features/:featureName/favorites',

--- a/src/lib/routes/admin-api/feature-type.ts
+++ b/src/lib/routes/admin-api/feature-type.ts
@@ -3,7 +3,6 @@ import { IUnleashServices } from '../../types/services';
 import FeatureTypeService from '../../services/feature-type-service';
 import { Logger } from '../../logger';
 import { IUnleashConfig } from '../../types/option';
-import { OpenApiService } from '../../services/openapi-service';
 import { ADMIN, NONE } from '../../types/permissions';
 import {
     featureTypesSchema,
@@ -26,8 +25,6 @@ const version = 1;
 export class FeatureTypeController extends Controller {
     private featureTypeService: FeatureTypeService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     private flagResolver: IFlagResolver;
@@ -39,9 +36,8 @@ export class FeatureTypeController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'featureTypeService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.featureTypeService = featureTypeService;
-        this.openApiService = openApiService;
         this.flagResolver = config.flagResolver;
         this.logger = config.getLogger('/admin-api/feature-type.js');
 

--- a/src/lib/routes/admin-api/feature.ts
+++ b/src/lib/routes/admin-api/feature.ts
@@ -18,7 +18,6 @@ import {
 import { TagSchema } from '../../openapi/spec/tag-schema';
 import { TagsSchema } from '../../openapi/spec/tags-schema';
 import { serializeDates } from '../../types/serialize-dates';
-import { OpenApiService } from '../../services/openapi-service';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import {
     createResponseSchema,
@@ -36,8 +35,6 @@ const version = 1;
 class FeatureController extends Controller {
     private tagService: FeatureTagService;
 
-    private openApiService: OpenApiService;
-
     private service: FeatureToggleService;
 
     constructor(
@@ -51,9 +48,8 @@ class FeatureController extends Controller {
             'featureTagService' | 'featureToggleServiceV2' | 'openApiService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.tagService = featureTagService;
-        this.openApiService = openApiService;
         this.service = featureToggleServiceV2;
 
         this.route({

--- a/src/lib/routes/admin-api/index.ts
+++ b/src/lib/routes/admin-api/index.ts
@@ -35,7 +35,7 @@ import ExportImportController from '../../features/export-import-toggles/export-
 
 class AdminApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices, db: Db) {
-        super(config);
+        super(config, { openApiService: services.openApiService });
 
         this.app.use(
             '/features',

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -11,7 +11,6 @@ import {
     InstanceStatsService,
     InstanceStatsSigned,
 } from '../../services/instance-stats-service';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     createCsvResponseSchema,
     createResponseSchema,
@@ -19,8 +18,6 @@ import {
 
 class InstanceAdminController extends Controller {
     private instanceStatsService: InstanceStatsService;
-
-    private openApiService: OpenApiService;
 
     private jsonCsvParser: Parser;
 
@@ -31,9 +28,8 @@ class InstanceAdminController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'instanceStatsService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.jsonCsvParser = new Parser();
-        this.openApiService = openApiService;
         this.instanceStatsService = instanceStatsService;
 
         this.route({

--- a/src/lib/routes/admin-api/maintenance.ts
+++ b/src/lib/routes/admin-api/maintenance.ts
@@ -8,7 +8,6 @@ import {
     emptyResponse,
     getStandardResponses,
 } from '../../openapi';
-import { OpenApiService } from '../../services';
 import { IAuthRequest } from '../unleash-types';
 import { extractUsername } from '../../util';
 import {
@@ -21,8 +20,6 @@ import { ToggleMaintenanceSchema } from 'lib/openapi/spec/toggle-maintenance-sch
 export default class MaintenanceController extends Controller {
     private maintenanceService: MaintenanceService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -32,9 +29,8 @@ export default class MaintenanceController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'maintenanceService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.maintenanceService = maintenanceService;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('routes/admin-api/maintenance');
         this.route({
             method: 'post',

--- a/src/lib/routes/admin-api/metrics.ts
+++ b/src/lib/routes/admin-api/metrics.ts
@@ -27,7 +27,7 @@ class MetricsController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'clientInstanceService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/metrics.ts');
 
         this.clientInstanceService = clientInstanceService;

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -23,7 +23,6 @@ import { ApiTokenType, IApiToken } from '../../../types/models/api-token';
 import {
     AccessService,
     ApiTokenService,
-    OpenApiService,
     ProxyService,
 } from '../../../services';
 import { extractUsername } from '../../../util';
@@ -49,8 +48,6 @@ export class ProjectApiTokenController extends Controller {
 
     private proxyService: ProxyService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -68,11 +65,10 @@ export class ProjectApiTokenController extends Controller {
             | 'openApiService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.apiTokenService = apiTokenService;
         this.accessService = accessService;
         this.proxyService = proxyService;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('project-api-token-controller.js');
 
         this.route({

--- a/src/lib/routes/admin-api/project/environments.ts
+++ b/src/lib/routes/admin-api/project/environments.ts
@@ -17,7 +17,6 @@ import {
     getStandardResponses,
     ProjectEnvironmentSchema,
 } from '../../../openapi';
-import { OpenApiService } from '../../../services';
 
 const PREFIX = '/:projectId/environments';
 
@@ -31,8 +30,6 @@ export default class EnvironmentsController extends Controller {
 
     private environmentService: EnvironmentService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -40,12 +37,10 @@ export default class EnvironmentsController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'environmentService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
 
         this.logger = config.getLogger('admin-api/project/environments.ts');
         this.environmentService = environmentService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'post',
             path: PREFIX,

--- a/src/lib/routes/admin-api/project/health-report.ts
+++ b/src/lib/routes/admin-api/project/health-report.ts
@@ -6,7 +6,6 @@ import ProjectHealthService from '../../../services/project-health-service';
 import { Logger } from '../../../logger';
 import { IProjectParam } from '../../../types/model';
 import { NONE } from '../../../types/permissions';
-import { OpenApiService } from '../../../services/openapi-service';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
 import { getStandardResponses } from '../../../openapi/util/standard-responses';
 import { serializeDates } from '../../../types/serialize-dates';
@@ -18,8 +17,6 @@ import {
 export default class ProjectHealthReport extends Controller {
     private projectHealthService: ProjectHealthService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -29,11 +26,9 @@ export default class ProjectHealthReport extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'projectHealthService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/project/health-report');
         this.projectHealthService = projectHealthService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'get',
             path: '/:projectId/health-report',

--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -21,7 +21,7 @@ import {
     ProjectsSchema,
 } from '../../../openapi';
 import { getStandardResponses } from '../../../openapi/util/standard-responses';
-import { OpenApiService, SettingService } from '../../../services';
+import { SettingService } from '../../../services';
 import { IAuthRequest } from '../../unleash-types';
 import { ProjectApiTokenController } from './api-token';
 import ProjectArchiveController from './project-archive';
@@ -33,10 +33,8 @@ export default class ProjectApi extends Controller {
 
     private settingService: SettingService;
 
-    private openApiService: OpenApiService;
-
     constructor(config: IUnleashConfig, services: IUnleashServices, db: Db) {
-        super(config);
+        super(config, { openApiService: services.openApiService });
         this.projectService = services.projectService;
         this.openApiService = services.openApiService;
         this.settingService = services.settingService;

--- a/src/lib/routes/admin-api/project/project-archive.ts
+++ b/src/lib/routes/admin-api/project/project-archive.ts
@@ -11,7 +11,6 @@ import { extractUsername } from '../../../util/extract-user';
 import { DELETE_FEATURE } from '../../../types/permissions';
 import FeatureToggleService from '../../../services/feature-toggle-service';
 import { IAuthRequest } from '../../unleash-types';
-import { OpenApiService } from '../../../services/openapi-service';
 import {
     emptyResponse,
     getStandardResponses,
@@ -29,8 +28,6 @@ export default class ProjectArchiveController extends Controller {
 
     private featureService: FeatureToggleService;
 
-    private openApiService: OpenApiService;
-
     private flagResolver: IFlagResolver;
 
     constructor(
@@ -40,10 +37,9 @@ export default class ProjectArchiveController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'featureToggleServiceV2' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/archive.js');
         this.featureService = featureToggleServiceV2;
-        this.openApiService = openApiService;
         this.flagResolver = config.flagResolver;
 
         this.route({

--- a/src/lib/routes/admin-api/project/project-features.ts
+++ b/src/lib/routes/admin-api/project/project-features.ts
@@ -41,11 +41,7 @@ import {
     UpdateFeatureSchema,
     UpdateFeatureStrategySchema,
 } from '../../../openapi';
-import {
-    OpenApiService,
-    FeatureToggleService,
-    FeatureTagService,
-} from '../../../services';
+import { FeatureToggleService, FeatureTagService } from '../../../services';
 import { querySchema } from '../../../schema/feature-schema';
 import { BatchStaleSchema } from '../../../openapi/spec/batch-stale-schema';
 import {
@@ -118,8 +114,6 @@ export default class ProjectFeaturesController extends Controller {
         db: UnleashTransaction,
     ) => FeatureToggleService;
 
-    private openApiService: OpenApiService;
-
     private flagResolver: IFlagResolver;
 
     private readonly logger: Logger;
@@ -136,12 +130,11 @@ export default class ProjectFeaturesController extends Controller {
         }: ProjectFeaturesServices,
         startTransaction: TransactionCreator<UnleashTransaction>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.featureService = featureToggleServiceV2;
         this.transactionalFeatureToggleService =
             transactionalFeatureToggleService;
         this.startTransaction = startTransaction;
-        this.openApiService = openApiService;
         this.featureTagService = featureTagService;
         this.flagResolver = config.flagResolver;
         this.logger = config.getLogger('/admin-api/project/features.ts');

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -55,7 +55,7 @@ export default class VariantsController extends Controller {
             'featureToggleService' | 'openApiService' | 'accessService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('admin-api/project/variants.ts');
         this.featureService = featureToggleService;
         this.accessService = accessService;

--- a/src/lib/routes/admin-api/public-signup.ts
+++ b/src/lib/routes/admin-api/public-signup.ts
@@ -8,11 +8,7 @@ import {
     serializeDates,
 } from '../../types';
 import { Logger } from '../../logger';
-import {
-    AccessService,
-    OpenApiService,
-    PublicSignupTokenService,
-} from '../../services';
+import { AccessService, PublicSignupTokenService } from '../../services';
 import { IAuthRequest } from '../unleash-types';
 import {
     createRequestSchema,
@@ -40,8 +36,6 @@ export class PublicSignupController extends Controller {
 
     private accessService: AccessService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -59,11 +53,10 @@ export class PublicSignupController extends Controller {
             | 'openApiService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.publicSignupTokenService = publicSignupTokenService;
         this.accessService = accessService;
         this.userService = userService;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('public-signup-controller.js');
 
         this.route({

--- a/src/lib/routes/admin-api/state.ts
+++ b/src/lib/routes/admin-api/state.ts
@@ -11,7 +11,6 @@ import { IUnleashServices } from '../../types/services';
 import { Logger } from '../../logger';
 import StateService from '../../services/state-service';
 import { IAuthRequest } from '../unleash-types';
-import { OpenApiService } from '../../services/openapi-service';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import {
@@ -41,8 +40,6 @@ class StateController extends Controller {
 
     private stateService: StateService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -50,10 +47,9 @@ class StateController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'stateService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/state.ts');
         this.stateService = stateService;
-        this.openApiService = openApiService;
         this.fileupload('/import', upload.single('file'), this.import, ADMIN);
         this.route({
             method: 'post',

--- a/src/lib/routes/admin-api/strategy.ts
+++ b/src/lib/routes/admin-api/strategy.ts
@@ -12,7 +12,6 @@ import {
 } from '../../types/permissions';
 import { Request, Response } from 'express';
 import { IAuthRequest } from '../unleash-types';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     emptyResponse,
     getStandardResponses,
@@ -40,8 +39,6 @@ class StrategyController extends Controller {
 
     private strategyService: StrategyService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -49,11 +46,9 @@ class StrategyController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'strategyService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/strategy.js');
         this.strategyService = strategyService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'get',
             path: '',

--- a/src/lib/routes/admin-api/tag-type.ts
+++ b/src/lib/routes/admin-api/tag-type.ts
@@ -24,7 +24,6 @@ import {
 } from '../../openapi/spec/validate-tag-type-schema';
 import { TagTypeSchema } from '../../openapi/spec/tag-type-schema';
 import { UpdateTagTypeSchema } from '../../openapi/spec/update-tag-type-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     emptyResponse,
     getStandardResponses,
@@ -37,8 +36,6 @@ class TagTypeController extends Controller {
 
     private tagTypeService: TagTypeService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -46,10 +43,9 @@ class TagTypeController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'tagTypeService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/admin-api/tag-type.js');
         this.tagTypeService = tagTypeService;
-        this.openApiService = openApiService;
         this.route({
             method: 'get',
             path: '',

--- a/src/lib/routes/admin-api/tag.ts
+++ b/src/lib/routes/admin-api/tag.ts
@@ -16,7 +16,6 @@ import {
 } from '../../openapi/util/create-response-schema';
 import { tagsSchema, TagsSchema } from '../../openapi/spec/tags-schema';
 import { TagSchema } from '../../openapi/spec/tag-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     tagWithVersionSchema,
     TagWithVersionSchema,
@@ -37,8 +36,6 @@ class TagController extends Controller {
 
     private featureTagService: FeatureTagService;
 
-    private openApiService: OpenApiService;
-
     private flagResolver: IFlagResolver;
 
     constructor(
@@ -52,9 +49,8 @@ class TagController extends Controller {
             'tagService' | 'openApiService' | 'featureTagService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.tagService = tagService;
-        this.openApiService = openApiService;
         this.featureTagService = featureTagService;
         this.logger = config.getLogger('/admin-api/tag.js');
         this.flagResolver = config.flagResolver;

--- a/src/lib/routes/admin-api/telemetry.ts
+++ b/src/lib/routes/admin-api/telemetry.ts
@@ -20,10 +20,8 @@ class TelemetryController extends Controller {
         config: IUnleashConfig,
         { openApiService }: Pick<IUnleashServices, 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.config = config;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'get',
             path: '/settings',

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -13,7 +13,6 @@ import SettingService from '../../services/setting-service';
 import { IUser, SimpleAuthSettings } from '../../server-impl';
 import { simpleAuthSettingsKey } from '../../types/settings/simple-auth-settings';
 import { anonymise } from '../../util/anonymise';
-import { OpenApiService } from '../../services/openapi-service';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import {
     createResponseSchema,
@@ -74,8 +73,6 @@ export default class UserAdminController extends Controller {
 
     private settingService: SettingService;
 
-    private openApiService: OpenApiService;
-
     private groupService: GroupService;
 
     readonly unleashUrl: string;
@@ -103,14 +100,13 @@ export default class UserAdminController extends Controller {
             | 'groupService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.userService = userService;
         this.accountService = accountService;
         this.accessService = accessService;
         this.emailService = emailService;
         this.resetTokenService = resetTokenService;
         this.settingService = settingService;
-        this.openApiService = openApiService;
         this.groupService = groupService;
         this.logger = config.getLogger('routes/user-controller.ts');
         this.unleashUrl = config.server.unleashUrl;

--- a/src/lib/routes/admin-api/user-feedback.ts
+++ b/src/lib/routes/admin-api/user-feedback.ts
@@ -6,7 +6,6 @@ import { IUnleashServices } from '../../types/services';
 import UserFeedbackService from '../../services/user-feedback-service';
 import { IAuthRequest } from '../unleash-types';
 import { NONE } from '../../types/permissions';
-import { OpenApiService } from '../../services/openapi-service';
 import { FeedbackCreateSchema } from '../../openapi/spec/feedback-create-schema';
 import { FeedbackUpdateSchema } from '../../openapi/spec/feedback-update-schema';
 import { FeedbackResponseSchema } from '../../openapi/spec/feedback-response-schema';
@@ -22,8 +21,6 @@ class UserFeedbackController extends Controller {
 
     private userFeedbackService: UserFeedbackService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -31,11 +28,9 @@ class UserFeedbackController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'userFeedbackService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('feedback-controller.ts');
         this.userFeedbackService = userFeedbackService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'post',
             path: '',

--- a/src/lib/routes/admin-api/user-splash.ts
+++ b/src/lib/routes/admin-api/user-splash.ts
@@ -6,7 +6,6 @@ import { IUnleashServices } from '../../types/services';
 import UserSplashService from '../../services/user-splash-service';
 import { IAuthRequest } from '../unleash-types';
 import { NONE } from '../../types/permissions';
-import { OpenApiService } from '../../services/openapi-service';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import { splashRequestSchema } from '../../openapi/spec/splash-request-schema';
 import { getStandardResponses } from '../../openapi';
@@ -17,8 +16,6 @@ class UserSplashController extends Controller {
 
     private userSplashService: UserSplashService;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -26,11 +23,9 @@ class UserSplashController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'userSplashService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('splash-controller.ts');
         this.userSplashService = userSplashService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'post',
             path: '/:id',

--- a/src/lib/routes/admin-api/user/pat.ts
+++ b/src/lib/routes/admin-api/user/pat.ts
@@ -12,7 +12,6 @@ import {
     resourceCreatedResponseSchema,
 } from '../../../openapi/util/create-response-schema';
 import { getStandardResponses } from '../../../openapi/util/standard-responses';
-import { OpenApiService } from '../../../services/openapi-service';
 import { emptyResponse } from '../../../openapi/util/standard-responses';
 
 import PatService from '../../../services/pat-service';
@@ -25,8 +24,6 @@ import { PatsSchema, patsSchema } from '../../../openapi/spec/pats-schema';
 export default class PatController extends Controller {
     private patService: PatService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     private flagResolver: IFlagResolver;
@@ -38,10 +35,9 @@ export default class PatController extends Controller {
             patService,
         }: Pick<IUnleashServices, 'openApiService' | 'patService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('lib/routes/auth/pat-controller.ts');
         this.flagResolver = config.flagResolver;
-        this.openApiService = openApiService;
         this.patService = patService;
         this.route({
             method: 'get',

--- a/src/lib/routes/admin-api/user/user.ts
+++ b/src/lib/routes/admin-api/user/user.ts
@@ -8,7 +8,6 @@ import UserService from '../../../services/user-service';
 import UserFeedbackService from '../../../services/user-feedback-service';
 import UserSplashService from '../../../services/user-splash-service';
 import { ADMIN, NONE } from '../../../types/permissions';
-import { OpenApiService } from '../../../services/openapi-service';
 import { createRequestSchema } from '../../../openapi/util/create-request-schema';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
 import { meSchema, MeSchema } from '../../../openapi/spec/me-schema';
@@ -34,8 +33,6 @@ class UserController extends Controller {
 
     private userSplashService: UserSplashService;
 
-    private openApiService: OpenApiService;
-
     private projectService: ProjectService;
 
     constructor(
@@ -57,12 +54,11 @@ class UserController extends Controller {
             | 'projectService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.accessService = accessService;
         this.userService = userService;
         this.userFeedbackService = userFeedbackService;
         this.userSplashService = userSplashService;
-        this.openApiService = openApiService;
         this.projectService = projectService;
 
         this.route({

--- a/src/lib/routes/auth/reset-password-controller.ts
+++ b/src/lib/routes/auth/reset-password-controller.ts
@@ -7,7 +7,6 @@ import { IUnleashServices } from '../../types';
 import { NONE } from '../../types/permissions';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     tokenUserSchema,
     TokenUserSchema,
@@ -35,8 +34,6 @@ interface SessionRequest<PARAMS, QUERY, BODY, K>
 class ResetPasswordController extends Controller {
     private userService: UserService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -46,11 +43,10 @@ class ResetPasswordController extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'userService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger(
             'lib/routes/auth/reset-password-controller.ts',
         );
-        this.openApiService = openApiService;
         this.userService = userService;
         this.route({
             method: 'get',

--- a/src/lib/routes/auth/simple-password-provider.ts
+++ b/src/lib/routes/auth/simple-password-provider.ts
@@ -1,5 +1,4 @@
 import { Response } from 'express';
-import { OpenApiService } from '../../services/openapi-service';
 import { Logger } from '../../logger';
 import { IUnleashConfig } from '../../server-impl';
 import UserService from '../../services/user-service';
@@ -17,8 +16,6 @@ import { getStandardResponses } from '../../openapi';
 export class SimplePasswordProvider extends Controller {
     private logger: Logger;
 
-    private openApiService: OpenApiService;
-
     private userService: UserService;
 
     constructor(
@@ -28,9 +25,8 @@ export class SimplePasswordProvider extends Controller {
             openApiService,
         }: Pick<IUnleashServices, 'userService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/auth/password-provider.js');
-        this.openApiService = openApiService;
         this.userService = userService;
 
         this.route({

--- a/src/lib/routes/backstage.ts
+++ b/src/lib/routes/backstage.ts
@@ -4,12 +4,16 @@ import { join } from 'path';
 import { register as prometheusRegister } from 'prom-client';
 import Controller from './controller';
 import { IUnleashConfig } from '../types/option';
+import { IUnleashServices } from 'lib/types';
 
 class BackstageController extends Controller {
     logger: any;
 
-    constructor(config: IUnleashConfig) {
-        super(config);
+    constructor(
+        config: IUnleashConfig,
+        { openApiService }: Pick<IUnleashServices, 'openApiService'>,
+    ) {
+        super(config, { openApiService });
 
         this.logger = config.getLogger('backstage.js');
 

--- a/src/lib/routes/client-api/feature.ts
+++ b/src/lib/routes/client-api/feature.ts
@@ -14,7 +14,6 @@ import ApiUser from '../../types/api-user';
 import { ALL, isAllProjects } from '../../types/models/api-token';
 import { FeatureConfigurationClient } from '../../types/stores/feature-strategies-store';
 import { ClientSpecService } from '../../services/client-spec-service';
-import { OpenApiService } from '../../services/openapi-service';
 import { NONE } from '../../types/permissions';
 import { createResponseSchema } from '../../openapi/util/create-response-schema';
 import { ClientFeaturesQuerySchema } from '../../openapi/spec/client-features-query-schema';
@@ -51,8 +50,6 @@ export default class FeatureController extends Controller {
 
     private clientSpecService: ClientSpecService;
 
-    private openApiService: OpenApiService;
-
     private configurationRevisionService: ConfigurationRevisionService;
 
     private featuresAndSegments: (
@@ -77,12 +74,11 @@ export default class FeatureController extends Controller {
         >,
         config: IUnleashConfig,
     ) {
-        super(config);
+        super(config, { openApiService });
         const { clientFeatureCaching } = config;
         this.featureToggleServiceV2 = featureToggleServiceV2;
         this.segmentService = segmentService;
         this.clientSpecService = clientSpecService;
-        this.openApiService = openApiService;
         this.configurationRevisionService = configurationRevisionService;
         this.logger = config.getLogger('client-api/feature.js');
 

--- a/src/lib/routes/client-api/index.ts
+++ b/src/lib/routes/client-api/index.ts
@@ -6,7 +6,7 @@ import { IUnleashConfig, IUnleashServices } from '../../types';
 
 export default class ClientApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
-        super(config);
+        super(config, { openApiService: services.openApiService });
 
         this.use('/features', new FeatureController(services, config).router);
         this.use('/metrics', new MetricsController(services, config).router);

--- a/src/lib/routes/client-api/metrics.ts
+++ b/src/lib/routes/client-api/metrics.ts
@@ -35,12 +35,11 @@ export default class ClientMetricsController extends Controller {
         >,
         config: IUnleashConfig,
     ) {
-        super(config);
+        super(config, { openApiService });
         const { getLogger } = config;
 
         this.logger = getLogger('/api/client/metrics');
         this.clientInstanceService = clientInstanceService;
-        this.openApiService = openApiService;
         this.metricsV2 = clientMetricsServiceV2;
 
         this.route({

--- a/src/lib/routes/client-api/register.ts
+++ b/src/lib/routes/client-api/register.ts
@@ -28,11 +28,9 @@ export default class RegisterController extends Controller {
         }: Pick<IUnleashServices, 'clientInstanceService' | 'openApiService'>,
         config: IUnleashConfig,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('/api/client/register');
         this.clientInstanceService = clientInstanceService;
-        this.openApiService = openApiService;
-
         this.route({
             method: 'post',
             path: '',

--- a/src/lib/routes/controller.ts
+++ b/src/lib/routes/controller.ts
@@ -129,6 +129,10 @@ export default class Controller {
                 errorCodes.add(415);
             }
 
+            if (options.path.includes(':')) {
+                errorCodes.add(404);
+            }
+
             if (options.permission !== NONE) {
                 errorCodes.add(403);
             }

--- a/src/lib/routes/controller.ts
+++ b/src/lib/routes/controller.ts
@@ -119,46 +119,44 @@ export default class Controller {
         );
     }
 
-    routeWithOpenApi(openApiService: OpenApiService) {
-        return ({
-            openApi,
-            ...options
-        }: IRouteOptions & { openApi: ApiOperation }): void => {
-            const errorCodes = new Set<StandardResponseCodes>([401]);
+    routeWithOpenApi({
+        openApi,
+        ...options
+    }: IRouteOptions & { openApi: ApiOperation }): void {
+        const errorCodes = new Set<StandardResponseCodes>([401]);
 
-            if (
-                ['put', 'post', 'patch'].includes(
-                    options?.method?.toLowerCase() || '',
-                )
-            ) {
-                errorCodes.add(400);
-                errorCodes.add(413);
-                errorCodes.add(415);
-            }
+        if (
+            ['put', 'post', 'patch'].includes(
+                options?.method?.toLowerCase() || '',
+            )
+        ) {
+            errorCodes.add(400);
+            errorCodes.add(413);
+            errorCodes.add(415);
+        }
 
-            if (options.path.includes(':')) {
-                errorCodes.add(404);
-            }
+        if (options.path.includes(':')) {
+            errorCodes.add(404);
+        }
 
-            if (options.permission !== NONE) {
-                errorCodes.add(403);
-            }
+        if (options.permission !== NONE) {
+            errorCodes.add(403);
+        }
 
-            const openApiWithErrorCodes = {
-                ...openApi,
-                responses: {
-                    ...getStandardResponses(...errorCodes),
-                    ...openApi.responses,
-                },
-            };
-            return this.route({
-                ...options,
-                middleware: [
-                    ...(options.middleware ?? []),
-                    openApiService.validPath(openApiWithErrorCodes),
-                ],
-            });
+        const openApiWithErrorCodes = {
+            ...openApi,
+            responses: {
+                ...getStandardResponses(...errorCodes),
+                ...openApi.responses,
+            },
         };
+        return this.route({
+            ...options,
+            middleware: [
+                ...(options.middleware ?? []),
+                this.openApiService.validPath(openApiWithErrorCodes),
+            ],
+        });
     }
 
     get(

--- a/src/lib/routes/controller.ts
+++ b/src/lib/routes/controller.ts
@@ -11,6 +11,7 @@ import {
     StandardResponseCodes,
 } from '../../lib/openapi';
 import { OpenApiService } from '../../lib/services';
+import { IUnleashServices } from 'lib/types';
 
 interface IRequestHandler<
     P = any,
@@ -77,12 +78,18 @@ export default class Controller {
 
     config: IUnleashConfig;
 
-    constructor(config: IUnleashConfig) {
+    protected openApiService: OpenApiService;
+
+    constructor(
+        config: IUnleashConfig,
+        { openApiService }: Pick<IUnleashServices, 'openApiService'>,
+    ) {
         this.ownLogger = config.getLogger(
             `controller/${this.constructor.name}`,
         );
         this.app = Router();
         this.config = config;
+        this.openApiService = openApiService;
     }
 
     private useRouteErrorHandler(handler: IRequestHandler): IRequestHandler {

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -12,7 +12,6 @@ import {
 } from '../../openapi/spec/validated-edge-tokens-schema';
 import ClientInstanceService from '../../services/client-metrics/instance-service';
 import EdgeService from '../../services/edge-service';
-import { OpenApiService } from '../../services/openapi-service';
 import {
     emptyResponse,
     getStandardResponses,
@@ -26,8 +25,6 @@ export default class EdgeController extends Controller {
     private readonly logger: Logger;
 
     private edgeService: EdgeService;
-
-    private openApiService: OpenApiService;
 
     private metricsV2: ClientMetricsServiceV2;
 
@@ -48,10 +45,9 @@ export default class EdgeController extends Controller {
             | 'clientInstanceService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('edge-api/index.ts');
         this.edgeService = edgeService;
-        this.openApiService = openApiService;
         this.metricsV2 = clientMetricsServiceV2;
         this.clientInstanceService = clientInstanceService;
 

--- a/src/lib/routes/health-check.ts
+++ b/src/lib/routes/health-check.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express';
 import { IUnleashConfig } from '../types/option';
 import { IUnleashServices } from '../types/services';
 import { Logger } from '../logger';
-import { OpenApiService } from '../services/openapi-service';
 
 import Controller from './controller';
 import { NONE } from '../types/permissions';
@@ -12,15 +11,12 @@ import { HealthCheckSchema } from '../openapi/spec/health-check-schema';
 export class HealthCheckController extends Controller {
     private logger: Logger;
 
-    private openApiService: OpenApiService;
-
     constructor(
         config: IUnleashConfig,
         { openApiService }: Pick<IUnleashServices, 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.logger = config.getLogger('health-check.js');
-        this.openApiService = openApiService;
 
         this.route({
             method: 'get',

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -17,14 +17,17 @@ import { minutesToMilliseconds } from 'date-fns';
 
 class IndexRouter extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices, db: Db) {
-        super(config);
+        super(config, { openApiService: services.openApiService });
 
         this.use('/health', new HealthCheckController(config, services).router);
         this.use(
             '/invite',
             new PublicInviteController(config, services).router,
         );
-        this.use('/internal-backstage', new BackstageController(config).router);
+        this.use(
+            '/internal-backstage',
+            new BackstageController(config, services).router,
+        );
         this.use('/logout', new LogoutController(config, services).router);
         this.useWithMiddleware(
             '/auth/simple',

--- a/src/lib/routes/logout.test.ts
+++ b/src/lib/routes/logout.test.ts
@@ -8,6 +8,7 @@ import SessionService from '../services/session-service';
 import FakeSessionStore from '../../test/fixtures/fake-session-store';
 import noLogger from '../../test/fixtures/no-logger';
 import { addDays } from 'date-fns';
+import { OpenApiService } from 'lib/services';
 
 test('should redirect to "/" after logout', async () => {
     const baseUriPath = '';
@@ -18,10 +19,12 @@ test('should redirect to "/" after logout', async () => {
         { sessionStore },
         { getLogger: noLogger },
     );
+    const openApiService = new OpenApiService(config);
     app.use(
         '/logout',
         new LogoutController(config, {
             sessionService,
+            openApiService,
         }).router,
     );
     const request = supertest(app);
@@ -41,7 +44,11 @@ test('should redirect to "/basePath" after logout when baseUriPath is set', asyn
         { sessionStore },
         { getLogger: noLogger },
     );
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
     const request = supertest(app);
     expect.assertions(0);
     await request
@@ -60,7 +67,11 @@ test('should set "Clear-Site-Data" header', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
     const request = supertest(app);
     expect.assertions(0);
     await request
@@ -82,7 +93,11 @@ test('should not set "Clear-Site-Data" header', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
     const request = supertest(app);
     expect.assertions(1);
     await request
@@ -103,7 +118,11 @@ test('should clear "unleash-session" cookies', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     expect.assertions(0);
@@ -129,7 +148,11 @@ test('should clear "unleash-session" cookie even when disabled clear site data',
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     expect.assertions(0);
@@ -159,7 +182,11 @@ test('should call destroy on session', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     await request.post(`${baseUriPath}/logout`);
@@ -183,7 +210,11 @@ test('should handle req.logout with callback function', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     await request.post(`${baseUriPath}/logout`);
@@ -208,7 +239,11 @@ test('should handle req.logout without callback function', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     await request.post(`${baseUriPath}/logout`);
@@ -234,7 +269,11 @@ test('should redirect to alternative logoutUrl', async () => {
         { getLogger: noLogger },
     );
 
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
 
     const request = supertest(app);
     await request
@@ -281,7 +320,11 @@ test('Should destroy sessions for user', async () => {
     });
     let activeSessionsBeforeLogout = await sessionStore.getSessionsForUser(1);
     expect(activeSessionsBeforeLogout).toHaveLength(2);
-    app.use('/logout', new LogoutController(config, { sessionService }).router);
+    const openApiService = new OpenApiService(config);
+    app.use(
+        '/logout',
+        new LogoutController(config, { sessionService, openApiService }).router,
+    );
     await supertest(app).post('/logout').expect(302);
     let activeSessions = await sessionStore.getSessionsForUser(1);
     expect(activeSessions).toHaveLength(0);

--- a/src/lib/routes/logout.ts
+++ b/src/lib/routes/logout.ts
@@ -17,9 +17,12 @@ class LogoutController extends Controller {
 
     constructor(
         config: IUnleashConfig,
-        { sessionService }: Pick<IUnleashServices, 'sessionService'>,
+        {
+            sessionService,
+            openApiService,
+        }: Pick<IUnleashServices, 'sessionService' | 'openApiService'>,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.sessionService = sessionService;
         this.baseUri = config.server.baseUriPath;
         this.clearSiteDataOnLogout = config.session.clearSiteDataOnLogout;

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -50,7 +50,7 @@ export default class ProxyController extends Controller {
         services: Services,
         flagResolver: IFlagResolver,
     ) {
-        super(config);
+        super(config, { openApiService: services.openApiService });
         this.logger = config.getLogger('proxy-api/index.ts');
         this.services = services;
         this.flagResolver = flagResolver;

--- a/src/lib/routes/public-invite.ts
+++ b/src/lib/routes/public-invite.ts
@@ -5,7 +5,6 @@ import { NONE } from '../types/permissions';
 import { Logger } from '../logger';
 import { IAuthRequest } from './unleash-types';
 import { IUnleashConfig, IUnleashServices } from '../types';
-import { OpenApiService } from '../services/openapi-service';
 import { createRequestSchema } from '../openapi/util/create-request-schema';
 import { createResponseSchema } from '../openapi/util/create-response-schema';
 import { serializeDates } from '../types/serialize-dates';
@@ -24,8 +23,6 @@ interface TokenParam {
 export class PublicInviteController extends Controller {
     private publicSignupTokenService: PublicSignupTokenService;
 
-    private openApiService: OpenApiService;
-
     private logger: Logger;
 
     constructor(
@@ -38,9 +35,8 @@ export class PublicInviteController extends Controller {
             'publicSignupTokenService' | 'openApiService'
         >,
     ) {
-        super(config);
+        super(config, { openApiService });
         this.publicSignupTokenService = publicSignupTokenService;
-        this.openApiService = openApiService;
         this.logger = config.getLogger('validate-invite-token-controller.js');
 
         this.route({


### PR DESCRIPTION
This change adds a routeWithOpenApi method to the base controller
class that we use. That method modifies the open api
configuration passed in and adds standard error codes. It uses that
method in the addon controller.

The goal here is to simplify how we add error codes to the openapi
doc, potentially removing the need for us to do that entirely.

This is just a proof of concept to show that it works. The API for it
could use some work (for instance, having to pass in the service is a
little inconvenient) and possibly some tests, but this shows that
it **is** possible. Might be a nice QOL improvement.

An idea would be to make the controller class `abstract` and require implementers to have an OpenApiService. All of our controllers should already have that, so that might be an easy win.