### PR TITLE
fix: point to `useUiFlag` instead of `useUiFlags`

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -8,7 +8,7 @@ export interface IUiConfig {
      * @deprecated `useUiFlags` can be used instead
      * @example
      * ```ts
-     *   const yourFlag = useUiFlags("yourFlag")
+     *   const yourFlag = useUiFlag("yourFlag")
      * ```
      */
     flags: UiFlags;


### PR DESCRIPTION
I was a little confused because I couldn't find `useUiFlags` in the
codebase.