### PR TITLE
chore: return 404 when projectid not found

### DIFF
--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -149,8 +149,7 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<void> {
         const { user } = req;
         const { projectId } = req.params;
-        // throws Not Found on store get() level
-        await this.projectService.getProject(projectId);
+        await this.projectService.getProject(projectId); // Validates that the project exists
 
         const projectTokens = await this.accessibleTokens(user, projectId);
         this.openApiService.respondWithValidation(
@@ -167,8 +166,7 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<any> {
         const createToken = await createApiToken.validateAsync(req.body);
         const { projectId } = req.params;
-        // throws Not Found on store get() level
-        await this.projectService.getProject(projectId);
+        await this.projectService.getProject(projectId); // Validates that the project exists
 
         const permissionRequired = CREATE_PROJECT_API_TOKEN;
         const hasPermission = await this.accessService.hasPermission(

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -24,6 +24,7 @@ import {
     AccessService,
     ApiTokenService,
     OpenApiService,
+    ProjectService,
     ProxyService,
 } from '../../../services';
 import { extractUsername } from '../../../util';
@@ -51,6 +52,8 @@ export class ProjectApiTokenController extends Controller {
 
     private openApiService: OpenApiService;
 
+    private projectService: ProjectService;
+
     private logger: Logger;
 
     constructor(
@@ -60,12 +63,14 @@ export class ProjectApiTokenController extends Controller {
             accessService,
             proxyService,
             openApiService,
+            projectService,
         }: Pick<
             IUnleashServices,
             | 'apiTokenService'
             | 'accessService'
             | 'proxyService'
             | 'openApiService'
+            | 'projectService'
         >,
     ) {
         super(config);
@@ -73,6 +78,7 @@ export class ProjectApiTokenController extends Controller {
         this.accessService = accessService;
         this.proxyService = proxyService;
         this.openApiService = openApiService;
+        this.projectService = projectService;
         this.logger = config.getLogger('project-api-token-controller.js');
 
         this.route({
@@ -110,7 +116,7 @@ export class ProjectApiTokenController extends Controller {
                         'Endpoint that allows creation of [project API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys#api-token-visibility) for the specified project.',
                     responses: {
                         201: resourceCreatedResponseSchema('apiTokenSchema'),
-                        ...getStandardResponses(400, 401, 403),
+                        ...getStandardResponses(400, 401, 403, 404),
                     },
                 }),
             ],
@@ -143,6 +149,11 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<void> {
         const { user } = req;
         const { projectId } = req.params;
+        const project = await this.projectService.getProject(projectId);
+        if (!project) {
+            res.status(404).end();
+        }
+
         const projectTokens = await this.accessibleTokens(user, projectId);
         this.openApiService.respondWithValidation(
             200,
@@ -158,6 +169,11 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<any> {
         const createToken = await createApiToken.validateAsync(req.body);
         const { projectId } = req.params;
+        const project = await this.projectService.getProject(projectId);
+        if (!project) {
+            res.status(404).end();
+        }
+
         const permissionRequired = CREATE_PROJECT_API_TOKEN;
         const hasPermission = await this.accessService.hasPermission(
             req.user,

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -149,10 +149,8 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<void> {
         const { user } = req;
         const { projectId } = req.params;
-        const project = await this.projectService.getProject(projectId);
-        if (!project) {
-            res.status(404).end();
-        }
+        // throws Not Found on store get() level
+        await this.projectService.getProject(projectId);
 
         const projectTokens = await this.accessibleTokens(user, projectId);
         this.openApiService.respondWithValidation(
@@ -169,10 +167,8 @@ export class ProjectApiTokenController extends Controller {
     ): Promise<any> {
         const createToken = await createApiToken.validateAsync(req.body);
         const { projectId } = req.params;
-        const project = await this.projectService.getProject(projectId);
-        if (!project) {
-            res.status(404).end();
-        }
+        // throws Not Found on store get() level
+        await this.projectService.getProject(projectId);
 
         const permissionRequired = CREATE_PROJECT_API_TOKEN;
         const hasPermission = await this.accessService.hasPermission(

--- a/src/test/e2e/api/admin/project/project.api.tokens.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/project.api.tokens.e2e.test.ts
@@ -38,6 +38,7 @@ test('Returns empty list of tokens', async () => {
             expect(res.body.tokens.length).toBe(0);
         });
 });
+
 test('Returns list of tokens', async () => {
     const tokenSecret = 'random-secret';
 
@@ -62,9 +63,9 @@ test('Returns 404 when given non-existant projectId', async () => {
     return app.request
         .get('/api/admin/projects/wrong/api-tokens')
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(404)
         .expect((res) => {
-            expect(res.body.tokens.length).toBe(0);
+            expect(res.body.tokens).toBe(undefined);
         });
 });
 
@@ -78,7 +79,7 @@ test('fails to create new client token when given wrong project', async () => {
             environment: 'default',
         })
         .set('Content-Type', 'application/json')
-        .expect(400);
+        .expect(404);
 });
 
 test('creates new client token', async () => {


### PR DESCRIPTION
## About the changes
Returns Not Found on create and get project api tokens when given a project id that doesn't exist

## Discussion points
- This is an extra lookup per execution of the endpoint