### PR TITLE
feature naming patterns: allow empty values in examples and patterns

### DIFF
--- a/src/lib/openapi/spec/create-feature-naming-pattern-schema.ts
+++ b/src/lib/openapi/spec/create-feature-naming-pattern-schema.ts
@@ -12,7 +12,6 @@ export const createFeatureNamingPatternSchema = {
             description:
                 'A JavaScript regular expression pattern, without the start and end delimiters. Optional flags are not allowed.',
             example: '[a-z]{2,5}.team-[a-z]+.[a-z-]+',
-            pattern: '.*',
         },
         example: {
             type: 'string',

--- a/src/lib/services/project-schema.ts
+++ b/src/lib/services/project-schema.ts
@@ -11,8 +11,8 @@ export const projectSchema = joi
         defaultStickiness: joi.string().default('default'),
         featureLimit: joi.number().allow(null).optional(),
         featureNaming: joi.object().keys({
-            pattern: joi.string().allow(null).optional(),
-            example: joi.string().allow(null).optional(),
+            pattern: joi.string().allow(null).allow('').optional(),
+            example: joi.string().allow(null).allow('').optional(),
         }),
     })
     .options({ allowUnknown: false, stripUnknown: true });


### PR DESCRIPTION
Allow empty patterns and examples for feature naming. 

This fixes an issue where the form would break, not allowing you to create new projects at all.