### PR TITLE
fix: prevent search being stacked on top of the form dropdown

### DIFF
--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -245,6 +245,8 @@ export const AdvancedPlayground: VFC<{
                     sx={{
                         background: theme.palette.background.elevation2,
                         borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+                        isolation: 'isolate',
+                        zIndex: 2,
                     }}
                 >
                     <Paper
@@ -279,6 +281,8 @@ export const AdvancedPlayground: VFC<{
                         width: resultsWidth,
                         transition: 'width 0.4s ease',
                         padding: theme.spacing(4, 4),
+                        isolation: 'isolate',
+                        zIndex: 1,
                     })}
                 >
                     <ConditionallyRender

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
@@ -35,7 +35,7 @@ export const PlaygroundForm: VFC<IPlaygroundFormProps> = ({
             onSubmit={onSubmit}
             sx={{
                 display: 'flex',
-                flexDirection: 'column'
+                flexDirection: 'column',
             }}
         >
             <PlaygroundConnectionFieldset

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
@@ -35,7 +35,7 @@ export const PlaygroundForm: VFC<IPlaygroundFormProps> = ({
             onSubmit={onSubmit}
             sx={{
                 display: 'flex',
-                flexDirection: 'column',
+                flexDirection: 'column'
             }}
         >
             <PlaygroundConnectionFieldset


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Setting stacking context of the form to be on top of the results section. 
We're explicitly setting isolation to get an explicit stacking context for upper and lower div. The upper div is given higher zIndex. This way we can prevent global zIndex wars and everything in the upper part (form elements) always overlays the lower part (table results).

Before:
<img width="857" alt="Screenshot 2023-12-04 at 11 02 29" src="https://github.com/Unleash/unleash/assets/1394682/7258fb2c-45c5-4eab-8ce9-45cc9f414700">


After:
<img width="1091" alt="Screenshot 2023-12-04 at 11 00 10" src="https://github.com/Unleash/unleash/assets/1394682/ecbe965d-ec2d-4698-88a6-296690f7e7da">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
