### PR TITLE
fix: rename Push to Environment button

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/PushVariantsButton/PushVariantsButton.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/PushVariantsButton/PushVariantsButton.tsx
@@ -100,7 +100,7 @@ export const PushVariantsButton = ({
                         aria-expanded={pushToOpen ? 'true' : undefined}
                         variant="outlined"
                     >
-                        Push to environment
+                        Copy to environment
                     </Button>
 
                     <StyledMenu


### PR DESCRIPTION
Rename to `Copy to Environment`

Closes # [1-1388](https://linear.app/unleash/issue/1-1388/update-the-text-for-the-button-push-to-environment-from-variants)

<img width="1423" alt="Screenshot 2023-09-18 at 13 46 57" src="https://github.com/Unleash/unleash/assets/104830839/c66747e5-a52a-4643-9274-51b72baf9f61">
