### PR TITLE
fix: handle check against non existing projects

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1168,19 +1168,26 @@ class FeatureToggleService {
         projectId: string,
         featureNames: string[],
     ): Promise<FeatureNameCheckResultWithFeaturePattern> {
-        const project = await this.projectStore.get(projectId);
-        const patternData = project.featureNaming;
-        const namingPattern = patternData?.pattern;
+        try {
+            const project = await this.projectStore.get(projectId);
 
-        if (namingPattern) {
-            const result = checkFeatureFlagNamesAgainstPattern(
-                featureNames,
-                namingPattern,
-            );
+            const patternData = project.featureNaming;
+            const namingPattern = patternData?.pattern;
 
-            if (result.state === 'invalid') {
-                return { ...result, featureNaming: patternData };
+            if (namingPattern) {
+                const result = checkFeatureFlagNamesAgainstPattern(
+                    featureNames,
+                    namingPattern,
+                );
+
+                if (result.state === 'invalid') {
+                    return { ...result, featureNaming: patternData };
+                }
             }
+        } catch {
+            // the project doesn't exist, so there's nothing to
+            // validate against
+            return { state: 'valid' };
         }
 
         return { state: 'valid' };

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1184,9 +1184,14 @@ class FeatureToggleService {
                     return { ...result, featureNaming: patternData };
                 }
             }
-        } catch {
+        } catch (error) {
             // the project doesn't exist, so there's nothing to
             // validate against
+            this.logger.info(
+                "Got an error when trying to validate flag naming patterns. It is probably because the target project doesn't exist. Here's the error:",
+                error.message,
+            );
+
             return { state: 'valid' };
         }
 

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -641,6 +641,20 @@ describe('flag name validation', () => {
             ).resolves.toBeFalsy();
         }
     });
+
+    test("should allow anything if the project doesn't exist", async () => {
+        const projectId = 'project-that-doesnt-exist';
+        const validFeatures = ['testpattern-feature', 'testpattern-feature2'];
+
+        for (const feature of validFeatures) {
+            await expect(
+                service.validateFeatureFlagNameAgainstPattern(
+                    feature,
+                    projectId,
+                ),
+            ).resolves.toBeFalsy();
+        }
+    });
 });
 
 test('Should return last seen at per environment', async () => {


### PR DESCRIPTION
Instead of throwing an error when the project doesn't exist, we say that the names are valid, because we have nothing to say that they're not. Presumably there is already something in place to prevent you from importing into a non-existent project.