### PR TITLE
feat: hide change actions when change request is scheduled

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -34,7 +34,9 @@ const useShowActions = (changeRequest: IChangeRequest, change: IChange) => {
         changeRequest.environment,
     );
 
-    const isPending = !['Cancelled', 'Applied', 'Scheduled'].includes(changeRequest.state);
+    const isPending = !['Cancelled', 'Applied', 'Scheduled'].includes(
+        changeRequest.state,
+    );
 
     const { user } = useAuthUser();
     const isAuthor = user?.id === changeRequest.createdBy.id;

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -33,7 +33,8 @@ const useShowActions = (changeRequest: IChangeRequest, change: IChange) => {
     const allowChangeRequestActions = isChangeRequestConfigured(
         changeRequest.environment,
     );
-    const isPending = !['Cancelled', 'Applied'].includes(changeRequest.state);
+
+    const isPending = !['Cancelled', 'Applied', 'Scheduled'].includes(changeRequest.state);
 
     const { user } = useAuthUser();
     const isAuthor = user?.id === changeRequest.createdBy.id;


### PR DESCRIPTION
Added 'Scheduled' state to the check for non-pending change requests

Closes # [1-1680](https://linear.app/unleash/issue/1-1680/remove-edit-change-ui-when-cr-is-scheduled)
<img width="868" alt="Screenshot 2023-11-30 at 11 54 44" src="https://github.com/Unleash/unleash/assets/104830839/8e6afec5-1353-4030-b49b-4a8f3eaee5f6">

