### PR TITLE
docs: update the bulleted list case in about-the-docs.md

### DIFF
--- a/website/docs/about-the-docs.md
+++ b/website/docs/about-the-docs.md
@@ -14,10 +14,10 @@ Have questions that you can't find the answer to in these docs? You can always t
 
 Our documentation is split into four parts, using the [Diátaxis documentation framework](https://diataxis.fr/):
 
-- [tutorials and introductory material](#tutorials)
-- [how-to guides](#how-to-guides)
-- [reference documentation](#reference-documentation)
-- [topic guides](#topic-guides)
+- [Tutorials and introductory material](#tutorials)
+- [How-to guides](#how-to-guides)
+- [Reference documentation](#reference-documentation)
+- [Topic guides](#topic-guides)
 
 ### Tutorials and introductory material {#tutorials}
 


### PR DESCRIPTION
## About the changes

While exploring the [About the docs](https://docs.getunleash.io) page for the first time, I observed the first bulleted list started with lowercase, which isn't consistent with other sections of the page. This minor PR capitalizes the first letter of the bullet lists in the "Documentation structure" section. This ensures the list follows the existing style across the page and the stable rule of written language ([reference](https://www.purchase.edu/editorial-style-guide/general-style-preferences/punctuation/bulleted-and-numbered-lists/#C)).