### PR TITLE
chore: unpin node version in build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - run: yarn
       - run: yarn build:frontend:if-needed


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1434/unpin-node-18-when-a-fix-is-out

Unpins the node version in our build step.
Continues the work of https://github.com/Unleash/unleash/pull/5146