### PR TITLE
refactor: move message banner interface to common file

### DIFF
--- a/frontend/src/component/messageBanners/MessageBanner/MessageBanner.tsx
+++ b/frontend/src/component/messageBanners/MessageBanner/MessageBanner.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { MessageBannerDialog } from './MessageBannerDialog/MessageBannerDialog';
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { BannerVariant, IMessageBanner } from 'interfaces/messageBanner';
 
 const StyledBar = styled('aside', {
     shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'sticky',
@@ -41,20 +42,6 @@ const StyledIcon = styled('div', {
     alignItems: 'center',
     color: theme.palette[variant].main,
 }));
-
-type BannerVariant = 'warning' | 'info' | 'error' | 'success';
-
-export interface IMessageBanner {
-    message: string;
-    variant?: BannerVariant;
-    sticky?: boolean;
-    icon?: string;
-    link?: string;
-    linkText?: string;
-    plausibleEvent?: string;
-    dialogTitle?: string;
-    dialog?: string;
-}
 
 interface IMessageBannerProps {
     messageBanner: IMessageBanner;

--- a/frontend/src/component/messageBanners/externalMessageBanners/ExternalMessageBanners.tsx
+++ b/frontend/src/component/messageBanners/externalMessageBanners/ExternalMessageBanners.tsx
@@ -1,9 +1,7 @@
-import {
-    IMessageBanner,
-    MessageBanner,
-} from 'component/messageBanners/MessageBanner/MessageBanner';
+import { MessageBanner } from 'component/messageBanners/MessageBanner/MessageBanner';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useVariant } from 'hooks/useVariant';
+import { IMessageBanner } from 'interfaces/messageBanner';
 
 export const ExternalMessageBanners = () => {
     const { uiConfig } = useUiConfig();

--- a/frontend/src/interfaces/messageBanner.ts
+++ b/frontend/src/interfaces/messageBanner.ts
@@ -2,7 +2,6 @@ export type BannerVariant = 'warning' | 'info' | 'error' | 'success';
 
 export interface IMessageBanner {
     message: string;
-    enabled?: boolean;
     variant?: BannerVariant;
     sticky?: boolean;
     icon?: string;
@@ -11,4 +10,10 @@ export interface IMessageBanner {
     plausibleEvent?: string;
     dialogTitle?: string;
     dialog?: string;
+}
+
+export interface IInternalMessageBanner extends IMessageBanner {
+    id: number;
+    enabled: boolean;
+    createdAt: string;
 }

--- a/frontend/src/interfaces/messageBanner.ts
+++ b/frontend/src/interfaces/messageBanner.ts
@@ -1,0 +1,14 @@
+export type BannerVariant = 'warning' | 'info' | 'error' | 'success';
+
+export interface IMessageBanner {
+    message: string;
+    enabled?: boolean;
+    variant?: BannerVariant;
+    sticky?: boolean;
+    icon?: string;
+    link?: string;
+    linkText?: string;
+    plausibleEvent?: string;
+    dialogTitle?: string;
+    dialog?: string;
+}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1527/set-up-message-banner-interfaces

Tiny refactor to move the message banner interface to its own file, since it will be used in multiple places.