### PR TITLE
Feat(#4209): add conflict marker to segment changes

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Conflict.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/Conflict.tsx
@@ -1,0 +1,24 @@
+import { Alert } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+
+export const ConflictWarning: React.FC<{
+    conflict: string | null | undefined;
+}> = ({ conflict }) => (
+    <ConditionallyRender
+        condition={Boolean(conflict)}
+        show={
+            <Alert
+                severity="warning"
+                sx={{
+                    px: 3,
+                    mb: 2,
+                    '&.MuiAlert-standardWarning': {
+                        borderStyle: 'none',
+                    },
+                }}
+            >
+                <strong>Conflict!</strong> {conflict}.
+            </Alert>
+        }
+    />
+);

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChange.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { Box, Card, Typography, Link } from '@mui/material';
 import { ISegmentChange } from '../../../changeRequest.types';
 import { SegmentChangeDetails } from './SegmentChangeDetails';
+import { ConflictWarning } from './Conflict';
 
 interface ISegmentChangeProps {
     segmentChange: ISegmentChange;
@@ -27,11 +28,15 @@ export const SegmentChange: FC<ISegmentChangeProps> = ({
                 borderRadius: theme =>
                     `${theme.shape.borderRadiusLarge}px ${theme.shape.borderRadiusLarge}px 0 0`,
                 border: '1px solid',
-                borderColor: theme => theme.palette.divider,
+                borderColor: theme =>
+                    segmentChange.conflict
+                        ? theme.palette.warning.border
+                        : theme.palette.divider,
                 borderBottom: 'none',
                 overflow: 'hidden',
             })}
         >
+            <ConflictWarning conflict={segmentChange.conflict} />
             <Box
                 sx={{
                     display: 'flex',

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
@@ -48,7 +48,14 @@ export const SegmentChangeDetails: VFC<{
     const { segment: currentSegment } = useSegment(change.payload.id);
 
     return (
-        <SegmentContainer>
+        <SegmentContainer
+            sx={theme => ({
+                borderColor: change.conflict
+                    ? theme.palette.warning.border
+                    : theme.palette.divider,
+                borderTopColor: theme.palette.divider,
+            })}
+        >
             {change.action === 'deleteSegment' && (
                 <ChangeItemWrapper>
                     <ChangeItemInfo>

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/FeatureToggleChanges.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/FeatureToggleChanges.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Alert, Box, Card, Typography, Link } from '@mui/material';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { Box, Card, Typography, Link } from '@mui/material';
+import { ConflictWarning } from './Change/Conflict';
 
 interface IFeatureToggleChanges {
     featureName: string;
@@ -40,23 +40,7 @@ export const FeatureToggleChanges: FC<IFeatureToggleChanges> = ({
                 overflow: 'hidden',
             })}
         >
-            <ConditionallyRender
-                condition={Boolean(conflict)}
-                show={
-                    <Alert
-                        severity="warning"
-                        sx={{
-                            px: 3,
-                            mb: 2,
-                            '&.MuiAlert-standardWarning': {
-                                borderStyle: 'none',
-                            },
-                        }}
-                    >
-                        <strong>Conflict!</strong> {conflict}.
-                    </Alert>
-                }
-            />
+            <ConflictWarning conflict={conflict} />
             <Box
                 sx={{
                     display: 'flex',

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -111,6 +111,7 @@ export interface IChangeRequestReorderStrategy
 
 export interface IChangeRequestUpdateSegment {
     action: 'updateSegment';
+    conflict?: string;
     payload: {
         id: number;
         name: string;
@@ -122,6 +123,7 @@ export interface IChangeRequestUpdateSegment {
 
 export interface IChangeRequestDeleteSegment {
     action: 'deleteSegment';
+    conflict?: string;
     payload: {
         id: number;
         name: string;


### PR DESCRIPTION
In doing so, we extract the shared conflict marker component from the
feature change and reuse it for both feature and segment changes.