### PR TITLE
feat: add copy button to feature flag name (#4098)

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { styled, Tab, Tabs, useMediaQuery } from '@mui/material';
-import { Archive, FileCopy, Label, WatchLater } from '@mui/icons-material';
+import { IconButton, styled, Tab, Tabs, Tooltip, useMediaQuery } from '@mui/material';
+import { Archive, FileCopy, Label, WatchLater, LibraryAdd, Check } from '@mui/icons-material';
 import {
     Link,
     Route,
@@ -36,6 +36,7 @@ import { ReactComponent as ChildLinkIcon } from 'assets/icons/link-child.svg';
 import { ReactComponent as ParentLinkIcon } from 'assets/icons/link-parent.svg';
 import { ChildrenTooltip } from './FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/ChildrenTooltip';
 import { useUiFlag } from 'hooks/useUiFlag';
+import copy from 'copy-to-clipboard';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -132,6 +133,7 @@ export const FeatureView = () => {
     const [openTagDialog, setOpenTagDialog] = useState(false);
     const [showDelDialog, setShowDelDialog] = useState(false);
     const [openStaleDialog, setOpenStaleDialog] = useState(false);
+    const [isFeatureNameCopied, setIsFeatureNameCopied] = useState(false);
     const smallScreen = useMediaQuery(`(max-width:${500}px)`);
 
     const { feature, loading, error, status } = useFeature(
@@ -185,6 +187,15 @@ export const FeatureView = () => {
         return <div ref={ref} />;
     }
 
+    const handleCopyToClipboard = () => {
+        copy(feature.name);
+        setIsFeatureNameCopied(true);
+
+        setTimeout(() => {
+            setIsFeatureNameCopied(false);
+        }, 3000);
+    };
+
     return (
         <div ref={ref}>
             <StyledHeader>
@@ -199,6 +210,12 @@ export const FeatureView = () => {
                                 <StyledFeatureViewHeader data-loading>
                                     {feature.name}{' '}
                                 </StyledFeatureViewHeader>
+                                <Tooltip title={isFeatureNameCopied ? 'Copied!' : 'Copy name'} arrow>
+                                    <IconButton onClick={handleCopyToClipboard}
+                                        style={{ marginLeft: 8}}>
+                                        {isFeatureNameCopied ? (<Check style={{ fontSize: 16 }}/> ): (<FileCopy style={{ fontSize: 16 }}/>)}
+                                    </IconButton>
+                                </Tooltip>
                                 <ConditionallyRender
                                     condition={!smallScreen}
                                     show={
@@ -254,10 +271,10 @@ export const FeatureView = () => {
                             component={Link}
                             to={`/projects/${projectId}/features/${featureId}/strategies/copy`}
                             tooltipProps={{
-                                title: 'Copy feature toggle',
+                                title: 'Clone',
                             }}
                         >
-                            <FileCopy />
+                            <LibraryAdd />
                         </PermissionIconButton>
                         <PermissionIconButton
                             permission={DELETE_FEATURE}

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -37,6 +37,7 @@ import { ReactComponent as ParentLinkIcon } from 'assets/icons/link-parent.svg';
 import { ChildrenTooltip } from './FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/ChildrenTooltip';
 import { useUiFlag } from 'hooks/useUiFlag';
 import copy from 'copy-to-clipboard';
+import useToast from 'hooks/useToast';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -129,6 +130,7 @@ export const FeatureView = () => {
     const { favorite, unfavorite } = useFavoriteFeaturesApi();
     const { refetchFeature } = useFeature(projectId, featureId);
     const dependentFeatures = useUiFlag('dependentFeatures');
+    const { setToastData } = useToast();
 
     const [openTagDialog, setOpenTagDialog] = useState(false);
     const [showDelDialog, setShowDelDialog] = useState(false);
@@ -188,12 +190,18 @@ export const FeatureView = () => {
     }
 
     const handleCopyToClipboard = () => {
-        copy(feature.name);
-        setIsFeatureNameCopied(true);
-
-        setTimeout(() => {
-            setIsFeatureNameCopied(false);
-        }, 3000);
+        try {
+            copy(feature.name);
+            setIsFeatureNameCopied(true);
+            setTimeout(() => {
+                setIsFeatureNameCopied(false);
+            }, 3000);
+        } catch (error: unknown) {
+            setToastData({
+                type: 'error',
+                title: 'Could not copy feature name',
+            });
+        }
     };
 
     return (

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -1,6 +1,20 @@
 import { useState } from 'react';
-import { IconButton, styled, Tab, Tabs, Tooltip, useMediaQuery } from '@mui/material';
-import { Archive, FileCopy, Label, WatchLater, LibraryAdd, Check } from '@mui/icons-material';
+import {
+    IconButton,
+    styled,
+    Tab,
+    Tabs,
+    Tooltip,
+    useMediaQuery,
+} from '@mui/material';
+import {
+    Archive,
+    FileCopy,
+    Label,
+    WatchLater,
+    LibraryAdd,
+    Check,
+} from '@mui/icons-material';
 import {
     Link,
     Route,
@@ -218,10 +232,25 @@ export const FeatureView = () => {
                                 <StyledFeatureViewHeader data-loading>
                                     {feature.name}{' '}
                                 </StyledFeatureViewHeader>
-                                <Tooltip title={isFeatureNameCopied ? 'Copied!' : 'Copy name'} arrow>
-                                    <IconButton onClick={handleCopyToClipboard}
-                                        style={{ marginLeft: 8}}>
-                                        {isFeatureNameCopied ? (<Check style={{ fontSize: 16 }}/> ): (<FileCopy style={{ fontSize: 16 }}/>)}
+                                <Tooltip
+                                    title={
+                                        isFeatureNameCopied
+                                            ? 'Copied!'
+                                            : 'Copy name'
+                                    }
+                                    arrow
+                                >
+                                    <IconButton
+                                        onClick={handleCopyToClipboard}
+                                        style={{ marginLeft: 8 }}
+                                    >
+                                        {isFeatureNameCopied ? (
+                                            <Check style={{ fontSize: 16 }} />
+                                        ) : (
+                                            <FileCopy
+                                                style={{ fontSize: 16 }}
+                                            />
+                                        )}
                                     </IconButton>
                                 </Tooltip>
                                 <ConditionallyRender

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -26,6 +26,7 @@ import {
 } from 'component/providers/AccessProvider/permissions';
 import { defaultBorderRadius } from 'themes/themeStyles';
 import copy from 'copy-to-clipboard';
+import useToast from 'hooks/useToast';
 
 const StyledBoxCell = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -53,6 +54,7 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
 }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [isFeatureNameCopied, setIsFeatureNameCopied] = useState(false);
+    const { setToastData } = useToast();
     const {
         original: { name: featureId, stale },
     } = row;
@@ -68,13 +70,20 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
     const menuId = `${id}-menu`;
 
     const handleCopyToClipboard = () => {
-        copy(featureId);
-        setIsFeatureNameCopied(true);
+        try {
+            copy(featureId);
+            setIsFeatureNameCopied(true);
 
-        setTimeout(() => {
-            handleClose();
-            setIsFeatureNameCopied(false);
-        }, 1000)
+            setTimeout(() => {
+                handleClose();
+                setIsFeatureNameCopied(false);
+            }, 1000);
+        } catch (error: unknown) {
+            setToastData({
+                type: 'error',
+                title: 'Could not copy feature name',
+            });
+        }
     };
 
     return (

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -121,7 +121,11 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
                         onClick={handleCopyToClipboard}
                     >
                         <ListItemIcon>
-                            {isFeatureNameCopied ? (<CheckIcon /> ): (<FileCopyIcon />)}
+                            {isFeatureNameCopied ? (
+                                <CheckIcon />
+                            ) : (
+                                <FileCopyIcon />
+                            )}
                         </ListItemIcon>
                         <ListItemText>
                             <Typography variant='body2'>

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -14,6 +14,8 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
+import LibraryAddIcon from '@mui/icons-material/LibraryAdd';
+import CheckIcon from '@mui/icons-material/Check';
 import ArchiveIcon from '@mui/icons-material/Archive';
 import WatchLaterIcon from '@mui/icons-material/WatchLater';
 import { PermissionHOC } from 'component/common/PermissionHOC/PermissionHOC';
@@ -23,6 +25,7 @@ import {
     UPDATE_FEATURE,
 } from 'component/providers/AccessProvider/permissions';
 import { defaultBorderRadius } from 'themes/themeStyles';
+import copy from 'copy-to-clipboard';
 
 const StyledBoxCell = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -49,6 +52,7 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
     onOpenStaleDialog,
 }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [isFeatureNameCopied, setIsFeatureNameCopied] = useState(false);
     const {
         original: { name: featureId, stale },
     } = row;
@@ -62,6 +66,16 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
     };
     const id = `feature-${featureId}-actions`;
     const menuId = `${id}-menu`;
+
+    const handleCopyToClipboard = () => {
+        copy(featureId);
+        setIsFeatureNameCopied(true);
+
+        setTimeout(() => {
+            handleClose();
+            setIsFeatureNameCopied(false);
+        }, 1000)
+    };
 
     return (
         <StyledBoxCell>
@@ -93,6 +107,19 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
                 }}
             >
                 <MenuList aria-labelledby={id}>
+                    <MenuItem
+                        sx={defaultBorderRadius}
+                        onClick={handleCopyToClipboard}
+                    >
+                        <ListItemIcon>
+                            {isFeatureNameCopied ? (<CheckIcon /> ): (<FileCopyIcon />)}
+                        </ListItemIcon>
+                        <ListItemText>
+                            <Typography variant='body2'>
+                                {isFeatureNameCopied ? 'Copied!' : 'Copy Name'}
+                            </Typography>
+                        </ListItemText>
+                    </MenuItem>
                     <PermissionHOC
                         projectId={projectId}
                         permission={CREATE_FEATURE}
@@ -106,11 +133,11 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
                                 to={`/projects/${projectId}/features/${featureId}/strategies/copy`}
                             >
                                 <ListItemIcon>
-                                    <FileCopyIcon />
+                                    <LibraryAddIcon />
                                 </ListItemIcon>
                                 <ListItemText>
                                     <Typography variant='body2'>
-                                        Copy
+                                        Clone
                                     </Typography>
                                 </ListItemText>
                             </MenuItem>


### PR DESCRIPTION

## About the changes
In ActionsCell.tsx file, 'Copy' with FileCopy icon is changed to 'Clone' with 'LibraryAdd' icon as this feature is used to clone a new feature from existing one. Upon copying the icon and text will change to 'Check' icon with 'Copied!' for one sec and closes automatically.
 
![image](https://github.com/Unleash/unleash/assets/55721773/47558244-172c-42cf-9c4d-3ebed3a6998d)
![image](https://github.com/Unleash/unleash/assets/55721773/0d970742-f05d-400b-9707-f14a739b952e)

In FeatureView.tsx file, 'FileCopy' icon is introduced next to Feature flag name and the existing FileCopy icon is changed to 'LibraryAdd' icon which represents cloning a new feature.

![image](https://github.com/Unleash/unleash/assets/55721773/33bef529-c441-4c2a-8052-ed83d9be5973)
![image](https://github.com/Unleash/unleash/assets/55721773/01a9d255-903c-4f7e-97ac-4e9225c483b7)


Closes #4098 

### Important files
ActionsCell.tsx
FeatureView.tsx


