### PR TITLE
chore(#4209): minor front-end fixes

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChange.tsx
@@ -44,7 +44,7 @@ export const SegmentChange: FC<ISegmentChangeProps> = ({
 
                 <Link
                     component={RouterLink}
-                    to={`/segments/${segmentChange.payload.id}`}
+                    to={`/segments/edit/${segmentChange.payload.id}`}
                     color="primary"
                     underline="hover"
                     sx={{

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
@@ -38,6 +38,7 @@ const SegmentContainer = styled(Box)(({ theme }) => ({
     borderColor: theme.palette.divider,
     borderTopColor: theme.palette.divider,
     padding: theme.spacing(3),
+    borderRadius: `0 0 ${theme.shape.borderRadiusLarge}px ${theme.shape.borderRadiusLarge}px`,
 }));
 
 export const SegmentChangeDetails: VFC<{


### PR DESCRIPTION
This PR fixes links to segments from change requests and the bottom border radius for segment change boxes.

Old border radius:
![image](https://github.com/Unleash/unleash/assets/17786332/e2485e8c-9dab-4fbc-8604-6abd48e13be1)


New border radius: 
![image](https://github.com/Unleash/unleash/assets/17786332/2e2f54b0-37c0-4cec-9902-14b43827beaf)
