### PR TITLE
fix: naming pattern update event should keep old project settings

### DIFF
--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -299,7 +299,7 @@ export default class ProjectService {
             type: PROJECT_UPDATED,
             project: updatedProject.id,
             createdBy: getCreatedBy(user),
-            data: updatedProject,
+            data: { ...preData, ...updatedProject },
             preData,
         });
     }

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -1991,6 +1991,14 @@ describe('feature flag naming patterns', () => {
             },
             user,
         );
+        const { events } = await eventService.getEvents();
+        expect(events[0]).toMatchObject({
+            preData: events[0].preData,
+            data: {
+                ...events[0].preData,
+                featureNaming: events[0].data.featureNaming,
+            },
+        });
 
         const updatedProject = await projectService.getProject(project.id);
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Before - all untouched settings were shown as deleted
<img width="1013" alt="Screenshot 2023-11-27 at 16 19 37" src="https://github.com/Unleash/unleash/assets/1394682/e5a2dffd-5283-489d-b4b6-04e043d2841a">

After - only changing fields are shown
<img width="1179" alt="Screenshot 2023-11-27 at 16 19 45" src="https://github.com/Unleash/unleash/assets/1394682/519900e6-c86b-423a-965b-21f8238783f4">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
