### PR TITLE
fix: drop staleness column form features archive

### DIFF
--- a/frontend/src/component/archive/ArchiveTable/ArchiveTable.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchiveTable.tsx
@@ -173,15 +173,6 @@ export const ArchiveTable = ({
                   ]
                 : []),
             {
-                Header: 'State',
-                accessor: 'stale',
-                Cell: FeatureStaleCell,
-                sortType: 'boolean',
-                maxWidth: 120,
-                filterName: 'state',
-                filterParsing: (value: any) => (value ? 'stale' : 'active'),
-            },
-            {
                 Header: 'Actions',
                 id: 'Actions',
                 align: 'center',


### PR DESCRIPTION
## About the changes
Drop "status" (stale or active) column from features archive table.

Closes #4315

(internal: https://linear.app/unleash/issue/1-1160/archived-toggles-are-always-displayed-as-active )
