### PR TITLE
fix: Change slackapp to using scheduleMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     ]
   },
   "dependencies": {
-    "@slack/web-api": "^6.8.1",
+    "@slack/web-api": "^6.9.0",
     "@unleash/express-openapi": "^0.3.0",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -12,7 +12,7 @@ import Addon from './addon';
 
 import slackAppDefinition from './slack-app-definition';
 import { IAddonConfig } from '../types/model';
-
+const SCHEDULE_MESSAGE_DELAY_IN_SECONDS = 10;
 import {
     FeatureEventFormatter,
     FeatureEventFormatterMd,
@@ -79,7 +79,7 @@ export default class SlackAppAddon extends Addon {
             const url = this.msgFormatter.featureLink(event);
             const requests = eventChannels.map((name) => {
                 const now = Math.floor(new Date().getTime() / 1000);
-                const postAt = now + 10;
+                const postAt = now + SCHEDULE_MESSAGE_DELAY_IN_SECONDS;
                 return this.slackClient!.chat.scheduleMessage({
                     channel: name,
                     text,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,24 +1068,24 @@
   dependencies:
     "@types/node" ">=12.0.0"
 
-"@slack/types@^2.0.0":
+"@slack/types@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.8.0.tgz#11ea10872262a7e6f86f54e5bcd4f91e3a41fe91"
   integrity sha512-ghdfZSF0b4NC9ckBA8QnQgC9DJw2ZceDq0BIjjRSv6XAZBXJdWgxIsYz0TYnWSiqsKZGH2ZXbj9jYABZdH3OSQ==
 
-"@slack/web-api@^6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.8.1.tgz#c6c1e7405c884c4d9048f8b1d3901bd138d00610"
-  integrity sha512-eMPk2S99S613gcu7odSw/LV+Qxr8A+RXvBD0GYW510wJuTERiTjP5TgCsH8X09+lxSumbDE88wvWbuFuvGa74g==
+"@slack/web-api@^6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.9.0.tgz#d829dcfef490dbce8e338912706b6f39dcde3ad2"
+  integrity sha512-RME5/F+jvQmZHkoP+ogrDbixq1Ms1mBmylzuWq4sf3f7GCpMPWoiZ+WqWk+sism3vrlveKWIgO9R4Qg9fiRyoQ==
   dependencies:
     "@slack/logger" "^3.0.0"
-    "@slack/types" "^2.0.0"
+    "@slack/types" "^2.8.0"
     "@types/is-stream" "^1.1.0"
     "@types/node" ">=12.0.0"
     axios "^0.27.2"
     eventemitter3 "^3.1.0"
     form-data "^2.5.0"
-    is-electron "2.2.0"
+    is-electron "2.2.2"
     is-stream "^1.1.0"
     p-queue "^6.6.1"
     p-retry "^4.0.0"
@@ -4359,10 +4359,10 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-electron@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
-  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
+is-electron@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
 
 is-extendable@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
### What
This PR changes the slack-app addon to use slack-api's scheduleMessage instead of postMessage.

### Why
When using postMessage we had to find the channel id in order to be able to post the message to the channel. scheduleMessage allows using the channel name instead of the id, which saves the entire struggle of finding the channel name. It did mean that we had to move to defining blocks of content instead of the easier formatting we did with postMessage. 

### Message look
![image](https://github.com/Unleash/unleash/assets/177402/a9079c4d-07c0-4846-ad0c-67130e77fb3b)
