### PR TITLE
1-1192: track the feature type and the new lifetime

### DIFF
--- a/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.tsx
@@ -79,14 +79,19 @@ export const FeatureTypeForm: VFC<FeatureTypeFormProps> = ({
                 throw new Error('No feature toggle type loaded');
 
             const value = doesntExpire ? 0 : lifetime;
-            await updateFeatureTypeLifetime(featureType?.id, value);
+            await updateFeatureTypeLifetime(featureType.id, value);
             refetch();
             setToastData({
                 title: 'Feature type updated',
                 type: 'success',
             });
             navigate('/feature-toggle-type');
-            tracker.trackEvent('feature-type-edit');
+            tracker.trackEvent('feature-type-edit', {
+                props: {
+                    featureTypeId: featureType.id,
+                    newLifetime: value,
+                },
+            });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
         }


### PR DESCRIPTION
This PR adds tracking of the feature type and the new lifetime to the
existing plausible event. This allows us extra insights into what users change it to.