### PR TITLE
fix: simplify channels logic in slack app integration

### DIFF
--- a/src/lib/addons/slack-app-definition.ts
+++ b/src/lib/addons/slack-app-definition.ts
@@ -51,17 +51,9 @@ const slackAppDefinition: IAddonDefinition = {
         },
         {
             name: 'defaultChannels',
-            displayName: 'Default channels',
+            displayName: 'Channels',
             description:
-                'A comma-separated list of channels to post to if no tagged channels are found (e.g. a toggle without tags, or an event with no tags associated).',
-            type: 'text',
-            required: false,
-            sensitive: false,
-        },
-        {
-            name: 'alwaysPostToDefault',
-            displayName: 'Always post to default channels',
-            description: `If set to 'true' or 'yes', the app will always post events to the default channels, even if the feature toggle has slack tags`,
+                'A comma-separated list of channels to post the configured events to. These channels are always notified, regardless of the event type or the presence of a slack tag.',
             type: 'text',
             required: false,
             sensitive: false,

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -22,7 +22,6 @@ import { IEvent } from '../types/events';
 interface ISlackAppAddonParameters {
     accessToken: string;
     defaultChannels: string;
-    alwaysPostToDefault: string;
 }
 
 export default class SlackAppAddon extends Addon {
@@ -45,28 +44,20 @@ export default class SlackAppAddon extends Addon {
         parameters: ISlackAppAddonParameters,
     ): Promise<void> {
         try {
-            const { accessToken, defaultChannels, alwaysPostToDefault } =
-                parameters;
+            const { accessToken, defaultChannels } = parameters;
             if (!accessToken) {
                 this.logger.warn('No access token provided.');
                 return;
             }
 
-            const postToDefault =
-                alwaysPostToDefault === 'true' || alwaysPostToDefault === 'yes';
-            this.logger.debug(`Post to default was set to ${postToDefault}`);
-
             const taggedChannels = this.findTaggedChannels(event);
-            let eventChannels: string[];
-            if (postToDefault) {
-                eventChannels = taggedChannels.concat(
-                    this.getDefaultChannels(defaultChannels),
-                );
-            } else {
-                eventChannels = taggedChannels.length
-                    ? taggedChannels
-                    : this.getDefaultChannels(defaultChannels);
-            }
+            const eventChannels = [
+                ...new Set(
+                    taggedChannels.concat(
+                        this.getDefaultChannels(defaultChannels),
+                    ),
+                ),
+            ];
 
             if (!eventChannels.length) {
                 this.logger.debug(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1393/drop-the-always-post-to-default-channels-field

This drops the "Always post to default channels" field in the Slack App integration in favor of always posting to the configured channels. This should simplify the configuration of this integration.

Here's a breakdown of the logic with this change:
 - Always post to the configured Slack channels, regardless of tags;
 - Tags are still respected. E.g. if we have a configured channel "channel-1" and a tag for "channel-2", then we post to both channels;
 - As channels are optional, if you would like to skip default channels for certain events and handle everything through tags, you can just create a new configuration without any default channels;

This also updates the labels and changes the tests to better reflect the intended behavior.

![image](https://github.com/Unleash/unleash/assets/14320932/a2427bdd-4b92-44b3-9bad-8adb0f94c34d)