### PR TITLE
fix: new SCHEDULED_CHANGE_REQUEST_EXECUTED on scheduled cr execution

### DIFF
--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -127,8 +127,8 @@ export const CHANGE_REQUEST_CANCELLED = 'change-request-cancelled' as const;
 export const CHANGE_REQUEST_SENT_TO_REVIEW =
     'change-request-sent-to-review' as const;
 export const CHANGE_REQUEST_APPLIED = 'change-request-applied' as const;
-export const SCHEDULED_CHANGE_REQUEST_EXECUTION_FAILED =
-    'scheduled-change-request-execution-failed' as const;
+export const SCHEDULED_CHANGE_REQUEST_EXECUTED =
+    'scheduled-change-request-executed' as const;
 export const CHANGE_REQUEST_SCHEDULED = 'change-request-scheduled' as const;
 
 export const API_TOKEN_CREATED = 'api-token-created' as const;
@@ -249,7 +249,7 @@ export const IEventTypes = [
     CHANGE_REQUEST_APPROVAL_ADDED,
     CHANGE_REQUEST_CANCELLED,
     CHANGE_REQUEST_SENT_TO_REVIEW,
-    SCHEDULED_CHANGE_REQUEST_EXECUTION_FAILED,
+    SCHEDULED_CHANGE_REQUEST_EXECUTED,
     CHANGE_REQUEST_APPLIED,
     CHANGE_REQUEST_SCHEDULED,
     API_TOKEN_CREATED,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -127,8 +127,8 @@ export const CHANGE_REQUEST_CANCELLED = 'change-request-cancelled' as const;
 export const CHANGE_REQUEST_SENT_TO_REVIEW =
     'change-request-sent-to-review' as const;
 export const CHANGE_REQUEST_APPLIED = 'change-request-applied' as const;
-export const SCHEDULED_CHANGE_REQUEST_EXECUTED =
-    'scheduled-change-request-executed' as const;
+export const SCHEDULED_CHANGE_REQUEST_EXECUTION_FAILED =
+    'scheduled-change-request-execution-failed' as const;
 export const CHANGE_REQUEST_SCHEDULED = 'change-request-scheduled' as const;
 
 export const API_TOKEN_CREATED = 'api-token-created' as const;
@@ -249,7 +249,7 @@ export const IEventTypes = [
     CHANGE_REQUEST_APPROVAL_ADDED,
     CHANGE_REQUEST_CANCELLED,
     CHANGE_REQUEST_SENT_TO_REVIEW,
-    SCHEDULED_CHANGE_REQUEST_EXECUTED,
+    SCHEDULED_CHANGE_REQUEST_EXECUTION_FAILED,
     CHANGE_REQUEST_APPLIED,
     CHANGE_REQUEST_SCHEDULED,
     API_TOKEN_CREATED,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -127,8 +127,8 @@ export const CHANGE_REQUEST_CANCELLED = 'change-request-cancelled' as const;
 export const CHANGE_REQUEST_SENT_TO_REVIEW =
     'change-request-sent-to-review' as const;
 export const CHANGE_REQUEST_APPLIED = 'change-request-applied' as const;
-export const SCHEDULED_CHANGE_REQUEST_APPLIED =
-    'scheduled-change-request-applied' as const;
+export const SCHEDULED_CHANGE_REQUEST_EXECUTED =
+    'scheduled-change-request-executed' as const;
 export const CHANGE_REQUEST_SCHEDULED = 'change-request-scheduled' as const;
 
 export const API_TOKEN_CREATED = 'api-token-created' as const;
@@ -249,8 +249,8 @@ export const IEventTypes = [
     CHANGE_REQUEST_APPROVAL_ADDED,
     CHANGE_REQUEST_CANCELLED,
     CHANGE_REQUEST_SENT_TO_REVIEW,
+    SCHEDULED_CHANGE_REQUEST_EXECUTED,
     CHANGE_REQUEST_APPLIED,
-    SCHEDULED_CHANGE_REQUEST_APPLIED,
     CHANGE_REQUEST_SCHEDULED,
     API_TOKEN_CREATED,
     API_TOKEN_UPDATED,


### PR DESCRIPTION
Rename event to SCHEDULED_CHANGE_REQUEST_EXECUTED

This event will be triggered when the executor runs a scheduled change request.
The ChangeRequestApplied event will remain as is (going out to project members - but will have a scheduled = true  property in the data if it scheduled.
This new event will fire on execution of the schedule and have a result = "failed" | "succeeded" property.
Because notifications are tied to events, this notification will go out to the creator and the applier