### PR TITLE
fix: do not allow segment deletion when used in private projects

### DIFF
--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -348,7 +348,10 @@ export class SegmentsController extends Controller {
     ): Promise<void> {
         const { id } = req.params;
         const { user } = req;
-        const strategies = await this.segmentService.getStrategies(id, user.id);
+        const strategies = await this.segmentService.getVisibleStrategies(
+            id,
+            user.id,
+        );
 
         // Remove unnecessary IFeatureStrategy fields from the response.
         const segmentStrategies = strategies.map((strategy) => ({
@@ -369,8 +372,7 @@ export class SegmentsController extends Controller {
         res: Response,
     ): Promise<void> {
         const id = Number(req.params.id);
-        const { user } = req;
-        const strategies = await this.segmentService.getStrategies(id, user.id);
+        const strategies = await this.segmentService.getStrategies(id);
 
         if (strategies.length > 0) {
             res.status(409).send();

--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -372,7 +372,7 @@ export class SegmentsController extends Controller {
         res: Response,
     ): Promise<void> {
         const id = Number(req.params.id);
-        const strategies = await this.segmentService.getStrategies(id);
+        const strategies = await this.segmentService.getAllStrategies(id);
 
         if (strategies.length > 0) {
             res.status(409).send();

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -19,7 +19,7 @@ export interface ISegmentService {
      * For most use cases, use `getVisibleStrategies`
      * @param id segment id
      */
-    getStrategies(id: number): Promise<IFeatureStrategy[]>;
+    getAllStrategies(id: number): Promise<IFeatureStrategy[]>;
 
     getVisibleStrategies(
         id: number,

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -17,7 +17,6 @@ export interface ISegmentService {
      * Gets all strategies for a segment
      * This is NOT considering the private projects
      * For most use cases, use `getVisibleStrategies`
-     * @param id segment id
      */
     getAllStrategies(id: number): Promise<IFeatureStrategy[]>;
 

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -13,7 +13,18 @@ export interface ISegmentService {
 
     get(id: number): Promise<ISegment>;
 
-    getStrategies(id: number, userId: number): Promise<IFeatureStrategy[]>;
+    /**
+     * Gets all strategies for a segment
+     * This is NOT considering the private projects
+     * For most use cases, use `getVisibleStrategies`
+     * @param id segment id
+     */
+    getStrategies(id: number): Promise<IFeatureStrategy[]>;
+
+    getVisibleStrategies(
+        id: number,
+        userId: number,
+    ): Promise<IFeatureStrategy[]>;
 
     validateName(name: string): Promise<void>;
 

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -77,18 +77,15 @@ export class SegmentService implements ISegmentService {
         return this.segmentStore.getActiveForClient();
     }
 
-    // Used by unleash-enterprise.
     async getByStrategy(strategyId: string): Promise<ISegment[]> {
         return this.segmentStore.getByStrategy(strategyId);
     }
 
-    // Used by unleash-enterprise.
-    async getStrategies(
+    async getVisibleStrategies(
         id: number,
         userId: number,
     ): Promise<IFeatureStrategy[]> {
-        const strategies =
-            await this.featureStrategiesStore.getStrategiesBySegment(id);
+        const strategies = await this.getStrategies(id);
         if (this.flagResolver.isEnabled('privateProjects')) {
             const accessibleProjects =
                 await this.privateProjectChecker.getUserAccessibleProjects(
@@ -102,6 +99,12 @@ export class SegmentService implements ISegmentService {
                 );
             }
         }
+        return strategies;
+    }
+
+    async getStrategies(id: number): Promise<IFeatureStrategy[]> {
+        const strategies =
+            await this.featureStrategiesStore.getStrategiesBySegment(id);
         return strategies;
     }
 

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -85,7 +85,7 @@ export class SegmentService implements ISegmentService {
         id: number,
         userId: number,
     ): Promise<IFeatureStrategy[]> {
-        const strategies = await this.getStrategies(id);
+        const strategies = await this.getAllStrategies(id);
         if (this.flagResolver.isEnabled('privateProjects')) {
             const accessibleProjects =
                 await this.privateProjectChecker.getUserAccessibleProjects(
@@ -102,7 +102,7 @@ export class SegmentService implements ISegmentService {
         return strategies;
     }
 
-    async getStrategies(id: number): Promise<IFeatureStrategy[]> {
+    async getAllStrategies(id: number): Promise<IFeatureStrategy[]> {
         const strategies =
             await this.featureStrategiesStore.getStrategiesBySegment(id);
         return strategies;


### PR DESCRIPTION
Splitted the `getStrategies` into `getVisibleStrategies` and `getAllStrategies`, which will handle the permissions.
If we are deleting a segment, `getAllStrategies` will be used and private projects will not be counted.