### PR TITLE
fix: prevent blur when selecting text

### DIFF
--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -114,7 +114,6 @@ export const Search = ({
     useKeyboardShortcut({ key: 'Escape' }, () => {
         if (searchContainerRef.current?.contains(document.activeElement)) {
             searchInputRef.current?.blur();
-            hideSuggestions();
         }
     });
     const placeholder = `${customPlaceholder ?? 'Search'} (${hotkey})`;

--- a/frontend/src/hooks/useOnBlur.ts
+++ b/frontend/src/hooks/useOnBlur.ts
@@ -5,17 +5,27 @@ export const useOnBlur = (
     callback: () => void
 ): void => {
     useEffect(() => {
+        let mouseDownInside = false;
+
+        const handleMouseDown = (event: MouseEvent) => {
+            mouseDownInside = containerRef.current?.contains(event.target as Node) || false;
+        };
+
         const handleBlur = (event: FocusEvent) => {
-            // setTimeout is used because activeElement might not immediately be the new focused element after a blur event
             setTimeout(() => {
                 if (
+                    !mouseDownInside &&
                     containerRef.current &&
                     !containerRef.current.contains(document.activeElement)
                 ) {
                     callback();
                 }
+                // Reset the flag for the next sequence of events.
+                mouseDownInside = false;
             }, 0);
         };
+
+        document.addEventListener('mousedown', handleMouseDown);
 
         const containerElement = containerRef.current;
         if (containerElement) {
@@ -23,6 +33,7 @@ export const useOnBlur = (
         }
 
         return () => {
+            document.removeEventListener('mousedown', handleMouseDown);
             if (containerElement) {
                 containerElement.removeEventListener('blur', handleBlur, true);
             }

--- a/frontend/src/hooks/useOnBlur.ts
+++ b/frontend/src/hooks/useOnBlur.ts
@@ -2,13 +2,14 @@ import { useEffect } from 'react';
 
 export const useOnBlur = (
     containerRef: React.RefObject<HTMLElement>,
-    callback: () => void,
+    callback: () => void
 ): void => {
     useEffect(() => {
         let mouseDownInside = false;
 
         const handleMouseDown = (event: MouseEvent) => {
-            mouseDownInside = containerRef.current?.contains(event.target as Node) || false;
+            mouseDownInside =
+                containerRef.current?.contains(event.target as Node) || false;
         };
 
         const handleBlur = (event: FocusEvent) => {

--- a/frontend/src/hooks/useOnBlur.ts
+++ b/frontend/src/hooks/useOnBlur.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export const useOnBlur = (
     containerRef: React.RefObject<HTMLElement>,
-    callback: () => void
+    callback: () => void,
 ): void => {
     useEffect(() => {
         let mouseDownInside = false;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Selecting text in search suggestions was triggering blur and hiding all the suggestions:
<img width="633" alt="Screenshot 2023-09-18 at 13 51 07" src="https://github.com/Unleash/unleash/assets/1394682/8edd0250-9f89-40cb-8485-13a5f2da9a88">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
