### PR TITLE
fix: sort toggleNames before updating last seen

### DIFF
--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -174,7 +174,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         const environmentArrays = this.mapMetricDataToEnvBuckets(data);
         try {
             for (const env of Object.keys(environmentArrays)) {
-                const toggleNames = environmentArrays[env];
+                const toggleNames = environmentArrays[env].sort();
                 await this.db(FEATURE_ENVIRONMENTS_TABLE)
                     .update({ last_seen_at: now })
                     .where('environment', env)


### PR DESCRIPTION
Seems like when 2 pods are trying to POST lastSeen metrics, the db gets into a deadlock state. 

This is an attempt to fix the deadlock by sorting the toggleNames before the update.

The hypothesis is that sorted toggle names will reduce the chance of working on the same row at the same exact time

Closes # [1-1382](https://linear.app/unleash/issue/1-1382/order-data-before-updating-the-lastseen-to-reduce-change-of-deadlock)