### PR TITLE
fix: include tags in variants event

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1959,6 +1959,8 @@ class FeatureToggleService {
             ).variants ||
             [];
 
+        const tags = await this.tagStore.getAllTagsForFeature(featureName);
+
         await this.eventStore.store(
             new EnvironmentVariantEvent({
                 featureName,
@@ -1967,6 +1969,7 @@ class FeatureToggleService {
                 createdBy: user,
                 oldVariants: theOldVariants,
                 newVariants: fixedVariants,
+                tags,
             }),
         );
         await this.featureEnvironmentStore.setVariantsToFeatureEnvironments(
@@ -2032,6 +2035,9 @@ class FeatureToggleService {
             });
             oldVariants[env] = featureEnv.variants || [];
         }
+
+        const tags = await this.tagStore.getAllTagsForFeature(featureName);
+
         await this.eventStore.batchStore(
             environments.map(
                 (environment) =>
@@ -2042,6 +2048,7 @@ class FeatureToggleService {
                         createdBy: user,
                         oldVariants: oldVariants[environment],
                         newVariants: fixedVariants,
+                        tags,
                     }),
             ),
         );

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -431,10 +431,11 @@ export class EnvironmentVariantEvent extends BaseEvent {
         environment: string;
         project: string;
         createdBy: string | IUser;
+        tags: ITag[];
         newVariants: IVariant[];
         oldVariants: IVariant[];
     }) {
-        super(FEATURE_ENVIRONMENT_VARIANTS_UPDATED, p.createdBy);
+        super(FEATURE_ENVIRONMENT_VARIANTS_UPDATED, p.createdBy, p.tags);
         this.featureName = p.featureName;
         this.environment = p.environment;
         this.project = p.project;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1396/fix-variants-event-should-include-the-respective-feature-flag-tags

This fixes an issue where the `feature-environment-variants-updated` event would not post to a tagged Slack channel, since it would not take into consideration the feature flag tags.