### PR TITLE
feat: ensure at least one owner on remove user/group access

### DIFF
--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -14,7 +14,6 @@ import FakeGroupStore from '../../../test/fixtures/fake-group-store';
 import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import ProjectStore from '../../db/project-store';
 import FeatureToggleStore from '../feature-toggle/feature-toggle-store';
-import FeatureTypeStore from '../../db/feature-type-store';
 import { FeatureEnvironmentStore } from '../../db/feature-environment-store';
 import ProjectStatsStore from '../../db/project-stats-store';
 import {
@@ -41,7 +40,6 @@ import {
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
-import { LastSeenAtReadModel } from '../../services/client-metrics/last-seen/last-seen-read-model';
 import { FakeLastSeenReadModel } from '../../services/client-metrics/last-seen/fake-last-seen-read-model';
 
 export const createProjectService = (
@@ -57,13 +55,7 @@ export const createProjectService = (
         flagResolver,
     );
     const groupStore = new GroupStore(db);
-    const featureToggleStore = new FeatureToggleStore(
-        db,
-        eventBus,
-        getLogger,
-        flagResolver,
-    );
-    const featureTypeStore = new FeatureTypeStore(db, getLogger);
+    const featureToggleStore = new FeatureToggleStore(db, eventBus, getLogger);
     const accountStore = new AccountStore(db, getLogger);
     const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
     const featureEnvironmentStore = new FeatureEnvironmentStore(
@@ -106,14 +98,12 @@ export const createProjectService = (
     );
 
     const privateProjectChecker = createPrivateProjectChecker(db, config);
-    const lastSeenReadModel = new LastSeenAtReadModel(db);
 
     return new ProjectService(
         {
             projectStore,
             eventStore,
             featureToggleStore,
-            featureTypeStore,
             environmentStore,
             featureEnvironmentStore,
             accountStore,
@@ -126,7 +116,6 @@ export const createProjectService = (
         favoriteService,
         eventService,
         privateProjectChecker,
-        lastSeenReadModel,
     );
 };
 
@@ -138,7 +127,6 @@ export const createFakeProjectService = (
     const projectStore = new FakeProjectStore();
     const groupStore = new FakeGroupStore();
     const featureToggleStore = new FakeFeatureToggleStore();
-    const featureTypeStore = new FakeFeatureTypeStore();
     const accountStore = new FakeAccountStore();
     const environmentStore = new FakeEnvironmentStore();
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
@@ -169,14 +157,12 @@ export const createFakeProjectService = (
     );
 
     const privateProjectChecker = createFakePrivateProjectChecker();
-    const fakeLastSeenReadModel = new FakeLastSeenReadModel();
 
     return new ProjectService(
         {
             projectStore,
             eventStore,
             featureToggleStore,
-            featureTypeStore,
             environmentStore,
             featureEnvironmentStore,
             accountStore,
@@ -189,6 +175,5 @@ export const createFakeProjectService = (
         favoriteService,
         eventService,
         privateProjectChecker,
-        fakeLastSeenReadModel,
     );
 };

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -53,7 +53,12 @@ export const createProjectService = (
         flagResolver,
     );
     const groupStore = new GroupStore(db);
-    const featureToggleStore = new FeatureToggleStore(db, eventBus, getLogger);
+    const featureToggleStore = new FeatureToggleStore(
+        db,
+        eventBus,
+        getLogger,
+        flagResolver,
+    );
     const accountStore = new AccountStore(db, getLogger);
     const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
     const featureEnvironmentStore = new FeatureEnvironmentStore(

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -28,7 +28,6 @@ import { FavoriteFeaturesStore } from '../../db/favorite-features-store';
 import { FavoriteProjectsStore } from '../../db/favorite-projects-store';
 import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 import FakeFeatureToggleStore from '../feature-toggle/fakes/fake-feature-toggle-store';
-import FakeFeatureTypeStore from '../../../test/fixtures/fake-feature-type-store';
 import FakeEnvironmentStore from '../../../test/fixtures/fake-environment-store';
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
 import FakeProjectStatsStore from '../../../test/fixtures/fake-project-stats-store';
@@ -40,7 +39,6 @@ import {
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
-import { FakeLastSeenReadModel } from '../../services/client-metrics/last-seen/fake-last-seen-read-model';
 
 export const createProjectService = (
     db: Db,

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -552,6 +552,7 @@ export class AccessService {
         owner: IUser,
         projectId: string,
     ): Promise<void> {
+        console.log(16);
         if (!projectId) {
             throw new Error('ProjectId cannot be empty');
         }
@@ -571,6 +572,7 @@ export class AccessService {
         owner: User,
         projectId: string,
     ): Promise<void> {
+        console.log(17);
         this.logger.info(`Removing project roles for ${projectId}`);
         return this.roleStore.removeRolesForProject(projectId);
     }

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -568,7 +568,7 @@ export class AccessService {
     }
 
     async removeDefaultProjectRoles(
-        owner: User,
+        owner: IUser,
         projectId: string,
     ): Promise<void> {
         this.logger.info(`Removing project roles for ${projectId}`);

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -552,7 +552,6 @@ export class AccessService {
         owner: IUser,
         projectId: string,
     ): Promise<void> {
-        console.log(16);
         if (!projectId) {
             throw new Error('ProjectId cannot be empty');
         }
@@ -572,7 +571,6 @@ export class AccessService {
         owner: User,
         projectId: string,
     ): Promise<void> {
-        console.log(17);
         this.logger.info(`Removing project roles for ${projectId}`);
         return this.roleStore.removeRolesForProject(projectId);
     }

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -1,6 +1,6 @@
 import { subDays } from 'date-fns';
 import { ValidationError } from 'joi';
-import User, { IUser } from '../types/user';
+import { IUser } from '../types/user';
 import { AccessService, AccessWithRoles } from './access-service';
 import NameExistsError from '../error/name-exists-error';
 import InvalidOperationError from '../error/invalid-operation-error';
@@ -259,7 +259,7 @@ export default class ProjectService {
         return data;
     }
 
-    async updateProject(updatedProject: IProject, user: User): Promise<void> {
+    async updateProject(updatedProject: IProject, user: IUser): Promise<void> {
         const preData = await this.projectStore.get(updatedProject.id);
 
         await this.projectStore.update(updatedProject);
@@ -275,7 +275,7 @@ export default class ProjectService {
 
     async updateProjectEnterpriseSettings(
         updatedProject: IProjectEnterpriseSettingsUpdate,
-        user: User,
+        user: IUser,
     ): Promise<void> {
         const preData = await this.projectStore.get(updatedProject.id);
 
@@ -322,7 +322,7 @@ export default class ProjectService {
     async changeProject(
         newProjectId: string,
         featureName: string,
-        user: User,
+        user: IUser,
         currentProjectId: string,
     ): Promise<any> {
         const feature = await this.featureToggleStore.get(featureName);
@@ -364,7 +364,7 @@ export default class ProjectService {
         return updatedFeature;
     }
 
-    async deleteProject(id: string, user: User): Promise<void> {
+    async deleteProject(id: string, user: IUser): Promise<void> {
         if (id === DEFAULT_PROJECT) {
             throw new InvalidOperationError(
                 'You can not delete the default project!',

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -491,7 +491,7 @@ export default class ProjectService {
         userId: number,
         createdBy: string,
     ): Promise<void> {
-        const userRoles = await this.accessService.getProjectRolesForUser(
+        const existingRoles = await this.accessService.getProjectRolesForUser(
             projectId,
             userId,
         );
@@ -508,7 +508,7 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 preData: {
-                    roles: userRoles,
+                    roles: existingRoles,
                     userId,
                 },
             }),
@@ -520,7 +520,7 @@ export default class ProjectService {
         groupId: number,
         createdBy: string,
     ): Promise<void> {
-        const groupRoles = await this.accessService.getProjectRolesForGroup(
+        const existingRoles = await this.accessService.getProjectRolesForGroup(
             projectId,
             groupId,
         );
@@ -537,7 +537,7 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 preData: {
-                    roles: groupRoles,
+                    roles: existingRoles,
                     groupId,
                 },
             }),
@@ -678,7 +678,7 @@ export default class ProjectService {
         roles: number[],
         createdByUserName: string,
     ): Promise<void> {
-        const userRoles = await this.accessService.getProjectRolesForUser(
+        const existingRoles = await this.accessService.getProjectRolesForUser(
             projectId,
             userId,
         );
@@ -686,7 +686,14 @@ export default class ProjectService {
         const ownerRole = await this.accessService.getRoleByName(
             RoleName.OWNER,
         );
-        await this.validateAtLeastOneOwner(projectId, ownerRole);
+
+        if (
+            existingRoles.some((roleId) => roleId === ownerRole.id) &&
+            !roles.some((roleId) => roleId === ownerRole.id)
+        ) {
+            // only check if the user is getting the owner role removed
+            await this.validateAtLeastOneOwner(projectId, ownerRole);
+        }
 
         await this.accessService.setProjectRolesForUser(
             projectId,
@@ -702,7 +709,7 @@ export default class ProjectService {
                     userId,
                 },
                 preData: {
-                    roles: userRoles,
+                    roles: existingRoles,
                     userId,
                 },
             }),
@@ -715,7 +722,7 @@ export default class ProjectService {
         roles: number[],
         createdBy: string,
     ): Promise<void> {
-        const groupRoles = await this.accessService.getProjectRolesForGroup(
+        const existingRoles = await this.accessService.getProjectRolesForGroup(
             projectId,
             groupId,
         );
@@ -723,6 +730,13 @@ export default class ProjectService {
         const ownerRole = await this.accessService.getRoleByName(
             RoleName.OWNER,
         );
+        if (
+            existingRoles.some((roleId) => roleId === ownerRole.id) &&
+            !roles.some((roleId) => roleId === ownerRole.id)
+        ) {
+            // only check if the group is getting the owner role removed
+            await this.validateAtLeastOneOwner(projectId, ownerRole);
+        }
         await this.validateAtLeastOneOwner(projectId, ownerRole);
 
         await this.accessService.setProjectRolesForGroup(
@@ -740,7 +754,7 @@ export default class ProjectService {
                     groupId,
                 },
                 preData: {
-                    roles: groupRoles,
+                    roles: existingRoles,
                     groupId,
                 },
             }),

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -707,10 +707,25 @@ export default class ProjectService {
         roles: number[],
         createdByUserName: string,
     ): Promise<void> {
-        const existingRoles = await this.accessService.getProjectRolesForUser(
+        const userRoles = await this.accessService.getProjectRolesForUser(
             projectId,
             userId,
         );
+
+        const ownerRole = await this.accessService.getRoleByName(
+            RoleName.OWNER,
+        );
+        // if user is part of owners and we're removing it from owners and it's the only one, we cannot remove the access
+        if (
+            userRoles.some((roleId) => roleId === ownerRole.id) &&
+            !roles.some((roleId) => roleId === ownerRole.id) &&
+            (await this.totalAccessWithRole(projectId, ownerRole.id)) === 1
+        ) {
+            throw new InvalidOperationError(
+                `Cannot remove user ${userId} from owners of ${projectId} as they are the only owner`,
+            );
+        }
+
         await this.accessService.setProjectRolesForUser(
             projectId,
             userId,
@@ -725,7 +740,7 @@ export default class ProjectService {
                     userId,
                 },
                 preData: {
-                    roles: existingRoles,
+                    roles: userRoles,
                     userId,
                 },
             }),
@@ -738,10 +753,25 @@ export default class ProjectService {
         roles: number[],
         createdBy: string,
     ): Promise<void> {
-        const existingRoles = await this.accessService.getProjectRolesForGroup(
+        const groupRoles = await this.accessService.getProjectRolesForGroup(
             projectId,
             groupId,
         );
+
+        const ownerRole = await this.accessService.getRoleByName(
+            RoleName.OWNER,
+        );
+        // if user is part of owners and we're removing it from owners and it's the only one, we cannot remove the access
+        if (
+            groupRoles.some((roleId) => roleId === ownerRole.id) &&
+            !roles.some((roleId) => roleId === ownerRole.id) &&
+            (await this.totalAccessWithRole(projectId, ownerRole.id)) === 1
+        ) {
+            throw new InvalidOperationError(
+                `Cannot remove group ${groupId} from owners of ${projectId} as they are the only owner`,
+            );
+        }
+
         await this.accessService.setProjectRolesForGroup(
             projectId,
             groupId,
@@ -757,7 +787,7 @@ export default class ProjectService {
                     groupId,
                 },
                 preData: {
-                    roles: existingRoles,
+                    roles: groupRoles,
                     groupId,
                 },
             }),

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -86,6 +86,10 @@ interface ICalculateStatus {
     updates: IProjectStats;
 }
 
+function includes(list: number[], { id }: { id: number }): boolean {
+    return list.some((l) => l === id);
+}
+
 export default class ProjectService {
     private projectStore: IProjectStore;
 
@@ -675,10 +679,10 @@ export default class ProjectService {
     async setRolesForUser(
         projectId: string,
         userId: number,
-        roles: number[],
+        newRoles: number[],
         createdByUserName: string,
     ): Promise<void> {
-        const existingRoles = await this.accessService.getProjectRolesForUser(
+        const currentRoles = await this.accessService.getProjectRolesForUser(
             projectId,
             userId,
         );
@@ -687,29 +691,27 @@ export default class ProjectService {
             RoleName.OWNER,
         );
 
-        if (
-            existingRoles.some((roleId) => roleId === ownerRole.id) &&
-            !roles.some((roleId) => roleId === ownerRole.id)
-        ) {
-            // only check if the user is getting the owner role removed
+        const hasOwnerRole = includes(currentRoles, ownerRole);
+        const isRemovingOwnerRole = !includes(newRoles, ownerRole);
+        if (hasOwnerRole && isRemovingOwnerRole) {
             await this.validateAtLeastOneOwner(projectId, ownerRole);
         }
 
         await this.accessService.setProjectRolesForUser(
             projectId,
             userId,
-            roles,
+            newRoles,
         );
         await this.eventService.storeEvent(
             new ProjectAccessUserRolesUpdated({
                 project: projectId,
                 createdBy: createdByUserName,
                 data: {
-                    roles,
+                    roles: newRoles,
                     userId,
                 },
                 preData: {
-                    roles: existingRoles,
+                    roles: currentRoles,
                     userId,
                 },
             }),
@@ -719,10 +721,10 @@ export default class ProjectService {
     async setRolesForGroup(
         projectId: string,
         groupId: number,
-        roles: number[],
+        newRoles: number[],
         createdBy: string,
     ): Promise<void> {
-        const existingRoles = await this.accessService.getProjectRolesForGroup(
+        const currentRoles = await this.accessService.getProjectRolesForGroup(
             projectId,
             groupId,
         );
@@ -730,11 +732,9 @@ export default class ProjectService {
         const ownerRole = await this.accessService.getRoleByName(
             RoleName.OWNER,
         );
-        if (
-            existingRoles.some((roleId) => roleId === ownerRole.id) &&
-            !roles.some((roleId) => roleId === ownerRole.id)
-        ) {
-            // only check if the group is getting the owner role removed
+        const hasOwnerRole = includes(currentRoles, ownerRole);
+        const isRemovingOwnerRole = !includes(newRoles, ownerRole);
+        if (hasOwnerRole && isRemovingOwnerRole) {
             await this.validateAtLeastOneOwner(projectId, ownerRole);
         }
         await this.validateAtLeastOneOwner(projectId, ownerRole);
@@ -742,7 +742,7 @@ export default class ProjectService {
         await this.accessService.setProjectRolesForGroup(
             projectId,
             groupId,
-            roles,
+            newRoles,
             createdBy,
         );
         await this.eventService.storeEvent(
@@ -750,11 +750,11 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 data: {
-                    roles,
+                    roles: newRoles,
                     groupId,
                 },
                 preData: {
-                    roles: existingRoles,
+                    roles: currentRoles,
                     groupId,
                 },
             }),

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -44,7 +44,7 @@ const isProjectUser = async (
 beforeAll(async () => {
     db = await dbInit('project_service_serial', getLogger);
     stores = db.stores;
-    // @ts-ignore User type missing generateImageUrl
+    // @ts-ignore return type IUser type missing generateImageUrl
     user = await stores.userStore.insert({
         name: 'Some Name',
         email: 'test@getunleash.io',
@@ -55,7 +55,6 @@ beforeAll(async () => {
     });
     const config = createTestConfig({
         getLogger,
-        // @ts-ignore
         experimental: {
             flags: { privateProjects: true },
         },
@@ -172,7 +171,7 @@ test('should not be able to delete project with toggles', async () => {
     await projectService.createProject(project, user);
     await stores.featureToggleStore.create(project.id, {
         name: 'test-project-delete',
-        // @ts-ignore
+        // @ts-ignore project does not exist in type FeatureToggleDTO
         project: project.id,
         enabled: false,
         defaultStickiness: 'default',
@@ -512,6 +511,7 @@ test('should not change project if feature toggle project does not match current
     const toggle = { name: 'test-toggle' };
 
     await projectService.createProject(project, user);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(project.id, toggle, user);
 
     try {
@@ -539,6 +539,7 @@ test('should return 404 if no project is found with the project id', async () =>
     const toggle = { name: 'test-toggle-2' };
 
     await projectService.createProject(project, user);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(project.id, toggle, user);
 
     try {
@@ -578,6 +579,7 @@ test('should fail if user is not authorized', async () => {
 
     await projectService.createProject(project, user);
     await projectService.createProject(projectDestination, projectAdmin1);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(project.id, toggle, user);
 
     try {
@@ -610,6 +612,7 @@ test('should change project when checks pass', async () => {
 
     await projectService.createProject(projectA, user);
     await projectService.createProject(projectB, user);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(projectA.id, toggle, user);
     await projectService.changeProject(
         projectB.id,
@@ -640,6 +643,7 @@ test('changing project should emit event even if user does not have a username s
     const toggle = { name: randomId() };
     await projectService.createProject(projectA, user);
     await projectService.createProject(projectB, user);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(projectA.id, toggle, user);
     const eventsBeforeChange = await stores.eventStore.getEvents();
     await projectService.changeProject(
@@ -670,6 +674,7 @@ test('should require equal project environments to move features', async () => {
 
     await projectService.createProject(projectA, user);
     await projectService.createProject(projectB, user);
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(projectA.id, toggle, user);
     await stores.environmentStore.create(environment);
     await environmentService.addEnvironmentToProject(
@@ -1180,7 +1185,7 @@ test('Should allow bulk update of group permissions', async () => {
         mode: 'open' as const,
         defaultStickiness: 'clientId',
     };
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
     const groupStore = stores.groupStore;
 
@@ -1249,7 +1254,7 @@ test('Should allow bulk update of only groups', async () => {
     };
     const groupStore = stores.groupStore;
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const group1 = await groupStore.create({
@@ -1284,7 +1289,7 @@ test('Should allow permutations of roles, groups and users when adding a new acc
         defaultStickiness: 'clientId',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const group1 = await stores.groupStore.create({
@@ -1359,11 +1364,13 @@ test('should only count active feature toggles for project', async () => {
 
     await stores.featureToggleStore.create(project.id, {
         name: 'only-active-t1',
+        // @ts-ignore project property does not exist in FeatureToggleDTO
         project: project.id,
         enabled: false,
     });
     await stores.featureToggleStore.create(project.id, {
         name: 'only-active-t2',
+        // @ts-ignore project property does not exist in FeatureToggleDTO
         project: project.id,
         enabled: false,
     });
@@ -1388,6 +1395,7 @@ test('should list projects with all features archived', async () => {
 
     await stores.featureToggleStore.create(project.id, {
         name: 'archived-toggle',
+        // @ts-ignore project property does not exist in FeatureToggleDTO
         project: project.id,
         enabled: false,
     });
@@ -1421,7 +1429,7 @@ test('should calculate average time to production', async () => {
         defaultStickiness: 'clientId',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1437,6 +1445,7 @@ test('should calculate average time to production', async () => {
             return featureToggleService.createFeatureToggle(
                 project.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type, should be string
                 user,
             );
         }),
@@ -1488,7 +1497,7 @@ test('should calculate average time to production ignoring some items', async ()
         tags: [],
     });
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
     await stores.environmentStore.create({
         name: 'customEnv',
@@ -1498,6 +1507,7 @@ test('should calculate average time to production ignoring some items', async ()
 
     // actual toggle we take for calculations
     const toggle = { name: 'main-toggle' };
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(project.id, toggle, user);
     await updateFeature(toggle.name, {
         created_at: subDays(new Date(), 20),
@@ -1513,6 +1523,7 @@ test('should calculate average time to production ignoring some items', async ()
 
     // ignore toggles enabled in non-prod envs
     const devToggle = { name: 'dev-toggle' };
+    // @ts-ignore user is wrong parameter type, should be string
     await featureToggleService.createFeatureToggle(project.id, devToggle, user);
     await eventService.storeEvent(
         new FeatureEnvironmentEvent({
@@ -1526,6 +1537,7 @@ test('should calculate average time to production ignoring some items', async ()
     await featureToggleService.createFeatureToggle(
         'default',
         otherProjectToggle,
+        // @ts-ignore user is wrong parameter type, should be string
         user,
     );
     await eventService.storeEvent(
@@ -1537,6 +1549,7 @@ test('should calculate average time to production ignoring some items', async ()
     await featureToggleService.createFeatureToggle(
         project.id,
         nonReleaseToggle,
+        // @ts-ignore user is wrong parameter type, should be string
         user,
     );
     await eventService.storeEvent(
@@ -1548,6 +1561,7 @@ test('should calculate average time to production ignoring some items', async ()
     await featureToggleService.createFeatureToggle(
         project.id,
         previouslyDeleteToggle,
+        // @ts-ignore user is wrong parameter type, should be string
         user,
     );
     await eventService.storeEvent(
@@ -1570,7 +1584,7 @@ test('should get correct amount of features created in current and past window',
         defaultStickiness: 'clientId',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1585,6 +1599,7 @@ test('should get correct amount of features created in current and past window',
             return featureToggleService.createFeatureToggle(
                 project.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type
                 user,
             );
         }),
@@ -1608,7 +1623,7 @@ test('should get correct amount of features archived in current and past window'
         defaultStickiness: 'clientId',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1623,6 +1638,7 @@ test('should get correct amount of features archived in current and past window'
             return featureToggleService.createFeatureToggle(
                 project.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type, should be string
                 user,
             );
         }),
@@ -1660,7 +1676,7 @@ test('should get correct amount of project members for current and past window',
         defaultStickiness: 'default',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const users = [
@@ -1701,7 +1717,7 @@ test('should return average time to production per toggle', async () => {
         defaultStickiness: 'clientId',
     };
 
-    // @ts-ignore
+    // @ts-ignore user.id is wrong type should be user
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1766,7 +1782,9 @@ test('should return average time to production per toggle for a specific project
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project1, user.id);
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project2, user.id);
 
     const togglesProject1 = [
@@ -1785,6 +1803,7 @@ test('should return average time to production per toggle for a specific project
             return featureToggleService.createFeatureToggle(
                 project1.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type, should be string
                 user,
             );
         }),
@@ -1795,6 +1814,7 @@ test('should return average time to production per toggle for a specific project
             return featureToggleService.createFeatureToggle(
                 project2.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type, should be string
                 user,
             );
         }),
@@ -1859,6 +1879,7 @@ test('should return average time to production per toggle and include archived t
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project1, user.id);
 
     const togglesProject1 = [
@@ -1872,6 +1893,7 @@ test('should return average time to production per toggle and include archived t
             return featureToggleService.createFeatureToggle(
                 project1.id,
                 toggle,
+                // @ts-ignore user is wrong parameter type, should be string
                 user,
             );
         }),
@@ -1923,7 +1945,7 @@ describe('feature flag naming patterns', () => {
             featureNaming,
         };
 
-        // @ts-ignore
+        // @ts-ignore user.id is wrong parameter type, should be user
         await projectService.createProject(project, user.id);
 
         await projectService.updateProjectEnterpriseSettings(project, user);
@@ -1938,6 +1960,7 @@ describe('feature flag naming patterns', () => {
                 ...project,
                 featureNaming: { pattern: newPattern },
             },
+            // @ts-ignore user.id is wrong parameter type, should be user
             user.id,
         );
 

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1979,10 +1979,12 @@ test('deleting a project with archived toggles should result in any remaining ar
     };
     const toggleName = 'archived-and-deleted';
 
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project, user.id);
 
     await stores.featureToggleStore.create(project.id, {
         name: toggleName,
+        // @ts-ignore project property does not exist in FeatureToggleDTO
         project: project.id,
         enabled: false,
         defaultStickiness: 'default',
@@ -1993,6 +1995,7 @@ test('deleting a project with archived toggles should result in any remaining ar
 
     // bring the project back again, previously this would allow those archived toggles to be resurrected
     // we now expect them to be deleted correctly
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project, user.id);
 
     const toggles = await stores.featureToggleStore.getAll({
@@ -2009,6 +2012,7 @@ test('deleting a project with no archived toggles should not result in an error'
         name: 'project-with-nothing',
     };
 
+    // @ts-ignore user.id is wrong parameter type, should be user
     await projectService.createProject(project, user.id);
     await projectService.deleteProject(project.id, user);
 });

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -17,7 +17,8 @@ import {
     createFeatureToggleService,
     createProjectService,
 } from '../../../lib/features';
-import { IGroup, IUnleashStores, IUser } from 'lib/types';
+import { IGroup, IUnleashStores } from 'lib/types';
+import { User } from 'lib/server-impl';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -27,7 +28,7 @@ let accessService: AccessService;
 let eventService: EventService;
 let environmentService: EnvironmentService;
 let featureToggleService: FeatureToggleService;
-let user: IUser;
+let user: User; // many methods in this test use User instead of IUser
 let group: IGroup;
 
 const isProjectUser = async (
@@ -43,6 +44,7 @@ const isProjectUser = async (
 beforeAll(async () => {
     db = await dbInit('project_service_serial', getLogger);
     stores = db.stores;
+    // @ts-ignore User type missing generateImageUrl
     user = await stores.userStore.insert({
         name: 'Some Name',
         email: 'test@getunleash.io',
@@ -170,6 +172,7 @@ test('should not be able to delete project with toggles', async () => {
     await projectService.createProject(project, user);
     await stores.featureToggleStore.create(project.id, {
         name: 'test-project-delete',
+        // @ts-ignore
         project: project.id,
         enabled: false,
         defaultStickiness: 'default',
@@ -1177,6 +1180,7 @@ test('Should allow bulk update of group permissions', async () => {
         mode: 'open' as const,
         defaultStickiness: 'clientId',
     };
+    // @ts-ignore
     await projectService.createProject(project, user.id);
     const groupStore = stores.groupStore;
 
@@ -1245,6 +1249,7 @@ test('Should allow bulk update of only groups', async () => {
     };
     const groupStore = stores.groupStore;
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const group1 = await groupStore.create({
@@ -1279,6 +1284,7 @@ test('Should allow permutations of roles, groups and users when adding a new acc
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const group1 = await stores.groupStore.create({
@@ -1415,6 +1421,7 @@ test('should calculate average time to production', async () => {
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1481,6 +1488,7 @@ test('should calculate average time to production ignoring some items', async ()
         tags: [],
     });
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
     await stores.environmentStore.create({
         name: 'customEnv',
@@ -1562,6 +1570,7 @@ test('should get correct amount of features created in current and past window',
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1599,6 +1608,7 @@ test('should get correct amount of features archived in current and past window'
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1650,6 +1660,7 @@ test('should get correct amount of project members for current and past window',
         defaultStickiness: 'default',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const users = [
@@ -1690,6 +1701,7 @@ test('should return average time to production per toggle', async () => {
         defaultStickiness: 'clientId',
     };
 
+    // @ts-ignore
     await projectService.createProject(project, user.id);
 
     const toggles = [
@@ -1705,7 +1717,7 @@ test('should return average time to production per toggle', async () => {
             return featureToggleService.createFeatureToggle(
                 project.id,
                 toggle,
-                user,
+                user.email!,
             );
         }),
     );
@@ -1911,6 +1923,7 @@ describe('feature flag naming patterns', () => {
             featureNaming,
         };
 
+        // @ts-ignore
         await projectService.createProject(project, user.id);
 
         await projectService.updateProjectEnterpriseSettings(project, user);


### PR DESCRIPTION
## About the changes
This makes sure that projects have at least one owner, either a group or a user. This is to prevent accidentally losing access to a project.

We check this when removing a user/group or when changing  the role of a user/group

**Note**: We can still leave a group empty as the only owner of the project, but that's okay because we can still add more users to the group
