### PR TITLE
fix: settings change events now include body

### DIFF
--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -43,21 +43,24 @@ export default class SettingService {
     }
 
     async insert(id: string, value: object, createdBy: string): Promise<void> {
-        const exists = await this.settingStore.exists(id);
-        if (exists) {
+        const existingSettings = await this.settingStore.get<object>(id);
+        if (existingSettings) {
             await this.settingStore.updateRow(id, value);
             await this.eventService.storeEvent(
-                new SettingUpdatedEvent({
-                    createdBy,
-                    data: { id },
-                }),
+                new SettingUpdatedEvent(
+                    {
+                        createdBy,
+                        data: value,
+                    },
+                    existingSettings,
+                ),
             );
         } else {
             await this.settingStore.insert(id, value);
             await this.eventService.storeEvent(
                 new SettingCreatedEvent({
                     createdBy,
-                    data: { id },
+                    data: value,
                 }),
             );
         }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -973,12 +973,18 @@ export class SettingDeletedEvent extends BaseEvent {
 export class SettingUpdatedEvent extends BaseEvent {
     readonly data: any;
 
+    readonly preData: any;
+
     /**
      * @param createdBy accepts a string for backward compatibility. Prefer using IUser for standardization
      */
-    constructor(eventData: { createdBy: string | IUser; data: any }) {
+    constructor(
+        eventData: { createdBy: string | IUser; data: any },
+        preData: any,
+    ) {
         super(SETTING_UPDATED, eventData.createdBy);
         this.data = eventData.data;
+        this.preData = preData;
     }
 }
 


### PR DESCRIPTION
Changes the way settings events are created, they now use the body of the data that changes, rather than just the ID. They also include the `preData` for update events