### PR TITLE
docs: Update recommended postgres to 14

### DIFF
--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -15,7 +15,7 @@ We have created a set of ADRs to help guide the development of the backend:
 
 Before developing on this project you will need two things:
 
-- PostgreSQL 12.x or newer
+- PostgreSQL 14.x or newer
 - Node.js 14.x or newer
 
 ```sh
@@ -25,9 +25,9 @@ yarn dev
 
 ## PostgreSQL {#postgresql}
 
-To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v12.x or newer) locally.
+To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v14.x or newer) locally.
 
-Unleash currently also work with PostgreSQL v12+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v10.
+Unleash currently also work with PostgreSQL v14+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v12.
 
 ### Create a local unleash databases in postgres {#create-a-local-unleash-databases-in-postgres}
 

--- a/website/docs/using-unleash/deploy/database-setup.md
+++ b/website/docs/using-unleash/deploy/database-setup.md
@@ -2,7 +2,7 @@
 title: Database Setup
 ---
 
-To run Unleash you need to have PostgreSQL database (PostgreSQL v10.x or newer).
+To run Unleash you need to have PostgreSQL database (PostgreSQL v14.x or newer).
 
 1. Create a local unleash databases in PostgreSQL
 


### PR DESCRIPTION
We've been caught out here, we added a migration that used PG>=11 syntax, but our docs still state that we support v10, when it reached EoL Nov 2022. This updates our docs to state v14 and newer, v14 came out in 2021 and as such won't be EoL until 2026 according to [Postgres 5 year versioning scheme support](https://www.postgresql.org/support/versioning/) 