### PR TITLE
feat: feature changes counted in new table

### DIFF
--- a/src/lib/db/event-store.ts
+++ b/src/lib/db/event-store.ts
@@ -146,9 +146,7 @@ class EventStore implements IEventStore {
 
     async batchStore(events: IBaseEvent[]): Promise<void> {
         try {
-            await this.db(TABLE)
-                .insert(events.map(this.eventToDbRow))
-                .returning(EVENT_COLUMNS);
+            await this.db(TABLE).insert(events.map(this.eventToDbRow));
         } catch (error: unknown) {
             this.logger.warn(`Failed to store events: ${error}`);
         }

--- a/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
@@ -23,7 +23,13 @@ const mockRawEventDaysAgo = (
     days: number,
     environment: string = 'production',
 ) => {
-    const day = subDays(new Date(), days);
+    return {
+        type: 'FEATURE_UPDATED',
+        created_by: 'testrunner',
+        environment,
+        feature_name: 'test.feature',
+        announced: true,
+    };
 };
 
 beforeAll(async () => {
@@ -78,77 +84,12 @@ test('should handle intervals of activity', async () => {
     });
 });
 
-/*
 test('an event being saved should add a count to the table', async () => {
-    const users = await db
-        .rawDatabase('events')
-        .insert(mockRawEventDaysAgo(mockEventDaysAgo(100))
-        .returning('id');
-    const userId = users[0].id;
-    await db
-        .rawDatabase('personal_access_tokens')
-        .insert(mockTokenDaysAgo(userId, 31));
+    await db.rawDatabase('events').insert(mockRawEventDaysAgo(70));
 
-    expect(getActiveUsers()).resolves.toEqual({
-        last7: 0,
+    expect(getProductionChanges()).resolves.toEqual({
         last30: 0,
-        last60: 1,
+        last60: 0,
         last90: 1,
     });
 });
-
-test('should prioritize user seen_at if newer then token seen_at', async () => {
-    const users = await db
-        .rawDatabase('users')
-        .insert(mockEventDaysAgo(14))
-        .returning('id');
-    const userId = users[0].id;
-    await db
-        .rawDatabase('personal_access_tokens')
-        .insert([
-            mockTokenDaysAgo(userId, 31),
-            mockTokenDaysAgo(userId, 61),
-            mockTokenDaysAgo(userId, 91),
-        ]);
-
-    expect(getActiveUsers()).resolves.toEqual({
-        last7: 0,
-        last30: 1,
-        last60: 1,
-        last90: 1,
-    });
-});
-
-test('should handle multiple users and with multiple tokens', async () => {
-    const users = await db
-        .rawDatabase('users')
-        .insert([
-            mockEventDaysAgo(5),
-            mockEventDaysAgo(10),
-            mockEventDaysAgo(20),
-            mockEventDaysAgo(40),
-            mockEventDaysAgo(70),
-            mockEventDaysAgo(100),
-        ])
-        .returning('id');
-
-    await db
-        .rawDatabase('personal_access_tokens')
-        .insert([
-            mockTokenDaysAgo(users[0].id, 31),
-            mockTokenDaysAgo(users[1].id, 61),
-            mockTokenDaysAgo(users[1].id, 15),
-            mockTokenDaysAgo(users[1].id, 55),
-            mockTokenDaysAgo(users[2].id, 4),
-            mockTokenDaysAgo(users[3].id, 91),
-            mockTokenDaysAgo(users[4].id, 91),
-        ]);
-
-    expect(getActiveUsers()).resolves.toEqual({
-        last7: 2,
-        last30: 3,
-        last60: 4,
-        last90: 5,
-    });
-});
-*/

--- a/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
@@ -1,4 +1,3 @@
-import { createGetActiveUsers, type GetActiveUsers } from './getActiveUsers';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import getLogger from '../../../test/fixtures/no-logger';
 import {

--- a/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
@@ -118,7 +118,7 @@ test('an event with no environment should not be counted', async () => {
 
 test('five events per day should be counted correctly', async () => {
     for (let i = 0; i < 100; i++) {
-        for (let j; j < 5; j++) {
+        for (let j: number = 0; j < 5; j++) {
             await db.rawDatabase.table('events').insert(mockRawEventDaysAgo(i));
         }
     }

--- a/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.e2e.test.ts
@@ -1,0 +1,154 @@
+import { createGetActiveUsers, type GetActiveUsers } from './getActiveUsers';
+import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
+import getLogger from '../../../test/fixtures/no-logger';
+import {
+    createGetProductionChanges,
+    GetProductionChanges,
+} from './getProductionChanges';
+import subDays from 'date-fns/subDays';
+let db: ITestDb;
+let getProductionChanges: GetProductionChanges;
+
+const mockEventDaysAgo = (days: number, environment: string = 'production') => {
+    const result = new Date();
+    result.setDate(result.getDate() - days);
+    return {
+        day: result,
+        environment,
+        updates: 1,
+    };
+};
+
+const mockRawEventDaysAgo = (
+    days: number,
+    environment: string = 'production',
+) => {
+    const day = subDays(new Date(), days);
+};
+
+beforeAll(async () => {
+    db = await dbInit('product_changes_serial', getLogger);
+    getProductionChanges = createGetProductionChanges(db.rawDatabase);
+});
+
+afterEach(async () => {
+    await db.rawDatabase('stat_environment_updates').delete();
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+test('should return 0 changes from an empty database', async () => {
+    await expect(getProductionChanges()).resolves.toEqual({
+        last30: 0,
+        last60: 0,
+        last90: 0,
+    });
+});
+
+test('should return 1 change', async () => {
+    await db
+        .rawDatabase('stat_environment_updates')
+        .insert(mockEventDaysAgo(1));
+
+    await expect(getProductionChanges()).resolves.toEqual({
+        last30: 1,
+        last60: 1,
+        last90: 1,
+    });
+});
+
+test('should handle intervals of activity', async () => {
+    await db
+        .rawDatabase('stat_environment_updates')
+        .insert([
+            mockEventDaysAgo(5),
+            mockEventDaysAgo(10),
+            mockEventDaysAgo(20),
+            mockEventDaysAgo(40),
+            mockEventDaysAgo(70),
+            mockEventDaysAgo(100),
+        ]);
+
+    await expect(getProductionChanges()).resolves.toEqual({
+        last30: 3,
+        last60: 4,
+        last90: 5,
+    });
+});
+
+/*
+test('an event being saved should add a count to the table', async () => {
+    const users = await db
+        .rawDatabase('events')
+        .insert(mockRawEventDaysAgo(mockEventDaysAgo(100))
+        .returning('id');
+    const userId = users[0].id;
+    await db
+        .rawDatabase('personal_access_tokens')
+        .insert(mockTokenDaysAgo(userId, 31));
+
+    expect(getActiveUsers()).resolves.toEqual({
+        last7: 0,
+        last30: 0,
+        last60: 1,
+        last90: 1,
+    });
+});
+
+test('should prioritize user seen_at if newer then token seen_at', async () => {
+    const users = await db
+        .rawDatabase('users')
+        .insert(mockEventDaysAgo(14))
+        .returning('id');
+    const userId = users[0].id;
+    await db
+        .rawDatabase('personal_access_tokens')
+        .insert([
+            mockTokenDaysAgo(userId, 31),
+            mockTokenDaysAgo(userId, 61),
+            mockTokenDaysAgo(userId, 91),
+        ]);
+
+    expect(getActiveUsers()).resolves.toEqual({
+        last7: 0,
+        last30: 1,
+        last60: 1,
+        last90: 1,
+    });
+});
+
+test('should handle multiple users and with multiple tokens', async () => {
+    const users = await db
+        .rawDatabase('users')
+        .insert([
+            mockEventDaysAgo(5),
+            mockEventDaysAgo(10),
+            mockEventDaysAgo(20),
+            mockEventDaysAgo(40),
+            mockEventDaysAgo(70),
+            mockEventDaysAgo(100),
+        ])
+        .returning('id');
+
+    await db
+        .rawDatabase('personal_access_tokens')
+        .insert([
+            mockTokenDaysAgo(users[0].id, 31),
+            mockTokenDaysAgo(users[1].id, 61),
+            mockTokenDaysAgo(users[1].id, 15),
+            mockTokenDaysAgo(users[1].id, 55),
+            mockTokenDaysAgo(users[2].id, 4),
+            mockTokenDaysAgo(users[3].id, 91),
+            mockTokenDaysAgo(users[4].id, 91),
+        ]);
+
+    expect(getActiveUsers()).resolves.toEqual({
+        last7: 2,
+        last30: 3,
+        last60: 4,
+        last90: 5,
+    });
+});
+*/

--- a/src/lib/features/instance-stats/getProductionChanges.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.ts
@@ -12,19 +12,22 @@ export const createGetProductionChanges =
         const productionChanges = await db
             .select({
                 last_month: db.raw(
-                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '1 month' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '1 month' THEN updates END)",
                 ),
                 last_two_months: db.raw(
-                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '2 months' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '60 days' THEN updates END)",
                 ),
                 last_quarter: db.raw(
-                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '3 months' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '90 days' THEN updates END)",
                 ),
             })
             .from('stat_environment_updates');
         return {
             last30: parseInt(productionChanges?.[0]?.last_month || '0', 10),
-            last60: parseInt(productionChanges?.[0]?.last_month || '0', 10),
-            last90: parseInt(productionChanges?.[0]?.last_month || '0', 10),
+            last60: parseInt(
+                productionChanges?.[0]?.last_two_months || '0',
+                10,
+            ),
+            last90: parseInt(productionChanges?.[0]?.last_quarter || '0', 10),
         };
     };

--- a/src/lib/features/instance-stats/getProductionChanges.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.ts
@@ -1,4 +1,5 @@
 import { type Db } from 'lib/server-impl';
+import { GetActiveUsers } from './getActiveUsers';
 
 export type GetProductionChanges = () => Promise<{
     last30: number;
@@ -31,3 +32,13 @@ export const createGetProductionChanges =
             last90: parseInt(productionChanges?.[0]?.last_quarter || '0', 10),
         };
     };
+export const createFakeGetProductionChanges =
+    (
+        changesInProduction: Awaited<ReturnType<GetProductionChanges>> = {
+            last30: 0,
+            last60: 0,
+            last90: 0,
+        },
+    ): GetProductionChanges =>
+    () =>
+        Promise.resolve(changesInProduction);

--- a/src/lib/features/instance-stats/getProductionChanges.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.ts
@@ -13,7 +13,7 @@ export const createGetProductionChanges =
         const productionChanges = await db
             .select({
                 last_month: db.raw(
-                    "SUM(CASE WHEN day > NOW() - INTERVAL '1 month' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '30 days' THEN updates END)",
                 ),
                 last_two_months: db.raw(
                     "SUM(CASE WHEN day > NOW() - INTERVAL '60 days' THEN updates END)",

--- a/src/lib/features/instance-stats/getProductionChanges.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.ts
@@ -13,13 +13,13 @@ export const createGetProductionChanges =
         const productionChanges = await db
             .select({
                 last_month: db.raw(
-                    "SUM(CASE WHEN day > NOW() - INTERVAL '30 days' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '30 days' WHERE environment = 'production' THEN updates END)",
                 ),
                 last_two_months: db.raw(
-                    "SUM(CASE WHEN day > NOW() - INTERVAL '60 days' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '60 days' WHERE environment = 'production' THEN updates END)",
                 ),
                 last_quarter: db.raw(
-                    "SUM(CASE WHEN day > NOW() - INTERVAL '90 days' THEN updates END)",
+                    "SUM(CASE WHEN day > NOW() - INTERVAL '90 days' WHERE environment = 'production' THEN updates END)",
                 ),
             })
             .from('stat_environment_updates');

--- a/src/lib/features/instance-stats/getProductionChanges.ts
+++ b/src/lib/features/instance-stats/getProductionChanges.ts
@@ -1,0 +1,30 @@
+import { type Db } from 'lib/server-impl';
+
+export type GetProductionChanges = () => Promise<{
+    last30: number;
+    last60: number;
+    last90: number;
+}>;
+
+export const createGetProductionChanges =
+    (db: Db): GetProductionChanges =>
+    async () => {
+        const productionChanges = await db
+            .select({
+                last_month: db.raw(
+                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '1 month' THEN updates END)",
+                ),
+                last_two_months: db.raw(
+                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '2 months' THEN updates END)",
+                ),
+                last_quarter: db.raw(
+                    "SUM(DISTINCT CASE WHEN day > NOW() - INTERVAL '3 months' THEN updates END)",
+                ),
+            })
+            .from('stat_environment_updates');
+        return {
+            last30: parseInt(productionChanges?.[0]?.last_month || '0', 10),
+            last60: parseInt(productionChanges?.[0]?.last_month || '0', 10),
+            last90: parseInt(productionChanges?.[0]?.last_month || '0', 10),
+        };
+    };

--- a/src/lib/features/instance-stats/instance-stats-service.test.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.test.ts
@@ -22,6 +22,7 @@ beforeEach(() => {
         config,
         versionService,
         createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
     );
 
     jest.spyOn(instanceStatsService, 'refreshStatsSnapshot');

--- a/src/lib/features/instance-stats/instance-stats-service.test.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.test.ts
@@ -3,6 +3,7 @@ import { InstanceStatsService } from './instance-stats-service';
 import createStores from '../../../test/fixtures/store';
 import VersionService from '../../services/version-service';
 import { createFakeGetActiveUsers } from './getActiveUsers';
+import { createFakeGetProductionChanges } from './getProductionChanges';
 
 let instanceStatsService: InstanceStatsService;
 let versionService: VersionService;
@@ -10,7 +11,12 @@ let versionService: VersionService;
 beforeEach(() => {
     const config = createTestConfig();
     const stores = createStores();
-    versionService = new VersionService(stores, config);
+    versionService = new VersionService(
+        stores,
+        config,
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     instanceStatsService = new InstanceStatsService(
         stores,
         config,

--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -21,6 +21,7 @@ import { FEATURES_EXPORTED, FEATURES_IMPORTED } from '../../types';
 import { CUSTOM_ROOT_ROLE_TYPE } from '../../util';
 import { type GetActiveUsers } from './getActiveUsers';
 import { ProjectModeCount } from '../../db/project-store';
+import { GetProductionChanges } from './getProductionChanges';
 
 export type TimeRange = 'allTime' | '30d' | '7d';
 
@@ -46,6 +47,7 @@ export interface InstanceStats {
     OIDCenabled: boolean;
     clientApps: { range: TimeRange; count: number }[];
     activeUsers: Awaited<ReturnType<GetActiveUsers>>;
+    productionChanges: Awaited<ReturnType<GetProductionChanges>>;
 }
 
 export type InstanceStatsSigned = Omit<InstanceStats, 'projects'> & {
@@ -88,6 +90,8 @@ export class InstanceStatsService {
 
     private getActiveUsers: GetActiveUsers;
 
+    private getProductionChanges: GetProductionChanges;
+
     constructor(
         {
             featureToggleStore,
@@ -120,6 +124,7 @@ export class InstanceStatsService {
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
         versionService: VersionService,
         getActiveUsers: GetActiveUsers,
+        getProductionChanges: GetProductionChanges,
     ) {
         this.strategyStore = strategyStore;
         this.userStore = userStore;
@@ -136,6 +141,7 @@ export class InstanceStatsService {
         this.clientInstanceStore = clientInstanceStore;
         this.logger = getLogger('services/stats-service.js');
         this.getActiveUsers = getActiveUsers;
+        this.getProductionChanges = getProductionChanges;
     }
 
     async refreshStatsSnapshot(): Promise<void> {
@@ -203,6 +209,7 @@ export class InstanceStatsService {
             clientApps,
             featureExports,
             featureImports,
+            productionChanges,
         ] = await Promise.all([
             this.getToggleCount(),
             this.userStore.count(),
@@ -221,6 +228,7 @@ export class InstanceStatsService {
             this.getLabeledAppCounts(),
             this.eventStore.filteredCount({ type: FEATURES_EXPORTED }),
             this.eventStore.filteredCount({ type: FEATURES_IMPORTED }),
+            this.getProductionChanges(),
         ]);
 
         return {
@@ -245,6 +253,7 @@ export class InstanceStatsService {
             clientApps,
             featureExports,
             featureImports,
+            productionChanges,
         };
     }
 

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -13,6 +13,7 @@ import createStores from '../test/fixtures/store';
 import { InstanceStatsService } from './features/instance-stats/instance-stats-service';
 import VersionService from './services/version-service';
 import { createFakeGetActiveUsers } from './features/instance-stats/getActiveUsers';
+import { createFakeGetProductionChanges } from './features/instance-stats/getProductionChanges';
 
 const monitor = createMetricsMonitor();
 const eventBus = new EventEmitter();
@@ -28,7 +29,12 @@ beforeAll(() => {
     });
     stores = createStores();
     eventStore = stores.eventStore;
-    const versionService = new VersionService(stores, config);
+    const versionService = new VersionService(
+        stores,
+        config,
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     statsService = new InstanceStatsService(
         stores,
         config,

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -40,6 +40,7 @@ beforeAll(() => {
         config,
         versionService,
         createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
     );
 
     const db = {

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -174,6 +174,22 @@ export default class MetricsMonitor {
             labelNames: ['status'],
         });
 
+        const productionChanges30 = new client.Gauge({
+            name: 'production_changes_30',
+            help: 'Changes made to production environment last 30 days',
+            labelNames: ['environment'],
+        });
+        const productionChanges60 = new client.Gauge({
+            name: 'production_changes_60',
+            help: 'Changes made to production environment last 60 days',
+            labelNames: ['environment'],
+        });
+        const productionChanges90 = new client.Gauge({
+            name: 'production_changes_90',
+            help: 'Changes made to production environment last 90 days',
+            labelNames: ['environment'],
+        });
+
         async function collectStaticCounters() {
             try {
                 const stats = await instanceStatsService.getStats();
@@ -192,6 +208,13 @@ export default class MetricsMonitor {
                 usersActive60days.set(stats.activeUsers.last60);
                 usersActive90days.reset();
                 usersActive90days.set(stats.activeUsers.last90);
+
+                productionChanges30.reset();
+                productionChanges30.set(stats.productionChanges.last30);
+                productionChanges60.reset();
+                productionChanges60.set(stats.productionChanges.last60);
+                productionChanges90.reset();
+                productionChanges90.set(stats.productionChanges.last90);
 
                 projectsTotal.reset();
                 stats.projects.forEach((projectStat) => {

--- a/src/lib/openapi/spec/instance-admin-stats-schema.ts
+++ b/src/lib/openapi/spec/instance-admin-stats-schema.ts
@@ -74,6 +74,34 @@ export const instanceAdminStatsSchema = {
                 },
             },
         },
+        productionChanges: {
+            type: 'object',
+            description:
+                'The number of changes to the production environment in the last 30, 60 and 90 days',
+            properties: {
+                last30: {
+                    type: 'number',
+                    description:
+                        'The number of changes in production in the last 30 days',
+                    example: 10,
+                    minimum: 0,
+                },
+                last60: {
+                    type: 'number',
+                    description:
+                        'The number of changes in production in the last 60 days',
+                    example: 12,
+                    minimum: 0,
+                },
+                last90: {
+                    type: 'number',
+                    description:
+                        'The number of changes in production in the last 90 days',
+                    example: 15,
+                    minimum: 0,
+                },
+            },
+        },
         featureToggles: {
             type: 'number',
             description: 'The number of feature-toggles this instance has',

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -113,6 +113,11 @@ class InstanceAdminController extends Controller {
                 last30: 10,
                 last7: 5,
             },
+            productionChanges: {
+                last30: 100,
+                last60: 200,
+                last90: 200,
+            },
         };
     }
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -346,6 +346,7 @@ export const createServices = (
         config,
         versionService,
         db ? createGetActiveUsers(db) : createFakeGetActiveUsers(),
+        db ? createGetProductionChanges(db) : createFakeGetProductionChanges(),
     );
 
     const schedulerService = new SchedulerService(config.getLogger);

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -85,6 +85,10 @@ import {
     createFakeLastSeenService,
     createLastSeenService,
 } from './client-metrics/last-seen/createLastSeenService';
+import {
+    createFakeGetProductionChanges,
+    createGetProductionChanges,
+} from '../features/instance-stats/getProductionChanges';
 
 // TODO: will be moved to scheduler feature directory
 export const scheduleServices = async (
@@ -226,7 +230,19 @@ export const createServices = (
     const accountService = new AccountService(stores, config, {
         accessService,
     });
-    const versionService = new VersionService(stores, config);
+    const getActiveUsers = db
+        ? createGetActiveUsers(db)
+        : createFakeGetActiveUsers();
+    const getProductionChanges = db
+        ? createGetProductionChanges(db)
+        : createFakeGetProductionChanges();
+
+    const versionService = new VersionService(
+        stores,
+        config,
+        getActiveUsers,
+        getProductionChanges,
+    );
     const healthService = new HealthService(stores, config);
     const userFeedbackService = new UserFeedbackService(stores, config);
     const changeRequestAccessReadModel = db

--- a/src/lib/services/version-service.test.ts
+++ b/src/lib/services/version-service.test.ts
@@ -5,6 +5,8 @@ import getLogger from '../../test/fixtures/no-logger';
 import VersionService from './version-service';
 import { v4 as uuidv4 } from 'uuid';
 import { randomId } from '../util/random-id';
+import { createFakeGetActiveUsers } from '../features/instance-stats/getActiveUsers';
+import { createFakeGetProductionChanges } from '../features/instance-stats/getProductionChanges';
 
 beforeAll(() => {
     nock.disableNetConnect();
@@ -31,11 +33,16 @@ test('yields current versions', async () => {
                 versions: latest,
             }),
         ]);
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: true },
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: true },
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     const versionInfo = service.getVersionInfo();
     expect(scope.isDone()).toEqual(true);
@@ -64,12 +71,17 @@ test('supports setting enterprise version as well', async () => {
             }),
         ]);
 
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: true },
-        enterpriseVersion,
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: true },
+            enterpriseVersion,
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     const versionInfo = service.getVersionInfo();
     expect(scope.isDone()).toEqual(true);
@@ -98,12 +110,17 @@ test('if version check is not enabled should not make any calls', async () => {
             }),
         ]);
 
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: false },
-        enterpriseVersion,
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: false },
+            enterpriseVersion,
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     const versionInfo = service.getVersionInfo();
     expect(scope.isDone()).toEqual(false);
@@ -140,12 +157,17 @@ test('sets featureinfo', async () => {
             }),
         ]);
 
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: true },
-        enterpriseVersion,
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: true },
+            enterpriseVersion,
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     expect(scope.isDone()).toEqual(true);
     nock.cleanAll();
@@ -189,12 +211,17 @@ test('counts toggles', async () => {
             }),
         ]);
 
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: true },
-        enterpriseVersion,
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: true },
+            enterpriseVersion,
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     expect(scope.isDone()).toEqual(true);
     nock.cleanAll();
@@ -253,12 +280,17 @@ test('counts custom strategies', async () => {
             }),
         ]);
 
-    const service = new VersionService(stores, {
-        getLogger,
-        versionCheck: { url, enable: true },
-        enterpriseVersion,
-        telemetry: true,
-    });
+    const service = new VersionService(
+        stores,
+        {
+            getLogger,
+            versionCheck: { url, enable: true },
+            enterpriseVersion,
+            telemetry: true,
+        },
+        createFakeGetActiveUsers(),
+        createFakeGetProductionChanges(),
+    );
     await service.checkLatestVersion();
     expect(scope.isDone()).toEqual(true);
     nock.cleanAll();

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -185,7 +185,6 @@ export default class VersionService {
         this.telemetryEnabled = telemetry;
         this.versionCheckUrl = versionCheck.url;
         this.isLatest = true;
-        //        this.getActiveUsers = getActiveUsers;
         process.nextTick(() => this.setup());
     }
 

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -24,6 +24,10 @@ import {
     createGetActiveUsers,
     GetActiveUsers,
 } from '../features/instance-stats/getActiveUsers';
+import {
+    createGetProductionChanges,
+    GetProductionChanges,
+} from '../features/instance-stats/getProductionChanges';
 
 export interface IVersionInfo {
     oss: string;
@@ -99,6 +103,8 @@ export default class VersionService {
 
     private getActiveUsers: GetActiveUsers;
 
+    private getProductionChanges: GetProductionChanges;
+
     private current: IVersionInfo;
 
     private latest?: IVersionInfo;
@@ -153,6 +159,8 @@ export default class VersionService {
             IUnleashConfig,
             'getLogger' | 'versionCheck' | 'enterpriseVersion' | 'telemetry'
         >,
+        getActiveUsers: GetActiveUsers,
+        getProductionChanges: GetProductionChanges,
     ) {
         this.logger = getLogger('lib/services/version-service.js');
         this.settingStore = settingStore;
@@ -166,6 +174,8 @@ export default class VersionService {
         this.roleStore = roleStore;
         this.segmentStore = segmentStore;
         this.eventStore = eventStore;
+        this.getActiveUsers = getActiveUsers;
+        this.getProductionChanges = getProductionChanges;
         this.featureStrategiesStore = featureStrategiesStore;
         this.current = {
             oss: version,
@@ -329,7 +339,7 @@ export default class VersionService {
         last60: number;
         last90: number;
     }> {
-        return { last30: 0, last60: 0, last90: 0 };
+        return this.getProductionChanges();
     }
 
     async hasOIDC(): Promise<boolean> {

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -66,9 +66,9 @@ export interface IFeatureUsageInfo {
     OIDCenabled: boolean;
     customStrategies: number;
     customStrategiesInUse: number;
-    activeUser30: number;
-    activeUser60: number;
-    activeUser90: number;
+    activeUsers30: number;
+    activeUsers60: number;
+    activeUsers90: number;
     productionChanges30: number;
     productionChanges60: number;
     productionChanges90: number;
@@ -315,9 +315,9 @@ export default class VersionService {
             instanceId: versionInfo.instanceId,
             versionOSS: versionInfo.current.oss,
             versionEnterprise: versionInfo.current.enterprise,
-            activeUser30: userActive.last30,
-            activeUser60: userActive.last60,
-            activeUser90: userActive.last90,
+            activeUsers30: userActive.last30,
+            activeUsers60: userActive.last60,
+            activeUsers90: userActive.last90,
             productionChanges30: productionChanges.last30,
             productionChanges60: productionChanges.last60,
             productionChanges90: productionChanges.last90,

--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -18,7 +18,7 @@ exports.up = function(db, cb) {
     $unleash_update_changes_counter$ LANGUAGE plpgsql;
 
     CREATE TRIGGER unleash_update_stat_environment_changes
-    BEFORE INSERT ON events
+    AFTER INSERT ON events
     FOR EACH ROW EXECUTE FUNCTION unleash_update_stat_environment_changes_counter();
   `, cb);
 };

--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -9,7 +9,10 @@ exports.up = function(db, cb) {
 
     CREATE FUNCTION unleash_update_stat_environment_changes_counter() RETURNS trigger AS $unleash_update_changes_counter$
         BEGIN
-            INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), COALESCE(NEW.environment, 'unknown'), 1 ON CONFLICT (day, environment) DO UPDATE SET updates = EXCLUDED.updates + 1;
+            IF NEW.environment IS NOT NULL THEN
+                INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), NEW.environment, 1 ON CONFLICT (day, environment) DO UPDATE SET updates = EXCLUDED.updates + 1;
+            END IF;
+
             return null;
         END;
     $unleash_update_changes_counter$ LANGUAGE plpgsql;

--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -1,0 +1,29 @@
+exports.up = function(db, cb) {
+  db.runSql(`
+    CREATE TABLE stat_environment_updates(
+        day DATE NOT NULL,
+        environment TEXT,
+        updates BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (day, environment)
+    );
+
+    CREATE FUNCTION unleash_update_stat_environment_changes_counter() RETURNS trigger AS $unleash_update_changes_counter$
+        BEGIN
+            INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), COALESCE(NEW.environment, 'unknown'), 1 ON CONFLICT (day, environment) DO UPDATE SET updates = EXCLUDED.updates + 1;
+            return null;
+        END;
+    $unleash_update_changes_counter$ LANGUAGE plpgsql;
+
+    CREATE TRIGGER unleash_update_stat_environment_changes
+    BEFORE INSERT ON events
+    FOR EACH ROW EXECUTE FUNCTION unleash_update_stat_environment_changes_counter();
+  `, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`
+    DROP TRIGGER IF EXISTS unleash_update_stat_environment_changes ON events;
+    DROP FUNCTION IF EXISTS unleash_update_stat_environment_changes_counter;
+    DROP TABLE IF EXISTS stat_environment_updates;
+  `, cb);
+};

--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -10,7 +10,7 @@ exports.up = function(db, cb) {
     CREATE FUNCTION unleash_update_stat_environment_changes_counter() RETURNS trigger AS $unleash_update_changes_counter$
         BEGIN
             IF NEW.environment IS NOT NULL THEN
-                INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), NEW.environment, 1 ON CONFLICT (day, environment) DO UPDATE SET updates = EXCLUDED.updates + 1;
+                INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), NEW.environment, 1 ON CONFLICT (day, environment) DO UPDATE SET updates = stat_environment_updates.updates + 1;
             END IF;
 
             return null;


### PR DESCRIPTION
As part of more telemetry on the usage of Unleash. 

This PR adds a new `stat_` prefixed table as well as a trigger on the events table trigger on each insert to increment a counter per environment per day.

The trigger will trigger on every insert into the events base, but will filter and only increment the counter for events that actually have the environment set. (there are events, like user-created, that does not relate to a specific environment).

Bit wary on this, but since we truncate down to row per (day, environment) combo, finding conflict and incrementing shouldn't take too long here.

@ivarconr was it something like this you were considering?