### PR TITLE
docs: add slack app redirect

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -288,6 +288,10 @@ module.exports = {
                         to: '/reference/integrations/slack',
                     },
                     {
+                        from: ['/addons/slack-app', '/reference/addons/slack-app'],
+                        to: '/reference/integrations/slack-app',
+                    },
+                    {
                         from: ['/addons/teams', '/reference/addons/teams'],
                         to: '/reference/integrations/teams',
                     },
@@ -645,10 +649,10 @@ module.exports = {
                         to: '/using-unleash/deploy/google-auth-hook',
                     },
                     {
-                        from:[  
+                        from:[
                             '/deploy/migration_guide',
                             '/reference/deploy/migration-guide',
-                        ],  
+                        ],
                         to: '/using-unleash/deploy/upgrading-unleash',
                     },
                     {


### PR DESCRIPTION
Adds a redirect rule for the Slack App integration (fix current broken link).