### PR TITLE
feat: use update count in cr summary

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
@@ -13,6 +13,7 @@ import {
 } from './ChangeRequestHeader.styles';
 import { Separator } from '../../ChangeRequestSidebar/ChangeRequestSidebar';
 import { ChangeRequestTitle } from '../../ChangeRequestSidebar/EnvironmentChangeRequest/ChangeRequestTitle';
+import { UpdateCount } from 'component/changeRequest/UpdateCount';
 
 export const ChangeRequestHeader: FC<{ changeRequest: IChangeRequest }> = ({
     changeRequest,
@@ -73,18 +74,12 @@ export const ChangeRequestHeader: FC<{ changeRequest: IChangeRequest }> = ({
                             >
                                 {changeRequest?.environment}
                             </Typography>{' '}
-                            <Separator /> Updates:{' '}
-                            <Typography
-                                variant="body2"
-                                display="inline"
-                                fontWeight="bold"
-                                component="span"
-                            >
-                                {changeRequest.features.length}{' '}
-                                {changeRequest.features.length === 1
-                                    ? 'feature toggle'
-                                    : 'feature toggles'}
-                            </Typography>
+                            <Separator />
+                            Updates:
+                            <UpdateCount
+                                featuresCount={changeRequest.features.length}
+                                segmentsCount={changeRequest.segments.length}
+                            />
                         </Typography>
                     </StyledCard>
                 </Box>

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -67,49 +67,6 @@ export const Separator = () => (
     </Typography>
 );
 
-export const UpdateCount: FC<{
-    featuresCount: number;
-    segmentsCount: number;
-}> = ({ featuresCount, segmentsCount }) => (
-    <Box>
-        <Typography component="span" variant="body1" color="text.secondary">
-            Updates:{' '}
-        </Typography>
-        <Typography
-            component="span"
-            sx={{
-                fontWeight: 'bold',
-            }}
-        >
-            {featuresCount}{' '}
-            {featuresCount === 1 ? 'feature toggle' : 'feature toggles'}
-        </Typography>
-        <ConditionallyRender
-            condition={segmentsCount > 0}
-            show={
-                <>
-                    <Typography
-                        component="span"
-                        variant="body1"
-                        color="text.secondary"
-                    >
-                        {' and '}
-                    </Typography>
-                    <Typography
-                        component="span"
-                        sx={{
-                            fontWeight: 'bold',
-                        }}
-                    >
-                        {segmentsCount}{' '}
-                        {segmentsCount === 1 ? 'segment' : 'segments'}
-                    </Typography>
-                </>
-            }
-        />
-    </Box>
-);
-
 export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
     open,
     project,

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
@@ -16,13 +16,13 @@ import {
     Separator,
     StyledFlexAlignCenterBox,
     StyledSuccessIcon,
-    UpdateCount,
 } from '../ChangeRequestSidebar';
 import { CloudCircle } from '@mui/icons-material';
 import { AddCommentField } from '../../ChangeRequestOverview/ChangeRequestComments/AddCommentField';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import Input from 'component/common/Input/Input';
 import { ChangeRequestTitle } from './ChangeRequestTitle';
+import { UpdateCount } from 'component/changeRequest/UpdateCount';
 
 const SubmitChangeRequestButton: FC<{ onClick: () => void; count: number }> = ({
     onClick,
@@ -85,6 +85,13 @@ export const EnvironmentChangeRequest: FC<{
                             {environmentChangeRequest.environment}
                         </Typography>
                         <Separator />
+                        <Typography
+                            component="span"
+                            variant="body2"
+                            color="text.secondary"
+                        >
+                            Updates:
+                        </Typography>
                         <UpdateCount
                             featuresCount={
                                 environmentChangeRequest.features.length

--- a/frontend/src/component/changeRequest/UpdateCount.test.tsx
+++ b/frontend/src/component/changeRequest/UpdateCount.test.tsx
@@ -1,6 +1,6 @@
 import { render } from 'utils/testRenderer';
 import React from 'react';
-import { UpdateCount } from './ChangeRequestSidebar';
+import { UpdateCount } from './UpdateCount';
 import { screen } from '@testing-library/react';
 
 test('Show only features count when no segments', async () => {

--- a/frontend/src/component/changeRequest/UpdateCount.tsx
+++ b/frontend/src/component/changeRequest/UpdateCount.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+import { ConditionallyRender } from '../common/ConditionallyRender/ConditionallyRender';
+
+export const UpdateCount: FC<{
+    featuresCount: number;
+    segmentsCount: number;
+}> = ({ featuresCount, segmentsCount }) => (
+    <Box sx={{ display: 'inline', pl: 0.5 }}>
+        <Typography
+            component="span"
+            variant="body2"
+            fontWeight="bold"
+            display="inline"
+        >
+            {featuresCount}{' '}
+            {featuresCount === 1 ? 'feature toggle' : 'feature toggles'}
+        </Typography>
+        <ConditionallyRender
+            condition={segmentsCount > 0}
+            show={
+                <>
+                    <Typography component="span" variant="body2">
+                        {' and '}
+                    </Typography>
+                    <Typography
+                        component="span"
+                        variant="body2"
+                        fontWeight="bold"
+                        display="inline"
+                    >
+                        {segmentsCount}{' '}
+                        {segmentsCount === 1 ? 'segment' : 'segments'}
+                    </Typography>
+                </>
+            }
+        />
+    </Box>
+);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Update count is used not just in sidebar but also the summary screen. I tried to extract a shared component.

<img width="898" alt="Screenshot 2023-08-11 at 14 36 23" src="https://github.com/Unleash/unleash/assets/1394682/df0fa53d-a334-4fcb-8836-919d8be49092">

<img width="963" alt="Screenshot 2023-08-11 at 14 36 28" src="https://github.com/Unleash/unleash/assets/1394682/31ed4a1c-5ed0-47f7-bba4-0747205f5bab">



### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
