### PR TITLE
task: Added workflow for calling update-version-action

### DIFF
--- a/.github/workflows/update_version_for_version_checker.yml
+++ b/.github/workflows/update_version_for_version_checker.yml
@@ -1,0 +1,35 @@
+name: Update version for version checker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Which version should we set OSS to"
+        type: 'string'
+        required: true
+
+jobs:
+  update:
+    if: ${{ !(contains(github.ref, 'beta') || contains(github.ref, 'alpha')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate Google IAM
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/340004706233/locations/global/workloadIdentityPools/gh-actions-pool/providers/github-actions-oidc-unleash'
+          service_account: 'versionUpdateSa@metrics-304612.iam.gserviceaccount.com'
+          token_format: 'access_token'
+      - name: Update version
+        if: ${{ github.event_name == 'release' }}
+        uses: 'Unleash/update-version-action@v0'
+        with:
+          version: ${{ github.event.release.tag_name }}
+          distribution: 'oss'
+      - name: Update version from manual dispatch
+        if: ${{ inputs.version != '' }}
+        uses: 'Unleash/update-version-action@v0'
+        with:
+          version: ${{ inputs.version }}
+          distribution: 'oss'


### PR DESCRIPTION
## What
This adds a workflow which automatically triggers on published releases to update the version number for our version checker. In addition it adds a workflow dispatch, in case the version number ended up wrong after an automatic run (for instance when patching an earlier released minor). 

## Observations
Currently the version checker which receives the update only validates that the new version is also valid semver, it does not however check/verify that we're not suddenly telling it an older version is the newest (improvement available in the version updater repo).