### PR TITLE
fix: post global events even when filtering by env

### DIFF
--- a/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
@@ -381,6 +381,7 @@ export const IntegrationForm: VFC<IntegrationFormProps> = ({
                                 onChange={setEnvironments}
                                 entityName="environment"
                                 selectAllEnabled={true}
+                                description="Global events that are not specific to an environment will still be received."
                             />
                         </div>
                     </StyledConfigurationSection>

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationMultiSelector/IntegrationMultiSelector.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationMultiSelector/IntegrationMultiSelector.tsx
@@ -155,12 +155,12 @@ export const IntegrationMultiSelector: VFC<IIntegrationMultiSelectorProps> = ({
                 ) : null}
             </StyledTitle>
             <ConditionallyRender
-                condition={description !== undefined}
-                show={<StyledHelpText>{description}</StyledHelpText>}
-            />
-            <ConditionallyRender
                 condition={selectAllEnabled}
                 show={<DefaultHelpText />}
+            />
+            <ConditionallyRender
+                condition={description !== undefined}
+                show={<StyledHelpText>{description}</StyledHelpText>}
             />
             <ConditionallyRender
                 condition={selectAllEnabled}

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -292,6 +292,43 @@ test('should filter events on environment if addon is setup to filter for it', a
     expect(events[0].event.data.name).toBe('some-toggle');
 });
 
+test('should not filter out global events (no specific environment) even if addon is setup to filter for environments', async () => {
+    const { addonService, stores } = getSetup();
+    const filteredEnvironment = 'filtered';
+    const config = {
+        provider: 'simple',
+        enabled: true,
+        events: [FEATURE_CREATED],
+        projects: [],
+        environments: [filteredEnvironment],
+        description: '',
+        parameters: {
+            url: 'http://localhost:wh',
+        },
+    };
+
+    const globalEventWithNoEnvironment = {
+        type: FEATURE_CREATED,
+        createdBy: 'some@user.com',
+        project: 'some-project',
+        data: {
+            name: 'some-toggle',
+            enabled: false,
+            strategies: [{ name: 'default' }],
+        },
+    };
+
+    await addonService.createAddon(config, 'me@mail.com');
+    await stores.eventStore.store(globalEventWithNoEnvironment);
+    const simpleProvider = addonService.addonProviders.simple;
+    // @ts-expect-error
+    const events = simpleProvider.getEvents();
+
+    expect(events.length).toBe(1);
+    expect(events[0].event.type).toBe(FEATURE_CREATED);
+    expect(events[0].event.data.name).toBe('some-toggle');
+});
+
 test('should support wildcard option for filtering addons', async () => {
     const { addonService, stores } = getSetup();
     const desiredProjects = ['desired', 'desired2'];

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -121,6 +121,7 @@ export default class AddonService {
                     )
                     .filter(
                         (addon) =>
+                            !event.environment ||
                             !addon.environments ||
                             addon.environments.length == 0 ||
                             addon.environments[0] === WILDCARD_OPTION ||


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1276/deal-with-events-without-an-environment

This makes it so that global events (events not tied to a specific environment) are always received, no matter the configured environment filter.

It also includes a respective test and small sentence on the UI explaining the behavior.

![image](https://github.com/Unleash/unleash/assets/14320932/021a3622-78fe-45af-b68c-dde0813f32f0)