### PR TITLE
test: enforce behavior via test

### DIFF
--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1801,10 +1801,14 @@ describe('feature flag naming patterns', () => {
         ).toMatchObject(featureNaming);
 
         const newPattern = 'new-pattern.+';
-        await projectService.updateProject(project.id, {
-            name: project.name,
-            featureNaming: { pattern: newPattern },
-        });
+        await projectService.updateProject(
+            {
+                id: project.id,
+                name: project.name,
+                featureNaming: { pattern: newPattern },
+            },
+            user.id,
+        );
 
         const updatedProject = await projectService.getProject(project.id);
 

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1791,6 +1791,7 @@ describe('feature flag naming patterns', () => {
             name: 'Project',
             mode: 'open' as const,
             defaultStickiness: 'clientId',
+            description: 'description',
             featureNaming,
         };
 
@@ -1803,8 +1804,7 @@ describe('feature flag naming patterns', () => {
         const newPattern = 'new-pattern.+';
         await projectService.updateProject(
             {
-                id: project.id,
-                name: project.name,
+                ...project,
                 featureNaming: { pattern: newPattern },
             },
             user.id,

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1777,3 +1777,39 @@ test('should return average time to production per toggle and include archived t
 
     expect(resultProject1.features).toHaveLength(3);
 });
+
+describe('feature flag naming patterns', () => {
+    test(`should clear existing example and description if the payload doesn't contain them`, async () => {
+        const featureNaming = {
+            pattern: '.+',
+            example: 'example',
+            description: 'description',
+        };
+
+        const project = {
+            id: 'feature-flag-naming-patterns-cleanup',
+            name: 'Project',
+            mode: 'open' as const,
+            defaultStickiness: 'clientId',
+            featureNaming,
+        };
+
+        await projectService.createProject(project, user.id);
+
+        expect(
+            (await projectService.getProject(project.id)).featureNaming,
+        ).toMatchObject(featureNaming);
+
+        const newPattern = 'new-pattern.+';
+        await projectService.updateProject(project.id, {
+            name: project.name,
+            featureNaming: { pattern: newPattern },
+        });
+
+        const updatedProject = await projectService.getProject(project.id);
+
+        expect(updatedProject.featureNaming!.pattern).toBe(newPattern);
+        expect(updatedProject.featureNaming!.example).toBeFalsy();
+        expect(updatedProject.featureNaming!.description).toBeFalsy();
+    });
+});


### PR DESCRIPTION
This test enforces that descriptions and examples are cleared if they are not present in the feature naming data.

This behavior is already present, but it hasn't been encoded in any tests before.