### PR TITLE
fix: missing uiFlag newInviteLink

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -65,6 +65,7 @@ export type UiFlags = {
     doraMetrics?: boolean;
     variantTypeNumber?: boolean;
     privateProjects?: boolean;
+    newInviteLink?: boolean;
     accessOverview?: boolean;
     datadogJsonTemplate?: boolean;
     dependentFeatures?: boolean;


### PR DESCRIPTION
Adds a missing uiFlag: `newInviteLink`