### PR TITLE
Refactor/project overview api calls

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -144,7 +144,7 @@ export const FeatureView = () => {
     const { favorite, unfavorite } = useFavoriteFeaturesApi();
     const { refetchFeature } = useFeature(projectId, featureId);
     const dependentFeatures = useUiFlag('dependentFeatures');
-    const { setToastData } = useToast();
+    const { setToastData, setToastApiError } = useToast();
 
     const [openTagDialog, setOpenTagDialog] = useState(false);
     const [showDelDialog, setShowDelDialog] = useState(false);
@@ -187,12 +187,16 @@ export const FeatureView = () => {
         tabData.find((tab) => tab.path === pathname) ?? tabData[0];
 
     const onFavorite = async () => {
-        if (feature?.favorite) {
-            await unfavorite(projectId, feature.name);
-        } else {
-            await favorite(projectId, feature.name);
+        try {
+            if (feature?.favorite) {
+                await unfavorite(projectId, feature.name);
+            } else {
+                await favorite(projectId, feature.name);
+            }
+            refetchFeature();
+        } catch (error) {
+            setToastApiError('Something went wrong, could not update favorite');
         }
-        refetchFeature();
     };
 
     if (status === 404) {

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -64,7 +64,7 @@ export const Project = () => {
     const params = useQueryParams();
     const { project, loading, error, refetch } = useProject(projectId);
     const ref = useLoading(loading);
-    const { setToastData } = useToast();
+    const { setToastData, setToastApiError } = useToast();
     const [modalOpen, setModalOpen] = useState(false);
     const navigate = useNavigate();
     const { pathname } = useLocation();
@@ -155,12 +155,16 @@ export const Project = () => {
     }
 
     const onFavorite = async () => {
-        if (project?.favorite) {
-            await unfavorite(projectId);
-        } else {
-            await favorite(projectId);
+        try {
+            if (project?.favorite) {
+                await unfavorite(projectId);
+            } else {
+                await favorite(projectId);
+            }
+            refetch();
+        } catch (error) {
+            setToastApiError('Something went wrong, could not update favorite');
         }
-        refetch();
     };
 
     const enterpriseIcon = (

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/LegacyProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/LegacyProjectFeatureToggles.tsx
@@ -65,6 +65,7 @@ import { RowSelectCell } from './RowSelectCell/RowSelectCell';
 import { BatchSelectionActionsBar } from '../../../common/BatchSelectionActionsBar/BatchSelectionActionsBar';
 import { ProjectFeaturesBatchActions } from './ProjectFeaturesBatchActions/ProjectFeaturesBatchActions';
 import { FeatureEnvironmentSeenCell } from '../../../common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell';
+import useToast from 'hooks/useToast';
 
 const StyledResponsiveButton = styled(ResponsiveButton)(() => ({
     whiteSpace: 'nowrap',
@@ -135,7 +136,7 @@ export const ProjectFeatureToggles = ({
         string | undefined
     >();
     const projectId = useRequiredPathParam('projectId');
-
+    const { setToastApiError } = useToast();
     const { value: storedParams, setValue: setStoredParams } =
         createLocalStorage(
             `${projectId}:FeatureToggleListTable:v1`,
@@ -171,14 +172,20 @@ export const ProjectFeatureToggles = ({
 
     const onFavorite = useCallback(
         async (feature: IFeatureToggleListItem) => {
-            if (feature?.favorite) {
-                await unfavorite(projectId, feature.name);
-            } else {
-                await favorite(projectId, feature.name);
+            try {
+                if (feature?.favorite) {
+                    await unfavorite(projectId, feature.name);
+                } else {
+                    await favorite(projectId, feature.name);
+                }
+                refetch();
+            } catch (error) {
+                setToastApiError(
+                    'Something went wrong, could not update favorite',
+                );
             }
-            refetch();
         },
-        [projectId, refetch],
+        [projectId, refetch, setToastApiError],
     );
 
     const showTagsColumn = useMemo(

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -63,6 +63,7 @@ import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { ListItemType } from './ProjectFeatureToggles.types';
 import { createFeatureToggleCell } from './FeatureToggleSwitch/createFeatureToggleCell';
 import { useFeatureToggleSwitch } from './FeatureToggleSwitch/useFeatureToggleSwitch';
+import useToast from 'hooks/useToast';
 
 const StyledResponsiveButton = styled(ResponsiveButton)(() => ({
     whiteSpace: 'nowrap',
@@ -91,6 +92,7 @@ export const ProjectFeatureToggles = ({
 }: IProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const theme = useTheme();
+    const { setToastApiError } = useToast();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
     const [strategiesDialogState, setStrategiesDialogState] = useState({
         open: false,
@@ -138,12 +140,18 @@ export const ProjectFeatureToggles = ({
 
     const onFavorite = useCallback(
         async (feature: IFeatureToggleListItem) => {
-            if (feature?.favorite) {
-                await unfavorite(projectId, feature.name);
-            } else {
-                await favorite(projectId, feature.name);
+            try {
+                if (feature?.favorite) {
+                    await unfavorite(projectId, feature.name);
+                } else {
+                    await favorite(projectId, feature.name);
+                }
+                onChange();
+            } catch (error) {
+                setToastApiError(
+                    'Something went wrong, could not update favorite',
+                );
             }
-            onChange();
         },
         [projectId, onChange],
     );

--- a/frontend/src/component/project/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/ProjectCard.tsx
@@ -27,6 +27,7 @@ import {
     StyledDivInfoContainer,
     StyledParagraphInfo,
 } from './ProjectCard.styles';
+import useToast from 'hooks/useToast';
 
 interface IProjectCardProps {
     name: string;
@@ -48,6 +49,7 @@ export const ProjectCard = ({
     isFavorite = false,
 }: IProjectCardProps) => {
     const { hasAccess } = useContext(AccessContext);
+    const { setToastApiError } = useToast();
     const { isOss } = useUiConfig();
     const [anchorEl, setAnchorEl] = useState<Element | null>(null);
     const [showDelDialog, setShowDelDialog] = useState(false);
@@ -62,12 +64,16 @@ export const ProjectCard = ({
 
     const onFavorite = async (e: React.SyntheticEvent) => {
         e.preventDefault();
-        if (isFavorite) {
-            await unfavorite(id);
-        } else {
-            await favorite(id);
+        try {
+            if (isFavorite) {
+                await unfavorite(id);
+            } else {
+                await favorite(id);
+            }
+            refetch();
+        } catch (error) {
+            setToastApiError('Something went wrong, could not update favorite');
         }
-        refetch();
     };
 
     return (

--- a/frontend/src/hooks/api/actions/useApi/useApi.ts
+++ b/frontend/src/hooks/api/actions/useApi/useApi.ts
@@ -246,6 +246,11 @@ const useAPI = ({
         ): Promise<Response> => {
             try {
                 const res = await apiCaller();
+
+                if (!res.ok) {
+                    throw new Error();
+                }
+
                 return res;
             } catch (e) {
                 throw new Error('Could not make request | makeLightRequest');

--- a/frontend/src/hooks/api/actions/useApi/useApi.ts
+++ b/frontend/src/hooks/api/actions/useApi/useApi.ts
@@ -58,9 +58,8 @@ const timeApiCallEnd = (startTime: number, requestId: string) => {
             requestId,
             duration,
         );
-    } else {
-        console.log('API call took less than 500ms', requestId, duration);
     }
+
     return duration;
 };
 

--- a/frontend/src/hooks/api/actions/useApi/useApi.ts
+++ b/frontend/src/hooks/api/actions/useApi/useApi.ts
@@ -24,6 +24,13 @@ type ApiErrorHandler = (
     requestId: string,
 ) => void;
 
+type ApiCaller = () => Promise<Response>;
+type RequestFunction = (
+    apiCaller: ApiCaller,
+    requestId: string,
+    loadingOn?: boolean,
+) => Promise<Response>;
+
 interface IUseAPI {
     handleBadRequest?: ApiErrorHandler;
     handleNotFound?: ApiErrorHandler;
@@ -180,13 +187,6 @@ const useAPI = ({
             propagateErrors,
         ],
     );
-
-    type ApiCaller = () => Promise<Response>;
-    type RequestFunction = (
-        apiCaller: ApiCaller,
-        requestId: string,
-        loadingOn?: boolean,
-    ) => Promise<Response>;
 
     const requestWithTimer = (requestFunction: RequestFunction) => {
         return async (

--- a/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
+++ b/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
@@ -5,10 +5,9 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import useAPI from '../useApi/useApi';
 
 export const useFavoriteFeaturesApi = () => {
-    const { makeRequest, makeLightRequest, createRequest, errors, loading } =
-        useAPI({
-            propagateErrors: true,
-        });
+    const { makeLightRequest, createRequest, errors, loading } = useAPI({
+        propagateErrors: true,
+    });
     const { setToastData, setToastApiError } = useToast();
     const { trackEvent } = usePlausibleTracker();
 

--- a/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
+++ b/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
@@ -5,9 +5,10 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import useAPI from '../useApi/useApi';
 
 export const useFavoriteFeaturesApi = () => {
-    const { makeRequest, createRequest, errors, loading } = useAPI({
-        propagateErrors: true,
-    });
+    const { makeRequest, makeLightRequest, createRequest, errors, loading } =
+        useAPI({
+            propagateErrors: true,
+        });
     const { setToastData, setToastApiError } = useToast();
     const { trackEvent } = usePlausibleTracker();
 
@@ -21,7 +22,7 @@ export const useFavoriteFeaturesApi = () => {
             );
 
             try {
-                await makeRequest(req.caller, req.id);
+                await makeLightRequest(req.caller, req.id);
 
                 setToastData({
                     title: 'Toggle added to favorites',
@@ -36,7 +37,7 @@ export const useFavoriteFeaturesApi = () => {
                 setToastApiError(formatUnknownError(error));
             }
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     const unfavorite = useCallback(
@@ -49,7 +50,7 @@ export const useFavoriteFeaturesApi = () => {
             );
 
             try {
-                await makeRequest(req.caller, req.id);
+                await makeLightRequest(req.caller, req.id);
 
                 setToastData({
                     title: 'Toggle removed from favorites',
@@ -64,7 +65,7 @@ export const useFavoriteFeaturesApi = () => {
                 setToastApiError(formatUnknownError(error));
             }
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     return {

--- a/frontend/src/hooks/api/actions/useFavoriteProjectsApi/useFavoriteProjectsApi.ts
+++ b/frontend/src/hooks/api/actions/useFavoriteProjectsApi/useFavoriteProjectsApi.ts
@@ -5,7 +5,7 @@ import useAPI from '../useApi/useApi';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 export const useFavoriteProjectsApi = () => {
-    const { makeRequest, createRequest, errors, loading } = useAPI({
+    const { makeLightRequest, createRequest, errors, loading } = useAPI({
         propagateErrors: true,
     });
     const { setToastData, setToastApiError } = useToast();
@@ -21,7 +21,7 @@ export const useFavoriteProjectsApi = () => {
             );
 
             try {
-                await makeRequest(req.caller, req.id);
+                await makeLightRequest(req.caller, req.id);
 
                 setToastData({
                     title: 'Project added to favorites',
@@ -36,7 +36,7 @@ export const useFavoriteProjectsApi = () => {
                 setToastApiError(formatUnknownError(error));
             }
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     const unfavorite = useCallback(
@@ -49,7 +49,7 @@ export const useFavoriteProjectsApi = () => {
             );
 
             try {
-                await makeRequest(req.caller, req.id);
+                await makeLightRequest(req.caller, req.id);
 
                 setToastData({
                     title: 'Project removed from favorites',
@@ -64,7 +64,7 @@ export const useFavoriteProjectsApi = () => {
                 setToastApiError(formatUnknownError(error));
             }
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     return {

--- a/frontend/src/hooks/api/actions/useFeatureApi/useFeatureApi.ts
+++ b/frontend/src/hooks/api/actions/useFeatureApi/useFeatureApi.ts
@@ -7,9 +7,10 @@ import useAPI from '../useApi/useApi';
 import { IFeatureVariant } from 'interfaces/featureToggle';
 
 const useFeatureApi = () => {
-    const { makeRequest, createRequest, errors, loading } = useAPI({
-        propagateErrors: true,
-    });
+    const { makeRequest, makeLightRequest, createRequest, errors, loading } =
+        useAPI({
+            propagateErrors: true,
+        });
 
     const validateFeatureToggleName = async (
         name: string | undefined,
@@ -61,9 +62,9 @@ const useFeatureApi = () => {
                 'toggleFeatureEnvironmentOn',
             );
 
-            return makeRequest(req.caller, req.id);
+            return makeLightRequest(req.caller, req.id);
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     const bulkToggleFeaturesEnvironmentOn = useCallback(
@@ -119,9 +120,9 @@ const useFeatureApi = () => {
                 'toggleFeatureEnvironmentOff',
             );
 
-            return makeRequest(req.caller, req.id);
+            return makeLightRequest(req.caller, req.id);
         },
-        [createRequest, makeRequest],
+        [createRequest, makeLightRequest],
     );
 
     const changeFeatureProject = async (

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -49,7 +49,7 @@ process.nextTick(async () => {
                         playgroundImprovements: true,
                         featureSwitchRefactor: true,
                         featureSearchAPI: true,
-                        featureSearchFrontend: true,
+                        featureSearchFrontend: false,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -49,7 +49,7 @@ process.nextTick(async () => {
                         playgroundImprovements: true,
                         featureSwitchRefactor: true,
                         featureSearchAPI: true,
-                        featureSearchFrontend: false,
+                        featureSearchFrontend: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
This PR reduces the overhead of making API calls on pages with heavy renders. We forego loading states and default error handling in favor of more speed by avoiding triggering multiple re-renders from the API call. 

When the page is heavy on elements, such as when you have lot of environments active on the project overview screen, this will reduce the overhead significantly. In my testing it was reduced from between 900-1900ms to 50-80ms on localhost.

Also added a timer that will time API calls in development and notify you via the console when you have a slow API call.