### PR TITLE
refactor: maintenance read model

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -25,7 +25,7 @@ import { findPublicFolder } from './util/findPublicFolder';
 import { conditionalMiddleware } from './middleware/conditional-middleware';
 import patMiddleware from './middleware/pat-middleware';
 import { Knex } from 'knex';
-import maintenanceMiddleware from './middleware/maintenance-middleware';
+import maintenanceMiddleware from './features/maintenance/maintenance-middleware';
 import { unless } from './middleware/unless-middleware';
 import { catchAllErrorHandler } from './middleware/catch-all-error-handler';
 import NotFoundError from './error/notfound-error';

--- a/src/lib/features/maintenance/maintenance-controller.ts
+++ b/src/lib/features/maintenance/maintenance-controller.ts
@@ -1,6 +1,6 @@
 import { ADMIN, IUnleashConfig, IUnleashServices } from '../../types';
 import { Request, Response } from 'express';
-import Controller from '../controller';
+import Controller from '../../routes/controller';
 import { Logger } from '../../logger';
 import {
     createRequestSchema,
@@ -9,13 +9,13 @@ import {
     getStandardResponses,
 } from '../../openapi';
 import { OpenApiService } from '../../services';
-import { IAuthRequest } from '../unleash-types';
+import { IAuthRequest } from '../../routes/unleash-types';
 import { extractUsername } from '../../util';
 import {
     MaintenanceSchema,
     maintenanceSchema,
 } from '../../openapi/spec/maintenance-schema';
-import MaintenanceService from 'lib/services/maintenance-service';
+import MaintenanceService from 'lib/features/maintenance/maintenance-service';
 import { ToggleMaintenanceSchema } from 'lib/openapi/spec/toggle-maintenance-schema';
 
 export default class MaintenanceController extends Controller {

--- a/src/lib/features/maintenance/maintenance-middleware.ts
+++ b/src/lib/features/maintenance/maintenance-middleware.ts
@@ -1,6 +1,6 @@
-import { IUnleashConfig } from '../types';
-import MaintenanceService from '../services/maintenance-service';
-import { IAuthRequest } from '../routes/unleash-types';
+import { IUnleashConfig } from '../../types';
+import MaintenanceService from './maintenance-service';
+import { IAuthRequest } from '../../routes/unleash-types';
 
 export const MAINTENANCE_MODE_ENABLED =
     'Unleash is currently in maintenance mode.';

--- a/src/lib/features/maintenance/maintenance-service.test.ts
+++ b/src/lib/features/maintenance/maintenance-service.test.ts
@@ -1,9 +1,9 @@
-import { SchedulerService } from '../features/scheduler/scheduler-service';
+import { SchedulerService } from '../scheduler/scheduler-service';
 import MaintenanceService from './maintenance-service';
-import SettingService from './setting-service';
-import { createTestConfig } from '../../test/config/test-config';
-import FakeSettingStore from '../../test/fixtures/fake-setting-store';
-import EventService from './event-service';
+import SettingService from '../../services/setting-service';
+import { createTestConfig } from '../../../test/config/test-config';
+import FakeSettingStore from '../../../test/fixtures/fake-setting-store';
+import EventService from '../../services/event-service';
 
 test('Scheduler should run scheduled functions if maintenance mode is off', async () => {
     const config = createTestConfig();

--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -1,10 +1,14 @@
-import { IUnleashConfig } from '../types';
-import { Logger } from '../logger';
-import SettingService from './setting-service';
-import { maintenanceSettingsKey } from '../types/settings/maintenance-settings';
-import { MaintenanceSchema } from '../openapi/spec/maintenance-schema';
+import { IUnleashConfig } from '../../types';
+import { Logger } from '../../logger';
+import SettingService from '../../services/setting-service';
+import { maintenanceSettingsKey } from '../../types/settings/maintenance-settings';
+import { MaintenanceSchema } from '../../openapi/spec/maintenance-schema';
 
-export default class MaintenanceService {
+export interface IMaintenanceStatus {
+    isMaintenanceMode(): Promise<boolean>;
+}
+
+export default class MaintenanceService implements IMaintenanceStatus {
     private config: IUnleashConfig;
 
     private logger: Logger;

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -1,6 +1,6 @@
 import { SchedulerService } from './scheduler-service';
-import { LogProvider, Logger } from '../../logger';
-import MaintenanceService from '../../services/maintenance-service';
+import { LogProvider } from '../../logger';
+import MaintenanceService from '../maintenance/maintenance-service';
 import { createTestConfig } from '../../../test/config/test-config';
 import SettingService from '../../services/setting-service';
 import FakeSettingStore from '../../../test/fixtures/fake-setting-store';

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import { Logger, LogProvider } from '../../logger';
-import MaintenanceService from '../../services/maintenance-service';
+import { IMaintenanceStatus } from '../maintenance/maintenance-service';
 import { SCHEDULER_JOB_TIME } from '../../metric-events';
 
 export class SchedulerService {
@@ -8,17 +8,17 @@ export class SchedulerService {
 
     private logger: Logger;
 
-    private maintenanceService: MaintenanceService;
+    private maintenanceStatus: IMaintenanceStatus;
 
     private eventBus: EventEmitter;
 
     constructor(
         getLogger: LogProvider,
-        maintenanceService: MaintenanceService,
+        maintenanceStatus: IMaintenanceStatus,
         eventBus: EventEmitter,
     ) {
         this.logger = getLogger('/services/scheduler-service.ts');
-        this.maintenanceService = maintenanceService;
+        this.maintenanceStatus = maintenanceStatus;
         this.eventBus = eventBus;
     }
 
@@ -46,7 +46,7 @@ export class SchedulerService {
             setInterval(async () => {
                 try {
                     const maintenanceMode =
-                        await this.maintenanceService.isMaintenanceMode();
+                        await this.maintenanceStatus.isMaintenanceMode();
                     if (!maintenanceMode) {
                         await runScheduledFunctionWithEvent();
                     }
@@ -59,7 +59,7 @@ export class SchedulerService {
         );
         try {
             const maintenanceMode =
-                await this.maintenanceService.isMaintenanceMode();
+                await this.maintenanceStatus.isMaintenanceMode();
             if (!maintenanceMode) {
                 await runScheduledFunctionWithEvent();
             }

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -25,7 +25,7 @@ import NotFoundError from '../../error/notfound-error';
 import { SetUiConfigSchema } from '../../openapi/spec/set-ui-config-schema';
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { ProxyService } from 'lib/services';
-import MaintenanceService from 'lib/services/maintenance-service';
+import MaintenanceService from 'lib/features/maintenance/maintenance-service';
 
 class ConfigController extends Controller {
     private versionService: VersionService;

--- a/src/lib/routes/admin-api/index.ts
+++ b/src/lib/routes/admin-api/index.ts
@@ -28,7 +28,7 @@ import { PublicSignupController } from './public-signup';
 import InstanceAdminController from './instance-admin';
 import TelemetryController from './telemetry';
 import FavoritesController from './favorites';
-import MaintenanceController from './maintenance';
+import MaintenanceController from '../../features/maintenance/maintenance-controller';
 import { createKnexTransactionStarter } from '../../db/transaction';
 import { Db } from '../../db/db';
 import ExportImportController from '../../features/export-import-toggles/export-import-controller';

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -38,7 +38,7 @@ import { PublicSignupTokenService } from './public-signup-token-service';
 import { LastSeenService } from './client-metrics/last-seen/last-seen-service';
 import { InstanceStatsService } from '../features/instance-stats/instance-stats-service';
 import { FavoritesService } from './favorites-service';
-import MaintenanceService from './maintenance-service';
+import MaintenanceService from '../features/maintenance/maintenance-service';
 import { AccountService } from './account-service';
 import { SchedulerService } from '../features/scheduler/scheduler-service';
 import { Knex } from 'knex';

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -35,7 +35,7 @@ import { PublicSignupTokenService } from '../services/public-signup-token-servic
 import { LastSeenService } from '../services/client-metrics/last-seen/last-seen-service';
 import { InstanceStatsService } from '../features/instance-stats/instance-stats-service';
 import { FavoritesService } from '../services/favorites-service';
-import MaintenanceService from '../services/maintenance-service';
+import MaintenanceService from '../features/maintenance/maintenance-service';
 import { AccountService } from '../services/account-service';
 import { SchedulerService } from '../features/scheduler/scheduler-service';
 import { Knex } from 'knex';


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1655/refactor-maintenance-to-feature-folder-and-add-a-read-model-for-status

This PR does 2 things:
 - Moves all "maintenance" files to a `maintenance` features folder
 - Adds a `IMaintenanceStatus` read model that only includes `isMaintenanceMode()`, so we can use this interface in SchedulerService and expose only the `isMaintenanceMode()` method instead of the entire `MaintenanceService`

Is this what you meant in https://github.com/Unleash/unleash/pull/5363#discussion_r1400170835 @FredrikOseberg?