### PR TITLE
refactor: rename message banners to banners - events

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -41,9 +41,9 @@ import {
     GROUP_UPDATED,
     IConstraint,
     IEvent,
-    MESSAGE_BANNER_CREATED,
-    MESSAGE_BANNER_DELETED,
-    MESSAGE_BANNER_UPDATED,
+    BANNER_CREATED,
+    BANNER_DELETED,
+    BANNER_UPDATED,
     PROJECT_CREATED,
     PROJECT_DELETED,
     SEGMENT_CREATED,
@@ -232,16 +232,16 @@ const EVENT_MAP: Record<string, IEventData> = {
         action: '*{{user}}* updated group *{{event.preData.name}}*',
         path: '/admin/groups',
     },
-    [MESSAGE_BANNER_CREATED]: {
-        action: '*{{user}}* created message banner *{{event.data.message}}*',
+    [BANNER_CREATED]: {
+        action: '*{{user}}* created banner *{{event.data.message}}*',
         path: '/admin/message-banners',
     },
-    [MESSAGE_BANNER_DELETED]: {
-        action: '*{{user}}* deleted message banner *{{event.preData.message}}*',
+    [BANNER_DELETED]: {
+        action: '*{{user}}* deleted banner *{{event.preData.message}}*',
         path: '/admin/message-banners',
     },
-    [MESSAGE_BANNER_UPDATED]: {
-        action: '*{{user}}* updated message banner *{{event.preData.message}}*',
+    [BANNER_UPDATED]: {
+        action: '*{{user}}* updated banner *{{event.preData.message}}*',
         path: '/admin/message-banners',
     },
     [PROJECT_CREATED]: {

--- a/src/lib/addons/slack-app-definition.ts
+++ b/src/lib/addons/slack-app-definition.ts
@@ -49,9 +49,9 @@ import {
     SERVICE_ACCOUNT_DELETED,
     SERVICE_ACCOUNT_UPDATED,
     GROUP_DELETED,
-    MESSAGE_BANNER_CREATED,
-    MESSAGE_BANNER_UPDATED,
-    MESSAGE_BANNER_DELETED,
+    BANNER_CREATED,
+    BANNER_UPDATED,
+    BANNER_DELETED,
 } from '../types/events';
 import { IAddonDefinition } from '../types/model';
 
@@ -127,9 +127,9 @@ const slackAppDefinition: IAddonDefinition = {
         GROUP_CREATED,
         GROUP_DELETED,
         GROUP_UPDATED,
-        MESSAGE_BANNER_CREATED,
-        MESSAGE_BANNER_UPDATED,
-        MESSAGE_BANNER_DELETED,
+        BANNER_CREATED,
+        BANNER_UPDATED,
+        BANNER_DELETED,
         PROJECT_CREATED,
         PROJECT_DELETED,
         SEGMENT_CREATED,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -146,9 +146,9 @@ export const SERVICE_ACCOUNT_DELETED = 'service-account-deleted' as const;
 export const FEATURE_POTENTIALLY_STALE_ON =
     'feature-potentially-stale-on' as const;
 
-export const MESSAGE_BANNER_CREATED = 'message-banner-created' as const;
-export const MESSAGE_BANNER_UPDATED = 'message-banner-updated' as const;
-export const MESSAGE_BANNER_DELETED = 'message-banner-deleted' as const;
+export const BANNER_CREATED = 'banner-created' as const;
+export const BANNER_UPDATED = 'banner-updated' as const;
+export const BANNER_DELETED = 'banner-deleted' as const;
 
 export const IEventTypes = [
     APPLICATION_CREATED,
@@ -263,9 +263,9 @@ export const IEventTypes = [
     FEATURE_DEPENDENCY_ADDED,
     FEATURE_DEPENDENCY_REMOVED,
     FEATURE_DEPENDENCIES_REMOVED,
-    MESSAGE_BANNER_CREATED,
-    MESSAGE_BANNER_UPDATED,
-    MESSAGE_BANNER_DELETED,
+    BANNER_CREATED,
+    BANNER_UPDATED,
+    BANNER_DELETED,
 ] as const;
 export type IEventType = typeof IEventTypes[number];
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1531/rename-message-banners-to-banners

Follow up to https://github.com/Unleash/unleash/pull/5098
This one adapts the existing events.