### PR TITLE
fix: tag type deleted should indicate data deletion

### DIFF
--- a/src/lib/services/tag-type-service.ts
+++ b/src/lib/services/tag-type-service.ts
@@ -74,11 +74,12 @@ export default class TagTypeService {
     }
 
     async deleteTagType(name: string, userName: string): Promise<void> {
+        const tagType = await this.tagTypeStore.get(name);
         await this.tagTypeStore.delete(name);
         await this.eventService.storeEvent({
             type: TAG_TYPE_DELETED,
             createdBy: userName || 'unleash-system',
-            data: { name },
+            preData: tagType,
         });
     }
 

--- a/src/test/e2e/api/admin/tag-types.e2e.test.ts
+++ b/src/test/e2e/api/admin/tag-types.e2e.test.ts
@@ -158,13 +158,15 @@ test('Invalid tag-types get refused by validator', async () => {
 });
 
 test('Can delete tag type', async () => {
-    expect.assertions(0);
-
     await app.request
         .delete('/api/admin/tag-types/simple')
         .set('Content-Type', 'application/json')
         .expect(200);
-    return app.request.get('/api/admin/tag-types/simple').expect(404);
+    await app.request.get('/api/admin/tag-types/simple').expect(404);
+
+    const { body } = await app.getRecordedEvents();
+    expect(body.events[0].preData).toMatchObject({ name: 'simple' });
+    expect(body.events[0].data).toBe(null);
 });
 
 test('Non unique tag-types gets rejected', async () => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Before - green indicator for tag name:
<img width="795" alt="Screenshot 2023-11-27 at 14 38 48" src="https://github.com/Unleash/unleash/assets/1394682/c7019deb-21c3-4481-805d-f326bf36ec4f">


After - red indicator for all fields:
<img width="709" alt="Screenshot 2023-11-27 at 14 38 09" src="https://github.com/Unleash/unleash/assets/1394682/0c1b4fd3-d659-495f-944f-e5298b3900c1">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
When the new code tries to delete non existent tag it returns 404 and it should be fine since idempotency requirement applies to resource state not the HTTP code: https://stackoverflow.com/questions/24713945/does-idempotency-include-response-codes/24713946#24713946