### PR TITLE
chore: type our path parameters

### DIFF
--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -363,6 +363,15 @@ export default class UserAdminController extends Controller {
                     description:
                         'Only the explicitly specified fields get updated.',
                     requestBody: createRequestSchema('updateUserSchema'),
+                    parameters: [
+                        {
+                            name: 'id',
+                            in: 'path',
+                            schema: {
+                                type: 'integer',
+                            },
+                        },
+                    ],
                     responses: {
                         200: createResponseSchema('createUserResponseSchema'),
                         ...getStandardResponses(400, 401, 403, 404),


### PR DESCRIPTION
Path types in our openapi are inferred as string (which is a sensible default). But we can be more specific and provide the right type for each parameter. This is one example of how we can do that

@thomasheartman WDYT?