### PR TITLE
1-1385: hide display of pattern info behind a flag

### DIFF
--- a/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
+++ b/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
@@ -23,7 +23,6 @@ import React from 'react';
 import { useAuthPermissions } from 'hooks/api/getters/useAuth/useAuthPermissions';
 import { FeatureNamingType } from 'interfaces/project';
 import { FeatureNamingPatternInfo } from '../FeatureNamingPatternInfo/FeatureNamingPatternInfo';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IFeatureToggleForm {

--- a/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
+++ b/frontend/src/component/feature/FeatureForm/FeatureForm.tsx
@@ -23,6 +23,8 @@ import React from 'react';
 import { useAuthPermissions } from 'hooks/api/getters/useAuth/useAuthPermissions';
 import { FeatureNamingType } from 'interfaces/project';
 import { FeatureNamingPatternInfo } from '../FeatureNamingPatternInfo/FeatureNamingPatternInfo';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IFeatureToggleForm {
     type: string;
@@ -121,12 +123,15 @@ const FeatureForm: React.FC<IFeatureToggleForm> = ({
     const navigate = useNavigate();
     const { permissions } = useAuthPermissions();
     const editable = mode !== 'Edit';
+    const featureNamingPatternEnabled = useUiFlag('featureNamingPattern');
 
     const renderToggleDescription = () => {
         return featureTypes.find(toggle => toggle.id === type)?.description;
     };
 
-    const displayFeatureNamingInfo = Boolean(featureNaming?.pattern);
+    const displayFeatureNamingInfo = Boolean(
+        featureNamingPatternEnabled && featureNaming?.pattern
+    );
 
     React.useEffect(() => {
         if (featureNaming?.pattern && validateToggleName && name) {


### PR DESCRIPTION
Previously, the front end would show info about the pattern if it
exists, regardless of whether the feature is active or not. The
pattern wouldn't be enforced, but it's confusing anyway, so let's hide
it.