### PR TITLE
refactor: show project features on a hidden page

### DIFF
--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -88,9 +88,9 @@ export const PageContent: FC<IPageContentProps> = ({
 
     const content = (
         <StyledPaper
-            {...rest}
-            {...paperProps}
-            className={classnames(className)}
+        {...paperProps}
+        className={classnames(className)}
+        {...rest}
         >
             <ConditionallyRender
                 condition={Boolean(header)}

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -40,6 +40,7 @@ import { EnterpriseBadge } from 'component/common/EnterpriseBadge/EnterpriseBadg
 import { Badge } from 'component/common/Badge/Badge';
 import { ProjectDoraMetrics } from './ProjectDoraMetrics/ProjectDoraMetrics';
 import { UiFlags } from 'interfaces/uiConfig';
+import { ProjectFeaturesExperimental } from './ProjectFeaturesExperimental/ProjectFeaturesExperimental';
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
     position: 'absolute',
@@ -283,6 +284,7 @@ export const Project = () => {
                 <Route path='environments' element={<ProjectEnvironment />} />
                 <Route path='archive' element={<ProjectFeaturesArchive />} />
                 <Route path='logs' element={<ProjectLog />} />
+                <Route path='features' element={<ProjectFeaturesExperimental />} />
                 <Route
                     path='change-requests'
                     element={<ProjectChangeRequests />}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
@@ -79,6 +79,7 @@ interface IPaginatedProjectFeatureTogglesProps {
     searchValue: string;
     setSearchValue: React.Dispatch<React.SetStateAction<string>>;
     paginationBar: JSX.Element;
+    style?: React.CSSProperties;
 }
 
 const staticColumns = ['Select', 'Actions', 'name', 'favorite'];
@@ -97,6 +98,7 @@ export const PaginatedProjectFeatureToggles = ({
     searchValue,
     setSearchValue,
     paginationBar,
+    style = {}
 }: IPaginatedProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const bodyLoadingRef = useLoading(loading);
@@ -512,7 +514,7 @@ export const PaginatedProjectFeatureToggles = ({
     ]);
 
     const showPaginationBar = Boolean(total && total > 25);
-    const style = showPaginationBar
+    const pageContentStyle = showPaginationBar
         ? { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }
         : {};
 
@@ -522,7 +524,8 @@ export const PaginatedProjectFeatureToggles = ({
                 disableLoading
                 disablePadding
                 className={styles.container}
-                sx={style}
+                sx={{...pageContentStyle }}
+                style={style}
                 header={
                     <Box
                         ref={headerLoadingRef}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -75,6 +75,7 @@ interface IProjectFeatureTogglesProps {
     loading: boolean;
     onChange: () => void;
     total?: number;
+    style?: React.CSSProperties;
 }
 
 const staticColumns = ['Select', 'Actions', 'name', 'favorite'];
@@ -92,6 +93,7 @@ export const ProjectFeatureToggles = ({
     environments: newEnvironments = [],
     onChange,
     total,
+    style
 }: IProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const theme = useTheme();
@@ -500,12 +502,13 @@ export const ProjectFeatureToggles = ({
         setSearchParams,
         isFavoritesPinned,
     ]);
-
+    
     return (
         <>
             <PageContent
                 isLoading={loading}
                 className={styles.container}
+                style={style}
                 header={
                     <PageHeader
                         titleElement={

--- a/frontend/src/component/project/Project/ProjectFeaturesExperimental/ProjectFeaturesExperimental.tsx
+++ b/frontend/src/component/project/Project/ProjectFeaturesExperimental/ProjectFeaturesExperimental.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from 'react';
+import useProject, {
+    useProjectNameOrId,
+} from 'hooks/api/getters/useProject/useProject';
+import { Box, styled } from '@mui/material';
+import { ProjectFeatureToggles as LegacyProjectFeatureToggles } from '../ProjectFeatureToggles/LegacyProjectFeatureToggles';
+import { ProjectFeatureToggles } from '../ProjectFeatureToggles/ProjectFeatureToggles';
+import { usePageTitle } from 'hooks/usePageTitle';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useLastViewedProject } from 'hooks/useLastViewedProject';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { PaginatedProjectFeatureToggles } from '../ProjectFeatureToggles/PaginatedProjectFeatureToggles';
+import { useSearchParams } from 'react-router-dom';
+
+import { PaginationBar } from 'component/common/PaginationBar/PaginationBar';
+
+const refreshInterval = 15 * 1000;
+
+const StyledContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    [theme.breakpoints.down('md')]: {
+        flexDirection: 'column',
+    },
+}));
+
+const StyledProjectToggles = styled('div')(() => ({
+    width: '100%',
+    minWidth: 0,
+}));
+
+const StyledContentContainer = styled(Box)(() => ({
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    minWidth: 0,
+}));
+
+const PaginatedProjectOverview = () => {
+    const projectId = useRequiredPathParam('projectId');
+    const [searchParams] = useSearchParams();
+    const { project, } = useProject(projectId, {
+        refreshInterval,
+    });
+    const [pageLimit, setPageLimit] = useState(25);
+    const [currentOffset, setCurrentOffset] = useState(0);
+
+    const [searchValue, setSearchValue] = useState(
+        searchParams.get('search') || '',
+    );
+
+    const {
+        features: searchFeatures,
+        total,
+        refetch,
+        loading,
+        initialLoad,
+    } = useFeatureSearch(currentOffset, pageLimit, projectId, searchValue, {
+        refreshInterval,
+    });
+
+    const { environments } =
+        project;
+    const fetchNextPage = () => {
+        if (!loading) {
+            setCurrentOffset(Math.min(total, currentOffset + pageLimit));
+        }
+    };
+    const fetchPrevPage = () => {
+        setCurrentOffset(Math.max(0, currentOffset - pageLimit));
+    };
+
+    const hasPreviousPage = currentOffset > 0;
+    const hasNextPage = currentOffset + pageLimit < total;
+
+    return (
+        <StyledContainer>
+            <StyledContentContainer>
+                <StyledProjectToggles>
+                    <PaginatedProjectFeatureToggles
+                        key={
+                            loading && searchFeatures.length === 0
+                                ? 'loading'
+                                : 'ready'
+                        }
+                        features={searchFeatures}
+                        environments={environments}
+                        initialLoad={initialLoad && searchFeatures.length === 0}
+                        loading={loading && searchFeatures.length === 0}
+                        onChange={refetch}
+                        total={total}
+                        searchValue={searchValue}
+                        setSearchValue={setSearchValue}
+                        style={{ width: '100%', margin: 0 }}
+                        paginationBar={
+                            <StickyPaginationBar>
+                                <PaginationBar
+                                    total={total}
+                                    hasNextPage={hasNextPage}
+                                    hasPreviousPage={hasPreviousPage}
+                                    fetchNextPage={fetchNextPage}
+                                    fetchPrevPage={fetchPrevPage}
+                                    currentOffset={currentOffset}
+                                    pageLimit={pageLimit}
+                                    setPageLimit={setPageLimit}
+                                />
+                            </StickyPaginationBar>
+                        }
+                    />
+                </StyledProjectToggles>
+            </StyledContentContainer>
+        </StyledContainer>
+    );
+};
+
+const StyledStickyBar = styled('div')(({ theme }) => ({
+    position: 'sticky',
+    bottom: 0,
+    backgroundColor: theme.palette.background.paper,
+    padding: theme.spacing(2),
+    zIndex: 9999,
+    borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+    borderBottomRightRadius: theme.shape.borderRadiusMedium,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    boxShadow: `0px -2px 8px 0px rgba(32, 32, 33, 0.06)`,
+    height: '52px',
+}));
+
+const StyledStickyBarContentContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '100%',
+    minWidth: 0,
+}));
+
+const StickyPaginationBar: React.FC = ({ children }) => {
+    return (
+        <StyledStickyBar>
+            <StyledStickyBarContentContainer>
+                {children}
+            </StyledStickyBarContentContainer>
+        </StyledStickyBar>
+    );
+};
+
+/**
+ * @deprecated remove when flag `featureSearchFrontend` is removed
+ */
+export const ProjectFeaturesExperimental = () => {
+    const projectId = useRequiredPathParam('projectId');
+    const projectName = useProjectNameOrId(projectId);
+    const { project, loading, refetch } = useProject(projectId, {
+        refreshInterval,
+    });
+    const {  features, environments } =
+        project;
+    usePageTitle(`Project overview – ${projectName}`);
+    const { setLastViewed } = useLastViewedProject();
+    const featureSwitchRefactor = useUiFlag('featureSwitchRefactor');
+    const featureSearchFrontend = useUiFlag('featureSearchFrontend');
+
+    useEffect(() => {
+        setLastViewed(projectId);
+    }, [projectId, setLastViewed]);
+
+    if (featureSearchFrontend) return <PaginatedProjectOverview />;
+
+    return (
+        <StyledContainer>
+            <StyledContentContainer>
+                <StyledProjectToggles>
+                    <ConditionallyRender
+                        condition={Boolean(featureSwitchRefactor)}
+                        show={() => (
+                            <ProjectFeatureToggles
+                                key={loading ? 'loading' : 'ready'}
+                                features={features}
+                                environments={environments}
+                                loading={loading}
+                                onChange={refetch}
+                                style={{ width: '100%', margin: 0}}
+                            />
+                        )}
+                        elseShow={() => (
+                            <LegacyProjectFeatureToggles
+                                key={loading ? 'loading' : 'ready'}
+                                features={features}
+                                environments={environments}
+                                loading={loading}
+                            />
+                        )}
+                    />
+                </StyledProjectToggles>
+            </StyledContentContainer>
+        </StyledContainer>
+    );
+};
+


### PR DESCRIPTION
This PR creates a copy of project overview to show how the table could look on a hidden new path: `/project/{projectId}/features`