### PR TITLE
chore: Remove duplicated tags

### DIFF
--- a/src/lib/openapi/util/openapi-tags.test.ts
+++ b/src/lib/openapi/util/openapi-tags.test.ts
@@ -1,0 +1,8 @@
+import { openApiTags } from './openapi-tags';
+
+test('no duplicate tags', () => {
+    openApiTags.reduce((acc, tag) => {
+        expect(acc).not.toContain(tag.name);
+        return [...acc, tag.name];
+    }, []);
+});

--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -34,11 +34,6 @@ const OPENAPI_TAGS = [
     },
     { name: 'Auth', description: 'Manage logins, passwords, etc.' },
     {
-        name: 'Change Requests',
-        description:
-            'Operations related to [Change Requests](https://docs.getunleash.io/reference/change-requests).',
-    },
-    {
         name: 'Client',
         description:
             'Endpoints for [Unleash server-side clients](https://docs.getunleash.io/reference/sdks).',
@@ -77,11 +72,6 @@ const OPENAPI_TAGS = [
     {
         name: 'Metrics',
         description: 'Register, read, or delete metrics recorded by Unleash.',
-    },
-    {
-        name: 'Notifications',
-        description:
-            'Manage [notifications](https://docs.getunleash.io/reference/notifications).',
     },
     {
         name: 'Operational',


### PR DESCRIPTION
## About the changes
At https://github.com/Unleash/unleash/pull/4432 we've introduced the same tags twice which causes issues when generating the api clients.

Closes #2-1350-fix-openapi-duplicated-tags
