### PR TITLE
fix: handle concurrent service account updates

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -468,11 +468,14 @@ export class AccessStore implements IAccessStore {
         roleId: number,
         projectId?: string,
     ): Promise<void> {
-        return this.db(T.ROLE_USER).insert({
-            user_id: userId,
-            role_id: roleId,
-            project: projectId,
-        });
+        this.db(T.ROLE_USER)
+            .insert({
+                user_id: userId,
+                role_id: roleId,
+                project: projectId,
+            })
+            .onConflict(['user_id', 'role_id', 'project'])
+            .ignore();
     }
 
     async removeUserFromRole(

--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -468,7 +468,7 @@ export class AccessStore implements IAccessStore {
         roleId: number,
         projectId?: string,
     ): Promise<void> {
-        this.db(T.ROLE_USER)
+        await this.db(T.ROLE_USER)
             .insert({
                 user_id: userId,
                 role_id: roleId,


### PR DESCRIPTION
How we replicated the problem (note this may happen in other endpoints as well). Check at the end we received some 500 errors:
```shell
$ hey -m PUT -H 'Authorization: *:*.unleash-insecure-admin-api-token'     -H 'Content-Type: application/json'     -d '{
  "name": "sa1-mod",
  "username": "sa1-mod",
  "rootRole": 1
}' http://localhost:4242/api/admin/service-account/2

Summary:
  Total:	0.7555 secs
  Slowest:	0.2489 secs
  Fastest:	0.0277 secs
  Average:	0.1691 secs
  Requests/sec:	264.7318
  
  Total data:	46452 bytes
  Size/request:	232 bytes

Response time histogram:
  0.028 [1]	|■
  0.050 [3]	|■■
  0.072 [2]	|■
  0.094 [6]	|■■■
  0.116 [5]	|■■■
  0.138 [12]	|■■■■■■■
  0.160 [18]	|■■■■■■■■■■
  0.183 [70]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.205 [73]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.227 [5]	|■■■
  0.249 [5]	|■■■


Latency distribution:
  10% in 0.1238 secs
  25% in 0.1633 secs
  50% in 0.1802 secs
  75% in 0.1874 secs
  90% in 0.1926 secs
  95% in 0.2063 secs
  99% in 0.2399 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.0277 secs, 0.2489 secs
  DNS-lookup:	0.0002 secs, 0.0000 secs, 0.0020 secs
  req write:	0.0002 secs, 0.0000 secs, 0.0038 secs
  resp wait:	0.1684 secs, 0.0264 secs, 0.2455 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0003 secs

Status code distribution:
  [200]	52 responses
  [500]	148 responses

```

After the fix, we linked unleash open source to the enterprise version and ran the test again resulting in all 200s:
```shell
$ hey -m PUT -H 'Authorization: *:*.unleash-insecure-admin-api-token'     -H 'Content-Type: application/json'     -d '{
  "name": "sa1-mod",
  "username": "sa1-mod",
  "rootRole": 1
}' http://localhost:4242/api/admin/service-account/2

Summary:
  Total:	1.0352 secs
  Slowest:	0.3420 secs
  Fastest:	0.0589 secs
  Average:	0.2329 secs
  Requests/sec:	193.2079
  
  Total data:	46600 bytes
  Size/request:	233 bytes

Response time histogram:
  0.059 [1]	|
  0.087 [3]	|■
  0.116 [5]	|■■
  0.144 [4]	|■
  0.172 [7]	|■■■
  0.200 [4]	|■
  0.229 [27]	|■■■■■■■■■■
  0.257 [107]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.285 [30]	|■■■■■■■■■■■
  0.314 [7]	|■■■
  0.342 [5]	|■■


Latency distribution:
  10% in 0.1799 secs
  25% in 0.2285 secs
  50% in 0.2394 secs
  75% in 0.2536 secs
  90% in 0.2727 secs
  95% in 0.2983 secs
  99% in 0.3353 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0012 secs, 0.0589 secs, 0.3420 secs
  DNS-lookup:	0.0006 secs, 0.0000 secs, 0.0055 secs
  req write:	0.0003 secs, 0.0000 secs, 0.0037 secs
  resp wait:	0.2312 secs, 0.0544 secs, 0.3353 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0002 secs

Status code distribution:
  [200]	200 responses
```