### PR TITLE
fix: do not track empty strings in playground token input

### DIFF
--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -184,7 +184,7 @@ export const AdvancedPlayground: VFC<{
 
         setHasFormBeenSubmitted(true);
 
-        if (token) {
+        if (token && token !== '') {
             trackEvent('playground_token_input_used');
         }
 


### PR DESCRIPTION
do not track empty strings in playground token input