### PR TITLE
docs/video embed, academy video embed fixes

### DIFF
--- a/website/docs/reference/deploy/environment-import-export.mdx
+++ b/website/docs/reference/deploy/environment-import-export.mdx
@@ -1,6 +1,7 @@
 ---
 title: Environment Import & Export
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
 
 :::info Availability
 
@@ -8,6 +9,9 @@ The environment import and export first appeared in Unleash 4.22.0.
 
 :::
 
+  
+<VideoContent videoUrls={["https://www.youtube.com/embed/Bs73l2fZxJ4"]}/>
+  
 Environment export and import lets you copy feature configurations from one environment to another and even copy features from one Unleash instance to another.
 
 When exporting, you select a set of features and **one** environment to export the configuration from. The environment must be the same for all features.

--- a/website/docs/reference/playground.mdx
+++ b/website/docs/reference/playground.mdx
@@ -2,12 +2,16 @@
 title: The Playground
 ---
 import Figure from '@site/src/components/Figure/Figure.tsx'
+import VideoContent from '@site/src/components/VideoContent.jsx'
 
 :::info Availability
 
 The Unleash playground is available in all Unleash versions from Unleash 4.14 onwards. Unleash 5.3 introduced a more advanced playground that allows you to query multiple environments and multiple values for a single context value at the same time.
 
 :::
+
+
+<VideoContent videoUrls={["https://www.youtube.com/embed/-HP6axX5jUo"]}/>
 
 ![The Unleash Playground form and an indication of where in the nav menu it is located.](/img/playground-form.png)
 

--- a/website/docs/reference/strategy-constraints.md
+++ b/website/docs/reference/strategy-constraints.md
@@ -1,6 +1,7 @@
 ---
 title: Strategy Constraints
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
 
 :::info Availability
 
@@ -29,6 +30,9 @@ Strategy constraints use fields from the [Unleash Context](../reference/unleash-
 You can constrain both on [standard context fields](../reference/unleash-context#structure) and on [custom context fields](../reference/unleash-context#custom-context-fields).
 
 This page explains what strategy constraints are in Unleash and how they work. If you want to know *how you add* strategy constraints to an activation strategy, see [the corresponding how-to guide](../how-to/how-to-add-strategy-constraints.md "how to add strategy constraints").
+
+<VideoContent videoUrls={["https://www.youtube.com/embed/kqtqMFhLRBE"]}/>
+
 
 ## Constraining on custom context fields
 

--- a/website/docs/topics/a-b-testing.md
+++ b/website/docs/topics/a-b-testing.md
@@ -1,12 +1,16 @@
 ---
 title: A/B and multivariate testing
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
 
 A/B testing is a type of randomized controlled experiment, where you test two different versions of a feature to see which version performs better. If you have more than two versions, it's known as _multivariate testing_. Coupled with analytics, A/B and multivariate testing enables you to better understand your users and how you can serve them better.
 
 To facilitate A/B testing and experimentation, Unleash has a built-in 'experiment' [toggle type](../reference/feature-toggle-types.md#feature-toggle-types) and lets you give toggles any number of [variants](../reference/feature-toggle-variants.md). To see a concrete example of configuring multivariate testing with unleash, see [our blog post on A/B testing with Unleash and Google Analytics](https://www.getunleash.io/blog/a-b-n-experiments-in-3-simple-steps).
 
 In the rest of this document, _A/B testing_ will refer to both strict A/B testing and multivariate testing unless otherwise specified.
+
+<VideoContent videoUrls={["https://www.youtube.com/embed/bxYdeMb9ffw?si=XSnKk74HbZg3puXO"]}/>
+
 
 ## What is A/B testing
 

--- a/website/docs/tutorials/academy-advanced-for-devs.md
+++ b/website/docs/tutorials/academy-advanced-for-devs.md
@@ -2,6 +2,8 @@
 id: academy-advanced-for-devs
 title: Advanced for Developers
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
+
 :::info
 **This Unleash Academy course is for all developer roles working with Unleash, after Foundational content has been reviewed.**
 :::
@@ -23,9 +25,9 @@ You’ll master advanced use cases and implement best practices - this course wi
   
 ## Course Detail
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?si=ry507OKlfb1liKFD&amp;list=PLcVJ5JY19ncXmAbFqfamyAV698WINtQaJ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen playsinline></iframe>
-
-
+<VideoContent videoUrls={["https://www.youtube.com/embed/videoseries?si=ry507OKlfb1liKFD&amp;list=PLcVJ5JY19ncXmAbFqfamyAV698WINtQaJ"]}/>
+  
+  
 :::info Embedded Player
 The full course is shown above.  
 Click the icon in the top right corner of the embedded player to view your progress as you work through the videos.  

--- a/website/docs/tutorials/academy-foundational.md
+++ b/website/docs/tutorials/academy-foundational.md
@@ -2,6 +2,8 @@
 id: academy-foundational
 title: Foundational
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
+
 :::info
 **This Unleash Academy course is for all roles working with Unleash - Developers, Product owners, Leaders.**
 :::
@@ -42,9 +44,7 @@ An understanding of Unleash anatomy and architecture and how the different syste
   
 ## Course Detail
   
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?si=YyLiIYQck7fsG5HK&amp;list=PLcVJ5JY19ncU_6cq2QaCuXDBbbitiJEn4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen playsinline></iframe>
-  
+<VideoContent videoUrls={["https://www.youtube.com/embed/videoseries?si=YyLiIYQck7fsG5HK&amp;list=PLcVJ5JY19ncU_6cq2QaCuXDBbbitiJEn4"]}/>
   
 
 :::info Embedded Player

--- a/website/docs/tutorials/academy-managing-unleash-for-devops.md
+++ b/website/docs/tutorials/academy-managing-unleash-for-devops.md
@@ -2,6 +2,8 @@
 id: academy-managing-unleash-for-devops
 title: Managing Unleash for DevOps/Admins
 ---
+import VideoContent from '@site/src/components/VideoContent.jsx'
+
 :::info
 **This Unleash Academy course is for all DevOps and Admin roles working with Unleash, after Foundational content has been reviewed.**
 :::
@@ -23,9 +25,9 @@ Understand how to deploy Unleash in a secure and performant manner through Edge,
 
 ## Course Detail
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?si=m0PkzvBqtGphGblK&amp;list=PLcVJ5JY19ncVxAesGfmcs8vshai0mSdAS" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen playsinline></iframe>
+<VideoContent videoUrls={["https://www.youtube.com/embed/videoseries?si=m0PkzvBqtGphGblK&amp;list=PLcVJ5JY19ncVxAesGfmcs8vshai0mSdAS"]}/>
 
-
+  
 :::info Embedded Player
 The full course is shown above.  
 Click the icon in the top right corner of the embedded player to view your progress as you work through the videos.  


### PR DESCRIPTION
PR contains the following:

1) New video embeds for the following docs:

- website/docs/reference/deploy/environment-import-export.mdx
- website/docs/reference/playground.mdx
- website/docs/reference/strategy-constraints.md
- website/docs/topics/a-b-testing.md

2) Improvements to the Academy course playlist embedding for the three Academy courses. Tested the standard method of embedding video, and it seems this works well for playlists too.
Switching to the native Docusaurus embed solves the issue with dynamic resizing. Rather than a static embed size the video will now scale to the browser window size.

