### PR TITLE
1-1329: return 400 when pattern is empty but example is not

### DIFF
--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -180,6 +180,12 @@ export default class ProjectService {
                     `You've provided a feature flag naming example ("${example}") that doesn't match your feature flag naming pattern ("${pattern}"). Please provide an example that matches your supplied pattern.`,
                 );
             }
+
+            if (!pattern && example) {
+                throw new BadDataError(
+                    "You've provided a feature flag naming example, but no feature flag naming pattern. You must specify a pattern to use an example.",
+                );
+            }
         }
     };
 


### PR DESCRIPTION
Adding an example when there is no pattern doesn't make any sense, so it should be an error.

Tests in https://github.com/ivarconr/unleash-enterprise/pull/721