### PR TITLE
#4205: update to prepare for emitting potentially stale events

### DIFF
--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -379,7 +379,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         return toggle;
     }
 
-    async markPotentiallyStaleFeatures(
+    async updatePotentiallyStaleFeatures(
         currentTime?: string,
     ): Promise<{ name: string; potentiallyStale: boolean }[]> {
         const previousState = (

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -391,24 +391,221 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             return previousValue;
         }, {});
 
-        const updateQuery = this.db(TABLE)
-            .update(
-                'potentially_stale',
-                this.db.raw(
-                    `(? > (features.created_at + ((
+        const isPotentiallyStale = this.db.raw(
+            `(? > (features.created_at + ((
                             SELECT feature_types.lifetime_days
                             FROM feature_types
                             WHERE feature_types.id = features.type
                         ) * INTERVAL '1 day')))`,
-                    [currentTime || this.db.fn.now()],
-                ),
+            [currentTime || this.db.fn.now()],
+        );
+
+        const simpleQuery = this.db.raw(
+            `SELECT name, potentially_stale, (? > (features.created_at + ((
+                            SELECT feature_types.lifetime_days
+                            FROM feature_types
+                            WHERE feature_types.id = features.type
+                        ) * INTERVAL '1 day'))) as current_staleness
+            FROM features
+            WHERE NOT stale = true`,
+            [currentTime || this.db.fn.now()],
+        );
+
+        const features = (await simpleQuery).rows;
+        // console.log(
+        //     'q5',
+        //     simpleQuery.toSQL().toNative(),
+        //     (await simpleQuery).rows,
+        // );
+
+        const needUpdates = features
+            .filter(
+                ({ potentially_stale, current_staleness }) =>
+                    (potentially_stale ?? false) !==
+                    (current_staleness ?? false),
             )
+            .map(({ current_staleness, name }) => ({
+                potentiallyStale: current_staleness ?? false,
+                name,
+            }));
+
+        console.log('need updates', needUpdates);
+
+        const update2 = await this.db(TABLE)
+            .update('potentially_stale', true)
+            .whereIn(
+                'name',
+                needUpdates
+                    .filter((feature) => feature.potentiallyStale === true)
+                    .map((feature) => feature.name),
+            )
+            .returning(['name', 'potentially_stale']);
+
+        // console.log(
+        //     'update2',
+        //     update2,
+        //     'need updates',
+        //     needUpdates.filter((f) => f.current_staleness === true),
+        // );
+
+        const update3 = await this.db(TABLE)
+            .update('potentially_stale', false)
+            .whereIn(
+                'name',
+                needUpdates
+                    .filter((feature) => feature.potentiallyStale !== true)
+                    .map((feature) => feature.name),
+            )
+            .returning(['name', 'potentially_stale']);
+
+        console.log('update3', update3);
+
+        return needUpdates;
+        // const q4 = this.db(TABLE)
+        //     .select(['name,', 'potentially_stale'])
+        //     .(
+        //         `(? > (features.created_at + ((
+        //                     SELECT feature_types.lifetime_days
+        //                     FROM feature_types
+        //                     WHERE feature_types.id = features.type
+        //                 ) * INTERVAL '1 day')))`,
+        //     )
+        //     .as('current_staleness')
+        //     .whereNot('stale', true);
+
+        // console.log('q4', q4.toSQL().toNative(), await q4);
+
+        // const needsUpdated
+
+        const updateQuery = this.db(TABLE)
+            // .with('mark', isPotentiallyStale)
+            .update('potentially_stale', isPotentiallyStale)
+            .where(
+                (builder) => builder.where(isPotentiallyStale),
+                // .andWhereNot('potentially_stale', true)
+                // .or.where('potentially_stale', true),
+            )
+            // .andWhereNot('potentially_stale', true)
+            // .where((builder) =>
+            //     builder.where((subBuilder) =>
+            //         subBuilder
+            //             .where(isPotentiallyStale)
+            //             .andWhereNot('potentially_stale', true),
+            //     ),
+            // )
+            .whereNot('potentially_stale', true)
             .whereNot('stale', true);
 
         const currentState: {
             name: string;
             potentially_stale: boolean | null;
         }[] = await updateQuery.returning(['name', 'potentially_stale']);
+
+        // console.log(updateQuery.toSQL().toNative(), currentState);
+
+        // const time = [currentTime || this.db.fn.now()];
+
+        // const rawQ = this.db.raw(
+        //     `
+        //             WITH
+        //             feature_types_data AS (
+        //                 SELECT id, lifetime_days
+        //                 FROM feature_types),
+        //             current_ts AS (
+        //                 SELECT ? AS current_ts),
+        //             comparison AS (
+        //                 SELECT
+        //                 features.name,
+        //                 (current_ts.current_ts > (features.created_at + (feature_types_data.lifetime_days * INTERVAL '1 day'))) AS is_stale
+        //                 FROM
+        //                 features
+        //                 JOIN
+        //                 feature_types_data ON features.type = feature_types_data.id
+        //                 CROSS JOIN
+        //                 current_ts)
+        //             UPDATE features
+        //             SET potentially_stale = comparison.is_stale
+        //             FROM comparison
+        //             WHERE features.name = comparison.name
+        //             AND (
+        //                 (comparison.is_stale AND NOT potentially_stale = TRUE)
+        //                 OR (NOT comparison.is_stale AND potentially_stale = TRUE)
+        //             )
+        //             AND NOT stale = TRUE
+        //             RETURNING features.name, potentially_stale;
+        // `,
+        //     time,
+        // );
+
+        // console.log(rawQ.toSQL().toNative(), await rawQ);
+
+        // const newQ = this.db(TABLE)
+        //     .with('feature_types_data', (qb) => {
+        //         qb.select('id', 'lifetime_days').from('feature_types');
+        //     })
+        //     .with('current_ts', (qb) => {
+        //         qb.select(this.db.raw('? AS current_ts', time));
+        //     })
+        //     .with('comparison', (qb) => {
+        //         qb.select('features.name')
+        //             .select(
+        //                 this.db.raw(
+        //                     "(current_ts.current_ts > (features.created_at + (feature_types_data.lifetime_days * INTERVAL '1 day'))) AS is_stale",
+        //                 ),
+        //             )
+        //             .from('features')
+        //             .join(
+        //                 'feature_types_data',
+        //                 'features.type',
+        //                 'feature_types_data.id',
+        //             )
+        //             .crossJoin('current_ts');
+        //     })
+        //     .update({ potentially_stale: this.db.raw('comparison.is_stale') })
+        //     .from('features')
+        //     .join('comparison', 'features.name', 'comparison.name')
+        //     .where(function () {
+        //         this.where(function () {
+        //             this.where('comparison.is_stale', true).andWhereNot(
+        //                 'potentially_stale',
+        //                 true,
+        //             );
+        //         })
+        //             .orWhere(function () {
+        //                 this.where('comparison.is_stale', false).andWhere(
+        //                     'potentially_stale',
+        //                     true,
+        //                 );
+        //             })
+        //             .andWhereNot('stale', true);
+        //     })
+        //     .returning(['features.name', 'potentially_stale']);
+
+        // console.log(newQ.toSQL().toNative(), await newQ);
+
+        const q3 = this.db(TABLE)
+            .update({
+                potentially_stale: isPotentiallyStale,
+            })
+            .where((qb) =>
+                qb
+                    .where((builder) =>
+                        builder
+                            // update rows that are potentially stale but not marked as such
+                            .where(isPotentiallyStale)
+                            .andWhereNot('potentially_stale', true),
+                    )
+                    .orWhere((builder) =>
+                        builder
+                            // update rows that are not potentially stale but **are** marked as such
+                            .whereNot(isPotentiallyStale)
+                            .andWhere('potentially_stale', true),
+                    ),
+            )
+            .whereNot('stale', true)
+            .returning(['name', 'potentially_stale']);
+
+        console.log(q3.toSQL().toNative(), await q3);
 
         const diff = currentState
             .map(({ name, potentially_stale }) => {

--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -410,22 +410,20 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             potentially_stale: boolean | null;
         }[] = await updateQuery.returning(['name', 'potentially_stale']);
 
-        const diff: { name: string; potentiallyStale: boolean }[] = currentState
+        const diff = currentState
             .map(({ name, potentially_stale }) => {
                 const previous = previousState[name] ?? false;
                 const hasChanged = previous !== (potentially_stale ?? false);
                 if (hasChanged) {
-                    const result: { name: string; potentiallyStale: boolean } =
-                        {
-                            name,
-                            potentiallyStale: potentially_stale ?? false,
-                        };
-                    return result;
+                    return {
+                        name,
+                        potentiallyStale: potentially_stale ?? false,
+                    };
                 } else {
                     return undefined;
                 }
             })
-            .filter(Boolean);
+            .filter(Boolean) as { name: string; potentiallyStale: boolean }[];
 
         return diff;
     }

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -39,7 +39,6 @@ import {
     SKIP_CHANGE_REQUEST,
     Unsaved,
     WeightType,
-    FEATURE_POTENTIALLY_STALE_UPDATED,
 } from '../types';
 import { Logger } from '../logger';
 import BadDataError from '../error/bad-data-error';
@@ -1968,24 +1967,7 @@ class FeatureToggleService {
     }
 
     async updatePotentiallyStaleFeatures(): Promise<void> {
-        const potentiallyStaleFeatures =
-            await this.featureToggleStore.updatePotentiallyStaleFeatures();
-        if (this.flagResolver.isEnabled('emitPotentiallyStaleEvents')) {
-            if (potentiallyStaleFeatures.length) {
-                return this.eventStore.batchStore(
-                    potentiallyStaleFeatures.map(
-                        ({ name, potentiallyStale }) => ({
-                            type: FEATURE_POTENTIALLY_STALE_UPDATED,
-                            createdBy: 'unleash-system',
-                            data: {
-                                name,
-                                potentiallyStale,
-                            },
-                        }),
-                    ),
-                );
-            }
-        }
+        await this.featureToggleStore.updatePotentiallyStaleFeatures();
     }
 }
 

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1973,18 +1973,16 @@ class FeatureToggleService {
         if (this.flagResolver.isEnabled('emitPotentiallyStaleEvents')) {
             if (potentiallyStaleFeatures.length) {
                 return this.eventStore.batchStore(
-                    potentiallyStaleFeatures.map((feature) => ({
-                        type: FEATURE_POTENTIALLY_STALE_UPDATED,
-                        createdBy: 'unleash-system',
-                        data: {
-                            name: feature,
-                            potentiallyStale: true,
-                        },
-                        preData: {
-                            name: feature,
-                            potentiallyStale: false,
-                        },
-                    })),
+                    potentiallyStaleFeatures.map(
+                        ({ name, potentiallyStale }) => ({
+                            type: FEATURE_POTENTIALLY_STALE_UPDATED,
+                            createdBy: 'unleash-system',
+                            data: {
+                                name,
+                                potentiallyStale,
+                            },
+                        }),
+                    ),
                 );
             }
         }

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1967,9 +1967,9 @@ class FeatureToggleService {
         }
     }
 
-    async markPotentiallyStaleFeatures(): Promise<void> {
+    async updatePotentiallyStaleFeatures(): Promise<void> {
         const potentiallyStaleFeatures =
-            await this.featureToggleStore.markPotentiallyStaleFeatures();
+            await this.featureToggleStore.updatePotentiallyStaleFeatures();
         if (this.flagResolver.isEnabled('emitPotentiallyStaleEvents')) {
             if (potentiallyStaleFeatures.length) {
                 return this.eventStore.batchStore(

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -128,7 +128,7 @@ export const scheduleServices = async (
     );
 
     schedulerService.schedule(
-        featureToggleService.markPotentiallyStaleFeatures.bind(
+        featureToggleService.updatePotentiallyStaleFeatures.bind(
             featureToggleService,
         ),
         minutesToMilliseconds(1),

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -122,6 +122,9 @@ export const SERVICE_ACCOUNT_CREATED = 'service-account-created' as const;
 export const SERVICE_ACCOUNT_UPDATED = 'service-account-updated' as const;
 export const SERVICE_ACCOUNT_DELETED = 'service-account-deleted' as const;
 
+export const FEATURE_POTENTIALLY_STALE_UPDATED =
+    'feature-potentially-stale-updated' as const;
+
 export const IEventTypes = [
     APPLICATION_CREATED,
     FEATURE_CREATED,
@@ -223,6 +226,7 @@ export const IEventTypes = [
     SERVICE_ACCOUNT_CREATED,
     SERVICE_ACCOUNT_DELETED,
     SERVICE_ACCOUNT_UPDATED,
+    FEATURE_POTENTIALLY_STALE_UPDATED,
 ] as const;
 export type IEventType = typeof IEventTypes[number];
 

--- a/src/lib/types/stores/feature-toggle-store.ts
+++ b/src/lib/types/stores/feature-toggle-store.ts
@@ -32,7 +32,9 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
         range?: string[];
         dateAccessor: string;
     }): Promise<number>;
-    markPotentiallyStaleFeatures(currentTime?: string): Promise<string[]>;
+    markPotentiallyStaleFeatures(
+        currentTime?: string,
+    ): Promise<{ name: string; potentiallyStale: boolean }[]>;
     isPotentiallyStale(featureName: string): Promise<boolean>;
 
     /**

--- a/src/lib/types/stores/feature-toggle-store.ts
+++ b/src/lib/types/stores/feature-toggle-store.ts
@@ -32,7 +32,7 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
         range?: string[];
         dateAccessor: string;
     }): Promise<number>;
-    markPotentiallyStaleFeatures(
+    updatePotentiallyStaleFeatures(
         currentTime?: string,
     ): Promise<{ name: string; potentiallyStale: boolean }[]>;
     isPotentiallyStale(featureName: string): Promise<boolean>;

--- a/src/test/e2e/stores/feature-toggle-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-toggle-store.e2e.test.ts
@@ -60,6 +60,7 @@ describe('potentially_stale marking', () => {
 
         expect(markedToggles).toStrictEqual([]);
     });
+
     test('it returns only updated toggles', async () => {
         const features: FeatureToggleDTO[] = [
             {

--- a/src/test/e2e/stores/feature-toggle-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-toggle-store.e2e.test.ts
@@ -56,7 +56,7 @@ describe('potentially_stale marking', () => {
         );
 
         const markedToggles =
-            await featureToggleStore.markPotentiallyStaleFeatures();
+            await featureToggleStore.updatePotentiallyStaleFeatures();
 
         expect(markedToggles).toStrictEqual([]);
     });
@@ -78,7 +78,7 @@ describe('potentially_stale marking', () => {
         );
 
         const markedToggles =
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(41),
             );
 
@@ -113,7 +113,7 @@ describe('potentially_stale marking', () => {
             }
 
             const markedToggles =
-                await featureToggleStore.markPotentiallyStaleFeatures(
+                await featureToggleStore.updatePotentiallyStaleFeatures(
                     getFutureTimestamp(daysElapsed),
                 );
 
@@ -148,7 +148,7 @@ describe('potentially_stale marking', () => {
             ),
         );
         const markedToggles =
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(1000),
             );
         expect(markedToggles).toStrictEqual([]);
@@ -167,7 +167,7 @@ describe('potentially_stale marking', () => {
             ),
         );
         const markedToggles =
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(50),
             );
 
@@ -180,7 +180,7 @@ describe('potentially_stale marking', () => {
         ).toBeTruthy();
 
         const secondPass =
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(100),
             );
 
@@ -201,7 +201,7 @@ describe('potentially_stale marking', () => {
                 ),
             );
             const markedToggles =
-                await featureToggleStore.markPotentiallyStaleFeatures(
+                await featureToggleStore.updatePotentiallyStaleFeatures(
                     getFutureTimestamp(50),
                 );
 
@@ -219,7 +219,7 @@ describe('potentially_stale marking', () => {
             });
 
             expect(
-                await featureToggleStore.markPotentiallyStaleFeatures(),
+                await featureToggleStore.updatePotentiallyStaleFeatures(),
             ).toStrictEqual([{ name: 'feature1', potentiallyStale: false }]);
 
             const potentiallyStale =
@@ -241,7 +241,7 @@ describe('potentially_stale marking', () => {
                 ),
             );
             const markedToggles =
-                await featureToggleStore.markPotentiallyStaleFeatures(
+                await featureToggleStore.updatePotentiallyStaleFeatures(
                     getFutureTimestamp(50),
                 );
 
@@ -252,7 +252,7 @@ describe('potentially_stale marking', () => {
                 type: 'release',
             });
 
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(40),
             );
             const potentiallyStale =
@@ -280,7 +280,7 @@ describe('potentially_stale marking', () => {
                 type: 'release',
             });
 
-            await featureToggleStore.markPotentiallyStaleFeatures(
+            await featureToggleStore.updatePotentiallyStaleFeatures(
                 getFutureTimestamp(40),
             );
 

--- a/src/test/fixtures/fake-feature-toggle-store.ts
+++ b/src/test/fixtures/fake-feature-toggle-store.ts
@@ -253,7 +253,7 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
         return Promise.resolve();
     }
 
-    markPotentiallyStaleFeatures(): Promise<
+    updatePotentiallyStaleFeatures(): Promise<
         { name: string; potentiallyStale: boolean }[]
     > {
         throw new Error('Method not implemented.');

--- a/src/test/fixtures/fake-feature-toggle-store.ts
+++ b/src/test/fixtures/fake-feature-toggle-store.ts
@@ -253,7 +253,9 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
         return Promise.resolve();
     }
 
-    markPotentiallyStaleFeatures(): Promise<string[]> {
+    markPotentiallyStaleFeatures(): Promise<
+        { name: string; potentiallyStale: boolean }[]
+    > {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
This PR adds updates the potentially stale status change events whenever the potentially stale update function is run.

No events are emitted yet. While the emission is only a few lines of code, I'd like to do that in a separate PR so that we can give it the attention it deserves in the form of tests, etc.

This PR also moves the potentially stale update functionality from the `update` method to only being done in the `updatePotentiallyStaleFeatures` method. This keeps all functionality related to marking `potentiallyStale` in one place.

The emission implementation was removed in https://github.com/Unleash/unleash/commit/4fb7cbde03b43320442633888f5ba4c0c3c77b31

## The update queries

While it would be possible to do the state updates in a single query instead of three separate ones, wrangling this into knex proved to be troublesome (and would also probably be harder to understand and reason about). The current solution uses three smaller queries (one select, two updates), as Jaanus suggested in a private slack thread.

Input is welcome if you have any.