### PR TITLE
fix(tests): correctly set baseUriPath in setupAppWithBaseUrl

### DIFF
--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -217,7 +217,6 @@ async function createApp(
         },
         server: {
             unleashUrl: 'http://localhost:4242',
-            ...(customOptions?.server ?? {}),
         },
         disableScheduler: true,
         ...{

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -217,6 +217,7 @@ async function createApp(
         },
         server: {
             unleashUrl: 'http://localhost:4242',
+            ...(customOptions.server || {}),
         },
         disableScheduler: true,
         ...{
@@ -296,7 +297,7 @@ export async function setupAppWithBaseUrl(
     return createApp(stores, undefined, undefined, {
         server: {
             unleashUrl: 'http://localhost:4242',
-            basePathUri: '/hosted',
+            baseUriPath: '/hosted',
         },
     });
 }

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -217,7 +217,7 @@ async function createApp(
         },
         server: {
             unleashUrl: 'http://localhost:4242',
-            ...(customOptions.server || {}),
+            ...(customOptions?.server ?? {}),
         },
         disableScheduler: true,
         ...{

--- a/src/test/e2e/routes/routes.test.ts
+++ b/src/test/e2e/routes/routes.test.ts
@@ -20,7 +20,7 @@ afterAll(async () => {
 test('hitting a baseUri path returns HTML document', async () => {
     expect.assertions(0);
     await app.request
-        .get('/hosted')
+        .get('/hosted/projects')
         .expect(200)
         .expect('Content-Type', 'text/html; charset=utf-8');
 });
@@ -33,7 +33,7 @@ test('hitting an api path that does not exist returns 404', async () => {
 test('hitting an /admin/api returns HTML document', async () => {
     expect.assertions(0);
     await app.request
-        .get('/admin/api')
+        .get('/hosted/admin/api')
         .expect(200)
         .expect('Content-Type', 'text/html; charset=utf-8');
 });


### PR DESCRIPTION
This appears to be a bug. I can confirm that the base path did not take effect with the previous incarnation, but this should fix that.