### PR TITLE
Strategy variants stickiness

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -248,7 +248,11 @@ export const FeatureStrategyForm = ({
             />
             <StyledHr />
             <ConditionallyRender
-                condition={Boolean(uiConfig?.flags?.strategyVariant)}
+                condition={
+                    Boolean(uiConfig?.flags?.strategyVariant) &&
+                    strategy.parameters != null &&
+                    'stickiness' in strategy.parameters
+                }
                 show={
                     <StrategyVariants
                         strategy={strategy}

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal.tsx
@@ -390,7 +390,7 @@ export const EnvironmentVariantsModal = ({
                                         )
                                     )
                                 }
-                                apiPayload={apiPayload}
+                                error={apiPayload.error}
                             />
                         ))}
                     </StyledVariantForms>

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -1,20 +1,24 @@
-import { useEffect, useState } from "react";
-import Input from "component/common/Input/Input";
-import { HelpIcon } from "component/common/HelpIcon/HelpIcon";
-import SelectMenu from "component/common/select";
+import { useEffect, useState } from 'react';
+import Input from 'component/common/Input/Input';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import SelectMenu from 'component/common/select';
+import { OverrideConfig } from 'component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/VariantOverrides';
 import {
-    OverrideConfig
-} from "component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/VariantOverrides";
-import { Button, FormControlLabel, IconButton, InputAdornment, styled, Switch, Tooltip } from "@mui/material";
-import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
-import { IPayload } from "interfaces/featureToggle";
-import {
-    useOverrides
-} from "component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/useOverrides";
-import useUnleashContext from "hooks/api/getters/useUnleashContext/useUnleashContext";
-import { WeightType } from "constants/variantTypes";
-import { IFeatureVariantEdit } from "../EnvironmentVariantsModal";
-import { Delete } from "@mui/icons-material";
+    Button,
+    FormControlLabel,
+    IconButton,
+    InputAdornment,
+    styled,
+    Switch,
+    Tooltip,
+} from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { IPayload } from 'interfaces/featureToggle';
+import { useOverrides } from 'component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/useOverrides';
+import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
+import { WeightType } from 'constants/variantTypes';
+import { IFeatureVariantEdit } from '../EnvironmentVariantsModal';
+import { Delete } from '@mui/icons-material';
 
 const StyledVariantForm = styled('div')(({ theme }) => ({
     position: 'relative',

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -1,25 +1,20 @@
-import { useEffect, useState } from 'react';
-import Input from 'component/common/Input/Input';
-import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
-import SelectMenu from 'component/common/select';
-import { OverrideConfig } from 'component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/VariantOverrides';
+import { useEffect, useState } from "react";
+import Input from "component/common/Input/Input";
+import { HelpIcon } from "component/common/HelpIcon/HelpIcon";
+import SelectMenu from "component/common/select";
 import {
-    Button,
-    FormControlLabel,
-    IconButton,
-    InputAdornment,
-    styled,
-    Switch,
-    Tooltip,
-} from '@mui/material';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { IPayload } from 'interfaces/featureToggle';
-import { useOverrides } from 'component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/useOverrides';
-import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
-import { WeightType } from 'constants/variantTypes';
-import { IFeatureVariantEdit } from '../EnvironmentVariantsModal';
-import { Operation } from 'fast-json-patch';
-import { Delete } from '@mui/icons-material';
+    OverrideConfig
+} from "component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/VariantOverrides";
+import { Button, FormControlLabel, IconButton, InputAdornment, styled, Switch, Tooltip } from "@mui/material";
+import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
+import { IPayload } from "interfaces/featureToggle";
+import {
+    useOverrides
+} from "component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantOverrides/useOverrides";
+import useUnleashContext from "hooks/api/getters/useUnleashContext/useUnleashContext";
+import { WeightType } from "constants/variantTypes";
+import { IFeatureVariantEdit } from "../EnvironmentVariantsModal";
+import { Delete } from "@mui/icons-material";
 
 const StyledVariantForm = styled('div')(({ theme }) => ({
     position: 'relative',
@@ -150,10 +145,7 @@ interface IVariantFormProps {
     variants: IFeatureVariantEdit[];
     updateVariant: (updatedVariant: IFeatureVariantEdit) => void;
     removeVariant: (variantId: string) => void;
-    apiPayload: {
-        patch: Operation[];
-        error?: string;
-    };
+    error?: string;
 }
 
 export const VariantForm = ({
@@ -161,7 +153,7 @@ export const VariantForm = ({
     variants,
     updateVariant,
     removeVariant,
-    apiPayload,
+    error,
 }: IVariantFormProps) => {
     const [name, setName] = useState(variant.name);
     const [customPercentage, setCustomPercentage] = useState(
@@ -188,10 +180,10 @@ export const VariantForm = ({
 
     useEffect(() => {
         clearError(ErrorField.PERCENTAGE);
-        if (apiPayload.error?.includes('%')) {
+        if (error?.includes('%')) {
             setError(ErrorField.PERCENTAGE, 'Total weight must equal 100%');
         }
-    }, [apiPayload.error]);
+    }, [error]);
 
     const editing = !variant.new;
     const customPercentageVisible =
@@ -292,7 +284,7 @@ export const VariantForm = ({
                 isNameUnique(name, variant.id) &&
                 isValidPercentage(percentage) &&
                 isValidPayload(payload) &&
-                !apiPayload.error,
+                !error,
         });
     }, [name, customPercentage, percentage, payload, overrides]);
 

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { StrategyVariants } from './StrategyVariants';
+import { Route, Routes } from 'react-router-dom';
+import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from '../../providers/AccessProvider/permissions';
+import { IFeatureStrategy } from '../../../interfaces/strategy';
+import React, { useState } from 'react';
+
+test('should render variants', async () => {
+    const Parent = () => {
+        const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>({
+            name: '',
+            constraints: [],
+            parameters: { stickiness: 'clientId' },
+            variants: [
+                {
+                    name: 'variantName',
+                    stickiness: 'default',
+                    weight: 1000,
+                    weightType: 'variable',
+                    payload: {
+                        type: 'string',
+                        value: 'variantValue',
+                    },
+                },
+            ],
+        });
+        return (
+            <StrategyVariants strategy={strategy} setStrategy={setStrategy} />
+        );
+    };
+    render(
+        <Routes>
+            <Route
+                path={'projects/:projectId/features/:featureId/strategies/edit'}
+                element={<Parent />}
+            />
+        </Routes>,
+        {
+            route: 'projects/default/features/colors/strategies/edit?environmentId=development&strategyId=2e4f0555-518b-45b3-b0cd-a32cca388a92',
+            permissions: [
+                {
+                    permission: UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+                    project: 'default',
+                    environment: 'development',
+                },
+            ],
+        }
+    );
+
+    // static form info
+    await screen.findByText('Variants');
+    const button = await screen.findByText('Add variant');
+
+    // variant form populated
+    const variantInput = screen.getByDisplayValue('variantValue');
+    expect(variantInput).toBeInTheDocument();
+
+    // overrides disabled
+    expect(screen.queryByText('Overrides')).not.toBeInTheDocument();
+
+    button.click();
+
+    const matchedElements = screen.getAllByText('Custom percentage');
+
+    expect(matchedElements.length).toBe(2);
+});

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
@@ -65,11 +65,14 @@ test('should render variants', async () => {
     // overrides disabled
     expect(screen.queryByText('Overrides')).not.toBeInTheDocument();
 
+    // add second variant
     button.click();
 
+    // UI allows to adjust percentages
     const matchedElements = screen.getAllByText('Custom percentage');
-
     expect(matchedElements.length).toBe(2);
+
+    // correct variants set on the parent
     await waitFor(() => {
         expect(currentStrategy).toMatchObject({
             ...initialStrategy,

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -42,7 +42,15 @@ export const StrategyVariants: FC<{
         );
     }, []);
 
-    useEffect(() => {
+    const updateVariant = (updatedVariant: IFeatureVariantEdit, id: string) => {
+        setVariantsEdit(prevVariants =>
+            updateWeightEdit(
+                prevVariants.map(prevVariant =>
+                    prevVariant.id === id ? updatedVariant : prevVariant
+                ),
+                1000
+            )
+        );
         setStrategy(prev => ({
             ...prev,
             variants: variantsEdit.map(variant => ({
@@ -53,17 +61,6 @@ export const StrategyVariants: FC<{
                 weightType: variant.weightType,
             })),
         }));
-    }, [JSON.stringify(variantsEdit), stickiness]);
-
-    const updateVariant = (updatedVariant: IFeatureVariantEdit, id: string) => {
-        setVariantsEdit(prevVariants =>
-            updateWeightEdit(
-                prevVariants.map(prevVariant =>
-                    prevVariant.id === id ? updatedVariant : prevVariant
-                ),
-                1000
-            )
-        );
     };
 
     const addVariant = () => {

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -7,8 +7,7 @@ import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from '../../providers/AccessProvi
 import { v4 as uuidv4 } from 'uuid';
 import { WeightType } from '../../../constants/variantTypes';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useDefaultProjectSettings } from 'hooks/useDefaultProjectSettings';
-import { styled } from '@mui/material';
+import { styled, Typography } from '@mui/material';
 import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
 import { IFeatureStrategy } from 'interfaces/strategy';
 
@@ -26,8 +25,10 @@ export const StrategyVariants: FC<{
     const projectId = useRequiredPathParam('projectId');
     const environment = useRequiredQueryParam('environmentId');
     const [variantsEdit, setVariantsEdit] = useState<IFeatureVariantEdit[]>([]);
-    const [newVariant, setNewVariant] = useState<string>();
-    const { defaultStickiness, loading } = useDefaultProjectSettings(projectId);
+    const stickiness =
+        strategy?.parameters && 'stickiness' in strategy?.parameters
+            ? String(strategy.parameters.stickiness)
+            : 'default';
 
     useEffect(() => {
         setVariantsEdit(
@@ -47,12 +48,12 @@ export const StrategyVariants: FC<{
             variants: variantsEdit.map(variant => ({
                 name: variant.name,
                 weight: variant.weight,
-                stickiness: variant.stickiness,
+                stickiness,
                 payload: variant.payload,
                 weightType: variant.weightType,
             })),
         }));
-    }, [JSON.stringify(variantsEdit)]);
+    }, [JSON.stringify(variantsEdit), stickiness]);
 
     const updateVariant = (updatedVariant: IFeatureVariantEdit, id: string) => {
         setVariantsEdit(prevVariants =>
@@ -73,24 +74,23 @@ export const StrategyVariants: FC<{
                 name: '',
                 weightType: WeightType.VARIABLE,
                 weight: 0,
-                overrides: [],
-                stickiness:
-                    variantsEdit?.length > 0
-                        ? variantsEdit[0].stickiness
-                        : defaultStickiness,
+                stickiness,
                 new: true,
                 isValid: false,
                 id,
             },
         ]);
-        setNewVariant(id);
     };
 
     return (
         <>
+            <Typography component="h3" sx={{ m: 0 }} variant="h3">
+                Variants
+            </Typography>
             <StyledVariantForms>
                 {variantsEdit.map(variant => (
                     <VariantForm
+                        disableOverrides={true}
                         key={variant.id}
                         variant={variant}
                         variants={variantsEdit}

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -107,7 +107,6 @@ export const StrategyVariants: FC<{
                                 )
                             )
                         }
-                        apiPayload={{ patch: [] }}
                     />
                 ))}
             </StyledVariantForms>

--- a/frontend/src/interfaces/featureToggle.ts
+++ b/frontend/src/interfaces/featureToggle.ts
@@ -53,15 +53,7 @@ export interface IFeatureVariant {
     stickiness: string;
     weight: number;
     weightType: string;
-    overrides: IOverride[];
-    payload?: IPayload;
-}
-
-export interface IFeatureStrategyVariant {
-    name: string;
-    stickiness: string;
-    weight: number;
-    weightType: string;
+    overrides?: IOverride[];
     payload?: IPayload;
 }
 

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -1,5 +1,5 @@
 import { Operator } from 'constants/operators';
-import { IFeatureStrategyVariant } from './featureToggle';
+import { IFeatureVariant } from './featureToggle';
 
 export interface IFeatureStrategy {
     id: string;
@@ -8,7 +8,7 @@ export interface IFeatureStrategy {
     title?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
-    variants?: IFeatureStrategyVariant[];
+    variants?: IFeatureVariant[];
     featureName?: string;
     projectId?: string;
     environment?: string;
@@ -26,7 +26,7 @@ export interface IFeatureStrategyPayload {
     title?: string;
     constraints: IConstraint[];
     parameters: IFeatureStrategyParameters;
-    variants?: IFeatureStrategyVariant[];
+    variants?: IFeatureVariant[];
     segments?: number[];
     disabled?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<img width="1268" alt="Screenshot 2023-07-17 at 11 21 42" src="https://github.com/Unleash/unleash/assets/1394682/17ca3027-9241-4c90-9539-7fa04362f544">



* Passing stickiness from the strategy to the variants so that they are always in sync for the strategy variants
* IFeatureStrategyVariant removed and back to IFeatureVariant with optional overrides. It is less invasive in the existing code
* Ability to disableOverrides in VariantForm since the new strategy variants don't need to override anythings (they have access to constraints and segments as first class citizens)
* stickiness param presence enables strategy variants support so any strategy that has it will automatically get variants



### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
