### PR TITLE
chore: reduce build time

### DIFF
--- a/.github/workflows/build_prs_jest_report.yaml
+++ b/.github/workflows/build_prs_jest_report.yaml
@@ -1,10 +1,11 @@
 name: PR -> Test & Coverage
 
 on:
-  pull_request:
-    paths-ignore:
-      - frontend/**
-      - website/**
+  # pull_request:
+  #   paths-ignore:
+  #     - frontend/**
+  #     - website/**
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build_prs_jest_report.yaml
+++ b/.github/workflows/build_prs_jest_report.yaml
@@ -1,10 +1,12 @@
-name: PR -> Test & Coverage
+name: Test & Coverage
 
 on:
   # pull_request:
   #   paths-ignore:
   #     - frontend/**
   #     - website/**
+  schedule: # Run every day
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prebuild:watch": "yarn run clean",
     "build:watch": "tsc -w --strictNullChecks false",
     "prebuild": "yarn run clean",
-    "test": "NODE_ENV=test PORT=4243 jest",
+    "test": "NODE_ENV=test PORT=4243 jest --maxWorkers=20",
     "test:unit": "NODE_ENV=test PORT=4243 jest --testPathIgnorePatterns=src/test/e2e --testPathIgnorePatterns=dist",
     "test:docker": "./scripts/docker-postgres.sh",
     "test:report": "NODE_ENV=test PORT=4243 jest --reporters=\"default\" --reporters=\"jest-junit\"",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:watch": "yarn test --watch",
     "test:coverage": "NODE_ENV=test PORT=4243 jest --coverage --testLocationInResults --outputFile=\"coverage/report.json\" --forceExit --testTimeout=10000",
     "pretest:coverage:jest": "yarn build:frontend",
-    "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000",
+    "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000 --maxWorkers=20",
     "seed:setup": "ts-node --compilerOptions '{\"strictNullChecks\": false}' src/test/e2e/seed/segment.seed.ts",
     "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prebuild:watch": "yarn run clean",
     "build:watch": "tsc -w --strictNullChecks false",
     "prebuild": "yarn run clean",
-    "test": "NODE_ENV=test PORT=4243 jest --maxWorkers=20",
+    "test": "NODE_ENV=test PORT=4243 jest",
     "test:unit": "NODE_ENV=test PORT=4243 jest --testPathIgnorePatterns=src/test/e2e --testPathIgnorePatterns=dist",
     "test:docker": "./scripts/docker-postgres.sh",
     "test:report": "NODE_ENV=test PORT=4243 jest --reporters=\"default\" --reporters=\"jest-junit\"",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:watch": "yarn test --watch",
     "test:coverage": "NODE_ENV=test PORT=4243 jest --coverage --testLocationInResults --outputFile=\"coverage/report.json\" --forceExit --testTimeout=10000",
     "pretest:coverage:jest": "yarn build:frontend",
-    "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000 --maxWorkers=20",
+    "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000",
     "seed:setup": "ts-node --compilerOptions '{\"strictNullChecks\": false}' src/test/e2e/seed/segment.seed.ts",
     "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",


### PR DESCRIPTION
## About the changes
~~Test if max-workers can speed up test runs~~ No, this didn't help.
Disabling the job that takes longer should help mitigate. We lose the coverage report but we still test our code: https://github.com/Unleash/unleash/actions/runs/5751945832/job/15591813034?pr=4405#step:7:2396

This cuts the build time by 50% and moving this to a daily schedule