### PR TITLE
bug: remove strategies from copy breadcrumbs

### DIFF
--- a/frontend/src/component/feature/CopyFeature/CopyFeature.test.tsx
+++ b/frontend/src/component/feature/CopyFeature/CopyFeature.test.tsx
@@ -49,9 +49,7 @@ test('should render an alert when change request is enabled in any env when copy
     render(
         <Routes>
             <Route
-                path={
-                    '/projects/:projectId/features/:featureId/copy'
-                }
+                path={'/projects/:projectId/features/:featureId/copy'}
                 element={<CopyFeatureToggle />}
             />
         </Routes>,

--- a/frontend/src/component/feature/CopyFeature/CopyFeature.test.tsx
+++ b/frontend/src/component/feature/CopyFeature/CopyFeature.test.tsx
@@ -50,13 +50,13 @@ test('should render an alert when change request is enabled in any env when copy
         <Routes>
             <Route
                 path={
-                    '/projects/:projectId/features/:featureId/strategies/copy'
+                    '/projects/:projectId/features/:featureId/copy'
                 }
                 element={<CopyFeatureToggle />}
             />
         </Routes>,
         {
-            route: '/projects/default/features/someFeature/strategies/copy',
+            route: '/projects/default/features/someFeature/copy',
             permissions: [{ permission: CREATE_FEATURE }],
         },
     );
@@ -71,12 +71,12 @@ test('should not render an alert when change request is disabled when copying fe
     render(
         <Routes>
             <Route
-                path={'projects/:projectId/features/:featureId/strategies/copy'}
+                path={'projects/:projectId/features/:featureId/copy'}
                 element={<CopyFeatureToggle />}
             />
         </Routes>,
         {
-            route: '/projects/default/features/someFeature/strategies/copy',
+            route: '/projects/default/features/someFeature/copy',
             permissions: [{ permission: CREATE_FEATURE }],
         },
     );

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -248,7 +248,7 @@ export const FeatureView = () => {
                             projectId={projectId}
                             data-loading
                             component={Link}
-                            to={`/projects/${projectId}/features/${featureId}/strategies/copy`}
+                            to={`/projects/${projectId}/features/${featureId}/copy`}
                             tooltipProps={{
                                 title: 'Copy feature toggle',
                             }}

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`returns all baseRoutes 1`] = `
   {
     "component": [Function],
     "menu": {},
-    "parent": "/projects/:projectId/features/:featureId/:activeTab",
-    "path": "/projects/:projectId/features/:featureId/:activeTab/copy",
+    "parent": "/projects/:projectId/features/:featureId/",
+    "path": "/projects/:projectId/features/:featureId/copy",
     "title": "Copy",
     "type": "protected",
   },

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -76,8 +76,8 @@ export const routes: IRoute[] = [
         menu: {},
     },
     {
-        path: '/projects/:projectId/features/:featureId/:activeTab/copy',
-        parent: '/projects/:projectId/features/:featureId/:activeTab',
+        path: '/projects/:projectId/features/:featureId/copy',
+        parent: '/projects/:projectId/features/:featureId/',
         title: 'Copy',
         component: CopyFeatureToggle,
         type: 'protected',

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -103,7 +103,7 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
                                 onClick={handleClose}
                                 disabled={!hasAccess}
                                 component={RouterLink}
-                                to={`/projects/${projectId}/features/${featureId}/strategies/copy`}
+                                to={`/projects/${projectId}/features/${featureId}/copy`}
                             >
                                 <ListItemIcon>
                                     <FileCopyIcon />


### PR DESCRIPTION
Previous:
![image](https://github.com/Unleash/unleash/assets/964450/263080ce-2e84-4477-bff1-d7bb9e7995c8)
Now:
![image](https://github.com/Unleash/unleash/assets/964450/e582deaf-9e4c-4c5e-b1b1-a6871ec36131)
