### PR TITLE
refactor: memoize heavy components in project overview

### DIFF
--- a/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell.tsx
@@ -20,3 +20,7 @@ export const FeatureEnvironmentSeenCell: VFC<IFeatureSeenCellProps> = ({
         />
     );
 };
+
+export const MemoizedFeatureEnvironmentSeenCell = React.memo(
+    FeatureEnvironmentSeenCell,
+);

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
@@ -7,19 +7,6 @@ import { FeatureToggleSwitch } from './FeatureToggleSwitch';
 import type { ListItemType } from '../ProjectFeatureToggles.types';
 import type { UseFeatureToggleSwitchType } from './FeatureToggleSwitch.types';
 
-interface ICreateFeatureCell {
-    projectId: string;
-    environmentName: string;
-    isChangeRequestEnabled: boolean;
-    refetch: () => void;
-    onFeatureToggleSwitch: ReturnType<UseFeatureToggleSwitchType>['onToggle'];
-}
-
-type FeatureCellProps = ICreateFeatureCell & {
-    feature: ListItemType;
-    value: boolean;
-};
-
 const StyledSwitchContainer = styled('div', {
     shouldForwardProp: (prop) => prop !== 'hasWarning',
 })<{ hasWarning?: boolean }>(({ theme, hasWarning }) => ({
@@ -35,6 +22,16 @@ const StyledSwitchContainer = styled('div', {
     }),
 }));
 
+interface IFeatureToggleCellProps {
+    projectId: string;
+    environmentName: string;
+    isChangeRequestEnabled: boolean;
+    refetch: () => void;
+    onFeatureToggleSwitch: ReturnType<UseFeatureToggleSwitchType>['onToggle'];
+    value: boolean;
+    feature: ListItemType;
+}
+
 const FeatureToggleCellComponent = ({
     value,
     feature,
@@ -43,7 +40,7 @@ const FeatureToggleCellComponent = ({
     isChangeRequestEnabled,
     refetch,
     onFeatureToggleSwitch,
-}: FeatureCellProps) => {
+}: IFeatureToggleCellProps) => {
     const environment = feature.environments[environmentName];
 
     const hasWarning = useMemo(
@@ -88,7 +85,13 @@ const FeatureToggleCellComponent = ({
 const MemoizedFeatureToggleCell = React.memo(FeatureToggleCellComponent);
 
 export const createFeatureToggleCell =
-    (config: ICreateFeatureCell) =>
+    (
+        projectId: string,
+        environmentName: string,
+        isChangeRequestEnabled: boolean,
+        refetch: () => void,
+        onFeatureToggleSwitch: ReturnType<UseFeatureToggleSwitchType>['onToggle'],
+    ) =>
     ({
         value,
         row: { original: feature },
@@ -100,11 +103,11 @@ export const createFeatureToggleCell =
             <MemoizedFeatureToggleCell
                 value={value}
                 feature={feature}
-                projectId={config.projectId}
-                environmentName={config.environmentName}
-                isChangeRequestEnabled={config.isChangeRequestEnabled}
-                refetch={config.refetch}
-                onFeatureToggleSwitch={config.onFeatureToggleSwitch}
+                projectId={projectId}
+                environmentName={environmentName}
+                isChangeRequestEnabled={isChangeRequestEnabled}
+                refetch={refetch}
+                onFeatureToggleSwitch={onFeatureToggleSwitch}
             />
         );
     };

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
@@ -15,8 +15,10 @@ interface ICreateFeatureCell {
     onFeatureToggleSwitch: ReturnType<UseFeatureToggleSwitchType>['onToggle'];
 }
 
-type FeatureCellProps = ICreateFeatureCell & { feature: ListItemType, value: boolean }
-
+type FeatureCellProps = ICreateFeatureCell & {
+    feature: ListItemType;
+    value: boolean;
+};
 
 const StyledSwitchContainer = styled('div', {
     shouldForwardProp: (prop) => prop !== 'hasWarning',
@@ -86,9 +88,7 @@ const FeatureToggleCellComponent = ({
 const MemoizedFeatureToggleCell = React.memo(FeatureToggleCellComponent);
 
 export const createFeatureToggleCell =
-    (
-      config: ICreateFeatureCell
-    ) =>
+    (config: ICreateFeatureCell) =>
     ({
         value,
         row: { original: feature },

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -148,20 +148,17 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
             };
 
             const handleToggleEnvironmentOn: Middleware = async (next) => {
-                console.time('toggleEnv');
                 if (newState !== true) {
                     return next();
                 }
 
                 try {
-                    console.time('toggleAPICall');
                     await toggleFeatureEnvironmentOn(
                         config.projectId,
                         config.featureId,
                         config.environmentName,
                         shouldActivateDisabledStrategies,
                     );
-                    console.timeEnd('toggleAPICall');
 
                     setToastData({
                         type: 'success',
@@ -173,8 +170,6 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     setToastApiError(formatUnknownError(error));
                     config.onRollback?.();
                 }
-
-                console.timeEnd('toggleEnv');
             };
 
             const handleToggleEnvironmentOff: Middleware = async (next) => {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -148,17 +148,21 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
             };
 
             const handleToggleEnvironmentOn: Middleware = async (next) => {
+                console.time('toggleEnv');
                 if (newState !== true) {
                     return next();
                 }
 
                 try {
+                    console.time('toggleAPICall');
                     await toggleFeatureEnvironmentOn(
                         config.projectId,
                         config.featureId,
                         config.environmentName,
                         shouldActivateDisabledStrategies,
                     );
+                    console.timeEnd('toggleAPICall');
+
                     setToastData({
                         type: 'success',
                         title: `Enabled in ${config.environmentName}`,
@@ -169,6 +173,8 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     setToastApiError(formatUnknownError(error));
                     config.onRollback?.();
                 }
+
+                console.timeEnd('toggleEnv');
             };
 
             const handleToggleEnvironmentOff: Middleware = async (next) => {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Checkbox,
     IconButton,
@@ -55,10 +55,10 @@ import { useGlobalLocalStorage } from 'hooks/useGlobalLocalStorage';
 import FileDownload from '@mui/icons-material/FileDownload';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ExportDialog } from 'component/feature/FeatureToggleList/ExportDialog';
-import { RowSelectCell } from './RowSelectCell/RowSelectCell';
+import { MemoizedRowSelectCell } from './RowSelectCell/RowSelectCell';
 import { BatchSelectionActionsBar } from '../../../common/BatchSelectionActionsBar/BatchSelectionActionsBar';
 import { ProjectFeaturesBatchActions } from './ProjectFeaturesBatchActions/ProjectFeaturesBatchActions';
-import { FeatureEnvironmentSeenCell } from '../../../common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell';
+import { MemoizedFeatureEnvironmentSeenCell } from '../../../common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell';
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { ListItemType } from './ProjectFeatureToggles.types';
 import { createFeatureToggleCell } from './FeatureToggleSwitch/createFeatureToggleCell';
@@ -158,7 +158,9 @@ export const ProjectFeatureToggles = ({
                     <Checkbox {...getToggleAllRowsSelectedProps()} />
                 ),
                 Cell: ({ row }: any) => (
-                    <RowSelectCell {...row?.getToggleRowSelectedProps?.()} />
+                    <MemoizedRowSelectCell
+                        {...row?.getToggleRowSelectedProps?.()}
+                    />
                 ),
                 maxWidth: 50,
                 disableSortBy: true,
@@ -188,7 +190,7 @@ export const ProjectFeatureToggles = ({
                 accessor: 'lastSeenAt',
                 Cell: ({ value, row: { original: feature } }: any) => {
                     return showEnvironmentLastSeen ? (
-                        <FeatureEnvironmentSeenCell feature={feature} />
+                        <MemoizedFeatureEnvironmentSeenCell feature={feature} />
                     ) : (
                         <FeatureSeenCell value={value} />
                     );

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Box, Checkbox, styled } from '@mui/material';
 import { FC } from 'react';
 import { BATCH_SELECT } from 'utils/testIds';
@@ -23,3 +24,5 @@ export const RowSelectCell: FC<IRowSelectCellProps> = ({
         <Checkbox onChange={onChange} title={title} checked={checked} />
     </StyledBoxCell>
 );
+
+export const MemoizedRowSelectCell = React.memo(RowSelectCell);


### PR DESCRIPTION
This PR memoizes some of the heavier components in our project overview table