### PR TITLE
fix: force deletion of archived toggles when deleting a project

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -174,20 +174,20 @@ class FeatureToggleService {
             featureToggleStore,
             clientFeatureToggleStore,
             projectStore,
+            featureTagStore,
             featureEnvironmentStore,
             contextFieldStore,
             strategyStore,
-            featureTagStore,
         }: Pick<
             IUnleashStores,
             | 'featureStrategiesStore'
             | 'featureToggleStore'
             | 'clientFeatureToggleStore'
             | 'projectStore'
+            | 'featureTagStore'
             | 'featureEnvironmentStore'
             | 'contextFieldStore'
             | 'strategyStore'
-            | 'featureTagStore'
         >,
         {
             getLogger,

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -174,20 +174,20 @@ class FeatureToggleService {
             featureToggleStore,
             clientFeatureToggleStore,
             projectStore,
-            featureTagStore,
             featureEnvironmentStore,
             contextFieldStore,
             strategyStore,
+            featureTagStore,
         }: Pick<
             IUnleashStores,
             | 'featureStrategiesStore'
             | 'featureToggleStore'
             | 'clientFeatureToggleStore'
             | 'projectStore'
-            | 'featureTagStore'
             | 'featureEnvironmentStore'
             | 'contextFieldStore'
             | 'strategyStore'
+            | 'featureTagStore'
         >,
         {
             getLogger,

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -390,6 +390,14 @@ export default class ProjectService {
             );
         }
 
+        const archivedToggles = await this.featureToggleStore.getAll({
+            project: id,
+            archived: true,
+        });
+
+        await this.featureToggleStore.batchDelete(
+            archivedToggles.map((toggleName) => toggleName.name),
+        );
         await this.projectStore.delete(id);
 
         await this.eventService.storeEvent({

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -40,6 +40,7 @@ import {
     ProjectAccessUserRolesDeleted,
     IFeatureNaming,
     CreateProject,
+    FeatureDeletedEvent,
 } from '../types';
 import {
     IProjectQuery,
@@ -395,9 +396,12 @@ export default class ProjectService {
             archived: true,
         });
 
-        await this.featureToggleStore.batchDelete(
-            archivedToggles.map((toggleName) => toggleName.name),
+        this.featureToggleService.deleteFeatures(
+            archivedToggles.map((toggle) => toggle.name),
+            id,
+            user.name,
         );
+
         await this.projectStore.delete(id);
 
         await this.eventService.storeEvent({

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -40,7 +40,6 @@ import {
     ProjectAccessUserRolesDeleted,
     IFeatureNaming,
     CreateProject,
-    FeatureDeletedEvent,
 } from '../types';
 import {
     IProjectQuery,

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1855,28 +1855,3 @@ test('deleting a project with no archived toggles should not result in an error'
     await projectService.createProject(project, user.id);
     await projectService.deleteProject(project.id, user);
 });
-
-test('deleting a project with archived toggles should emit events for the deleted toggles', async () => {
-    const project = {
-        id: 'project-with-archived-toggles-should-emit-events',
-        name: 'project-with-archived-toggles',
-    };
-    const toggleName = 'deleted-and-emitted-event';
-
-    await projectService.createProject(project, user.id);
-
-    await stores.featureToggleStore.create(project.id, {
-        name: toggleName,
-        project: project.id,
-        enabled: false,
-        defaultStickiness: 'default',
-    });
-
-    await stores.featureToggleStore.archive(toggleName);
-    await projectService.deleteProject(project.id, user);
-
-    const deletionEvent = await (
-        await eventService.getEvents()
-    ).events.find((event) => event.featureName === toggleName);
-    expect(deletionEvent).toBeDefined();
-});


### PR DESCRIPTION
This forces the project service to delete archived toggles when a project is deleted. Previously, when deleting a project, you were blocked if you had one or more active toggles but once they're archived the project can be deleted. Those archived toggles would persist indefinitely and when a new project was created that matched the old project name, they would immediately be bound to that project in an archived state. This was really confusing for users across teams, since they could create a project that someone else had created, used and then deleted and they would get a bunch of toggles in their project that they had never touched