### PR TITLE
feat: improve slack app addon scalability

### DIFF
--- a/src/lib/addons/__snapshots__/slack-app.test.ts.snap
+++ b/src/lib/addons/__snapshots__/slack-app.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should not post to unexisting tagged channels 1`] = `
+exports[`SlackAppAddon should not post to unexisting tagged channels 1`] = `
 {
   "attachments": [
     {
@@ -21,7 +21,7 @@ exports[`Should not post to unexisting tagged channels 1`] = `
 }
 `;
 
-exports[`Should post message when feature is toggled 1`] = `
+exports[`SlackAppAddon should post message when feature is toggled 1`] = `
 {
   "attachments": [
     {
@@ -42,7 +42,7 @@ exports[`Should post message when feature is toggled 1`] = `
 }
 `;
 
-exports[`Should post to all channels in tags 1`] = `
+exports[`SlackAppAddon should post to all channels in tags 1`] = `
 {
   "attachments": [
     {
@@ -63,7 +63,7 @@ exports[`Should post to all channels in tags 1`] = `
 }
 `;
 
-exports[`Should post to all channels in tags 2`] = `
+exports[`SlackAppAddon should post to all channels in tags 2`] = `
 {
   "attachments": [
     {

--- a/src/lib/addons/addon.ts
+++ b/src/lib/addons/addon.ts
@@ -66,4 +66,6 @@ export default abstract class Addon {
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     abstract handleEvent(event: IEvent, parameters: any): Promise<void>;
+
+    destroy?(): void;
 }

--- a/src/lib/addons/slack-app.test.ts
+++ b/src/lib/addons/slack-app.test.ts
@@ -2,19 +2,12 @@ import { IEvent, FEATURE_ENVIRONMENT_ENABLED } from '../types/events';
 import SlackAppAddon from './slack-app';
 import { ChatPostMessageArguments, ErrorCode } from '@slack/web-api';
 
-let addon;
-const accessToken = 'test-access-token';
 const slackApiCalls: ChatPostMessageArguments[] = [];
-let conversationsList = jest.fn();
-const loggerMock = {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    fatal: jest.fn(),
-};
-
-const getLogger = jest.fn(() => loggerMock);
+const conversationsList = jest.fn();
+let postMessage = jest.fn().mockImplementation((options) => {
+    slackApiCalls.push(options);
+    return Promise.resolve();
+});
 
 jest.mock('@slack/web-api', () => ({
     WebClient: jest.fn().mockImplementation(() => ({
@@ -29,37 +22,42 @@ jest.mock('@slack/web-api', () => ({
                         id: 2,
                         name: 'another-channel-1',
                     },
+                    {
+                        id: 3,
+                        name: 'another-channel-2',
+                    },
                 ],
             })),
         },
         chat: {
-            postMessage: jest.fn().mockImplementation((options) => {
-                slackApiCalls.push(options);
-                return Promise.resolve();
-            }),
+            postMessage,
         },
+        on: jest.fn(),
     })),
     ErrorCode: {
         PlatformError: 'slack_webapi_platform_error',
     },
+    WebClientEvent: {
+        RATE_LIMITED: 'rate_limited',
+    },
 }));
 
-beforeEach(() => {
-    jest.useFakeTimers();
-    slackApiCalls.length = 0;
-    conversationsList.mockClear();
-    addon = new SlackAppAddon({
-        getLogger,
-        unleashUrl: 'http://some-url.com',
-    });
-});
+describe('SlackAppAddon', () => {
+    let addon;
+    const accessToken = 'test-access-token';
+    const loggerMock = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        fatal: jest.fn(),
+    };
+    const getLogger = jest.fn(() => loggerMock);
+    const mockError = {
+        code: ErrorCode.PlatformError,
+        data: 'Platform error message',
+    };
 
-afterEach(() => {
-    jest.useRealTimers();
-    addon.destroy();
-});
-
-test('Should post message when feature is toggled', async () => {
     const event: IEvent = {
         id: 1,
         createdAt: new Date(),
@@ -77,161 +75,120 @@ test('Should post message when feature is toggled', async () => {
         tags: [{ type: 'slack', value: 'general' }],
     };
 
-    await addon.handleEvent(event, { accessToken });
-    expect(slackApiCalls.length).toBe(1);
-    expect(slackApiCalls[0].channel).toBe(1);
-    expect(slackApiCalls[0]).toMatchSnapshot();
-});
-
-test('Should post to all channels in tags', async () => {
-    const event: IEvent = {
-        id: 2,
-        createdAt: new Date(),
-        type: FEATURE_ENVIRONMENT_ENABLED,
-        createdBy: 'some@user.com',
-        project: 'default',
-        featureName: 'some-toggle',
-        environment: 'development',
-        data: {
-            name: 'some-toggle',
-        },
-        tags: [
-            { type: 'slack', value: 'general' },
-            { type: 'slack', value: 'another-channel-1' },
-        ],
-    };
-
-    await addon.handleEvent(event, { accessToken });
-    expect(slackApiCalls.length).toBe(2);
-    expect(slackApiCalls[0].channel).toBe(1);
-    expect(slackApiCalls[0]).toMatchSnapshot();
-    expect(slackApiCalls[1].channel).toBe(2);
-    expect(slackApiCalls[1]).toMatchSnapshot();
-});
-
-test('Should not post to unexisting tagged channels', async () => {
-    const event: IEvent = {
-        id: 3,
-        createdAt: new Date(),
-        type: FEATURE_ENVIRONMENT_ENABLED,
-        createdBy: 'some@user.com',
-        project: 'default',
-        featureName: 'some-toggle',
-        environment: 'development',
-        data: {
-            name: 'some-toggle',
-        },
-        tags: [
-            { type: 'slack', value: 'random' },
-            { type: 'slack', value: 'another-channel-1' },
-        ],
-    };
-
-    await addon.handleEvent(event, { accessToken });
-    expect(slackApiCalls.length).toBe(1);
-    expect(slackApiCalls[0].channel).toBe(2);
-    expect(slackApiCalls[0]).toMatchSnapshot();
-});
-
-test('Should cache Slack channels', async () => {
-    const event: IEvent = {
-        id: 4,
-        createdAt: new Date(),
-        type: FEATURE_ENVIRONMENT_ENABLED,
-        createdBy: 'some@user.com',
-        project: 'default',
-        featureName: 'some-toggle',
-        environment: 'development',
-        data: {
-            name: 'some-toggle',
-        },
-        tags: [{ type: 'slack', value: 'general' }],
-    };
-
-    await addon.handleEvent(event, { accessToken });
-    await addon.handleEvent(event, { accessToken });
-    expect(slackApiCalls.length).toBe(2);
-    expect(conversationsList).toHaveBeenCalledTimes(1);
-});
-
-test('Should refresh Slack channels cache after 30 seconds', async () => {
-    const event: IEvent = {
-        id: 5,
-        createdAt: new Date(),
-        type: FEATURE_ENVIRONMENT_ENABLED,
-        createdBy: 'some@user.com',
-        project: 'default',
-        featureName: 'some-toggle',
-        environment: 'development',
-        data: {
-            name: 'some-toggle',
-        },
-        tags: [{ type: 'slack', value: 'general' }],
-    };
-
-    await addon.handleEvent(event, { accessToken });
-    jest.advanceTimersByTime(30000);
-    await addon.handleEvent(event, { accessToken });
-    expect(slackApiCalls.length).toBe(2);
-    expect(conversationsList).toHaveBeenCalledTimes(2);
-});
-
-test('Should log error when an API call fails', async () => {
-    const event: IEvent = {
-        id: 6,
-        createdAt: new Date(),
-        type: FEATURE_ENVIRONMENT_ENABLED,
-        createdBy: 'some@user.com',
-        project: 'default',
-        featureName: 'some-toggle',
-        environment: 'development',
-        data: {
-            name: 'some-toggle',
-        },
-        tags: [{ type: 'slack', value: 'general' }],
-    };
-
-    const mockError = {
-        code: ErrorCode.PlatformError,
-        data: 'Platform error message',
-    };
-
-    jest.resetModules();
-    jest.doMock('@slack/web-api', () => ({
-        WebClient: jest.fn().mockImplementation(() => ({
-            conversations: {
-                list: jest.fn().mockResolvedValue({
-                    channels: [
-                        {
-                            id: 1,
-                            name: 'general',
-                        },
-                        {
-                            id: 2,
-                            name: 'another-channel-1',
-                        },
-                    ],
-                }),
-            },
-            chat: {
-                postMessage: jest.fn().mockRejectedValue(mockError),
-            },
-        })),
-        ErrorCode: {
-            PlatformError: 'slack_webapi_platform_error',
-        },
-    }));
-
-    const { default: NewSlackAppAddon } = await import('./slack-app');
-    addon = new NewSlackAppAddon({
-        getLogger,
-        unleashUrl: 'http://some-url.com',
+    beforeEach(() => {
+        jest.useFakeTimers();
+        slackApiCalls.length = 0;
+        conversationsList.mockClear();
+        addon = new SlackAppAddon({
+            getLogger,
+            unleashUrl: 'http://some-url.com',
+        });
     });
 
-    await addon.handleEvent(event, { accessToken });
+    afterEach(() => {
+        jest.useRealTimers();
+        addon.destroy();
+    });
 
-    expect(loggerMock.error).toHaveBeenCalledWith(
-        `Error handling event ${event.type}. A platform error occurred: Platform error message`,
-        expect.any(Object),
-    );
+    it('should post message when feature is toggled', async () => {
+        await addon.handleEvent(event, { accessToken });
+
+        expect(slackApiCalls.length).toBe(1);
+        expect(slackApiCalls[0].channel).toBe(1);
+        expect(slackApiCalls[0]).toMatchSnapshot();
+    });
+
+    it('should post to all channels in tags', async () => {
+        const eventWith2Tags: IEvent = {
+            ...event,
+            tags: [
+                { type: 'slack', value: 'general' },
+                { type: 'slack', value: 'another-channel-1' },
+            ],
+        };
+
+        await addon.handleEvent(eventWith2Tags, { accessToken });
+
+        expect(slackApiCalls.length).toBe(2);
+        expect(slackApiCalls[0].channel).toBe(1);
+        expect(slackApiCalls[0]).toMatchSnapshot();
+        expect(slackApiCalls[1].channel).toBe(2);
+        expect(slackApiCalls[1]).toMatchSnapshot();
+    });
+
+    it('should not post to unexisting tagged channels', async () => {
+        const eventWithUnexistingTaggedChannel: IEvent = {
+            ...event,
+            tags: [
+                { type: 'slack', value: 'random' },
+                { type: 'slack', value: 'another-channel-1' },
+            ],
+        };
+
+        await addon.handleEvent(eventWithUnexistingTaggedChannel, {
+            accessToken,
+        });
+
+        expect(slackApiCalls.length).toBe(1);
+        expect(slackApiCalls[0].channel).toBe(2);
+        expect(slackApiCalls[0]).toMatchSnapshot();
+    });
+
+    it('should cache Slack channels', async () => {
+        await addon.handleEvent(event, { accessToken });
+        await addon.handleEvent(event, { accessToken });
+
+        expect(slackApiCalls.length).toBe(2);
+        expect(conversationsList).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh Slack channels cache after 30 seconds', async () => {
+        await addon.handleEvent(event, { accessToken });
+
+        jest.advanceTimersByTime(30000);
+
+        await addon.handleEvent(event, { accessToken });
+
+        expect(slackApiCalls.length).toBe(2);
+        expect(conversationsList).toHaveBeenCalledTimes(2);
+    });
+
+    it('should log error when an API call fails', async () => {
+        postMessage = jest.fn().mockRejectedValue(mockError);
+
+        await addon.handleEvent(event, { accessToken });
+
+        expect(loggerMock.warn).toHaveBeenCalledWith(
+            `Error handling event ${event.type}. A platform error occurred: Platform error message`,
+            expect.any(Object),
+        );
+    });
+
+    it('should handle rejections in chat.postMessage', async () => {
+        const eventWith3Tags: IEvent = {
+            ...event,
+            tags: [
+                { type: 'slack', value: 'general' },
+                { type: 'slack', value: 'another-channel-1' },
+                { type: 'slack', value: 'another-channel-2' },
+            ],
+        };
+
+        postMessage = jest
+            .fn()
+            .mockResolvedValueOnce({ ok: true })
+            .mockResolvedValueOnce({ ok: true })
+            .mockRejectedValueOnce(mockError);
+
+        await addon.handleEvent(eventWith3Tags, { accessToken });
+
+        expect(postMessage).toHaveBeenCalledTimes(3);
+        expect(loggerMock.warn).toHaveBeenCalledWith(
+            `Error handling event ${FEATURE_ENVIRONMENT_ENABLED}. A platform error occurred: Platform error message`,
+            expect.any(Object),
+        );
+        expect(loggerMock.info).toHaveBeenCalledWith(
+            `Handled event ${FEATURE_ENVIRONMENT_ENABLED} dispatching 2 out of 3 messages successfully.`,
+        );
+    });
 });

--- a/src/lib/addons/slack-app.test.ts
+++ b/src/lib/addons/slack-app.test.ts
@@ -1,12 +1,20 @@
 import { IEvent, FEATURE_ENVIRONMENT_ENABLED } from '../types/events';
 import SlackAppAddon from './slack-app';
-import noLogger from '../../test/fixtures/no-logger';
-import { ChatPostMessageArguments } from '@slack/web-api';
+import { ChatPostMessageArguments, ErrorCode } from '@slack/web-api';
 
 let addon;
 const accessToken = 'test-access-token';
 const slackApiCalls: ChatPostMessageArguments[] = [];
 let conversationsList = jest.fn();
+const loggerMock = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+};
+
+const getLogger = jest.fn(() => loggerMock);
 
 jest.mock('@slack/web-api', () => ({
     WebClient: jest.fn().mockImplementation(() => ({
@@ -31,6 +39,9 @@ jest.mock('@slack/web-api', () => ({
             }),
         },
     })),
+    ErrorCode: {
+        PlatformError: 'slack_webapi_platform_error',
+    },
 }));
 
 beforeEach(() => {
@@ -38,7 +49,7 @@ beforeEach(() => {
     slackApiCalls.length = 0;
     conversationsList.mockClear();
     addon = new SlackAppAddon({
-        getLogger: noLogger,
+        getLogger,
         unleashUrl: 'http://some-url.com',
     });
 });
@@ -163,4 +174,64 @@ test('Should refresh Slack channels cache after 30 seconds', async () => {
     await addon.handleEvent(event, { accessToken });
     expect(slackApiCalls.length).toBe(2);
     expect(conversationsList).toHaveBeenCalledTimes(2);
+});
+
+test('Should log error when an API call fails', async () => {
+    const event: IEvent = {
+        id: 6,
+        createdAt: new Date(),
+        type: FEATURE_ENVIRONMENT_ENABLED,
+        createdBy: 'some@user.com',
+        project: 'default',
+        featureName: 'some-toggle',
+        environment: 'development',
+        data: {
+            name: 'some-toggle',
+        },
+        tags: [{ type: 'slack', value: 'general' }],
+    };
+
+    const mockError = {
+        code: ErrorCode.PlatformError,
+        data: 'Platform error message',
+    };
+
+    jest.resetModules();
+    jest.doMock('@slack/web-api', () => ({
+        WebClient: jest.fn().mockImplementation(() => ({
+            conversations: {
+                list: jest.fn().mockResolvedValue({
+                    channels: [
+                        {
+                            id: 1,
+                            name: 'general',
+                        },
+                        {
+                            id: 2,
+                            name: 'another-channel-1',
+                        },
+                    ],
+                }),
+            },
+            chat: {
+                postMessage: jest.fn().mockRejectedValue(mockError),
+            },
+        })),
+        ErrorCode: {
+            PlatformError: 'slack_webapi_platform_error',
+        },
+    }));
+
+    const { default: NewSlackAppAddon } = await import('./slack-app');
+    addon = new NewSlackAppAddon({
+        getLogger,
+        unleashUrl: 'http://some-url.com',
+    });
+
+    await addon.handleEvent(event, { accessToken });
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+        `Error handling event ${event.type}. A platform error occurred: Platform error message`,
+        expect.any(Object),
+    );
 });

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -74,8 +74,10 @@ export default class SlackAppAddon extends Addon {
                 );
             }
 
-            if (this.slackChannels?.length) {
-                const slackChannelsToPostTo = this.slackChannels.filter(
+            const currentSlackChannels = [...this.slackChannels];
+
+            if (currentSlackChannels.length) {
+                const slackChannelsToPostTo = currentSlackChannels.filter(
                     ({ id, name }) =>
                         id && name && taggedChannels.includes(name),
                 );

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -57,7 +57,10 @@ export default class SlackAppAddon extends Addon {
                     await this.slackClient.conversations.list({
                         types: 'public_channel,private_channel',
                     });
-                this.slackChannels = slackConversationsList.channels;
+                this.slackChannels = slackConversationsList.channels || [];
+                this.logger.debug(
+                    `Fetched ${this.slackChannels.length} Slack channels`,
+                );
             }
 
             const taggedChannels = this.findTaggedChannels(event);
@@ -93,7 +96,9 @@ export default class SlackAppAddon extends Addon {
                 );
 
                 await Promise.all(requests);
-                this.logger.info(`Handled event ${event.type} dispatching ${requests.length} messages`);
+                this.logger.info(
+                    `Handled event ${event.type} dispatching ${requests.length} messages`,
+                );
             }
         } catch (error) {
             if (error.code === ErrorCode.PlatformError) {

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -115,8 +115,9 @@ export default class SlackAppAddon extends Addon {
                     `Error handling event ${event.type}. An HTTP error occurred: status code ${error.statusCode}`,
                     error,
                 );
+            } else {
+                this.logger.error(`Error handling event ${event.type}.`, error);
             }
-            this.logger.error(`Error handling event ${event.type}.`, error);
         }
     }
 

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -49,6 +49,7 @@ export default class SlackAppAddon extends Addon {
 
             if (!this.slackClient || this.accessToken !== accessToken) {
                 this.slackClient = new WebClient(accessToken);
+                this.accessToken = accessToken;
             }
 
             if (!this.slackChannels) {

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -93,7 +93,7 @@ export default class SlackAppAddon extends Addon {
                 );
 
                 await Promise.all(requests);
-                this.logger.info(`Handled event ${event.type}.`);
+                this.logger.info(`Handled event ${event.type} dispatching ${requests.length} messages`);
             }
         } catch (error) {
             if (error.code === ErrorCode.PlatformError) {

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -70,7 +70,7 @@ export default class SlackAppAddon extends Addon {
             if (!this.slackClient || this.accessToken !== accessToken) {
                 const client = new WebClient(accessToken);
                 client.on(WebClientEvent.RATE_LIMITED, (numSeconds) => {
-                    this.logger.warn(
+                    this.logger.debug(
                         `Rate limit reached for event ${event.type}. Retry scheduled after ${numSeconds} seconds`,
                     );
                 });

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -52,6 +52,10 @@ export default class SlackAppAddon extends Addon {
                 this.accessToken = accessToken;
             }
 
+            const taggedChannels = this.findTaggedChannels(event);
+
+            if (!taggedChannels.length) return;
+
             if (!this.slackChannels) {
                 const slackConversationsList =
                     await this.slackClient.conversations.list({
@@ -63,9 +67,7 @@ export default class SlackAppAddon extends Addon {
                 );
             }
 
-            const taggedChannels = this.findTaggedChannels(event);
-
-            if (this.slackChannels?.length && taggedChannels.length) {
+            if (this.slackChannels?.length) {
                 const slackChannelsToPostTo = this.slackChannels.filter(
                     ({ id, name }) =>
                         id && name && taggedChannels.includes(name),

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -59,6 +59,7 @@ async function createApp(
         stores.clientInstanceStore.destroy();
         services.clientMetricsServiceV2.destroy();
         services.proxyService.destroy();
+        services.addonService.destroy();
         await db.destroy();
     };
 

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -301,4 +301,12 @@ export default class AddonService {
         }
         return true;
     }
+
+    destroy(): void {
+        Object.values(this.addonProviders).forEach((addon) => {
+            if (addon.destroy) {
+                addon.destroy();
+            }
+        });
+    }
 }

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -303,10 +303,8 @@ export default class AddonService {
     }
 
     destroy(): void {
-        Object.values(this.addonProviders).forEach((addon) => {
-            if (addon.destroy) {
-                addon.destroy();
-            }
-        });
+        Object.values(this.addonProviders).forEach((addon) =>
+            addon.destroy?.(),
+        );
     }
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1237/explore-slack-app-addon-scalability-and-limitations

Relevant document: https://linear.app/unleash/document/894e12b7-802c-4bc5-8c22-75af0e66fa4b

 - Implements 30s cache layer for Slack channels;
 - Adds error logging;
 - Adds respective tests;
 - Slight refactors and improvements for overall robustness;