### PR TITLE
chore: find segment strategies in CRs

### DIFF
--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
@@ -133,3 +133,43 @@ describe.each([
         },
     );
 });
+
+describe.each([
+    [
+        'updateStrategy',
+        (segmentId: number) =>
+            updateStrategyInCr(randomId(), segmentId, FLAG_NAME),
+    ],
+    [
+        'addStrategy',
+        (segmentId: number) => addStrategyToCr(segmentId, FLAG_NAME),
+    ],
+])(
+    '%s events should show up in used strategies correctly',
+    (_, addOrUpdateStrategy) => {
+        test.each([
+            ['Draft', true],
+            ['In Review', true],
+            ['Scheduled', true],
+            ['Approved', true],
+            ['Rejected', false],
+            ['Cancelled', false],
+            ['Applied', false],
+        ])(
+            'Changes in %s CRs should make it %s',
+            async (state, expectedOutcome) => {
+                await createCR(state);
+
+                const segmentId = 3;
+                await addOrUpdateStrategy(segmentId);
+
+                expect(readModel).get;
+                expect(
+                    await readModel.isSegmentUsedInActiveChangeRequests(
+                        segmentId,
+                    ),
+                ).toBe(expectedOutcome);
+            },
+        );
+    },
+);

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
@@ -113,7 +113,7 @@ describe.each([
 ])('Should handle %s changes correctly', (_, addOrUpdateStrategy) => {
     test.each([
         ['Draft', true],
-        ['In Review', true],
+        ['In review', true],
         ['Scheduled', true],
         ['Approved', true],
         ['Rejected', false],
@@ -137,7 +137,7 @@ describe.each([
 describe('addStrategy events should show up in used strategies correctly', () => {
     test.each([
         ['Draft', true],
-        ['In Review', true],
+        ['In review', true],
         ['Scheduled', true],
         ['Approved', true],
         ['Rejected', false],
@@ -152,18 +152,21 @@ describe('addStrategy events should show up in used strategies correctly', () =>
 
             await addStrategyToCr(segmentId, FLAG_NAME);
 
-            const result = await readModel.isSegmentUsedInActiveChangeRequests(
-                segmentId,
-            );
+            const result =
+                await readModel.getStrategiesUsedInActiveChangeRequests(
+                    segmentId,
+                );
             if (shouldShow) {
-                expect(result).toBe({
-                    projectId: 'default',
-                    strategyName: 'flexibleRollout',
-                    environment: 'default',
-                    featureName: FLAG_NAME,
-                });
+                expect(result).toStrictEqual([
+                    {
+                        projectId: 'default',
+                        strategyName: 'flexibleRollout',
+                        environment: 'default',
+                        featureName: FLAG_NAME,
+                    },
+                ]);
             } else {
-                expect(result).toBe([]);
+                expect(result).toStrictEqual([]);
             }
         },
     );
@@ -172,7 +175,7 @@ describe('addStrategy events should show up in used strategies correctly', () =>
 describe('updateStrategy events should show up in used strategies correctly', () => {
     test.each([
         ['Draft', true],
-        ['In Review', true],
+        ['In review', true],
         ['Scheduled', true],
         ['Approved', true],
         ['Rejected', false],
@@ -204,7 +207,7 @@ describe('updateStrategy events should show up in used strategies correctly', ()
                     },
                 ]);
             } else {
-                expect(result).toBe([]);
+                expect(result).toStrictEqual([]);
             }
         },
     );

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
@@ -134,81 +134,75 @@ describe.each([
     );
 });
 
-describe('addStrategy events should show up in used strategies correctly', () => {
-    test.each([
-        ['Draft', true],
-        ['In review', true],
-        ['Scheduled', true],
-        ['Approved', true],
-        ['Rejected', false],
-        ['Cancelled', false],
-        ['Applied', false],
-    ])(
-        'addStrategy events in %s CRs should show up only of the CR is active',
-        async (state, isActiveCr) => {
-            await createCR(state);
+test.each([
+    ['Draft', true],
+    ['In review', true],
+    ['Scheduled', true],
+    ['Approved', true],
+    ['Rejected', false],
+    ['Cancelled', false],
+    ['Applied', false],
+])(
+    'addStrategy events in %s CRs should show up only of the CR is active',
+    async (state, isActiveCr) => {
+        await createCR(state);
 
-            const segmentId = 3;
+        const segmentId = 3;
 
-            await addStrategyToCr(segmentId, FLAG_NAME);
+        await addStrategyToCr(segmentId, FLAG_NAME);
 
-            const result =
-                await readModel.getStrategiesUsedInActiveChangeRequests(
-                    segmentId,
-                );
-            if (isActiveCr) {
-                expect(result).toStrictEqual([
-                    {
-                        projectId: 'default',
-                        strategyName: 'flexibleRollout',
-                        environment: 'default',
-                        featureName: FLAG_NAME,
-                    },
-                ]);
-            } else {
-                expect(result).toStrictEqual([]);
-            }
-        },
-    );
-});
+        const result = await readModel.getStrategiesUsedInActiveChangeRequests(
+            segmentId,
+        );
+        if (isActiveCr) {
+            expect(result).toStrictEqual([
+                {
+                    projectId: 'default',
+                    strategyName: 'flexibleRollout',
+                    environment: 'default',
+                    featureName: FLAG_NAME,
+                },
+            ]);
+        } else {
+            expect(result).toStrictEqual([]);
+        }
+    },
+);
 
-describe('updateStrategy events should show up in used strategies correctly', () => {
-    test.each([
-        ['Draft', true],
-        ['In review', true],
-        ['Scheduled', true],
-        ['Approved', true],
-        ['Rejected', false],
-        ['Cancelled', false],
-        ['Applied', false],
-    ])(
-        `updateStrategy events in %s CRs should show up only of the CR is active`,
-        async (state, isActiveCr) => {
-            await createCR(state);
+test.each([
+    ['Draft', true],
+    ['In review', true],
+    ['Scheduled', true],
+    ['Approved', true],
+    ['Rejected', false],
+    ['Cancelled', false],
+    ['Applied', false],
+])(
+    `updateStrategy events in %s CRs should show up only of the CR is active`,
+    async (state, isActiveCr) => {
+        await createCR(state);
 
-            const segmentId = 3;
+        const segmentId = 3;
 
-            const strategyId = randomId();
-            await updateStrategyInCr(strategyId, segmentId, FLAG_NAME);
+        const strategyId = randomId();
+        await updateStrategyInCr(strategyId, segmentId, FLAG_NAME);
 
-            const result =
-                await readModel.getStrategiesUsedInActiveChangeRequests(
-                    segmentId,
-                );
+        const result = await readModel.getStrategiesUsedInActiveChangeRequests(
+            segmentId,
+        );
 
-            if (isActiveCr) {
-                expect(result).toMatchObject([
-                    {
-                        id: strategyId,
-                        projectId: 'default',
-                        strategyName: 'flexibleRollout',
-                        environment: 'default',
-                        featureName: FLAG_NAME,
-                    },
-                ]);
-            } else {
-                expect(result).toStrictEqual([]);
-            }
-        },
-    );
-});
+        if (isActiveCr) {
+            expect(result).toMatchObject([
+                {
+                    id: strategyId,
+                    projectId: 'default',
+                    strategyName: 'flexibleRollout',
+                    environment: 'default',
+                    featureName: FLAG_NAME,
+                },
+            ]);
+        } else {
+            expect(result).toStrictEqual([]);
+        }
+    },
+);

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
@@ -144,8 +144,8 @@ describe('addStrategy events should show up in used strategies correctly', () =>
         ['Cancelled', false],
         ['Applied', false],
     ])(
-        'addStrategy events in %s CRs should show up',
-        async (state, shouldShow) => {
+        'addStrategy events in %s CRs should show up only of the CR is active',
+        async (state, isActiveCr) => {
             await createCR(state);
 
             const segmentId = 3;
@@ -156,7 +156,7 @@ describe('addStrategy events should show up in used strategies correctly', () =>
                 await readModel.getStrategiesUsedInActiveChangeRequests(
                     segmentId,
                 );
-            if (shouldShow) {
+            if (isActiveCr) {
                 expect(result).toStrictEqual([
                     {
                         projectId: 'default',
@@ -182,8 +182,8 @@ describe('updateStrategy events should show up in used strategies correctly', ()
         ['Cancelled', false],
         ['Applied', false],
     ])(
-        'updateStrategy events in %s CRs should show up',
-        async (state, shouldShow) => {
+        `updateStrategy events in %s CRs should show up only of the CR is active`,
+        async (state, isActiveCr) => {
             await createCR(state);
 
             const segmentId = 3;
@@ -196,7 +196,7 @@ describe('updateStrategy events should show up in used strategies correctly', ()
                     segmentId,
                 );
 
-            if (shouldShow) {
+            if (isActiveCr) {
                 expect(result).toMatchObject([
                     {
                         id: strategyId,

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -7,7 +7,7 @@ type NewStrategy = {
 
 type ExistingStrategy = NewStrategy & { id?: string };
 
-type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
+export type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
 
 export interface IChangeRequestSegmentUsageReadModel {
     isSegmentUsedInActiveChangeRequests(segmentId: number): Promise<boolean>;

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -1,4 +1,15 @@
+type NewStrategy = {
+    projectId: string;
+    featureName: string;
+    strategyName: string;
+    environment: string;
+};
+
+type ExistingStrategy = NewStrategy & { id?: string };
+
+type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
+
 export interface IChangeRequestSegmentUsageReadModel {
     isSegmentUsedInActiveChangeRequests(segmentId: number): Promise<boolean>;
-    getSegmentsUsedInActiveChangeRequests(): Promise<{}[]>;
+    getSegmentsUsedInActiveChangeRequests(): Promise<ChangeRequestStrategy[]>;
 }

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -5,7 +5,7 @@ type NewStrategy = {
     environment: string;
 };
 
-type ExistingStrategy = NewStrategy & { id?: string };
+type ExistingStrategy = NewStrategy & { id: string };
 
 export type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
 

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -11,5 +11,7 @@ type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
 
 export interface IChangeRequestSegmentUsageReadModel {
     isSegmentUsedInActiveChangeRequests(segmentId: number): Promise<boolean>;
-    getSegmentsUsedInActiveChangeRequests(): Promise<ChangeRequestStrategy[]>;
+    getStrategiesUsedInActiveChangeRequests(
+        segmentId: number,
+    ): Promise<ChangeRequestStrategy[]>;
 }

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -1,3 +1,4 @@
 export interface IChangeRequestSegmentUsageReadModel {
     isSegmentUsedInActiveChangeRequests(segmentId: number): Promise<boolean>;
+    getSegmentsUsedInActiveChangeRequests(): Promise<{}[]>;
 }

--- a/src/lib/features/change-request-segment-usage-service/fake-change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/fake-change-request-segment-usage-read-model.ts
@@ -1,16 +1,32 @@
-import { IChangeRequestSegmentUsageReadModel } from './change-request-segment-usage-read-model';
+import {
+    ChangeRequestStrategy,
+    IChangeRequestSegmentUsageReadModel,
+} from './change-request-segment-usage-read-model';
 
 export class FakeChangeRequestSegmentUsageReadModel
     implements IChangeRequestSegmentUsageReadModel
 {
     private isSegmentUsedInActiveChangeRequestsValue: boolean;
+    strategiesUsedInActiveChangeRequests: ChangeRequestStrategy[];
 
-    constructor(isSegmentUsedInActiveChangeRequests = false) {
+    constructor(
+        isSegmentUsedInActiveChangeRequests = false,
+        strategiesUsedInActiveChangeRequests = [],
+    ) {
         this.isSegmentUsedInActiveChangeRequestsValue =
             isSegmentUsedInActiveChangeRequests;
+
+        this.strategiesUsedInActiveChangeRequests =
+            strategiesUsedInActiveChangeRequests;
     }
 
     public async isSegmentUsedInActiveChangeRequests(): Promise<boolean> {
         return this.isSegmentUsedInActiveChangeRequestsValue;
+    }
+
+    public async getStrategiesUsedInActiveChangeRequests(): Promise<
+        ChangeRequestStrategy[]
+    > {
+        return this.strategiesUsedInActiveChangeRequests;
     }
 }

--- a/src/lib/openapi/spec/admin-strategies-schema.ts
+++ b/src/lib/openapi/spec/admin-strategies-schema.ts
@@ -26,7 +26,8 @@ export const segmentStrategiesSchema = {
                     },
                     featureName: {
                         type: 'string',
-                        description: 'The ID of the strategy',
+                        description:
+                            'The name of the feature flag that this strategy belongs to.',
                         example: 'new-signup-flow',
                     },
                     projectId: {

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -249,7 +249,7 @@ test('should not delete segments used by strategies in CRs', async () => {
     await db.rawDatabase.table('change_requests').insert({
         id: CR_ID,
         environment: 'default',
-        state: 'In Review',
+        state: 'In review',
         project: 'default',
         created_by: user.id,
         created_at: '2023-01-01 00:00:00',

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -234,6 +234,57 @@ test('should not delete segments used by strategies', async () => {
     expect((await fetchSegments()).length).toEqual(1);
 });
 
+test('should not delete segments used by strategies in CRs', async () => {
+    await createSegment({ name: 'a', constraints: [] });
+    const toggle = mockFeatureToggle();
+    await createFeatureToggle(app, toggle);
+    const [segment] = await fetchSegments();
+
+    const CR_ID = 54321;
+
+    const user = await db.stores.userStore.insert({
+        username: 'test',
+    });
+
+    await db.rawDatabase.table('change_requests').insert({
+        id: CR_ID,
+        environment: 'default',
+        state: 'In Review',
+        project: 'default',
+        created_by: user.id,
+        created_at: '2023-01-01 00:00:00',
+        min_approvals: 1,
+        title: 'My change request',
+    });
+
+    await db.rawDatabase.table('change_request_events').insert({
+        feature: toggle.name,
+        action: 'addStrategy',
+        payload: {
+            name: 'flexibleRollout',
+            title: '',
+            disabled: false,
+            segments: [segment.id],
+            variants: [],
+            parameters: {
+                groupId: toggle.name,
+                rollout: '100',
+                stickiness: 'default',
+            },
+            constraints: [],
+        },
+        created_at: '2023-01-01 00:01:00',
+        change_request_id: CR_ID,
+        created_by: user.id,
+    });
+
+    expect((await fetchSegments()).length).toEqual(1);
+
+    await app.request.delete(`${SEGMENTS_BASE_PATH}/${segment.id}`).expect(409);
+
+    expect((await fetchSegments()).length).toEqual(1);
+});
+
 test('should list strategies by segment', async () => {
     await createSegment({ name: 'S1', constraints: [] });
     await createSegment({ name: 'S2', constraints: [] });
@@ -425,216 +476,4 @@ test('Should show usage in features and projects', async () => {
 
     const segments = await fetchSegments();
     expect(segments).toMatchObject([{ usedInFeatures: 1, usedInProjects: 1 }]);
-});
-
-describe('detect strategy usage in change requests', () => {
-    const CR_ID = 54321;
-    let user;
-
-    beforeAll(async () => {
-        user = await db.stores.userStore.insert({
-            username: 'test',
-        });
-    });
-    afterAll(async () => {
-        user = await db.stores.userStore.delete(user.id);
-    });
-
-    beforeEach(async () => {
-        await db.rawDatabase.table('change_requests').insert({
-            id: CR_ID,
-            environment: 'default',
-            state: 'In Review',
-            project: 'default',
-            created_by: user.id,
-            created_at: '2023-01-01 00:00:00',
-            min_approvals: 1,
-            title: 'My change request',
-        });
-    });
-
-    afterEach(async () => {
-        await db.rawDatabase.table('change_requests').delete();
-    });
-
-    test('should not delete segments used by strategies in CRs', async () => {
-        await createSegment({ name: 'a', constraints: [] });
-        const toggle = mockFeatureToggle();
-        await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
-
-        await db.rawDatabase.table('change_request_events').insert({
-            feature: toggle.name,
-            action: 'addStrategy',
-            payload: {
-                name: 'flexibleRollout',
-                title: '',
-                disabled: false,
-                segments: [segment.id],
-                variants: [],
-                parameters: {
-                    groupId: toggle.name,
-                    rollout: '100',
-                    stickiness: 'default',
-                },
-                constraints: [],
-            },
-            created_at: '2023-01-01 00:01:00',
-            change_request_id: CR_ID,
-            created_by: user.id,
-        });
-
-        expect((await fetchSegments()).length).toEqual(1);
-
-        await app.request
-            .delete(`${SEGMENTS_BASE_PATH}/${segment.id}`)
-            .expect(409);
-
-        expect((await fetchSegments()).length).toEqual(1);
-    });
-
-    test('Should show segment usage in addStrategy events', async () => {
-        await createSegment({ name: 'a', constraints: [] });
-        const toggle = mockFeatureToggle();
-        await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
-
-        // create change request
-
-        await db.rawDatabase.table('change_request_events').insert({
-            feature: toggle.name,
-            action: 'updateStrategy',
-            payload: {
-                name: 'flexibleRollout',
-                title: '',
-                disabled: false,
-                segments: [segment.id],
-                variants: [],
-                parameters: {
-                    groupId: toggle.name,
-                    rollout: '100',
-                    stickiness: 'default',
-                },
-                constraints: [],
-            },
-            created_at: '2023-01-01 00:01:00',
-            change_request_id: CR_ID,
-            created_by: user.id,
-        });
-
-        // for addStrategy, add strategy to feature with segment
-        // check that getStrategies for segments contains the CR strategies
-
-        const segmentStrategies = await fetchSegmentStrategies(segment.id);
-
-        expect(segmentStrategies).not.toHaveLength(0);
-    });
-
-    test('Should show segment usage in updateStrategy events', async () => {
-        await createSegment({ name: 'a', constraints: [] });
-        const toggle = mockFeatureToggle();
-        await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
-
-        await addStrategyToFeatureEnv(
-            app,
-            { ...toggle.strategies[0] },
-            'default',
-            toggle.name,
-        );
-
-        await addStrategyToFeatureEnv(
-            app,
-            { ...toggle.strategies[0] },
-            'default',
-            toggle.name,
-        );
-
-        const [{ strategies }] = await fetchFeatures();
-
-        const strategyId = strategies[0].id;
-
-        await db.rawDatabase.table('change_request_events').insert({
-            feature: toggle.name,
-            action: 'addStrategy',
-            payload: {
-                id: strategyId,
-                name: 'flexibleRollout',
-                title: '',
-                disabled: false,
-                segments: [segment.id],
-                variants: [],
-                parameters: {
-                    groupId: toggle.name,
-                    rollout: '100',
-                    stickiness: 'default',
-                },
-                constraints: [],
-            },
-            created_at: '2023-01-01 00:01:00',
-            change_request_id: CR_ID,
-            created_by: user.id,
-        });
-
-        // for updateStrategy, add existing strategy, then add segment in CR
-        // check that getStrategies for segments contains the CR strategies
-
-        const segmentStrategies = await fetchSegmentStrategies(segment.id);
-
-        expect(segmentStrategies).not.toHaveLength(0);
-    });
-
-    test('If a segment is used in an existing strategy and in a CR for the same strategy, the strategy should only be listed once', async () => {
-        await createSegment({ name: 'a', constraints: [] });
-        const toggle = mockFeatureToggle();
-        await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
-
-        await addStrategyToFeatureEnv(
-            app,
-            { ...toggle.strategies[0] },
-            'default',
-            toggle.name,
-        );
-
-        await addStrategyToFeatureEnv(
-            app,
-            { ...toggle.strategies[0] },
-            'default',
-            toggle.name,
-        );
-
-        const [{ strategies }] = await fetchFeatures();
-
-        const strategyId = strategies[0].id;
-
-        await db.rawDatabase.table('change_request_events').insert({
-            feature: toggle.name,
-            action: 'addStrategy',
-            payload: {
-                id: strategyId,
-                name: 'flexibleRollout',
-                title: '',
-                disabled: false,
-                segments: [segment.id],
-                variants: [],
-                parameters: {
-                    groupId: toggle.name,
-                    rollout: '100',
-                    stickiness: 'default',
-                },
-                constraints: [],
-            },
-            created_at: '2023-01-01 00:01:00',
-            change_request_id: CR_ID,
-            created_by: user.id,
-        });
-
-        // for updateStrategy, add existing strategy, then add segment in CR
-        // check that getStrategies for segments contains the CR strategies
-
-        const segmentStrategies = await fetchSegmentStrategies(segment.id);
-
-        expect(segmentStrategies).not.toHaveLength(0);
-    });
 });

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -523,7 +523,6 @@ describe('detect strategy usage in change requests', () => {
         });
 
         // for addStrategy, add strategy to feature with segment
-        // for updateStrategy, add existing strategy, then add segment in CR
         // check that getStrategies for segments contains the CR strategies
 
         const segmentStrategies = await fetchSegmentStrategies(segment.id);
@@ -577,7 +576,6 @@ describe('detect strategy usage in change requests', () => {
             created_by: user.id,
         });
 
-        // for addStrategy, add strategy to feature with segment
         // for updateStrategy, add existing strategy, then add segment in CR
         // check that getStrategies for segments contains the CR strategies
 


### PR DESCRIPTION
This PR adds the ability to detect which strategies use a specific segment in active change requests.

It does not wire this functionality up to anything just yet. Follow-up PRs will integrate this with the segment service and eventually with the front end.