### PR TITLE
fix: message banner internal link assumption

### DIFF
--- a/frontend/src/component/messageBanners/MessageBanner/MessageBanner.tsx
+++ b/frontend/src/component/messageBanners/MessageBanner/MessageBanner.tsx
@@ -139,7 +139,7 @@ const BannerButton = ({
     if (!link) return null;
 
     const dialog = link === 'dialog';
-    const internal = !link.startsWith('http');
+    const internal = link.startsWith('/');
 
     const trackEvent = () => {
         if (!plausibleEvent) return;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1504/fix-message-banner-internal-link-assumption

Fixes the internal link assumption in message banner to `.startsWith('/')` - Any other links will be treated as external (normal `href`).