### PR TITLE
1-1315: revalidate feature name whenever the project changes

### DIFF
--- a/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
+++ b/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
@@ -138,6 +138,13 @@ const FeatureForm: React.FC<IFeatureToggleForm> = ({
 
     const displayFeatureNamingInfo = Boolean(featureNaming?.pattern);
 
+    React.useEffect(() => {
+        if (featureNaming?.pattern && validateToggleName && name) {
+            clearErrors();
+            validateToggleName();
+        }
+    }, [featureNaming?.pattern]);
+
     return (
         <StyledForm onSubmit={handleSubmit}>
             <StyledContainer>


### PR DESCRIPTION
This change makes it so that the flag name is revalidated against the new
project pattern whenever you change the target project for a flag.

The validation is not run if the name is empty, if there is no
pattern, or if there is no validation method.

This solves the case where you input a name, then change the project,
and where the name isn't valid for the new project. Previously, it
wouldn't revalidate, but now it does.