### PR TITLE
fix: total number should be correct now in search

### DIFF
--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -319,61 +319,61 @@ test('should sort features', async () => {
     await app.enableFeature('my_feature_c', 'default');
     await app.favoriteFeature('my_feature_b');
 
-    const { body: ascName } = await sortFeatures({
-        sortBy: 'name',
-        sortOrder: 'asc',
-    });
-
-    expect(ascName).toMatchObject({
-        features: [
-            { name: 'my_feature_a' },
-            { name: 'my_feature_b' },
-            { name: 'my_feature_c' },
-        ],
-        total: 3,
-    });
-
-    const { body: descName } = await sortFeatures({
-        sortBy: 'name',
-        sortOrder: 'desc',
-    });
-
-    expect(descName).toMatchObject({
-        features: [
-            { name: 'my_feature_c' },
-            { name: 'my_feature_b' },
-            { name: 'my_feature_a' },
-        ],
-        total: 3,
-    });
-
-    const { body: defaultCreatedAt } = await sortFeatures({
-        sortBy: '',
-        sortOrder: '',
-    });
-
-    expect(defaultCreatedAt).toMatchObject({
-        features: [
-            { name: 'my_feature_a' },
-            { name: 'my_feature_c' },
-            { name: 'my_feature_b' },
-        ],
-        total: 3,
-    });
-
-    const { body: environmentAscSort } = await sortFeatures({
-        sortBy: 'environment:default',
-        sortOrder: 'asc',
-    });
-
-    expect(environmentAscSort).toMatchObject({
-        features: [
-            { name: 'my_feature_a' },
-            { name: 'my_feature_b' },
-            { name: 'my_feature_c' },
-        ],
-        total: 3,
-    });
+    // const { body: ascName } = await sortFeatures({
+    //     sortBy: 'name',
+    //     sortOrder: 'asc',
+    // });
+    //
+    // expect(ascName).toMatchObject({
+    //     features: [
+    //         { name: 'my_feature_a' },
+    //         { name: 'my_feature_b' },
+    //         { name: 'my_feature_c' },
+    //     ],
+    //     total: 3,
+    // });
+    //
+    // const { body: descName } = await sortFeatures({
+    //     sortBy: 'name',
+    //     sortOrder: 'desc',
+    // });
+    //
+    // expect(descName).toMatchObject({
+    //     features: [
+    //         { name: 'my_feature_c' },
+    //         { name: 'my_feature_b' },
+    //         { name: 'my_feature_a' },
+    //     ],
+    //     total: 3,
+    // });
+    //
+    // const { body: defaultCreatedAt } = await sortFeatures({
+    //     sortBy: '',
+    //     sortOrder: '',
+    // });
+    //
+    // expect(defaultCreatedAt).toMatchObject({
+    //     features: [
+    //         { name: 'my_feature_a' },
+    //         { name: 'my_feature_c' },
+    //         { name: 'my_feature_b' },
+    //     ],
+    //     total: 3,
+    // });
+    //
+    // const { body: environmentAscSort } = await sortFeatures({
+    //     sortBy: 'environment:default',
+    //     sortOrder: 'asc',
+    // });
+    //
+    // expect(environmentAscSort).toMatchObject({
+    //     features: [
+    //         { name: 'my_feature_a' },
+    //         { name: 'my_feature_b' },
+    //         { name: 'my_feature_c' },
+    //     ],
+    //     total: 3,
+    // });
 
     const { body: environmentDescSort } = await sortFeatures({
         sortBy: 'environment:default',
@@ -389,20 +389,20 @@ test('should sort features', async () => {
         total: 3,
     });
 
-    const { body: favoriteEnvironmentDescSort } = await sortFeatures({
-        sortBy: 'environment:default',
-        sortOrder: 'desc',
-        favoritesFirst: 'true',
-    });
-
-    expect(favoriteEnvironmentDescSort).toMatchObject({
-        features: [
-            { name: 'my_feature_b' },
-            { name: 'my_feature_c' },
-            { name: 'my_feature_a' },
-        ],
-        total: 3,
-    });
+    // const { body: favoriteEnvironmentDescSort } = await sortFeatures({
+    //     sortBy: 'environment:default',
+    //     sortOrder: 'desc',
+    //     favoritesFirst: 'true',
+    // });
+    //
+    // expect(favoriteEnvironmentDescSort).toMatchObject({
+    //     features: [
+    //         { name: 'my_feature_b' },
+    //         { name: 'my_feature_c' },
+    //         { name: 'my_feature_a' },
+    //     ],
+    //     total: 3,
+    // });
 });
 test('should paginate correctly when using tags', async () => {
     await app.createFeature('my_feature_a');

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -319,61 +319,61 @@ test('should sort features', async () => {
     await app.enableFeature('my_feature_c', 'default');
     await app.favoriteFeature('my_feature_b');
 
-    // const { body: ascName } = await sortFeatures({
-    //     sortBy: 'name',
-    //     sortOrder: 'asc',
-    // });
-    //
-    // expect(ascName).toMatchObject({
-    //     features: [
-    //         { name: 'my_feature_a' },
-    //         { name: 'my_feature_b' },
-    //         { name: 'my_feature_c' },
-    //     ],
-    //     total: 3,
-    // });
-    //
-    // const { body: descName } = await sortFeatures({
-    //     sortBy: 'name',
-    //     sortOrder: 'desc',
-    // });
-    //
-    // expect(descName).toMatchObject({
-    //     features: [
-    //         { name: 'my_feature_c' },
-    //         { name: 'my_feature_b' },
-    //         { name: 'my_feature_a' },
-    //     ],
-    //     total: 3,
-    // });
-    //
-    // const { body: defaultCreatedAt } = await sortFeatures({
-    //     sortBy: '',
-    //     sortOrder: '',
-    // });
-    //
-    // expect(defaultCreatedAt).toMatchObject({
-    //     features: [
-    //         { name: 'my_feature_a' },
-    //         { name: 'my_feature_c' },
-    //         { name: 'my_feature_b' },
-    //     ],
-    //     total: 3,
-    // });
-    //
-    // const { body: environmentAscSort } = await sortFeatures({
-    //     sortBy: 'environment:default',
-    //     sortOrder: 'asc',
-    // });
-    //
-    // expect(environmentAscSort).toMatchObject({
-    //     features: [
-    //         { name: 'my_feature_a' },
-    //         { name: 'my_feature_b' },
-    //         { name: 'my_feature_c' },
-    //     ],
-    //     total: 3,
-    // });
+    const { body: ascName } = await sortFeatures({
+        sortBy: 'name',
+        sortOrder: 'asc',
+    });
+
+    expect(ascName).toMatchObject({
+        features: [
+            { name: 'my_feature_a' },
+            { name: 'my_feature_b' },
+            { name: 'my_feature_c' },
+        ],
+        total: 3,
+    });
+
+    const { body: descName } = await sortFeatures({
+        sortBy: 'name',
+        sortOrder: 'desc',
+    });
+
+    expect(descName).toMatchObject({
+        features: [
+            { name: 'my_feature_c' },
+            { name: 'my_feature_b' },
+            { name: 'my_feature_a' },
+        ],
+        total: 3,
+    });
+
+    const { body: defaultCreatedAt } = await sortFeatures({
+        sortBy: '',
+        sortOrder: '',
+    });
+
+    expect(defaultCreatedAt).toMatchObject({
+        features: [
+            { name: 'my_feature_a' },
+            { name: 'my_feature_c' },
+            { name: 'my_feature_b' },
+        ],
+        total: 3,
+    });
+
+    const { body: environmentAscSort } = await sortFeatures({
+        sortBy: 'environment:default',
+        sortOrder: 'asc',
+    });
+
+    expect(environmentAscSort).toMatchObject({
+        features: [
+            { name: 'my_feature_a' },
+            { name: 'my_feature_b' },
+            { name: 'my_feature_c' },
+        ],
+        total: 3,
+    });
 
     const { body: environmentDescSort } = await sortFeatures({
         sortBy: 'environment:default',
@@ -389,20 +389,20 @@ test('should sort features', async () => {
         total: 3,
     });
 
-    // const { body: favoriteEnvironmentDescSort } = await sortFeatures({
-    //     sortBy: 'environment:default',
-    //     sortOrder: 'desc',
-    //     favoritesFirst: 'true',
-    // });
-    //
-    // expect(favoriteEnvironmentDescSort).toMatchObject({
-    //     features: [
-    //         { name: 'my_feature_b' },
-    //         { name: 'my_feature_c' },
-    //         { name: 'my_feature_a' },
-    //     ],
-    //     total: 3,
-    // });
+    const { body: favoriteEnvironmentDescSort } = await sortFeatures({
+        sortBy: 'environment:default',
+        sortOrder: 'desc',
+        favoritesFirst: 'true',
+    });
+
+    expect(favoriteEnvironmentDescSort).toMatchObject({
+        features: [
+            { name: 'my_feature_b' },
+            { name: 'my_feature_c' },
+            { name: 'my_feature_a' },
+        ],
+        total: 3,
+    });
 });
 test('should paginate correctly when using tags', async () => {
     await app.createFeature('my_feature_a');

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -709,7 +709,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     const [, envName] = sortBy.split(':');
                     rankingSql += this.db
                         .raw(
-                            `CASE WHEN feature_environments.environment = ? THEN feature_environments.enabled ELSE NULL END ${validatedSortOrder} NULLS LAST,`,
+                            `CASE WHEN feature_environments.environment = ? THEN feature_environments.enabled ELSE NULL END ${validatedSortOrder} NULLS LAST, features.created_at asc, features.name asc`,
                             [envName],
                         )
                         .toString();
@@ -718,9 +718,10 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                         .raw(`?? ${validatedSortOrder}`, [
                             sortByMapping[sortBy],
                         ])
-                        .toString()},`;
+                        .toString()}, features.created_at asc, features.name asc`;
+                } else {
+                    rankingSql += `features.created_at ${validatedSortOrder}, features.name asc`;
                 }
-                rankingSql += `features.created_at ${validatedSortOrder}, features.name ${validatedSortOrder}`;
 
                 query
                     .select(selectColumns)
@@ -735,6 +736,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             .joinRaw('CROSS JOIN total_features')
             .whereBetween('rank', [offset + 1, offset + limit]);
 
+        console.log(finalQuery.toQuery());
         const rows = await finalQuery;
 
         if (rows.length > 0) {

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -709,7 +709,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     const [, envName] = sortBy.split(':');
                     rankingSql += this.db
                         .raw(
-                            `CASE WHEN feature_environments.environment = ? THEN feature_environments.enabled ELSE NULL END ${validatedSortOrder} NULLS LAST, features.created_at asc`,
+                            `CASE WHEN feature_environments.environment = ? THEN feature_environments.enabled ELSE NULL END ${validatedSortOrder} NULLS LAST,`,
                             [envName],
                         )
                         .toString();
@@ -718,10 +718,9 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                         .raw(`?? ${validatedSortOrder}`, [
                             sortByMapping[sortBy],
                         ])
-                        .toString()}, features.created_at asc`;
-                } else {
-                    rankingSql += `features.created_at ${validatedSortOrder}`;
+                        .toString()},`;
                 }
+                rankingSql += `features.created_at ${validatedSortOrder}, features.name ${validatedSortOrder}`;
 
                 query
                     .select(selectColumns)

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -736,7 +736,6 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             .joinRaw('CROSS JOIN total_features')
             .whereBetween('rank', [offset + 1, offset + limit]);
 
-        console.log(finalQuery.toQuery());
         const rows = await finalQuery;
 
         if (rows.length > 0) {


### PR DESCRIPTION
The issue was that we all features were created exactly in same time, and our feature counter was expecting time to be unique to feature, which was not the case.