### PR TITLE
fix: project settings flag limit not properly set

### DIFF
--- a/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
+++ b/frontend/src/component/project/Project/ProjectForm/ProjectForm.tsx
@@ -184,8 +184,8 @@ const ProjectForm: React.FC<IProjectForm> = ({
                 }
             />
             <ConditionallyRender
-                condition={mode === 'Edit' && Boolean(setFeatureLimit)}
-                show={
+                condition={mode === 'Edit'}
+                show={() => (
                     <>
                         <Box
                             sx={{
@@ -202,17 +202,15 @@ const ProjectForm: React.FC<IProjectForm> = ({
                             Leave it empty if you don’t want to add a limit
                         </StyledSubtitle>
                         <StyledInputContainer>
-                            {featureLimit && setFeatureLimit && (
-                                <StyledInput
-                                    label={'Limit'}
-                                    name='value'
-                                    type={'number'}
-                                    value={featureLimit}
-                                    onChange={(e) =>
-                                        setFeatureLimit(e.target.value)
-                                    }
-                                />
-                            )}
+                            <StyledInput
+                                label={'Limit'}
+                                name='value'
+                                type={'number'}
+                                value={featureLimit!}
+                                onChange={(e) =>
+                                    setFeatureLimit!(e.target.value)
+                                }
+                            />
                             <ConditionallyRender
                                 condition={
                                     featureCount !== undefined &&
@@ -226,7 +224,7 @@ const ProjectForm: React.FC<IProjectForm> = ({
                             />
                         </StyledInputContainer>
                     </>
-                }
+                )}
             />
             <ConditionallyRender
                 condition={mode === 'Create' && isEnterprise()}

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -82,7 +82,7 @@ const useProjectForm = (
 
     const getFeatureLimitAsNumber = () => {
         if (featureLimit === '') {
-            return undefined;
+            return null;
         }
         return Number(featureLimit);
     };

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -267,20 +267,25 @@ class ProjectStore implements IProjectStore {
                 .where({ id: data.id })
                 .update(this.fieldToRow(data));
 
-            if (await this.hasProjectSettings(data.id)) {
-                await this.db(SETTINGS_TABLE)
-                    .where({ project: data.id })
-                    .update({
+            if (
+                data.defaultStickiness !== undefined ||
+                data.featureLimit !== undefined
+            ) {
+                if (await this.hasProjectSettings(data.id)) {
+                    await this.db(SETTINGS_TABLE)
+                        .where({ project: data.id })
+                        .update({
+                            default_stickiness: data.defaultStickiness,
+                            feature_limit: data.featureLimit,
+                        });
+                } else {
+                    await this.db(SETTINGS_TABLE).insert({
+                        project: data.id,
                         default_stickiness: data.defaultStickiness,
                         feature_limit: data.featureLimit,
+                        project_mode: 'open',
                     });
-            } else {
-                await this.db(SETTINGS_TABLE).insert({
-                    project: data.id,
-                    default_stickiness: data.defaultStickiness,
-                    feature_limit: data.featureLimit,
-                    project_mode: 'open',
-                });
+                }
             }
         } catch (err) {
             this.logger.error('Could not update project, error: ', err);

--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -271,14 +271,14 @@ class ProjectStore implements IProjectStore {
                 await this.db(SETTINGS_TABLE)
                     .where({ project: data.id })
                     .update({
-                        default_stickiness: data.defaultStickiness || null,
-                        feature_limit: data.featureLimit || null,
+                        default_stickiness: data.defaultStickiness,
+                        feature_limit: data.featureLimit,
                     });
             } else {
                 await this.db(SETTINGS_TABLE).insert({
                     project: data.id,
-                    default_stickiness: data.defaultStickiness || null,
-                    feature_limit: data.featureLimit || null,
+                    default_stickiness: data.defaultStickiness,
+                    feature_limit: data.featureLimit,
                     project_mode: 'open',
                 });
             }


### PR DESCRIPTION
https://linear.app/unleash/issue/SR-169/ticket-1107-project-feature-flag-limit-is-not-correctly-updated

Fixes #5315, an issue where it would not be possible to set an empty flag limit. 
This also fixes the UI behavior: Before, when the flag limit field was emptied, it would disappear from the UI.

I'm a bit unsure of the original intent of the `(data.defaultStickiness !== undefined || data.featureLimit !== undefined)` condition. We're in an update method, triggered by a PUT endpoint - I think it's safe to assume that we'll always want to set these values to whatever they come as, we just need to convert them to `null` in case they are not present (i.e. `undefined`).