### PR TITLE
feat: Cursor based hateoas

### DIFF
--- a/src/lib/features/feature-search/feature-search-service.ts
+++ b/src/lib/features/feature-search/feature-search-service.ts
@@ -3,6 +3,7 @@ import {
     IFeatureStrategiesStore,
     IUnleashConfig,
     IUnleashStores,
+    serializeDates,
 } from '../../types';
 import { IFeatureSearchParams } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 
@@ -24,6 +25,11 @@ export class FeatureSearchService {
             params,
         );
 
-        return features;
+        const nextCursor =
+            features.length > 0
+                ? features[features.length - 1].createdAt.toJSON()
+                : undefined;
+
+        return { features, nextCursor };
     }
 }

--- a/src/lib/features/feature-search/feature-search-service.ts
+++ b/src/lib/features/feature-search/feature-search-service.ts
@@ -21,15 +21,24 @@ export class FeatureSearchService {
     }
 
     async search(params: IFeatureSearchParams) {
-        const features = await this.featureStrategiesStore.searchFeatures(
-            params,
-        );
+        // fetch one more item than needed to get a cursor of the next item
+        const features = await this.featureStrategiesStore.searchFeatures({
+            ...params,
+            limit: params.limit + 1,
+        });
 
         const nextCursor =
-            features.length > 0
+            features.length > params.limit
                 ? features[features.length - 1].createdAt.toJSON()
                 : undefined;
 
-        return { features, nextCursor };
+        // do not return the items with the next cursor
+        return {
+            features:
+                features.length > params.limit
+                    ? features.slice(0, -1)
+                    : features,
+            nextCursor,
+        };
     }
 }

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -130,13 +130,7 @@ test('should paginate with cursor', async () => {
         features: [{ name: 'my_feature_c' }, { name: 'my_feature_d' }],
     });
 
-    const { body: lastPage, headers: lastHeaders } = await getPage(
-        secondHeaders.link,
-    );
-    expect(lastPage).toMatchObject({
-        features: [],
-    });
-    expect(lastHeaders.link).toBe('');
+    expect(secondHeaders.link).toBe('');
 });
 
 test('should filter features by type', async () => {

--- a/src/lib/features/feature-search/next-link.test.ts
+++ b/src/lib/features/feature-search/next-link.test.ts
@@ -1,0 +1,55 @@
+import { nextLink } from './next-link';
+import { Request } from 'express';
+
+describe('nextLink', () => {
+    it('should generate the correct next link with a cursor', () => {
+        const req = {
+            baseUrl: '/api/events',
+            path: '/',
+            query: { page: '2', limit: '10' },
+        } as Pick<Request, 'baseUrl' | 'path' | 'query'>;
+
+        const cursor = 'abc123';
+        const result = nextLink(req, cursor);
+
+        expect(result).toBe('/api/events/?page=2&limit=10&cursor=abc123');
+    });
+
+    it('should generate the correct next link without a cursor', () => {
+        const req = {
+            baseUrl: '/api/events',
+            path: '/',
+            query: { page: '2', limit: '10' },
+        } as Pick<Request, 'baseUrl' | 'path' | 'query'>;
+
+        const result = nextLink(req);
+
+        expect(result).toBe('');
+    });
+
+    it('should exclude existing cursor from query parameters', () => {
+        const req = {
+            baseUrl: '/api/events',
+            path: '/',
+            query: { page: '2', limit: '10', cursor: 'oldCursor' },
+        } as Pick<Request, 'baseUrl' | 'path' | 'query'>;
+
+        const cursor = 'newCursor';
+        const result = nextLink(req, cursor);
+
+        expect(result).toBe('/api/events/?page=2&limit=10&cursor=newCursor');
+    });
+
+    it('should handle empty query parameters correctly', () => {
+        const req = {
+            baseUrl: '/api/events',
+            path: '/',
+            query: {},
+        } as Pick<Request, 'baseUrl' | 'path' | 'query'>;
+
+        const cursor = 'abc123';
+        const result = nextLink(req, cursor);
+
+        expect(result).toBe('/api/events/?cursor=abc123');
+    });
+});

--- a/src/lib/features/feature-search/next-link.ts
+++ b/src/lib/features/feature-search/next-link.ts
@@ -1,0 +1,18 @@
+import { Request } from 'express';
+
+export function nextLink(
+    req: Pick<Request, 'baseUrl' | 'path' | 'query'>,
+    cursor?: string,
+): string {
+    if (!cursor) {
+        return '';
+    }
+
+    const url = `${req.baseUrl}${req.path}?`;
+
+    const params = new URLSearchParams(req.query as Record<string, string>);
+
+    params.set('cursor', cursor);
+
+    return `${url}${params.toString()}`;
+}

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -533,7 +533,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         cursor,
         limit,
     }: IFeatureSearchParams): Promise<IFeatureOverview[]> {
-        let query = this.db('features');
+        let query = this.db('features').limit(limit);
         if (projectId) {
             query = query.where({ project: projectId });
         }
@@ -582,20 +582,10 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             });
         }
 
-        // workaround for imprecise timestamp that was including the cursor itself
-        const addMillisecond = (cursor: string) =>
-            format(
-                addMilliseconds(parseISO(cursor), 1),
-                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-            );
         if (cursor) {
-            query = query.where(
-                'features.created_at',
-                '>',
-                addMillisecond(cursor),
-            );
+            query = query.where('features.created_at', '>=', cursor);
         }
-        query = query.orderBy('features.created_at', 'asc').limit(limit);
+        query = query.orderBy('features.created_at', 'asc');
 
         query = query
             .modify(FeatureToggleStore.filterByArchived, false)

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -61,17 +61,17 @@ export const featureSearchQueryParameters = [
         name: 'cursor',
         schema: {
             type: 'string',
-            example: '1',
+            example: '2023-10-31T09:21:04.056Z',
         },
         description:
-            'The last feature id the client has seen. Used for cursor-based pagination.',
+            'The last feature create at date the client has seen. Used for cursor-based pagination. Empty if starting from the beginning.',
         in: 'query',
     },
     {
         name: 'limit',
         schema: {
-            type: 'number',
-            example: 10,
+            type: 'string',
+            example: '10',
         },
         description:
             'The number of results to return in a page. By default it is set to 50',

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -64,7 +64,7 @@ export const featureSearchQueryParameters = [
             example: '2023-10-31T09:21:04.056Z',
         },
         description:
-            'The last feature create at date the client has seen. Used for cursor-based pagination. Empty if starting from the beginning.',
+            'The next feature created at date the client has not seen. Used for cursor-based pagination. Empty if starting from the beginning.',
         in: 'query',
     },
     {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Generates link to the next page and allows for easy HATEOAS based navigation. 

Changes:
* added utility for calculating next page (eventually we'll move it up the directory tree if needed)
* changed cursor calculation logic to take the cursor of the next item instead of the cursor of the last used item

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Currently only Link to next page is provided and it's easy to parse. We may add extra rel=next later to the header but it complicates parsing