### PR TITLE
fix: hardcoded stickiness and mode fields

### DIFF
--- a/src/lib/db/project-store.ts
+++ b/src/lib/db/project-store.ts
@@ -206,8 +206,8 @@ class ProjectStore implements IProjectStore {
             memberCount: Number(row.number_of_users) || 0,
             updatedAt: row.updated_at,
             createdAt: row.created_at,
-            mode: row.project_mode,
-            defaultStickiness: row.default_stickiness,
+            mode: row.project_mode || 'open',
+            defaultStickiness: row.default_stickiness || 'default',
         };
     }
 

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -177,6 +177,7 @@ export default class ProjectService {
             query,
             userId,
         );
+
         if (this.flagResolver.isEnabled('privateProjects') && userId) {
             const projectAccess =
                 await this.privateProjectChecker.getUserAccessibleProjects(

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1999,3 +1999,49 @@ test('deleting a project with no archived toggles should not result in an error'
     await projectService.createProject(project, user);
     await projectService.deleteProject(project.id, user);
 });
+
+test('should get project settings with mode', async () => {
+    const projectOne = {
+        id: 'mode-private',
+        name: 'New project',
+        description: 'Desc',
+        mode: 'open' as const,
+        defaultStickiness: 'default',
+    };
+
+    const projectTwo = {
+        id: 'mode-open',
+        name: 'New project',
+        description: 'Desc',
+        mode: 'open' as const,
+        defaultStickiness: 'default',
+    };
+
+    const updatedProject = {
+        id: 'mode-private',
+        name: 'New name',
+        description: 'Desc',
+        mode: 'private' as const,
+        defaultStickiness: 'clientId',
+    };
+
+    const { mode, id, ...rest } = updatedProject;
+
+    await projectService.createProject(projectOne, user);
+    await projectService.createProject(projectTwo, user);
+    await projectService.updateProject({ id, ...rest }, user);
+    await projectService.updateProjectEnterpriseSettings({ mode, id }, user);
+
+    const projects = await projectService.getProjects();
+    const foundProjectOne = projects.find(
+        (project) => projectOne.id === project.id,
+    );
+    const foundProjectTwo = projects.find(
+        (project) => projectTwo.id === project.id,
+    );
+
+    expect(foundProjectOne!.mode).toBe('private');
+    expect(foundProjectOne!.defaultStickiness).toBe('clientId');
+    expect(foundProjectTwo!.mode).toBe('open');
+    expect(foundProjectTwo!.defaultStickiness).toBe('default');
+});


### PR DESCRIPTION
This PR fixes an issue where project overview would return hardcoded project mode and stickiness fields.