### PR TITLE
fix: add additionalproperties to the sdkContextSchema

### DIFF
--- a/src/lib/openapi/spec/sdk-context-schema.ts
+++ b/src/lib/openapi/spec/sdk-context-schema.ts
@@ -5,6 +5,7 @@ export const sdkContextSchema = {
     description: 'The Unleash context as modeled in client SDKs',
     type: 'object',
     required: ['appName'],
+    additionalProperties: true,
     properties: {
         appName: {
             type: 'string',


### PR DESCRIPTION
This was changed a month ago, but it ends up breaking the frontend when we regenerate the types because the playground needs to have this structure for now. We'll need to add this back until we can rewrite the playground to follow the schema.