### PR TITLE
1-1320: allow you to update example with no pattern + update state better

### DIFF
--- a/frontend/src/component/project/Project/ProjectForm/FeatureFlagNamingTooltip.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/FeatureFlagNamingTooltip.tsx
@@ -14,7 +14,7 @@ export const FeatureFlagNamingTooltip: FC = () => {
                 <Box>
                     <h3>Enforce a naming convention for feature flags</h3>
                     <hr />
-                    <p>{`eg. ^[A - Za - z0 - 9]{2}[.][a-z]{4,12}$ matches 'a1.project'`}</p>
+                    <p>{`eg. ^[A-Za-z0-9]{2}[.][a-z]{4,12}$ matches 'a1.project'`}</p>
                     <div className="scrollable">
                         <h3>Brackets:</h3>
                         <table>

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -113,7 +113,7 @@ export const validateFeatureNamingExample = ({
 }: {
     pattern: string;
     example: string;
-    featureNamingPatternError?: string;
+    featureNamingPatternError: string | undefined;
 }): { state: 'valid' } | { state: 'invalid'; reason: string } => {
     if (featureNamingPatternError || !example || !pattern) {
         return { state: 'valid' };

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -135,22 +135,45 @@ const ProjectForm: React.FC<IProjectForm> = ({
 }) => {
     const { uiConfig } = useUiConfig();
     const shouldShowFlagNaming = uiConfig.flags.featureNamingPattern;
+
+    const validateFeatureNamingExample = () => {
+        if (featureNamingPattern && featureNamingExample) {
+            try {
+                const regex = new RegExp(featureNamingPattern);
+                const matches = regex.test(featureNamingExample);
+                if (!matches) {
+                    errors.namingExample = 'Example does not match regex';
+                } else {
+                    delete errors.namingExample;
+                }
+            } catch {
+                delete errors.namingExample;
+            }
+        }
+    };
+
     const onSetFeatureNamingPattern = (regex: string) => {
         try {
             new RegExp(regex);
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
-            clearErrors();
+            delete errors.featureNamingPattern;
+            validateFeatureNamingExample();
         } catch (e) {
             errors.featureNamingPattern = 'Invalid regular expression';
+            delete errors.namingExample;
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
         }
     };
 
     const onSetFeatureNamingExample = (example: string) => {
-        const regex = new RegExp(featureNamingPattern);
-        const matches = regex.test(example);
-        if (!matches) {
-            errors.namingExample = 'Example does not match regex';
+        if (example && !errors.featureNamingPattern) {
+            const regex = new RegExp(featureNamingPattern || '');
+            const matches = regex.test(example);
+            if (!matches) {
+                errors.namingExample = 'Example does not match regex';
+            } else {
+                delete errors.namingExample;
+            }
         } else {
             delete errors.namingExample;
         }
@@ -331,7 +354,8 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     value={featureNamingPattern || ''}
                                     error={Boolean(errors.featureNamingPattern)}
                                     errorText={errors.featureNamingPattern}
-                                    onFocus={() => clearErrors()}
+                                    // onFocus={() => clearErrors()}
+                                    // onBlur={validateFeatureNamingExample}
                                     onChange={e =>
                                         onSetFeatureNamingPattern(
                                             e.target.value
@@ -355,6 +379,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     placeholder="dx.feature1.1-135"
                                     error={Boolean(errors.namingExample)}
                                     errorText={errors.namingExample}
+                                    onBlur={validateFeatureNamingExample}
                                     onChange={e =>
                                         onSetFeatureNamingExample(
                                             e.target.value

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -147,16 +147,14 @@ const ProjectForm: React.FC<IProjectForm> = ({
     };
 
     const onSetFeatureNamingExample = (example: string) => {
-        if (featureNamingPattern) {
-            const regex = new RegExp(featureNamingPattern);
-            const matches = regex.test(example);
-            if (!matches) {
-                errors.namingExample = 'Example does not match regex';
-            } else {
-                delete errors.namingExample;
-            }
-            setFeatureNamingExample && setFeatureNamingExample(example);
+        const regex = new RegExp(featureNamingPattern);
+        const matches = regex.test(example);
+        if (!matches) {
+            errors.namingExample = 'Example does not match regex';
+        } else {
+            delete errors.namingExample;
         }
+        setFeatureNamingExample && setFeatureNamingExample(example);
     };
 
     const onSetFeatureNamingDescription = (description: string) => {

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -152,32 +152,53 @@ const ProjectForm: React.FC<IProjectForm> = ({
         }
     };
 
+    const validateFeatureNaming = ({
+        regex,
+        example,
+    }: {
+        regex?: string;
+        example?: string;
+    }) => {
+        const r = regex ?? featureNamingPattern;
+        const x = example ?? featureNamingExample;
+
+        if (errors.featureNamingPattern || !x || !r) {
+            console.log('Deleting naming example error');
+            delete errors.namingExample;
+        } else if (x && r) {
+            console.log('We have a valid pattern and an example, validating');
+
+            const regex = new RegExp(r);
+            const matches = regex.test(x);
+            if (!matches) {
+                console.log(x, 'does not match regex', r);
+
+                errors.namingExample = 'Example does not match regex';
+            } else {
+                console.log(x, 'matches regex', r);
+                delete errors.namingExample;
+            }
+        }
+    };
+
     const onSetFeatureNamingPattern = (regex: string) => {
+        console.log('New pattern', regex);
+
         try {
             new RegExp(regex);
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
             delete errors.featureNamingPattern;
-            validateFeatureNamingExample();
         } catch (e) {
             errors.featureNamingPattern = 'Invalid regular expression';
             delete errors.namingExample;
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
         }
+        validateFeatureNaming({ regex });
     };
 
     const onSetFeatureNamingExample = (example: string) => {
-        if (example && !errors.featureNamingPattern) {
-            const regex = new RegExp(featureNamingPattern || '');
-            const matches = regex.test(example);
-            if (!matches) {
-                errors.namingExample = 'Example does not match regex';
-            } else {
-                delete errors.namingExample;
-            }
-        } else {
-            delete errors.namingExample;
-        }
         setFeatureNamingExample && setFeatureNamingExample(example);
+        validateFeatureNaming({ example });
     };
 
     const onSetFeatureNamingDescription = (description: string) => {

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -154,28 +154,22 @@ const ProjectForm: React.FC<IProjectForm> = ({
 
     const validateFeatureNaming = ({
         regex,
-        example,
+        example: newExample,
     }: {
         regex?: string;
         example?: string;
     }) => {
-        const r = regex ?? featureNamingPattern;
-        const x = example ?? featureNamingExample;
+        const pattern = regex ?? featureNamingPattern;
+        const example = newExample ?? featureNamingExample;
 
-        if (errors.featureNamingPattern || !x || !r) {
-            console.log('Deleting naming example error');
+        if (errors.featureNamingPattern || !example || !pattern) {
             delete errors.namingExample;
-        } else if (x && r) {
-            console.log('We have a valid pattern and an example, validating');
-
-            const regex = new RegExp(r);
-            const matches = regex.test(x);
+        } else if (example && pattern) {
+            const regex = new RegExp(pattern);
+            const matches = regex.test(example);
             if (!matches) {
-                console.log(x, 'does not match regex', r);
-
                 errors.namingExample = 'Example does not match regex';
             } else {
-                console.log(x, 'matches regex', r);
                 delete errors.namingExample;
             }
         }

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -136,22 +136,6 @@ const ProjectForm: React.FC<IProjectForm> = ({
     const { uiConfig } = useUiConfig();
     const shouldShowFlagNaming = uiConfig.flags.featureNamingPattern;
 
-    const validateFeatureNamingExample = () => {
-        if (featureNamingPattern && featureNamingExample) {
-            try {
-                const regex = new RegExp(featureNamingPattern);
-                const matches = regex.test(featureNamingExample);
-                if (!matches) {
-                    errors.namingExample = 'Example does not match regex';
-                } else {
-                    delete errors.namingExample;
-                }
-            } catch {
-                delete errors.namingExample;
-            }
-        }
-    };
-
     const validateFeatureNaming = ({
         regex,
         example: newExample,
@@ -176,8 +160,6 @@ const ProjectForm: React.FC<IProjectForm> = ({
     };
 
     const onSetFeatureNamingPattern = (regex: string) => {
-        console.log('New pattern', regex);
-
         try {
             new RegExp(regex);
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
@@ -369,8 +351,6 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     value={featureNamingPattern || ''}
                                     error={Boolean(errors.featureNamingPattern)}
                                     errorText={errors.featureNamingPattern}
-                                    // onFocus={() => clearErrors()}
-                                    // onBlur={validateFeatureNamingExample}
                                     onChange={e =>
                                         onSetFeatureNamingPattern(
                                             e.target.value
@@ -394,7 +374,6 @@ const ProjectForm: React.FC<IProjectForm> = ({
                                     placeholder="dx.feature1.1-135"
                                     error={Boolean(errors.namingExample)}
                                     errorText={errors.namingExample}
-                                    onBlur={validateFeatureNamingExample}
                                     onChange={e =>
                                         onSetFeatureNamingExample(
                                             e.target.value

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -166,7 +166,6 @@ const ProjectForm: React.FC<IProjectForm> = ({
             delete errors.featureNamingPattern;
         } catch (e) {
             errors.featureNamingPattern = 'Invalid regular expression';
-            delete errors.namingExample;
             setFeatureNamingPattern && setFeatureNamingPattern(regex);
         }
         validateFeatureNaming({ regex });

--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -236,7 +236,9 @@ const ProjectForm: React.FC<IProjectForm> = ({
                     onChange={e => setProjectName(e.target.value)}
                     error={Boolean(errors.name)}
                     errorText={errors.name}
-                    onFocus={() => clearErrors()}
+                    onFocus={() => {
+                        delete errors.name;
+                    }}
                     data-testid={PROJECT_NAME_INPUT}
                     required
                 />

--- a/frontend/src/component/project/Project/ProjectForm/validate-feature-naming.test.ts
+++ b/frontend/src/component/project/Project/ProjectForm/validate-feature-naming.test.ts
@@ -1,0 +1,50 @@
+import { validateFeatureNamingExample } from './ProjectForm';
+
+describe('validateFeatureNaming', () => {
+    test.each(['+', 'valid regex$'])(
+        `if the featureNamingPatternError prop is present, it's always valid: %s`,
+        pattern => {
+            const result = validateFeatureNamingExample({
+                pattern,
+                example: 'aohutnasoehutns',
+                featureNamingPatternError: 'error',
+            });
+
+            expect(result.state).toBe('valid');
+        }
+    );
+    test(`if the pattern is empty, the example is always valid`, () => {
+        const result = validateFeatureNamingExample({
+            pattern: '',
+            example: 'aohutnasoehutns',
+            featureNamingPatternError: undefined,
+        });
+
+        expect(result.state).toBe('valid');
+    });
+    test(`if the example is empty, the it's always valid`, () => {
+        const result = validateFeatureNamingExample({
+            pattern: '^dx-[a-z]{1,5}$',
+            example: '',
+            featureNamingPatternError: undefined,
+        });
+
+        expect(result.state).toBe('valid');
+    });
+
+    test.each([
+        ['valid', 'dx-logs'],
+        ['invalid', 'axe-battles'],
+    ])(
+        `if example is %s, the state should be be the same`,
+        (state, example) => {
+            const result = validateFeatureNamingExample({
+                pattern: '^dx-[a-z]{1,5}$',
+                example,
+                featureNamingPatternError: undefined,
+            });
+
+            expect(result.state).toBe(state);
+        }
+    );
+});


### PR DESCRIPTION
While having a pattern when you have no example doesn't make a lot of sense, it's a problem that you can't delete the example after deleting the pattern: you previously had to remove the example before the pattern.

This PR fixes that by always allowing you to update the example, even if there is no pattern. Our server doesn't currently accept submitting an example with no pattern, but we could allow that if we want to (and probably just discard it on the back-end).

This PR also updates the validation of the example and the regex. There were more unhandled edge cases previously where the validation would disappear or be wrong. This should be fixed now. The new logic is that, whenever you update the either the pattern or the example, we check:
- if you have an error in your pattern, no pattern, or no example, then delete the example error if it exists
- have a well-formed pattern and an example then check if the example matches the pattern and add/delete an error accordingly

This does have some consequences: editing the pattern can render your example invalid. You'll also get immediate feedback instead of when you switch focus. I think this is often a bad pattern (giving the user too much negative feedback), but in terms of working with regexes, I think it might be a good thing. We also give immediate feedback today, so I don't think this is a regression.

Any thoughts are welcome.