### PR TITLE
feat: connect project overview table to search api

### DIFF
--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -72,6 +72,7 @@ interface IProjectFeatureTogglesProps {
     features: IProject['features'];
     environments: IProject['environments'];
     loading: boolean;
+    onChange: () => void;
 }
 
 const staticColumns = ['Select', 'Actions', 'name', 'favorite'];
@@ -84,6 +85,7 @@ export const ProjectFeatureToggles = ({
     features,
     loading,
     environments: newEnvironments = [],
+    onChange
 }: IProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const theme = useTheme();
@@ -118,7 +120,6 @@ export const ProjectFeatureToggles = ({
             ? [{ environment: 'a' }, { environment: 'b' }, { environment: 'c' }]
             : newEnvironments,
     );
-    const { refetch } = useProject(projectId);
     const { isFavoritesPinned, sortTypes, onChangeIsFavoritePinned } =
         usePinnedFavorites(
             searchParams.has('favorites')
@@ -140,9 +141,9 @@ export const ProjectFeatureToggles = ({
             } else {
                 await favorite(projectId, feature.name);
             }
-            refetch();
+            onChange();
         },
-        [projectId, refetch],
+        [projectId, onChange],
     );
 
     const showTagsColumn = useMemo(
@@ -263,7 +264,7 @@ export const ProjectFeatureToggles = ({
                     projectId,
                     name,
                     isChangeRequestEnabled,
-                    refetch,
+                    onChange,
                     onFeatureToggle,
                 );
 
@@ -617,16 +618,14 @@ export const ProjectFeatureToggles = ({
                     isOpen={Boolean(featureStaleDialogState.featureId)}
                     onClose={() => {
                         setFeatureStaleDialogState({});
-                        refetch();
+                        onChange();
                     }}
                     featureId={featureStaleDialogState.featureId || ''}
                     projectId={projectId}
                 />
                 <FeatureArchiveDialog
                     isOpen={Boolean(featureArchiveState)}
-                    onConfirm={() => {
-                        refetch();
-                    }}
+                    onConfirm={onChange}
                     onClose={() => {
                         setFeatureArchiveState(undefined);
                     }}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -85,7 +85,7 @@ export const ProjectFeatureToggles = ({
     features,
     loading,
     environments: newEnvironments = [],
-    onChange
+    onChange,
 }: IProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const theme = useTheme();

--- a/frontend/src/component/project/Project/ProjectOverview.tsx
+++ b/frontend/src/component/project/Project/ProjectOverview.tsx
@@ -83,13 +83,13 @@ const ProjectOverview = () => {
     usePageTitle(`Project overview – ${projectName}`);
     const { setLastViewed } = useLastViewedProject();
     const featureSwitchRefactor = useUiFlag('featureSwitchRefactor');
-    const featureSearchApi = useUiFlag('featureSearchAPI');
+    const featureSearchFrontend = useUiFlag('featureSearchFrontend');
 
     useEffect(() => {
         setLastViewed(projectId);
     }, [projectId, setLastViewed]);
 
-    if(featureSearchApi) return <InfiniteProjectOverview />;
+    if(featureSearchFrontend) return <InfiniteProjectOverview />;
 
     return (
         <StyledContainer>

--- a/frontend/src/component/project/Project/ProjectOverview.tsx
+++ b/frontend/src/component/project/Project/ProjectOverview.tsx
@@ -41,7 +41,11 @@ const InfiniteProjectOverview = () => {
         refreshInterval,
     });
     const [nextCursor, setNextCursor] = useState('');
-    const { features: searchFeatures, refetch, loading } = useFeatureSearch(nextCursor, projectId , { refreshInterval});
+    const {
+        features: searchFeatures,
+        refetch,
+        loading,
+    } = useFeatureSearch(nextCursor, projectId, { refreshInterval });
     const { members, features, health, description, environments, stats } =
         project;
 
@@ -69,7 +73,6 @@ const InfiniteProjectOverview = () => {
             </StyledContentContainer>
         </StyledContainer>
     );
-
 };
 
 const ProjectOverview = () => {
@@ -89,7 +92,7 @@ const ProjectOverview = () => {
         setLastViewed(projectId);
     }, [projectId, setLastViewed]);
 
-    if(featureSearchFrontend) return <InfiniteProjectOverview />;
+    if (featureSearchFrontend) return <InfiniteProjectOverview />;
 
     return (
         <StyledContainer>

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
@@ -3,8 +3,6 @@ import { useCallback } from 'react';
 import { IFeatureToggleListItem } from 'interfaces/featureToggle';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
-import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
-import { useUiFlag } from '../../../useUiFlag';
 
 type IFeatureSearchResponse = { features: IFeatureToggleListItem[] };
 
@@ -26,11 +24,8 @@ export const useFeatureSearch = (
     projectId = '',
     options: SWRConfiguration = {},
 ): IUseFeatureSearchOutput => {
-    const featureSearchApi = useUiFlag('featureSearchAPI');
     const { KEY, fetcher } = getFeatureSearchFetcher(projectId, cursor);
-    const { data, error, mutate } = useConditionalSWR<IFeatureSearchResponse>(
-        featureSearchApi,
-        fallbackFeatures,
+    const { data, error, mutate } = useSWR<IFeatureSearchResponse>(
         KEY,
         fetcher,
         options,

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -72,6 +72,7 @@ export type UiFlags = {
     featureSwitchRefactor?: boolean;
     scheduledConfigurationChanges?: boolean;
     featureSearchAPI?: boolean;
+    featureSearchFrontend?: boolean;
 };
 
 export interface IVersionInfo {

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -71,6 +71,7 @@ export type UiFlags = {
     playgroundImprovements?: boolean;
     featureSwitchRefactor?: boolean;
     scheduledConfigurationChanges?: boolean;
+    featureSearchAPI?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -86,6 +86,7 @@ exports[`should create default config 1`] = `
       "embedProxyFrontend": true,
       "featureNamingPattern": false,
       "featureSearchAPI": false,
+      "featureSearchFrontend": false,
       "featureSwitchRefactor": false,
       "featuresExportImport": true,
       "filterInvalidClientMetrics": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -36,6 +36,7 @@ export type IFlagKey =
     | 'playgroundImprovements'
     | 'featureSwitchRefactor'
     | 'featureSearchAPI'
+    | 'featureSearchFrontend'
     | 'scheduledConfigurationChanges';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -166,6 +167,10 @@ const flags: IFlags = {
     ),
     featureSearchAPI: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FEATURE_SEARCH_API,
+        false,
+    ),
+    featureSearchFrontend: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_FEATURE_SEARCH_FRONTEND,
         false,
     ),
     scheduledConfigurationChanges: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -49,6 +49,7 @@ process.nextTick(async () => {
                         playgroundImprovements: true,
                         featureSwitchRefactor: true,
                         featureSearchAPI: true,
+                        featureSearchFrontend: false,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Connecting project overview features list to the search API. Currently we only return the first results with no cursor increments. You can see that even though I have hundreds of feature we only show 26 results.
<img width="1377" alt="Screenshot 2023-11-01 at 11 05 32" src="https://github.com/Unleash/unleash/assets/1394682/c43e963d-d08b-42b9-9bca-43d686592aee">

To make it work I had to refactor existing component for a table to allow for configurable onChange. We can either refresh project API or search API in this onChange handler.

The code is based on a new flag:
<img width="416" alt="Screenshot 2023-11-01 at 11 19 09" src="https://github.com/Unleash/unleash/assets/1394682/63416f9e-2114-4891-aa27-4a1cf873882f">

Next PRs:
* add infinite loader and cursor changes
* translate search and filter into query params
* sort server side instead of client side
* add tests


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
