### PR TITLE
fix: project mode can not be set to null anymore

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -277,11 +277,11 @@ class ProjectStore implements IProjectStore {
                             feature_limit: data.featureLimit,
                         });
                 } else {
-                    // What happens with project mode in this case?
                     await this.db(SETTINGS_TABLE).insert({
                         project: data.id,
                         default_stickiness: data.defaultStickiness,
                         feature_limit: data.featureLimit,
+                        project_mode: 'open',
                     });
                 }
             }

--- a/src/migrations/20231025093422-default-project-mode.js
+++ b/src/migrations/20231025093422-default-project-mode.js
@@ -24,6 +24,9 @@ exports.down = function (db, cb) {
             ALTER COLUMN project_mode DROP DEFAULT;
 
         ALTER TABLE project_settings
+            ALTER COLUMN project_mode DROP NOT NULL;
+
+        ALTER TABLE project_settings
             DROP CONSTRAINT project_settings_project_mode_values;
     `, cb);
 };

--- a/src/migrations/20231025093422-default-project-mode.js
+++ b/src/migrations/20231025093422-default-project-mode.js
@@ -1,0 +1,29 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(`
+        ALTER TABLE project_settings
+            ALTER COLUMN project_mode SET DEFAULT 'open';
+
+        UPDATE project_settings
+            SET project_mode = 'open'
+                WHERE project_mode NOT IN ('open', 'protected', 'private') OR project_mode IS NULL;
+
+        ALTER TABLE project_settings
+            ALTER COLUMN project_mode SET NOT NULL;
+
+        ALTER TABLE project_settings
+            ADD CONSTRAINT project_settings_project_mode_values
+                CHECK (project_mode IN ('open', 'protected', 'private'));
+    `, cb);
+};
+
+exports.down = function (db, cb) {
+    db.runSql(`
+        ALTER TABLE project_settings
+            ALTER COLUMN project_mode DROP DEFAULT;
+
+        ALTER TABLE project_settings
+            DROP CONSTRAINT project_settings_project_mode_values;
+    `, cb);
+};


### PR DESCRIPTION
Currently, when there was no entry in project settings table, the project_mode was left null, which broke some logic.
Now we will set it and enforce database level restrictions on it.