### PR TITLE
fix: missing events in the event store

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -371,7 +371,7 @@ class EventStore implements IEventStore {
     eventToDbRow(e: IBaseEvent): Omit<IEventTable, 'id' | 'created_at'> {
         return {
             type: e.type,
-            created_by: e.createdBy,
+            created_by: e.createdBy ?? 'admin',
             data: Array.isArray(e.data) ? JSON.stringify(e.data) : e.data,
             pre_data: Array.isArray(e.preData)
                 ? JSON.stringify(e.preData)


### PR DESCRIPTION
## About the changes
We are losing some events because of not having "created by" which is required by a constraint in the DB. One scenario where this can happen is with the default user admin, because it doesn't have a username or an email (unless configured by the administrator). 

Our code makes assumptions on the existence of one of these 2 attributes (e.g. https://github.com/Unleash/unleash/blob/248118af7c478f55d8583d95834fa022096d920c/src/lib/services/user-service.ts#L220-L222).

Event lost metrics:
![Screenshot from 2023-07-24 14-17-20](https://github.com/Unleash/unleash/assets/455064/9b406ad0-bbcb-4263-98dc-74ddd307a5a2)


## Discussion points
The solution proposed here is falling back to a default value. I've chosen `"admin"` because it covers one of the use cases, but it can also be `"system"` mimicking https://github.com/Unleash/unleash/blob/248118af7c478f55d8583d95834fa022096d920c/src/lib/services/user-service.ts#L32 which is used as a default, or `"unknown"` which is sometimes used as a default: https://github.com/Unleash/unleash/blob/248118af7c478f55d8583d95834fa022096d920c/src/lib/services/project-service.ts#L57

Anyway, I believe it's better not to lose the event rather than be accurate with the "created by" that can be fixed later