### PR TITLE
fix: Addons toggle

### DIFF
--- a/frontend/src/component/addons/AddonList/ConfiguredAddons/ConfiguredAddons.tsx
+++ b/frontend/src/component/addons/AddonList/ConfiguredAddons/ConfiguredAddons.tsx
@@ -67,7 +67,7 @@ export const ConfiguredAddons = () => {
     const columns = useMemo(
         () => [
             {
-                id: 'Icon',
+                accessor: 'id',
                 Cell: ({
                     row: {
                         original: { provider },
@@ -75,6 +75,7 @@ export const ConfiguredAddons = () => {
                 }: any) => (
                     <IconCell icon={<AddonIcon name={provider as string} />} />
                 ),
+                disableSortBy: true,
             },
             {
                 Header: 'Name',
@@ -108,6 +109,7 @@ export const ConfiguredAddons = () => {
                     row: { original: IAddon };
                 }) => (
                     <ConfiguredAddonsActionsCell
+                        key={original.id}
                         setShowDelete={setShowDelete}
                         toggleAddon={toggleAddon}
                         setDeletedAddon={setDeletedAddon}
@@ -127,7 +129,10 @@ export const ConfiguredAddons = () => {
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'provider', desc: false }],
+            sortBy: [
+                { id: 'provider', desc: false },
+                { id: 'id', desc: false },
+            ],
             hiddenColumns: ['description'],
         }),
         []


### PR DESCRIPTION
## Issue
- When you you enable/disable an addon, in the same time another one is disabled/enabled
- Sometimes, when clicking enable/disable an addon the toggle switches quick back to the initial state

## About the changes
- Stable table sorting
- Switch toggle `key`

Closes https://linear.app/unleash/issue/1-1154/addons-enabledisable-action-misbehaves-changing-other-items
