### PR TITLE
fix: prevent concurrent queries from running out of transaction

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -52,6 +52,7 @@ import { FeatureNameCheckResultWithFeaturePattern } from '../feature-toggle/feat
 import { IDependentFeaturesReadModel } from '../dependent-features/dependent-features-read-model-type';
 import groupBy from 'lodash.groupby';
 import { ISegmentService } from '../../segments/segment-service-interface';
+import { allSettledWithRejection } from '../../util/allSettledWithRejection';
 
 export type IImportService = {
     validate(
@@ -252,7 +253,7 @@ export default class ExportImportService
         user: IUser,
         mode = 'regular' as Mode,
     ): Promise<void> {
-        await Promise.all([
+        await allSettledWithRejection([
             this.verifyStrategies(dto),
             this.verifyContextFields(dto),
             this.importPermissionsService.verifyPermissions(dto, user, mode),

--- a/src/lib/util/allSettledWithRejection.test.ts
+++ b/src/lib/util/allSettledWithRejection.test.ts
@@ -1,0 +1,47 @@
+import { allSettledWithRejection } from './allSettledWithRejection';
+
+describe('allSettledWithRejection', () => {
+    it('should resolve if all promises resolve', async () => {
+        const promises = [
+            Promise.resolve(1),
+            Promise.resolve(2),
+            Promise.resolve(3),
+        ];
+        await expect(allSettledWithRejection(promises)).resolves.toEqual([
+            1, 2, 3,
+        ]);
+    });
+
+    it('should reject with the reason of the first rejected promise', async () => {
+        const error = new Error('First rejection');
+        const promises = [
+            Promise.reject(error),
+            Promise.resolve(1),
+            Promise.resolve(2),
+        ];
+        await expect(allSettledWithRejection(promises)).rejects.toEqual(error);
+    });
+
+    it('should reject with the reason of the first rejected promise, even with multiple rejections', async () => {
+        const firstError = new Error('First rejection');
+        const secondError = new Error('Second rejection');
+        const promises = [
+            Promise.reject(firstError),
+            Promise.reject(secondError),
+            Promise.resolve(1),
+        ];
+        await expect(allSettledWithRejection(promises)).rejects.toEqual(
+            firstError,
+        );
+    });
+
+    it('should reject with the reason of the first rejected promise in mixed scenarios', async () => {
+        const error = new Error('Rejection');
+        const promises = [
+            Promise.resolve(1),
+            Promise.reject(error),
+            Promise.resolve(2),
+        ];
+        await expect(allSettledWithRejection(promises)).rejects.toEqual(error);
+    });
+});

--- a/src/lib/util/allSettledWithRejection.ts
+++ b/src/lib/util/allSettledWithRejection.ts
@@ -1,0 +1,16 @@
+export const allSettledWithRejection = (
+    promises: Promise<any>[],
+): Promise<any[]> =>
+    new Promise((resolve, reject) => {
+        Promise.allSettled(promises).then((results) => {
+            for (const result of results) {
+                if (result.status === 'rejected') {
+                    reject(result.reason);
+                    return;
+                }
+            }
+            resolve(
+                results.map((r) => (r as PromiseFulfilledResult<any>).value),
+            );
+        });
+    });


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

JS promises support Promise.all and Promise.allSettled. Promise.all rejects on the first rejecting promise. Promise.allSettled waits for all promises to settle and returns an array of resolved and rejected promises. I'm adding a new utility that behaves like Promise.all (rejects on the first rejection) but gives all promises a chance to finish. 

This new utility solves an issue where some of the promises were running after a transaction was closed because first rejected promise rejected much sooner than the other ones, the tx was closed and the remaining queries were left w/o a pending tx.

<img width="1466" alt="Screenshot 2023-11-24 at 10 41 02" src="https://github.com/Unleash/unleash/assets/1394682/7f6457d0-880b-44f6-93ea-2c024eda7236">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
