### PR TITLE
fix: set css preload to false

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,7 @@ export default mergeConfig(
             outDir: 'build',
             assetsDir: 'static',
             modulePreload: false,
+            cssCodeSplit: false,
         },
         server: {
             open: true,


### PR DESCRIPTION
After dependabot upgraded us to the new version of Vite, we started having failures on the preloading of CSS modules on certain lazy loaded modules. After investigation, it seems like Vite was adding another stylesheet into the head element when the lazy loaded modules were requested. These stylesheets had the wrong relative path when the assets were loaded from our CDN. We are not sure why this fails, but for now we are turning off cssPreloading. 

The impact is small, because we have few lazy loaded modules that preload the CSS.