### PR TITLE
fix: UI improvements on CR reorder strategy

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
@@ -25,16 +25,15 @@ const StyledStrategyExecutionWrapper = styled(Box)(({ theme }) => ({
     flexDirection: 'column',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    marginBottom: theme.spacing(2),
-    marginTop: theme.spacing(2),
     lineHeight: theme.spacing(3),
-    gap: theme.spacing(1),
+    gap: theme.spacing(2.5),
+    marginBottom: theme.spacing(1),
 }));
 
-const StyledStrategyContainer = styled('div')(({ theme }) => ({
+const StyledStrategyContainer = styled('div')({
     flexDirection: 'row',
-    marginBottom: theme.spacing(2),
-}));
+    width: '100%',
+});
 
 interface IEnvironmentStrategyExecutionOrderProps {
     feature: string;


### PR DESCRIPTION
- make the blocks that hold the constraints full width
- remove the margin-top and margin-bottom from the parent div + increase the gap: 20px on this parent div
- remove the margin-bottom from the constraints containers
- add the strategies in a div and add a margin-bottom: 8px

![Screenshot 2023-07-31 at 15 05 51](https://github.com/Unleash/unleash/assets/104830839/68c32324-99c3-4fab-99f0-bde1bf2b43e7)

