### PR TITLE
fix: missing user id in segment update

### DIFF
--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -47,7 +47,7 @@ export interface ISegmentService {
     update(
         id: number,
         data: UpsertSegmentSchema,
-        user: Partial<Pick<IUser, 'username' | 'email'>>,
+        user: Partial<Pick<IUser, 'username' | 'email' | 'id'>>,
     ): Promise<void>;
 
     unprotectedUpdate(

--- a/src/test/e2e/api/client/segment.e2e.test.ts
+++ b/src/test/e2e/api/client/segment.e2e.test.ts
@@ -61,6 +61,7 @@ const updateSegment = (
 ): Promise<void> => {
     return app.services.segmentService.update(id, postData, {
         email: 'test@example.com',
+        id: 1,
     });
 };
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Fix this error showing up in tests output:
<img width="1219" alt="Screenshot 2023-11-24 at 11 08 13" src="https://github.com/Unleash/unleash/assets/1394682/4e070c9e-aa2b-48ad-a740-4240d3562144">

Root cause:
* update segment verifies if change requests are enabled. Change request enabled check requires user id. The user id was not passed in unit tests even though in production code it is being passed

Solution:
* add user id in test
* update segment service interface to reflect the new requirement

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
