### PR TITLE
chore: update DATABASE_URL to use the database created via POSTGRES_D…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "4242:4242"
     environment:
       # This points Unleash to its backing database (defined in the `db` section below)
-      DATABASE_URL: "postgres://postgres:unleash@db/postgres"
+      DATABASE_URL: "postgres://postgres:unleash@db/db"
       # Disable SSL for database connections. @chriswk: why do we do this?
       DATABASE_SSL: "false"
       # Changing log levels:


### PR DESCRIPTION
…B in compose

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
I've noticed that all migrations are applied to the `postgres` database along we've the variable POSTGRES_DB=db in docker compose.
The reason is the DATABASE_URL variable still refers to `postgres` instead `db`. I updated the URL and now it works with `db`.
