### PR TITLE
chore: update default version in UI

### DIFF
--- a/frontend/src/hooks/api/getters/useUiConfig/defaultValue.ts
+++ b/frontend/src/hooks/api/getters/useUiConfig/defaultValue.ts
@@ -3,7 +3,7 @@ import { IUiConfig } from 'interfaces/uiConfig';
 
 export const defaultValue: IUiConfig = {
     name: 'Unleash',
-    version: '3.x',
+    version: '5.x',
     slogan: 'The enterprise ready feature toggle service.',
     flags: {
         P: false,


### PR DESCRIPTION
We get a flash of the Unleash scaffold when we first load the page. For a brief moment, we display version 3 and then overwrite it with the correct version. Looks kinda silly, we know we're in version 5.x so let's just do that