### PR TITLE
feat: slack-app can now post to both tagged and default channel

### DIFF
--- a/src/lib/addons/slack-app-definition.ts
+++ b/src/lib/addons/slack-app-definition.ts
@@ -57,6 +57,14 @@ const slackAppDefinition: IAddonDefinition = {
             required: false,
             sensitive: false,
         },
+        {
+            name: 'alwaysPostToDefault',
+            displayName: 'Always post to default channels',
+            description: `If set to 'true' or 'yes', the app will always post events to the default channels, even if the feature toggle has slack tags`,
+            type: 'text',
+            required: false,
+            sensitive: false,
+        },
     ],
     events: [
         FEATURE_CREATED,


### PR DESCRIPTION
Currently the slack-app addon only posts to either the tagged channel for the feature or the default channels. This PR adds a new field that will allow you to configure the addon to post to both the default channels and the tagged channel (s)