### PR TITLE
feat: add internalMessageBanner feature flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -66,6 +66,7 @@ export type UiFlags = {
     privateProjects?: boolean;
     accessOverview?: boolean;
     dependentFeatures?: boolean;
+    internalMessageBanner?: boolean;
     [key: string]: boolean | Variant | undefined;
 };
 

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -92,6 +92,7 @@ exports[`should create default config 1`] = `
       "featuresExportImport": true,
       "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
+      "internalMessageBanner": false,
       "lastSeenByEnvironment": false,
       "maintenanceMode": false,
       "messageBanner": {
@@ -133,6 +134,7 @@ exports[`should create default config 1`] = `
       "featuresExportImport": true,
       "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
+      "internalMessageBanner": false,
       "lastSeenByEnvironment": false,
       "maintenanceMode": false,
       "messageBanner": {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -33,7 +33,8 @@ export type IFlagKey =
     | 'datadogJsonTemplate'
     | 'disableMetrics'
     | 'transactionalDecorator'
-    | 'useLastSeenRefactor';
+    | 'useLastSeenRefactor'
+    | 'internalMessageBanner';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -155,6 +156,10 @@ const flags: IFlags = {
     ),
     useLastSeenRefactor: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_USE_LAST_SEEN_REFACTOR,
+        false,
+    ),
+    internalMessageBanner: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_INTERNAL_MESSAGE_BANNER,
         false,
     ),
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1487/feature-flag-add-a-new-internalmessagebanner-feature-flag-for-this

Adds a new `internalMessageBanner` feature flag.