### PR TITLE
feat: make maintenance-related 503s more intuitive

### DIFF
--- a/frontend/src/constants/statusCodes.ts
+++ b/frontend/src/constants/statusCodes.ts
@@ -4,3 +4,4 @@ export const CREATED = 201;
 export const NOT_FOUND = 404;
 export const FORBIDDEN = 403;
 export const UNAUTHORIZED = 401;
+export const UNAVAILABLE = 503;

--- a/frontend/src/hooks/api/actions/useApi/useApi.ts
+++ b/frontend/src/hooks/api/actions/useApi/useApi.ts
@@ -17,7 +17,6 @@ import {
 } from 'utils/apiUtils';
 import { formatApiPath } from 'utils/formatPath';
 import { ACCESS_DENIED_TEXT } from 'utils/formatAccessText';
-import { useMaintenance } from 'hooks/api/getters/useMaintenance/useMaintenance';
 
 type ApiErrorHandler = (
     setErrors: Dispatch<SetStateAction<{}>>,
@@ -42,7 +41,6 @@ const useAPI = ({
     handleUnavailable,
     propagateErrors = false,
 }: IUseAPI) => {
-    const { enabled: maintenanceMode } = useMaintenance();
     const [errors, setErrors] = useState<Record<string, string>>({});
     const [loading, setLoading] = useState(false);
 
@@ -121,12 +119,6 @@ const useAPI = ({
                 }
 
                 if (propagateErrors) {
-                    if (maintenanceMode) {
-                        throw new Error(
-                            'Operation unavailable: Maintenance mode is enabled',
-                        );
-                    }
-
                     const response = await res.json();
                     throw new UnavailableError(res.status, response);
                 }

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -12,7 +12,7 @@ export interface IErrorBody {
 }
 
 const getErrorMessage = (body: IErrorBody) =>
-    body.message || body.details?.[0]?.message;
+    body.details?.[0]?.message || body.message;
 
 export class AuthenticationError extends Error {
     statusCode: number;

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -3,6 +3,7 @@ import {
     FORBIDDEN,
     NOT_FOUND,
     UNAUTHORIZED,
+    UNAVAILABLE,
 } from 'constants/statusCodes';
 
 export interface IErrorBody {
@@ -30,6 +31,22 @@ export class ForbiddenError extends Error {
                 : 'You cannot perform this action',
         );
         this.name = 'ForbiddenError';
+        this.statusCode = statusCode;
+        this.body = body;
+    }
+}
+
+export class UnavailableError extends Error {
+    statusCode: number;
+    body: IErrorBody;
+
+    constructor(statusCode: number = UNAVAILABLE, body: IErrorBody = {}) {
+        super(
+            body.details?.length
+                ? body.details[0].message
+                : 'This operation is unavailable',
+        );
+        this.name = 'UnavailableError';
         this.statusCode = statusCode;
         this.body = body;
     }

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -7,8 +7,12 @@ import {
 } from 'constants/statusCodes';
 
 export interface IErrorBody {
+    message?: string;
     details?: { message: string }[];
 }
+
+const getErrorMessage = (body: IErrorBody) =>
+    body.message || body.details?.[0]?.message;
 
 export class AuthenticationError extends Error {
     statusCode: number;
@@ -25,11 +29,7 @@ export class ForbiddenError extends Error {
     body: IErrorBody;
 
     constructor(statusCode: number = FORBIDDEN, body: IErrorBody = {}) {
-        super(
-            body.details?.length
-                ? body.details[0].message
-                : 'You cannot perform this action',
-        );
+        super(getErrorMessage(body) || 'You cannot perform this action');
         this.name = 'ForbiddenError';
         this.statusCode = statusCode;
         this.body = body;
@@ -41,11 +41,7 @@ export class UnavailableError extends Error {
     body: IErrorBody;
 
     constructor(statusCode: number = UNAVAILABLE, body: IErrorBody = {}) {
-        super(
-            body.details?.length
-                ? body.details[0].message
-                : 'This operation is unavailable',
-        );
+        super(getErrorMessage(body) || 'This operation is unavailable');
         this.name = 'UnavailableError';
         this.statusCode = statusCode;
         this.body = body;
@@ -57,7 +53,7 @@ export class BadRequestError extends Error {
     body: IErrorBody;
 
     constructor(statusCode: number = BAD_REQUEST, body: IErrorBody = {}) {
-        super(body.details?.length ? body.details[0].message : 'Bad request');
+        super(getErrorMessage(body) || 'Bad request');
         this.name = 'BadRequestError';
         this.statusCode = statusCode;
         this.body = body;

--- a/src/lib/middleware/maintenance-middleware.ts
+++ b/src/lib/middleware/maintenance-middleware.ts
@@ -2,6 +2,9 @@ import { IUnleashConfig } from '../types';
 import MaintenanceService from '../services/maintenance-service';
 import { IAuthRequest } from '../routes/unleash-types';
 
+export const MAINTENANCE_MODE_ENABLED =
+    'Unleash is currently in maintenance mode.';
+
 const maintenanceMiddleware = (
     { getLogger }: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>,
     maintenanceService: MaintenanceService,
@@ -17,7 +20,9 @@ const maintenanceMiddleware = (
             writeMethod &&
             (await maintenanceService.isMaintenanceMode())
         ) {
-            res.status(503).send({});
+            res.status(503).send({
+                message: MAINTENANCE_MODE_ENABLED,
+            });
         } else {
             next();
         }


### PR DESCRIPTION
This makes maintenance-related 503s more intuitive on our UI by mentioning that maintenance banner is currently enabled.

![image](https://github.com/Unleash/unleash/assets/14320932/43142c58-6b87-4b2d-9239-50f2bb1409e6)