### PR TITLE
fix: refactor getProjectOverview store method

### DIFF
--- a/src/lib/db/feature-strategy-store.ts
+++ b/src/lib/db/feature-strategy-store.ts
@@ -117,9 +117,9 @@ const getUniqueRows = (rows: any[]) => {
 };
 
 const sortEnvironments = (overview: IFeatureOverview) => {
-    return Object.values(overview).map((o: IFeatureOverview) => ({
-        ...o,
-        environments: o.environments
+    return Object.values(overview).map((data: IFeatureOverview) => ({
+        ...data,
+        environments: data.environments
             .filter((f) => f.name)
             .sort((a, b) => {
                 if (a.sortOrder === b.sortOrder) {

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -1077,22 +1077,6 @@ export default class ProjectService {
             this.projectStatsStore.getProjectStats(projectId),
         ]);
 
-        let decoratedFeatures = features;
-
-        if (this.flagResolver.isEnabled('useLastSeenRefactor')) {
-            const mapper = new LastSeenMapper();
-
-            const featureNames = features.map((feature) => feature.name);
-            const lastSeenAtPerEnvironment =
-                await this.lastSeenReadModel.getForFeature(featureNames);
-
-            decoratedFeatures = mapper.mapToFeatures(
-                decoratedFeatures,
-                lastSeenAtPerEnvironment,
-                this.logger,
-            );
-        }
-
         return {
             stats: projectStats,
             name: project.name,
@@ -1106,7 +1090,7 @@ export default class ProjectService {
             updatedAt: project.updatedAt,
             createdAt: project.createdAt,
             environments,
-            features: decoratedFeatures,
+            features: features,
             members,
             version: 1,
         };


### PR DESCRIPTION
This PR cleans up and refactors the feature-strategy-store method getFeatureOverview to join on the new table and attempts to make the function more readable by extracting some of the logic into separate functions. Keeping the LastSeenMapper for now in case there is a reason to use it for the other endpoints.