### PR TITLE
feat: improve the format of project-access-added event

### DIFF
--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -116,13 +116,26 @@ test('should anonymise any PII fields, no matter the depth', async () => {
         new ProjectAccessAddedEvent({
             createdBy: 'some@email.com',
             data: {
-                groups: [
-                    {
-                        name: 'test',
-                        project: 'default',
+                roles: {
+                    1: {
+                        roleId: 1,
+                        groups: [
+                            {
+                                id: 4,
+                            },
+                        ],
                         users: [{ username: testUsername }],
                     },
-                ],
+                },
+            },
+            preData: {
+                roles: {
+                    1: {
+                        roleId: 1,
+                        groups: [],
+                        users: [],
+                    },
+                },
             },
             project: 'default',
         }),
@@ -133,7 +146,7 @@ test('should anonymise any PII fields, no matter the depth', async () => {
         .expect(200);
 
     expect(body.events.length).toBe(1);
-    expect(body.events[0].data.groups[0].users[0].username).not.toBe(
+    expect(body.events[0].data.roles[1].users[0].username).not.toBe(
         testUsername,
     );
 });

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -664,6 +664,7 @@ export default class ProjectService {
                     groups: usersAndGroups.groups.map(({ id }) => id),
                     users: usersAndGroups.users.map(({ id }) => id),
                 },
+                preData: {},
             }),
         );
     }
@@ -688,9 +689,24 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 data: {
-                    roles,
-                    groups,
-                    users,
+                    roles: roles.reduce((prev, curr) => {
+                        prev[curr] = {
+                            roleId: curr,
+                            groups,
+                            users,
+                        };
+                        return prev;
+                    }, {}),
+                },
+                preData: {
+                    roles: roles.reduce((prev, curr) => {
+                        prev[curr] = {
+                            roleId: curr,
+                            groups: [],
+                            users: [],
+                        };
+                        return prev;
+                    }, {}),
                 },
             }),
         );

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -655,16 +655,26 @@ export default class ProjectService {
             createdBy,
         );
 
+        const data = {
+            roles: {},
+        };
+        data.roles[roleId] = {
+            roleId,
+            users: usersAndGroups.users.map(({ id }) => id),
+            groups: usersAndGroups.groups.map(({ id }) => id),
+        };
+
+        const preData = {
+            roles: {},
+        };
+        preData.roles[roleId] = { roleId, users: [], groups: [] };
+
         await this.eventService.storeEvent(
             new ProjectAccessAddedEvent({
                 project: projectId,
                 createdBy,
-                data: {
-                    roleId,
-                    groups: usersAndGroups.groups.map(({ id }) => id),
-                    users: usersAndGroups.users.map(({ id }) => id),
-                },
-                preData: {},
+                data,
+                preData,
             }),
         );
     }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -863,12 +863,17 @@ export class ProjectAccessAddedEvent extends BaseEvent {
     /**
      * @param createdBy accepts a string for backward compatibility. Prefer using IUser for standardization
      */
-    constructor(p: { project: string; createdBy: string | IUser; data: any }) {
+    constructor(p: {
+        project: string;
+        createdBy: string | IUser;
+        data: any;
+        preData: any;
+    }) {
         super(PROJECT_ACCESS_ADDED, p.createdBy);
-        const { project, data } = p;
+        const { project, data, preData } = p;
         this.project = project;
         this.data = data;
-        this.preData = null;
+        this.preData = preData;
     }
 }
 


### PR DESCRIPTION
## About the changes

Improves the structure/format of the generated diff for project-access-added events.

Before:

<img width="331" alt="Skjermbilde 2023-11-30 kl  08 32 41" src="https://github.com/Unleash/unleash/assets/707867/1a5d4260-5f2a-4a4d-98ff-467517f865f4">

After:

<img width="291" alt="Skjermbilde 2023-11-30 kl  08 32 52" src="https://github.com/Unleash/unleash/assets/707867/72fe6c11-ed53-4130-bd3e-78d0b80fb14d">


## Discussion points
Couldn't find any relevant event formatter to update
