### PR TITLE
docs: add mention of multiple project roles

### DIFF
--- a/website/docs/how-to/how-to-create-and-assign-custom-project-roles.md
+++ b/website/docs/how-to/how-to-create-and-assign-custom-project-roles.md
@@ -34,7 +34,13 @@ It takes about three steps to create custom project roles:
 
 ## Assigning custom project roles
 
-Custom project role creation is a pretty straightforward process and requires around three steps, outlined below.
+:::info Multiple project roles
+
+Multiple project roles were introduced as a beta Enterprise feature in **Unleash 5.5**. See [multiple project roles](../reference/rbac.md#multiple-project-roles) for more info.
+
+:::
+
+Assigning a custom project role is a pretty straightforward process and requires around three steps, outlined below.
 
 To assign a custom project role to a user:
 1. Navigate to the project you want to assign the user a role in.

--- a/website/docs/how-to/how-to-create-and-assign-custom-project-roles.md
+++ b/website/docs/how-to/how-to-create-and-assign-custom-project-roles.md
@@ -40,7 +40,7 @@ Multiple project roles were introduced as a beta Enterprise feature in **Unleash
 
 :::
 
-Assigning a custom project role is a pretty straightforward process and requires around three steps, outlined below.
+Assigning a custom project role is a pretty straightforward process and requires three steps, outlined below.
 
 To assign a custom project role to a user:
 1. Navigate to the project you want to assign the user a role in.

--- a/website/docs/reference/rbac.md
+++ b/website/docs/reference/rbac.md
@@ -172,6 +172,18 @@ You can assign the following permissions on a per-environment level within the p
 | **apply a change request**            | Lets the user apply change requests in the environment.                                          |
 | **skip change requests**              | Lets the user ignore change request requirements. This applies **only when using the API** directly; when using the admin UI, users with this permission will still need to go through the normal change request flow. You can find more details in the section on [circumventing change requests](change-requests.md#circumventing-change-requests). |
 
+## Multiple Project Roles
+
+:::info availability
+
+Multiple project roles were introduced as a beta feature in **Unleash 5.5** and are only available in Unleash Enterprise. We plan to make this feature generally available to all Enterprise users in **Unleash 5.6**.
+
+:::
+
+Multiple project roles allow you to assign multiple project roles to a user or group within a project. By doing so, you can effectively merge the permissions associated with each role, resulting in a comprehensive set of permissions for the user or group in question. This ensures that individuals or teams have all the access they require to complete their tasks, as the system will automatically grant the most permissive rights from the combination of assigned roles.
+
+This multi-role assignment feature can be particularly beneficial in complex projects with dynamic teams where a user or group needs to wear multiple hats. For example, a team member could serve as both a developer and a quality assurance tester. By combining roles, you simplify the access management process, eliminating the need to create a new, custom role that encapsulates the needed permissions.
+
 ## User Groups
 
 :::info availability
@@ -194,7 +206,7 @@ Groups do nothing on their own. They must either be given a root role directly o
 
 Groups that do not have a root role need to be assigned a role on a project to be useful. You can assign both predefined roles and custom project roles to groups.
 
-Groups that *do* have a root role can't be assigned to a project. Any user that is a member of a group with a root role will inherit that root role's permissions on the root level.
+Any user that is a member of a group with a root role will inherit that root role's permissions on the root level.
 
 While a user can only have one role in a given project, a user may belong to multiple groups, and each of those groups may be given a role on a project. In the case where a given user is given permissions through more than one group, the user will inherit most permissive permissions of all their groups in that project.
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1130/documentation-about-multiple-project-roles

 - Adds a section for the feature in the "Role-based Access control" reference doc;
 - Removes the mention that "Groups that *do* have a root role can't be assigned to a project." which is no longer true;
 - Adds a reference to multiple project roles in the "How to create and assign custom project roles" guide;
 - Fixes a wrong sentence in the "Assigning custom project roles" section of the aforementioned guide;