### PR TITLE
Fix/clean last seen environments

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
@@ -78,7 +78,7 @@ export const FeatureEnvironmentSeen = ({
 }: IFeatureEnvironmentSeenProps) => {
     const getColor = useLastSeenColors();
 
-    const lastSeen = getLatestLastSeenAt(environments) || featureLastSeen;
+    const lastSeen = getLatestLastSeenAt(environments);
 
     return (
         <>

--- a/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
@@ -78,7 +78,7 @@ export const FeatureEnvironmentSeen = ({
 }: IFeatureEnvironmentSeenProps) => {
     const getColor = useLastSeenColors();
 
-    const lastSeen = getLatestLastSeenAt(environments);
+    const lastSeen = getLatestLastSeenAt(environments) || featureLastSeen;
 
     return (
         <>

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -386,6 +386,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 acc.description = r.description;
                 acc.project = r.project;
                 acc.stale = r.stale;
+                acc.lastSeenAt = r.last_seen_at;
 
                 acc.createdAt = r.created_at;
                 acc.type = r.type;
@@ -662,6 +663,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     'features.type as type',
                     'features.created_at as created_at',
                     'features.stale as stale',
+                    'features.last_seen_at as last_seen_at',
                     'features.impression_data as impression_data',
                     'feature_environments.enabled as enabled',
                     'feature_environments.environment as environment',
@@ -830,6 +832,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             'features.type as type',
             'features.created_at as created_at',
             'features.stale as stale',
+            'features.last_seen_at as last_seen_at',
             'features.impression_data as impression_data',
             'feature_environments.enabled as enabled',
             'feature_environments.environment as environment',
@@ -912,6 +915,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                     createdAt: row.created_at,
                     stale: row.stale,
                     impressionData: row.impression_data,
+                    lastSeenAt: row.last_seen_at,
                     environments: [FeatureStrategiesStore.getEnvironment(row)],
                 };
 
@@ -922,7 +926,8 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             const featureRow = acc[row.feature_name];
             if (
                 featureRow.lastSeenAt === undefined ||
-                new Date(row.env_last_seen_at) > new Date(featureRow.lastSeenAt)
+                new Date(row.env_last_seen_at) >
+                    new Date(featureRow.last_seen_at)
             ) {
                 featureRow.lastSeenAt = row.env_last_seen_at;
             }

--- a/src/lib/services/client-metrics/last-seen/last-seen-store.ts
+++ b/src/lib/services/client-metrics/last-seen/last-seen-store.ts
@@ -74,6 +74,10 @@ export default class LastSeenStore implements ILastSeenStore {
     async cleanLastSeen() {
         await this.db(TABLE)
             .whereNotIn('feature_name', this.db.select('name').from('features'))
+            .or.whereNotIn(
+                'environment',
+                this.db.select('name').from('environments'),
+            )
             .del();
     }
 }

--- a/src/lib/services/client-metrics/last-seen/tests/last-seen-service.e2e.test.ts
+++ b/src/lib/services/client-metrics/last-seen/tests/last-seen-service.e2e.test.ts
@@ -124,7 +124,6 @@ test('should clean unknown feature toggle environments from last seen store', as
         'SELECT * FROM last_seen_at_metrics;',
     );
 
-    console.log(stored.rows);
     expect(stored.rows.length).toBe(4);
 
     await lastSeenService.cleanLastSeen();

--- a/src/migrations/20231123100052-drop-last-seen-foreign-key.js
+++ b/src/migrations/20231123100052-drop-last-seen-foreign-key.js
@@ -1,0 +1,17 @@
+exports.up = function (db, cb) {
+  db.runSql(
+    `
+    ALTER TABLE last_seen_at_metrics DROP CONSTRAINT last_seen_at_metrics_environment_fkey;
+    `,
+    cb
+  );
+};
+
+exports.down = function (db, cb) {
+  db.runSql(
+    `
+    ALTER TABLE last_seen_at_metrics ADD CONSTRAINT last_seen_at_metrics_environment_fkey FOREIGN KEY (environment) REFERENCES environments(name);
+    `,
+    cb
+  );
+};


### PR DESCRIPTION
This PR addresses some cleanup related to removing the useLastSeenRefactor flag:

* Added fallback last seen to the feature table last_seen_at column 
* Remove foreign key on environment since we can not guarantee that we will get valid data in this field
* Add environments to cleanup function
* Add test for cleanup environments