### PR TITLE
fix: project features table initial state

### DIFF
--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/FeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/FeatureToggleSwitch.tsx
@@ -220,7 +220,7 @@ export const FeatureToggleSwitch: VFC<IFeatureToggleSwitchProps> = ({
                     permission={UPDATE_FEATURE_ENVIRONMENT}
                     inputProps={{ 'aria-label': environmentName }}
                     onClick={onClick}
-                    data-testId={'permission-switch'}
+                    data-testid={'permission-switch'}
                 />
             </StyledBoxContainer>
             <EnableEnvironmentDialog

--- a/frontend/src/component/project/Project/ProjectOverview.tsx
+++ b/frontend/src/component/project/Project/ProjectOverview.tsx
@@ -60,6 +60,7 @@ const ProjectOverview = () => {
                 <ProjectStats stats={project.stats} />
                 <StyledProjectToggles>
                     <ProjectFeatureToggles
+                        key={loading ? 'loading' : 'ready'}
                         features={features}
                         environments={environments}
                         loading={loading}


### PR DESCRIPTION
When loading don't keep initial state, but recalculate if after proper data is present

https://linear.app/unleash/issue/1-1432/project-overview-filtering-is-not-saved-correctly-4789