### PR TITLE
docs: add a custom_edit_url for sdks and edge/proxy

### DIFF
--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -119,6 +119,7 @@ module.exports.modifyContent =
             content: `---
 title: ${data.sidebarName}
 slug: ${processedSlug}
+custom_edit_url: ${data.repoUrl}/edit/${data.branch}/README.md
 ---
 
 :::info Generated content


### PR DESCRIPTION
This change adds custom edit urls for all the external readmes (sdks, edge, proxy) that we put in the docs. This makes it so that following the "edit this document" link takes you to the correct location, instead of to a file that doesn't exist in the main Unleash repo.

Important caveat: this will only work for repos where the readme is called `README.md` (capitalization matters). Currently, this is all our repos, but it's something to be aware of for later. 

We don't currently record what the readme files are called directly in the docs, so to know that for sure, we'd have to build an extra integration to check and fix that automatically. It may be worth doing in the future, but for now, I think it's fine. We could also just rename the readme files if we find any issues.