### PR TITLE
feat: promise timeout on lock

### DIFF
--- a/src/lib/util/db-lock.test.ts
+++ b/src/lib/util/db-lock.test.ts
@@ -46,7 +46,7 @@ test('should await other actions on lock', async () => {
 });
 
 test('should handle lock timeout', async () => {
-    const timeoutMs = 1;
+    const timeoutMs = 10;
     let loggedError = '';
     const lock = withDbLock(getDbConfig() as IDBOption, {
         lockKey: 1,
@@ -58,9 +58,7 @@ test('should handle lock timeout', async () => {
         } as unknown as Logger,
     });
 
-    // the query should fail because of the timeout. This one is a fallback when timeout
-    // was not triggered in the integration test
-    const asyncAction = () => Promise.reject(new Error('Query read timeout'));
+    const asyncAction = () => ms(100);
 
     await expect(lock(asyncAction)()).rejects.toStrictEqual(
         new Error('Query read timeout'),

--- a/src/lib/util/db-lock.ts
+++ b/src/lib/util/db-lock.ts
@@ -3,7 +3,7 @@ import { IDBOption } from '../types';
 import { Logger } from '../logger';
 
 export const defaultLockKey = 479341;
-export const defaultTimeout = 60000;
+export const defaultTimeout = 30 * 60000;
 
 interface IDbLockOptions {
     timeout: number;

--- a/src/lib/util/db-lock.ts
+++ b/src/lib/util/db-lock.ts
@@ -3,7 +3,7 @@ import { IDBOption } from '../types';
 import { Logger } from '../logger';
 
 export const defaultLockKey = 479341;
-export const defaultTimeout = 5000;
+export const defaultTimeout = 60000;
 
 interface IDbLockOptions {
     timeout: number;
@@ -23,13 +23,19 @@ export const withDbLock =
     async (...args: A): Promise<R> => {
         const client = new Client({
             ...dbConfig,
-            query_timeout: config.timeout,
         });
         try {
             await client.connect();
             // wait to obtain a lock
             await client.query('SELECT pg_advisory_lock($1)', [config.lockKey]);
-            const result = await fn(...args);
+            const promise = fn(...args);
+            const timeoutPromise = new Promise((_, reject) =>
+                setTimeout(
+                    () => reject(new Error('Query read timeout')),
+                    config.timeout,
+                ),
+            );
+            const result = (await Promise.race([promise, timeoutPromise])) as R;
             return result;
         } catch (e) {
             config.logger.error(`Locking error: ${e.message}`);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* Adding Promise timeout in DB lock. Once the lock is acquired the function that we're locking (e.g. DB migration) has 60 seconds (default value) to do its job. After the timeout elapsed we unlock the lock.
* This change may also remove some flakiness in the tests since I noticed that the previous incorrect implementation of the timeout did not close the client in the timeout test

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Is 60 second enough for the DB migrations to run?
for now I increase it to 30 minutes to be on the safe side.