### PR TITLE
feat: protect segment operations for change requests

### DIFF
--- a/src/lib/features/change-request-access-service/change-request-access-read-model.ts
+++ b/src/lib/features/change-request-access-service/change-request-access-read-model.ts
@@ -6,6 +6,10 @@ export interface IChangeRequestAccessReadModel {
         environment: string,
         user?: User,
     ): Promise<boolean>;
+    canBypassChangeRequestForProject(
+        project: string,
+        user?: User,
+    ): Promise<boolean>;
     isChangeRequestsEnabled(
         project: string,
         environment: string,

--- a/src/lib/features/change-request-access-service/fake-change-request-access-read-model.ts
+++ b/src/lib/features/change-request-access-service/fake-change-request-access-read-model.ts
@@ -16,6 +16,10 @@ export class FakeChangeRequestAccessReadModel
         return this.canBypass;
     }
 
+    public async canBypassChangeRequestForProject(): Promise<boolean> {
+        return this.canBypass;
+    }
+
     public async isChangeRequestsEnabled(): Promise<boolean> {
         return this.isChangeRequestEnabled;
     }

--- a/src/lib/features/change-request-access-service/sql-change-request-access-read-model.ts
+++ b/src/lib/features/change-request-access-service/sql-change-request-access-read-model.ts
@@ -32,7 +32,7 @@ export class ChangeRequestAccessReadModel
                 : Promise.resolve(false),
             this.isChangeRequestsEnabled(project, environment),
         ]);
-        return !(changeRequestEnabled && !canSkipChangeRequest);
+        return canSkipChangeRequest || !changeRequestEnabled;
     }
 
     public async canBypassChangeRequestForProject(
@@ -49,7 +49,7 @@ export class ChangeRequestAccessReadModel
                 : Promise.resolve(false),
             this.isChangeRequestsEnabledForProject(project),
         ]);
-        return !(changeRequestEnabled && !canSkipChangeRequest);
+        return canSkipChangeRequest || !changeRequestEnabled;
     }
 
     public async isChangeRequestsEnabled(

--- a/src/lib/features/change-request-access-service/sql-change-request-access-read-model.ts
+++ b/src/lib/features/change-request-access-service/sql-change-request-access-read-model.ts
@@ -35,6 +35,23 @@ export class ChangeRequestAccessReadModel
         return !(changeRequestEnabled && !canSkipChangeRequest);
     }
 
+    public async canBypassChangeRequestForProject(
+        project: string,
+        user?: User,
+    ): Promise<boolean> {
+        const [canSkipChangeRequest, changeRequestEnabled] = await Promise.all([
+            user
+                ? this.accessService.hasPermission(
+                      user,
+                      SKIP_CHANGE_REQUEST,
+                      project,
+                  )
+                : Promise.resolve(false),
+            this.isChangeRequestsEnabledForProject(project),
+        ]);
+        return !(changeRequestEnabled && !canSkipChangeRequest);
+    }
+
     public async isChangeRequestsEnabled(
         project: string,
         environment: string,

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -2,7 +2,6 @@ import {
     AccessService,
     FeatureToggleService,
     GroupService,
-    SegmentService,
 } from '../../services';
 import FeatureStrategiesStore from '../../db/feature-strategy-store';
 import FeatureToggleStore from '../../db/feature-toggle-store';
@@ -10,7 +9,6 @@ import FeatureToggleClientStore from '../../db/feature-toggle-client-store';
 import ProjectStore from '../../db/project-store';
 import FeatureTagStore from '../../db/feature-tag-store';
 import { FeatureEnvironmentStore } from '../../db/feature-environment-store';
-import SegmentStore from '../../db/segment-store';
 import ContextFieldStore from '../../db/context-field-store';
 import GroupStore from '../../db/group-store';
 import { AccountStore } from '../../db/account-store';
@@ -26,7 +24,6 @@ import FakeFeatureToggleClientStore from '../../../test/fixtures/fake-feature-to
 import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
-import FakeSegmentStore from '../../../test/fixtures/fake-segment-store';
 import FakeContextFieldStore from '../../../test/fixtures/fake-context-field-store';
 import FakeGroupStore from '../../../test/fixtures/fake-group-store';
 import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
@@ -38,6 +35,10 @@ import {
     createChangeRequestAccessReadModel,
     createFakeChangeRequestAccessService,
 } from '../change-request-access-service/createChangeRequestAccessReadModel';
+import {
+    createFakeSegmentService,
+    createSegmentService,
+} from '../segment/createSegmentService';
 
 export const createFeatureToggleService = (
     db: Db,
@@ -69,12 +70,6 @@ export const createFeatureToggleService = (
         eventBus,
         getLogger,
     );
-    const segmentStore = new SegmentStore(
-        db,
-        eventBus,
-        getLogger,
-        flagResolver,
-    );
     const contextFieldStore = new ContextFieldStore(
         db,
         getLogger,
@@ -95,11 +90,8 @@ export const createFeatureToggleService = (
         { getLogger, flagResolver },
         groupService,
     );
-    const segmentService = new SegmentService(
-        { segmentStore, featureStrategiesStore, eventStore },
-        config,
-    );
-    const changeRequestAccessReadMode = createChangeRequestAccessReadModel(
+    const segmentService = createSegmentService(db, config);
+    const changeRequestAccessReadModel = createChangeRequestAccessReadModel(
         db,
         config,
     );
@@ -117,7 +109,7 @@ export const createFeatureToggleService = (
         { getLogger, flagResolver },
         segmentService,
         accessService,
-        changeRequestAccessReadMode,
+        changeRequestAccessReadModel,
     );
     return featureToggleService;
 };
@@ -133,7 +125,6 @@ export const createFakeFeatureToggleService = (
     const projectStore = new FakeProjectStore();
     const featureTagStore = new FakeFeatureTagStore();
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
-    const segmentStore = new FakeSegmentStore();
     const contextFieldStore = new FakeContextFieldStore();
     const groupStore = new FakeGroupStore();
     const accountStore = new FakeAccountStore();
@@ -149,11 +140,8 @@ export const createFakeFeatureToggleService = (
         { getLogger, flagResolver },
         groupService,
     );
-    const segmentService = new SegmentService(
-        { segmentStore, featureStrategiesStore, eventStore },
-        config,
-    );
-    const changeRequestAccessReadMode = createFakeChangeRequestAccessService();
+    const segmentService = createFakeSegmentService(config);
+    const changeRequestAccessReadModel = createFakeChangeRequestAccessService();
     const featureToggleService = new FeatureToggleService(
         {
             featureStrategiesStore,
@@ -168,7 +156,7 @@ export const createFakeFeatureToggleService = (
         { getLogger, flagResolver },
         segmentService,
         accessService,
-        changeRequestAccessReadMode,
+        changeRequestAccessReadModel,
     );
     return featureToggleService;
 };

--- a/src/lib/features/segment/createSegmentService.ts
+++ b/src/lib/features/segment/createSegmentService.ts
@@ -7,11 +7,15 @@ import FeatureStrategiesStore from '../../db/feature-strategy-store';
 import SegmentStore from '../../db/segment-store';
 import FakeSegmentStore from '../../../test/fixtures/fake-segment-store';
 import FakeFeatureStrategiesStore from '../../../test/fixtures/fake-feature-strategies-store';
+import {
+    createChangeRequestAccessReadModel,
+    createFakeChangeRequestAccessService,
+} from '../change-request-access-service/createChangeRequestAccessReadModel';
 
 export const createSegmentService = (
     db: Db,
     config: IUnleashConfig,
-): ISegmentService => {
+): SegmentService => {
     const { eventBus, getLogger, flagResolver } = config;
     const eventStore = new EventStore(db, getLogger);
     const segmentStore = new SegmentStore(
@@ -26,9 +30,14 @@ export const createSegmentService = (
         getLogger,
         flagResolver,
     );
+    const changeRequestAccessReadModel = createChangeRequestAccessReadModel(
+        db,
+        config,
+    );
 
     return new SegmentService(
         { segmentStore, featureStrategiesStore, eventStore },
+        changeRequestAccessReadModel,
         config,
     );
 };
@@ -39,9 +48,11 @@ export const createFakeSegmentService = (
     const eventStore = new FakeEventStore();
     const segmentStore = new FakeSegmentStore();
     const featureStrategiesStore = new FakeFeatureStrategiesStore();
+    const changeRequestAccessReadModel = createFakeChangeRequestAccessService();
 
     return new SegmentService(
         { segmentStore, featureStrategiesStore, eventStore },
+        changeRequestAccessReadModel,
         config,
     );
 };

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -34,7 +34,15 @@ export interface ISegmentService {
         user: Partial<Pick<IUser, 'username' | 'email'>>,
     ): Promise<void>;
 
+    unprotectedUpdate(
+        id: number,
+        data: UpsertSegmentSchema,
+        user: Partial<Pick<IUser, 'username' | 'email'>>,
+    ): Promise<void>;
+
     delete(id: number, user: IUser): Promise<void>;
+
+    unprotectedDelete(id: number, user: IUser): Promise<void>;
 
     removeFromStrategy(id: number, strategyId: string): Promise<void>;
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -176,10 +176,14 @@ export const createServices = (
     const versionService = new VersionService(stores, config);
     const healthService = new HealthService(stores, config);
     const userFeedbackService = new UserFeedbackService(stores, config);
-    const segmentService = new SegmentService(stores, config);
     const changeRequestAccessReadModel = db
         ? createChangeRequestAccessReadModel(db, config)
         : createFakeChangeRequestAccessService();
+    const segmentService = new SegmentService(
+        stores,
+        changeRequestAccessReadModel,
+        config,
+    );
     const featureToggleServiceV2 = new FeatureToggleService(
         stores,
         config,

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -231,7 +231,7 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, config),
+        new SegmentService(stores, changeRequestAccessReadModel, config),
         accessService,
         changeRequestAccessReadModel,
     );

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -34,7 +34,7 @@ beforeAll(async () => {
     const featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, config),
+        new SegmentService(stores, changeRequestAccessReadModel, config),
         accessService,
         changeRequestAccessReadModel,
     );

--- a/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
+++ b/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
@@ -40,12 +40,17 @@ beforeAll(async () => {
     );
     unleashConfig = config;
     stores = db.stores;
-    segmentService = new SegmentService(stores, config);
+
     const groupService = new GroupService(stores, config);
     const accessService = new AccessService(stores, config, groupService);
     const changeRequestAccessReadModel = new ChangeRequestAccessReadModel(
         db.rawDatabase,
         accessService,
+    );
+    segmentService = new SegmentService(
+        stores,
+        changeRequestAccessReadModel,
+        config,
     );
     service = new FeatureToggleService(
         stores,

--- a/src/test/e2e/services/playground-service.test.ts
+++ b/src/test/e2e/services/playground-service.test.ts
@@ -36,12 +36,16 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('playground_service_serial', config.getLogger);
     stores = db.stores;
-    segmentService = new SegmentService(stores, config);
     const groupService = new GroupService(stores, config);
     const accessService = new AccessService(stores, config, groupService);
     const changeRequestAccessReadModel = new ChangeRequestAccessReadModel(
         db.rawDatabase,
         accessService,
+    );
+    segmentService = new SegmentService(
+        stores,
+        changeRequestAccessReadModel,
+        config,
     );
     featureToggleService = new FeatureToggleService(
         stores,

--- a/src/test/e2e/services/project-health-service.e2e.test.ts
+++ b/src/test/e2e/services/project-health-service.e2e.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, config),
+        new SegmentService(stores, changeRequestAccessReadModel, config),
         accessService,
         changeRequestAccessReadModel,
     );

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -58,7 +58,7 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, config),
+        new SegmentService(stores, changeRequestAccessReadModel, config),
         accessService,
         changeRequestAccessReadModel,
     );

--- a/src/test/fixtures/fake-project-store.ts
+++ b/src/test/fixtures/fake-project-store.ts
@@ -177,7 +177,7 @@ export default class FakeProjectStore implements IProjectStore {
         projectId: string,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         environment: string,
-    ): Promise<CreateFeatureStrategySchema | undefined> {
+    ): Promise<CreateFeatureStrategySchema | null> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Update segment and delete segment now have protected mode which means that with CR enabled you can't change them willy-nilly. You either need skip permission for any project environment or go through a change request.

There's a corresponding enterprise change where I have tests and fix breaking changes.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I noticed that we have interface for the segment service. Since this is the only service with an interface it looks odd. I'm tempted to remove it since there's only one impl of the interface and TS is structurally typed. @gastonfournier since you added the interface WDYT?