### PR TITLE
fix: environment id missing bug

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -143,7 +143,7 @@ export const ChangeActions: FC<{
                                         </ListItemIcon>
                                         <ListItemText>
                                             <Typography variant="body2">
-                                                Edit changes
+                                                Edit change
                                             </Typography>
                                         </ListItemText>
                                         <EditChange

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -143,7 +143,7 @@ export const ChangeActions: FC<{
                                         </ListItemIcon>
                                         <ListItemText>
                                             <Typography variant="body2">
-                                                Edit change
+                                                Edit changes
                                             </Typography>
                                         </ListItemText>
                                         <EditChange

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -257,6 +257,8 @@ export const FeatureStrategyForm = ({
                     <StrategyVariants
                         strategy={strategy}
                         setStrategy={setStrategy}
+                        environment={environmentId}
+                        projectId={projectId}
                     />
                 }
             />

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.test.tsx
@@ -32,7 +32,12 @@ test('should render variants', async () => {
         currentStrategy = strategy;
 
         return (
-            <StrategyVariants strategy={strategy} setStrategy={setStrategy} />
+            <StrategyVariants
+                strategy={strategy}
+                setStrategy={setStrategy}
+                projectId={'default'}
+                environment={'development'}
+            />
         );
     };
     render(

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -24,9 +24,9 @@ export const StrategyVariants: FC<{
         React.SetStateAction<Partial<IFeatureStrategy>>
     >;
     strategy: Partial<IFeatureStrategy>;
-}> = ({ strategy, setStrategy }) => {
-    const projectId = useRequiredPathParam('projectId');
-    const environment = useRequiredQueryParam('environmentId');
+    projectId: string;
+    environment: string;
+}> = ({ strategy, setStrategy, projectId, environment }) => {
     const [variantsEdit, setVariantsEdit] = useState<IFeatureVariantEdit[]>([]);
     const theme = useTheme();
     const stickiness =


### PR DESCRIPTION
When editing change request, there are no query params set, so need to pass in as props.

![image](https://github.com/Unleash/unleash/assets/964450/1855b219-1cc9-4b60-88b8-08419026e637)