### PR TITLE
fix: typo in enabled event

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -166,7 +166,7 @@ const EVENT_MAP: Record<string, IEventData> = {
         path: '/projects/{{event.project}}/features/{{event.featureName}}',
     },
     [FEATURE_ENVIRONMENT_ENABLED]: {
-        action: '*{{user}}* disabled *{{feature}}* for the *{{event.environment}}* environment in project *{{project}}*',
+        action: '*{{user}}* enabled *{{feature}}* for the *{{event.environment}}* environment in project *{{project}}*',
         path: '/projects/{{event.project}}/features/{{event.featureName}}',
     },
     [FEATURE_ENVIRONMENT_VARIANTS_UPDATED]: {


### PR DESCRIPTION
Fixes a typo where we would send `disabled` for `enabled` events.

https://unleash-community.slack.com/archives/C03GWTN7XMG/p1696631381409369