### PR TITLE
fix: check whether a usage data is defined

### DIFF
--- a/src/lib/db/segment-store.ts
+++ b/src/lib/db/segment-store.ts
@@ -12,6 +12,7 @@ import { PartialSome } from '../types/partial';
 import User from '../types/user';
 import { Db } from './db';
 import { IFlagResolver } from '../types';
+import { isDefined } from '../util';
 
 const T = {
     segments: 'segments',
@@ -373,10 +374,10 @@ export default class SegmentStore implements ISegmentStore {
             constraints: row.constraints,
             createdBy: row.created_by,
             createdAt: row.created_at,
-            ...(row.used_in_projects && {
+            ...(isDefined(row.used_in_projects) && {
                 usedInProjects: Number(row.used_in_projects),
             }),
-            ...(row.used_in_features && {
+            ...(isDefined(row.used_in_features) && {
                 usedInFeatures: Number(row.used_in_features),
             }),
         };

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -660,7 +660,8 @@ describe('detect strategy usage in change requests', () => {
                 .then((res) => res.body.segments);
 
         // because they use the same db, we can use the regular app
-        // (through createSegment) to create the segment and the flag
+        // (through `createSegment` and `createFeatureToggle`) to
+        // create the segment and the flag
         await createSegment({ name: 'a', constraints: [] });
         const toggle = mockFeatureToggle();
         await createFeatureToggle(app, toggle);

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -108,24 +108,19 @@ const validateSegment = (
         .expect(expectStatusCode);
 
 beforeAll(async () => {
-    db = await dbInit('segments_api_serial', getLogger, {
+    const customOptions = {
         experimental: {
             flags: {
                 anonymiseEventLog: true,
                 detectSegmentUsageInChangeRequests: true,
             },
         },
-    });
+    };
+
+    db = await dbInit('segments_api_serial', getLogger, customOptions);
     app = await setupAppWithCustomConfig(
         db.stores,
-        {
-            experimental: {
-                flags: {
-                    anonymiseEventLog: true,
-                    detectSegmentUsageInChangeRequests: true,
-                },
-            },
-        },
+        customOptions,
         db.rawDatabase,
     );
 });

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -108,7 +108,14 @@ const validateSegment = (
         .expect(expectStatusCode);
 
 beforeAll(async () => {
-    db = await dbInit('segments_api_serial', getLogger);
+    db = await dbInit('segments_api_serial', getLogger, {
+        experimental: {
+            flags: {
+                anonymiseEventLog: true,
+                detectSegmentUsageInChangeRequests: true,
+            },
+        },
+    });
     app = await setupAppWithCustomConfig(
         db.stores,
         {

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -639,10 +639,37 @@ describe('detect strategy usage in change requests', () => {
     });
 
     test('Should show usage in features and projects in CRs', async () => {
+        // Change request data is only counted for enterprise
+        // instances, so we'll instantiate our own version of the app
+        // for that.
+        const enterpriseApp = await setupAppWithCustomConfig(
+            db.stores,
+            {
+                enterpriseVersion: '5.3.0',
+                ui: { environment: 'Enterprise' },
+                experimental: {
+                    flags: {
+                        detectSegmentUsageInChangeRequests: true,
+                    },
+                },
+            },
+            db.rawDatabase,
+        );
+
+        // likewise, we want to fetch from the right app to make sure
+        // we get the right data
+        const enterpriseFetchSegments = () =>
+            enterpriseApp.request
+                .get(SEGMENTS_BASE_PATH)
+                .expect(200)
+                .then((res) => res.body.segments);
+
+        // because they use the same db, we can use the regular app
+        // (through createSegment) to create the segment and the flag
         await createSegment({ name: 'a', constraints: [] });
         const toggle = mockFeatureToggle();
         await createFeatureToggle(app, toggle);
-        const [segment] = await fetchSegments();
+        const [segment] = await enterpriseFetchSegments();
 
         expect(segment).toMatchObject({ usedInFeatures: 0, usedInProjects: 0 });
 
@@ -667,7 +694,7 @@ describe('detect strategy usage in change requests', () => {
             created_by: user.id,
         });
 
-        const segments = await fetchSegments();
+        const segments = await enterpriseFetchSegments();
         expect(segments).toMatchObject([
             { usedInFeatures: 1, usedInProjects: 1 },
         ]);


### PR DESCRIPTION
The previous check would return `false` if the value was 0, causing a
bug where the usage data wouldn't be included.

This also adds tests to ensure that usage data for CR segments is propagated correctly because that's where I first encountered the issue.

Before this fix, if the values were 0, the data would display like the bottom element in the screenshot:

![image](https://github.com/Unleash/unleash/assets/17786332/9642b945-12c4-4217-aec9-7fef4a88e9af)
