### PR TITLE
docs: POST and PUT body handling

### DIFF
--- a/website/docs/contributing/ADRs/ADRs.md
+++ b/website/docs/contributing/ADRs/ADRs.md
@@ -23,7 +23,7 @@ We are in the process of defining ADRs for the back end. At the time of writing 
 * [Naming](./back-end/naming.md)
 * [Preferred export](./back-end/preferred-export.md)
 * [Breaking DB changes](./back-end/breaking-db-changes.md)
-* [Preferred export](./back-end/POST-PUT-api-payload.md)
+* [POST/PUT API payload](./back-end/POST-PUT-api-payload.md)
 
 ## Front-end ADRs
 

--- a/website/docs/contributing/ADRs/ADRs.md
+++ b/website/docs/contributing/ADRs/ADRs.md
@@ -22,6 +22,8 @@ We are in the process of defining ADRs for the back end. At the time of writing 
 
 * [Naming](./back-end/naming.md)
 * [Preferred export](./back-end/preferred-export.md)
+* [Preferred export](./back-end/breaking-db-changes.md)
+* [Preferred export](./back-end/POST-PUT-api-payload.md)
 
 ## Front-end ADRs
 

--- a/website/docs/contributing/ADRs/ADRs.md
+++ b/website/docs/contributing/ADRs/ADRs.md
@@ -22,7 +22,7 @@ We are in the process of defining ADRs for the back end. At the time of writing 
 
 * [Naming](./back-end/naming.md)
 * [Preferred export](./back-end/preferred-export.md)
-* [Preferred export](./back-end/breaking-db-changes.md)
+* [Breaking DB changes](./back-end/breaking-db-changes.md)
 * [Preferred export](./back-end/POST-PUT-api-payload.md)
 
 ## Front-end ADRs

--- a/website/docs/contributing/ADRs/back-end/POST-PUT-api-payload.md
+++ b/website/docs/contributing/ADRs/back-end/POST-PUT-api-payload.md
@@ -6,7 +6,7 @@ title: "ADR: POST/PUT API payload"
 
 Whenever we receive a payload in our backend for POST or PUT request we need to take into account backward compatibility. When we add a new field to an existing API payload, clients using the previous version of the payload will not know about that new field. This means that we need to make sure that the new field is optional. If we make the field required, clients using the previous version of the payload will result in overriding the value of the new field with an empty value or null.
 
-### Example: adding new settings to project settings
+### Example: adding new setting field to project settings
 
 Project settings on unleash 5.3:
 ```shell
@@ -37,7 +37,9 @@ curl --location --request PUT 'http://localhost:4242/api/admin/projects/default'
 }'
 ```
 
-Pay attention to the new field feature limit. If a customer updates their server to 5.6 but their integration still does not send that field. If we treat that field as null then our API will override the value of the new field with an empty value.
+Pay attention to the new field feature limit. If a customer updates their server to 5.6 but their integration still does not send that field, it may result in the unwanted behavior of setting that field to empty in the database (in case the server assumes that not sending the field is tring to set it to empty).
+
+This bug can easily be an oversight but can be prevented by following some rules when designing the API payload.
 
 ## Decision
 

--- a/website/docs/contributing/ADRs/back-end/POST-PUT-api-payload.md
+++ b/website/docs/contributing/ADRs/back-end/POST-PUT-api-payload.md
@@ -4,11 +4,11 @@ title: "ADR: POST/PUT API payload"
 
 ## Background
 
-Whenever we receive a payload in our backend for POST or PUT request we need to take into account backward compatibility. When we add a new field to an existing API payload, clients using the previous version of the payload will not know about that new field. This means that we need to make sure that the new field is optional. If we make the field required, clients using the previous version of the payload will result in overriding the value of the new field with an empty value or null.
+Whenever we receive a payload in our backend for POST or PUT requests we need to take into account backwards compatibility. When we add a new field to an existing API payload, clients using the previous version of the payload will not know about that new field. This means that we need to make sure that the new field is optional. If we make the field required, clients using the previous version of the payload will override the value of the new field with an empty value or null.
 
 ### Example: adding new setting field to project settings
 
-Project settings on unleash 5.3:
+Project settings on Unleash 5.3:
 ```shell
 curl --location --request PUT 'http://localhost:4242/api/admin/projects/default' \
 --header 'Authorization: INSERT_API_KEY' \
@@ -22,7 +22,7 @@ curl --location --request PUT 'http://localhost:4242/api/admin/projects/default'
 }'
 ```
 
-New version of project settings (unleash 5.6):
+New version of project settings (Unleash 5.6):
 
 ```shell
 curl --location --request PUT 'http://localhost:4242/api/admin/projects/default' \
@@ -37,7 +37,7 @@ curl --location --request PUT 'http://localhost:4242/api/admin/projects/default'
 }'
 ```
 
-Pay attention to the new field feature limit. If a customer updates their server to 5.6 but their integration still does not send that field, it may result in the unwanted behavior of setting that field to empty in the database (in case the server assumes that not sending the field is tring to set it to empty).
+Pay attention to the new field feature limit. If a customer updates Unleash to 5.6 but their integration still does not send that field, it may result in the unwanted behavior of setting that field to empty in the database, in case the server assumes that not sending the field means setting it to empty / `null`.
 
 This bug can easily be an oversight but can be prevented by following some rules when designing the API payload.
 
@@ -48,4 +48,6 @@ When receiving a body from a request we need to take into account 3 possible cas
 2. The field is `undefined` or not part of the payload
 3. The field is `null`
 
-In case the field has a value, we need to update or set that value in the DB. In case the field is `undefined` or not part of the payload, we need to leave the value in the DB as it is. In case, the field is `null`, we need to remove the value from the DB.
+- If the field has a value, we need to update or set that value in the DB.
+- If the field is `undefined` or not part of the payload, we need to leave the value in the DB as it is.
+- If the field is `null`, we need to remove the value from the DB (set it as `null` on the DB).


### PR DESCRIPTION
## About the changes
While working on Terraform I identified some issues with how our backend handled some requests. This happened because the Terraform client was unaware of new fields and was not sending them. This resulted in bad behavior as some of those missing fields were treated in the backend as `null` and removed existing data from the DB.

This ADR aims to shed some light on the problem and specifies how our server should handle these requests.