### PR TITLE
openapi: remove all the extra data info

### DIFF
--- a/src/lib/openapi/spec/event-schema.ts
+++ b/src/lib/openapi/spec/event-schema.ts
@@ -6,6 +6,7 @@ import { variantSchema } from './variant-schema';
 const eventDataSchema = {
     type: 'object',
     nullable: true,
+    'x-enforcer-exception-skip-codes': 'WSCH006', // allow additional properties in example (openapi enforcer)
     additionalProperties: true,
     description:
         'Extra associated data related to the event, such as feature toggle state, segment configuration, etc., if applicable.',

--- a/src/lib/openapi/spec/event-schema.ts
+++ b/src/lib/openapi/spec/event-schema.ts
@@ -5,70 +5,8 @@ import { variantSchema } from './variant-schema';
 
 const eventDataSchema = {
     type: 'object',
+    nullable: true,
     additionalProperties: true,
-    properties: {
-        name: {
-            type: 'string',
-            description:
-                'Name of the feature toggle/strategy/environment that this event relates to',
-            example: 'my.first.toggle',
-            nullable: true,
-        },
-        description: {
-            type: 'string',
-            description: 'The description of the object this event relates to',
-            example: 'Toggle description',
-            nullable: true,
-        },
-        type: {
-            type: 'string',
-            description:
-                'If this event relates to a feature toggle, the type of feature toggle.',
-            example: 'release',
-            nullable: true,
-        },
-        project: {
-            type: 'string',
-            description: 'The project this event relates to',
-            example: 'default',
-            nullable: true,
-        },
-        stale: {
-            description: 'Is the feature toggle this event relates to stale',
-            type: 'boolean',
-            example: true,
-            nullable: true,
-        },
-        variants: {
-            description: 'Variants configured for this toggle',
-            type: 'array',
-            items: {
-                $ref: '#/components/schemas/variantSchema',
-            },
-            nullable: true,
-        },
-        createdAt: {
-            type: 'string',
-            format: 'date-time',
-            description:
-                'The time the event happened as a RFC 3339-conformant timestamp.',
-            example: '2023-07-05T12:56:00.000Z',
-            nullable: true,
-        },
-        lastSeenAt: {
-            type: 'string',
-            format: 'date-time',
-            description: 'The time the feature was last seen',
-            example: '2023-07-05T12:56:00.000Z',
-            nullable: true,
-        },
-        impressionData: {
-            description:
-                'Should [impression events](https://docs.getunleash.io/reference/impression-data) activate for this feature toggle',
-            type: 'boolean',
-            example: false,
-        },
-    },
     description:
         'Extra associated data related to the event, such as feature toggle state, segment configuration, etc., if applicable.',
     example: {
@@ -139,7 +77,6 @@ export const eventSchema = {
             ...eventDataSchema,
             description:
                 "Data relating to the previous state of the event's subject.",
-            nullable: true,
         },
         tags: {
             type: 'array',

--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -13,7 +13,7 @@ const ajv = new Ajv({
     ),
     // example was superseded by examples in openapi 3.1, but we're still on 3.0, so
     // let's add it back in!
-    keywords: ['example'],
+    keywords: ['example', 'x-enforcer-exception-skip-codes'],
     formats: {
         'date-time': true,
         uri: true,


### PR DESCRIPTION
This change makes the `eventData` object nullable (because it is),
and also removes all the properties that we had to declare to have an
example.

This should help us avoid a fair few warnings about data being
mismatched when it can really be anything.

## Context

The OpenAPI enforcer gives you warnings when you provide examples that use additional properties. But since we really don't know what the data is in this case, that's the best way forward. 

There's two options: either allow additional properties in all examples or use the `x-enforcer-exception-skip-codes` to allow it only in a single place.

I'm leaning towards the latter (and that's what's in this PR) because it can be useful to have the warning in other places, so I don't think we should ignore it completely. The tradeoff is that the OpenAPI schema gets rendered with that extra property in it. 