### PR TITLE
feat: check toggle limit on import

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -370,29 +370,26 @@ export default class ExportImportService {
     private async createOrUpdateToggles(dto: ImportTogglesSchema, user: User) {
         const existingFeatures = await this.getExistingProjectFeatures(dto);
         const username = extractUsernameFromUser(user);
-        await Promise.all(
-            dto.data.features.map((feature) => {
-                if (existingFeatures.includes(feature.name)) {
-                    const { archivedAt, createdAt, ...rest } = feature;
-                    return this.featureToggleService.updateFeatureToggle(
-                        dto.project,
-                        rest as FeatureToggleDTO,
-                        username,
-                        feature.name,
-                    );
-                }
-                return this.featureToggleService
-                    .validateName(feature.name)
-                    .then(() => {
-                        const { archivedAt, createdAt, ...rest } = feature;
-                        return this.featureToggleService.createFeatureToggle(
-                            dto.project,
-                            rest as FeatureToggleDTO,
-                            extractUsernameFromUser(user),
-                        );
-                    });
-            }),
-        );
+
+        for (const feature of dto.data.features) {
+            if (existingFeatures.includes(feature.name)) {
+                const { archivedAt, createdAt, ...rest } = feature;
+                await this.featureToggleService.updateFeatureToggle(
+                    dto.project,
+                    rest as FeatureToggleDTO,
+                    username,
+                    feature.name,
+                );
+            } else {
+                await this.featureToggleService.validateName(feature.name);
+                const { archivedAt, createdAt, ...rest } = feature;
+                await this.featureToggleService.createFeatureToggle(
+                    dto.project,
+                    rest as FeatureToggleDTO,
+                    username,
+                );
+            }
+        }
     }
 
     private async verifyContextFields(dto: ImportTogglesSchema) {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Make the creation of toggles from import sequential so that we can count the toggles that already got created. 

The last import stage should fail on limit exceeded:
<img width="313" alt="Screenshot 2023-09-12 at 12 07 17" src="https://github.com/Unleash/unleash/assets/1394682/516e4227-7c2c-40d5-9937-fa0caa5126c9">

<img width="263" alt="Screenshot 2023-09-12 at 12 07 15" src="https://github.com/Unleash/unleash/assets/1394682/5ecc063b-5340-47cb-b12c-cc58b0af0d4c">

This PR is not touching the validation stage yet. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
This line from the toggle service is on the critical path and for 500 toggles it will run over and over again.
```ts
await this.projectStore.isFeatureLimitReached(projectId)
```