### PR TITLE
fix: add metrics for service account and api tokens

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -96,10 +96,24 @@ export class ApiTokenStore implements IApiTokenStore {
             });
     }
 
-    count(): Promise<number> {
+    async count(): Promise<number> {
         return this.db(TABLE)
             .count('*')
             .then((res) => Number(res[0].count));
+    }
+
+    async countByType(): Promise<Map<string, number>> {
+        return this.db(TABLE)
+            .select('type')
+            .count('*')
+            .groupBy('type')
+            .then((res) => {
+                const map = new Map<string, number>();
+                res.forEach((row) => {
+                    map.set(row.type.toString(), Number(row.count));
+                });
+                return map;
+            });
     }
 
     async getAll(): Promise<IApiToken[]> {

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -201,6 +201,16 @@ class UserStore implements IUserStore {
             .then((res) => Number(res[0].count));
     }
 
+    async countServiceAccounts(): Promise<number> {
+        return this.db(TABLE)
+            .where({
+                deleted_at: null,
+                is_service: true,
+            })
+            .count('*')
+            .then((res) => Number(res[0].count));
+    }
+
     destroy(): void {}
 
     async exists(id: number): Promise<boolean> {

--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -17,7 +17,11 @@ import { ISegmentStore } from '../../types/stores/segment-store';
 import { IRoleStore } from '../../types/stores/role-store';
 import VersionService from '../../services/version-service';
 import { ISettingStore } from '../../types/stores/settings-store';
-import { FEATURES_EXPORTED, FEATURES_IMPORTED } from '../../types';
+import {
+    FEATURES_EXPORTED,
+    FEATURES_IMPORTED,
+    IApiTokenStore,
+} from '../../types';
 import { CUSTOM_ROOT_ROLE_TYPE } from '../../util';
 import { type GetActiveUsers } from './getActiveUsers';
 import { ProjectModeCount } from '../../db/project-store';
@@ -31,6 +35,8 @@ export interface InstanceStats {
     versionOSS: string;
     versionEnterprise?: string;
     users: number;
+    serviceAccounts: number;
+    apiTokens: Map<string, number>;
     featureToggles: number;
     projects: ProjectModeCount[];
     contextFields: number;
@@ -78,6 +84,8 @@ export class InstanceStatsService {
 
     private eventStore: IEventStore;
 
+    private apiTokenStore: IApiTokenStore;
+
     private versionService: VersionService;
 
     private settingStore: ISettingStore;
@@ -106,6 +114,7 @@ export class InstanceStatsService {
             settingStore,
             clientInstanceStore,
             eventStore,
+            apiTokenStore,
         }: Pick<
             IUnleashStores,
             | 'featureToggleStore'
@@ -120,6 +129,7 @@ export class InstanceStatsService {
             | 'settingStore'
             | 'clientInstanceStore'
             | 'eventStore'
+            | 'apiTokenStore'
         >,
         { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
         versionService: VersionService,
@@ -142,6 +152,7 @@ export class InstanceStatsService {
         this.logger = getLogger('services/stats-service.js');
         this.getActiveUsers = getActiveUsers;
         this.getProductionChanges = getProductionChanges;
+        this.apiTokenStore = apiTokenStore;
     }
 
     async refreshStatsSnapshot(): Promise<void> {
@@ -194,6 +205,8 @@ export class InstanceStatsService {
         const [
             featureToggles,
             users,
+            serviceAccounts,
+            apiTokens,
             activeUsers,
             projects,
             contextFields,
@@ -213,6 +226,8 @@ export class InstanceStatsService {
         ] = await Promise.all([
             this.getToggleCount(),
             this.userStore.count(),
+            this.userStore.countServiceAccounts(),
+            this.apiTokenStore.countByType(),
             this.getActiveUsers(),
             this.getProjectModeCount(),
             this.contextFieldStore.count(),
@@ -237,6 +252,8 @@ export class InstanceStatsService {
             versionOSS: versionInfo.current.oss,
             versionEnterprise: versionInfo.current.enterprise,
             users,
+            serviceAccounts,
+            apiTokens,
             activeUsers,
             featureToggles,
             projects,

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -105,6 +105,8 @@ class InstanceAdminController extends Controller {
             sum: 'some-sha256-hash',
             timestamp: new Date(2023, 6, 12, 10, 0, 0, 0),
             users: 10,
+            serviceAccounts: 2,
+            apiTokens: new Map([]),
             versionEnterprise: '5.1.7',
             versionOSS: '5.1.7',
             activeUsers: {

--- a/src/lib/types/stores/api-token-store.ts
+++ b/src/lib/types/stores/api-token-store.ts
@@ -7,4 +7,5 @@ export interface IApiTokenStore extends Store<IApiToken, string> {
     setExpiry(secret: string, expiresAt: Date): Promise<IApiToken>;
     markSeenAt(secrets: string[]): Promise<void>;
     count(): Promise<number>;
+    countByType(): Promise<Map<string, number>>;
 }

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -32,4 +32,5 @@ export interface IUserStore extends Store<IUser, number> {
     incLoginAttempts(user: IUser): Promise<void>;
     successfullyLogin(user: IUser): Promise<void>;
     count(): Promise<number>;
+    countServiceAccounts(): Promise<number>;
 }

--- a/src/test/fixtures/fake-api-token-store.ts
+++ b/src/test/fixtures/fake-api-token-store.ts
@@ -1,5 +1,9 @@
 import { IApiTokenStore } from '../../lib/types/stores/api-token-store';
-import { IApiToken, IApiTokenCreate } from '../../lib/types/models/api-token';
+import {
+    ApiTokenType,
+    IApiToken,
+    IApiTokenCreate,
+} from '../../lib/types/models/api-token';
 
 import NotFoundError from '../../lib/error/notfound-error';
 import EventEmitter from 'events';
@@ -8,6 +12,9 @@ export default class FakeApiTokenStore
     extends EventEmitter
     implements IApiTokenStore
 {
+    countByType(): Promise<Map<ApiTokenType, number>> {
+        return Promise.resolve(new Map());
+    }
     tokens: IApiToken[] = [];
 
     async delete(key: string): Promise<void> {

--- a/src/test/fixtures/fake-user-store.ts
+++ b/src/test/fixtures/fake-user-store.ts
@@ -14,6 +14,9 @@ class UserStoreMock implements IUserStore {
         this.idSeq = 1;
         this.data = [];
     }
+    countServiceAccounts(): Promise<number> {
+        return Promise.resolve(0);
+    }
 
     async hasUser({
         id,


### PR DESCRIPTION
This PR adds Prometheus metrics for the number of "service accounts" and "api tokens". 

Service Accounts:
![image](https://github.com/Unleash/unleash/assets/158948/12934b8f-3cca-42bb-9857-61bd843356a7)

Api tokens (label for type):
![image](https://github.com/Unleash/unleash/assets/158948/f6f5f2e5-fa98-4f65-b6ad-1ea087b8ae40)
