### PR TITLE
feat: render segments changes in feature strategy update event messages

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -415,7 +415,11 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
             preData?.constraints,
             data?.constraints,
         );
-        const strategySpecificText = [usersText, constraintText]
+        const segmentsText = this.segmentsChangeText(
+            preData?.segments,
+            data?.segments,
+        );
+        const strategySpecificText = [usersText, constraintText, segmentsText]
             .filter((x) => x.length)
             .join(';');
         return `by updating strategy *${this.getStrategyTitle(
@@ -453,11 +457,16 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
             preData?.constraints,
             data?.constraints,
         );
+        const segmentsText = this.segmentsChangeText(
+            preData?.segments,
+            data?.segments,
+        );
         const strategySpecificText = [
             stickinessText,
             rolloutText,
             groupIdText,
             constraintText,
+            segmentsText,
         ]
             .filter((txt) => txt.length)
             .join(';');
@@ -468,12 +477,20 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
 
     private defaultStrategyChangeText(event: IEvent) {
         const { preData, data, environment } = event;
-        return `by updating strategy *${this.getStrategyTitle(
-            event,
-        )}* in *${environment}*${this.constraintChangeText(
+        const constraintText = this.constraintChangeText(
             preData?.constraints,
             data?.constraints,
-        )}`;
+        );
+        const segmentsText = this.segmentsChangeText(
+            preData?.segments,
+            data?.segments,
+        );
+        const strategySpecificText = [constraintText, segmentsText]
+            .filter((txt) => txt.length)
+            .join(';');
+        return `by updating strategy *${this.getStrategyTitle(
+            event,
+        )}* in *${environment}*${strategySpecificText}`;
     }
 
     private constraintChangeText(
@@ -523,6 +540,23 @@ export class FeatureEventFormatterMd implements FeatureEventFormatter {
         return oldConstraintText === newConstraintText
             ? ''
             : ` constraints from ${oldConstraintText} to ${newConstraintText}`;
+    }
+
+    private segmentsChangeText(
+        oldSegments: string[] = [],
+        newSegments: string[] = [],
+    ) {
+        const formatSegments = (segments: string[]) => {
+            return segments.length === 0
+                ? 'empty set of segments'
+                : `(${segments.join(',')})`;
+        };
+        const oldSegmentsText = formatSegments(oldSegments);
+        const newSegmentsText = formatSegments(newSegments);
+
+        return oldSegmentsText === newSegmentsText
+            ? ''
+            : ` segments from ${oldSegmentsText} to ${newSegmentsText}`;
     }
 
     format(event: IEvent): {

--- a/src/lib/services/feature-toggle-service.ts
+++ b/src/lib/services/feature-toggle-service.ts
@@ -704,6 +704,7 @@ class FeatureToggleService {
             projectId,
             updates.segments,
         );
+        const existingSegments = await this.segmentService.getByStrategy(id);
 
         if (existingStrategy.id === id) {
             if (updates.constraints && updates.constraints.length > 0) {
@@ -738,7 +739,7 @@ class FeatureToggleService {
             const data = this.featureStrategyToPublic(strategy, segments);
             const preData = this.featureStrategyToPublic(
                 existingStrategy,
-                segments,
+                existingSegments,
             );
             await this.eventService.storeEvent(
                 new FeatureStrategyUpdateEvent({
@@ -775,6 +776,9 @@ class FeatureToggleService {
 
         if (existingStrategy.id === id) {
             existingStrategy.parameters[name] = String(value);
+            const existingSegments = await this.segmentService.getByStrategy(
+                id,
+            );
             const strategy = await this.featureStrategiesStore.updateStrategy(
                 id,
                 existingStrategy,
@@ -785,7 +789,7 @@ class FeatureToggleService {
             const data = this.featureStrategyToPublic(strategy, segments);
             const preData = this.featureStrategyToPublic(
                 existingStrategy,
-                segments,
+                existingSegments,
             );
             await this.eventService.storeEvent(
                 new FeatureStrategyUpdateEvent({


### PR DESCRIPTION
## About the changes

Segment changes in predata and data columns were both showing the new segments list

Adds formatting of what's changed with segments to feature strategy update events, so when a user changes the strategy from using constraints, to using segments instead, it's communicated in event updates

results in: 

admin updated [sample-toggle](http://localhost/projects/default/features/sample-toggle) in project [default](http://localhost/projects/default) by updating strategy Sample Strategy in development constraints from [userId is one of (1,2,3)] to empty set of constraints; segments from empty set of segments to (1)


Closes #
#4912 

### Important files

- `src/lib/services/feature-toggle-service.ts` - Segment changes in preData and data
- `src/lib/addons/feature-event-formatter-md.ts` - Formatting segments

## Discussion points

This is an SR least effort PR - we should plan a task where we look at how to render this list of segments in a more comprehensible way (it's just rendering ids now)