### PR TITLE
feat: scheduler runtime control

### DIFF
--- a/src/lib/features/scheduler/scheduleServices.ts
+++ b/src/lib/features/scheduler/scheduleServices.ts
@@ -1,0 +1,140 @@
+import {
+    hoursToMilliseconds,
+    minutesToMilliseconds,
+    secondsToMilliseconds,
+} from 'date-fns';
+import { IUnleashServices } from '../../server-impl';
+
+export const scheduleServices = async (
+    services: IUnleashServices,
+): Promise<void> => {
+    const {
+        schedulerService,
+        apiTokenService,
+        instanceStatsService,
+        clientInstanceService,
+        projectService,
+        projectHealthService,
+        configurationRevisionService,
+        eventAnnouncerService,
+        featureToggleService,
+        versionService,
+        lastSeenService,
+        proxyService,
+        clientMetricsServiceV2,
+    } = services;
+
+    schedulerService.schedule(
+        lastSeenService.cleanLastSeen.bind(lastSeenService),
+        hoursToMilliseconds(1),
+        'cleanLastSeen',
+    );
+
+    schedulerService.schedule(
+        lastSeenService.store.bind(lastSeenService),
+        secondsToMilliseconds(30),
+        'storeLastSeen',
+    );
+
+    schedulerService.schedule(
+        apiTokenService.fetchActiveTokens.bind(apiTokenService),
+        minutesToMilliseconds(1),
+        'fetchActiveTokens',
+    );
+
+    schedulerService.schedule(
+        apiTokenService.updateLastSeen.bind(apiTokenService),
+        minutesToMilliseconds(3),
+        'updateLastSeen',
+    );
+
+    schedulerService.schedule(
+        instanceStatsService.refreshStatsSnapshot.bind(instanceStatsService),
+        minutesToMilliseconds(5),
+        'refreshStatsSnapshot',
+    );
+
+    schedulerService.schedule(
+        clientInstanceService.removeInstancesOlderThanTwoDays.bind(
+            clientInstanceService,
+        ),
+        hoursToMilliseconds(24),
+        'removeInstancesOlderThanTwoDays',
+    );
+
+    schedulerService.schedule(
+        clientInstanceService.bulkAdd.bind(clientInstanceService),
+        secondsToMilliseconds(5),
+        'bulkAddInstances',
+    );
+
+    schedulerService.schedule(
+        clientInstanceService.announceUnannounced.bind(clientInstanceService),
+        minutesToMilliseconds(5),
+        'announceUnannounced',
+    );
+
+    schedulerService.schedule(
+        projectService.statusJob.bind(projectService),
+        hoursToMilliseconds(24),
+        'statusJob',
+    );
+
+    schedulerService.schedule(
+        projectHealthService.setHealthRating.bind(projectHealthService),
+        hoursToMilliseconds(1),
+        'setHealthRating',
+    );
+
+    schedulerService.schedule(
+        configurationRevisionService.updateMaxRevisionId.bind(
+            configurationRevisionService,
+        ),
+        secondsToMilliseconds(1),
+        'updateMaxRevisionId',
+    );
+
+    schedulerService.schedule(
+        eventAnnouncerService.publishUnannouncedEvents.bind(
+            eventAnnouncerService,
+        ),
+        secondsToMilliseconds(1),
+        'publishUnannouncedEvents',
+    );
+
+    schedulerService.schedule(
+        featureToggleService.updatePotentiallyStaleFeatures.bind(
+            featureToggleService,
+        ),
+        minutesToMilliseconds(1),
+        'updatePotentiallyStaleFeatures',
+    );
+
+    schedulerService.schedule(
+        versionService.checkLatestVersion.bind(versionService),
+        hoursToMilliseconds(48),
+        'checkLatestVersion',
+    );
+
+    schedulerService.schedule(
+        proxyService.fetchFrontendSettings.bind(proxyService),
+        minutesToMilliseconds(2),
+        'fetchFrontendSettings',
+    );
+
+    schedulerService.schedule(
+        () => {
+            clientMetricsServiceV2.bulkAdd().catch(console.error);
+        },
+        secondsToMilliseconds(5),
+        'bulkAddMetrics',
+    );
+
+    schedulerService.schedule(
+        () => {
+            clientMetricsServiceV2.clearMetrics(48).catch(console.error);
+        },
+        hoursToMilliseconds(12),
+        'clearMetrics',
+    );
+};

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -1,10 +1,10 @@
 import { SchedulerService } from './scheduler-service';
-import { LogProvider } from '../logger';
-import MaintenanceService from './maintenance-service';
-import { createTestConfig } from '../../test/config/test-config';
-import SettingService from './setting-service';
-import FakeSettingStore from '../../test/fixtures/fake-setting-store';
-import EventService from './event-service';
+import { LogProvider } from '../../logger';
+import MaintenanceService from '../../services/maintenance-service';
+import { createTestConfig } from '../../../test/config/test-config';
+import SettingService from '../../services/setting-service';
+import FakeSettingStore from '../../../test/fixtures/fake-setting-store';
+import EventService from '../../services/event-service';
 
 function ms(timeMs) {
     return new Promise((resolve) => setTimeout(resolve, timeMs));

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -1,5 +1,5 @@
-import { Logger, LogProvider } from '../logger';
-import MaintenanceService from './maintenance-service';
+import { Logger, LogProvider } from '../../logger';
+import MaintenanceService from '../../services/maintenance-service';
 
 export type SchedulerMode = 'active' | 'paused';
 
@@ -62,9 +62,5 @@ export class SchedulerService {
 
     resume(): void {
         this.mode = 'active';
-    }
-
-    getMode(): SchedulerMode {
-        return this.mode;
     }
 }

--- a/src/lib/middleware/cors-origin-middleware.test.ts
+++ b/src/lib/middleware/cors-origin-middleware.test.ts
@@ -4,15 +4,9 @@ import { createTestConfig } from '../../test/config/test-config';
 import FakeEventStore from '../../test/fixtures/fake-event-store';
 import { randomId } from '../util/random-id';
 import FakeProjectStore from '../../test/fixtures/fake-project-store';
-import {
-    EventService,
-    ProxyService,
-    SchedulerService,
-    SettingService,
-} from '../../lib/services';
+import { EventService, ProxyService, SettingService } from '../../lib/services';
 import { ISettingStore } from '../../lib/types';
 import { frontendSettingsKey } from '../../lib/types/settings/frontend-settings';
-import { minutesToMilliseconds } from 'date-fns';
 import FakeFeatureTagStore from '../../test/fixtures/fake-feature-tag-store';
 
 const createSettingService = (

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -5,7 +5,7 @@ import { migrateDb } from '../migrator';
 import getApp from './app';
 import { createMetricsMonitor } from './metrics';
 import { createStores } from './db';
-import { createServices, scheduleServices } from './services';
+import { createServices } from './services';
 import { createConfig } from './create-config';
 import registerGracefulShutdown from './util/graceful-shutdown';
 import { createDb } from './db/db-pool';
@@ -33,6 +33,7 @@ import * as permissions from './types/permissions';
 import * as eventType from './types/events';
 import { Db } from './db/db';
 import { defaultLockKey, defaultTimeout, withDbLock } from './util/db-lock';
+import { scheduleServices } from './features/scheduler/scheduleServices';
 
 async function createApp(
     config: IUnleashConfig,
@@ -45,7 +46,7 @@ async function createApp(
     const stores = createStores(config, db);
     const services = createServices(stores, config, db);
     if (!config.disableScheduler) {
-        await scheduleServices(services, config.flagResolver);
+        await scheduleServices(services);
     }
 
     const metricsMonitor = createMetricsMonitor();

--- a/src/lib/services/client-metrics/last-seen/last-seen-service.ts
+++ b/src/lib/services/client-metrics/last-seen/last-seen-service.ts
@@ -1,9 +1,12 @@
-import { secondsToMilliseconds } from 'date-fns';
 import { Logger } from '../../../logger';
 import { IUnleashConfig } from '../../../server-impl';
 import { IClientMetricsEnv } from '../../../types/stores/client-metrics-store-v2';
 import { ILastSeenStore } from './types/last-seen-store-type';
-import { IFeatureToggleStore, IUnleashStores } from '../../../../lib/types';
+import {
+    IFeatureToggleStore,
+    IFlagResolver,
+    IUnleashStores,
+} from '../../../../lib/types';
 
 export type LastSeenInput = {
     featureName: string;
@@ -21,6 +24,8 @@ export class LastSeenService {
 
     private config: IUnleashConfig;
 
+    private flagResolver: IFlagResolver;
+
     constructor(
         {
             featureToggleStore,
@@ -33,6 +38,7 @@ export class LastSeenService {
         this.logger = config.getLogger(
             '/services/client-metrics/last-seen-service.ts',
         );
+        this.flagResolver = config.flagResolver;
         this.config = config;
     }
 
@@ -75,6 +81,8 @@ export class LastSeenService {
     }
 
     async cleanLastSeen() {
-        await this.lastSeenStore.cleanLastSeen();
+        if (this.flagResolver.isEnabled('useLastSeenRefactor')) {
+            await this.lastSeenStore.cleanLastSeen();
+        }
     }
 }

--- a/src/lib/services/maintenance-service.test.ts
+++ b/src/lib/services/maintenance-service.test.ts
@@ -1,17 +1,40 @@
 import { SchedulerService } from './scheduler-service';
 import MaintenanceService from './maintenance-service';
-import { IUnleashStores } from '../types';
 import SettingService from './setting-service';
 import { createTestConfig } from '../../test/config/test-config';
+import FakeSettingStore from '../../test/fixtures/fake-setting-store';
+import EventService from './event-service';
 
-test('Maintenance on should pause scheduler', async () => {
+test('Scheduler should run scheduled functions if maintenance mode is off', async () => {
     const config = createTestConfig();
-    const schedulerService = new SchedulerService(config.getLogger);
-    const maintenanceService = new MaintenanceService(
-        {} as IUnleashStores,
-        config,
-        { insert() {} } as unknown as SettingService,
-        schedulerService,
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
+    const job = jest.fn();
+
+    await schedulerService.schedule(job, 10, 'test-id');
+
+    expect(job).toBeCalledTimes(1);
+    schedulerService.stop();
+});
+
+test('Scheduler should not run scheduled functions if maintenance mode is on', async () => {
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
     );
 
     await maintenanceService.toggleMaintenanceMode(
@@ -19,26 +42,10 @@ test('Maintenance on should pause scheduler', async () => {
         'irrelevant user',
     );
 
-    expect(schedulerService.getMode()).toBe('paused');
-    schedulerService.stop();
-});
+    const job = jest.fn();
 
-test('Maintenance off should resume scheduler', async () => {
-    const config = createTestConfig({ disableScheduler: false });
-    const schedulerService = new SchedulerService(config.getLogger);
-    schedulerService.pause();
-    const maintenanceService = new MaintenanceService(
-        {} as IUnleashStores,
-        config,
-        { insert() {} } as unknown as SettingService,
-        schedulerService,
-    );
+    await schedulerService.schedule(job, 10, 'test-id');
 
-    await maintenanceService.toggleMaintenanceMode(
-        { enabled: false },
-        'irrelevant user',
-    );
-
-    expect(schedulerService.getMode()).toBe('active');
+    expect(job).toBeCalledTimes(0);
     schedulerService.stop();
 });

--- a/src/lib/services/maintenance-service.test.ts
+++ b/src/lib/services/maintenance-service.test.ts
@@ -1,4 +1,4 @@
-import { SchedulerService } from './scheduler-service';
+import { SchedulerService } from '../features/scheduler/scheduler-service';
 import MaintenanceService from './maintenance-service';
 import SettingService from './setting-service';
 import { createTestConfig } from '../../test/config/test-config';

--- a/src/lib/services/maintenance-service.ts
+++ b/src/lib/services/maintenance-service.ts
@@ -1,40 +1,20 @@
-import { IUnleashConfig, IUnleashStores } from '../types';
+import { IUnleashConfig } from '../types';
 import { Logger } from '../logger';
-import { IPatStore } from '../types/stores/pat-store';
-import { IEventStore } from '../types/stores/event-store';
 import SettingService from './setting-service';
 import { maintenanceSettingsKey } from '../types/settings/maintenance-settings';
 import { MaintenanceSchema } from '../openapi/spec/maintenance-schema';
-import { SchedulerService } from './scheduler-service';
 
 export default class MaintenanceService {
     private config: IUnleashConfig;
 
     private logger: Logger;
 
-    private patStore: IPatStore;
-
-    private eventStore: IEventStore;
-
     private settingService: SettingService;
 
-    private schedulerService: SchedulerService;
-
-    constructor(
-        {
-            patStore,
-            eventStore,
-        }: Pick<IUnleashStores, 'patStore' | 'eventStore'>,
-        config: IUnleashConfig,
-        settingService: SettingService,
-        schedulerService: SchedulerService,
-    ) {
+    constructor(config: IUnleashConfig, settingService: SettingService) {
         this.config = config;
         this.logger = config.getLogger('services/pat-service.ts');
-        this.patStore = patStore;
-        this.eventStore = eventStore;
         this.settingService = settingService;
-        this.schedulerService = schedulerService;
     }
 
     async isMaintenanceMode(): Promise<boolean> {
@@ -56,11 +36,6 @@ export default class MaintenanceService {
         setting: MaintenanceSchema,
         user: string,
     ): Promise<void> {
-        if (setting.enabled) {
-            this.schedulerService.pause();
-        } else if (!this.config.disableScheduler) {
-            this.schedulerService.resume();
-        }
         return this.settingService.insert(
             maintenanceSettingsKey,
             setting,

--- a/src/lib/services/scheduler-service.test.ts
+++ b/src/lib/services/scheduler-service.test.ts
@@ -1,5 +1,10 @@
 import { SchedulerService } from './scheduler-service';
 import { LogProvider } from '../logger';
+import MaintenanceService from './maintenance-service';
+import { createTestConfig } from '../../test/config/test-config';
+import SettingService from './setting-service';
+import FakeSettingStore from '../../test/fixtures/fake-setting-store';
+import EventService from './event-service';
 
 function ms(timeMs) {
     return new Promise((resolve) => setTimeout(resolve, timeMs));
@@ -22,34 +27,61 @@ const getLogger = () => {
 };
 
 test('Schedules job immediately', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
 
-    schedulerService.schedule(job, 10, 'test-id');
+    await schedulerService.schedule(job, 10, 'test-id');
 
     expect(job).toBeCalledTimes(1);
     schedulerService.stop();
 });
 
 test('Does not schedule job immediately when paused', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
 
     schedulerService.pause();
-    schedulerService.schedule(job, 10, 'test-id-2');
+    await schedulerService.schedule(job, 10, 'test-id-2');
 
     expect(job).toBeCalledTimes(0);
     schedulerService.stop();
 });
 
 test('Can schedule a single regular job', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
 
-    schedulerService.schedule(job, 50, 'test-id-3');
+    await schedulerService.schedule(job, 50, 'test-id-3');
     await ms(75);
 
     expect(job).toBeCalledTimes(2);
@@ -57,12 +89,21 @@ test('Can schedule a single regular job', async () => {
 });
 
 test('Scheduled job ignored in a paused mode', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
 
     schedulerService.pause();
-    schedulerService.schedule(job, 50, 'test-id-4');
+    await schedulerService.schedule(job, 50, 'test-id-4');
     await ms(75);
 
     expect(job).toBeCalledTimes(0);
@@ -70,12 +111,21 @@ test('Scheduled job ignored in a paused mode', async () => {
 });
 
 test('Can resume paused job', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
 
     schedulerService.pause();
-    schedulerService.schedule(job, 50, 'test-id-5');
+    await schedulerService.schedule(job, 50, 'test-id-5');
     schedulerService.resume();
     await ms(75);
 
@@ -84,13 +134,22 @@ test('Can resume paused job', async () => {
 });
 
 test('Can schedule multiple jobs at the same interval', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     const job = jest.fn();
     const anotherJob = jest.fn();
 
-    schedulerService.schedule(job, 50, 'test-id-6');
-    schedulerService.schedule(anotherJob, 50, 'test-id-7');
+    await schedulerService.schedule(job, 50, 'test-id-6');
+    await schedulerService.schedule(anotherJob, 50, 'test-id-7');
     await ms(75);
 
     expect(job).toBeCalledTimes(2);
@@ -99,13 +158,21 @@ test('Can schedule multiple jobs at the same interval', async () => {
 });
 
 test('Can schedule multiple jobs at the different intervals', async () => {
-    const { logger } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = createTestConfig();
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(
+        config.getLogger,
+        maintenanceService,
+    );
     const job = jest.fn();
     const anotherJob = jest.fn();
 
-    schedulerService.schedule(job, 100, 'test-id-8');
-    schedulerService.schedule(anotherJob, 200, 'test-id-9');
+    await schedulerService.schedule(job, 100, 'test-id-8');
+    await schedulerService.schedule(anotherJob, 200, 'test-id-9');
     await ms(250);
 
     expect(job).toBeCalledTimes(3);
@@ -115,12 +182,19 @@ test('Can schedule multiple jobs at the different intervals', async () => {
 
 test('Can handle crash of a async job', async () => {
     const { logger, getRecords } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = { ...createTestConfig(), logger };
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(logger, maintenanceService);
+
     const job = async () => {
         await Promise.reject('async reason');
     };
 
-    schedulerService.schedule(job, 50, 'test-id-10');
+    await schedulerService.schedule(job, 50, 'test-id-10');
     await ms(75);
 
     schedulerService.stop();
@@ -132,12 +206,19 @@ test('Can handle crash of a async job', async () => {
 
 test('Can handle crash of a sync job', async () => {
     const { logger, getRecords } = getLogger();
-    const schedulerService = new SchedulerService(logger);
+    const config = { ...createTestConfig(), logger };
+    const settingStore = new FakeSettingStore();
+    const settingService = new SettingService({ settingStore }, config, {
+        storeEvent() {},
+    } as unknown as EventService);
+    const maintenanceService = new MaintenanceService(config, settingService);
+    const schedulerService = new SchedulerService(logger, maintenanceService);
+
     const job = () => {
         throw new Error('sync reason');
     };
 
-    schedulerService.schedule(job, 50, 'test-id-11');
+    await schedulerService.schedule(job, 50, 'test-id-11');
     await ms(75);
 
     schedulerService.stop();

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -37,7 +37,7 @@ import { InstanceStatsService } from '../features/instance-stats/instance-stats-
 import { FavoritesService } from '../services/favorites-service';
 import MaintenanceService from '../services/maintenance-service';
 import { AccountService } from '../services/account-service';
-import { SchedulerService } from '../services/scheduler-service';
+import { SchedulerService } from '../features/scheduler/scheduler-service';
 import { Knex } from 'knex';
 import {
     IExportService,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1645/address-post-mortem-action-point-all-flags-should-be-runtime

Refactor with the goal of ensuring that flags are runtime controllable, mostly focused on the current scheduler logic.

This includes the following changes:
 - Moves scheduler into its own "scheduler" feature folder
 - Reverts dependency: SchedulerService takes in the MaintenanceService, not the other way around
 - Scheduler now evaluates maintenance mode at runtime instead of relying on its mode state (active / paused)
 - Favors flag checks to happen inside the scheduled methods, instead of controlling whether the method is scheduled at all (favor runtime over startup)
 - Updates tests accordingly
 - Boyscouting

Scheduler mode is currently not being used, along with its respective methods, except in tests. Should we remove it in favor of only controlling the scheduler state through maintenance mode?

Are there any other tests we should add?