### PR TITLE
fix: add timezones to timestamps

### DIFF
--- a/src/migrations/20230814115436-change-request-timzone-timestamps.js
+++ b/src/migrations/20230814115436-change-request-timzone-timestamps.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            ALTER TABLE change_request_rejections ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
+            ALTER TABLE change_request_approvals ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
+            ALTER TABLE change_request_comments ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
+            ALTER TABLE change_request_events ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
+            ALTER TABLE change_requests ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    callback();
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

All change request tables use timestamps with timezones now.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I'm assuming that we don't need to specify default now() if it was specified originally. Also I'm assuming this is a nonbreaking change. Finally I don't provide back migration similarly to previous similar changes.