### PR TITLE
chore: split interfaces for import and export

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -50,7 +50,25 @@ import { ImportValidationMessages } from './import-validation-messages';
 import { findDuplicates } from '../../util/findDuplicates';
 import { FeatureNameCheckResultWithFeaturePattern } from '../feature-toggle/feature-toggle-service';
 
-export default class ExportImportService {
+export type IImportService = {
+    validate(
+        dto: ImportTogglesSchema,
+        user: User,
+    ): Promise<ImportTogglesValidateSchema>;
+
+    import(dto: ImportTogglesSchema, user: User): Promise<void>;
+};
+
+export type IExportService = {
+    export(
+        query: ExportQuerySchema,
+        userName: string,
+    ): Promise<ExportResultSchema>;
+};
+
+export default class ExportImportService
+    implements IExportService, IImportService
+{
     private logger: Logger;
 
     private toggleStore: IFeatureToggleStore;

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -299,7 +299,7 @@ export const createServices = (
     const exportImportService = db
         ? createExportImportTogglesService(db, config)
         : createFakeExportImportTogglesService(config);
-    const exportImportServiceV2 = db
+    const importService = db
         ? withTransactional(deferredExportImportTogglesService(config), db)
         : withFakeTransactional(createFakeExportImportTogglesService(config));
     const transactionalExportImportService = (txDb: Knex.Transaction) =>
@@ -403,9 +403,9 @@ export const createServices = (
         instanceStatsService,
         favoritesService,
         maintenanceService,
-        exportImportService,
+        exportService: exportImportService,
         transactionalExportImportService,
-        exportImportServiceV2,
+        importService,
         schedulerService,
         configurationRevisionService,
         transactionalFeatureToggleService,

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -39,7 +39,9 @@ import MaintenanceService from '../services/maintenance-service';
 import { AccountService } from '../services/account-service';
 import { SchedulerService } from '../services/scheduler-service';
 import { Knex } from 'knex';
-import ExportImportService from '../features/export-import-toggles/export-import-service';
+import ExportImportService, {
+    IExportService,
+} from '../features/export-import-toggles/export-import-service';
 import { ISegmentService } from '../segments/segment-service-interface';
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 import EventAnnouncerService from 'lib/services/event-announcer-service';
@@ -89,9 +91,8 @@ export interface IUnleashServices {
     instanceStatsService: InstanceStatsService;
     favoritesService: FavoritesService;
     maintenanceService: MaintenanceService;
-    /** @deprecated prefer exportImportServiceV2, we're doing a gradual rollout */
-    exportImportService: ExportImportService;
-    exportImportServiceV2: WithTransactional<ExportImportService>;
+    exportService: IExportService;
+    importService: WithTransactional<ExportImportService>;
     configurationRevisionService: ConfigurationRevisionService;
     schedulerService: SchedulerService;
     eventAnnouncerService: EventAnnouncerService;

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -39,8 +39,9 @@ import MaintenanceService from '../services/maintenance-service';
 import { AccountService } from '../services/account-service';
 import { SchedulerService } from '../services/scheduler-service';
 import { Knex } from 'knex';
-import ExportImportService, {
+import {
     IExportService,
+    IImportService,
 } from '../features/export-import-toggles/export-import-service';
 import { ISegmentService } from '../segments/segment-service-interface';
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
@@ -92,14 +93,12 @@ export interface IUnleashServices {
     favoritesService: FavoritesService;
     maintenanceService: MaintenanceService;
     exportService: IExportService;
-    importService: WithTransactional<ExportImportService>;
+    importService: WithTransactional<IImportService>;
     configurationRevisionService: ConfigurationRevisionService;
     schedulerService: SchedulerService;
     eventAnnouncerService: EventAnnouncerService;
     /** @deprecated prefer exportImportServiceV2, we're doing a gradual rollout */
-    transactionalExportImportService: (
-        db: Knex.Transaction,
-    ) => Pick<ExportImportService, 'import' | 'validate'>;
+    transactionalExportImportService: (db: Knex.Transaction) => IImportService;
     transactionalFeatureToggleService: (
         db: Knex.Transaction,
     ) => FeatureToggleService;


### PR DESCRIPTION
## About the changes
This splits the interfaces for import and export, especially because the import functionality has to be replaced in enterprise repo.

This is a breaking change because of the service renames, but I'll have the PR for the other repository ready so we reduce the time to fix. I intentionally avoided doing it backward compatible because of time.