### PR TITLE
docs(#4205): update feature toggle types doc to add lifetime info

### DIFF
--- a/website/docs/reference/feature-toggle-types.md
+++ b/website/docs/reference/feature-toggle-types.md
@@ -16,23 +16,39 @@ Classifying feature toggles by their type makes it easier for you manage them: t
 
 ![Five feature toggles, each of a different type, showing the different icons that Unleash uses for each toggle type.](/img/toggle_type_icons.png "Feature toggle type icons")
 
-A toggle's type also helps Unleash understand the [toggle's expected lifetime](https://www.getunleash.io/blog/feature-toggle-life-time-best-practices): some feature toggles are meant to live for a few weeks as you work on new functionality, while others stay in for much longer. When a feature toggle lives past its expected lifetime, Unleash will mark it as _potentially stale_. See the [technical debt section](../reference/technical-debt) for more information on what this means and how to handle it.
-
+A toggle's type also helps Unleash understand the [toggle's expected lifetime](#expected-lifetimes).
 ## Feature toggle types
 
 Here's the list of the feature toggle types that Unleash supports together with their intended use case and expected lifetime:
 
-- **Release** -  Enable trunk-based development for teams practicing Continuous Delivery. _Expected lifetime 40 days_
-- **Experiment** - Perform multivariate or A/B testing. _Expected lifetime 40 days_
-- **Operational** - Control operational aspects of the system's behavior. _Expected lifetime 7 days_
-- **Kill switch** - Gracefully degrade system functionality. You can read about [kill switch best practices](https://www.getunleash.io/blog/kill-switches-best-practice) on our blog. _(permanent)_
-- **Permission** - Change the features or product experience that certain users receive. _(permanent)_
+| Feature toggle type | Used to ...                                                                                                                                                       | Expected lifetime |
+|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| Release             | Enable trunk-based development for teams practicing Continuous Delivery.                                                                                          | 40 days           |
+| Experiment          | Perform multivariate or A/B testing.                                                                                                                              | 40 days           |
+| Operational         | Control operational aspects of the system's behavior.                                                                                                             | 7 days            |
+| Kill switch         | Gracefully degrade system functionality. You can read about [kill switch best practices](https://www.getunleash.io/blog/kill-switches-best-practice) on our blog. | Permanent         |
+| Permission          | Change the features or product experience that certain users receive.                                                                                             | Permanent         |
+
+### Expected lifetimes
+
+:::info
+
+The ability to update a feature toggle type's expected lifetime is currently in development. We expect to release it in one of the upcoming releases.
+
+:::
+
+A feature toggle's expected lifetime is an indicator of how long Unleash expects toggles of that type to be around. Some feature toggles are meant to live for a few weeks as you work on new functionality, while others stick around for much longer. As a part of good code hygiene, you should clean up your feature toggles when they have served their purpose. This is further explored in the document on [technical debt](technical-debt.md).
+
+Each feature toggle type in Unleash has an assigned expected lifetime, after which the system will consider this feature _potentially stale_. The reasoning behind each type's expected lifetime is detailed in this [blog post on best practices for feature toggle lifetimes](https://www.getunleash.io/blog/feature-toggle-life-time-best-practices).
+
+Unleash admins can change the expected lifetime of Unleash's feature types from the Unleash configuration menu.
+
 
 ## Deprecating feature toggles {#deprecate-a-feature-toggle}
 
-You can mark feature toggles as `stale`. This is a way to deprecate a feature toggle without removing the active configuration for connected applications. Use this to signal that you should stop using the feature in your applications. Stale toggles will show as stale in the ["technical debt dashboard"](../reference/technical-debt).
+You can mark feature toggles as `stale`. This is a way to deprecate a feature toggle without removing the active configuration for connected applications. Use this to signal that you should stop using the feature in your applications. Stale toggles will show as stale in the ["technical debt dashboard"](technical-debt.md).
 
-When you mark a toggle as stale, Unleash will emit an event. You can use [an addon](../reference/addons/addons.md) to integrate this with your systems, for instance to post a message in a Slack channel.
+When you mark a toggle as stale, Unleash will emit an event. You can use [an addon](addons/addons.md) to integrate this with your systems, for instance to post a message in a Slack channel.
 
 Additionally, with some extra work, you can also use the `stale` property to:
 


### PR DESCRIPTION
This change updates the existing feature toggle types document to add
a new `expected lifetime` section. This section explains better what
lifetimes are, where they come from, and that admins can (soon) change
the expected lifetimes for feature toggles.