### PR TITLE
1-1333: fix type problems

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -239,9 +239,9 @@ class ProjectStore implements IProjectStore {
                 project_mode: project.mode,
                 default_stickiness: project.defaultStickiness,
                 feature_limit: project.featureLimit,
-                feature_naming_pattern: project.featureNamingPattern,
-                feature_naming_example: project.featureNamingExample,
-                feature_naming_description: project.featureNamingDescription,
+                feature_naming_pattern: project.featureNaming?.pattern,
+                feature_naming_example: project.featureNaming?.example,
+                feature_naming_description: project.featureNaming?.description,
             })
             .returning('*');
         return this.mapRow({ ...row[0], ...settingsRow[0] });

--- a/src/lib/types/stores/project-store.ts
+++ b/src/lib/types/stores/project-store.ts
@@ -4,6 +4,7 @@ import {
 } from '../../db/project-store';
 import {
     IEnvironment,
+    IFeatureNaming,
     IProject,
     IProjectWithCount,
     ProjectMode,
@@ -19,9 +20,7 @@ export interface IProjectInsert {
     changeRequestsEnabled?: boolean;
     mode: ProjectMode;
     featureLimit?: number;
-    featureNamingPattern?: string;
-    featureNamingExample?: string;
-    featureNamingDescription?: string;
+    featureNaming?: IFeatureNaming;
 }
 
 export interface IProjectSettings {


### PR DESCRIPTION
This change makes it so that you can save flag naming data on project
creation.

There was a mismatch between flattened and nested data in the creation
endpoint. Likely because we went back and forth a bit when we created
the feature originally.