### PR TITLE
Fixes hangs when sending incorrect parameters to deleteProjectApiToken endpoint

### DIFF
--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -130,7 +130,7 @@ export class ProjectApiTokenController extends Controller {
                     description: `This operation deletes the API token specified in the request URL. If the token doesn't exist, returns an OK response (status code 200).`,
                     responses: {
                         200: emptyResponse,
-                        ...getStandardResponses(401, 403),
+                        ...getStandardResponses(400, 401, 403, 404),
                     },
                 }),
             ],

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -213,6 +213,10 @@ export class ProjectApiTokenController extends Controller {
             await this.apiTokenService.delete(token, extractUsername(req));
             await this.proxyService.deleteClientForProxyToken(token);
             res.status(200).end();
+        } else if (!storedToken) {
+            res.status(404).end();
+        } else {
+            res.status(400).end();
         }
     }
 


### PR DESCRIPTION
## About the changes
Returns either 400 or 404 when token isn't found or doesn't match single project must be provided projectId criteria

<!-- Does it close an issue? Multiple? -->
Closes #
Linear 2-1003

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Is projects.length > 1 a 400?