### PR TITLE
feat: default session id in frontend api

### DIFF
--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -74,12 +74,19 @@ export class ProxyService {
         const client = await this.clientForProxyToken(token);
         const definitions = client.getFeatureToggleDefinitions() || [];
 
+        const sessionId = context.sessionId || String(Math.random());
+
         return definitions
-            .filter((feature) => client.isEnabled(feature.name, context))
+            .filter((feature) =>
+                client.isEnabled(feature.name, { ...context, sessionId }),
+            )
             .map((feature) => ({
                 name: feature.name,
                 enabled: Boolean(feature.enabled),
-                variant: client.forceGetVariant(feature.name, context),
+                variant: client.getVariant(feature.name, {
+                    ...context,
+                    sessionId,
+                }),
                 impressionData: Boolean(feature.impressionData),
             }));
     }

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -1271,6 +1271,7 @@ test('should resolve variable rollout percentage consistently', async () => {
             .expect(200);
 
         if (body.toggles.length > 0) {
+            // disabled variant should not be possible for enabled toggles
             expect(body.toggles[0].variant.name).toBe('a');
         }
     }

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -1236,3 +1236,42 @@ test('should return 204 if metrics are disabled', async () => {
         })
         .expect(204);
 });
+
+test('should resolve variable rollout percentage consistently', async () => {
+    const frontendToken = await createApiToken(ApiTokenType.FRONTEND);
+    await createFeatureToggle({
+        name: 'randomFeature',
+        enabled: true,
+        strategies: [
+            {
+                name: 'flexibleRollout',
+                constraints: [],
+                parameters: {
+                    rollout: '50',
+                    stickiness: 'default',
+                    groupId: 'some-new',
+                },
+                variants: [
+                    {
+                        name: 'a',
+                        stickiness: 'default',
+                        weightType: 'variable',
+                        weight: 1000,
+                    },
+                ],
+            },
+        ],
+    });
+
+    for (let i = 0; i < 10; ++i) {
+        const { body } = await app.request
+            .get('/api/frontend')
+            .set('Authorization', frontendToken.secret)
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        if (body.toggles.length > 0) {
+            expect(body.toggles[0].variant.name).toBe('a');
+        }
+    }
+});


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

What problem are we solving?
* enabled info and variant info in the same feature have to be consistent when stickiness is set to default
* also we want to have consistency between parent and child features 

Solution:
* if the user didn't provide sessionId, generate one one the fly

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Is Math.random() good enough?