### PR TITLE
fix: specify permission table

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -204,7 +204,7 @@ export class AccessStore implements IAccessStore {
         let userPermissionQuery = this.db
             .select(
                 'project',
-                'permission',
+                'p.permission',
                 'environment',
                 'type',
                 'ur.role_id',
@@ -217,7 +217,7 @@ export class AccessStore implements IAccessStore {
         userPermissionQuery = userPermissionQuery.union((db) => {
             db.select(
                 'project',
-                'permission',
+                'p.permission',
                 'environment',
                 'p.type',
                 'gr.role_id',
@@ -233,7 +233,7 @@ export class AccessStore implements IAccessStore {
         userPermissionQuery = userPermissionQuery.union((db) => {
             db.select(
                 this.db.raw("'default' as project"),
-                'permission',
+                'p.permission',
                 'environment',
                 'p.type',
                 'g.root_role_id as role_id',
@@ -796,9 +796,8 @@ export class AccessStore implements IAccessStore {
             }
         });
         // no need to pass down the environment in this particular case because it'll be overriden
-        const permissionsWithIds = await this.resolvePermissions(
-            permissionsAsRefs,
-        );
+        const permissionsWithIds =
+            await this.resolvePermissions(permissionsAsRefs);
 
         const newRoles = permissionsWithIds.map((p) => ({
             role_id,

--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -796,8 +796,9 @@ export class AccessStore implements IAccessStore {
             }
         });
         // no need to pass down the environment in this particular case because it'll be overriden
-        const permissionsWithIds =
-            await this.resolvePermissions(permissionsAsRefs);
+        const permissionsWithIds = await this.resolvePermissions(
+            permissionsAsRefs,
+        );
 
         const newRoles = permissionsWithIds.map((p) => ({
             role_id,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1672/hotfix-specify-table-in-permission-column-queries

This specifies the table that we are querying the `permission` column from, hopefully preventing ambiguity issues.
You can find the relevant changes here: [#5409](https://github.com/Unleash/unleash/pull/5409/files#diff-5cb4eca71e6a03ec3d123986d657368a3386f80e986dfef2e3feb0abb0673d87)