### PR TITLE
fix: scheduled cr failed email

### DIFF
--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -71,7 +71,6 @@ export class EmailService {
     }
 
     async sendScheduledExecutionFailedEmail(
-        name: string,
         recipient: string,
         changeRequestLink: string,
         changeRequestTitle: string,
@@ -85,9 +84,9 @@ export class EmailService {
                 TemplateFormat.HTML,
                 {
                     changeRequestLink,
+                    changeRequestTitle,
                     scheduledAt,
                     errorMessage,
-                    name,
                     year,
                 },
             );
@@ -99,7 +98,6 @@ export class EmailService {
                     changeRequestTitle,
                     scheduledAt,
                     errorMessage,
-                    name,
                     year,
                 },
             );


### PR DESCRIPTION
Relates to # [1-1687](https://linear.app/unleash/issue/1-1687/send-an-email-when-the-scheduling-fails)

Removed `name` - not in template
Added missed `changeRequestTitle` for the html template context