### PR TITLE
fix: disallow empty summaries and descriptions

### DIFF
--- a/src/test/e2e/api/openapi/openapi.e2e.test.ts
+++ b/src/test/e2e/api/openapi/openapi.e2e.test.ts
@@ -193,7 +193,7 @@ test('all tags are listed in the root "tags" list', async () => {
     expect(invalidTags).toStrictEqual({});
 });
 
-test('all API operations have summaries and descriptions', async () => {
+test('all API operations have non-empty summaries and descriptions', async () => {
     const { body: spec } = await app.request
         .get('/docs/openapi.json')
         .expect('Content-Type', /json/)
@@ -203,8 +203,8 @@ test('all API operations have summaries and descriptions', async () => {
         return Object.entries(data)
             .map(([verb, operationDescription]) => {
                 if (
-                    'summary' in operationDescription &&
-                    'description' in operationDescription
+                    operationDescription.summary &&
+                    operationDescription.description
                 ) {
                     return undefined;
                 } else {


### PR DESCRIPTION
This change tests that all OpenAPI operations not only have summaries and descriptions, but that they are non-empty. This is important because empty summaries and descriptions (i.e. '') break the OpenAPI generation in our docs, blocking all doc builds.