### PR TITLE
chore: pin node version 18.17.1

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [18-alpine]
+        version: [18.17.1-alpine]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=18-alpine
+ARG NODE_VERSION=18.17.1-alpine
 
 FROM node:$NODE_VERSION as builder
 


### PR DESCRIPTION
We are pinning node to version 18.17.1 as we have seen some performance degregation on node 18.18.0 on arm64. We will investigate this further at a later point. This is to mitigate the issue.

Our next step in pinpointing the issue will be to compare between running on musl vs libc on arm64.
