### PR TITLE
chore: prepare next release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
-  "version": "5.2.0-main",
+  "version": "5.3.0-main",
   "keywords": [
     "unleash",
     "feature toggle",


### PR DESCRIPTION
We should have changed this with 5.2 release, but we forgot and I have plans of automating this
