### PR TITLE
feat: extend usage of transactional decorator to project-features

### DIFF
--- a/src/lib/routes/admin-api/project/index.ts
+++ b/src/lib/routes/admin-api/project/index.ts
@@ -105,14 +105,7 @@ export default class ProjectApi extends Controller {
             ],
         });
 
-        this.use(
-            '/',
-            new ProjectFeaturesController(
-                config,
-                services,
-                createKnexTransactionStarter(db),
-            ).router,
-        );
+        this.use('/', new ProjectFeaturesController(config, services).router);
         this.use(
             '/',
             new DependentFeaturesController(

--- a/src/lib/routes/admin-api/project/project-features.ts
+++ b/src/lib/routes/admin-api/project/project-features.ts
@@ -99,7 +99,7 @@ const PATH_STRATEGY = `${PATH_STRATEGIES}/:strategyId`;
 
 type ProjectFeaturesServices = Pick<
     IUnleashServices,
-    | 'featureToggleService'
+    | 'featureToggleServiceTransactional'
     | 'projectHealthService'
     | 'openApiService'
     | 'featureTagService'
@@ -119,13 +119,13 @@ export default class ProjectFeaturesController extends Controller {
     constructor(
         config: IUnleashConfig,
         {
-            featureToggleService,
+            featureToggleServiceTransactional,
             openApiService,
             featureTagService,
         }: ProjectFeaturesServices,
     ) {
         super(config);
-        this.featureService = featureToggleService;
+        this.featureService = featureToggleServiceTransactional;
         this.openApiService = openApiService;
         this.featureTagService = featureTagService;
         this.flagResolver = config.flagResolver;

--- a/src/lib/routes/admin-api/project/project-features.ts
+++ b/src/lib/routes/admin-api/project/project-features.ts
@@ -99,7 +99,7 @@ const PATH_STRATEGY = `${PATH_STRATEGIES}/:strategyId`;
 
 type ProjectFeaturesServices = Pick<
     IUnleashServices,
-    | 'featureToggleServiceTransactional'
+    | 'featureToggleService'
     | 'projectHealthService'
     | 'openApiService'
     | 'featureTagService'
@@ -119,13 +119,13 @@ export default class ProjectFeaturesController extends Controller {
     constructor(
         config: IUnleashConfig,
         {
-            featureToggleServiceTransactional,
+            featureToggleService,
             openApiService,
             featureTagService,
         }: ProjectFeaturesServices,
     ) {
         super(config);
-        this.featureService = featureToggleServiceTransactional;
+        this.featureService = featureToggleService;
         this.openApiService = openApiService;
         this.featureTagService = featureTagService;
         this.flagResolver = config.flagResolver;

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -257,6 +257,17 @@ export const createServices = (
         ? withTransactional(deferredCreateFeatureToggleService(config), db)
         : withFakeTransactional(createFakeFeatureToggleService(config));
 
+    const featureToggleServiceV2 = new FeatureToggleService(
+        stores,
+        config,
+        segmentService,
+        accessService,
+        eventService,
+        changeRequestAccessReadModel,
+        privateProjectChecker,
+        dependentFeaturesReadModel,
+        dependentFeaturesService,
+    );
     const environmentService = new EnvironmentService(stores, config);
     const featureTagService = new FeatureTagService(
         stores,
@@ -288,7 +299,7 @@ export const createServices = (
     const openApiService = new OpenApiService(config);
     const clientSpecService = new ClientSpecService(config);
     const playgroundService = new PlaygroundService(config, {
-        featureToggleServiceV2: featureToggleServiceTransactional,
+        featureToggleServiceV2,
         segmentService,
         privateProjectChecker,
     });
@@ -299,7 +310,7 @@ export const createServices = (
     );
 
     const proxyService = new ProxyService(config, stores, {
-        featureToggleServiceV2: featureToggleServiceTransactional,
+        featureToggleServiceV2,
         clientMetricsServiceV2,
         segmentService,
         settingService,
@@ -340,8 +351,9 @@ export const createServices = (
         accountService,
         addonService,
         eventAnnouncerService,
-        featureToggleService: featureToggleServiceTransactional,
-        featureToggleServiceV2: featureToggleServiceTransactional,
+        featureToggleService: featureToggleServiceV2,
+        featureToggleServiceV2,
+        featureToggleServiceTransactional,
         featureTypeService,
         healthService,
         projectService,

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -60,9 +60,10 @@ import {
 } from '../features/change-request-access-service/createChangeRequestAccessReadModel';
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 import {
+    createFakeFeatureToggleService,
     createFakeProjectService,
-    createFeatureToggleService,
     createProjectService,
+    deferredCreateFeatureToggleService,
 } from '../features';
 import EventAnnouncerService from './event-announcer-service';
 import { createGroupService } from '../features/group/createGroupService';
@@ -252,6 +253,10 @@ export const createServices = (
     const transactionalDependentFeaturesService = (txDb: Knex.Transaction) =>
         createDependentFeaturesService(txDb, config);
 
+    const featureToggleServiceTransactional = db
+        ? withTransactional(deferredCreateFeatureToggleService(config), db)
+        : withFakeTransactional(createFakeFeatureToggleService(config));
+
     const featureToggleServiceV2 = new FeatureToggleService(
         stores,
         config,
@@ -288,8 +293,6 @@ export const createServices = (
         : withFakeTransactional(createFakeExportImportTogglesService(config));
     const transactionalExportImportService = (txDb: Knex.Transaction) =>
         createExportImportTogglesService(txDb, config);
-    const transactionalFeatureToggleService = (txDb: Knex.Transaction) =>
-        createFeatureToggleService(txDb, config);
     const transactionalGroupService = (txDb: Knex.Transaction) =>
         createGroupService(txDb, config);
     const userSplashService = new UserSplashService(stores, config);
@@ -350,6 +353,7 @@ export const createServices = (
         eventAnnouncerService,
         featureToggleService: featureToggleServiceV2,
         featureToggleServiceV2,
+        featureToggleServiceTransactional,
         featureTypeService,
         healthService,
         projectService,
@@ -391,7 +395,6 @@ export const createServices = (
         exportImportServiceV2,
         schedulerService,
         configurationRevisionService,
-        transactionalFeatureToggleService,
         transactionalGroupService,
         privateProjectChecker,
         dependentFeaturesService,

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -257,17 +257,6 @@ export const createServices = (
         ? withTransactional(deferredCreateFeatureToggleService(config), db)
         : withFakeTransactional(createFakeFeatureToggleService(config));
 
-    const featureToggleServiceV2 = new FeatureToggleService(
-        stores,
-        config,
-        segmentService,
-        accessService,
-        eventService,
-        changeRequestAccessReadModel,
-        privateProjectChecker,
-        dependentFeaturesReadModel,
-        dependentFeaturesService,
-    );
     const environmentService = new EnvironmentService(stores, config);
     const featureTagService = new FeatureTagService(
         stores,
@@ -299,7 +288,7 @@ export const createServices = (
     const openApiService = new OpenApiService(config);
     const clientSpecService = new ClientSpecService(config);
     const playgroundService = new PlaygroundService(config, {
-        featureToggleServiceV2,
+        featureToggleServiceV2: featureToggleServiceTransactional,
         segmentService,
         privateProjectChecker,
     });
@@ -310,7 +299,7 @@ export const createServices = (
     );
 
     const proxyService = new ProxyService(config, stores, {
-        featureToggleServiceV2,
+        featureToggleServiceV2: featureToggleServiceTransactional,
         clientMetricsServiceV2,
         segmentService,
         settingService,
@@ -351,9 +340,8 @@ export const createServices = (
         accountService,
         addonService,
         eventAnnouncerService,
-        featureToggleService: featureToggleServiceV2,
-        featureToggleServiceV2,
-        featureToggleServiceTransactional,
+        featureToggleService: featureToggleServiceTransactional,
+        featureToggleServiceV2: featureToggleServiceTransactional,
         featureTypeService,
         healthService,
         projectService,

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -60,9 +60,9 @@ export interface IUnleashServices {
     eventService: EventService;
     edgeService: EdgeService;
     featureTagService: FeatureTagService;
-    featureToggleService: FeatureToggleService;
-    featureToggleServiceV2: FeatureToggleService; // deprecated
-    featureToggleServiceTransactional: WithTransactional<FeatureToggleService>;
+    featureToggleService: WithTransactional<FeatureToggleService>;
+    /** @deprecated use featureToggleService variable instead */
+    featureToggleServiceV2: WithTransactional<FeatureToggleService>;
     featureTypeService: FeatureTypeService;
     groupService: GroupService;
     healthService: HealthService;

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -60,9 +60,9 @@ export interface IUnleashServices {
     eventService: EventService;
     edgeService: EdgeService;
     featureTagService: FeatureTagService;
-    featureToggleService: WithTransactional<FeatureToggleService>;
-    /** @deprecated use featureToggleService variable instead */
-    featureToggleServiceV2: WithTransactional<FeatureToggleService>;
+    featureToggleService: FeatureToggleService;
+    featureToggleServiceV2: FeatureToggleService; // deprecated
+    featureToggleServiceTransactional: WithTransactional<FeatureToggleService>;
     featureTypeService: FeatureTypeService;
     groupService: GroupService;
     healthService: HealthService;

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -62,6 +62,7 @@ export interface IUnleashServices {
     featureTagService: FeatureTagService;
     featureToggleService: FeatureToggleService;
     featureToggleServiceV2: FeatureToggleService; // deprecated
+    featureToggleServiceTransactional: WithTransactional<FeatureToggleService>;
     featureTypeService: FeatureTypeService;
     groupService: GroupService;
     healthService: HealthService;
@@ -99,9 +100,6 @@ export interface IUnleashServices {
     transactionalExportImportService: (
         db: Knex.Transaction,
     ) => Pick<ExportImportService, 'import' | 'validate'>;
-    transactionalFeatureToggleService: (
-        db: Knex.Transaction,
-    ) => FeatureToggleService;
     transactionalGroupService: (db: Knex.Transaction) => GroupService;
     privateProjectChecker: IPrivateProjectChecker;
     dependentFeaturesService: DependentFeaturesService;


### PR DESCRIPTION
## About the changes
Use `WithTransactional<FeatureToggleService>` as a drop-in replacement of `FeatureToggleService`