### PR TITLE
fix: EventStore#getMaxRevisionId can return null

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -162,7 +162,7 @@ class EventStore implements IEventStore {
             )
             .andWhere('id', '>=', largerThan)
             .first();
-        return row ? row.max : -1;
+        return row?.max ?? 0;
     }
 
     async delete(key: number): Promise<void> {

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -18,10 +18,11 @@ export default class ConfigurationRevisionService extends EventEmitter {
         super();
         this.logger = getLogger('configuration-revision-service.ts');
         this.eventStore = eventStore;
+        this.revisionId = 0;
     }
 
     async getMaxRevisionId(): Promise<number> {
-        if (this.revisionId) {
+        if (this.revisionId > 0) {
             return this.revisionId;
         } else {
             return this.updateMaxRevisionId();


### PR DESCRIPTION
In a new fresh Unleash instance with cache enabled this can cause feature toggles to never get updated.

We saw in our client that the ETag was ETag: "60e35fba:null" Which looked incorrect for us.

I also did manual testing and if the andWhere had a value of largerThan higher than whatever the id was then we would get back { max: null }.

This should fix that issue.