### PR TITLE
feat: context/segment usage private

### DIFF
--- a/frontend/src/component/segments/SegmentFormStepOne.tsx
+++ b/frontend/src/component/segments/SegmentFormStepOne.tsx
@@ -77,7 +77,6 @@ export const SegmentFormStepOne: React.FC<ISegmentFormPartOneProps> = ({
     const projectsUsed = new Set<string>(
         strategies.map(({ projectId }) => projectId!).filter(Boolean)
     );
-
     const availableProjects = projects.filter(
         ({ id }) =>
             !projectsUsed.size ||

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -38,7 +38,6 @@ export const SegmentProjectAlert = ({
             },
         });
     };
-    console.log('projects user', projectsUsed);
     const projectList = (
         <StyledUl>
             {Array.from(projectsUsed).map(projectId => (

--- a/frontend/src/component/segments/SegmentProjectAlert.tsx
+++ b/frontend/src/component/segments/SegmentProjectAlert.tsx
@@ -5,6 +5,7 @@ import { IFeatureStrategy } from 'interfaces/strategy';
 import { Link } from 'react-router-dom';
 import { formatStrategyName } from 'utils/strategyNames';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledUl = styled('ul')(({ theme }) => ({
     listStyle: 'none',
@@ -37,7 +38,7 @@ export const SegmentProjectAlert = ({
             },
         });
     };
-
+    console.log('projects user', projectsUsed);
     const projectList = (
         <StyledUl>
             {Array.from(projectsUsed).map(projectId => (
@@ -78,11 +79,19 @@ export const SegmentProjectAlert = ({
         </StyledUl>
     );
 
-    if (projectsUsed.length > 1) {
+    if (projectsUsed.length > 0) {
         return (
             <StyledAlert severity="info">
-                You can't specify a project for this segment because it is used
-                in multiple projects:
+                <ConditionallyRender
+                    condition={projectsUsed.length > 1}
+                    show={
+                        <span>
+                            You can't specify a project for this segment because
+                            it is used in multiple projects:
+                        </span>
+                    }
+                    elseShow={<span>Usage of this segment:</span>}
+                />
                 {projectList}
             </StyledAlert>
         );

--- a/src/lib/features/export-import-toggles/createExportImportService.ts
+++ b/src/lib/features/export-import-toggles/createExportImportService.ts
@@ -38,11 +38,15 @@ import FakeFeatureStrategiesStore from '../../../test/fixtures/fake-feature-stra
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
 import FakeStrategiesStore from '../../../test/fixtures/fake-strategies-store';
 import EventStore from '../../db/event-store';
+import {
+    createFakePrivateProjectChecker,
+    createPrivateProjectChecker,
+} from '../private-project/createPrivateProjectChecker';
 
 export const createFakeExportImportTogglesService = (
     config: IUnleashConfig,
 ): ExportImportService => {
-    const { getLogger } = config;
+    const { getLogger, flagResolver } = config;
     const importTogglesStore = {} as ImportTogglesStore;
     const featureToggleStore = new FakeFeatureToggleStore();
     const tagStore = new FakeTagStore();
@@ -57,6 +61,7 @@ export const createFakeExportImportTogglesService = (
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
     const accessService = createFakeAccessService(config);
     const featureToggleService = createFakeFeatureToggleService(config);
+    const privateProjectChecker = createFakePrivateProjectChecker();
 
     const featureTagService = new FeatureTagService(
         {
@@ -74,7 +79,8 @@ export const createFakeExportImportTogglesService = (
             contextFieldStore,
             featureStrategiesStore,
         },
-        { getLogger },
+        { getLogger, flagResolver },
+        privateProjectChecker,
     );
     const strategyService = new StrategyService(
         { strategyStore, eventStore },
@@ -152,6 +158,7 @@ export const createExportImportTogglesService = (
     const eventStore = new EventStore(db, getLogger);
     const accessService = createAccessService(db, config);
     const featureToggleService = createFeatureToggleService(db, config);
+    const privateProjectChecker = createPrivateProjectChecker(db, config);
 
     const featureTagService = new FeatureTagService(
         {
@@ -169,7 +176,8 @@ export const createExportImportTogglesService = (
             contextFieldStore,
             featureStrategiesStore,
         },
-        { getLogger },
+        { getLogger, flagResolver },
+        privateProjectChecker,
     );
     const strategyService = new StrategyService(
         { strategyStore, eventStore },

--- a/src/lib/features/segment/createSegmentService.ts
+++ b/src/lib/features/segment/createSegmentService.ts
@@ -11,6 +11,10 @@ import {
     createChangeRequestAccessReadModel,
     createFakeChangeRequestAccessService,
 } from '../change-request-access-service/createChangeRequestAccessReadModel';
+import {
+    createFakePrivateProjectChecker,
+    createPrivateProjectChecker,
+} from '../private-project/createPrivateProjectChecker';
 
 export const createSegmentService = (
     db: Db,
@@ -34,11 +38,13 @@ export const createSegmentService = (
         db,
         config,
     );
+    const privateProjectChecker = createPrivateProjectChecker(db, config);
 
     return new SegmentService(
         { segmentStore, featureStrategiesStore, eventStore },
         changeRequestAccessReadModel,
         config,
+        privateProjectChecker,
     );
 };
 
@@ -50,9 +56,12 @@ export const createFakeSegmentService = (
     const featureStrategiesStore = new FakeFeatureStrategiesStore();
     const changeRequestAccessReadModel = createFakeChangeRequestAccessService();
 
+    const privateProjectChecker = createFakePrivateProjectChecker();
+
     return new SegmentService(
         { segmentStore, featureStrategiesStore, eventStore },
         changeRequestAccessReadModel,
         config,
+        privateProjectChecker,
     );
 };

--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -347,7 +347,8 @@ export class SegmentsController extends Controller {
         res: Response<SegmentStrategiesSchema>,
     ): Promise<void> {
         const { id } = req.params;
-        const strategies = await this.segmentService.getStrategies(id);
+        const { user } = req;
+        const strategies = await this.segmentService.getStrategies(id, user.id);
 
         // Remove unnecessary IFeatureStrategy fields from the response.
         const segmentStrategies = strategies.map((strategy) => ({
@@ -368,7 +369,8 @@ export class SegmentsController extends Controller {
         res: Response,
     ): Promise<void> {
         const id = Number(req.params.id);
-        const strategies = await this.segmentService.getStrategies(id);
+        const { user } = req;
+        const strategies = await this.segmentService.getStrategies(id, user.id);
 
         if (strategies.length > 0) {
             res.status(409).send();

--- a/src/lib/routes/admin-api/context.ts
+++ b/src/lib/routes/admin-api/context.ts
@@ -301,8 +301,12 @@ export class ContextController extends Controller {
         res: Response<ContextFieldStrategiesSchema>,
     ): Promise<void> {
         const { contextField } = req.params;
+        const { user } = req;
         const contextFields =
-            await this.contextService.getStrategiesByContextField(contextField);
+            await this.contextService.getStrategiesByContextField(
+                contextField,
+                user.id,
+            );
 
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -13,7 +13,7 @@ export interface ISegmentService {
 
     get(id: number): Promise<ISegment>;
 
-    getStrategies(id: number): Promise<IFeatureStrategy[]>;
+    getStrategies(id: number, userId: number): Promise<IFeatureStrategy[]>;
 
     validateName(name: string): Promise<void>;
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -169,7 +169,15 @@ export const createServices = (
         config,
         lastSeenService,
     );
-    const contextService = new ContextService(stores, config);
+    const privateProjectChecker = db
+        ? createPrivateProjectChecker(db, config)
+        : createFakePrivateProjectChecker();
+
+    const contextService = new ContextService(
+        stores,
+        config,
+        privateProjectChecker,
+    );
     const emailService = new EmailService(config.email, config.getLogger);
     const eventService = new EventService(stores, config);
     const featureTypeService = new FeatureTypeService(stores, config);
@@ -201,11 +209,9 @@ export const createServices = (
         stores,
         changeRequestAccessReadModel,
         config,
+        privateProjectChecker,
     );
 
-    const privateProjectChecker = db
-        ? createPrivateProjectChecker(db, config)
-        : createFakePrivateProjectChecker();
     const clientInstanceService = new ClientInstanceService(
         stores,
         config,

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -253,7 +253,12 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, changeRequestAccessReadModel, config),
+        new SegmentService(
+            stores,
+            changeRequestAccessReadModel,
+            config,
+            privateProjectChecker,
+        ),
         accessService,
         changeRequestAccessReadModel,
         privateProjectChecker,

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -39,7 +39,12 @@ beforeAll(async () => {
     const featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, changeRequestAccessReadModel, config),
+        new SegmentService(
+            stores,
+            changeRequestAccessReadModel,
+            config,
+            privateProjectChecker,
+        ),
         accessService,
         changeRequestAccessReadModel,
         privateProjectChecker,

--- a/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
+++ b/src/test/e2e/services/feature-toggle-service-v2.e2e.test.ts
@@ -54,15 +54,17 @@ beforeAll(async () => {
         db.rawDatabase,
         accessService,
     );
-    segmentService = new SegmentService(
-        stores,
-        changeRequestAccessReadModel,
-        config,
-    );
     const privateProjectChecker = createPrivateProjectChecker(
         db.rawDatabase,
         config,
     );
+    segmentService = new SegmentService(
+        stores,
+        changeRequestAccessReadModel,
+        config,
+        privateProjectChecker,
+    );
+
     service = new FeatureToggleService(
         stores,
         config,

--- a/src/test/e2e/services/playground-service.test.ts
+++ b/src/test/e2e/services/playground-service.test.ts
@@ -43,15 +43,17 @@ beforeAll(async () => {
         db.rawDatabase,
         accessService,
     );
-    segmentService = new SegmentService(
-        stores,
-        changeRequestAccessReadModel,
-        config,
-    );
     const privateProjectChecker = createPrivateProjectChecker(
         db.rawDatabase,
         config,
     );
+    segmentService = new SegmentService(
+        stores,
+        changeRequestAccessReadModel,
+        config,
+        privateProjectChecker,
+    );
+
     featureToggleService = new FeatureToggleService(
         stores,
         config,

--- a/src/test/e2e/services/project-health-service.e2e.test.ts
+++ b/src/test/e2e/services/project-health-service.e2e.test.ts
@@ -44,7 +44,12 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, changeRequestAccessReadModel, config),
+        new SegmentService(
+            stores,
+            changeRequestAccessReadModel,
+            config,
+            privateProjectChecker,
+        ),
         accessService,
         changeRequestAccessReadModel,
         privateProjectChecker,

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -65,7 +65,12 @@ beforeAll(async () => {
     featureToggleService = new FeatureToggleService(
         stores,
         config,
-        new SegmentService(stores, changeRequestAccessReadModel, config),
+        new SegmentService(
+            stores,
+            changeRequestAccessReadModel,
+            config,
+            privateProjectChecker,
+        ),
         accessService,
         changeRequestAccessReadModel,
         privateProjectChecker,


### PR DESCRIPTION
1. GET single context field strategies will now hide private projects
2. GET single segment strategies will now hide private projects

This is just reusing the private project checker method, which is heavily tested in enterprise.