### PR TITLE
fix: add project filter to feature-toggle-list-builder

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -198,6 +198,10 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             builder.addSelectColumn('df.enabled as parent_enabled');
         }
 
+        if (featureQuery?.project) {
+            builder.forProject(featureQuery.project);
+        }
+
         const rows = await builder.internalQuery.select(
             builder.getSelectColumns(),
         );

--- a/src/lib/features/feature-toggle/query-builders/feature-toggle-list-builder.ts
+++ b/src/lib/features/feature-toggle/query-builders/feature-toggle-list-builder.ts
@@ -129,7 +129,11 @@ export class FeatureToggleListBuilder {
                 userId,
             );
         });
-        
+
         return this;
+    }
+
+    forProject = (project: string[]) => {
+        this.internalQuery.whereIn('features.project', project);
     }
 }

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -101,7 +101,7 @@ export class PlaygroundService {
     ): Promise<AdvancedPlaygroundFeatureEvaluationResult[]> {
         const segments = await this.segmentService.getActive();
 
-        let filteredProjects: typeof projects;
+        let filteredProjects: typeof projects = projects;
         if (this.flagResolver.isEnabled('privateProjects')) {
             const projectAccess =
                 await this.privateProjectChecker.getUserAccessibleProjects(


### PR DESCRIPTION
Adds `forProject` filter to FeatureToggleQueryBuilder
Filters playground results 

Closes # [1-1525](https://linear.app/unleash/issue/1-1525/getting-results-for-all-projects-when-defining-a-single-project-in-the)