### PR TITLE
chore: use query to get strategies instead of whether a segment is in use

### DIFF
--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.test.ts
@@ -100,40 +100,6 @@ const updateStrategyInCr = async (
     });
 };
 
-describe.each([
-    [
-        'updateStrategy',
-        (segmentId: number) =>
-            updateStrategyInCr(randomId(), segmentId, FLAG_NAME),
-    ],
-    [
-        'addStrategy',
-        (segmentId: number) => addStrategyToCr(segmentId, FLAG_NAME),
-    ],
-])('Should handle %s changes correctly', (_, addOrUpdateStrategy) => {
-    test.each([
-        ['Draft', true],
-        ['In review', true],
-        ['Scheduled', true],
-        ['Approved', true],
-        ['Rejected', false],
-        ['Cancelled', false],
-        ['Applied', false],
-    ])(
-        'Changes in %s CRs should make it %s',
-        async (state, expectedOutcome) => {
-            await createCR(state);
-
-            const segmentId = 3;
-            await addOrUpdateStrategy(segmentId);
-
-            expect(
-                await readModel.isSegmentUsedInActiveChangeRequests(segmentId),
-            ).toBe(expectedOutcome);
-        },
-    );
-});
-
 test.each([
     ['Draft', true],
     ['In review', true],

--- a/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/change-request-segment-usage-read-model.ts
@@ -10,7 +10,6 @@ type ExistingStrategy = NewStrategy & { id: string };
 export type ChangeRequestStrategy = NewStrategy | ExistingStrategy;
 
 export interface IChangeRequestSegmentUsageReadModel {
-    isSegmentUsedInActiveChangeRequests(segmentId: number): Promise<boolean>;
     getStrategiesUsedInActiveChangeRequests(
         segmentId: number,
     ): Promise<ChangeRequestStrategy[]>;

--- a/src/lib/features/change-request-segment-usage-service/fake-change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/fake-change-request-segment-usage-read-model.ts
@@ -6,22 +6,11 @@ import {
 export class FakeChangeRequestSegmentUsageReadModel
     implements IChangeRequestSegmentUsageReadModel
 {
-    private isSegmentUsedInActiveChangeRequestsValue: boolean;
     strategiesUsedInActiveChangeRequests: ChangeRequestStrategy[];
 
-    constructor(
-        isSegmentUsedInActiveChangeRequests = false,
-        strategiesUsedInActiveChangeRequests = [],
-    ) {
-        this.isSegmentUsedInActiveChangeRequestsValue =
-            isSegmentUsedInActiveChangeRequests;
-
+    constructor(strategiesUsedInActiveChangeRequests = []) {
         this.strategiesUsedInActiveChangeRequests =
             strategiesUsedInActiveChangeRequests;
-    }
-
-    public async isSegmentUsedInActiveChangeRequests(): Promise<boolean> {
-        return this.isSegmentUsedInActiveChangeRequestsValue;
     }
 
     public async getStrategiesUsedInActiveChangeRequests(): Promise<

--- a/src/lib/features/change-request-segment-usage-service/sql-change-request-segment-usage-read-model.ts
+++ b/src/lib/features/change-request-segment-usage-service/sql-change-request-segment-usage-read-model.ts
@@ -12,23 +12,6 @@ export class ChangeRequestSegmentUsageReadModel
     constructor(db: Db) {
         this.db = db;
     }
-    public async isSegmentUsedInActiveChangeRequests(
-        segmentId: number,
-    ): Promise<boolean> {
-        const result = await this.db.raw(
-            `SELECT events.*
-             FROM change_request_events events
-             JOIN change_requests cr ON events.change_request_id = cr.id
-             WHERE cr.state IN ('Draft', 'In review', 'Scheduled', 'Approved')
-             AND events.action IN ('updateStrategy', 'addStrategy');`,
-        );
-
-        const isUsed = result.rows.some((row) =>
-            row.payload?.segments?.includes(segmentId),
-        );
-
-        return isUsed;
-    }
 
     mapRow = (row): ChangeRequestStrategy => {
         const { payload, project, environment, feature } = row;


### PR DESCRIPTION
This change is in preparation for the upcoming implementation (working
in https://github.com/Unleash/unleash/pull/5369). However, because the
implementation is a lot of lines, this PR is to break it apart and
make it easier to merge.

In this stage, we refactor the segment usage read model. Instead of
checking just whether a segment is in use, we now extract the list of
strategies that use this segment. This is slightly more costly,
perhaps, but it will be necessary for the upcoming implementation.