### PR TITLE
feat: get api tokens by name

### DIFF
--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -182,7 +182,7 @@ export class ApiTokenController extends Controller {
                     operationId: 'getApiTokensByName',
                     summary: 'Get API tokens by name',
                     description:
-                        'Retrieves all API tokens that match a given token name. Token names are not unique so 0, 1 or many tokens can be returned.',
+                        'Retrieves all API tokens that match a given token name. Because token names are not unique, this endpoint will always return a list. If no tokens with the provided name exist, the list will be empty. Otherwise, it will contain all the tokens with the given name. 
                     responses: {
                         200: createResponseSchema('apiTokensSchema'),
                         ...getStandardResponses(401, 403),

--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -182,7 +182,7 @@ export class ApiTokenController extends Controller {
                     operationId: 'getApiTokensByName',
                     summary: 'Get API tokens by name',
                     description:
-                        'Retrieves all API tokens that match a given token name. Because token names are not unique, this endpoint will always return a list. If no tokens with the provided name exist, the list will be empty. Otherwise, it will contain all the tokens with the given name. 
+                        'Retrieves all API tokens that match a given token name. Because token names are not unique, this endpoint will always return a list. If no tokens with the provided name exist, the list will be empty. Otherwise, it will contain all the tokens with the given name.',
                     responses: {
                         200: createResponseSchema('apiTokensSchema'),
                         ...getStandardResponses(401, 403),

--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -48,6 +48,9 @@ import { OperationDeniedError } from '../../error';
 interface TokenParam {
     token: string;
 }
+interface TokenNameParam {
+    name: string;
+}
 export const tokenTypeToCreatePermission: (
     tokenType: ApiTokenType,
 ) => string = (tokenType) => {
@@ -169,6 +172,26 @@ export class ApiTokenController extends Controller {
         });
 
         this.route({
+            method: 'get',
+            path: '/:name',
+            handler: this.getApiTokensByName,
+            permission: [ADMIN, READ_CLIENT_API_TOKEN, READ_FRONTEND_API_TOKEN],
+            middleware: [
+                openApiService.validPath({
+                    tags: ['API tokens'],
+                    operationId: 'getApiTokensByName',
+                    summary: 'Get API tokens by name',
+                    description:
+                        'Retrieves all API tokens that match a given token name. Token names are not unique so 0, 1 or many tokens can be returned.',
+                    responses: {
+                        200: createResponseSchema('apiTokensSchema'),
+                        ...getStandardResponses(401, 403),
+                    },
+                }),
+            ],
+        });
+
+        this.route({
             method: 'post',
             path: '',
             handler: this.createApiToken,
@@ -251,6 +274,22 @@ export class ApiTokenController extends Controller {
     ): Promise<void> {
         const { user } = req;
         const tokens = await this.accessibleTokens(user);
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            apiTokensSchema.$id,
+            { tokens: serializeDates(tokens) },
+        );
+    }
+
+    async getApiTokensByName(
+        req: IAuthRequest<TokenNameParam>,
+        res: Response<ApiTokensSchema>,
+    ): Promise<void> {
+        const { user } = req;
+        const { name } = req.params;
+
+        const tokens = await this.accessibleTokensByName(name, user);
         this.openApiService.respondWithValidation(
             200,
             res,
@@ -359,6 +398,14 @@ export class ApiTokenController extends Controller {
         await this.apiTokenService.delete(token, extractUsername(req));
         await this.proxyService.deleteClientForProxyToken(token);
         res.status(200).end();
+    }
+
+    private async accessibleTokensByName(
+        tokenName: string,
+        user: User,
+    ): Promise<IApiToken[]> {
+        const allTokens = await this.accessibleTokens(user);
+        return allTokens.filter((token) => token.tokenName === tokenName);
     }
 
     private async accessibleTokens(user: User): Promise<IApiToken[]> {

--- a/src/test/e2e/api/admin/api-token.e2e.test.ts
+++ b/src/test/e2e/api/admin/api-token.e2e.test.ts
@@ -157,9 +157,17 @@ test('creates a lot of client tokens', async () => {
         );
     }
     await Promise.all(requests);
-    expect.assertions(2);
-    return app.request
+    expect.assertions(4);
+    await app.request
         .get('/api/admin/api-tokens')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.tokens.length).toBe(10);
+            expect(res.body.tokens[2].type).toBe('client');
+        });
+    await app.request
+        .get('/api/admin/api-tokens/default-client')
         .expect('Content-Type', /json/)
         .expect(200)
         .expect((res) => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* Get API tokens by name
* There can be 0, 1 or many tokens. I decided to always return 200 with either empty list, one element list, multi-element list. It feels the most idiomatic approach with a list returned. Originally the plan was to return 404 when the token doesn't exist but for the list/collection based APIs this feels wrong. 
* Current I'm adding in-memory filtering so that we don't have to over-invest in DB access code. Once the capability is found to be useful we can follow-up with more perf optimized solution.
* Also the existing code for tokens was mostly implemented in the controller layer instead of the service layer. I don't want to do massive refactoring and move everything to the service layer in this PR

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
