### PR TITLE
feat: scheduled functions observability

### DIFF
--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -41,7 +41,10 @@ const toggleMaintenanceMode = async (
 const createSchedulerTestService = ({
     loggerOverride,
     eventBusOverride,
-}: { loggerOverride?: Logger; eventBusOverride?: EventEmitter } = {}) => {
+}: {
+    loggerOverride?: Logger | LogProvider;
+    eventBusOverride?: EventEmitter;
+} = {}) => {
     const config = {
         ...createTestConfig(),
         eventBus: eventBusOverride || new EventEmitter(),
@@ -233,7 +236,7 @@ it('should emit scheduler job time event when scheduled function is run', async 
             try {
                 expect(jobId).toBe('testJobId');
                 expect(typeof time).toBe('number');
-                resolve();
+                resolve(null);
             } catch (e) {
                 reject(e);
             }

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -42,7 +42,7 @@ const createSchedulerTestService = ({
     loggerOverride,
     eventBusOverride,
 }: {
-    loggerOverride?: Logger | LogProvider;
+    loggerOverride?: LogProvider;
     eventBusOverride?: EventEmitter;
 } = {}) => {
     const config = {

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -1,5 +1,7 @@
+import EventEmitter from 'events';
 import { Logger, LogProvider } from '../../logger';
 import MaintenanceService from '../../services/maintenance-service';
+import { SCHEDULER_JOB_TIME } from '../../metric-events';
 
 export class SchedulerService {
     private intervalIds: NodeJS.Timer[] = [];
@@ -8,12 +10,16 @@ export class SchedulerService {
 
     private maintenanceService: MaintenanceService;
 
+    private eventBus: EventEmitter;
+
     constructor(
         getLogger: LogProvider,
         maintenanceService: MaintenanceService,
+        eventBus: EventEmitter,
     ) {
         this.logger = getLogger('/services/scheduler-service.ts');
         this.maintenanceService = maintenanceService;
+        this.eventBus = eventBus;
     }
 
     async schedule(
@@ -21,13 +27,28 @@ export class SchedulerService {
         timeMs: number,
         id: string,
     ): Promise<void> {
+        const runScheduledFunctionWithEvent = async () => {
+            const startTime = process.hrtime();
+            await scheduledFunction();
+            const endTime = process.hrtime(startTime);
+
+            // Process hrtime returns a list with two numbers representing high-resolution time.
+            // The first number is the number of seconds, the second is the number of nanoseconds.
+            // Since there are 1e9 (1,000,000,000) nanoseconds in a second, endTime[1] / 1e9 converts the nanoseconds to seconds.
+            const durationInSeconds = endTime[0] + endTime[1] / 1e9;
+            this.eventBus.emit(SCHEDULER_JOB_TIME, {
+                jobId: id,
+                time: durationInSeconds,
+            });
+        };
+
         this.intervalIds.push(
             setInterval(async () => {
                 try {
                     const maintenanceMode =
                         await this.maintenanceService.isMaintenanceMode();
                     if (!maintenanceMode) {
-                        await scheduledFunction();
+                        await runScheduledFunctionWithEvent();
                     }
                 } catch (e) {
                     this.logger.error(
@@ -40,7 +61,7 @@ export class SchedulerService {
             const maintenanceMode =
                 await this.maintenanceService.isMaintenanceMode();
             if (!maintenanceMode) {
-                await scheduledFunction();
+                await runScheduledFunctionWithEvent();
             }
         } catch (e) {
             this.logger.error(`scheduled job failed | id: ${id} | ${e}`);

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -1,4 +1,5 @@
 const REQUEST_TIME = 'request_time';
 const DB_TIME = 'db_time';
+const SCHEDULER_JOB_TIME = 'scheduler_job_time';
 
-export { REQUEST_TIME, DB_TIME };
+export { REQUEST_TIME, DB_TIME, SCHEDULER_JOB_TIME };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -59,6 +59,14 @@ export default class MetricsMonitor {
             maxAgeSeconds: 600,
             ageBuckets: 5,
         });
+        const schedulerDuration = new client.Summary({
+            name: 'scheduler_duration_seconds',
+            help: 'Scheduler duration time',
+            labelNames: ['jobId'],
+            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+            maxAgeSeconds: 600,
+            ageBuckets: 5,
+        });
         const dbDuration = new client.Summary({
             name: 'db_query_duration_seconds',
             help: 'DB query duration time',
@@ -320,6 +328,10 @@ export default class MetricsMonitor {
                     .observe(time);
             },
         );
+
+        eventBus.on(events.SCHEDULER_JOB_TIME, ({ jobId, time }) => {
+            schedulerDuration.labels(jobId).observe(time);
+        });
 
         eventBus.on('optimal304Differ', ({ status }) => {
             optimal304DiffingCounter.labels(status).inc();

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -290,6 +290,7 @@ export const createServices = (
     const schedulerService = new SchedulerService(
         config.getLogger,
         maintenanceService,
+        config.eventBus,
     );
 
     const eventAnnouncerService = new EventAnnouncerService(stores, config);

--- a/src/lib/services/maintenance-service.test.ts
+++ b/src/lib/services/maintenance-service.test.ts
@@ -15,6 +15,7 @@ test('Scheduler should run scheduled functions if maintenance mode is off', asyn
     const schedulerService = new SchedulerService(
         config.getLogger,
         maintenanceService,
+        config.eventBus,
     );
 
     const job = jest.fn();
@@ -35,6 +36,7 @@ test('Scheduler should not run scheduled functions if maintenance mode is on', a
     const schedulerService = new SchedulerService(
         config.getLogger,
         maintenanceService,
+        config.eventBus,
     );
 
     await maintenanceService.toggleMaintenanceMode(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -19,6 +19,7 @@ process.nextTick(async () => {
                 },
                 server: {
                     enableRequestLogger: true,
+                    serverMetrics: true,
                     baseUriPath: '',
                     // keepAliveTimeout: 1,
                     gracefulShutdownEnable: true,

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -19,7 +19,6 @@ process.nextTick(async () => {
                 },
                 server: {
                     enableRequestLogger: true,
-                    serverMetrics: true,
                     baseUriPath: '',
                     // keepAliveTimeout: 1,
                     gracefulShutdownEnable: true,


### PR DESCRIPTION
See linear issue: https://linear.app/unleash/issue/1-1656/add-scheduler-observability

As per post mortem actions, we are adding observability to scheduled functions.

This PR adds prometheus observability to our scheduled functions via a summary. In addition to timing these functions with the more accurate process.hrtime, we are getting a counter for free per scheduled job id.

Prometheus example: 

<img width="731" alt="Skjermbilde 2023-11-21 kl  13 36 33" src="https://github.com/Unleash/unleash/assets/16081982/08a2064d-5152-4b4f-8a08-eb06e726757a">

