### PR TITLE
Add condition for getting max revision id from store

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -3,6 +3,7 @@ import {
     IBaseEvent,
     SEGMENT_UPDATED,
     FEATURE_IMPORT,
+    FEATURES_IMPORTED,
     IEventType,
 } from '../types/events';
 import { LogProvider, Logger } from '../logger';
@@ -159,7 +160,11 @@ class EventStore implements IEventStore {
             .where((builder) =>
                 builder
                     .whereNotNull('feature_name')
-                    .orWhereIn('type', [SEGMENT_UPDATED, FEATURE_IMPORT]),
+                    .orWhereIn('type', [
+                        SEGMENT_UPDATED,
+                        FEATURE_IMPORT,
+                        FEATURES_IMPORTED,
+                    ]),
             )
             .andWhere('id', '>=', largerThan)
             .first();

--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -2,6 +2,7 @@ import {
     IEvent,
     IBaseEvent,
     SEGMENT_UPDATED,
+    FEATURE_IMPORT,
     IEventType,
 } from '../types/events';
 import { LogProvider, Logger } from '../logger';
@@ -158,7 +159,7 @@ class EventStore implements IEventStore {
             .where((builder) =>
                 builder
                     .whereNotNull('feature_name')
-                    .orWhere('type', SEGMENT_UPDATED),
+                    .orWhereIn('type', [SEGMENT_UPDATED, FEATURE_IMPORT]),
             )
             .andWhere('id', '>=', largerThan)
             .first();


### PR DESCRIPTION
## About the changes
In our staging setup, we create ad-hoc environments and import Unleash state from production. After unleash is deployed on such environment, the import job kicks in and feeds Unleash instance with feature flags from production.

Between Unleash being up and running and the import job running, some applications start polling Unleash. They get an empty feature toggle list with `meta.revisionId=0`. Then apps use this as part of `eTag` header in subsequent requests. Even though after import Unleash server finally has toggles to serve, it doesn't because it calculates _max revision id_ based on toggle updates (not null `feature_name` column in query) or `SEGMENT_UPDATED`.

This change adds an extra condition to query so feature toggles import is considered something that should invalidate the cache.
