### PR TITLE
feat: show dependencies only when using pro/enterprise or at least on…

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'utils/testRenderer';
 import { FeatureOverviewSidePanelDetails } from './FeatureOverviewSidePanelDetails';
-import { IDependency, IFeatureToggle } from 'interfaces/featureToggle';
+import { IFeatureToggle } from 'interfaces/featureToggle';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
 import ToastRenderer from 'component/common/ToastRenderer/ToastRenderer';
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
@@ -30,6 +30,19 @@ const setupApi = () => {
         'delete',
         200,
     );
+    testServerRoute(server, '/api/admin/projects/default/dependencies', false);
+};
+
+const setupOssWithExistingDependencies = () => {
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: {
+            dependentFeatures: true,
+        },
+        versionInfo: {
+            current: { oss: 'some value' },
+        },
+    });
+    testServerRoute(server, '/api/admin/projects/default/dependencies', true);
 };
 
 const setupChangeRequestApi = () => {
@@ -64,6 +77,36 @@ beforeEach(() => {
 });
 
 test('show dependency dialogue', async () => {
+    render(
+        <FeatureOverviewSidePanelDetails
+            feature={
+                {
+                    name: 'feature',
+                    project: 'default',
+                    dependencies: [] as Array<{ feature: string }>,
+                    children: [] as string[],
+                } as IFeatureToggle
+            }
+            header={''}
+        />,
+        {
+            permissions: [
+                { permission: 'UPDATE_FEATURE_DEPENDENCY', project: 'default' },
+            ],
+        },
+    );
+
+    const addParentButton = await screen.findByText('Add parent feature');
+
+    addParentButton.click();
+
+    expect(
+        screen.getByText('Add parent feature dependency'),
+    ).toBeInTheDocument();
+});
+
+test('show dependency dialogue for OSS with dependencies', async () => {
+    setupOssWithExistingDependencies();
     render(
         <FeatureOverviewSidePanelDetails
             feature={

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.tsx
@@ -7,8 +7,8 @@ import { FeatureEnvironmentSeen } from '../../../FeatureEnvironmentSeen/FeatureE
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { DependencyRow } from './DependencyRow';
 import { FlexRow, StyledDetail, StyledLabel } from './StyledRow';
-import { useUiFlag } from 'hooks/useUiFlag';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useShowDependentFeatures } from './useShowDependentFeatures';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -28,7 +28,7 @@ export const FeatureOverviewSidePanelDetails = ({
 }: IFeatureOverviewSidePanelDetailsProps) => {
     const { locationSettings } = useLocationSettings();
     const { uiConfig } = useUiConfig();
-    const dependentFeatures = useUiFlag('dependentFeatures');
+    const showDependentFeatures = useShowDependentFeatures(feature.project);
 
     const showLastSeenByEnvironment = Boolean(
         uiConfig.flags.lastSeenByEnvironment,
@@ -56,7 +56,7 @@ export const FeatureOverviewSidePanelDetails = ({
                 )}
             </FlexRow>
             <ConditionallyRender
-                condition={dependentFeatures}
+                condition={showDependentFeatures}
                 show={<DependencyRow feature={feature} />}
             />
         </StyledContainer>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/useShowDependentFeatures.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/useShowDependentFeatures.ts
@@ -1,0 +1,13 @@
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useCheckDependenciesExist } from 'hooks/api/getters/useCheckDependenciesExist/useCheckDependenciesExist';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+
+export const useShowDependentFeatures = (project: string) => {
+    const dependentFeatures = useUiFlag('dependentFeatures');
+    const { dependenciesExist } = useCheckDependenciesExist(project);
+    const { isOss } = useUiConfig();
+
+    return Boolean(
+        isOss() ? dependenciesExist && dependentFeatures : dependentFeatures,
+    );
+};

--- a/frontend/src/hooks/api/getters/useCheckDependenciesExist/useCheckDependenciesExist.ts
+++ b/frontend/src/hooks/api/getters/useCheckDependenciesExist/useCheckDependenciesExist.ts
@@ -1,0 +1,32 @@
+import { SWRConfiguration } from 'swr';
+import { formatApiPath } from 'utils/formatPath';
+import handleErrorResponses from '../httpErrorResponseHandler';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
+
+export const useCheckDependenciesExist = (
+    project: string,
+    options: SWRConfiguration = {},
+) => {
+    const path = formatApiPath(`/api/admin/projects/${project}/dependencies`);
+    const { data, error } = useConditionalSWR(
+        project,
+        false,
+        path,
+        fetcher,
+        options,
+    );
+
+    return {
+        dependenciesExist: data,
+        error,
+        loading: !error && !data,
+    };
+};
+
+const fetcher = async (path: string): Promise<boolean> => {
+    const res = await fetch(path).then(
+        handleErrorResponses('Dependencies exist check'),
+    );
+    const data = await res.json();
+    return data;
+};

--- a/frontend/src/utils/testServer.ts
+++ b/frontend/src/utils/testServer.ts
@@ -14,7 +14,7 @@ export const testServerSetup = (): SetupServerApi => {
 export const testServerRoute = (
     server: SetupServerApi,
     path: string,
-    json: object,
+    json: object | boolean | string | number,
     method: 'get' | 'post' | 'put' | 'delete' = 'get',
     status: number = 200,
 ) => {

--- a/src/lib/features/dependent-features/dependent-features-controller.ts
+++ b/src/lib/features/dependent-features/dependent-features-controller.ts
@@ -180,7 +180,7 @@ export default class DependentFeaturesController extends Controller {
                         'Check if any dependencies exist in this Unleash instance',
                     operationId: 'checkDependenciesExist',
                     responses: {
-                        200: createResponseSchema('dependencyExistsSchema'),
+                        200: createResponseSchema('dependenciesExistSchema'),
                         ...getStandardResponses(401, 403),
                     },
                 }),

--- a/src/lib/features/dependent-features/dependent-features-controller.ts
+++ b/src/lib/features/dependent-features/dependent-features-controller.ts
@@ -38,6 +38,7 @@ interface DeleteDependencyParams extends ProjectParams {
 const PATH = '/:projectId/features';
 const PATH_FEATURE = `${PATH}/:child`;
 const PATH_DEPENDENCIES = `${PATH_FEATURE}/dependencies`;
+const PATH_DEPENDENCIES_CHECK = `/:projectId/dependencies`;
 const PATH_PARENTS = `${PATH_FEATURE}/parents`;
 const PATH_DEPENDENCY = `${PATH_FEATURE}/dependencies/:parent`;
 
@@ -165,6 +166,26 @@ export default class DependentFeaturesController extends Controller {
                 }),
             ],
         });
+
+        this.route({
+            method: 'get',
+            path: PATH_DEPENDENCIES_CHECK,
+            handler: this.checkDependenciesExist,
+            permission: NONE,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Dependencies'],
+                    summary: 'Check dependencies exist.',
+                    description:
+                        'Check if any dependencies exist in this Unleash instance',
+                    operationId: 'checkDependenciesExist',
+                    responses: {
+                        200: createResponseSchema('dependencyExistsSchema'),
+                        ...getStandardResponses(401, 403),
+                    },
+                }),
+            ],
+        });
     }
 
     async addFeatureDependency(
@@ -249,6 +270,23 @@ export default class DependentFeaturesController extends Controller {
             const parentOptions =
                 await this.dependentFeaturesService.getParentOptions(child);
             res.send(parentOptions);
+        } else {
+            throw new InvalidOperationError(
+                'Dependent features are not enabled',
+            );
+        }
+    }
+
+    async checkDependenciesExist(
+        req: IAuthRequest,
+        res: Response,
+    ): Promise<void> {
+        const { child } = req.params;
+
+        if (this.config.flagResolver.isEnabled('dependentFeatures')) {
+            const exist =
+                await this.dependentFeaturesService.checkDependenciesExist();
+            res.send(exist);
         } else {
             throw new InvalidOperationError(
                 'Dependent features are not enabled',

--- a/src/lib/features/dependent-features/dependent-features-read-model-type.ts
+++ b/src/lib/features/dependent-features/dependent-features-read-model-type.ts
@@ -10,4 +10,5 @@ export interface IDependentFeaturesReadModel {
     getDependencies(children: string[]): Promise<IFeatureDependency[]>;
     getParentOptions(child: string): Promise<string[]>;
     hasDependencies(feature: string): Promise<boolean>;
+    hasAnyDependencies(): Promise<boolean>;
 }

--- a/src/lib/features/dependent-features/dependent-features-read-model.ts
+++ b/src/lib/features/dependent-features/dependent-features-read-model.ts
@@ -90,4 +90,12 @@ export class DependentFeaturesReadModel implements IDependentFeaturesReadModel {
 
         return parents.length > 0;
     }
+
+    async hasAnyDependencies(): Promise<boolean> {
+        const result = await this.db.raw(
+            `SELECT EXISTS (SELECT 1 FROM dependent_features) AS present`,
+        );
+        const { present } = result.rows[0];
+        return present;
+    }
 }

--- a/src/lib/features/dependent-features/dependent-features-service.ts
+++ b/src/lib/features/dependent-features/dependent-features-service.ts
@@ -197,6 +197,10 @@ export class DependentFeaturesService {
         return this.dependentFeaturesReadModel.getParentOptions(feature);
     }
 
+    async checkDependenciesExist(): Promise<boolean> {
+        return this.dependentFeaturesReadModel.hasAnyDependencies();
+    }
+
     private async stopWhenChangeRequestsEnabled(project: string, user?: User) {
         const canBypass =
             await this.changeRequestAccessReadModel.canBypassChangeRequestForProject(

--- a/src/lib/features/dependent-features/dependent.features.e2e.test.ts
+++ b/src/lib/features/dependent-features/dependent.features.e2e.test.ts
@@ -86,6 +86,12 @@ const getParentOptions = async (childFeature: string, expectedCode = 200) => {
         .expect(expectedCode);
 };
 
+const checkDependenciesExist = async (expectedCode = 200) => {
+    return app.request
+        .get(`/api/admin/projects/default/dependencies`)
+        .expect(expectedCode);
+};
+
 test('should add and delete feature dependencies', async () => {
     const parent = uuidv4();
     const child = uuidv4();
@@ -166,4 +172,21 @@ test('should not allow to add archived parent dependency', async () => {
         },
         403,
     );
+});
+
+test('should check if any dependencies exist', async () => {
+    const parent = uuidv4();
+    const child = uuidv4();
+    await app.createFeature(child);
+    await app.createFeature(parent);
+
+    const { body: dependenciesExistBefore } = await checkDependenciesExist();
+    expect(dependenciesExistBefore).toBe(false);
+
+    await addFeatureDependency(child, {
+        feature: parent,
+    });
+
+    const { body: dependenciesExistAfter } = await checkDependenciesExist();
+    expect(dependenciesExistAfter).toBe(true);
 });

--- a/src/lib/features/dependent-features/dependent.features.e2e.test.ts
+++ b/src/lib/features/dependent-features/dependent.features.e2e.test.ts
@@ -44,6 +44,10 @@ afterAll(async () => {
     await db.destroy();
 });
 
+beforeEach(async () => {
+    await db.stores.dependentFeaturesStore.deleteAll();
+});
+
 const addFeatureDependency = async (
     childFeature: string,
     payload: CreateDependentFeatureSchema,

--- a/src/lib/features/dependent-features/fake-dependent-features-read-model.ts
+++ b/src/lib/features/dependent-features/fake-dependent-features-read-model.ts
@@ -27,4 +27,8 @@ export class FakeDependentFeaturesReadModel
     getOrphanParents(parentsAndChildren: string[]): Promise<string[]> {
         return Promise.resolve([]);
     }
+
+    hasAnyDependencies(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
 }

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -164,6 +164,7 @@ import {
     dependentFeatureSchema,
     createDependentFeatureSchema,
     parentFeatureOptionsSchema,
+    dependenciesExistSchema,
 } from './spec';
 import { IServerOption } from '../types';
 import { mapValues, omitKeys } from '../util';
@@ -391,6 +392,7 @@ export const schemas: UnleashSchemas = {
     createDependentFeatureSchema,
     parentFeatureOptionsSchema,
     featureDependenciesSchema,
+    dependenciesExistSchema,
 };
 
 // Remove JSONSchema keys that would result in an invalid OpenAPI spec.

--- a/src/lib/openapi/meta-schema-rules.test.ts
+++ b/src/lib/openapi/meta-schema-rules.test.ts
@@ -35,7 +35,7 @@ const metaRules: Rule[] = [
         metaSchema: {
             type: 'object',
             properties: {
-                type: { type: 'string', enum: ['object', 'array'] },
+                type: { type: 'string', enum: ['object', 'array', 'boolean'] },
             },
             required: ['type'],
         },

--- a/src/lib/openapi/spec/dependencies-exist-schema.ts
+++ b/src/lib/openapi/spec/dependencies-exist-schema.ts
@@ -1,0 +1,13 @@
+import { FromSchema } from 'json-schema-to-ts';
+
+export const dependenciesExistSchema = {
+    $id: '#/components/schemas/dependenciesExistSchema',
+    type: 'boolean',
+    description:
+        '`true` when any dependencies exist, `false` when no dependencies exist.',
+    components: {},
+} as const;
+
+export type DependenciesExistSchema = FromSchema<
+    typeof dependenciesExistSchema
+>;

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -164,3 +164,4 @@ export * from './dependent-feature-schema';
 export * from './create-dependent-feature-schema';
 export * from './parent-feature-options-schema';
 export * from './feature-dependencies-schema';
+export * from './dependencies-exist-schema';


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Dependent features makes UI more complicated. OSS usually needs simpler feature set so this feature will be disabled for them unless one dependency already exists in the system. 

We're only hiding this part of the UI since it's the only way to create a new dependency
<img width="313" alt="Screenshot 2023-10-16 at 14 27 39" src="https://github.com/Unleash/unleash/assets/1394682/5ef9b6cf-0972-4e3b-ab42-42c5c6f55bca">

Impl details:
* added backend route for checking if any dependencies exists
* added frontend hook that looks at a flag and makes API call to check if any dependencies exist
* added backend and frontend tests

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
