### PR TITLE
docs: update postgres ssl docs to accurately use ca over key

### DIFF
--- a/website/docs/reference/deploy/configuring-unleash.md
+++ b/website/docs/reference/deploy/configuring-unleash.md
@@ -299,7 +299,7 @@ const unleashOptions = {
 <TabItem value="env" label="Environment variables (bash)">
 
 ```bash title="Reading from the file system with bash"
-DATABASE_SSL="{ \"key\": \"$(cat /path/to/server-certificates/root.crt)\" }"
+DATABASE_SSL="{ \"ca\": \"$(cat /path/to/server-certificates/root.crt)\" }"
 ```
 
 </TabItem>
@@ -331,7 +331,7 @@ const unleashOptions = {
 <TabItem value="env" label="Environment variables (bash)">
 
 ```bash title="Enable self-signed certificates"
-DATABASE_SSL="{ \"rejectUnauthorized\": false, \"key\": \"$(cat /path/to/server-certificates/root.crt)\" }"
+DATABASE_SSL="{ \"rejectUnauthorized\": false, \"ca\": \"$(cat /path/to/server-certificates/root.crt)\" }"
 ```
 
 </TabItem>


### PR DESCRIPTION
Our documentation has mismatched code snippets when showing how to use self signed SSL certs. In the JS version, it specifies using a "ca" property, but in the bash version it uses "key" instead. "ca" is correct, so this PR just patches the bash snippet