### PR TITLE
feat: allow defining initial admin user as env variable

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -19,6 +19,10 @@ exports[`should create default config 1`] = `
     "customAuthHandler": [Function],
     "enableApiToken": true,
     "initApiTokens": [],
+    "initialAdminUser": {
+      "password": "unleash4all",
+      "username": "admin",
+    },
     "type": "open-source",
   },
   "clientFeatureCaching": {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -195,6 +195,10 @@ const defaultAuthentication: IAuthOption = {
     type: authTypeFromString(process.env.AUTH_TYPE),
     customAuthHandler: defaultCustomAuthDenyAll,
     createAdminUser: true,
+    initialAdminUser: {
+        username: process.env.UNLEASH_DEFAULT_ADMIN_USERNAME ?? 'admin',
+        password: process.env.UNLEASH_DEFAULT_ADMIN_PASSWORD ?? 'unleash4all',
+    },
     initApiTokens: [],
 };
 

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -57,7 +57,11 @@ export interface IAuthOption {
     enableApiToken: boolean;
     type: IAuthType;
     customAuthHandler?: Function;
-    createAdminUser: boolean;
+    createAdminUser?: boolean;
+    initialAdminUser?: {
+        username: string;
+        password: string;
+    };
     initApiTokens: ILegacyApiTokenCreate[];
 }
 

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -63,7 +63,13 @@ afterEach(async () => {
 });
 
 test('should create initial admin user', async () => {
-    await userService.initAdminUser();
+    await userService.initAdminUser({
+        createAdminUser: true,
+        initialAdminUser: {
+            username: 'admin',
+            password: 'unleash4all',
+        },
+    });
     await expect(async () =>
         userService.loginUser('admin', 'wrong-password'),
     ).rejects.toThrow(Error);
@@ -78,7 +84,13 @@ test('should not init default user if we already have users', async () => {
         password: 'A very strange P4ssw0rd_',
         rootRole: adminRole.id,
     });
-    await userService.initAdminUser();
+    await userService.initAdminUser({
+        createAdminUser: true,
+        initialAdminUser: {
+            username: 'admin',
+            password: 'unleash4all',
+        },
+    });
     const users = await userService.getAll();
     expect(users).toHaveLength(1);
     expect(users[0].username).toBe('test');

--- a/website/docs/reference/deploy/configuring-unleash.md
+++ b/website/docs/reference/deploy/configuring-unleash.md
@@ -66,7 +66,7 @@ unleash.start(unleashOptions);
     - `none` - Turn off authentication all together
     - `demo` - Only requires an email to sign in (was default in v3)
   - `customAuthHandler`: function `(app: any, config: IUnleashConfig): void` — custom express middleware handling authentication. Used when type is set to `custom`. Can not be set via environment variables.
-  - `createAdminUser`: `boolean` — whether to create an admin user with default password - Defaults to `true`. Can not be set via environment variables. Can not be set via environment variables.
+  - `initialAdminUser`: `{ username: string, password: string} | null` — whether to create an admin user with default password - Defaults to using `admin` and `unleash4all` as the username and password. Can not be overridden by setting the `UNLEASH_DEFAULT_ADMIN_USERNAME` and `UNLEASH_DEFAULT_ADMIN_PASSWORD` environment variables.
   - `initApiTokens` / `INIT_ADMIN_API_TOKENS` and `INIT_CLIENT_API_TOKENS` (see below): `ApiTokens[]` — Array of API tokens to create on startup. The tokens will only be created if the database doesn't already contain any API tokens. Example:
 
     ```ts

--- a/website/docs/reference/deploy/getting-started.md
+++ b/website/docs/reference/deploy/getting-started.md
@@ -31,6 +31,14 @@ To run multiple replicas of Unleash simply point all instances to the same datab
 - username: `admin`
 - password: `unleash4all`
 
+If you'd like the default admin user to be created with a different username and password, you may define the following environment variables when running Unleash:
+
+- `UNLEASH_DEFAULT_ADMIN_USERNAME`
+- UNLEASH_DEFAULT_ADMIN_PASSWORD
+
+The way of defining these variables may vary depending on how you run Unleash.
+
+
 ### Option 1 - use Docker {#option-one---use-docker}
 
 **Useful links:**


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This PR adds a way of defining the username and password for the "default admin user" via environment variables. It defaults to using `admin` and `unleash4all`, so it should be completely backwards compatible.

<!-- Does it close an issue? Multiple? -->
Closes #4560
