### PR TITLE
fix: Password hash is null should yield PasswordMissmatch

### DIFF
--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -34,7 +34,6 @@ class IndexRouter extends Controller {
                 max: 10,
                 standardHeaders: true,
                 legacyHeaders: false,
-                validate: false,
             }),
         );
         this.use(

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -34,6 +34,7 @@ class IndexRouter extends Controller {
                 max: 10,
                 standardHeaders: true,
                 legacyHeaders: false,
+                validate: false,
             }),
         );
         this.use(

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -296,13 +296,12 @@ class UserService {
             ? { email: usernameOrEmail }
             : { username: usernameOrEmail };
 
-        let user;
+        let user, passwordHash;
         try {
             user = await this.store.getByQuery(idQuery);
+            passwordHash = await this.store.getPasswordHash(user.id);
         } catch (error) {}
-        if (user) {
-            const passwordHash = await this.store.getPasswordHash(user.id);
-
+        if (user && passwordHash) {
             const match = await bcrypt.compare(password, passwordHash);
             if (match) {
                 await this.store.successfullyLogin(user);

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -122,6 +122,25 @@ test('should not be able to login with deleted user', async () => {
     );
 });
 
+test('should not be able to login without password_hash on user', async () => {
+    const user = await userService.createUser({
+        username: 'deleted_user',
+        password: 'unleash4all',
+        rootRole: adminRole.id,
+    });
+
+    /*@ts-ignore: we are testing for null on purpose! */
+    await userStore.setPasswordHash(user.id, null);
+
+    await expect(
+        userService.loginUser('deleted_user', 'anything-should-fail'),
+    ).rejects.toThrow(
+        new PasswordMismatch(
+            `The combination of password and username you provided is invalid. If you have forgotten your password, visit /forgotten-password or get in touch with your instance administrator.`,
+        ),
+    );
+});
+
 test('should not login user if simple auth is disabled', async () => {
     await settingService.insert(
         simpleAuthSettingsKey,


### PR DESCRIPTION
We are giving a strange error message if the user does not have a password_hash defined in the database. 