### PR TITLE
fix: Client metrics name validation

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -15,16 +15,7 @@ exports[`should create default config 1`] = `
     "createAdminUser": true,
     "customAuthHandler": [Function],
     "enableApiToken": true,
-    "initApiTokens": [
-      {
-        "createdAt": undefined,
-        "environment": "*",
-        "project": "*",
-        "secret": "*:*.unleash-insecure-admin-api-token",
-        "tokenName": "admin",
-        "type": "admin",
-      },
-    ],
+    "initApiTokens": [],
     "type": "open-source",
   },
   "clientFeatureCaching": {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -15,7 +15,16 @@ exports[`should create default config 1`] = `
     "createAdminUser": true,
     "customAuthHandler": [Function],
     "enableApiToken": true,
-    "initApiTokens": [],
+    "initApiTokens": [
+      {
+        "createdAt": undefined,
+        "environment": "*",
+        "project": "*",
+        "secret": "*:*.unleash-insecure-admin-api-token",
+        "tokenName": "admin",
+        "type": "admin",
+      },
+    ],
     "type": "open-source",
   },
   "clientFeatureCaching": {
@@ -79,6 +88,7 @@ exports[`should create default config 1`] = `
       "embedProxyFrontend": true,
       "experimentalExtendedTelemetry": false,
       "featuresExportImport": true,
+      "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
       "groupRootRoles": false,
       "maintenanceMode": false,
@@ -113,6 +123,7 @@ exports[`should create default config 1`] = `
       "embedProxyFrontend": true,
       "experimentalExtendedTelemetry": false,
       "featuresExportImport": true,
+      "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
       "groupRootRoles": false,
       "maintenanceMode": false,

--- a/src/lib/routes/client-api/metrics.ts
+++ b/src/lib/routes/client-api/metrics.ts
@@ -65,11 +65,14 @@ export default class ClientMetricsController extends Controller {
     }
 
     async registerMetrics(req: IAuthRequest, res: Response): Promise<void> {
-        const { body: data, ip: clientIp, user } = req;
-        data.environment = this.metricsV2.resolveMetricsEnvironment(user, data);
-        await this.clientInstanceService.registerInstance(data, clientIp);
-
         try {
+            const { body: data, ip: clientIp, user } = req;
+            data.environment = this.metricsV2.resolveMetricsEnvironment(
+                user,
+                data,
+            );
+            await this.clientInstanceService.registerInstance(data, clientIp);
+
             await this.metricsV2.registerClientMetrics(data, clientIp);
             res.status(202).end();
         } catch (e) {

--- a/src/lib/services/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.test.ts
@@ -7,7 +7,7 @@ import EventEmitter from 'events';
 import { LastSeenService } from './last-seen-service';
 import { IUnleashConfig } from 'lib/types';
 
-function testSClientMetrics() {
+function testSClientMetrics(flagEnabled = true) {
     const stores = createStores();
 
     const eventBus = new EventEmitter();
@@ -19,7 +19,18 @@ function testSClientMetrics() {
     const lastSeenService = new LastSeenService(stores, config);
     lastSeenService.updateLastSeen = jest.fn();
 
-    const service = new ClientMetricsServiceV2(stores, config, lastSeenService);
+    const flagResolver = {
+        isEnabled: () => {
+            return flagEnabled;
+        },
+    };
+
+    const service = new ClientMetricsServiceV2(
+        stores,
+        config,
+        lastSeenService,
+        flagResolver,
+    );
     return { clientMetricsService: service, eventBus, lastSeenService };
 }
 
@@ -57,9 +68,35 @@ test('process metrics properly', async () => {
     expect(lastSeenService.updateLastSeen).toHaveBeenCalledTimes(1);
 });
 
-test('process metrics properly even when some names are not url friendly', async () => {
+test('flag on: process metrics properly even when some names are not url friendly, filtering out invalid names', async () => {
     const { clientMetricsService, eventBus, lastSeenService } =
         testSClientMetrics();
+    await clientMetricsService.registerClientMetrics(
+        {
+            appName: 'test',
+            bucket: {
+                start: '1982-07-25T12:00:00.000Z',
+                stop: '2023-07-25T12:00:00.000Z',
+                toggles: {
+                    'not url friendly ☹': {
+                        yes: 0,
+                        no: 100,
+                    },
+                },
+            },
+            environment: 'test',
+        },
+        '127.0.0.1',
+    );
+
+    // only toggle with a bad name gets filtered out
+    expect(eventBus.emit).not.toHaveBeenCalled();
+    expect(lastSeenService.updateLastSeen).not.toHaveBeenCalled();
+});
+
+test('flag off: process metrics properly even when some names are not url friendly, with default behavior', async () => {
+    const { clientMetricsService, eventBus, lastSeenService } =
+        testSClientMetrics(false);
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',

--- a/src/lib/services/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.test.ts
@@ -7,13 +7,12 @@ import EventEmitter from 'events';
 import { LastSeenService } from './last-seen-service';
 import { IUnleashConfig } from 'lib/types';
 
-function testSClientMetrics(flagEnabled = true) {
+function initClientMetrics(flagEnabled = true) {
     const stores = createStores();
 
     const eventBus = new EventEmitter();
     eventBus.emit = jest.fn();
 
-    // @ts-ignore only add config we care about
     const config = {
         eventBus,
         getLogger,
@@ -22,7 +21,7 @@ function testSClientMetrics(flagEnabled = true) {
                 return flagEnabled;
             },
         },
-    } as IUnleashConfig;
+    } as unknown as IUnleashConfig;
 
     const lastSeenService = new LastSeenService(stores, config);
     lastSeenService.updateLastSeen = jest.fn();
@@ -33,7 +32,7 @@ function testSClientMetrics(flagEnabled = true) {
 
 test('process metrics properly', async () => {
     const { clientMetricsService, eventBus, lastSeenService } =
-        testSClientMetrics();
+        initClientMetrics();
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',
@@ -65,9 +64,9 @@ test('process metrics properly', async () => {
     expect(lastSeenService.updateLastSeen).toHaveBeenCalledTimes(1);
 });
 
-test('flag on: process metrics properly even when some names are not url friendly, filtering out invalid names', async () => {
+test('process metrics properly even when some names are not url friendly, filtering out invalid names when flag is on', async () => {
     const { clientMetricsService, eventBus, lastSeenService } =
-        testSClientMetrics();
+        initClientMetrics();
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',
@@ -91,9 +90,9 @@ test('flag on: process metrics properly even when some names are not url friendl
     expect(lastSeenService.updateLastSeen).not.toHaveBeenCalled();
 });
 
-test('flag off: process metrics properly even when some names are not url friendly, with default behavior', async () => {
+test('process metrics properly even when some names are not url friendly, with default behavior when flag is off', async () => {
     const { clientMetricsService, eventBus, lastSeenService } =
-        testSClientMetrics(false);
+        initClientMetrics(false);
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',

--- a/src/lib/services/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.test.ts
@@ -14,23 +14,20 @@ function testSClientMetrics(flagEnabled = true) {
     eventBus.emit = jest.fn();
 
     // @ts-ignore only add config we care about
-    const config = { eventBus, getLogger } as IUnleashConfig;
+    const config = {
+        eventBus,
+        getLogger,
+        flagResolver: {
+            isEnabled: () => {
+                return flagEnabled;
+            },
+        },
+    } as IUnleashConfig;
 
     const lastSeenService = new LastSeenService(stores, config);
     lastSeenService.updateLastSeen = jest.fn();
 
-    const flagResolver = {
-        isEnabled: () => {
-            return flagEnabled;
-        },
-    };
-
-    const service = new ClientMetricsServiceV2(
-        stores,
-        config,
-        lastSeenService,
-        flagResolver,
-    );
+    const service = new ClientMetricsServiceV2(stores, config, lastSeenService);
     return { clientMetricsService: service, eventBus, lastSeenService };
 }
 

--- a/src/lib/services/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.test.ts
@@ -1,0 +1,83 @@
+import ClientMetricsServiceV2 from './metrics-service-v2';
+
+import getLogger from '../../../test/fixtures/no-logger';
+
+import createStores from '../../../test/fixtures/store';
+import EventEmitter from 'events';
+import { LastSeenService } from './last-seen-service';
+import { IUnleashConfig } from 'lib/types';
+
+function testSClientMetrics() {
+    const stores = createStores();
+
+    const eventBus = new EventEmitter();
+    eventBus.emit = jest.fn();
+
+    // @ts-ignore only add config we care about
+    const config = { eventBus, getLogger } as IUnleashConfig;
+
+    const lastSeenService = new LastSeenService(stores, config);
+    lastSeenService.updateLastSeen = jest.fn();
+
+    const service = new ClientMetricsServiceV2(stores, config, lastSeenService);
+    return { clientMetricsService: service, eventBus, lastSeenService };
+}
+
+test('process metrics properly', async () => {
+    const { clientMetricsService, eventBus, lastSeenService } =
+        testSClientMetrics();
+    await clientMetricsService.registerClientMetrics(
+        {
+            appName: 'test',
+            bucket: {
+                start: '1982-07-25T12:00:00.000Z',
+                stop: '2023-07-25T12:00:00.000Z',
+                toggles: {
+                    myCoolToggle: {
+                        yes: 25,
+                        no: 42,
+                        variants: {
+                            blue: 6,
+                            green: 15,
+                            red: 46,
+                        },
+                    },
+                    myOtherToggle: {
+                        yes: 0,
+                        no: 100,
+                    },
+                },
+            },
+            environment: 'test',
+        },
+        '127.0.0.1',
+    );
+
+    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(lastSeenService.updateLastSeen).toHaveBeenCalledTimes(1);
+});
+
+test('process metrics properly even when some names are not url friendly', async () => {
+    const { clientMetricsService, eventBus, lastSeenService } =
+        testSClientMetrics();
+    await clientMetricsService.registerClientMetrics(
+        {
+            appName: 'test',
+            bucket: {
+                start: '1982-07-25T12:00:00.000Z',
+                stop: '2023-07-25T12:00:00.000Z',
+                toggles: {
+                    'not url friendly ☹': {
+                        yes: 0,
+                        no: 100,
+                    },
+                },
+            },
+            environment: 'test',
+        },
+        '127.0.0.1',
+    );
+
+    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(lastSeenService.updateLastSeen).toHaveBeenCalledTimes(1);
+});

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -41,16 +41,15 @@ export default class ClientMetricsServiceV2 {
         { clientMetricsStoreV2 }: Pick<IUnleashStores, 'clientMetricsStoreV2'>,
         config: IUnleashConfig,
         lastSeenService: LastSeenService,
-        flagResolver: Pick<IFlagResolver, 'isEnabled'>,
         bulkInterval = secondsToMilliseconds(5),
     ) {
         this.clientMetricsStoreV2 = clientMetricsStoreV2;
         this.lastSeenService = lastSeenService;
-        this.flagResolver = flagResolver;
         this.config = config;
         this.logger = config.getLogger(
             '/services/client-metrics/client-metrics-service-v2.ts',
         );
+        this.flagResolver = config.flagResolver;
 
         this.timers.push(
             setInterval(() => {
@@ -65,7 +64,7 @@ export default class ClientMetricsServiceV2 {
         );
     }
 
-    async validate(toggleNames: string[]): Promise<string[]> {
+    async validToggleNames(toggleNames: string[]): Promise<string[]> {
         const nameValidations: Promise<
             PromiseFulfilledResult<{ name: string }> | PromiseRejectedResult
         >[] = [];
@@ -113,7 +112,7 @@ export default class ClientMetricsServiceV2 {
                 ),
         );
 
-        const validatedToggleNames = await this.validate(toggleNames);
+        const validatedToggleNames = await this.validToggleNames(toggleNames);
 
         this.logger.debug(
             `Got ${toggleNames.length} (${validatedToggleNames.length} valid) metrics from ${clientIp}`,

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -20,6 +20,8 @@ import { collapseHourlyMetrics } from '../../util/collapseHourlyMetrics';
 import { LastSeenService } from './last-seen-service';
 import { generateHourBuckets } from '../../util/time-utils';
 import { ClientMetricsSchema } from 'lib/openapi';
+import { nameSchema } from '../../schema/feature-schema';
+import { BadDataError } from '../../error';
 
 export default class ClientMetricsServiceV2 {
     private config: IUnleashConfig;
@@ -80,6 +82,14 @@ export default class ClientMetricsServiceV2 {
                     value.bucket.toggles[name].no === 0
                 ),
         );
+
+        for (const toggle of toggleNames) {
+            if (!(await nameSchema.validateAsync({ name: toggle }))) {
+                throw new BadDataError(
+                    `Invalid feature toggle name "${toggle}"`,
+                );
+            }
+        }
 
         this.logger.debug(`got metrics from ${clientIp}`);
 

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -123,10 +123,10 @@ export default class ClientMetricsServiceV2 {
                 (name) => ({
                     featureName: name,
                     appName: value.appName,
-                    environment: value.environment,
+                    environment: value.environment ?? 'default',
                     timestamp: value.bucket.start, //we might need to approximate between start/stop...
-                    yes: value.bucket.toggles[name].yes,
-                    no: value.bucket.toggles[name].no,
+                    yes: value.bucket.toggles[name].yes ?? 0,
+                    no: value.bucket.toggles[name].no ?? 0,
                     variants: value.bucket.toggles[name].variants,
                 }),
             );

--- a/src/lib/services/client-metrics/metrics-service-v2.ts
+++ b/src/lib/services/client-metrics/metrics-service-v2.ts
@@ -64,13 +64,12 @@ export default class ClientMetricsServiceV2 {
         );
     }
 
-    async validToggleNames(toggleNames: string[]): Promise<string[]> {
+    async filterValidToggleNames(toggleNames: string[]): Promise<string[]> {
         const nameValidations: Promise<
             PromiseFulfilledResult<{ name: string }> | PromiseRejectedResult
-        >[] = [];
-        for (const toggle of toggleNames) {
-            nameValidations.push(nameSchema.validateAsync({ name: toggle }));
-        }
+        >[] = toggleNames.map((toggleName) =>
+            nameSchema.validateAsync({ name: toggleName }),
+        );
         const badNames = (await Promise.allSettled(nameValidations)).filter(
             (r) => r.status === 'rejected',
         );
@@ -112,7 +111,9 @@ export default class ClientMetricsServiceV2 {
                 ),
         );
 
-        const validatedToggleNames = await this.validToggleNames(toggleNames);
+        const validatedToggleNames = await this.filterValidToggleNames(
+            toggleNames,
+        );
 
         this.logger.debug(
             `Got ${toggleNames.length} (${validatedToggleNames.length} valid) metrics from ${clientIp}`,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -25,7 +25,8 @@ export type IFlagKey =
     | 'disableNotifications'
     | 'advancedPlayground'
     | 'customRootRoles'
-    | 'strategySplittedButton';
+    | 'strategySplittedButton'
+    | 'filterInvalidClientMetrics';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -116,6 +117,10 @@ const flags: IFlags = {
     ),
     customRootRoles: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CUSTOM_ROOT_ROLES,
+        false,
+    ),
+    filterInvalidClientMetrics: parseEnvVarBoolean(
+        process.env.FILTER_INVALID_CLIENT_METRICS,
         false,
     ),
 };


### PR DESCRIPTION
## About the changes
1. Add a test for the failing use case (we can see it [here](https://github.com/Unleash/unleash/actions/runs/5656229196/job/15322845002?pr=4339#step:5:783)):
```
FAIL src/lib/services/client-metrics/metrics-service-v2.test.ts
  ● process metrics properly even when some names are not url friendly

    ValidationError: "name" must be URL friendly
```
2. Fix and handle this gracefully

Fixes: https://github.com/Unleash/unleash/pull/4193