### PR TITLE
fix: multiline textarea resizing for json input

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -86,9 +86,10 @@ const StyledFieldColumn = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledInput = styled(Input)(() => ({
+const StyledInput = styled(Input)(({theme}) => ({
     width: '100%',
     '& textarea': {
+        minHeight: theme.spacing(3),
         resize: 'vertical',
     },
 }));

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -88,6 +88,9 @@ const StyledFieldColumn = styled('div')(({ theme }) => ({
 
 const StyledInput = styled(Input)(() => ({
     width: '100%',
+    '& textarea': {
+        resize: 'vertical',
+    },
 }));
 
 const StyledPercentageContainer = styled('div')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -86,7 +86,7 @@ const StyledFieldColumn = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledInput = styled(Input)(({theme}) => ({
+const StyledInput = styled(Input)(({ theme }) => ({
     width: '100%',
     '& textarea': {
         minHeight: theme.spacing(3),


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

### Background
https://github.com/orgs/Unleash/discussions/4450

### Problem
The textarea when adding JSON payload was of fixed size and did not allow resizing. Although MUI knows to render [TextareaAutosize](https://mui.com/material-ui/react-textarea-autosize/) when `multiline=true` as suggested in their docs - https://mui.com/material-ui/react-text-field/#multiline, but even in their examples in the docs, the resizing is not present. So perhaps some bug on their end  

### Solution
With this PR we are adding `resize: vertical` styling if the `Input` component is rendering the native `textarea`. 
This solution will make both `json` and `csv` payload type inputs resizable since they both render as `textarea`

https://github.com/Unleash/unleash/assets/5814269/a484c457-25fc-47bc-bf92-5de4770d16cd