### PR TITLE
Updated scripts to use owner

### DIFF
--- a/scripts/resetdatabase.sql
+++ b/scripts/resetdatabase.sql
@@ -1,3 +1,2 @@
 DROP DATABASE unleash;
-CREATE DATABASE unleash;
-GRANT ALL PRIVILEGES ON DATABASE unleash TO unleash_user;
+CREATE DATABASE unleash WITH OWNER unleash_user;

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -27,7 +27,7 @@ yarn dev
 
 To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v14.x or newer) locally.
 
-Unleash currently also work with PostgreSQL v14+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v12.
+Unleash currently also work with PostgreSQL v14+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v12. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
 
 ### Create a local unleash databases in postgres {#create-a-local-unleash-databases-in-postgres}
 

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -34,10 +34,8 @@ Unleash currently also work with PostgreSQL v14+, but this might change in a fut
 ```bash
 $ psql postgres <<SQL
 CREATE USER unleash_user WITH PASSWORD 'password';
-CREATE DATABASE unleash;
-GRANT ALL PRIVILEGES ON DATABASE unleash to unleash_user;
-CREATE DATABASE unleash_test;
-GRANT ALL PRIVILEGES ON DATABASE unleash_test to unleash_user;
+CREATE DATABASE unleash WITH OWNER unleash_user;
+CREATE DATABASE unleash_test WITH OWNER unleash_user;
 ALTER DATABASE unleash_test SET timezone TO 'UTC';
 SQL
 ```


### PR DESCRIPTION
See [Linear issue 2-1627](https://linear.app/unleash/issue/2-1627/db-permissions-update-docs-and-migration-guides).

Since we now use functions, we need more permissions than just GRANT ALL PERMISSIONS ON DATBASE. In addition we need to be allowed to create functions in the schema that's actually being used. This PR takes the easy way out and say that we need OWNER privileges on the database. That guarantees that we can do all we do in our migration scripts.

### Discussion points
We might encounter some pushback on this, if so, we'll need to say that we need
`GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN <schema>` in addition to GRANT ALL PRIVILEGES ON DATABASE, where <schema> is the schema selected in their configuration.