### PR TITLE
feat: serach and filter input to query param parser

### DIFF
--- a/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.test.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.test.ts
@@ -1,0 +1,45 @@
+import { translateToQueryParams } from './searchToQueryParams';
+
+describe('translateToQueryParams', () => {
+    describe.each([
+        ['search', 'query=search'],
+        [' search', 'query=search'],
+        [' search ', 'query=search'],
+        ['search ', 'query=search'],
+        ['search with space', 'query=search with space'],
+        ['search type:release', 'query=search&type[]=release'],
+        [' search type:release ', 'query=search&type[]=release'],
+        [
+            'search type:release,experiment',
+            'query=search&type[]=release&type[]=experiment',
+        ],
+        [
+            'search type:release ,experiment',
+            'query=search&type[]=release&type[]=experiment',
+        ],
+        [
+            'search type:release, experiment',
+            'query=search&type[]=release&type[]=experiment',
+        ],
+        [
+            'search type:release , experiment',
+            'query=search&type[]=release&type[]=experiment',
+        ],
+        ['type:release', 'type[]=release'],
+        ['production:enabled', 'status[]=production:enabled'],
+        [
+            'development:enabled,disabled',
+            'status[]=development:enabled&status[]=development:disabled',
+        ],
+        ['tag:simple:web', 'tag[]=simple:web'],
+        ['tag:enabled:enabled', 'tag[]=enabled:enabled'],
+        [
+            'tag:simple:web,complex:native',
+            'tag[]=simple:web&tag[]=complex:native',
+        ],
+    ])('when input is "%s"', (input, expected) => {
+        it(`returns "${expected}"`, () => {
+            expect(translateToQueryParams(input)).toBe(expected);
+        });
+    });
+});

--- a/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.test.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.test.ts
@@ -25,7 +25,12 @@ describe('translateToQueryParams', () => {
             'search type:release , experiment',
             'query=search&type[]=release&type[]=experiment',
         ],
+        [
+            'search type: release , experiment',
+            'query=search&type[]=release&type[]=experiment',
+        ],
         ['type:release', 'type[]=release'],
+        ['type:  release', 'type[]=release'],
         ['production:enabled', 'status[]=production:enabled'],
         [
             'development:enabled,disabled',

--- a/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.ts
@@ -84,7 +84,7 @@ const appendFilterParamsToQueryParts = (
 const convertToQueryString = (
     params: Record<string, string | string[]>,
 ): string => {
-    const { query, ...filterParams } = params; // Destructure to separate query and filterParams
+    const { query, ...filterParams } = params;
     let queryParts: string[] = [];
 
     if (query) {

--- a/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/searchToQueryParams.ts
@@ -1,0 +1,117 @@
+const splitInputQuery = (searchString: string): string[] =>
+    searchString.trim().split(/ (?=\w+:)/);
+
+const isFilter = (part: string): boolean => part.includes(':');
+
+const isStatusFilter = (key: string, values: string[]): boolean =>
+    values.every((value) => value === 'enabled' || value === 'disabled');
+
+const addStatusFilters = (
+    key: string,
+    values: string[],
+    filterParams: Record<string, string | string[]>,
+): Record<string, string | string[]> => {
+    const newStatuses = values.map((value) => `${key}:${value}`);
+    return {
+        ...filterParams,
+        status: [...(filterParams.status || []), ...newStatuses],
+    };
+};
+
+const addTagFilters = (
+    values: string[],
+    filterParams: Record<string, string | string[]>,
+): Record<string, string | string[]> => ({
+    ...filterParams,
+    tag: [...(filterParams.tag || []), ...values],
+});
+
+const addRegularFilters = (
+    key: string,
+    values: string[],
+    filterParams: Record<string, string | string[]>,
+): Record<string, string | string[]> => ({
+    ...filterParams,
+    [key]: [...(filterParams[key] || []), ...values],
+});
+
+const handleFilter = (
+    part: string,
+    filterParams: Record<string, string | string[]>,
+): Record<string, string | string[]> => {
+    const [key, ...valueParts] = part.split(':');
+    const valueString = valueParts.join(':').trim();
+    const values = valueString.split(',').map((value) => value.trim());
+
+    if (isStatusFilter(key, values)) {
+        return addStatusFilters(key, values, filterParams);
+    } else if (key === 'tag') {
+        return addTagFilters(values, filterParams);
+    } else {
+        return addRegularFilters(key, values, filterParams);
+    }
+};
+
+const handleSearchTerm = (
+    part: string,
+    filterParams: Record<string, string | string[]>,
+): Record<string, string | string[]> => ({
+    ...filterParams,
+    query: filterParams.query
+        ? `${filterParams.query} ${part.trim()}`
+        : part.trim(),
+});
+
+const appendFilterParamsToQueryParts = (
+    params: Record<string, string | string[]>,
+): string[] => {
+    let newQueryParts: string[] = [];
+
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            newQueryParts = [
+                ...newQueryParts,
+                ...value.map((item) => `${key}[]=${item}`),
+            ];
+        } else {
+            newQueryParts.push(`${key}=${value}`);
+        }
+    }
+
+    return newQueryParts;
+};
+
+const convertToQueryString = (
+    params: Record<string, string | string[]>,
+): string => {
+    const { query, ...filterParams } = params; // Destructure to separate query and filterParams
+    let queryParts: string[] = [];
+
+    if (query) {
+        queryParts.push(`query=${query}`);
+    }
+
+    queryParts = queryParts.concat(
+        appendFilterParamsToQueryParts(filterParams),
+    );
+
+    return queryParts.join('&');
+};
+
+const buildSearchParams = (
+    input: string,
+): Record<string, string | string[]> => {
+    const parts = splitInputQuery(input);
+    return parts.reduce(
+        (searchAndFilterParams, part) =>
+            isFilter(part)
+                ? handleFilter(part, searchAndFilterParams)
+                : handleSearchTerm(part, searchAndFilterParams),
+        {},
+    );
+};
+
+export const translateToQueryParams = (searchString: string): string => {
+    const searchParams = buildSearchParams(searchString);
+    return convertToQueryString(searchParams);
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

As we're migrating from the client side search to server side search I created a pure function responsible for translating search and filter string into query params e.g.:

`searchString type:release,experimental tag:simple:web` should translate to `query=searchString&type[]=release&type[]=experimental&tag[]=simple:web`

This code handles all the corner cases I could think of:
* extra spaces around filter items (compared to our client side search we allows spaces after colon e.g. `type: release` and not just `type:release`)
* one and multiple filter values
* only search, only filter, search and filter
* special case for environment status enabled/disabled (any environment should be supported and we detect it by value of disabled/enabled)

As a result this code should also work for other searcher outside of the project overview. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
