### PR TITLE
fix(removeapitokenbutton.tsx): add environment name in delete token modal

### DIFF
--- a/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
+++ b/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
@@ -69,6 +69,9 @@ export const RemoveApiTokenButton = ({
                         <li>
                             <strong>type</strong>: <code>{token.type}</code>
                         </li>
+                        <li>
+                            <strong>environment</strong>: <code>{token.environment}</code>
+                        </li>
                     </StyledUl>
                 </div>
             </Dialogue>

--- a/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
+++ b/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
@@ -70,7 +70,8 @@ export const RemoveApiTokenButton = ({
                             <strong>type</strong>: <code>{token.type}</code>
                         </li>
                         <li>
-                            <strong>environment</strong>: <code>{token.environment}</code>
+                            <strong>environment</strong>:{' '}
+                            <code>{token.environment}</code>
                         </li>
                     </StyledUl>
                 </div>


### PR DESCRIPTION
fix #5444

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
I have added an "environment" row to the file RemoveApiTokenButton.tsx to prompt users to confirm their intention before deleting a token. This enhancement aims to prevent accidental deletions and improve user experience.

<!-- Does it close an issue? Multiple? -->
Closes #5444 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
The key file modified in this PR is RemoveApiTokenButton.tsx Reviewers should pay special attention to this file to understand the implementation of the "environment" row.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I would appreciate feedback on the implementation of the "environment" row and its impact on user interactions. Additionally, if there are alternative approaches or considerations that should be taken into account, please let me know.
