### PR TITLE
openapi: Add new tags for API operations.

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -34,6 +34,11 @@ const OPENAPI_TAGS = [
     },
     { name: 'Auth', description: 'Manage logins, passwords, etc.' },
     {
+        name: 'Change Requests',
+        description:
+            'Operations related to [Change Requests](https://docs.getunleash.io/reference/change-requests).',
+    },
+    {
         name: 'Client',
         description:
             'Endpoints for [Unleash server-side clients](https://docs.getunleash.io/reference/sdks).',
@@ -55,6 +60,11 @@ const OPENAPI_TAGS = [
             'Create, update, and delete [features toggles](https://docs.getunleash.io/reference/feature-toggles).',
     },
     {
+        name: 'Feature Types',
+        description:
+            'Manage [feature toggle types](https://docs.getunleash.io/reference/feature-toggle-types).',
+    },
+    {
         name: 'Import/Export',
         description:
             '[Import and export](https://docs.getunleash.io/deploy/import_export) the state of your Unleash instance.',
@@ -67,6 +77,11 @@ const OPENAPI_TAGS = [
     {
         name: 'Metrics',
         description: 'Register, read, or delete metrics recorded by Unleash.',
+    },
+    {
+        name: 'Notifications',
+        description:
+            'Manage [notifications](https://docs.getunleash.io/reference/notifications).',
     },
     {
         name: 'Operational',


### PR DESCRIPTION
The new endpoints will be used to categorize and stabilize operations currently marked as unstable.