### PR TITLE
feat: add a setting for toggling requesting additional scopes

### DIFF
--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -23,7 +23,7 @@ import { SsoGroupSettings } from '../SsoGroupSettings';
 const initialState = {
     enabled: false,
     enableSingleSignOut: false,
-    enableAdditionalScopes: false,
+    enableGroupScope: false,
     enableGroupSyncing: false,
     autoCreate: false,
     unleashHostname: location.hostname,
@@ -59,10 +59,6 @@ export const OidcAuth = () => {
     const updateSingleSignOut = () => {
         setData({ ...data, enableSingleSignOut: !data.enableSingleSignOut });
     };
-
-    const updateAdditionalScopes = () => {
-        setData({ ...data, enableAdditionalScopes: !data.enableAdditionalScopes });
-    }
 
     const setValue = (name: string, value: string | boolean) => {
         setData({
@@ -241,34 +237,6 @@ export const OidcAuth = () => {
                     data={data}
                     setValue={setValue}
                 />
-                <Grid container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Enable Additional Scopes</strong>
-                        <p>
-                            If you enable additional scopes Unleash will request
-                            the additional scopes needed to match configuration
-                            beyond openid, profile, and email. For example 'groups'.
-                        </p>
-                    </Grid>
-                    <Grid item md={6} style={{ padding: '20px' }}>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    onChange={updateAdditionalScopes}
-                                    value={data.enableAdditionalScopes}
-                                    disabled={!data.enabled}
-                                    name="enableAdditionalScopes"
-                                    checked={data.enableAdditionalScopes}
-                                />
-                            }
-                            label={
-                                data.enableAdditionalScopes
-                                    ? 'Enabled'
-                                    : 'Disabled'
-                            }
-                        />
-                    </Grid>
-                </Grid>{' '}
                 <AutoCreateForm data={data} setValue={setValue} />
                 <Grid container spacing={3} mb={2}>
                     <Grid item md={5}>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -23,6 +23,7 @@ import { SsoGroupSettings } from '../SsoGroupSettings';
 const initialState = {
     enabled: false,
     enableSingleSignOut: false,
+    enableAdditionalScopes: false,
     enableGroupSyncing: false,
     autoCreate: false,
     unleashHostname: location.hostname,
@@ -58,6 +59,10 @@ export const OidcAuth = () => {
     const updateSingleSignOut = () => {
         setData({ ...data, enableSingleSignOut: !data.enableSingleSignOut });
     };
+
+    const updateAdditionalScopes = () => {
+        setData({ ...data, enableAdditionalScopes: !data.enableAdditionalScopes });
+    }
 
     const setValue = (name: string, value: string | boolean) => {
         setData({
@@ -236,6 +241,34 @@ export const OidcAuth = () => {
                     data={data}
                     setValue={setValue}
                 />
+                <Grid container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Enable Additional Scopes</strong>
+                        <p>
+                            If you enable additional scopes unleash will request
+                            the additional scopes needed to match configuration
+                            beyond openid, profile, and email. For example 'groups'.
+                        </p>
+                    </Grid>
+                    <Grid item md={6} style={{ padding: '20px' }}>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    onChange={updateAdditionalScopes}
+                                    value={data.enableAdditionalScopes}
+                                    disabled={!data.enabled}
+                                    name="enableAdditionalScopes"
+                                    checked={data.enableAdditionalScopes}
+                                />
+                            }
+                            label={
+                                data.enableAdditionalScopes
+                                    ? 'Enabled'
+                                    : 'Disabled'
+                            }
+                        />
+                    </Grid>
+                </Grid>{' '}
                 <AutoCreateForm data={data} setValue={setValue} />
                 <Grid container spacing={3} mb={2}>
                     <Grid item md={5}>

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -23,7 +23,7 @@ import { SsoGroupSettings } from '../SsoGroupSettings';
 const initialState = {
     enabled: false,
     enableSingleSignOut: false,
-    enableGroupScope: false,
+    addGroupsScope: false,
     enableGroupSyncing: false,
     autoCreate: false,
     unleashHostname: location.hostname,

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -245,7 +245,7 @@ export const OidcAuth = () => {
                     <Grid item md={5}>
                         <strong>Enable Additional Scopes</strong>
                         <p>
-                            If you enable additional scopes unleash will request
+                            If you enable additional scopes Unleash will request
                             the additional scopes needed to match configuration
                             beyond openid, profile, and email. For example 'groups'.
                         </p>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -20,6 +20,7 @@ const initialState = {
     enabled: false,
     autoCreate: false,
     enableGroupSyncing: false,
+    addGroupsScope: false,
     unleashHostname: location.hostname,
     entityId: '',
     signOnUrl: '',

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { FormControlLabel, Grid, Switch, TextField } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 interface SsoGroupSettingsProps {
     ssoType: 'OIDC' | 'SAML';
@@ -32,7 +33,7 @@ export const SsoGroupSettings = ({
 
     const updateAddGroupScope = () => {
         setValue('addGroupsScope', !data.addGroupsScope);
-    }
+    };
     return (
         <>
             <Grid container spacing={3} mb={2}>
@@ -81,32 +82,36 @@ export const SsoGroupSettings = ({
                     />
                 </Grid>
             </Grid>
-            <Grid container spacing={3} mb={2}>
-                    <Grid item md={5}>
-                        <strong>Request 'groups' Scope</strong>
-                        <p>
-                            When enabled Unleash will also request the 'groups' scope as part of the login request.
-                        </p>
+            <ConditionallyRender
+                condition={ssoType === 'OIDC'}
+                show={
+                    <Grid container spacing={3} mb={2}>
+                        <Grid item md={5}>
+                            <strong>Request 'groups' Scope</strong>
+                            <p>
+                                When enabled Unleash will also request the
+                                'groups' scope as part of the login request.
+                            </p>
+                        </Grid>
+                        <Grid item md={6} style={{ padding: '20px' }}>
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        onChange={updateAddGroupScope}
+                                        value={data.addGroupsScope}
+                                        disabled={!data.enableGroupSyncing}
+                                        name="addGroupsScope"
+                                        checked={data.addGroupsScope}
+                                    />
+                                }
+                                label={
+                                    data.addGroupsScope ? 'Enabled' : 'Disabled'
+                                }
+                            />
+                        </Grid>
                     </Grid>
-                    <Grid item md={6} style={{ padding: '20px' }}>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    onChange={updateAddGroupScope}
-                                    value={data.addGroupsScope}
-                                    disabled={!data.enableGroupSyncing}
-                                    name="addGroupsScope"
-                                    checked={data.addGroupsScope}
-                                />
-                            }
-                            label={
-                                data.addGroupsScope
-                                    ? 'Enabled'
-                                    : 'Disabled'
-                            }
-                        />
-                    </Grid>
-                </Grid>
-            </>
+                }
+            />
+        </>
     );
 };

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -7,6 +7,7 @@ interface SsoGroupSettingsProps {
         enabled: boolean;
         enableGroupSyncing: boolean;
         groupJsonPath: string;
+        enableGroupScope: boolean;
     };
     setValue: (name: string, value: string | boolean) => void;
 }
@@ -17,6 +18,7 @@ export const SsoGroupSettings = ({
         enabled: false,
         enableGroupSyncing: false,
         groupJsonPath: '',
+        enableGroupScope: false,
     },
     setValue,
 }: SsoGroupSettingsProps) => {
@@ -28,6 +30,9 @@ export const SsoGroupSettings = ({
         setValue(event.target.name, event.target.value);
     };
 
+    const updateGroupScope = () => {
+        setValue('enableGroupScope', !data.enableGroupScope);
+    }
     return (
         <>
             <Grid container spacing={3} mb={2}>
@@ -76,6 +81,32 @@ export const SsoGroupSettings = ({
                     />
                 </Grid>
             </Grid>
-        </>
+            <Grid container spacing={3} mb={2}>
+                    <Grid item md={5}>
+                        <strong>Request 'groups' Scope</strong>
+                        <p>
+                            When enabled Unleash will also request the 'groups' scope as part of the login request.
+                        </p>
+                    </Grid>
+                    <Grid item md={6} style={{ padding: '20px' }}>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    onChange={updateGroupScope}
+                                    value={data.enableGroupScope}
+                                    disabled={!data.enableGroupSyncing}
+                                    name="enableGroupScope"
+                                    checked={data.enableGroupScope}
+                                />
+                            }
+                            label={
+                                data.enableGroupScope
+                                    ? 'Enabled'
+                                    : 'Disabled'
+                            }
+                        />
+                    </Grid>
+                </Grid>
+            </>
     );
 };

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -7,7 +7,7 @@ interface SsoGroupSettingsProps {
         enabled: boolean;
         enableGroupSyncing: boolean;
         groupJsonPath: string;
-        enableGroupScope: boolean;
+        addGroupsScope: boolean;
     };
     setValue: (name: string, value: string | boolean) => void;
 }
@@ -18,7 +18,7 @@ export const SsoGroupSettings = ({
         enabled: false,
         enableGroupSyncing: false,
         groupJsonPath: '',
-        enableGroupScope: false,
+        addGroupsScope: false,
     },
     setValue,
 }: SsoGroupSettingsProps) => {
@@ -30,8 +30,8 @@ export const SsoGroupSettings = ({
         setValue(event.target.name, event.target.value);
     };
 
-    const updateGroupScope = () => {
-        setValue('enableGroupScope', !data.enableGroupScope);
+    const updateAddGroupScope = () => {
+        setValue('addGroupsScope', !data.addGroupsScope);
     }
     return (
         <>
@@ -92,15 +92,15 @@ export const SsoGroupSettings = ({
                         <FormControlLabel
                             control={
                                 <Switch
-                                    onChange={updateGroupScope}
-                                    value={data.enableGroupScope}
+                                    onChange={updateAddGroupScope}
+                                    value={data.addGroupsScope}
                                     disabled={!data.enableGroupSyncing}
-                                    name="enableGroupScope"
-                                    checked={data.enableGroupScope}
+                                    name="addGroupsScope"
+                                    checked={data.addGroupsScope}
                                 />
                             }
                             label={
-                                data.enableGroupScope
+                                data.addGroupsScope
                                     ? 'Enabled'
                                     : 'Disabled'
                             }


### PR DESCRIPTION
Adds a setting to OIDC SSO configuration that controls whether or not additional scopes are to be requested during login

<img width="944" alt="Skjermbilde 2023-08-24 kl  09 00 54" src="https://github.com/Unleash/unleash/assets/707867/8cf06fb4-aefd-48cd-b09b-99d35a2a10ed">

