### PR TITLE
fix: make test for last seen by env not rely on array order

### DIFF
--- a/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
@@ -188,7 +188,7 @@ test('response should include last seen at per environment correctly for a singl
         .get(`/api/admin/projects/default/features/${featureName}`)
         .expect(200);
 
-    expect(body.environments).toMatchObject([
+    const expected = [
         {
             name: 'default',
             lastSeenAt: '2023-08-01T12:30:56.000Z',
@@ -201,5 +201,15 @@ test('response should include last seen at per environment correctly for a singl
             name: 'production',
             lastSeenAt: '2023-08-01T12:30:56.000Z',
         },
-    ]);
+    ];
+
+    const toDict = (lastSeenAtEnvData) =>
+        Object.fromEntries(
+            lastSeenAtEnvData.map((e) => [
+                e.name,
+                { lastSeenAt: e.lastSeenAt },
+            ]),
+        );
+
+    expect(toDict(body.environments)).toMatchObject(toDict(expected));
 });

--- a/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
@@ -205,9 +205,9 @@ test('response should include last seen at per environment correctly for a singl
 
     const toObject = (lastSeenAtEnvData) =>
         Object.fromEntries(
-            lastSeenAtEnvData.map((e) => [
-                e.name,
-                { lastSeenAt: e.lastSeenAt },
+            lastSeenAtEnvData.map((env) => [
+                env.name,
+                { lastSeenAt: env.lastSeenAt },
             ]),
         );
 

--- a/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-last-seen-at.e2e.test.ts
@@ -203,7 +203,7 @@ test('response should include last seen at per environment correctly for a singl
         },
     ];
 
-    const toDict = (lastSeenAtEnvData) =>
+    const toObject = (lastSeenAtEnvData) =>
         Object.fromEntries(
             lastSeenAtEnvData.map((e) => [
                 e.name,
@@ -211,5 +211,5 @@ test('response should include last seen at per environment correctly for a singl
             ]),
         );
 
-    expect(toDict(body.environments)).toMatchObject(toDict(expected));
+    expect(toObject(body.environments)).toMatchObject(toObject(expected));
 });


### PR DESCRIPTION
This test was flaky because it relied on the order of the array
returned. To make it less flaky, we now turn the array into an object
instead and compare that.