### PR TITLE
fix: Remove the info from the variants page

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
@@ -264,7 +264,6 @@ export const FeatureEnvironmentVariants = () => {
                 </PageHeader>
             }
         >
-            <VariantInfoAlert mode='feature' />
             <StrategyVariantsPreferredAlert />
             {environments.map((environment) => {
                 const otherEnvsWithVariants = environments.filter(


### PR DESCRIPTION
Remove the info from the variants page

Closes # [UNL-231](https://linear.app/unleash/issue/UNL-231/remove-the-info-from-the-variants-page)
<img width="1408" alt="Screenshot 2023-10-05 at 15 11 33" src="https://github.com/Unleash/unleash/assets/104830839/68bac945-af00-4c9b-ae6d-faeed92ec4bb">
