### PR TITLE
fix: segment project fetch when global

### DIFF
--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -3,7 +3,6 @@ import {
     DELETE_FEATURE,
     ADMIN,
     UPDATE_FEATURE,
-    DELETE_SEGMENT,
     UPDATE_PROJECT_SEGMENT,
 } from '../types/permissions';
 import { IUnleashConfig } from '../types/option';
@@ -96,7 +95,8 @@ const rbacMiddleware = (
             // This is needed to check if the user has the right permissions on a project level
             if (
                 !projectId &&
-                permissionsArray.includes(UPDATE_PROJECT_SEGMENT)
+                permissionsArray.includes(UPDATE_PROJECT_SEGMENT) &&
+                params.id
             ) {
                 const { id } = params;
                 const { project } = await segmentStore.get(id);


### PR DESCRIPTION
This fixes an edge case not caught originally in https://github.com/Unleash/unleash/pull/5304 - When creating a new segment on the global level:
 - There is no `projectId`, either in the params or body
 - The `UPDATE_PROJECT_SEGMENT` is still a part of the permissions checked on the endpoint
 - There is no `id` on the params

This made it so that we would run `segmentStore.get(id)` with an undefined `id`, causing issues.

The fix was simply checking for the presence of `params.id` before proceeding.