### PR TITLE
chore: only return change request data if the unleash instance is an enterprise instance

### DIFF
--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -49,7 +49,7 @@ describe('usage counting', () => {
         await db.rawDatabase.table('change_requests').delete();
     });
 
-    test('segment usage in active CRs is also counted', async () => {
+    test("segment usage in active CRs is counted iff we're on an enterprise instance", async () => {
         const CR_ID = 54321;
 
         const flag1 = await db.stores.featureToggleStore.create('default', {

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -123,7 +123,7 @@ describe('usage counting', () => {
             created_by: user.id,
         });
 
-        const [storedSegment] = await segmentStore.getAll();
+        const [storedSegment] = await segmentStore.getAll(true);
 
         expect(storedSegment.usedInFeatures).toBe(2);
         expect(storedSegment.usedInProjects).toBe(1);
@@ -204,7 +204,7 @@ describe('usage counting', () => {
             created_by: user.id,
         });
 
-        const storedSegments = await segmentStore.getAll();
+        const storedSegments = await segmentStore.getAll(true);
 
         expect(storedSegments).toMatchObject([
             { usedInFeatures: 1, usedInProjects: 1 },

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -49,7 +49,7 @@ describe('usage counting', () => {
         await db.rawDatabase.table('change_requests').delete();
     });
 
-    test("segment usage in active CRs is counted iff we're on an enterprise instance", async () => {
+    test('segment usage in active CRs is counted iff we ask for it', async () => {
         const CR_ID = 54321;
 
         const flag1 = await db.stores.featureToggleStore.create('default', {

--- a/src/lib/db/segment-store.test.ts
+++ b/src/lib/db/segment-store.test.ts
@@ -123,10 +123,15 @@ describe('usage counting', () => {
             created_by: user.id,
         });
 
-        const [storedSegment] = await segmentStore.getAll(true);
+        const [enterpriseData] = await segmentStore.getAll(true);
 
-        expect(storedSegment.usedInFeatures).toBe(2);
-        expect(storedSegment.usedInProjects).toBe(1);
+        expect(enterpriseData.usedInFeatures).toBe(2);
+        expect(enterpriseData.usedInProjects).toBe(1);
+
+        const [ossData] = await segmentStore.getAll(false);
+
+        expect(ossData.usedInFeatures).toBe(0);
+        expect(ossData.usedInProjects).toBe(0);
     });
 
     test('Segment usage is only counted once per feature', async () => {

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -111,8 +111,11 @@ export default class SegmentStore implements ISegmentStore {
         return this.db(T.segments).where({ id }).del();
     }
 
-    async getAll(): Promise<ISegment[]> {
-        if (this.flagResolver.isEnabled('detectSegmentUsageInChangeRequests')) {
+    async getAll(isEnterprise: boolean): Promise<ISegment[]> {
+        if (
+            isEnterprise &&
+            this.flagResolver.isEnabled('detectSegmentUsageInChangeRequests')
+        ) {
             const pendingCRs = await this.db
                 .select('id', 'project')
                 .from('change_requests')

--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -111,9 +111,11 @@ export default class SegmentStore implements ISegmentStore {
         return this.db(T.segments).where({ id }).del();
     }
 
-    async getAll(isEnterprise: boolean): Promise<ISegment[]> {
+    async getAll(
+        includeChangeRequestUsageData: boolean = false,
+    ): Promise<ISegment[]> {
         if (
-            isEnterprise &&
+            includeChangeRequestUsageData &&
             this.flagResolver.isEnabled('detectSegmentUsageInChangeRequests')
         ) {
             const pendingCRs = await this.db

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -75,7 +75,7 @@ export class SegmentService implements ISegmentService {
     }
 
     async getAll(): Promise<ISegment[]> {
-        return this.segmentStore.getAll();
+        return this.segmentStore.getAll(this.config.isEnterprise);
     }
 
     async getActive(): Promise<ISegment[]> {

--- a/src/lib/types/stores/segment-store.ts
+++ b/src/lib/types/stores/segment-store.ts
@@ -3,7 +3,7 @@ import { Store } from './store';
 import User from '../user';
 
 export interface ISegmentStore extends Store<ISegment, number> {
-    getAll(): Promise<ISegment[]>;
+    getAll(isEnterprise: boolean): Promise<ISegment[]>;
 
     getActive(): Promise<ISegment[]>;
 

--- a/src/lib/types/stores/segment-store.ts
+++ b/src/lib/types/stores/segment-store.ts
@@ -3,7 +3,7 @@ import { Store } from './store';
 import User from '../user';
 
 export interface ISegmentStore extends Store<ISegment, number> {
-    getAll(isEnterprise: boolean): Promise<ISegment[]>;
+    getAll(includeChangeRequestUsageData?: boolean): Promise<ISegment[]>;
 
     getActive(): Promise<ISegment[]>;
 


### PR DESCRIPTION
Otherwise, we might accidentally display CR data to open source users.
But more importantly, it might keep them from being able to delete a
segment that's in use by a CR in their database that they can't touch.

So by checking that they're on an enterprise instance, we avoid this
potential blocker.

I've added the `includeChangeRequestUsageData` parameter as a boolean now, but I'm open to other suggestions.