### PR TITLE
fix: make sure we are still pg10 compatible.

### DIFF
--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -7,7 +7,7 @@ exports.up = function(db, cb) {
         PRIMARY KEY (day, environment)
     );
 
-    CREATE FUNCTION unleash_update_stat_environment_changes_counter() RETURNS trigger AS $unleash_update_changes_counter$
+    CREATE OR REPLACE FUNCTION unleash_update_stat_environment_changes_counter() RETURNS trigger AS $unleash_update_changes_counter$
         BEGIN
             IF NEW.environment IS NOT NULL THEN
                 INSERT INTO stat_environment_updates(day, environment, updates) SELECT DATE_TRUNC('Day', NEW.created_at), NEW.environment, 1 ON CONFLICT (day, environment) DO UPDATE SET updates = stat_environment_updates.updates + 1;
@@ -19,7 +19,7 @@ exports.up = function(db, cb) {
 
     CREATE TRIGGER unleash_update_stat_environment_changes
     AFTER INSERT ON events
-    FOR EACH ROW EXECUTE FUNCTION unleash_update_stat_environment_changes_counter();
+    FOR EACH ROW EXECUTE PROCEDURE unleash_update_stat_environment_changes_counter();
   `, cb);
 };
 


### PR DESCRIPTION
`EXECUTE FUNCTION` was introduced in Postgres v11. In Postgres v10 the syntax was `EXECUTE PROCEDURE`. This fix changes the syntax to `EXECUTE PROCEDURE`, which is perfectly fine sense our function does not return anything. 
