### PR TITLE
fix: private projects early exit when not root viewer

### DIFF
--- a/src/lib/features/private-project/privateProjectStore.ts
+++ b/src/lib/features/private-project/privateProjectStore.ts
@@ -40,9 +40,9 @@ class PrivateProjectStore implements IPrivateProjectStore {
                 'roles.type': 'root',
             })
             .count('*')
-            .first();
+            .then((res) => Number(res[0].count));
 
-        if (!isViewer || isViewer.count === 0) {
+        if (isViewer === 0) {
             return ALL_PROJECT_ACCESS;
         }
 


### PR DESCRIPTION
If you are not root viewer, it should give instantly all access.
This PR fixes the issue and now it will early exit.