### PR TITLE
#4209: add 'add to draft' button for segments.

### DIFF
--- a/frontend/src/component/common/UpdateButton/UpdateButton.tsx
+++ b/frontend/src/component/common/UpdateButton/UpdateButton.tsx
@@ -2,10 +2,13 @@ import PermissionButton, {
     IPermissionButtonProps,
 } from 'component/common/PermissionButton/PermissionButton';
 
-export const UpdateButton = ({ ...rest }: IPermissionButtonProps) => {
+export const UpdateButton = ({
+    children = 'Save',
+    ...rest
+}: IPermissionButtonProps) => {
     return (
         <PermissionButton type="submit" {...rest}>
-            Save
+            {children}
         </PermissionButton>
     );
 };

--- a/frontend/src/component/segments/EditSegment/EditSegment.tsx
+++ b/frontend/src/component/segments/EditSegment/EditSegment.tsx
@@ -19,6 +19,7 @@ import { useSegmentValuesCount } from 'component/segments/hooks/useSegmentValues
 import { SEGMENT_SAVE_BTN_ID } from 'utils/testIds';
 import { useSegmentLimits } from 'hooks/api/getters/useSegmentLimits/useSegmentLimits';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 
 interface IEditSegmentProps {
     modal?: boolean;
@@ -56,6 +57,10 @@ export const EditSegment = ({ modal }: IEditSegmentProps) => {
     const hasValidConstraints = useConstraintsValidation(constraints);
     const segmentValuesCount = useSegmentValuesCount(constraints);
     const { segmentValuesLimit } = useSegmentLimits();
+
+    const { isChangeRequestConfiguredInAnyEnv } = useChangeRequestsEnabled(
+        segment?.project || ''
+    );
 
     const overSegmentValuesLimit: boolean = Boolean(
         segmentValuesLimit && segmentValuesCount > segmentValuesLimit

--- a/frontend/src/component/segments/EditSegment/EditSegment.tsx
+++ b/frontend/src/component/segments/EditSegment/EditSegment.tsx
@@ -76,7 +76,7 @@ export const EditSegment = ({ modal }: IEditSegmentProps) => {
             clearErrors();
             try {
                 await updateSegment(segment.id, getSegmentPayload());
-                await refetchSegments();
+                refetchSegments();
                 if (projectId) {
                     navigate(`/projects/${projectId}/settings/segments/`);
                 } else {

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -55,6 +55,7 @@ export interface IFlags {
     newProjectLayout?: boolean;
     configurableFeatureTypeLifetimes?: boolean;
     frontendNavigationUpdate?: boolean;
+    segmentChangeRequests?: boolean;
 }
 
 export interface IVersionInfo {


### PR DESCRIPTION
Note: it doesn't work yet! It just throws an error.

This PR adds some logic to conditionally display "Add to draft" button for segments if the segment is part of a project that has change requests enabled and the flag is enabled.

Also adds a flag (`segmentChangeRequests`) to the frontend.

Holding off on actually adding the change to a draft until the API/orval has been updated with the most recent changes.