### PR TITLE
chore: schedule renovate to run early in the morning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": ["config:base"],
+  "timezone": "Europe/Madrid",
+  "schedule": "before 5am every weekday",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "timezone": "Europe/Madrid",
-  "schedule": "before 5am every weekday",
+  "schedule": ["after 7pm every weekday", "before 5am every weekday"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## About the changes
Schedule renovate to run and merge PRs before working hours to reduce noise. 
https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours

From the documentation:
![image](https://github.com/Unleash/unleash/assets/455064/fc38f19f-09c3-4daa-a740-826d68cdbd06)
