### PR TITLE
feat: keyboard navigation in search

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "start:demo": "UNLEASH_BASE_PATH=/demo/ UNLEASH_API=https://app.unleash-hosted.com/ yarn run start",
     "test": "tsc && NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest run",
     "test:snapshot": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" yarn test -u",
-    "test:watch": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest watch SearchSuggestions",
+    "test:watch": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest watch",
     "lint": "eslint --fix ./src",
     "lint:check": "eslint ./src",
     "fmt": "prettier src --write --loglevel warn",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "start:demo": "UNLEASH_BASE_PATH=/demo/ UNLEASH_API=https://app.unleash-hosted.com/ yarn run start",
     "test": "tsc && NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest run",
     "test:snapshot": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" yarn test -u",
-    "test:watch": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest watch",
+    "test:watch": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest watch SearchSuggestions",
     "lint": "eslint --fix ./src",
     "lint:check": "eslint ./src",
     "fmt": "prettier src --write --loglevel warn",

--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -9,7 +9,7 @@ import { useKeyboardShortcut } from 'hooks/useKeyboardShortcut';
 import { SEARCH_INPUT } from 'utils/testIds';
 import { useOnClickOutside } from 'hooks/useOnClickOutside';
 import { useSavedQuery } from './useSavedQuery';
-import { useOnBlur } from '../../../hooks/useOnBlur';
+import { useOnBlur } from 'hooks/useOnBlur';
 
 interface ISearchProps {
     id?: string;

--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -9,6 +9,7 @@ import { useKeyboardShortcut } from 'hooks/useKeyboardShortcut';
 import { SEARCH_INPUT } from 'utils/testIds';
 import { useOnClickOutside } from 'hooks/useOnClickOutside';
 import { useSavedQuery } from './useSavedQuery';
+import { useOnBlur } from '../../../hooks/useOnBlur';
 
 interface ISearchProps {
     id?: string;
@@ -111,7 +112,10 @@ export const Search = ({
         }
     );
     useKeyboardShortcut({ key: 'Escape' }, () => {
-        if (document.activeElement === searchInputRef.current) {
+        if (
+            document.activeElement === searchInputRef.current ||
+            searchContainerRef.current?.contains(document.activeElement)
+        ) {
             searchInputRef.current?.blur();
             hideSuggestions();
         }
@@ -119,6 +123,7 @@ export const Search = ({
     const placeholder = `${customPlaceholder ?? 'Search'} (${hotkey})`;
 
     useOnClickOutside([searchContainerRef], hideSuggestions);
+    useOnBlur(searchContainerRef, hideSuggestions);
 
     return (
         <StyledContainer

--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -112,10 +112,7 @@ export const Search = ({
         }
     );
     useKeyboardShortcut({ key: 'Escape' }, () => {
-        if (
-            document.activeElement === searchInputRef.current ||
-            searchContainerRef.current?.contains(document.activeElement)
-        ) {
+        if (searchContainerRef.current?.contains(document.activeElement)) {
             searchInputRef.current?.blur();
             hideSuggestions();
         }

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { VFC } from 'react';
-import { onEnter } from '../onKeyActions';
+import { onEnter } from '../onEnter';
 
 const StyledHeader = styled('span')(({ theme }) => ({
     fontSize: theme.fontSizes.smallBody,

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { VFC } from 'react';
+import { onEnter } from '../onKeyActions';
 
 const StyledHeader = styled('span')(({ theme }) => ({
     fontSize: theme.fontSizes.smallBody,
@@ -13,9 +14,12 @@ export const StyledCode = styled('span')(({ theme }) => ({
     padding: theme.spacing(0.2, 1),
     borderRadius: theme.spacing(0.5),
     cursor: 'pointer',
-    '&:hover': {
+    '&:hover, &:focus-visible': {
         transition: 'background-color 0.2s ease-in-out',
         backgroundColor: theme.palette.seen.primary,
+    },
+    '&:focus-visible': {
+        outline: `2px solid ${theme.palette.primary.main}`,
     },
 }));
 
@@ -57,6 +61,10 @@ export const SearchInstructions: VFC<ISearchInstructionsProps> = ({
                         condition={filter.options.length > 0}
                         show={
                             <StyledCode
+                                tabIndex={0}
+                                onKeyDown={onEnter(() =>
+                                    onClick(firstFilterOption(filter))
+                                )}
                                 onClick={() =>
                                     onClick(firstFilterOption(filter))
                                 }
@@ -71,6 +79,7 @@ export const SearchInstructions: VFC<ISearchInstructionsProps> = ({
                             <>
                                 {' or '}
                                 <StyledCode
+                                    tabIndex={0}
                                     onClick={() => {
                                         onClick(secondFilterOption(filter));
                                     }}

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchInstructions/SearchInstructions.tsx
@@ -80,6 +80,9 @@ export const SearchInstructions: VFC<ISearchInstructionsProps> = ({
                                 {' or '}
                                 <StyledCode
                                     tabIndex={0}
+                                    onKeyDown={onEnter(() =>
+                                        onClick(secondFilterOption(filter))
+                                    )}
                                     onClick={() => {
                                         onClick(secondFilterOption(filter));
                                     }}

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.test.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.test.tsx
@@ -33,6 +33,36 @@ const searchContext = {
     ],
 };
 
+const searchContextWithoutFilters = {
+    data: [
+        {
+            title: 'Title A',
+            environment: 'prod',
+        },
+        {
+            title: 'Title B',
+            environment: 'dev env',
+        },
+        {
+            title: 'Title C',
+            environment: 'stage\npre-prod',
+        },
+    ],
+    searchValue: '',
+    columns: [
+        {
+            Header: 'Title',
+            searchable: true,
+            accessor: 'title',
+        },
+        {
+            Header: 'Environment',
+            accessor: 'environment',
+            searchable: true,
+        },
+    ],
+};
+
 test('displays search and filter instructions when no search value is provided', () => {
     let recordedSuggestion = '';
     render(
@@ -105,4 +135,23 @@ test('displays search and filter instructions when filter value is provided', ()
 
     screen.getByText(/Title A/i).click();
     expect(recordedSuggestion).toBe('environment:"dev env" Title A');
+});
+
+test('displays search instructions without filters', () => {
+    let recordedSuggestion = '';
+    render(
+        <SearchSuggestions
+            onSuggestion={suggestion => {
+                recordedSuggestion = suggestion;
+            }}
+            getSearchContext={() => searchContextWithoutFilters}
+        />
+    );
+
+    expect(
+        screen.getByText(/Start typing to search in Title, Environment/i)
+    ).toBeInTheDocument();
+
+    screen.getByText(/Title A/i).click();
+    expect(recordedSuggestion).toBe('Title A');
 });

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
@@ -14,6 +14,7 @@ import {
     StyledCode,
 } from './SearchInstructions/SearchInstructions';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { onEnter } from './onKeyActions';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
     position: 'absolute',
@@ -107,6 +108,31 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
         filter => `${filter.name}:${filter.suggestedOption}`
     )[0];
 
+    const onFilter = (suggestion: string) => {
+        onSuggestion(suggestion);
+        trackEvent('search-filter-suggestions', {
+            props: {
+                eventType: 'filter',
+            },
+        });
+    };
+    const onSearchAndFilter = () => {
+        onSuggestion(selectedFilter + ' ' + suggestedTextSearch);
+        trackEvent('search-filter-suggestions', {
+            props: {
+                eventType: 'search and filter',
+            },
+        });
+    };
+    const onSavedQuery = () => {
+        onSuggestion(savedQuery || '');
+        trackEvent('search-filter-suggestions', {
+            props: {
+                eventType: 'saved query',
+            },
+        });
+    };
+
     return (
         <StyledPaper className="dropdown-outline">
             <ConditionallyRender
@@ -116,14 +142,9 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
                         <StyledBox>
                             <StyledHistory />
                             <StyledCode
-                                onClick={() => {
-                                    onSuggestion(savedQuery || '');
-                                    trackEvent('search-filter-suggestions', {
-                                        props: {
-                                            eventType: 'saved query',
-                                        },
-                                    });
-                                }}
+                                tabIndex={0}
+                                onClick={onSavedQuery}
+                                onKeyDown={onEnter(onSavedQuery)}
                             >
                                 <span>{savedQuery}</span>
                             </StyledCode>
@@ -153,14 +174,7 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
                                 searchableColumnsString={
                                     searchableColumnsString
                                 }
-                                onClick={suggestion => {
-                                    onSuggestion(suggestion);
-                                    trackEvent('search-filter-suggestions', {
-                                        props: {
-                                            eventType: 'filter',
-                                        },
-                                    });
-                                }}
+                                onClick={onFilter}
                             />
                         }
                     />
@@ -173,16 +187,9 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
                     show="Combine filters and search: "
                 />
                 <StyledCode
-                    onClick={() => {
-                        onSuggestion(
-                            selectedFilter + ' ' + suggestedTextSearch
-                        );
-                        trackEvent('search-filter-suggestions', {
-                            props: {
-                                eventType: 'search and filter',
-                            },
-                        });
-                    }}
+                    tabIndex={0}
+                    onClick={onSearchAndFilter}
+                    onKeyDown={onEnter(onSearchAndFilter)}
                 >
                     <span key={selectedFilter}>{selectedFilter}</span>{' '}
                     <span>{suggestedTextSearch}</span>

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
@@ -104,9 +104,12 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
             ? getColumnValues(searchableColumns[0], searchContext.data[0])
             : 'example-search-text';
 
-    const selectedFilter = filters.map(
-        filter => `${filter.name}:${filter.suggestedOption}`
-    )[0];
+    const selectedFilter =
+        filters.length === 0
+            ? ''
+            : filters.map(
+                  filter => `${filter.name}:${filter.suggestedOption}`
+              )[0];
 
     const onFilter = (suggestion: string) => {
         onSuggestion(suggestion);
@@ -117,7 +120,7 @@ export const SearchSuggestions: VFC<SearchSuggestionsProps> = ({
         });
     };
     const onSearchAndFilter = () => {
-        onSuggestion(selectedFilter + ' ' + suggestedTextSearch);
+        onSuggestion((selectedFilter + ' ' + suggestedTextSearch).trim());
         trackEvent('search-filter-suggestions', {
             props: {
                 eventType: 'search and filter',

--- a/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
+++ b/frontend/src/component/common/Search/SearchSuggestions/SearchSuggestions.tsx
@@ -14,7 +14,7 @@ import {
     StyledCode,
 } from './SearchInstructions/SearchInstructions';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
-import { onEnter } from './onKeyActions';
+import { onEnter } from './onEnter';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
     position: 'absolute',

--- a/frontend/src/component/common/Search/SearchSuggestions/onEnter.ts
+++ b/frontend/src/component/common/Search/SearchSuggestions/onEnter.ts
@@ -1,0 +1,7 @@
+export const onEnter = (callback: () => void) => {
+    return (event: React.KeyboardEvent<HTMLSpanElement>): void => {
+        if (event.key === 'Enter' || event.keyCode === 13) {
+            callback();
+        }
+    };
+};

--- a/frontend/src/hooks/useOnBlur.test.tsx
+++ b/frontend/src/hooks/useOnBlur.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { useOnBlur } from './useOnBlur';
+
+function TestComponent(props: { onBlurHandler: () => void }) {
+    const divRef = useRef(null);
+    useOnBlur(divRef, props.onBlurHandler);
+
+    return (
+        <div data-testid="wrapper">
+            <div tabIndex={0} data-testid="inside" ref={divRef}>
+                Inside
+            </div>
+            <div tabIndex={0} data-testid="outside">
+                Outside
+            </div>
+        </div>
+    );
+}
+
+test('should not call the callback when blurring within the same container', () => {
+    let mockCallbackCallCount = 0;
+    const mockCallback = () => mockCallbackCallCount++;
+
+    render(<TestComponent onBlurHandler={mockCallback} />);
+
+    const insideDiv = screen.getByTestId('inside');
+
+    fireEvent.focus(insideDiv);
+    fireEvent.blur(insideDiv);
+
+    expect(mockCallbackCallCount).toBe(0);
+});
+
+test('should call the callback when blurring outside of the container', () => {
+    let mockCallbackCallCount = 0;
+    const mockCallback = () => mockCallbackCallCount++;
+
+    render(<TestComponent onBlurHandler={mockCallback} />);
+
+    const insideDiv = screen.getByTestId('inside');
+    const outsideDiv = screen.getByTestId('outside');
+
+    fireEvent.focus(insideDiv);
+    fireEvent.focus(outsideDiv);
+
+    expect(mockCallbackCallCount).toBe(1);
+});

--- a/frontend/src/hooks/useOnBlur.test.tsx
+++ b/frontend/src/hooks/useOnBlur.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useRef } from 'react';
 import { useOnBlur } from './useOnBlur';
 
@@ -18,7 +18,7 @@ function TestComponent(props: { onBlurHandler: () => void }) {
     );
 }
 
-test('should not call the callback when blurring within the same container', () => {
+test('should not call the callback when blurring within the same container', async () => {
     let mockCallbackCallCount = 0;
     const mockCallback = () => mockCallbackCallCount++;
 
@@ -26,13 +26,15 @@ test('should not call the callback when blurring within the same container', () 
 
     const insideDiv = screen.getByTestId('inside');
 
-    fireEvent.focus(insideDiv);
-    fireEvent.blur(insideDiv);
+    insideDiv.focus();
+    insideDiv.blur();
 
-    expect(mockCallbackCallCount).toBe(0);
+    await waitFor(() => {
+        expect(mockCallbackCallCount).toBe(0);
+    });
 });
 
-test('should call the callback when blurring outside of the container', () => {
+test('should call the callback when blurring outside of the container', async () => {
     let mockCallbackCallCount = 0;
     const mockCallback = () => mockCallbackCallCount++;
 
@@ -41,8 +43,10 @@ test('should call the callback when blurring outside of the container', () => {
     const insideDiv = screen.getByTestId('inside');
     const outsideDiv = screen.getByTestId('outside');
 
-    fireEvent.focus(insideDiv);
-    fireEvent.focus(outsideDiv);
+    insideDiv.focus();
+    outsideDiv.focus();
 
-    expect(mockCallbackCallCount).toBe(1);
+    await waitFor(() => {
+        expect(mockCallbackCallCount).toBe(1);
+    });
 });

--- a/frontend/src/hooks/useOnBlur.ts
+++ b/frontend/src/hooks/useOnBlur.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+export const useOnBlur = (
+    containerRef: React.RefObject<HTMLElement>,
+    callback: () => void
+): void => {
+    useEffect(() => {
+        const handleBlur = (event: FocusEvent) => {
+            // setTimeout is used because activeElement might not immediately be the new focused element after a blur event
+            setTimeout(() => {
+                if (
+                    containerRef.current &&
+                    !containerRef.current.contains(document.activeElement)
+                ) {
+                    callback();
+                }
+            }, 0);
+        };
+
+        const containerElement = containerRef.current;
+        if (containerElement) {
+            containerElement.addEventListener('blur', handleBlur, true);
+        }
+
+        return () => {
+            if (containerElement) {
+                containerElement.removeEventListener('blur', handleBlur, true);
+            }
+        };
+    }, [containerRef, callback]);
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<img width="726" alt="Screenshot 2023-09-11 at 11 45 51" src="https://github.com/Unleash/unleash/assets/1394682/978b852a-1cec-42f2-9cdd-5fbfd425af67">

* tab navigation inside search suggestions and outside search suggestions
* when tab moves away from the search suggestions, the suggestions are hidden
* also supports escape key from the search suggestions
* added onUseBlur reusable hook that handles element loosing focus
* fix search and filter to filter our filters if they don't exists (previously it was undefined)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
For now the elements we tab between are spans even though button would be more correct. Buttons add too many styles that we'd need to remove. 