### PR TITLE
fix: proper aggregation of strategies

### DIFF
--- a/src/lib/openapi/spec/playground-strategy-schema.ts
+++ b/src/lib/openapi/spec/playground-strategy-schema.ts
@@ -28,7 +28,7 @@ export const strategyEvaluationResults = {
                     description:
                         "Whether this strategy resolves to `false` or if it might resolve to `true`. Because Unleash can't evaluate the strategy, it can't say for certain whether it will be `true`, but if you have failing constraints or segments, it _can_ determine that your strategy would be `false`.",
                     anyOf: [
-                        { type: 'boolean', enum: [false] },
+                        { type: 'boolean', default: false },
                         {
                             type: 'string',
                             enum: [playgroundStrategyEvaluation.unknownResult],

--- a/src/lib/openapi/spec/playground-strategy-schema.ts
+++ b/src/lib/openapi/spec/playground-strategy-schema.ts
@@ -28,7 +28,7 @@ export const strategyEvaluationResults = {
                     description:
                         "Whether this strategy resolves to `false` or if it might resolve to `true`. Because Unleash can't evaluate the strategy, it can't say for certain whether it will be `true`, but if you have failing constraints or segments, it _can_ determine that your strategy would be `false`.",
                     anyOf: [
-                        { type: 'boolean', default: false },
+                        { type: 'boolean', enum: [false] },
                         {
                             type: 'string',
                             enum: [playgroundStrategyEvaluation.unknownResult],

--- a/src/lib/routes/admin-api/strategy.ts
+++ b/src/lib/routes/admin-api/strategy.ts
@@ -138,7 +138,7 @@ class StrategyController extends Controller {
 
         this.route({
             method: 'put',
-            path: '/:strategyName',
+            path: '/:name',
             handler: this.updateStrategy,
             permission: UPDATE_STRATEGY,
             middleware: [

--- a/src/lib/routes/admin-api/strategy.ts
+++ b/src/lib/routes/admin-api/strategy.ts
@@ -257,13 +257,13 @@ class StrategyController extends Controller {
     }
 
     async updateStrategy(
-        req: IAuthRequest<{ strategyName: string }, UpdateStrategySchema>,
+        req: IAuthRequest<{ name: string }, UpdateStrategySchema>,
         res: Response<void>,
     ): Promise<void> {
         const userName = extractUsername(req);
 
         await this.strategyService.updateStrategy(
-            { ...req.body, name: req.params.strategyName },
+            { ...req.body, name: req.params.name },
             userName,
         );
         res.status(200).end();


### PR DESCRIPTION
## About the changes
Open API is creating 2 resources under the same URL path, we want them aggregated:
```shell
$ curl -s https://us.app.unleash-hosted.com/ushosted/docs/openapi.json | jq '.paths."/api/admin/strategies/{name}" | keys'
[
  "delete",
  "get"
]
gaston@gaston-Summit-E16Flip-A12UCT: ~/poc/terraform-provider-unleash on main [!$]
$ curl -s https://us.app.unleash-hosted.com/ushosted/docs/openapi.json | jq '.paths."/api/admin/strategies/{strategyName}" | keys'
[
  "put"
]
```

Note one is under `{name}` while the other is under `{strategyName}` 