### PR TITLE
fix: sync enabled and variant status

### DIFF
--- a/src/lib/features/playground/feature-evaluator/feature-evaluator.ts
+++ b/src/lib/features/playground/feature-evaluator/feature-evaluator.ts
@@ -104,6 +104,10 @@ export class FeatureEvaluator {
 
     forceGetVariant(
         name: string,
+        forcedResults: Pick<
+            FeatureStrategiesEvaluationResult,
+            'result' | 'variant'
+        >,
         context: Context = {},
         fallbackVariant?: Variant,
     ): Variant {
@@ -111,6 +115,7 @@ export class FeatureEvaluator {
         return this.client.forceGetVariant(
             name,
             enhancedContext,
+            forcedResults,
             fallbackVariant,
         );
     }

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -176,7 +176,11 @@ export class PlaygroundService {
                             data: strategyEvaluationResult.strategies,
                         },
                         projectId: featureProject[feature.name],
-                        variant: client.getVariant(feature.name, clientContext),
+                        variant: client.forceGetVariant(
+                            feature.name,
+                            strategyEvaluationResult,
+                            clientContext,
+                        ),
                         name: feature.name,
                         environment,
                         context,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When we have non 100% gradual rollout with random stickiness enabled status and variant value were getting out of sync. This was because variant is checking isEnabled under the hood. In the new version we also verify isEnabled result (than contains enabled strategy variant). The new force version accepts the explicit evaluation result instead of a boolean flag.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
