### PR TITLE
fix: don't clean up settings when optional data is not present

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -6,6 +6,7 @@ import {
     IEnvironment,
     IFlagResolver,
     IProject,
+    IProjectUpdate,
     IProjectWithCount,
     ProjectMode,
 } from '../types';
@@ -259,25 +260,32 @@ class ProjectStore implements IProjectStore {
         return present;
     }
 
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async update(data): Promise<void> {
+    async update(data: IProjectUpdate): Promise<void> {
         try {
             await this.db(TABLE)
                 .where({ id: data.id })
                 .update(this.fieldToRow(data));
-            if (await this.hasProjectSettings(data.id)) {
-                await this.db(SETTINGS_TABLE)
-                    .where({ project: data.id })
-                    .update({
+            if (
+                data.defaultStickiness !== undefined ||
+                data.featureLimit !== undefined
+            ) {
+                if (await this.hasProjectSettings(data.id)) {
+                    await this.db(SETTINGS_TABLE)
+                        .where({ project: data.id })
+                        .update({
+                            default_stickiness: data.defaultStickiness,
+                            feature_limit: data.featureLimit,
+                        });
+                } else {
+                    // What happens with project mode in this case?
+                    await this.db(SETTINGS_TABLE).insert({
+                        project: data.id,
                         default_stickiness: data.defaultStickiness,
                         feature_limit: data.featureLimit,
                     });
+                }
             } else {
-                await this.db(SETTINGS_TABLE).insert({
-                    project: data.id,
-                    default_stickiness: data.defaultStickiness,
-                    feature_limit: data.featureLimit,
-                });
+                this.logger.warn('NOT UPDATING PROJECT SETTINGS');
             }
         } catch (err) {
             this.logger.error('Could not update project, error: ', err);

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -284,8 +284,6 @@ class ProjectStore implements IProjectStore {
                         feature_limit: data.featureLimit,
                     });
                 }
-            } else {
-                this.logger.warn('NOT UPDATING PROJECT SETTINGS');
             }
         } catch (err) {
             this.logger.error('Could not update project, error: ', err);

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -39,6 +39,7 @@ import {
     ProjectAccessUserRolesDeleted,
     IFeatureNaming,
     CreateProject,
+    IProjectUpdate,
 } from '../types';
 import {
     IProjectQuery,
@@ -259,16 +260,22 @@ export default class ProjectService {
         return data;
     }
 
-    async updateProject(updatedProject: IProject, user: IUser): Promise<void> {
+    async updateProject(
+        updatedProject: IProjectUpdate,
+        user: IUser,
+    ): Promise<void> {
         const preData = await this.projectStore.get(updatedProject.id);
 
         await this.projectStore.update(updatedProject);
+
+        // updated project contains instructions to update the project but it may not represent a whole project
+        const afterData = await this.projectStore.get(updatedProject.id);
 
         await this.eventStore.store({
             type: PROJECT_UPDATED,
             project: updatedProject.id,
             createdBy: getCreatedBy(user),
-            data: updatedProject,
+            data: afterData,
             preData,
         });
     }

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -447,6 +447,16 @@ export interface IProject {
     featureNaming?: IFeatureNaming;
 }
 
+// mimics UpdateProjectSchema
+export interface IProjectUpdate {
+    id: string;
+    name: string;
+    description?: string;
+    mode?: ProjectMode;
+    defaultStickiness?: string;
+    featureLimit?: number;
+}
+
 /**
  * Extends IRole making description mandatory
  */


### PR DESCRIPTION
## About the changes
This fixes a bug updating a project, when optional data (defaultStickiness and featureLimit are not part of the payload).

Example:
```shell
curl -XPUT http://localhost:4242/api/admin/projects/default -H 'Authorization: *:*.unleash-insecure-admin-api-token' -H 'Content-Type: application/json' -d '{"description":"test description","name":"RenamedToThisString"}'
```

Then if you try to get the project with a PAT, the API will return a 403. The reason is that the **project mode** gets cleared (mode=null) because of the following update statement that does not check if defaultStickiness or featureLimit are present, resulting in an update without fields that clears the table https://github.com/Unleash/unleash/blob/main/src/lib/db/project-store.ts#L268-L281

Note that the project still exists, and this can be checked using the initial admin token:
```shell
curl http://localhost:4242/api/admin/projects/default -H 'Authorization: *:*.unleash-insecure-admin-api-token'
```

The problem happens due to:
1. ProjectController does not use the type: UpdateProjectSchema for the request body (will be addressed in another PR in unleash-enterprise)
2. Project Store interface does not match UpdateProjectSchema (but it relies on accepting `additional properties: true`, which is what we agreed on for input)
3. Feature limit is not defined in UpdateProjectSchema (also addressed in the other PR)