### PR TITLE
feat: add job that cleans last seen every 24 hours

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -44,7 +44,7 @@ async function createApp(
     const stores = createStores(config, db);
     const services = createServices(stores, config, db);
     if (!config.disableScheduler) {
-        await scheduleServices(services);
+        await scheduleServices(services, config.flagResolver);
     }
 
     const metricsMonitor = createMetricsMonitor();

--- a/src/lib/services/client-metrics/last-seen/fake-last-seen-store.ts
+++ b/src/lib/services/client-metrics/last-seen/fake-last-seen-store.ts
@@ -6,4 +6,8 @@ export class FakeLastSeenStore implements ILastSeenStore {
         data.map((lastSeen) => lastSeen);
         return Promise.resolve();
     }
+
+    cleanLastSeen(): Promise<void> {
+        return Promise.resolve();
+    }
 }

--- a/src/lib/services/client-metrics/last-seen/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen/last-seen-service.ts
@@ -39,7 +39,13 @@ export class LastSeenService {
         this.config = config;
 
         this.timers.push(
-            setInterval(() => this.store(), lastSeenInterval).unref(),
+            setInterval(() => {
+                if (this.config.flagResolver.isEnabled('useLastSeenRefactor')) {
+                    return;
+                }
+
+                this.store();
+            }, lastSeenInterval).unref(),
         );
     }
 
@@ -79,6 +85,10 @@ export class LastSeenService {
                     environment: clientMetric.environment,
                 });
             });
+    }
+
+    async cleanLastSeen() {
+        await this.lastSeenStore.cleanLastSeen();
     }
 
     destroy(): void {

--- a/src/lib/services/client-metrics/last-seen/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen/last-seen-service.ts
@@ -29,7 +29,6 @@ export class LastSeenService {
             lastSeenStore,
         }: Pick<IUnleashStores, 'featureToggleStore' | 'lastSeenStore'>,
         config: IUnleashConfig,
-        lastSeenInterval = secondsToMilliseconds(30),
     ) {
         this.lastSeenStore = lastSeenStore;
         this.featureToggleStore = featureToggleStore;
@@ -37,16 +36,6 @@ export class LastSeenService {
             '/services/client-metrics/last-seen-service.ts',
         );
         this.config = config;
-
-        this.timers.push(
-            setInterval(() => {
-                if (this.config.flagResolver.isEnabled('useLastSeenRefactor')) {
-                    return;
-                }
-
-                this.store();
-            }, lastSeenInterval).unref(),
-        );
     }
 
     async store(): Promise<number> {

--- a/src/lib/services/client-metrics/last-seen/last-seen-store.ts
+++ b/src/lib/services/client-metrics/last-seen/last-seen-store.ts
@@ -58,6 +58,12 @@ export default class LastSeenStore implements ILastSeenStore {
             this.logger.error('Could not update lastSeen, error: ', err);
         }
     }
+
+    async cleanLastSeen() {
+        await this.db(TABLE)
+            .whereNotIn('feature_name', this.db.select('name').from('features'))
+            .del();
+    }
 }
 
 module.exports = LastSeenStore;

--- a/src/lib/services/client-metrics/last-seen/tests/last-seen-service.e2e.test.ts
+++ b/src/lib/services/client-metrics/last-seen/tests/last-seen-service.e2e.test.ts
@@ -1,0 +1,82 @@
+import dbInit, { ITestDb } from '../../../../../test/e2e/helpers/database-init';
+import {
+    IUnleashTest,
+    setupAppWithCustomConfig,
+} from '../../../../../test/e2e/helpers/test-helper';
+import getLogger from '../../../../../test/fixtures/no-logger';
+
+let app: IUnleashTest;
+let db: ITestDb;
+
+beforeAll(async () => {
+    db = await dbInit('last_seen_at_service_e2e', getLogger);
+    app = await setupAppWithCustomConfig(
+        db.stores,
+        {
+            experimental: {
+                flags: {
+                    strictSchemaValidation: true,
+                    disableEnvsOnRevive: true,
+                    useLastSeenRefactor: true,
+                },
+            },
+        },
+        db.rawDatabase,
+    );
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+test('should clean unknown feature toggle names from last seen store', async () => {
+    const { lastSeenService, featureToggleService } = app.services;
+
+    const clean = ['clean1', 'clean2', 'clean3', 'clean4'];
+    const dirty = ['dirty1', 'dirty2', 'dirty3', 'dirty4'];
+
+    await Promise.all(
+        clean.map((featureName) =>
+            featureToggleService.createFeatureToggle(
+                'default',
+                { name: featureName },
+                'user',
+            ),
+        ),
+    );
+
+    const inserts = [...clean, ...dirty].map((feature) => {
+        return {
+            featureName: feature,
+            environment: 'default',
+            yes: 1,
+            no: 0,
+            appName: 'test',
+            timestamp: new Date(),
+        };
+    });
+
+    lastSeenService.updateLastSeen(inserts);
+    await lastSeenService.store();
+
+    // We have no method to get these from the last seen service or any other service or store
+    let stored = await db.rawDatabase.raw(
+        'SELECT * FROM last_seen_at_metrics;',
+    );
+
+    expect(stored.rows.length).toBe(8);
+
+    await lastSeenService.cleanLastSeen();
+
+    stored = await db.rawDatabase.raw('SELECT * FROM last_seen_at_metrics;');
+
+    expect(stored.rows.length).toBe(4);
+    expect(stored.rows).toMatch;
+
+    const notInDirty = stored.rows.filter(
+        (row) => !dirty.includes(row.feature_name),
+    );
+
+    expect(notInDirty.length).toBe(4);
+});

--- a/src/lib/services/client-metrics/last-seen/types/last-seen-store-type.ts
+++ b/src/lib/services/client-metrics/last-seen/types/last-seen-store-type.ts
@@ -2,4 +2,5 @@ import { LastSeenInput } from '../last-seen-service';
 
 export interface ILastSeenStore {
     setLastSeen(data: LastSeenInput[]): Promise<void>;
+    cleanLastSeen: () => Promise<void>;
 }

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,4 +1,9 @@
-import { IUnleashConfig, IUnleashStores, IUnleashServices } from '../types';
+import {
+    IUnleashConfig,
+    IUnleashStores,
+    IUnleashServices,
+    IFlagResolver,
+} from '../types';
 import FeatureTypeService from './feature-type-service';
 import EventService from './event-service';
 import HealthService from './health-service';
@@ -98,6 +103,7 @@ import { ClientFeatureToggleService } from '../features/client-feature-toggles/c
 // TODO: will be moved to scheduler feature directory
 export const scheduleServices = async (
     services: IUnleashServices,
+    flagResolver: IFlagResolver,
 ): Promise<void> => {
     const {
         schedulerService,
@@ -110,10 +116,25 @@ export const scheduleServices = async (
         maintenanceService,
         eventAnnouncerService,
         featureToggleService,
+        lastSeenService,
     } = services;
 
     if (await maintenanceService.isMaintenanceMode()) {
         schedulerService.pause();
+    }
+
+    if (flagResolver.isEnabled('useLastSeenRefactor')) {
+        schedulerService.schedule(
+            lastSeenService.cleanLastSeen.bind(lastSeenService),
+            hoursToMilliseconds(24),
+            'cleanLastSeen',
+        );
+
+        schedulerService.schedule(
+            lastSeenService.store.bind(lastSeenService),
+            secondsToMilliseconds(30),
+            'storeLastSeen',
+        );
     }
 
     schedulerService.schedule(

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -126,16 +126,16 @@ export const scheduleServices = async (
     if (flagResolver.isEnabled('useLastSeenRefactor')) {
         schedulerService.schedule(
             lastSeenService.cleanLastSeen.bind(lastSeenService),
-            hoursToMilliseconds(24),
+            hoursToMilliseconds(1),
             'cleanLastSeen',
         );
-
-        schedulerService.schedule(
-            lastSeenService.store.bind(lastSeenService),
-            secondsToMilliseconds(30),
-            'storeLastSeen',
-        );
     }
+
+    schedulerService.schedule(
+        lastSeenService.store.bind(lastSeenService),
+        secondsToMilliseconds(30),
+        'storeLastSeen',
+    );
 
     schedulerService.schedule(
         apiTokenService.fetchActiveTokens.bind(apiTokenService),

--- a/src/test/e2e/services/last-seen-service.e2e.test.ts
+++ b/src/test/e2e/services/last-seen-service.e2e.test.ts
@@ -68,7 +68,6 @@ test('Should not update last seen toggles with 0 metrics', async () => {
             featureToggleStore: stores.featureToggleStore,
         },
         config,
-        30,
     );
     const time = Date.now();
     await stores.featureToggleStore.create('default', { name: 'tb1' });
@@ -115,7 +114,6 @@ test('Should not update anything for 0 toggles', async () => {
             featureToggleStore: stores.featureToggleStore,
         },
         config,
-        30,
     );
     const time = Date.now();
     await stores.featureToggleStore.create('default', { name: 'tb1' });

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -38,6 +38,7 @@ import FakeFavoriteProjectsStore from './fake-favorite-projects-store';
 import { FakeAccountStore } from './fake-account-store';
 import FakeProjectStatsStore from './fake-project-stats-store';
 import { FakeDependentFeaturesStore } from '../../lib/features/dependent-features/fake-dependent-features-store';
+import { FakeLastSeenStore } from '../../lib/services/client-metrics/last-seen/fake-last-seen-store';
 
 const db = {
     select: () => ({
@@ -85,7 +86,7 @@ const createStores: () => IUnleashStores = () => {
         importTogglesStore: {} as IImportTogglesStore,
         privateProjectStore: {} as IPrivateProjectStore,
         dependentFeaturesStore: new FakeDependentFeaturesStore(),
-        lastSeenStore: { setLastSeen: async () => {} },
+        lastSeenStore: new FakeLastSeenStore(),
     };
 };
 


### PR DESCRIPTION
This PR adds a cleanup job that removes unknown feature flags from last_seen_at_metrics table every 24 hours since we no longer have a foreign key on the name column in the features table.