### PR TITLE
fix: datadog addon needs flagResolver

### DIFF
--- a/src/lib/addons/index.ts
+++ b/src/lib/addons/index.ts
@@ -5,6 +5,7 @@ import DatadogAddon from './datadog';
 import Addon from './addon';
 import { LogProvider } from '../logger';
 import SlackAppAddon from './slack-app';
+import { IFlagResolver } from '../types';
 
 export interface IAddonProviders {
     [key: string]: Addon;
@@ -13,7 +14,8 @@ export interface IAddonProviders {
 export const getAddons: (args: {
     getLogger: LogProvider;
     unleashUrl: string;
-}) => IAddonProviders = ({ getLogger, unleashUrl }) => {
+    flagResolver: IFlagResolver;
+}) => IAddonProviders = ({ getLogger, unleashUrl, flagResolver }) => {
     const addons: Addon[] = [
         new Webhook({ getLogger }),
         new SlackAddon({ getLogger, unleashUrl }),

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -49,7 +49,11 @@ export default class AddonService {
             IUnleashStores,
             'addonStore' | 'eventStore' | 'featureToggleStore'
         >,
-        { getLogger, server }: Pick<IUnleashConfig, 'getLogger' | 'server'>,
+        {
+            getLogger,
+            server,
+            flagResolver,
+        }: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>,
         tagTypeService: TagTypeService,
         addons?: IAddonProviders,
     ) {
@@ -64,6 +68,7 @@ export default class AddonService {
             getAddons({
                 getLogger,
                 unleashUrl: server.unleashUrl,
+                flagResolver,
             });
         this.sensitiveParams = this.loadSensitiveParams(this.addonProviders);
         if (addonStore) {


### PR DESCRIPTION
Fixes what this breaks: https://github.com/Unleash/unleash/pull/4765 - The Datadog integration needs a `flagResolver`.