### PR TITLE
fix: extract username from user should not return undefined

### DIFF
--- a/src/lib/util/extract-user.test.ts
+++ b/src/lib/util/extract-user.test.ts
@@ -1,0 +1,32 @@
+import { IUser } from '../server-impl';
+import { extractUsernameFromUser } from './extract-user';
+
+describe('extractUsernameFromUser', () => {
+    test('Should return the email if it exists', () => {
+        const user = {
+            email: 'ratatoskr@yggdrasil.com',
+            username: 'ratatoskr',
+        } as IUser;
+
+        expect(extractUsernameFromUser(user)).toBe(user.email);
+    });
+
+    test('Should return the username if it exists and email does not', () => {
+        const user = {
+            username: 'ratatoskr',
+        } as IUser;
+
+        expect(extractUsernameFromUser(user)).toBe(user.username);
+    });
+
+    test('Should return "unknown" if neither email nor username exists', () => {
+        const user = {} as IUser;
+
+        expect(extractUsernameFromUser(user)).toBe('unknown');
+    });
+
+    test('Should return "unknown" if user is null', () => {
+        // @ts-expect-error
+        expect(extractUsernameFromUser(null)).toBe('unknown');
+    });
+});

--- a/src/lib/util/extract-user.test.ts
+++ b/src/lib/util/extract-user.test.ts
@@ -26,7 +26,7 @@ describe('extractUsernameFromUser', () => {
     });
 
     test('Should return "unknown" if user is null', () => {
-        // @ts-expect-error
-        expect(extractUsernameFromUser(null)).toBe('unknown');
+        const user = null as unknown as IUser;
+        expect(extractUsernameFromUser(user)).toBe('unknown');
     });
 });

--- a/src/lib/util/extract-user.ts
+++ b/src/lib/util/extract-user.ts
@@ -1,7 +1,7 @@
 import { IAuthRequest, IUser } from '../server-impl';
 
 export function extractUsernameFromUser(user: IUser): string {
-    return user ? user.email || user.username : 'unknown';
+    return user?.email || user?.username || 'unknown';
 }
 
 export function extractUsername(req: IAuthRequest): string {


### PR DESCRIPTION
This fixes a return type error by changing the logic of `extractUsernameFromUser` to never return undefined.

In the previous code, `user` could be truthy, but that doesn't mean `email` or `username` were defined. This assumes we always fallback to "unknown" in those scenarios.