### PR TITLE
add descriptions in form

### DIFF
--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -311,7 +311,14 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     naming pattern.
                                 </p>
                             </StyledSubtitle>
-                            <StyledInputContainer>
+                            <StyledInputContainer
+                                sx={{
+                                    flexDirection: 'column',
+                                    alignItems: 'flex-start',
+                                    mt: theme => theme.spacing(1),
+                                    '& > *': { width: '100%' },
+                                }}
+                            >
                                 <StyledInput
                                     label={'Naming Pattern'}
                                     name="pattern"
@@ -328,25 +335,19 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                         )
                                     }
                                 />
-                                <StyledInput
-                                    label={'Naming Example'}
-                                    name="example"
-                                    type={'text'}
-                                    value={featureNamingExample || ''}
-                                    placeholder="dx-feature1"
-                                    error={Boolean(errors.namingExample)}
-                                    errorText={errors.namingExample}
-                                    onChange={e =>
-                                        onSetFeatureNamingExample(
-                                            e.target.value
-                                        )
-                                    }
-                                />
+                                <StyledSubtitle>
+                                    <p id="pattern-example-description">
+                                        The example will be shown to users when
+                                        they create a new feature flag in this
+                                        project.
+                                    </p>
+                                </StyledSubtitle>
 
                                 <StyledInput
                                     label={'Naming Example'}
                                     name="example"
                                     type={'text'}
+                                    aria-describedBy="pattern-example-description"
                                     value={featureNamingExample || ''}
                                     placeholder="dx-feature1"
                                     error={Boolean(errors.namingExample)}

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -100,7 +100,7 @@ const StyledFlagNamingContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',
-    mt: theme => theme.spacing(1),
+    mt: theme.spacing(1),
     '& > *': { width: '100%' },
 }));
 

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -96,6 +96,14 @@ const StyledInputContainer = styled('div')(() => ({
     alignItems: 'center',
 }));
 
+const StyledFlagNamingContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    mt: theme => theme.spacing(1),
+    '& > *': { width: '100%' },
+}));
+
 const ProjectForm: React.FC<IProjectForm> = ({
     children,
     handleSubmit,
@@ -311,14 +319,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     naming pattern.
                                 </p>
                             </StyledSubtitle>
-                            <StyledInputContainer
-                                sx={{
-                                    flexDirection: 'column',
-                                    alignItems: 'flex-start',
-                                    mt: theme => theme.spacing(1),
-                                    '& > *': { width: '100%' },
-                                }}
-                            >
+                            <StyledFlagNamingContainer>
                                 <StyledInput
                                     label={'Naming Pattern'}
                                     name="pattern"
@@ -358,7 +359,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                         )
                                     }
                                 />
-                            </StyledInputContainer>
+                            </StyledFlagNamingContainer>
                         </StyledFieldset>
                     }
                 />

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -4,7 +4,7 @@ import { StickinessSelect } from 'component/feature/StrategyTypes/FlexibleStrate
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import Select from 'component/common/select';
 import { ProjectMode } from '../hooks/useProjectForm';
-import { Box, Link, styled, TextField } from '@mui/material';
+import { Box, styled, TextField } from '@mui/material';
 import { CollaborationModeTooltip } from './CollaborationModeTooltip';
 import Input from 'component/common/Input/Input';
 import { FeatureTogglesLimitTooltip } from './FeatureTogglesLimitTooltip';

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -4,7 +4,7 @@ import { StickinessSelect } from 'component/feature/StrategyTypes/FlexibleStrate
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import Select from 'component/common/select';
 import { ProjectMode } from '../hooks/useProjectForm';
-import { Box, styled, TextField } from '@mui/material';
+import { Box, Link, styled, TextField } from '@mui/material';
 import { CollaborationModeTooltip } from './CollaborationModeTooltip';
 import Input from 'component/common/Input/Input';
 import { FeatureTogglesLimitTooltip } from './FeatureTogglesLimitTooltip';
@@ -73,6 +73,11 @@ const StyledInput = styled(Input)(({ theme }) => ({
 const StyledTextField = styled(TextField)(({ theme }) => ({
     width: '100%',
     marginBottom: theme.spacing(2),
+}));
+
+const StyledFieldset = styled('fieldset')(() => ({
+    padding: 0,
+    border: 'none',
 }));
 
 const StyledSelect = styled(Select)(({ theme }) => ({
@@ -276,7 +281,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                         setFeatureNamingExample != null
                     }
                     show={
-                        <>
+                        <StyledFieldset>
                             <Box
                                 sx={{
                                     display: 'flex',
@@ -285,17 +290,33 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     gap: 1,
                                 }}
                             >
-                                <p>Feature flag naming pattern?</p>
+                                <legend>Feature flag naming pattern?</legend>
                                 <FeatureFlagNamingTooltip />
                             </Box>
                             <StyledSubtitle>
-                                Leave it empty if you don’t want to add a naming
-                                pattern
+                                <p id="pattern-naming-description">
+                                    A feature flag naming pattern is a{' '}
+                                    <a
+                                        href={`https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        JavaScript RegEx
+                                    </a>{' '}
+                                    used to enforce feature flag names within
+                                    this project.
+                                </p>
+                                <p>
+                                    Leave it empty if you don’t want to add a
+                                    naming pattern.
+                                </p>
                             </StyledSubtitle>
                             <StyledInputContainer>
                                 <StyledInput
                                     label={'Naming Pattern'}
                                     name="pattern"
+                                    aria-describedby="pattern-naming-description"
+                                    placeholder="^[A-Za-z]+-[A-Za-z0-9]+$"
                                     type={'text'}
                                     value={featureNamingPattern || ''}
                                     error={Boolean(errors.featureNamingPattern)}
@@ -312,6 +333,22 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     name="example"
                                     type={'text'}
                                     value={featureNamingExample || ''}
+                                    placeholder="dx-feature1"
+                                    error={Boolean(errors.namingExample)}
+                                    errorText={errors.namingExample}
+                                    onChange={e =>
+                                        onSetFeatureNamingExample(
+                                            e.target.value
+                                        )
+                                    }
+                                />
+
+                                <StyledInput
+                                    label={'Naming Example'}
+                                    name="example"
+                                    type={'text'}
+                                    value={featureNamingExample || ''}
+                                    placeholder="dx-feature1"
                                     error={Boolean(errors.namingExample)}
                                     errorText={errors.namingExample}
                                     onChange={e =>
@@ -321,7 +358,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     }
                                 />
                             </StyledInputContainer>
-                        </>
+                        </StyledFieldset>
                     }
                 />
             </StyledContainer>


### PR DESCRIPTION
This PR adds descriptions of the various feature flag naming input fields in the project settings form. It also wraps the feature naming fields in a fieldset to group them semantically.

![image](https://github.com/Unleash/unleash/assets/17786332/a8d5c2c6-3381-4b76-89a1-18316c2e5193)
