### PR TITLE
test: fix import and access e2e tests due to recent changes

### DIFF
--- a/frontend/cypress/integration/import/import.spec.ts
+++ b/frontend/cypress/integration/import/import.spec.ts
@@ -122,6 +122,10 @@ describe('imports', () => {
         )
             .invoke('attr', 'aria-label')
             .should('eq', 'development');
+
+        cy.get(
+            '[data-testid="FEATURE_ENVIRONMENT_ACCORDION_development"]'
+        ).click();
         cy.contains('50%');
     });
 });

--- a/frontend/cypress/integration/projects/access.spec.ts
+++ b/frontend/cypress/integration/projects/access.spec.ts
@@ -118,7 +118,9 @@ describe('project-access', () => {
         ).as('editAccess');
 
         cy.get(`[data-testid='${PA_ROLE_ID}']`).click();
-        cy.contains('within a project are allowed').click({ force: true });
+        cy.contains('update feature toggles within a project').click({
+            force: true,
+        });
 
         cy.get(`[data-testid='${PA_ASSIGN_CREATE_ID}']`).click();
         cy.wait('@editAccess');


### PR DESCRIPTION
This should fix `import` and `access` Cypress e2e tests after recent changes were introduced:

 - `import.spec.ts` - Expected '50%' to be contained in the page, however now [we are lazy loading the accordion content](https://github.com/Unleash/unleash/pull/4454);
 - `access.spec.ts` - Expected 'within a project are allowed' to be visible as a role description, however [we updated the predefined roles descriptions](https://github.com/Unleash/unleash/pull/4451);