### PR TITLE
chore: remove additionalProperterties annotation.

### DIFF
--- a/src/lib/openapi/spec/token-string-list-schema.ts
+++ b/src/lib/openapi/spec/token-string-list-schema.ts
@@ -3,7 +3,6 @@ import { FromSchema } from 'json-schema-to-ts';
 export const tokenStringListSchema = {
     $id: '#/components/schemas/tokenStringListSchema',
     type: 'object',
-    additionalProperties: true,
     description: 'A list of unleash tokens to validate against known tokens',
     required: ['tokens'],
     properties: {


### PR DESCRIPTION
Unless you set it to `false`, additional properties are always
allowed. By explicitly setting it to `true` the generated
examples contain additional properties, e.g.:

```json
{
  "tokens": [
    "aproject:development.randomstring",
    "[]:production.randomstring"
  ],
  "additionalProp1": {}
}
```

By removing the explicit annotation, we still allow additional
properties, but we don't get them in examples:

```json
{
  "tokens": [
    "aproject:development.randomstring",
    "[]:production.randomstring"
  ]
}
```