### PR TITLE
feat: allow trust proxy

### DIFF
--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -289,6 +289,7 @@ export default class UserAdminController extends Controller {
                 rateLimit({
                     windowMs: minutesToMilliseconds(1),
                     max: 20,
+                    validate: false,
                     standardHeaders: true,
                     legacyHeaders: false,
                 }),

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -32,6 +32,7 @@ class IndexRouter extends Controller {
             rateLimit({
                 windowMs: minutesToMilliseconds(1),
                 max: 10,
+                validate: false,
                 standardHeaders: true,
                 legacyHeaders: false,
             }),


### PR DESCRIPTION
We have configured the trust proxy setting to true. With this configuration, the application places trust in the "X-Forwarded-For" header and considers the left-most entry in the header as the client's IP address. By doing so, the application relies on the proxy or load balancer to accurately set the "X-Forwarded-For" header with the correct client IP address.

However, it is important to be aware that this configuration also opens up the possibility of bypassing IP-based rate limiting. The rate-limiter system is currently logging this situation as a warning to alert us.

With this PR we are suppressing the warning.