### PR TITLE
fix: permissions in the role payload

### DIFF
--- a/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
+++ b/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
@@ -44,7 +44,9 @@ export const useRoleForm = (
         name,
         description,
         type: type === ROOT_ROLE_TYPE ? 'root-custom' : 'custom',
-        permissions: Object.values(checkedPermissions),
+        permissions: Object.values(checkedPermissions).map(
+            ({ name, environment }) => ({ name, environment })
+        ),
     });
 
     const isNameUnique = (name: string) => {


### PR DESCRIPTION
Fixes the role payload to include only the needed properties from permissions. Fixes `400` (oneOf schema validation error) in project role creation.