### PR TITLE
feat: include more data in setting event

### DIFF
--- a/src/lib/services/maintenance-service.ts
+++ b/src/lib/services/maintenance-service.ts
@@ -40,6 +40,7 @@ export default class MaintenanceService {
             maintenanceSettingsKey,
             setting,
             user,
+            false,
         );
     }
 }

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -171,6 +171,7 @@ export class ProxyService {
             frontendSettingsKey,
             value,
             createdBy,
+            false,
         );
     }
 

--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -44,7 +44,7 @@ export default class SettingService {
 
     async insert(id: string, value: object, createdBy: string): Promise<void> {
         const exists = await this.settingStore.exists(id);
-        let data = value;
+        let data = { id };
         if (typeof value === 'object') {
             data = { id, ...value };
         } else {

--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -44,12 +44,19 @@ export default class SettingService {
 
     async insert(id: string, value: object, createdBy: string): Promise<void> {
         const exists = await this.settingStore.exists(id);
+        let data = value;
+        if (typeof value === 'object') {
+            data = { id, ...value };
+        } else {
+            this.logger.error('Invalid setting value, source: %s', id);
+        }
+
         if (exists) {
             await this.settingStore.updateRow(id, value);
             await this.eventService.storeEvent(
                 new SettingUpdatedEvent({
                     createdBy,
-                    data: { id, ...value },
+                    data,
                 }),
             );
         } else {
@@ -57,7 +64,7 @@ export default class SettingService {
             await this.eventService.storeEvent(
                 new SettingCreatedEvent({
                     createdBy,
-                    data: { id, ...value },
+                    data,
                 }),
             );
         }

--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -42,14 +42,20 @@ export default class SettingService {
         return value || defaultValue;
     }
 
-    async insert(id: string, value: object, createdBy: string): Promise<void> {
+    async insert(
+        id: string,
+        value: object,
+        createdBy: string,
+        hideEventDetails: boolean = true,
+    ): Promise<void> {
         const existingSettings = await this.settingStore.get<object>(id);
 
-        let data = { id };
-        if (typeof value === 'object') {
-            data = { id, ...value };
-        } else {
-            this.logger.error('Invalid setting value, source: %s', id);
+        let data: object = { id, ...value };
+        let preData = existingSettings;
+
+        if (hideEventDetails) {
+            preData = { hideEventDetails: true };
+            data = { id, hideEventDetails: true };
         }
 
         if (existingSettings) {
@@ -60,7 +66,7 @@ export default class SettingService {
                         createdBy,
                         data,
                     },
-                    existingSettings,
+                    preData,
                 ),
             );
         } else {

--- a/src/lib/services/setting-service.ts
+++ b/src/lib/services/setting-service.ts
@@ -49,7 +49,7 @@ export default class SettingService {
             await this.eventService.storeEvent(
                 new SettingUpdatedEvent({
                     createdBy,
-                    data: { id },
+                    data: { id, ...value },
                 }),
             );
         } else {
@@ -57,7 +57,7 @@ export default class SettingService {
             await this.eventService.storeEvent(
                 new SettingCreatedEvent({
                     createdBy,
-                    data: { id },
+                    data: { id, ...value },
                 }),
             );
         }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -972,13 +972,18 @@ export class SettingDeletedEvent extends BaseEvent {
 
 export class SettingUpdatedEvent extends BaseEvent {
     readonly data: any;
+    readonly preData: any;
 
     /**
      * @param createdBy accepts a string for backward compatibility. Prefer using IUser for standardization
      */
-    constructor(eventData: { createdBy: string | IUser; data: any }) {
+    constructor(
+        eventData: { createdBy: string | IUser; data: any },
+        preData: any,
+    ) {
         super(SETTING_UPDATED, eventData.createdBy);
         this.data = eventData.data;
+        this.preData = preData;
     }
 }
 

--- a/src/test/e2e/services/setting-service.test.ts
+++ b/src/test/e2e/services/setting-service.test.ts
@@ -38,7 +38,7 @@ test('Can create new setting', async () => {
         type: SETTING_CREATED,
     });
     expect(createdEvents).toHaveLength(1);
-    expect(createdEvents[0].data).toEqual({"id": "some-setting", "some": "blob"});
+    expect(createdEvents[0].data).toEqual({ id: 'some-setting', some: 'blob' });
 });
 
 test('Can delete setting', async () => {
@@ -68,6 +68,9 @@ test('Can update setting', async () => {
         type: SETTING_UPDATED,
     });
     expect(updatedEvents).toHaveLength(1);
-    expect(updatedEvents[0].data).toEqual({"id": "updated-setting", "some": "blob", "test": "fun"});
-
+    expect(updatedEvents[0].data).toEqual({
+        id: 'updated-setting',
+        some: 'blob',
+        test: 'fun',
+    });
 });

--- a/src/test/e2e/services/setting-service.test.ts
+++ b/src/test/e2e/services/setting-service.test.ts
@@ -38,6 +38,7 @@ test('Can create new setting', async () => {
         type: SETTING_CREATED,
     });
     expect(createdEvents).toHaveLength(1);
+    expect(createdEvents[0].data).toEqual({"id": "some-setting", "some": "blob"});
 });
 
 test('Can delete setting', async () => {
@@ -67,4 +68,6 @@ test('Can update setting', async () => {
         type: SETTING_UPDATED,
     });
     expect(updatedEvents).toHaveLength(1);
+    expect(updatedEvents[0].data).toEqual({"id": "updated-setting", "some": "blob", "test": "fun"});
+
 });

--- a/src/test/e2e/services/setting-service.test.ts
+++ b/src/test/e2e/services/setting-service.test.ts
@@ -8,6 +8,7 @@ import {
     SETTING_UPDATED,
 } from '../../../lib/types/events';
 import { EventService } from '../../../lib/services';
+import { property } from 'fast-check';
 
 let stores: IUnleashStores;
 let db;
@@ -29,7 +30,7 @@ afterAll(async () => {
 
 test('Can create new setting', async () => {
     const someData = { some: 'blob' };
-    await service.insert('some-setting', someData, 'test-user');
+    await service.insert('some-setting', someData, 'test-user', false);
     const actual = await service.get('some-setting');
 
     expect(actual).toStrictEqual(someData);
@@ -55,14 +56,31 @@ test('Can delete setting', async () => {
     expect(createdEvents).toHaveLength(1);
 });
 
+test('Sentitive SSO settings are redacted in event log', async () => {
+    const someData = { password: 'mySecretPassword' };
+    const property = 'unleash.enterprise.auth.oidc';
+    await service.insert(property, someData, 'a-user-in-places');
+
+    await service.insert(property, { password: 'changed' }, 'a-user-in-places');
+    const actual = await service.get(property);
+    const { eventStore } = stores;
+
+    const updatedEvents = await eventStore.searchEvents({
+        type: SETTING_UPDATED,
+    });
+    expect(updatedEvents[0].preData).toEqual({ hideEventDetails: true });
+    await service.delete(property, 'test-user');
+});
+
 test('Can update setting', async () => {
     const { eventStore } = stores;
     const someData = { some: 'blob' };
-    await service.insert('updated-setting', someData, 'test-user');
+    await service.insert('updated-setting', someData, 'test-user', false);
     await service.insert(
         'updated-setting',
         { ...someData, test: 'fun' },
         'test-user',
+        false,
     );
     const updatedEvents = await eventStore.searchEvents({
         type: SETTING_UPDATED,

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -211,6 +211,7 @@ test('should not login user if simple auth is disabled', async () => {
         simpleAuthSettingsKey,
         { disabled: true },
         randomId(),
+        true,
     );
 
     await userService.createUser({


### PR DESCRIPTION
This adds more data to the setting events, so that its possible to see what has changed

Used to look like:
```
{
  "id": "maintenance.mode"
}
```

Now it looks like this:
```
{
  "id": "maintenance.mode",
  "enabled": false
}
```