### PR TITLE
fix: change broken link to groups documentation

### DIFF
--- a/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
+++ b/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
@@ -87,7 +87,7 @@ export const CreateGroup = () => {
             loading={loading}
             title='Create group'
             description='Groups is the best and easiest way to organize users and then use them in projects to assign a specific role in one go to all the users in a group.'
-            documentationLink='https://docs.getunleash.io/advanced/groups'
+            documentationLink='https://docs.getunleash.io/reference/rbac#user-groups'
             documentationLinkLabel='Groups documentation'
             formatApiCode={formatApiCode}
         >

--- a/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
+++ b/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
@@ -123,7 +123,7 @@ export const EditGroup = ({
             loading={loading}
             title='Edit group'
             description='Groups is the best and easiest way to organize users and then use them in projects to assign a specific role in one go to all the users in a group.'
-            documentationLink='https://docs.getunleash.io/advanced/groups'
+            documentationLink='https://docs.getunleash.io/reference/rbac#user-groups'
             documentationLinkLabel='Groups documentation'
             formatApiCode={formatApiCode}
         >


### PR DESCRIPTION
Replaces the broken groups documentation link

CLoses: # [SR-75](https://linear.app/unleash/issue/SR-75/groups-documentation-link-broken)