### PR TITLE
fix: env variants event changelog

### DIFF
--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1962,9 +1962,6 @@ class FeatureToggleService {
             ).variants ||
             [];
 
-        console.log('old variants', theOldVariants);
-        console.log('new variants', fixedVariants);
-
         await this.eventStore.store(
             new EnvironmentVariantEvent({
                 featureName,

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -1898,7 +1898,10 @@ class FeatureToggleService {
             featureName,
             environment,
         );
-        const { newDocument } = await applyPatch(oldVariants, newVariants);
+        const { newDocument } = await applyPatch(
+            deepClone(oldVariants),
+            newVariants,
+        );
         return this.crProtectedSaveVariantsOnEnv(
             project,
             featureName,
@@ -1958,6 +1961,9 @@ class FeatureToggleService {
                 })
             ).variants ||
             [];
+
+        console.log('old variants', theOldVariants);
+        console.log('new variants', fixedVariants);
 
         await this.eventStore.store(
             new EnvironmentVariantEvent({


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1397/fix-environment-variants-change-event-does-not-include-changelogs

By running `applyPatch` without cloning the `oldVariants`, `applyPatch` would patch the `oldVariants` by reference, effectively making them the same as the `newVariants`. This fix `deepClone`s the oldVariants when sending them in as an `applyPatch` parameter so that the `oldVariants` variable is left untouched.

![image](https://github.com/Unleash/unleash/assets/14320932/089e118d-c5c4-432e-b11c-08d362ce155d)
