### PR TITLE
chore: introduce type to prevent potential issues

### DIFF
--- a/src/lib/db/transaction.ts
+++ b/src/lib/db/transaction.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { IUnleashConfig } from 'lib/server-impl';
 
 export type KnexTransaction = Knex.Transaction;
 
@@ -26,7 +27,15 @@ export const createKnexTransactionStarter = (
     return transaction;
 };
 
-export type DbServiceFactory<S> = (db: Knex) => S;
+export type DeferredServiceFactory<S> = (db: Knex) => S;
+/**
+ * Services need to be instantiated with a knex instance on a per-transaction basis.
+ * Limiting the input parameters, makes sure we don't inject already instantiated services
+ * that might be bound to a different transaction.
+ */
+export type ServiceFactory<S> = (
+    config: IUnleashConfig,
+) => DeferredServiceFactory<S>;
 export type WithTransactional<S> = S & {
     transactional: <R>(fn: (service: S) => R) => Promise<R>;
 };

--- a/src/lib/features/export-import-toggles/createExportImportService.ts
+++ b/src/lib/features/export-import-toggles/createExportImportService.ts
@@ -43,7 +43,7 @@ import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
-import { DbServiceFactory } from 'lib/db/transaction';
+import { DeferredServiceFactory } from 'lib/db/transaction';
 import { DependentFeaturesReadModel } from '../dependent-features/dependent-features-read-model';
 import { FakeDependentFeaturesReadModel } from '../dependent-features/fake-dependent-features-read-model';
 import {
@@ -149,7 +149,7 @@ export const createFakeExportImportTogglesService = (
 
 export const deferredExportImportTogglesService = (
     config: IUnleashConfig,
-): DbServiceFactory<ExportImportService> => {
+): DeferredServiceFactory<ExportImportService> => {
     return (db: Db) => {
         const { eventBus, getLogger, flagResolver } = config;
         const importTogglesStore = new ImportTogglesStore(db);


### PR DESCRIPTION
## About the changes
This small improvement aims to help developers when instantiating services. They need to be constructed without injecting services or stores created elsewhere so they can be bound to the same transactional scope. 

This suggests that you need to create the services and stores on your own