### PR TITLE
docs: fix an issue where it goes into an infinite loop when building

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -618,6 +618,7 @@ module.exports = {
                 outDir: 'docs/generated', // the base directory to output to.
                 documents: sdks.urls, // the file names to download
                 modifyContent: sdks.modifyContent,
+                noRuntimeDownloads: true,
             },
         ],
         [
@@ -629,6 +630,7 @@ module.exports = {
                 outDir: 'docs/generated/', // the base directory to output to.
                 documents: edgeAndProxy.urls, // the file names to download
                 modifyContent: edgeAndProxy.modifyContent,
+                noRuntimeDownloads: true,
             },
         ],
     ],

--- a/website/package.json
+++ b/website/package.json
@@ -7,9 +7,10 @@
   },
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
-    "build": "yarn generate && docusaurus build",
+    "start": "yarn fetch-remote-content && docusaurus start",
+    "build": "yarn generate && yarn fetch-remote-content && docusaurus build",
     "swizzle": "docusaurus swizzle",
+    "fetch-remote-content": "docusaurus download-remote-content-external && docusaurus download-remote-content-sdks",
     "generate": "docusaurus gen-api-docs all && node clean-generated-docs.js",
     "deploy": "yarn generate && docusaurus deploy",
     "clear": "docusaurus clear",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "swizzle": "docusaurus swizzle",
     "fetch-remote-content": "docusaurus download-remote-content-external && docusaurus download-remote-content-sdks",
     "generate": "docusaurus gen-api-docs all && node clean-generated-docs.js",
-    "deploy": "yarn generate && docusaurus deploy",
+    "deploy": "yarn generate && yarn fetch-remote-content && docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
This change sets `noRuntimeDownloads` to `true` for
`plugin-remote-content'` to avoid the infinite loop issue mentioned in
https://github.com/rdilweb/docusaurus-plugin-remote-content/issues/51,
as described in
https://github.com/rdilweb/docusaurus-plugin-remote-content#noruntimedownloads.

Note that this will require you to generate the files before
running the doc build, which may be more an issue, so it's a tradeoff.

To generate the files before building run:

```bash
yarn docusaurus download-remote-content-external
yarn docusaurus download-remote-content-sdks
```

We can of course write a simpler command that does this for us (or even make it part of the build step). In fact, I think we'll need to do exactly that. It seems to be failing now because the files are not generated by default by the build steps.

Creating this PR mostly to get feedback from @dgorton. What do you think?