### PR TITLE
docs: updated sidebars and added missing doc ID

### DIFF
--- a/website/docs/tutorials/getting-started.md
+++ b/website/docs/tutorials/getting-started.md
@@ -1,4 +1,5 @@
 ---
+id: getting-started
 title: Getting Started
 ---
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -13,17 +13,27 @@ module.exports = {
     documentation: [
         'about-the-docs',
         {
-            label: 'First steps and tutorials',
+            label: 'Getting Started',
             type: 'category',
             collapsed: false,
             link: {
-                type: 'generated-index',
-                title: 'First steps',
-                description: 'Learn how and where to get started with Unleash.',
-                slug: '/tutorials',
+                type: 'doc',
+                id: 'tutorials/getting-started',
             },
             items: [
-                'tutorials/getting-started',
+                {
+                    type: 'category',
+                    label: 'Unleash Academy',
+                    link: {
+                        type: 'doc',
+                        id: 'tutorials/academy',
+                    },
+                    items: [
+                        'tutorials/academy-foundational',
+                        'tutorials/academy-advanced-for-devs',
+                        'tutorials/academy-managing-unleash-for-devops',
+                    ],
+                },
                 'tutorials/unleash-overview',
                 'tutorials/important-concepts',
             ],


### PR DESCRIPTION
Updated `sidebars.js` to incorporate `Getting Started` as top level doc, with Unleash Academy in child structure (order as discussed with @dgorton ). See screenshot.

Also added missing `id` to `getting-started.md`

![image](https://github.com/Unleash/unleash/assets/128738155/52881918-a38b-4e6a-b6c8-bbeb1cd0a232)

