### PR TITLE
feat: variant with number payload

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -64,6 +64,7 @@ export type UiFlags = {
     multipleRoles?: boolean;
     featureNamingPattern?: boolean;
     doraMetrics?: boolean;
+    variantTypeNumber?: boolean;
     [key: string]: boolean | Variant | undefined;
 };
 

--- a/src/lib/features/playground/feature-evaluator/variant.ts
+++ b/src/lib/features/playground/feature-evaluator/variant.ts
@@ -10,7 +10,7 @@ interface Override {
 }
 
 export interface Payload {
-    type: 'string' | 'csv' | 'json';
+    type: 'string' | 'csv' | 'json' | 'number';
     value: string;
 }
 

--- a/src/lib/openapi/spec/create-strategy-variant-schema.ts
+++ b/src/lib/openapi/spec/create-strategy-variant-schema.ts
@@ -40,9 +40,9 @@ export const createStrategyVariantSchema = {
             properties: {
                 type: {
                     description:
-                        'The type of the value. Commonly used types are string, json and csv.',
+                        'The type of the value. Commonly used types are string, number, json and csv.',
                     type: 'string',
-                    enum: ['json', 'csv', 'string'],
+                    enum: ['json', 'csv', 'string', 'number'],
                 },
                 value: {
                     description: 'The actual value of payload',

--- a/src/lib/openapi/spec/playground-strategy-schema.ts
+++ b/src/lib/openapi/spec/playground-strategy-schema.ts
@@ -83,7 +83,7 @@ export const strategyEvaluationResults = {
                                 type: {
                                     description: 'The format of the payload.',
                                     type: 'string',
-                                    enum: ['json', 'csv', 'string'],
+                                    enum: ['json', 'csv', 'string', 'number'],
                                 },
                                 value: {
                                     type: 'string',

--- a/src/lib/openapi/spec/variant-schema.ts
+++ b/src/lib/openapi/spec/variant-schema.ts
@@ -42,9 +42,9 @@ export const variantSchema = {
             properties: {
                 type: {
                     description:
-                        'The type of the value. Commonly used types are string, json and csv.',
+                        'The type of the value. Commonly used types are string, number, json and csv.',
                     type: 'string',
-                    enum: ['json', 'csv', 'string'],
+                    enum: ['json', 'csv', 'string', 'number'],
                 },
                 value: {
                     description: 'The actual value of payload',

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -27,7 +27,8 @@ export type IFlagKey =
     | 'integrationsRework'
     | 'multipleRoles'
     | 'featureNamingPattern'
-    | 'doraMetrics';
+    | 'doraMetrics'
+    | 'variantTypeNumber';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -125,6 +126,10 @@ const flags: IFlags = {
     ),
     doraMetrics: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_DORA_METRICS,
+        false,
+    ),
+    variantTypeNumber: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_VARIANT_TYPE_NUMBER,
         false,
     ),
 };

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -123,7 +123,7 @@ export interface IVariant {
     weight: number;
     weightType: 'variable' | 'fix';
     payload?: {
-        type: 'json' | 'csv' | 'string';
+        type: 'json' | 'csv' | 'string' | 'number';
         value: string;
     };
     stickiness: string;

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -42,6 +42,7 @@ process.nextTick(async () => {
                         integrationsRework: true,
                         featureNamingPattern: true,
                         doraMetrics: true,
+                        variantTypeNumber: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Adds `number` as possible payload type for variant.
Adds a flag to enable the feature
Updates all relevant models and schemas
Adds the option to the UI

Closes: # [1-1357](https://linear.app/unleash/issue/1-1357/support-number-in-variant-payload)