### PR TITLE
Feat/pagination preload

### DIFF
--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -81,6 +81,7 @@ export const Search = ({
     containerStyles,
     expandable = false,
     debounceTime = 200,
+    ...rest
 }: ISearchProps) => {
     const searchInputRef = useRef<HTMLInputElement>(null);
     const searchContainerRef = useRef<HTMLInputElement>(null);
@@ -126,6 +127,7 @@ export const Search = ({
             ref={searchContainerRef}
             style={containerStyles}
             active={expandable && showSuggestions}
+            {...rest}
         >
             <StyledSearch className={className}>
                 <SearchIcon

--- a/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeader.tsx
+++ b/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeader.tsx
@@ -13,7 +13,7 @@ export const SortableTableHeader = <T extends object>({
 }) => (
     <TableHead className={className}>
         {headerGroups.map((headerGroup) => (
-            <TableRow {...headerGroup.getHeaderGroupProps()}>
+            <TableRow {...headerGroup.getHeaderGroupProps()} data-loading>
                 {headerGroup.headers.map((column: HeaderGroup<T>) => {
                     const content = column.render('Header');
 

--- a/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell.tsx
@@ -8,6 +8,7 @@ interface IFeatureSeenCellProps {
 
 export const FeatureEnvironmentSeenCell: VFC<IFeatureSeenCellProps> = ({
     feature,
+    ...rest
 }) => {
     const environments = feature.environments
         ? Object.values(feature.environments)
@@ -17,6 +18,7 @@ export const FeatureEnvironmentSeenCell: VFC<IFeatureSeenCellProps> = ({
         <FeatureEnvironmentSeen
             featureLastSeen={feature.lastSeenAt}
             environments={environments}
+            {...rest}
         />
     );
 };

--- a/frontend/src/component/common/Table/cells/FeatureSeenCell/LastSeenTooltip.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureSeenCell/LastSeenTooltip.tsx
@@ -72,7 +72,7 @@ export const LastSeenTooltip = ({
         Boolean(environment.lastSeenAt),
     );
     return (
-        <StyledDescription {...rest}>
+        <StyledDescription {...rest} data-loading>
             <StyledDescriptionHeader sx={{ mb: 0 }}>
                 Last usage reported
             </StyledDescriptionHeader>

--- a/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
@@ -74,13 +74,14 @@ export const FeatureEnvironmentSeen = ({
     featureLastSeen,
     environments,
     sx,
+    ...rest
 }: IFeatureEnvironmentSeenProps) => {
     const getColor = useLastSeenColors();
 
     const lastSeen = getLatestLastSeenAt(environments) || featureLastSeen;
 
     return (
-        <>
+        <div>
             {lastSeen ? (
                 <TimeAgo
                     date={lastSeen}
@@ -95,6 +96,7 @@ export const FeatureEnvironmentSeen = ({
                                     <LastSeenTooltip
                                         featureLastSeen={lastSeen}
                                         environments={environments}
+                                        {...rest}
                                     />
                                 }
                                 color={color}
@@ -112,6 +114,6 @@ export const FeatureEnvironmentSeen = ({
                     <UsageLine />
                 </TooltipContainer>
             )}
-        </>
+        </div>
     );
 };

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -228,6 +228,7 @@ export const Project = () => {
                         {filteredTabs.map((tab) => {
                             return (
                                 <StyledTab
+                                    data-loading
                                     key={tab.title}
                                     label={tab.title}
                                     value={tab.path}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -87,7 +87,7 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
     };
 
     return (
-        <StyledBoxCell>
+        <StyledBoxCell data-loading>
             <Tooltip title='Feature toggle actions' arrow describeChild>
                 <IconButton
                     id={id}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell.tsx
@@ -20,7 +20,7 @@ export const RowSelectCell: FC<IRowSelectCellProps> = ({
     checked,
     title,
 }) => (
-    <StyledBoxCell data-testid={BATCH_SELECT}>
+    <StyledBoxCell data-testid={BATCH_SELECT} data-loading>
         <Checkbox onChange={onChange} title={title} checked={checked} />
     </StyledBoxCell>
 );

--- a/frontend/src/component/project/Project/ProjectInfo/HealthWidget.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/HealthWidget.tsx
@@ -40,7 +40,7 @@ export const HealthWidget = ({ projectId, health }: IHealthWidgetProps) => {
                     gap: (theme) => theme.spacing(2),
                 }}
             >
-                <StyledPercentageText>
+                <StyledPercentageText data-loading>
                     <PercentageCircle percentage={health} />
                 </StyledPercentageText>
                 <StyledParagraphEmphasizedText data-loading>

--- a/frontend/src/component/project/Project/ProjectInfo/MetaWidget.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/MetaWidget.tsx
@@ -24,8 +24,8 @@ const StyledIDContainer = styled('div')(({ theme }) => ({
 export const MetaWidget: FC<IMetaWidgetProps> = ({ id, description }) => {
     return (
         <StyledProjectInfoWidgetContainer>
-            <StyledWidgetTitle>Project Meta</StyledWidgetTitle>
-            <StyledIDContainer>
+            <StyledWidgetTitle data-loading>Project Meta</StyledWidgetTitle>
+            <StyledIDContainer data-loading>
                 <Typography
                     component='span'
                     variant='body2'
@@ -39,6 +39,7 @@ export const MetaWidget: FC<IMetaWidgetProps> = ({ id, description }) => {
                 condition={Boolean(description)}
                 show={
                     <Typography
+                        data-loading
                         variant='body2'
                         sx={{
                             marginTop: (theme) => theme.spacing(1.5),

--- a/frontend/src/component/project/Project/ProjectInfo/ProjectMembersWidget.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/ProjectMembersWidget.tsx
@@ -30,6 +30,7 @@ export const ProjectMembersWidget = ({
         <StyledProjectInfoWidgetContainer>
             <StyledWidgetTitle data-loading>Project members</StyledWidgetTitle>
             <Box
+                data-loading
                 sx={{
                     display: 'flex',
                     justifyContent: 'center',
@@ -37,7 +38,9 @@ export const ProjectMembersWidget = ({
             >
                 <StatusBox boxText={`${memberCount}`} change={change} />
             </Box>
-            <WidgetFooterLink to={link}>View all members</WidgetFooterLink>
+            <WidgetFooterLink data-loading to={link}>
+                View all members
+            </WidgetFooterLink>
         </StyledProjectInfoWidgetContainer>
     );
 };

--- a/frontend/src/component/project/Project/ProjectInfo/ToggleTypesWidget.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/ToggleTypesWidget.tsx
@@ -84,7 +84,9 @@ export const ToggleTypesWidget = ({ features }: IToggleTypesWidgetProps) => {
         <StyledProjectInfoWidgetContainer
             sx={{ padding: (theme) => theme.spacing(3) }}
         >
-            <StyledWidgetTitle>Toggle types used</StyledWidgetTitle>
+            <StyledWidgetTitle data-loading>
+                Toggle types used
+            </StyledWidgetTitle>
             {Object.keys(featureTypeStats).map((type) => (
                 <ToggleTypesRow
                     type={type}

--- a/frontend/src/component/project/Project/ProjectInfo/WidgetFooterLink.tsx
+++ b/frontend/src/component/project/Project/ProjectInfo/WidgetFooterLink.tsx
@@ -12,6 +12,7 @@ export const WidgetFooterLink: FC<IWidgetFooterLinkProps> = ({
 }) => {
     return (
         <Typography
+            data-loading
             variant='body2'
             textAlign='center'
             sx={{

--- a/frontend/src/component/project/Project/ProjectOverview.tsx
+++ b/frontend/src/component/project/Project/ProjectOverview.tsx
@@ -45,7 +45,7 @@ const PaginatedProjectOverview = () => {
     const { project, loading: projectLoading } = useProject(projectId, {
         refreshInterval,
     });
-    const [pageLimit, setPageLimit] = useState(10);
+    const [pageLimit, setPageLimit] = useState(25);
     const [currentOffset, setCurrentOffset] = useState(0);
 
     const [searchValue, setSearchValue] = useState(

--- a/frontend/src/component/project/Project/ProjectOverview.tsx
+++ b/frontend/src/component/project/Project/ProjectOverview.tsx
@@ -57,6 +57,7 @@ const PaginatedProjectOverview = () => {
         total,
         refetch,
         loading,
+        initialLoad,
     } = useFeatureSearch(currentOffset, pageLimit, projectId, searchValue, {
         refreshInterval,
     });
@@ -96,6 +97,7 @@ const PaginatedProjectOverview = () => {
                         }
                         features={searchFeatures}
                         environments={environments}
+                        initialLoad={initialLoad && searchFeatures.length === 0}
                         loading={loading && searchFeatures.length === 0}
                         onChange={refetch}
                         total={total}
@@ -128,7 +130,7 @@ const StyledStickyBar = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2),
     marginLeft: theme.spacing(2),
-    zIndex: theme.zIndex.mobileStepper,
+    zIndex: 9999,
     borderBottomLeftRadius: theme.shape.borderRadiusMedium,
     borderBottomRightRadius: theme.shape.borderRadiusMedium,
     borderTop: `1px solid ${theme.palette.divider}`,

--- a/frontend/src/component/project/Project/ProjectStats/StatusBox.tsx
+++ b/frontend/src/component/project/Project/ProjectStats/StatusBox.tsx
@@ -65,7 +65,11 @@ export const StatusBox: FC<IStatusBoxProps> = ({
     <>
         <ConditionallyRender
             condition={Boolean(title)}
-            show={<StyledTypographyHeader>{title}</StyledTypographyHeader>}
+            show={
+                <StyledTypographyHeader data-loading>
+                    {title}
+                </StyledTypographyHeader>
+            }
         />
         {children}
         <Box
@@ -75,11 +79,13 @@ export const StatusBox: FC<IStatusBoxProps> = ({
                 width: 'auto',
             }}
         >
-            <StyledTypographyCount>{boxText}</StyledTypographyCount>
+            <StyledTypographyCount data-loading>
+                {boxText}
+            </StyledTypographyCount>
             <ConditionallyRender
                 condition={Boolean(customChangeElement)}
                 show={
-                    <StyledBoxChangeContainer>
+                    <StyledBoxChangeContainer data-loading>
                         {customChangeElement}
                     </StyledBoxChangeContainer>
                 }
@@ -87,7 +93,7 @@ export const StatusBox: FC<IStatusBoxProps> = ({
                     <ConditionallyRender
                         condition={change !== undefined && change !== 0}
                         show={
-                            <StyledBoxChangeContainer>
+                            <StyledBoxChangeContainer data-loading>
                                 <Box
                                     sx={{
                                         ...flexRow,
@@ -109,7 +115,7 @@ export const StatusBox: FC<IStatusBoxProps> = ({
                         }
                         elseShow={
                             <StyledBoxChangeContainer>
-                                <StyledTypographySubtext>
+                                <StyledTypographySubtext data-loading>
                                     No change
                                 </StyledTypographySubtext>
                             </StyledBoxChangeContainer>

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
@@ -26,37 +26,48 @@ const fallbackData: {
     total: 0,
 };
 
-export const useFeatureSearch = (
-    offset: number,
-    limit: number,
-    projectId = '',
-    searchValue = '',
-    options: SWRConfiguration = {},
-): IUseFeatureSearchOutput => {
-    const { KEY, fetcher } = getFeatureSearchFetcher(
-        projectId,
-        offset,
-        limit,
-        searchValue,
-    );
-    const { data, error, mutate } = useSWR<IFeatureSearchResponse>(
-        KEY,
-        fetcher,
-        options,
-    );
+const createFeatureSearch = () => {
+    let total = 0;
 
-    const refetch = useCallback(() => {
-        mutate();
-    }, [mutate]);
+    return (
+        offset: number,
+        limit: number,
+        projectId = '',
+        searchValue = '',
+        options: SWRConfiguration = {},
+    ): IUseFeatureSearchOutput => {
+        const { KEY, fetcher } = getFeatureSearchFetcher(
+            projectId,
+            offset,
+            limit,
+            searchValue,
+        );
+        const { data, error, mutate } = useSWR<IFeatureSearchResponse>(
+            KEY,
+            fetcher,
+            options,
+        );
 
-    const returnData = data || fallbackData;
-    return {
-        ...returnData,
-        loading: false,
-        error,
-        refetch,
+        const refetch = useCallback(() => {
+            mutate();
+        }, [mutate]);
+
+        if (data?.total) {
+            total = data.total;
+        }
+
+        const returnData = data || fallbackData;
+        return {
+            ...returnData,
+            loading: false,
+            error,
+            refetch,
+            total,
+        };
     };
 };
+
+export const useFeatureSearch = createFeatureSearch();
 
 const getFeatureSearchFetcher = (
     projectId: string,

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
@@ -14,6 +14,7 @@ interface IUseFeatureSearchOutput {
     features: IFeatureToggleListItem[];
     total: number;
     loading: boolean;
+    initialLoad: boolean;
     error: string;
     refetch: () => void;
 }
@@ -28,6 +29,7 @@ const fallbackData: {
 
 const createFeatureSearch = () => {
     let total = 0;
+    let initialLoad = true;
 
     return (
         offset: number,
@@ -42,11 +44,8 @@ const createFeatureSearch = () => {
             limit,
             searchValue,
         );
-        const { data, error, mutate } = useSWR<IFeatureSearchResponse>(
-            KEY,
-            fetcher,
-            options,
-        );
+        const { data, error, mutate, isLoading } =
+            useSWR<IFeatureSearchResponse>(KEY, fetcher, options);
 
         const refetch = useCallback(() => {
             mutate();
@@ -56,13 +55,18 @@ const createFeatureSearch = () => {
             total = data.total;
         }
 
+        if (!isLoading && initialLoad) {
+            initialLoad = false;
+        }
+
         const returnData = data || fallbackData;
         return {
             ...returnData,
-            loading: false,
+            loading: isLoading,
             error,
             refetch,
             total,
+            initialLoad: isLoading && initialLoad,
         };
     };
 };

--- a/frontend/src/themes/app.css
+++ b/frontend/src/themes/app.css
@@ -36,7 +36,7 @@ button {
 .skeleton {
     position: relative;
     overflow: hidden;
-    z-index: 9999;
+    z-index: 9990;
     box-shadow: none;
     fill: none;
     pointer-events: none;


### PR DESCRIPTION
This PR makes changes to how the project overview skeleton screen works. Important changes:

- Add skeleton screens to missing elements, creating a more comprehensive loading screen
- Split the page into different loading sections, so that we can load the table when we fetch the next page without affecting the rest of the page.

https://www.loom.com/share/e5d30dc897ac488ea80cfae11ffab646

Next steps:
* Hide bar if total is less than 25
* Add FE testing