### PR TITLE
fix: DigitalOcean template

### DIFF
--- a/.do/Dockerfile
+++ b/.do/Dockerfile
@@ -1,0 +1,1 @@
+FROM unleashorg/unleash-server

--- a/.do/Dockerfile
+++ b/.do/Dockerfile
@@ -1,1 +1,0 @@
-FROM unleashorg/unleash-server

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -2,10 +2,11 @@ spec:
   name: unleash
   services:
     - name: unleash-server
-      git:
-        branch: 'fix-do-template'
-        repo_clone_url: https://github.com/Unleash/unleash.git
-      dockerfile_path: .do/Dockerfile
+      image:
+        registry_type: DOCKER_HUB
+        registry: unleashorg
+        repository: unleash-server
+        tag: latest
       envs:
         - key: DATABASE_URL
           scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,7 @@ spec:
   services:
     - name: unleash-server
       git:
-        branch: HEAD
+        branch: 4.22
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,6 +3,7 @@ spec:
   services:
     - name: unleash-server
       git:
+        branch: 4.22
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,7 @@ spec:
   services:
     - name: unleash-server
       git:
-        branch: 4.22
+        branch: '4.22'
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -5,8 +5,7 @@ spec:
       git:
         branch: 'fix-do-template'
         repo_clone_url: https://github.com/Unleash/unleash.git
-      build_command: 'yarn build'
-      run_command: 'yarn start'
+      dockerfile_path: Dockerfile
       envs:
         - key: DATABASE_URL
           scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,7 @@ spec:
   services:
     - name: unleash-server
       git:
-        branch: '4.22'
+        branch: 'fix-do-template'
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -5,7 +5,7 @@ spec:
       git:
         branch: 'fix-do-template'
         repo_clone_url: https://github.com/Unleash/unleash.git
-      dockerfile_path: Dockerfile
+      dockerfile_path: .do/Dockerfile
       envs:
         - key: DATABASE_URL
           scope: RUN_TIME

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,6 @@ spec:
   services:
     - name: unleash-server
       git:
-        branch: 4.22
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,7 @@ spec:
   services:
     - name: unleash-server
       git:
-        branch: main
+        branch: HEAD
         repo_clone_url: https://github.com/Unleash/unleash.git
       build_command: 'yarn build'
       run_command: 'yarn start'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN yarn config set network-timeout 300000
 
 RUN yarn install --frozen-lockfile --ignore-scripts && yarn prepare:backend && yarn local:package
 
-# frontend/build should already exist (it needs to be built in the local filesystem
+# frontend/build should already exist (it needs to be built in the local filesystem but in case of a fresh build we'll build it here)
+RUN yarn build:frontend:if-needed
+
 RUN mkdir -p /unleash/build/frontend && mv /unleash/frontend/build /unleash/build/frontend/build
 
 WORKDIR /unleash/docker

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "copy-templates": "copyfiles -u 1 src/mailtemplates/**/*.mustache dist/",
     "build:backend": "tsc --pretty --strictNullChecks false",
     "build:frontend": "yarn --cwd ./frontend run build",
+    "build:frontend:if-needed": "if [ ! -d ./frontend/build ]; then yarn install --cwd ./frontend --frozen-lockfile --ignore-scripts && yarn build:frontend; fi",
     "build": "concurrently \"yarn:copy-templates\" \"yarn:build:frontend\" \"yarn:build:backend\"",
     "dev:backend": "TZ=UTC NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",
     "dev:frontend": "wait-on tcp:4242 && yarn --cwd ./frontend run dev",


### PR DESCRIPTION
## About the changes
Instead of building from source (we require Node 18 but [DigitalOcean buildpack currently does not support it](https://www.digitalocean.com/community/questions/app-platform-node-build-pack-can-t-use-node-version-18)), we're going to use our Docker image from DockerHub: https://hub.docker.com/r/unleashorg/unleash-server

Additionally, I realized that our Dockerfile only works in our CI (or performing a pre-build step which consists of building the frontend). With this PR I've also made a change to build the frontend if needed. That way our CI will continue to be optimal while anyone trying to build it from source will be able to do it by just running `docker build .`

Closes #4261