### PR TITLE
fix(docs): lowercase internal markdown links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
     url: 'https://docs.getunleash.io',
     baseUrl: '/',
     onBrokenLinks: 'throw',
-    onBrokenMarkdownLinks: 'warn',
+    onBrokenMarkdownLinks: 'throw',
     favicon: 'img/favicon.ico',
     organizationName: 'Unleash', // Usually your GitHub org/user name.
     projectName: 'unleash.github.io', // Usually your repo name.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
     url: 'https://docs.getunleash.io',
     baseUrl: '/',
     onBrokenLinks: 'throw',
-    onBrokenMarkdownLinks: 'throw',
+    onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',
     organizationName: 'Unleash', // Usually your GitHub org/user name.
     projectName: 'unleash.github.io', // Usually your repo name.

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -58,7 +58,7 @@ const replaceLinks = ({ content, repo }) => {
         // case 1
         if (url.startsWith('#')) {
             // ignore links to other doc sections
-            return url;
+            return url.toLowerCase();
         } else {
             return `${repo.url}/blob/${repo.branch}${separator}${url}`;
         }


### PR DESCRIPTION
Markdown generators (including GitHub) tend to lowercase the titles
when they create anchor links. It appears that the intra-doc links might not work correctly if they're incorrectly cased. 

This fixes the issue by lowercasing any links we find to internal headers in external documents (such as the SDKs and Edge/Proxy docs).

## Discussion point

Now, there is one potential issue with this: if someone creates an explicit link in the SDKs that uses uppercase letters, then this might break the docs build in the future.

However, I think this is unlikely to happen any time soon, and I would think that it's more likely that people will incorrectly case the header link.