### PR TITLE
openapi: enable strict schema validation by default and fix

### DIFF
--- a/src/lib/openapi/spec/__snapshots__/token-user-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/token-user-schema.test.ts.snap
@@ -15,15 +15,6 @@ exports[`tokenUserSchema 1`] = `
     {
       "instancePath": "",
       "keyword": "required",
-      "message": "must have required property 'name'",
-      "params": {
-        "missingProperty": "name",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
       "message": "must have required property 'email'",
       "params": {
         "missingProperty": "email",

--- a/src/lib/openapi/spec/public-signup-token-schema.ts
+++ b/src/lib/openapi/spec/public-signup-token-schema.ts
@@ -29,6 +29,7 @@ export const publicSignupTokenSchema = {
             description:
                 'The public signup link for the token. Users who follow this link will be taken to a signup page where they can create an Unleash user.',
             type: 'string',
+            nullable: true,
             example:
                 'https://sandbox.getunleash.io/enterprise/new-user?invite=a3c84b25409ea8ca1782ef17f94a42fc',
         },

--- a/src/lib/openapi/spec/token-user-schema.ts
+++ b/src/lib/openapi/spec/token-user-schema.ts
@@ -6,7 +6,7 @@ export const tokenUserSchema = {
     type: 'object',
     additionalProperties: false,
     description: 'A user identified by a token',
-    required: ['id', 'name', 'email', 'token', 'createdBy', 'role'],
+    required: ['id', 'email', 'token', 'createdBy', 'role'],
     properties: {
         id: {
             type: 'integer',

--- a/src/lib/openapi/spec/user-schema.ts
+++ b/src/lib/openapi/spec/user-schema.ts
@@ -25,6 +25,7 @@ export const userSchema = {
             description: 'Name of the user',
             type: 'string',
             example: 'User',
+            nullable: true,
         },
         email: {
             description: 'Email of the user',

--- a/src/lib/routes/admin-api/tag-type.ts
+++ b/src/lib/routes/admin-api/tag-type.ts
@@ -18,11 +18,11 @@ import {
     resourceCreatedResponseSchema,
 } from '../../openapi/util/create-response-schema';
 import { TagTypesSchema } from '../../openapi/spec/tag-types-schema';
-import { ValidateTagTypeSchema } from '../../openapi/spec/validate-tag-type-schema';
 import {
-    tagTypeSchema,
-    TagTypeSchema,
-} from '../../openapi/spec/tag-type-schema';
+    validateTagTypeSchema,
+    ValidateTagTypeSchema,
+} from '../../openapi/spec/validate-tag-type-schema';
+import { TagTypeSchema } from '../../openapi/spec/tag-type-schema';
 import { UpdateTagTypeSchema } from '../../openapi/spec/update-tag-type-schema';
 import { OpenApiService } from '../../services/openapi-service';
 import {
@@ -180,10 +180,16 @@ class TagTypeController extends Controller {
         res: Response<ValidateTagTypeSchema>,
     ): Promise<void> {
         await this.tagTypeService.validate(req.body);
-        this.openApiService.respondWithValidation(200, res, tagTypeSchema.$id, {
-            valid: true,
-            tagType: req.body,
-        });
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            validateTagTypeSchema.$id,
+            {
+                valid: true,
+                tagType: req.body,
+            },
+        );
     }
 
     async createTagType(

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -179,7 +179,16 @@ async function createApp(
         server: {
             unleashUrl: 'http://localhost:4242',
         },
-        ...customOptions,
+        ...{
+            ...customOptions,
+            experimental: {
+                ...(customOptions?.experimental ?? {}),
+                flags: {
+                    strictSchemaValidation: true,
+                    ...(customOptions?.experimental?.flags ?? {}),
+                },
+            },
+        },
     });
     const services = createServices(stores, config, db);
     const unleashSession = sessionDb(config, undefined);


### PR DESCRIPTION
Enable strict schema validation by default. It can still be overridden by explicitly setting it to false.

I've also fixed the validation errors that appeared when turning it on. I've opted for the simplest route and changed the schemas to comply with the tests.