### PR TITLE
meta: add CODEOWNERS and set thomas as docs owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# docs
+/website/ @thomasheartman


### PR DESCRIPTION
This change adds a CODEOWNERS file to the repository, which is used by
GitHub to automatically assign pull requests to the right people. It
also sets @thomasheartman as the owner of the docs directory (`/website`), which
means that he will be automatically assigned to pull requests that
touch docs.