### PR TITLE
fix: draft banner zIndex

### DIFF
--- a/frontend/src/component/common/Sticky/Sticky.tsx
+++ b/frontend/src/component/common/Sticky/Sticky.tsx
@@ -10,10 +10,10 @@ import { StickyContext } from './StickyContext';
 import { styled } from '@mui/material';
 
 const StyledSticky = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'top' && prop !== 'zIndex',
-})<{ top?: number; zIndex?: number }>(({ theme, top, zIndex }) => ({
+    shouldForwardProp: (prop) => prop !== 'top',
+})<{ top?: number }>(({ theme, top }) => ({
     position: 'sticky',
-    zIndex: zIndex ?? theme.zIndex.sticky - 100,
+    zIndex: theme.zIndex.sticky - 100,
     ...(top !== undefined
         ? {
               '&': {
@@ -34,7 +34,6 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
         null,
     );
     const [top, setTop] = useState<number>();
-    const [zIndex, setZIndex] = useState<number>();
 
     if (!context) {
         throw new Error(
@@ -51,11 +50,6 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
         if (ref.current && initialTopOffset === null) {
             setInitialTopOffset(
                 parseInt(getComputedStyle(ref.current).getPropertyValue('top')),
-            );
-            setZIndex(
-                parseInt(
-                    getComputedStyle(ref.current).getPropertyValue('z-index'),
-                ),
             );
         }
     }, []);
@@ -79,7 +73,7 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
     }, [ref, registerStickyItem, unregisterStickyItem]);
 
     return (
-        <StyledSticky ref={ref} top={top} zIndex={zIndex} {...props}>
+        <StyledSticky ref={ref} top={top} {...props}>
             {children}
         </StyledSticky>
     );

--- a/frontend/src/component/common/Sticky/Sticky.tsx
+++ b/frontend/src/component/common/Sticky/Sticky.tsx
@@ -10,10 +10,10 @@ import { StickyContext } from './StickyContext';
 import { styled } from '@mui/material';
 
 const StyledSticky = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'top',
-})<{ top?: number }>(({ theme, top }) => ({
+    shouldForwardProp: (prop) => prop !== 'top' && prop !== 'zIndex',
+})<{ top?: number; zIndex?: number }>(({ theme, top, zIndex }) => ({
     position: 'sticky',
-    zIndex: theme.zIndex.sticky - 100,
+    zIndex: zIndex ?? theme.zIndex.sticky - 100,
     ...(top !== undefined
         ? {
               '&': {
@@ -34,6 +34,7 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
         null,
     );
     const [top, setTop] = useState<number>();
+    const [zIndex, setZIndex] = useState<number>();
 
     if (!context) {
         throw new Error(
@@ -50,6 +51,11 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
         if (ref.current && initialTopOffset === null) {
             setInitialTopOffset(
                 parseInt(getComputedStyle(ref.current).getPropertyValue('top')),
+            );
+            setZIndex(
+                parseInt(
+                    getComputedStyle(ref.current).getPropertyValue('z-index'),
+                ),
             );
         }
     }, []);
@@ -73,7 +79,7 @@ export const Sticky = ({ children, ...props }: IStickyProps) => {
     }, [ref, registerStickyItem, unregisterStickyItem]);
 
     return (
-        <StyledSticky ref={ref} top={top} {...props}>
+        <StyledSticky ref={ref} top={top} zIndex={zIndex} {...props}>
             {children}
         </StyledSticky>
     );

--- a/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
+++ b/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
@@ -104,6 +104,7 @@ const StickyBanner = styled(Sticky)(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.warning.border}`,
     color: theme.palette.warning.contrastText,
     backgroundColor: theme.palette.warning.light,
+    zIndex: 250,
 }));
 
 export const DraftBanner: VFC<IDraftBannerProps> = ({ project }) => {


### PR DESCRIPTION
Tiny zIndex fix for the draft banner for a regression introduced in https://github.com/Unleash/unleash/pull/5088

### Before - Draft banner is displayed on top of the profile popup:
![image](https://github.com/Unleash/unleash/assets/14320932/63865f01-9bbe-42f1-9cc4-85c3c985334c)

### After - Profile popup displays on top of the draft banner:
![image](https://github.com/Unleash/unleash/assets/14320932/565e1017-5163-445d-bc0c-ee957023241b)