### PR TITLE
fix: sort toggleNames before updating last seen (#4747)

### DIFF
--- a/src/lib/db/feature-toggle-store.ts
+++ b/src/lib/db/feature-toggle-store.ts
@@ -174,7 +174,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         const environmentArrays = this.mapMetricDataToEnvBuckets(data);
         try {
             for (const env of Object.keys(environmentArrays)) {
-                const toggleNames = environmentArrays[env];
+                const toggleNames = environmentArrays[env].sort();
                 await this.db(FEATURE_ENVIRONMENTS_TABLE)
                     .update({ last_seen_at: now })
                     .where('environment', env)


### PR DESCRIPTION
Seems like when 2 pods are trying to POST lastSeen metrics, the db gets into a deadlock state.

This is an attempt to fix the deadlock by sorting the toggleNames before the update.

The hypothesis is that sorted toggle names will reduce the chance of working on the same row at the same exact time

Closes #
[1-1382](https://linear.app/unleash/issue/1-1382/order-data-before-updating-the-lastseen-to-reduce-change-of-deadlock)

Signed-off-by: andreas-unleash <andreas@getunleash.ai>
(cherry picked from commit 76a834ca91ca821d7fa1a0fb1794754a9767c8a9)

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
