### PR TITLE
chore: add detect segment usage in CRs flag

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -77,6 +77,7 @@ exports[`should create default config 1`] = `
       "customRootRolesKillSwitch": false,
       "demo": false,
       "dependentFeatures": false,
+      "detectSegmentUsageInChangeRequests": false,
       "disableBulkToggle": false,
       "disableEnvsOnRevive": false,
       "disableMetrics": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -36,7 +36,8 @@ export type IFlagKey =
     | 'featureSwitchRefactor'
     | 'featureSearchAPI'
     | 'featureSearchFrontend'
-    | 'scheduledConfigurationChanges';
+    | 'scheduledConfigurationChanges'
+    | 'detectSegmentUsageInChangeRequests';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -170,6 +171,11 @@ const flags: IFlags = {
     ),
     scheduledConfigurationChanges: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_SCHEDULED_CONFIGURATION_CHANGES,
+        false,
+    ),
+    detectSegmentUsageInChangeRequests: parseEnvVarBoolean(
+        process.env
+            .UNLEASH_EXPERIMENTAL_DETECT_SEGMENT_USAGE_IN_CHANGE_REQUESTS,
         false,
     ),
 };


### PR DESCRIPTION
As the title says, this PR adds a flag to unleash for detecting segment usage in CRs.