### PR TITLE
chore: merge one of with properties

### DIFF
--- a/src/lib/openapi/meta-schema-rules.test.ts
+++ b/src/lib/openapi/meta-schema-rules.test.ts
@@ -56,10 +56,9 @@ const metaRules: Rule[] = [
     },
     {
         name: 'should have properties with descriptions',
-        match: (_, schema) => {
+        match: (_, schema) =>
             // only match schemas that have a properties field
-            return 'properties' in schema;
-        },
+            'properties' in schema,
         metaSchema: {
             type: 'object',
             // properties of the meta schema
@@ -88,6 +87,17 @@ const metaRules: Rule[] = [
                     },
                 },
             },
+        },
+        knownExceptions: [],
+    },
+    {
+        name: 'should either have oneOf or properties, instead extract them in commonProps',
+        match: (_, schema) =>
+            // only match schemas that have a properties field
+            'properties' in schema && 'oneOf' in schema,
+        metaSchema: {
+            type: 'object',
+            additionalProperties: false, // this is a shortcut to say: it should fail
         },
         knownExceptions: [],
     },

--- a/src/lib/openapi/spec/export-query-schema.ts
+++ b/src/lib/openapi/spec/export-query-schema.ts
@@ -1,27 +1,28 @@
 import { FromSchema } from 'json-schema-to-ts';
 
+const commonProps = {
+    environment: {
+        type: 'string',
+        example: 'development',
+        description: 'The environment to export from',
+    },
+    downloadFile: {
+        type: 'boolean',
+        example: true,
+        description: 'Whether to return a downloadable file',
+    },
+} as const;
+
 export const exportQuerySchema = {
     $id: '#/components/schemas/exportQuerySchema',
     type: 'object',
-    required: ['environment'],
     description:
         'Available query parameters for  the [deprecated export/import](https://docs.getunleash.io/reference/deploy/import-export) functionality.',
-    properties: {
-        environment: {
-            type: 'string',
-            example: 'development',
-            description: 'The environment to export from',
-        },
-        downloadFile: {
-            type: 'boolean',
-            example: true,
-            description: 'Whether to return a downloadable file',
-        },
-    },
     oneOf: [
         {
-            required: ['features'],
+            required: ['environment', 'features'],
             properties: {
+                ...commonProps,
                 features: {
                     type: 'array',
                     example: ['MyAwesomeFeature'],
@@ -34,8 +35,9 @@ export const exportQuerySchema = {
             },
         },
         {
-            required: ['tag'],
+            required: ['environment', 'tag'],
             properties: {
+                ...commonProps,
                 tag: {
                     type: 'string',
                     example: 'release',


### PR DESCRIPTION
## About the changes
Open API code generator does not get along with `oneOf` alongside `properties`:
```shell
$ openapi-generator-cli validate -i modified-openapi.json --recommend
Validating spec (modified-openapi.json)
Warnings: 
        - Schemas defining properties and oneOf are not clearly defined in the OpenAPI
          Specification. While our tooling supports this, it may cause issues with other tools.
```

https://github.com/OpenAPITools/openapi-generator/blob/bab67e44e49422f51aca84d0ac1cc3987f443c62/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java#L25-L29

This PR adds a meta-schema rule to validate this and fixes one issue
