### PR TITLE
feat(#4205): add segment to drafts

### DIFF
--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -2,14 +2,15 @@ import useAPI from '../useApi/useApi';
 import { usePlausibleTracker } from '../../../usePlausibleTracker';
 
 export interface IChangeSchema {
-    feature: string;
+    feature: string | null;
     action:
         | 'updateEnabled'
         | 'addStrategy'
         | 'updateStrategy'
         | 'deleteStrategy'
         | 'patchVariant'
-        | 'reorderStrategy';
+        | 'reorderStrategy'
+        | 'updateSegment';
     payload: string | boolean | object | number;
 }
 

--- a/frontend/src/hooks/useChangeRequestsEnabled.ts
+++ b/frontend/src/hooks/useChangeRequestsEnabled.ts
@@ -41,9 +41,22 @@ export const useChangeRequestsEnabled = (projectId: string) => {
         return data.some(draft => draft.changeRequestEnabled);
     }, [JSON.stringify(data)]);
 
+    const highestPermissionChangeRequestEnv = React.useCallback(():
+        | string
+        | undefined => {
+        const changeRequestEnvs = data.filter(env => env.changeRequestEnabled);
+
+        const env =
+            changeRequestEnvs.find(env => env.environment === 'production') ??
+            changeRequestEnvs[0];
+
+        return env.environment;
+    }, [JSON.stringify(data)]);
+
     return {
         isChangeRequestConfigured,
         isChangeRequestConfiguredInAnyEnv,
         isChangeRequestConfiguredForReview,
+        highestPermissionChangeRequestEnv,
     };
 };


### PR DESCRIPTION
This PR sends segments to CR drafts when you use the `add to draft` button.

It also adds the logic for which environment to pick.

Segments sent to the API are added to drafts, but not displayed in the UI yet. CRs with only segment changes are also not listed in the table. This'll be covered in upcoming work.