### PR TITLE
fix: one of our deps breaks on node 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "types": "./dist/lib/server-impl.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=18 <21"
   },
   "license": "Apache-2.0",
   "main": "./dist/lib/server-impl.js",


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

In heroku our build breaks with:
```
   [build:frontend] [vite:css] Preprocessor dependency "sass" failed to load:
   [build:frontend] Cannot read properties of undefined (reading 'indexOf')
```

Root cause analysis:
* heroku installs node 21 which doesn't work with the sass dependency compiled from dart to js


More: https://stackoverflow.com/questions/77314799/vitecss-preprocessor-dependency-sass-failed-to-load-cannot-read-propertie

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
