### PR TITLE
feat: add experimental list on it's own page

### DIFF
--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -88,9 +88,9 @@ export const PageContent: FC<IPageContentProps> = ({
 
     const content = (
         <StyledPaper
-            {...rest}
             {...paperProps}
             className={classnames(className)}
+            {...rest}
         >
             <ConditionallyRender
                 condition={Boolean(header)}

--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -88,9 +88,9 @@ export const PageContent: FC<IPageContentProps> = ({
 
     const content = (
         <StyledPaper
+            {...rest}
             {...paperProps}
             className={classnames(className)}
-            {...rest}
         >
             <ConditionallyRender
                 condition={Boolean(header)}

--- a/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
+++ b/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
@@ -77,8 +77,7 @@ const PaginatedProjectOverview = () => {
         },
     );
 
-    const { environments } =
-        project;
+    const { environments } = project;
     const fetchNextPage = () => {
         if (!loading) {
             setCurrentOffset(Math.min(total, currentOffset + pageLimit));
@@ -172,8 +171,7 @@ export const ExperimentalProjectFeatures = () => {
     const { project, loading, refetch } = useProject(projectId, {
         refreshInterval,
     });
-    const { features, environments } =
-        project;
+    const { features, environments } = project;
     usePageTitle(`Project overview – ${projectName}`);
     const { setLastViewed } = useLastViewedProject();
     const featureSearchFrontend = useUiFlag('featureSearchFrontend');

--- a/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
+++ b/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import useProject, {
+    useProjectNameOrId,
+} from 'hooks/api/getters/useProject/useProject';
+import { Box, styled } from '@mui/material';
+import { ProjectFeatureToggles } from '../ProjectFeatureToggles/ProjectFeatureToggles';
+import { usePageTitle } from 'hooks/usePageTitle';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useLastViewedProject } from 'hooks/useLastViewedProject';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import {
+    ISortingRules,
+    PaginatedProjectFeatureToggles,
+} from '../ProjectFeatureToggles/PaginatedProjectFeatureToggles';
+import { useSearchParams } from 'react-router-dom';
+
+import { PaginationBar } from 'component/common/PaginationBar/PaginationBar';
+import { SortingRule } from 'react-table';
+
+const refreshInterval = 15 * 1000;
+
+const StyledContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    [theme.breakpoints.down('md')]: {
+        flexDirection: 'column',
+    },
+}));
+
+const StyledProjectToggles = styled('div')(() => ({
+    width: '100%',
+    minWidth: 0,
+}));
+
+const StyledContentContainer = styled(Box)(() => ({
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    minWidth: 0,
+}));
+
+export const DEFAULT_PAGE_LIMIT = 25;
+
+const PaginatedProjectOverview = () => {
+    const projectId = useRequiredPathParam('projectId');
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { project, loading: projectLoading } = useProject(projectId, {
+        refreshInterval,
+    });
+    const [pageLimit, setPageLimit] = useState(DEFAULT_PAGE_LIMIT);
+    const [currentOffset, setCurrentOffset] = useState(0);
+
+    const [searchValue, setSearchValue] = useState(
+        searchParams.get('search') || '',
+    );
+
+    const [sortingRules, setSortingRules] = useState<ISortingRules>({
+        sortBy: 'createdBy',
+        sortOrder: 'desc',
+        isFavoritesPinned: false,
+    });
+
+    const {
+        features: searchFeatures,
+        total,
+        refetch,
+        loading,
+        initialLoad,
+    } = useFeatureSearch(
+        currentOffset,
+        pageLimit,
+        sortingRules,
+        projectId,
+        searchValue,
+        {
+            refreshInterval,
+        },
+    );
+
+    const { environments } =
+        project;
+    const fetchNextPage = () => {
+        if (!loading) {
+            setCurrentOffset(Math.min(total, currentOffset + pageLimit));
+        }
+    };
+    const fetchPrevPage = () => {
+        setCurrentOffset(Math.max(0, currentOffset - pageLimit));
+    };
+
+    const hasPreviousPage = currentOffset > 0;
+    const hasNextPage = currentOffset + pageLimit < total;
+
+    return (
+        <StyledContainer>
+            <StyledContentContainer>
+                <StyledProjectToggles>
+                    <PaginatedProjectFeatureToggles
+                        key={
+                            loading && searchFeatures.length === 0
+                                ? 'loading'
+                                : 'ready'
+                        }
+                        features={searchFeatures}
+                        environments={environments}
+                        initialLoad={initialLoad && searchFeatures.length === 0}
+                        loading={loading && searchFeatures.length === 0}
+                        onChange={refetch}
+                        total={total}
+                        searchValue={searchValue}
+                        setSearchValue={setSearchValue}
+                        sortingRules={sortingRules}
+                        style={{ width: '100%', margin: 0 }}
+                        setSortingRules={setSortingRules}
+                        paginationBar={
+                            <StickyPaginationBar>
+                                <PaginationBar
+                                    total={total}
+                                    hasNextPage={hasNextPage}
+                                    hasPreviousPage={hasPreviousPage}
+                                    fetchNextPage={fetchNextPage}
+                                    fetchPrevPage={fetchPrevPage}
+                                    currentOffset={currentOffset}
+                                    pageLimit={pageLimit}
+                                    setPageLimit={setPageLimit}
+                                />
+                            </StickyPaginationBar>
+                        }
+                    />
+                </StyledProjectToggles>
+            </StyledContentContainer>
+        </StyledContainer>
+    );
+};
+
+const StyledStickyBar = styled('div')(({ theme }) => ({
+    position: 'sticky',
+    bottom: 0,
+    backgroundColor: theme.palette.background.paper,
+    padding: theme.spacing(2),
+    marginLeft: theme.spacing(2),
+    zIndex: 9999,
+    borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+    borderBottomRightRadius: theme.shape.borderRadiusMedium,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    boxShadow: `0px -2px 8px 0px rgba(32, 32, 33, 0.06)`,
+    height: '52px',
+}));
+
+const StyledStickyBarContentContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '100%',
+    minWidth: 0,
+}));
+
+const StickyPaginationBar: React.FC = ({ children }) => {
+    return (
+        <StyledStickyBar>
+            <StyledStickyBarContentContainer>
+                {children}
+            </StyledStickyBarContentContainer>
+        </StyledStickyBar>
+    );
+};
+
+/**
+ * @deprecated remove when flag `featureSearchFrontend` is removed
+ */
+export const ExperimentalProjectFeatures = () => {
+    const projectId = useRequiredPathParam('projectId');
+    const projectName = useProjectNameOrId(projectId);
+    const { project, loading, refetch } = useProject(projectId, {
+        refreshInterval,
+    });
+    const { features, environments } =
+        project;
+    usePageTitle(`Project overview – ${projectName}`);
+    const { setLastViewed } = useLastViewedProject();
+    const featureSearchFrontend = useUiFlag('featureSearchFrontend');
+
+    useEffect(() => {
+        setLastViewed(projectId);
+    }, [projectId, setLastViewed]);
+
+    if (featureSearchFrontend) return <PaginatedProjectOverview />;
+
+    return (
+        <StyledContainer>
+            <StyledContentContainer>
+                <StyledProjectToggles>
+                    <ProjectFeatureToggles
+                        key={loading ? 'loading' : 'ready'}
+                        features={features}
+                        environments={environments}
+                        loading={loading}
+                        onChange={refetch}
+                        style={{ width: '100%', margin: 0 }}
+                    />
+                </StyledProjectToggles>
+            </StyledContentContainer>
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
+++ b/frontend/src/component/project/Project/ExperimentalProjectFeatures/ExperimentalProjectFeatures.tsx
@@ -138,7 +138,6 @@ const StyledStickyBar = styled('div')(({ theme }) => ({
     bottom: 0,
     backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2),
-    marginLeft: theme.spacing(2),
     zIndex: 9999,
     borderBottomLeftRadius: theme.shape.borderRadiusMedium,
     borderBottomRightRadius: theme.shape.borderRadiusMedium,

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -40,6 +40,7 @@ import { EnterpriseBadge } from 'component/common/EnterpriseBadge/EnterpriseBadg
 import { Badge } from 'component/common/Badge/Badge';
 import { ProjectDoraMetrics } from './ProjectDoraMetrics/ProjectDoraMetrics';
 import { UiFlags } from 'interfaces/uiConfig';
+import { ExperimentalProjectFeatures } from './ExperimentalProjectFeatures/ExperimentalProjectFeatures';
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
     position: 'absolute',
@@ -282,6 +283,7 @@ export const Project = () => {
                 />
                 <Route path='environments' element={<ProjectEnvironment />} />
                 <Route path='archive' element={<ProjectFeaturesArchive />} />
+                <Route path='features' element={<ExperimentalProjectFeatures />} />
                 <Route path='logs' element={<ProjectLog />} />
                 <Route
                     path='change-requests'

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -283,7 +283,10 @@ export const Project = () => {
                 />
                 <Route path='environments' element={<ProjectEnvironment />} />
                 <Route path='archive' element={<ProjectFeaturesArchive />} />
-                <Route path='features' element={<ExperimentalProjectFeatures />} />
+                <Route
+                    path='features'
+                    element={<ExperimentalProjectFeatures />}
+                />
                 <Route path='logs' element={<ProjectLog />} />
                 <Route
                     path='change-requests'

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
@@ -517,8 +517,7 @@ export const PaginatedProjectFeatureToggles = ({
                 disableLoading
                 disablePadding
                 className={styles.container}
-                sx={paginatedPageContentStyle}
-                style={style}
+                sx={{ ...paginatedPageContentStyle, ...style }}
                 header={
                     <Box
                         ref={headerLoadingRef}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/PaginatedProjectFeatureToggles.tsx
@@ -517,7 +517,8 @@ export const PaginatedProjectFeatureToggles = ({
                 disableLoading
                 disablePadding
                 className={styles.container}
-                sx={{ ...paginatedPageContentStyle, ...style }}
+                sx={paginatedPageContentStyle}
+                style={style}
                 header={
                     <Box
                         ref={headerLoadingRef}

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -74,6 +74,7 @@ interface IProjectFeatureTogglesProps {
     loading: boolean;
     onChange: () => void;
     total?: number;
+    style?: React.CSSProperties;
 }
 
 const staticColumns = ['Select', 'Actions', 'name', 'favorite'];
@@ -91,6 +92,7 @@ export const ProjectFeatureToggles = ({
     environments: newEnvironments = [],
     onChange,
     total,
+    style = {},
 }: IProjectFeatureTogglesProps) => {
     const { classes: styles } = useStyles();
     const theme = useTheme();
@@ -506,6 +508,7 @@ export const ProjectFeatureToggles = ({
                 isLoading={loading}
                 disablePadding
                 className={styles.container}
+                style={style}
                 header={
                     <Box
                         sx={(theme) => ({

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -47,7 +47,7 @@ process.nextTick(async () => {
                         disableEnvsOnRevive: true,
                         playgroundImprovements: true,
                         featureSearchAPI: true,
-                        featureSearchFrontend: false,
+                        featureSearchFrontend: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Add a duplicate component of project overview list to it's own page