### PR TITLE
feat: add feature naming pattern tracking

### DIFF
--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -46,7 +46,8 @@ export type CustomEvents =
     | 'strategy-variants'
     | 'search-filter-suggestions'
     | 'project-metrics'
-    | 'open-integration';
+    | 'open-integration'
+    | 'feature-naming-pattern';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);


### PR DESCRIPTION
This PR adds plausible metrics for feature naming patterns. The changes are tracked whenever the form is submitted and the naming pattern has changed. We track three different actions:
- added :: if there was no pattern before and now there is one
- removed :: if there was a pattern before and now there is none
- changed :: if there was a pattern before and now there is a different one

The corresponding event type has been created in plausible.