### PR TITLE
feat: allow filtering projects with operators

### DIFF
--- a/src/lib/features/feature-search/feature-search-controller.ts
+++ b/src/lib/features/feature-search/feature-search-controller.ts
@@ -106,7 +106,7 @@ export default class FeatureSearchController extends Controller {
                 sortOrder === 'asc' || sortOrder === 'desc' ? sortOrder : 'asc';
             const normalizedFavoritesFirst = favoritesFirst === 'true';
             const { features, total } = await this.featureSearchService.search({
-                queryParams: normalizedQuery,
+                searchParams: normalizedQuery,
                 projectId,
                 type,
                 userId,

--- a/src/lib/features/feature-search/feature-search-service.ts
+++ b/src/lib/features/feature-search/feature-search-service.ts
@@ -5,7 +5,11 @@ import {
     IUnleashStores,
     serializeDates,
 } from '../../types';
-import { IFeatureSearchParams } from '../feature-toggle/types/feature-toggle-strategies-store-type';
+import {
+    IFeatureSearchParams,
+    IQueryOperator,
+    IQueryParam,
+} from '../feature-toggle/types/feature-toggle-strategies-store-type';
 
 export class FeatureSearchService {
     private featureStrategiesStore: IFeatureStrategiesStore;
@@ -21,15 +25,48 @@ export class FeatureSearchService {
     }
 
     async search(params: IFeatureSearchParams) {
+        const queryParams = this.convertToQueryParams(params);
         const { features, total } =
-            await this.featureStrategiesStore.searchFeatures({
-                ...params,
-                limit: params.limit,
-            });
+            await this.featureStrategiesStore.searchFeatures(
+                {
+                    ...params,
+                    limit: params.limit,
+                },
+                queryParams,
+            );
 
         return {
             features,
             total,
         };
     }
+
+    parseOperatorValue = (field: string, value: string): IQueryParam | null => {
+        const multiValueOperators = ['IS_ANY_OF', 'IS_NOT_ANY_OF'];
+        const pattern = /^(IS|IS_NOT|IS_ANY_OF|IS_NOT_ANY_OF):(.+)$/;
+        const match = value.match(pattern);
+
+        if (match) {
+            return {
+                field,
+                operator: match[1] as IQueryOperator,
+                value: multiValueOperators.includes(match[1])
+                    ? match[2].split(',')
+                    : match[2],
+            };
+        }
+
+        return null;
+    };
+
+    convertToQueryParams = (params: IFeatureSearchParams): IQueryParam[] => {
+        const queryParams: IQueryParam[] = [];
+
+        if (params.projectId) {
+            const parsed = this.parseOperatorValue('project', params.projectId);
+            if (parsed) queryParams.push(parsed);
+        }
+
+        return queryParams;
+    };
 }

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -496,7 +496,7 @@ test('should search features by project with operators', async () => {
     });
 
     await db.stores.featureToggleStore.create(createdProject, {
-        name: 'my_project_b',
+        name: 'my_feature_b',
     });
 
     const { body } = await searchFeatures({
@@ -504,5 +504,26 @@ test('should search features by project with operators', async () => {
     });
     expect(body).toMatchObject({
         features: [{ name: 'my_feature_a' }],
+    });
+
+    const { body: isNotBody } = await searchFeatures({
+        projectId: 'IS_NOT:default',
+    });
+    expect(isNotBody).toMatchObject({
+        features: [{ name: 'my_feature_b' }],
+    });
+
+    const { body: isAnyOfBody } = await searchFeatures({
+        projectId: 'IS_ANY_OF:default',
+    });
+    expect(isAnyOfBody).toMatchObject({
+        features: [{ name: 'my_feature_a' }],
+    });
+
+    const { body: isNotAnyBody } = await searchFeatures({
+        projectId: 'IS_NOT_ANY_OF:default',
+    });
+    expect(isNotAnyBody).toMatchObject({
+        features: [{ name: 'my_feature_b' }],
     });
 });

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -488,15 +488,24 @@ test('should support multiple search values', async () => {
 test('should search features by project with operators', async () => {
     await app.createFeature('my_feature_a');
 
-    const createdProject = 'project_b';
     await db.stores.projectStore.create({
-        name: createdProject,
+        name: 'project_b',
         description: '',
-        id: createdProject,
+        id: 'project_b',
     });
 
-    await db.stores.featureToggleStore.create(createdProject, {
+    await db.stores.featureToggleStore.create('project_b', {
         name: 'my_feature_b',
+    });
+
+    await db.stores.projectStore.create({
+        name: 'project_c',
+        description: '',
+        id: 'project_c',
+    });
+
+    await db.stores.featureToggleStore.create('project_c', {
+        name: 'my_feature_c',
     });
 
     const { body } = await searchFeatures({
@@ -510,18 +519,18 @@ test('should search features by project with operators', async () => {
         projectId: 'IS_NOT:default',
     });
     expect(isNotBody).toMatchObject({
-        features: [{ name: 'my_feature_b' }],
+        features: [{ name: 'my_feature_b' }, { name: 'my_feature_c' }],
     });
 
     const { body: isAnyOfBody } = await searchFeatures({
-        projectId: 'IS_ANY_OF:default',
+        projectId: 'IS_ANY_OF:default,project_c',
     });
     expect(isAnyOfBody).toMatchObject({
-        features: [{ name: 'my_feature_a' }],
+        features: [{ name: 'my_feature_a' }, { name: 'my_feature_c' }],
     });
 
     const { body: isNotAnyBody } = await searchFeatures({
-        projectId: 'IS_NOT_ANY_OF:default',
+        projectId: 'IS_NOT_ANY_OF:default,project_c',
     });
     expect(isNotAnyBody).toMatchObject({
         features: [{ name: 'my_feature_b' }],

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -25,7 +25,10 @@ import { ensureStringValue, mapValues } from '../../util';
 import { IFeatureProjectUserParams } from './feature-toggle-controller';
 import { Db } from '../../db/db';
 import Raw = Knex.Raw;
-import { IFeatureSearchParams } from './types/feature-toggle-strategies-store-type';
+import {
+    IFeatureSearchParams,
+    IQueryParam,
+} from './types/feature-toggle-strategies-store-type';
 
 const COLUMNS = [
     'id',
@@ -525,20 +528,21 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         };
     }
 
-    // WIP copy of getFeatureOverview to get the search PoC working
-    async searchFeatures({
-        projectId,
-        userId,
-        queryParams,
-        type,
-        tag,
-        status,
-        offset,
-        limit,
-        sortOrder,
-        sortBy,
-        favoritesFirst,
-    }: IFeatureSearchParams): Promise<{
+    async searchFeatures(
+        {
+            userId,
+            searchParams,
+            type,
+            tag,
+            status,
+            offset,
+            limit,
+            sortOrder,
+            sortBy,
+            favoritesFirst,
+        }: IFeatureSearchParams,
+        queryParams: IQueryParam[],
+    ): Promise<{
         features: IFeatureOverview[];
         total: number;
     }> {
@@ -548,13 +552,12 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         const finalQuery = this.db
             .with('ranked_features', (query) => {
                 query.from('features');
-                if (projectId) {
-                    query.where({ project: projectId });
-                }
-                const hasQueryString = queryParams?.length;
 
-                if (hasQueryString) {
-                    const sqlParameters = queryParams.map(
+                applyQueryParams(query, queryParams);
+
+                const hasSearchParams = searchParams?.length;
+                if (hasSearchParams) {
+                    const sqlParameters = searchParams.map(
                         (item) => `%${item}%`,
                     );
                     const sqlQueryParameters = sqlParameters
@@ -1032,6 +1035,28 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
         return rows.length;
     }
 }
+
+const applyQueryParams = (
+    query: Knex.QueryBuilder,
+    queryParams: IQueryParam[],
+): void => {
+    queryParams.forEach((param) => {
+        switch (param.operator) {
+            case 'IS':
+                query.where(param.field, '=', param.value);
+                break;
+            case 'IS_NOT':
+                query.where(param.field, '!=', param.value);
+                break;
+            case 'IS_ANY_OF':
+                query.whereIn(param.field, param.value as string[]);
+                break;
+            case 'IS_NOT_ANY_OF':
+                query.whereNotIn(param.field, param.value as string[]);
+                break;
+        }
+    });
+};
 
 module.exports = FeatureStrategiesStore;
 export default FeatureStrategiesStore;

--- a/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
@@ -23,7 +23,7 @@ export interface FeatureConfigurationClient {
 
 export interface IFeatureSearchParams {
     userId: number;
-    queryParams?: string[];
+    searchParams?: string[];
     projectId?: string;
     type?: string[];
     tag?: string[][];
@@ -33,6 +33,14 @@ export interface IFeatureSearchParams {
     limit: number;
     sortBy: string;
     sortOrder: 'asc' | 'desc';
+}
+
+export type IQueryOperator = 'IS' | 'IS_NOT' | 'IS_ANY_OF' | 'IS_NOT_ANY_OF';
+
+export interface IQueryParam {
+    field: string;
+    operator: IQueryOperator;
+    value: string | string[];
 }
 
 export interface IFeatureStrategiesStore
@@ -64,6 +72,7 @@ export interface IFeatureStrategiesStore
     ): Promise<IFeatureOverview[]>;
     searchFeatures(
         params: IFeatureSearchParams,
+        queryParams: IQueryParam[],
     ): Promise<{ features: IFeatureOverview[]; total: number }>;
     getStrategyById(id: string): Promise<IFeatureStrategy>;
     updateStrategy(

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -14,7 +14,9 @@ export const featureSearchQueryParameters = [
         name: 'projectId',
         schema: {
             type: 'string',
-            example: 'default',
+            example: 'IS:default',
+            pattern:
+                '^(IS|IS_NOT|IS_ANY_OF|IS_NOT_ANY_OF):(.*?)(,([a-zA-Z0-9_]+))*$',
         },
         description: 'Id of the project where search and filter is performed',
         in: 'query',


### PR DESCRIPTION
This is first iteration. When we add more fields to be filterable with operators, we can have more reusable components for this.