### PR TITLE
fix: disable all errors

### DIFF
--- a/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/api-token-schema.test.ts.snap
@@ -12,51 +12,6 @@ exports[`apiTokenSchema empty 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'tokenName'",
-      "params": {
-        "missingProperty": "tokenName",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'type'",
-      "params": {
-        "missingProperty": "type",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'project'",
-      "params": {
-        "missingProperty": "project",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'projects'",
-      "params": {
-        "missingProperty": "projects",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'createdAt'",
-      "params": {
-        "missingProperty": "createdAt",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/apiTokenSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/change-password-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/change-password-schema.test.ts.snap
@@ -12,15 +12,6 @@ exports[`changePasswordSchema empty 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'password'",
-      "params": {
-        "missingProperty": "password",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/changePasswordSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/client-application-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/client-application-schema.test.ts.snap
@@ -12,33 +12,6 @@ exports[`clientApplicationSchema no fields 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'interval'",
-      "params": {
-        "missingProperty": "interval",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'started'",
-      "params": {
-        "missingProperty": "started",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'strategies'",
-      "params": {
-        "missingProperty": "strategies",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/clientApplicationSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/client-features-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/client-features-schema.test.ts.snap
@@ -12,15 +12,6 @@ exports[`clientFeaturesSchema no fields 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'features'",
-      "params": {
-        "missingProperty": "features",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/clientFeaturesSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/feature-environment-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/feature-environment-schema.test.ts.snap
@@ -12,15 +12,6 @@ exports[`featureEnvironmentSchema empty 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'enabled'",
-      "params": {
-        "missingProperty": "enabled",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/featureEnvironmentSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/feature-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/feature-schema.test.ts.snap
@@ -34,15 +34,6 @@ exports[`featureSchema variant override values must be an array 1`] = `
       },
       "schemaPath": "#/properties/payload/properties/type/enum",
     },
-    {
-      "instancePath": "/variants/0/overrides/0/values",
-      "keyword": "type",
-      "message": "must be array",
-      "params": {
-        "type": "array",
-      },
-      "schemaPath": "#/components/schemas/overrideSchema/properties/values/type",
-    },
   ],
   "schema": "#/components/schemas/featureSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/feature-type-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/feature-type-schema.test.ts.snap
@@ -12,33 +12,6 @@ exports[`featureTypeSchema empty 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'name'",
-      "params": {
-        "missingProperty": "name",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'description'",
-      "params": {
-        "missingProperty": "description",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'lifetimeDays'",
-      "params": {
-        "missingProperty": "lifetimeDays",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/featureTypeSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/me-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/me-schema.test.ts.snap
@@ -12,33 +12,6 @@ exports[`meSchema empty 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'permissions'",
-      "params": {
-        "missingProperty": "permissions",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'feedback'",
-      "params": {
-        "missingProperty": "feedback",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'splash'",
-      "params": {
-        "missingProperty": "splash",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/meSchema",
 }
@@ -53,24 +26,6 @@ exports[`meSchema missing permissions 1`] = `
       "message": "must have required property 'permissions'",
       "params": {
         "missingProperty": "permissions",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'feedback'",
-      "params": {
-        "missingProperty": "feedback",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'splash'",
-      "params": {
-        "missingProperty": "splash",
       },
       "schemaPath": "#/required",
     },

--- a/src/lib/openapi/spec/__snapshots__/role-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/role-schema.test.ts.snap
@@ -12,24 +12,6 @@ exports[`roleSchema 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'type'",
-      "params": {
-        "missingProperty": "type",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'name'",
-      "params": {
-        "missingProperty": "name",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/roleSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/set-strategy-sort-order-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/set-strategy-sort-order-schema.test.ts.snap
@@ -12,15 +12,6 @@ exports[`setStrategySortOrderSchema missing id 1`] = `
       },
       "schemaPath": "#/items/required",
     },
-    {
-      "instancePath": "/1",
-      "keyword": "required",
-      "message": "must have required property 'id'",
-      "params": {
-        "missingProperty": "id",
-      },
-      "schemaPath": "#/items/required",
-    },
   ],
   "schema": "#/components/schemas/setStrategySortOrderSchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/strategy-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/strategy-schema.test.ts.snap
@@ -12,51 +12,6 @@ exports[`strategySchema 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'displayName'",
-      "params": {
-        "missingProperty": "displayName",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'description'",
-      "params": {
-        "missingProperty": "description",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'editable'",
-      "params": {
-        "missingProperty": "editable",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'deprecated'",
-      "params": {
-        "missingProperty": "deprecated",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'parameters'",
-      "params": {
-        "missingProperty": "parameters",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/strategySchema",
 }

--- a/src/lib/openapi/spec/__snapshots__/token-user-schema.test.ts.snap
+++ b/src/lib/openapi/spec/__snapshots__/token-user-schema.test.ts.snap
@@ -12,42 +12,6 @@ exports[`tokenUserSchema 1`] = `
       },
       "schemaPath": "#/required",
     },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'email'",
-      "params": {
-        "missingProperty": "email",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'token'",
-      "params": {
-        "missingProperty": "token",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'createdBy'",
-      "params": {
-        "missingProperty": "createdBy",
-      },
-      "schemaPath": "#/required",
-    },
-    {
-      "instancePath": "",
-      "keyword": "required",
-      "message": "must have required property 'role'",
-      "params": {
-        "missingProperty": "role",
-      },
-      "schemaPath": "#/required",
-    },
   ],
   "schema": "#/components/schemas/tokenUserSchema",
 }

--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -18,7 +18,6 @@ const ajv = new Ajv({
         'date-time': true,
         uri: true,
     },
-    allErrors: true,
 });
 
 export const addAjvSchema = (schemaObjects: any[]): any => {


### PR DESCRIPTION
This was recently flagged as a security warning by our pipeline. AJV
also tells users not to use this in prouduction, which we must have
missed: https://ajv.js.org/security.html#security-risks-of-trusted-schemas