### PR TITLE
chore: fix formatting of openapi description

### DIFF
--- a/src/lib/openapi/spec/search-events-schema.ts
+++ b/src/lib/openapi/spec/search-events-schema.ts
@@ -27,12 +27,7 @@ export const searchEventsSchema = {
         },
         query: {
             type: 'string',
-            description: `
-                Find events by a free-text search query.
-                The query will be matched against the event type,
-                the username or email that created the event (if any),
-                and the event data payload (if any).
-            `,
+            description: `Find events by a free-text search query. The query will be matched against the event type, the username or email that created the event (if any), and the event data payload (if any).`,
             example: 'admin@example.com',
         },
         limit: {


### PR DESCRIPTION
The indented formatting makes it interpreted as a markdown code block.
This isn't what we want. It's not as pretty, but putting it on one
line makes it render correctly.

What it looks like today:
![image](https://github.com/Unleash/unleash/assets/17786332/5e462931-5a3b-4b75-9cb5-0b21da4838b1)
