### PR TITLE
feat: include segment usage in CRs when showing usage in projects and flags

### DIFF
--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -34,3 +34,182 @@ describe('unexpected input handling for get segment', () => {
         }
     });
 });
+
+describe('usage counting', () => {
+    let user;
+    beforeAll(async () => {
+        user = await db.stores.userStore.insert({
+            username: 'test',
+        });
+    });
+
+    afterEach(async () => {
+        await db.stores.featureToggleStore.deleteAll();
+        await db.rawDatabase.table('change_requests').delete();
+    });
+
+    test('segment usage in active CRs is also counted', async () => {
+        const CR_ID = 54321;
+
+        const flag1 = await db.stores.featureToggleStore.create('default', {
+            name: 'test',
+        });
+
+        const flag2 = await db.stores.featureToggleStore.create('default', {
+            name: 'test2',
+        });
+
+        const segment = await segmentStore.create(
+            {
+                name: 'cr-segment',
+                constraints: [],
+                createdAt: new Date(),
+            },
+            user,
+        );
+
+        await db.rawDatabase.table('change_requests').insert({
+            id: CR_ID,
+            environment: 'default',
+            state: 'In Review',
+            project: 'default',
+            created_by: user.id,
+            created_at: '2023-01-01 00:00:00',
+            min_approvals: 1,
+            title: 'My change request',
+        });
+
+        await db.rawDatabase.table('change_request_events').insert({
+            feature: flag1.name,
+            action: 'addStrategy',
+            payload: {
+                name: 'flexibleRollout',
+                title: '',
+                disabled: false,
+                segments: [segment.id],
+                variants: [],
+                parameters: {
+                    groupId: flag1.name,
+                    rollout: '100',
+                    stickiness: 'default',
+                },
+                constraints: [],
+            },
+            created_at: '2023-01-01 00:01:00',
+            change_request_id: CR_ID,
+            created_by: user.id,
+        });
+
+        await db.rawDatabase.table('change_request_events').insert({
+            feature: flag2.name,
+            action: 'updateStrategy',
+            payload: {
+                strategyId: 'not-a-real-strategy-id',
+                name: 'flexibleRollout',
+                title: '',
+                disabled: false,
+                segments: [segment.id],
+                variants: [],
+                parameters: {
+                    groupId: flag2.name,
+                    rollout: '100',
+                    stickiness: 'default',
+                },
+                constraints: [],
+            },
+            created_at: '2023-01-01 00:01:00',
+            change_request_id: CR_ID,
+            created_by: user.id,
+        });
+
+        const [storedSegment] = await segmentStore.getAll();
+
+        console.log('segments', segment);
+
+        expect(storedSegment.usedInFeatures).toBe(2);
+        expect(storedSegment.usedInProjects).toBe(1);
+    });
+
+    test('Segment usage is only counted once per strategy', async () => {
+        // if the segment is used in a strategy, but there is also a change request updateStrategy event for the same strategy, it should only be counted once.
+        // Because updateStrategy events contain all existing segments, as well as any potentially newly added segments, we need to control for that.
+
+        const CR_ID = 54321;
+
+        const flag = await db.stores.featureToggleStore.create('default', {
+            name: 'test',
+        });
+
+        const segment1 = await segmentStore.create(
+            {
+                name: 'cr-segment',
+                constraints: [],
+                createdAt: new Date(),
+            },
+            user,
+        );
+
+        const segment2 = await segmentStore.create(
+            {
+                name: 'cr-segment-2',
+                constraints: [],
+                createdAt: new Date(),
+            },
+            user,
+        );
+
+        console.log(Object.keys(stores));
+
+        const strategy =
+            await stores.featureToggleStrategiesStore.createStrategyFeatureEnv({
+                featureName: flag.name,
+                projectId: 'default',
+                environment: 'default',
+                strategyName: 'flexibleRollout',
+                segments: [segment1.id],
+                parameters: {
+                    groupId: flag.name,
+                    rollout: '100',
+                    stickiness: 'default',
+                },
+            });
+
+        await db.rawDatabase.table('change_requests').insert({
+            id: CR_ID,
+            environment: 'default',
+            state: 'In Review',
+            project: 'default',
+            created_by: user.id,
+            created_at: '2023-01-01 00:00:00',
+            min_approvals: 1,
+            title: 'My change request',
+        });
+
+        await db.rawDatabase.table('change_request_events').insert({
+            feature: flag.name,
+            action: 'updateStrategy',
+            payload: {
+                strategyId: 'not-a-real-strategy-id',
+                name: 'flexibleRollout',
+                title: '',
+                disabled: false,
+                segments: [segment2.id],
+                variants: [],
+                parameters: {
+                    groupId: flag.name,
+                    rollout: '100',
+                    stickiness: 'default',
+                },
+                constraints: [],
+            },
+            created_at: '2023-01-01 00:01:00',
+            change_request_id: CR_ID,
+            created_by: user.id,
+        });
+
+        const [storedSegment] = await segmentStore.getAll();
+
+        expect(storedSegment.usedInFeatures).toBe(2);
+        expect(storedSegment.usedInProjects).toBe(1);
+    });
+});

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -8,7 +8,13 @@ let db;
 let segmentStore: ISegmentStore;
 
 beforeAll(async () => {
-    db = await dbInit('segment_store_serial', getLogger);
+    db = await dbInit('segment_store_serial', getLogger, {
+        experimental: {
+            flags: {
+                detectSegmentUsageInChangeRequests: true,
+            },
+        },
+    });
     stores = db.stores;
     segmentStore = stores.segmentStore;
 });

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -188,7 +188,6 @@ export default class SegmentStore implements ISegmentStore {
                         };
                     }
                 },
-                combinedUsageData,
             );
 
             const rows: ISegmentRow[] = await this.db

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -142,15 +142,20 @@ export default class SegmentStore implements ISegmentStore {
             const combinedUsageData = crFeatures.reduce((acc, segmentEvent) => {
                 const { payload, changeRequestId, feature } = segmentEvent;
                 const project = changeRequestToProjectMap[changeRequestId];
+
                 for (const segmentId of payload.segments) {
-                    acc[segmentId] = {
-                        features: acc[segmentId]?.features
-                            ? acc[segmentId].features.add(feature)
-                            : new Set([feature]),
-                        projects: acc[segmentId]?.projects
-                            ? acc[segmentId].projects.add(project)
-                            : new Set([project]),
-                    };
+                    const existingData = acc[segmentId];
+                    if (existingData) {
+                        acc[segmentId] = {
+                            features: existingData.features.add(feature),
+                            projects: existingData.projects.add(project),
+                        };
+                    } else {
+                        acc[segmentId] = {
+                            features: new Set([feature]),
+                            projects: new Set([project]),
+                        };
+                    }
                 }
                 return acc;
             }, {});

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -198,9 +198,7 @@ export default class SegmentStore implements ISegmentStore {
                 .orderBy('name', 'asc');
 
             const rowsWithUsageData: ISegmentRow[] = rows.map((row) => {
-                const { id } = row;
-
-                const usageData = combinedUsageData[id];
+                const usageData = combinedUsageData[row.id];
                 if (usageData) {
                     return {
                         ...row,

--- a/src/lib/openapi/spec/admin-segment-schema.ts
+++ b/src/lib/openapi/spec/admin-segment-schema.ts
@@ -37,14 +37,16 @@ export const adminSegmentSchema = {
         usedInFeatures: {
             type: 'integer',
             minimum: 0,
-            description: 'The number of projects that use this segment',
+            description:
+                'The number of feature flags that use this segment. The number also includes the any flags with pending change requests that would add this segment.',
             example: 3,
             nullable: true,
         },
         usedInProjects: {
             type: 'integer',
             minimum: 0,
-            description: 'The number of projects that use this segment',
+            description:
+                'The number of projects that use this segment. The number includes any projects with pending change requests that would add this segment.',
             example: 2,
             nullable: true,
         },

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -459,21 +459,32 @@ test('Should anonymise createdBy field if anonymiseEventLog flag is set', async 
     expect(segments[0].createdBy).toContain('unleash.run');
 });
 
-test('Should show usage in features and projects', async () => {
-    await createSegment({ name: 'a', constraints: [] });
-    const toggle = mockFeatureToggle();
-    await createFeatureToggle(app, toggle);
-    const [segment] = await fetchSegments();
-    await addStrategyToFeatureEnv(
-        app,
-        { ...toggle.strategies[0] },
-        'default',
-        toggle.name,
-    );
-    const [feature] = await fetchFeatures();
-    //@ts-ignore
-    await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
+describe('Usage stats', () => {
+    test('Should show usage in features and projects', async () => {
+        await createSegment({ name: 'a', constraints: [] });
+        const toggle = mockFeatureToggle();
+        await createFeatureToggle(app, toggle);
+        const [segment] = await fetchSegments();
+        await addStrategyToFeatureEnv(
+            app,
+            { ...toggle.strategies[0] },
+            'default',
+            toggle.name,
+        );
+        const [feature] = await fetchFeatures();
+        //@ts-ignore
+        await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
 
-    const segments = await fetchSegments();
-    expect(segments).toMatchObject([{ usedInFeatures: 1, usedInProjects: 1 }]);
+        const segments = await fetchSegments();
+        expect(segments).toMatchObject([
+            { usedInFeatures: 1, usedInProjects: 1 },
+        ]);
+    });
+
+    test('segment usage in active CRs is also counted', async () => {});
+
+    test('Segment usage is only counted once per strategy', async () => {
+        // if the segment is used in a strategy, but there is also a change request updateStrategy event for the same strategy, it should only be counted once.
+        // Because updateStrategy events contain all existing segments, as well as any potentially newly added segments, we need to control for that.
+    });
 });

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -459,32 +459,21 @@ test('Should anonymise createdBy field if anonymiseEventLog flag is set', async 
     expect(segments[0].createdBy).toContain('unleash.run');
 });
 
-describe('Usage stats', () => {
-    test('Should show usage in features and projects', async () => {
-        await createSegment({ name: 'a', constraints: [] });
-        const toggle = mockFeatureToggle();
-        await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
-        await addStrategyToFeatureEnv(
-            app,
-            { ...toggle.strategies[0] },
-            'default',
-            toggle.name,
-        );
-        const [feature] = await fetchFeatures();
-        //@ts-ignore
-        await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
+test('Should show usage in features and projects', async () => {
+    await createSegment({ name: 'a', constraints: [] });
+    const toggle = mockFeatureToggle();
+    await createFeatureToggle(app, toggle);
+    const [segment] = await fetchSegments();
+    await addStrategyToFeatureEnv(
+        app,
+        { ...toggle.strategies[0] },
+        'default',
+        toggle.name,
+    );
+    const [feature] = await fetchFeatures();
+    //@ts-ignore
+    await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
 
-        const segments = await fetchSegments();
-        expect(segments).toMatchObject([
-            { usedInFeatures: 1, usedInProjects: 1 },
-        ]);
-    });
-
-    test('segment usage in active CRs is also counted', async () => {});
-
-    test('Segment usage is only counted once per strategy', async () => {
-        // if the segment is used in a strategy, but there is also a change request updateStrategy event for the same strategy, it should only be counted once.
-        // Because updateStrategy events contain all existing segments, as well as any potentially newly added segments, we need to control for that.
-    });
+    const segments = await fetchSegments();
+    expect(segments).toMatchObject([{ usedInFeatures: 1, usedInProjects: 1 }]);
 });

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -183,7 +183,17 @@ const createTestSegments = async () => {
 
 beforeAll(async () => {
     db = await dbInit('segments', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {}, db.rawDatabase);
+    app = await setupAppWithCustomConfig(
+        db.stores,
+        {
+            experimental: {
+                flags: {
+                    detectSegmentUsageInChangeRequests: true,
+                },
+            },
+        },
+        db.rawDatabase,
+    );
 });
 
 afterAll(async () => {


### PR DESCRIPTION
This PR updates the segment usage counting to also include segment usage in pending change requests. 

The changes include:
- Updating the schema to explicitly call out that change request usage is included.
- Adding two tests to verify the new features
- Writing an alternate query to count this data

Specifically, it'll update the part of the UI that tells you how many places a segment is used:

![image](https://github.com/Unleash/unleash/assets/17786332/a77cf932-d735-4a13-ae43-a2840f7106cb)

## Implementation

Implementing this was a little tricky. Previously, we'd just count distinct instances of feature names and project names on the feature_strategy table. However, to merge this with change request data, we can't just count existing usage and change request usage separately, because that could cause duplicates.

Instead of turning this into a complex DB query, I've broken it up into a few separate queries and done the merging in JS. I think that's more readable and it was easier to reason about. 

Here's the breakdown:
1. Get the list of pending change requests. We need their IDs and their project.
2. Get the list of updateStrategy and addStrategy events that have segment data.
3. Take the result from step 2 and turn it into a dictionary of segment id to usage data.
4. Query the feature_strategy_segment and feature_strategies table, to get existing segment usage data
5. Fold that data into the change request data.
6. Perform the preexisting segment query (without counting logic) to get other segment data
7. Enrich the results of the query from step 2 with usage data.

## Discussion points

I feel like this could be done in a nicer way, so any ideas on how to achieve that (whether that's as a db query or just breaking up the code differently) is very welcome.

Second, using multiple queries obviously yields more overhead than just a single one. However, I do not think this is in the hot path, so I don't consider performance to be critical here, but I'm open to hearing opposing thoughts on this of course.