### PR TITLE
feat: add banners OpenAPI tag

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -25,6 +25,11 @@ const OPENAPI_TAGS = [
     },
     { name: 'Auth', description: 'Manage logins, passwords, etc.' },
     {
+        name: 'Banners',
+        description:
+            'Create, update, toggle, and delete [banners](https://docs.getunleash.io/reference/banners).',
+    },
+    {
         name: 'Change Requests',
         description:
             'API for managing [change requests](https://docs.getunleash.io/reference/change-requests).',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1515/create-new-api-tag-banners-for-ga

Adds a new OpenAPI tag "Banners" in preparation for GA.