### PR TITLE
refactor: remove check for feature naming data object

### DIFF
--- a/src/lib/features/feature-naming-pattern/feature-naming-validation.ts
+++ b/src/lib/features/feature-naming-pattern/feature-naming-validation.ts
@@ -2,6 +2,18 @@ import { IFeatureNaming } from '../../types/model';
 
 const compileRegex = (pattern: string) => new RegExp(`^${pattern}$`);
 
+const disallowedStrings = [' ', '\\t', '\\s', '\\n', '\\r', '\\f', '\\v'];
+
+// Helper functions for error messages
+const whitespaceError = (pattern: string) =>
+    `Feature flag names cannot contain whitespace. You've provided a feature flag naming pattern that contains a whitespace character: "${pattern}". Remove any whitespace characters from your pattern.`;
+
+const exampleMismatchError = (example: string, pattern: string) =>
+    `You've provided a feature flag naming example ("${example}") that doesn't match your feature flag naming pattern ("${pattern}").`;
+
+const invalidValueError = (valueName: string) =>
+    `You've provided a feature flag naming ${valueName}, but no feature flag naming pattern. You must specify a pattern to use a ${valueName}.`;
+
 export const checkFeatureNamingData = (
     featureNaming: IFeatureNaming,
 ):
@@ -9,30 +21,19 @@ export const checkFeatureNamingData = (
     | { state: 'invalid'; reasons: [string, ...string[]] } => {
     const { pattern, example, description } = featureNaming;
     const errors: string[] = [];
-    const disallowedStrings = [' ', '\\t', '\\s', '\\n', '\\r', '\\f', '\\v'];
 
-    if (pattern) {
-        if (disallowedStrings.some((str) => pattern.includes(str))) {
-            errors.push(
-                `Feature flag names can not contain whitespace. You've provided a feature flag naming pattern that contains a whitespace character: "${pattern}". Remove any whitespace characters from your pattern.`,
-            );
-        } else if (example && !example.match(compileRegex(pattern))) {
-            errors.push(
-                `You've provided a feature flag naming example ("${example}") that doesn't match your feature flag naming pattern ("${pattern}"). Please provide an example that matches your supplied pattern. Bear in mind that the pattern must match the whole example, as if it were surrounded by '^' and "$".`,
-            );
-        }
-    } else {
-        if (example) {
-            errors.push(
-                "You've provided a feature flag naming example, but no feature flag naming pattern. You must specify a pattern to use an example.",
-            );
-        }
+    if (disallowedStrings.some((str) => pattern?.includes(str))) {
+        errors.push(whitespaceError(pattern as string));
+    } else if (pattern && example && !compileRegex(pattern).test(example)) {
+        errors.push(exampleMismatchError(example, pattern));
+    }
 
-        if (description) {
-            errors.push(
-                "You've provided a feature flag naming pattern description, but no feature flag naming pattern. You must have a pattern to use a description.",
-            );
-        }
+    if (!pattern && example) {
+        errors.push(invalidValueError('example'));
+    }
+
+    if (!pattern && description) {
+        errors.push(invalidValueError('description'));
     }
 
     const [first, ...rest] = errors;

--- a/src/lib/features/feature-naming-pattern/feature-naming-validation.ts
+++ b/src/lib/features/feature-naming-pattern/feature-naming-validation.ts
@@ -3,51 +3,41 @@ import { IFeatureNaming } from '../../types/model';
 const compileRegex = (pattern: string) => new RegExp(`^${pattern}$`);
 
 export const checkFeatureNamingData = (
-    featureNaming?: IFeatureNaming,
+    featureNaming: IFeatureNaming,
 ):
     | { state: 'valid' }
     | { state: 'invalid'; reasons: [string, ...string[]] } => {
-    if (featureNaming) {
-        const { pattern, example, description } = featureNaming;
-        const errors: string[] = [];
-        const disallowedStrings = [
-            ' ',
-            '\\t',
-            '\\s',
-            '\\n',
-            '\\r',
-            '\\f',
-            '\\v',
-        ];
+    const { pattern, example, description } = featureNaming;
+    const errors: string[] = [];
+    const disallowedStrings = [' ', '\\t', '\\s', '\\n', '\\r', '\\f', '\\v'];
 
-        if (pattern) {
-            if (disallowedStrings.some((str) => pattern.includes(str))) {
-                errors.push(
-                    `Feature flag names can not contain whitespace. You've provided a feature flag naming pattern that contains a whitespace character: "${pattern}". Remove any whitespace characters from your pattern.`,
-                );
-            } else if (example && !example.match(compileRegex(pattern))) {
-                errors.push(
-                    `You've provided a feature flag naming example ("${example}") that doesn't match your feature flag naming pattern ("${pattern}"). Please provide an example that matches your supplied pattern. Bear in mind that the pattern must match the whole example, as if it were surrounded by '^' and "$".`,
-                );
-            }
-        } else {
-            if (example) {
-                errors.push(
-                    "You've provided a feature flag naming example, but no feature flag naming pattern. You must specify a pattern to use an example.",
-                );
-            }
-
-            if (description) {
-                errors.push(
-                    "You've provided a feature flag naming pattern description, but no feature flag naming pattern. You must have a pattern to use a description.",
-                );
-            }
+    if (pattern) {
+        if (disallowedStrings.some((str) => pattern.includes(str))) {
+            errors.push(
+                `Feature flag names can not contain whitespace. You've provided a feature flag naming pattern that contains a whitespace character: "${pattern}". Remove any whitespace characters from your pattern.`,
+            );
+        } else if (example && !example.match(compileRegex(pattern))) {
+            errors.push(
+                `You've provided a feature flag naming example ("${example}") that doesn't match your feature flag naming pattern ("${pattern}"). Please provide an example that matches your supplied pattern. Bear in mind that the pattern must match the whole example, as if it were surrounded by '^' and "$".`,
+            );
+        }
+    } else {
+        if (example) {
+            errors.push(
+                "You've provided a feature flag naming example, but no feature flag naming pattern. You must specify a pattern to use an example.",
+            );
         }
 
-        const [first, ...rest] = errors;
-        if (first) {
-            return { state: 'invalid', reasons: [first, ...rest] };
+        if (description) {
+            errors.push(
+                "You've provided a feature flag naming pattern description, but no feature flag naming pattern. You must have a pattern to use a description.",
+            );
         }
+    }
+
+    const [first, ...rest] = errors;
+    if (first) {
+        return { state: 'invalid', reasons: [first, ...rest] };
     }
 
     return { state: 'valid' };

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -203,9 +203,7 @@ export default class ProjectService {
         const data = await projectSchema.validateAsync(newProject);
         await this.validateUniqueId(data.id);
 
-        if (data.featureNaming) {
-            this.validateAndProcessFeatureNamingPattern(data.featureNaming);
-        }
+        this.validateAndProcessFeatureNamingPattern(data.featureNaming);
 
         await this.store.create(data);
 
@@ -238,11 +236,9 @@ export default class ProjectService {
     async updateProject(updatedProject: IProject, user: User): Promise<void> {
         const preData = await this.store.get(updatedProject.id);
 
-        if (updatedProject.featureNaming) {
-            this.validateAndProcessFeatureNamingPattern(
-                updatedProject.featureNaming,
-            );
-        }
+        this.validateAndProcessFeatureNamingPattern(
+            updatedProject.featureNaming,
+        );
 
         await this.store.update(updatedProject);
 

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -203,7 +203,9 @@ export default class ProjectService {
         const data = await projectSchema.validateAsync(newProject);
         await this.validateUniqueId(data.id);
 
-        this.validateAndProcessFeatureNamingPattern(data.featureNaming);
+        if (data.featureNaming) {
+            this.validateAndProcessFeatureNamingPattern(data.featureNaming);
+        }
 
         await this.store.create(data);
 
@@ -236,9 +238,11 @@ export default class ProjectService {
     async updateProject(updatedProject: IProject, user: User): Promise<void> {
         const preData = await this.store.get(updatedProject.id);
 
-        this.validateAndProcessFeatureNamingPattern(
-            updatedProject.featureNaming,
-        );
+        if (updatedProject.featureNaming) {
+            this.validateAndProcessFeatureNamingPattern(
+                updatedProject.featureNaming,
+            );
+        }
 
         await this.store.update(updatedProject);
 


### PR DESCRIPTION
We already check for its presence before doing anything. We don't need to
check it twice (we're not Santa Claus, after all).