### PR TITLE
refactor: bubble promise instead of return await

### DIFF
--- a/frontend/src/hooks/api/actions/useAddonsApi/useAddonsApi.ts
+++ b/frontend/src/hooks/api/actions/useAddonsApi/useAddonsApi.ts
@@ -25,7 +25,7 @@ const useAddonsApi = () => {
             method: 'DELETE',
         });
 
-        return await makeRequest(req.caller, req.id);
+        return makeRequest(req.caller, req.id);
     };
 
     const updateAddon = useCallback(

--- a/frontend/src/hooks/api/actions/useInviteTokenApi/useInviteTokenApi.ts
+++ b/frontend/src/hooks/api/actions/useInviteTokenApi/useInviteTokenApi.ts
@@ -20,7 +20,7 @@ export const useInviteTokenApi = () => {
                 body: JSON.stringify(request),
             });
 
-            return await makeRequest(req.caller, req.id);
+            return makeRequest(req.caller, req.id);
         },
         [createRequest, makeRequest],
     );
@@ -37,7 +37,7 @@ export const useInviteTokenApi = () => {
                 }),
             });
 
-            return await makeRequest(req.caller, req.id);
+            return makeRequest(req.caller, req.id);
         },
         [createRequest, makeRequest],
     );
@@ -49,7 +49,7 @@ export const useInviteTokenApi = () => {
                 body: JSON.stringify(value),
             });
 
-            return await makeRequest(req.caller, req.id);
+            return makeRequest(req.caller, req.id);
         },
         [createRequest, makeRequest],
     );

--- a/frontend/src/hooks/api/actions/useRolesApi/useRolesApi.ts
+++ b/frontend/src/hooks/api/actions/useRolesApi/useRolesApi.ts
@@ -24,7 +24,7 @@ export const useRolesApi = () => {
         );
 
         const response = await makeRequest(req.caller, req.id);
-        return await response.json();
+        return response.json();
     };
 
     const updateRole = async (roleId: number, role: IRolePayload) => {

--- a/frontend/src/hooks/api/actions/useServiceAccountsApi/useServiceAccountsApi.ts
+++ b/frontend/src/hooks/api/actions/useServiceAccountsApi/useServiceAccountsApi.ts
@@ -25,7 +25,7 @@ export const useServiceAccountsApi = () => {
         );
 
         const response = await makeRequest(req.caller, req.id);
-        return await response.json();
+        return response.json();
     };
 
     const removeServiceAccount = async (serviceAccountId: number) => {


### PR DESCRIPTION
Tiny refactor that bubbles promises instead of using `return await`. Should be more consistent with the rest of the changes in https://github.com/Unleash/unleash/pull/4903