### PR TITLE
chore: increase max app names to 1000

### DIFF
--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -7,7 +7,7 @@ import { InstanceStatsService } from 'lib/services';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _responseTime = responseTime.default;
 
-const appNameReportingThreshold = 100;
+const appNameReportingThreshold = 1000;
 
 export function responseTimeMetrics(
     eventBus: EventEmitter,


### PR DESCRIPTION
## About the changes
Looking at our metrics this number should be a good threshold, giving us more functionality than just limiting it to 100.