### PR TITLE
chore: add workspace .vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ unleash-server.tar.gz
 # Visual Studio Code
 jsconfig.json
 typings
-.vscode
 .nyc_output
 
 # We use yarn.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "biomejs.biome"
+}


### PR DESCRIPTION
Adds VSCode workspace settings `.vscode/settings.json` with a default formatter: `"editor.defaultFormatter": "biomejs.biome"`