### PR TITLE
fix: variant table deadlocks

### DIFF
--- a/src/lib/db/client-metrics-store-v2.ts
+++ b/src/lib/db/client-metrics-store-v2.ts
@@ -179,11 +179,21 @@ export class ClientMetricsStoreV2 implements IClientMetricsStoreV2 {
         await this.db.raw(query);
 
         const variantRows = spreadVariants(metrics).map(toVariantRow);
-        if (variantRows.length > 0) {
+
+        // Sort the rows to avoid deadlocks
+        const sortedVariantRows = variantRows.sort(
+            (a, b) =>
+                a.feature_name.localeCompare(b.feature_name) ||
+                a.app_name.localeCompare(b.app_name) ||
+                a.environment.localeCompare(b.environment) ||
+                a.variant.localeCompare(b.variant),
+        );
+
+        if (sortedVariantRows.length > 0) {
             const insertVariants = this.db<ClientMetricsEnvVariantTable>(
                 TABLE_VARIANTS,
             )
-                .insert(variantRows)
+                .insert(sortedVariantRows)
                 .toQuery();
             const variantsQuery = `${insertVariants.toString()} ON CONFLICT (feature_name, app_name, environment, timestamp, variant) DO UPDATE SET "count" = "client_metrics_env_variants"."count" + EXCLUDED.count`;
             await this.db.raw(variantsQuery);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Same as https://github.com/Unleash/unleash/pull/1100 but for the variant metrics table.

In client variant metrics v2 we utilize postgres to count the usage
across a few dimensions (feature_name, app_name, environment, variant).

It turns out that if the UPDATE values are not executed in a predictable
order we can end up in a deadlock scenario with postgresql.

In this fix we thus sort the variant metrics on the feature_name, app_name,
environment and variant, to make sure they always are executed in a predictable
order, and thus avoiding independent inserts colliding in to a deadlock
waiting for each-other.


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
