### PR TITLE
fix: api token schema

### DIFF
--- a/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
@@ -33,24 +33,6 @@ exports[`apiTokenSchema empty 1`] = `
     {
       "instancePath": "",
       "keyword": "required",
-      "message": "must have required property 'project'",
-      "params": {
-        "missingProperty": "project",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'projects'",
-      "params": {
-        "missingProperty": "projects",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
       "message": "must have required property 'createdAt'",
       "params": {
         "missingProperty": "createdAt",

--- a/src/lib/openapi/spec/api-token-schema.ts
+++ b/src/lib/openapi/spec/api-token-schema.ts
@@ -5,14 +5,7 @@ export const apiTokenSchema = {
     $id: '#/components/schemas/apiTokenSchema',
     type: 'object',
     additionalProperties: false,
-    required: [
-        'secret',
-        'tokenName',
-        'type',
-        'project',
-        'projects',
-        'createdAt',
-    ],
+    required: ['secret', 'tokenName', 'type', 'createdAt'],
     description:
         'An overview of an [Unleash API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys).',
     properties: {


### PR DESCRIPTION
## About the changes
Create api token schema can either provide the field `project` or its plural: `projects` so the joi validation makes them optional: https://github.com/Unleash/unleash/blob/2be77fb55ee85e18648afa455fbcee6b4d568f9d/src/lib/schema/api-token-schema.ts#L20-L24

This means that when returning the token, the response will either contain `project` or `projects` depending on what was provided as input. Therefore we need to make both fields optional in the response