### PR TITLE
1-1531: create db table for cr schedules

### DIFF
--- a/src/migrations/20231024121307-add-change-request-schedule.js
+++ b/src/migrations/20231024121307-add-change-request-schedule.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+            CREATE TABLE IF NOT EXISTS change_request_schedule (
+             change_request INTEGER PRIMARY KEY REFERENCES change_requests(id) ON DELETE CASCADE,
+             scheduled_at TIMESTAMP NOT NULL
+            );
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+            DROP TABLE IF EXISTS change_request_schedule;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
This PR adds a db table for CR schedules. The table has two columns:
1. `change_request` :: This acts as both a foreign key and as the primary key for this table.
2. `scheduled_at` :: When the change is scheduled to be applied.

We could use a separate ID column for these rows and put a `unique` constraint on the `change_request` FK, but I don't think that adds any more value. However, I'm happy to hear other thoughts around it.