### PR TITLE
feat: Refactor Table State Persistence in Feature Toggle List

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -46,11 +46,7 @@ import {
     useFeatureSearch,
 } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import mapValues from 'lodash.mapvalues';
-import {
-    NumberParam,
-    StringParam,
-    withDefault,
-} from 'use-query-params';
+import { NumberParam, StringParam, withDefault } from 'use-query-params';
 import { BooleansStringParam } from 'utils/serializeQueryParams';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -7,7 +7,7 @@ import {
     useMediaQuery,
     useTheme,
 } from '@mui/material';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import {
     useReactTable,
     getCoreRowModel,
@@ -47,14 +47,12 @@ import {
 } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import mapValues from 'lodash.mapvalues';
 import {
-    BooleanParam,
     NumberParam,
     StringParam,
-    useQueryParams,
     withDefault,
 } from 'use-query-params';
-import { createLocalStorage } from 'utils/createLocalStorage';
 import { BooleansStringParam } from 'utils/serializeQueryParams';
+import { usePersistentTableState } from 'hooks/usePersistentTableState';
 
 export const featuresPlaceholder = Array(15).fill({
     name: 'Name of the feature',
@@ -65,24 +63,6 @@ export const featuresPlaceholder = Array(15).fill({
 });
 
 const columnHelper = createColumnHelper<FeatureSchema>();
-
-const usePersistentSearchParams = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const { value, setValue } = createLocalStorage('feature-toggle-list', {});
-    useEffect(() => {
-        const params = Object.fromEntries(searchParams.entries());
-        if (Object.keys(params).length > 0) {
-            return;
-        }
-        if (Object.keys(value).length === 0) {
-            return;
-        }
-
-        setSearchParams(value, { replace: true });
-    }, []);
-
-    return setValue;
-};
 
 export const FeatureToggleListTable: VFC = () => {
     const theme = useTheme();
@@ -97,21 +77,17 @@ export const FeatureToggleListTable: VFC = () => {
     const { setToastApiError } = useToast();
     const { uiConfig } = useUiConfig();
 
-    const updateStoredParams = usePersistentSearchParams();
-
-    const [tableState, setTableState] = useQueryParams({
-        offset: withDefault(NumberParam, 0),
-        limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
-        query: StringParam,
-        favoritesFirst: withDefault(BooleansStringParam, true),
-        sortBy: withDefault(StringParam, 'createdAt'),
-        sortOrder: withDefault(StringParam, 'desc'),
-    });
-
-    useEffect(() => {
-        const { offset, ...rest } = tableState;
-        updateStoredParams(rest);
-    }, [JSON.stringify(tableState)]);
+    const [tableState, setTableState] = usePersistentTableState(
+        'features-list-table',
+        {
+            offset: withDefault(NumberParam, 0),
+            limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
+            query: StringParam,
+            favoritesFirst: withDefault(BooleansStringParam, true),
+            sortBy: withDefault(StringParam, 'createdAt'),
+            sortOrder: withDefault(StringParam, 'desc'),
+        },
+    );
 
     const {
         features = [],

--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { createLocalStorage } from 'utils/createLocalStorage';
+import { useQueryParams } from 'use-query-params';
+
+const usePersistentSearchParams = (key: string) => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { value, setValue } = createLocalStorage(key, {});
+    useEffect(() => {
+        const params = Object.fromEntries(searchParams.entries());
+        if (Object.keys(params).length > 0) {
+            return;
+        }
+        if (Object.keys(value).length === 0) {
+            return;
+        }
+
+        setSearchParams(value, { replace: true });
+    }, []);
+
+    return setValue;
+};
+
+export const usePersistentTableState = <
+    T extends Parameters<typeof useQueryParams>[0],
+>(
+    key: string,
+    queryParamsDefinition: T,
+) => {
+    const updateStoredParams = usePersistentSearchParams(key);
+
+    const [tableState, setTableState] = useQueryParams(queryParamsDefinition);
+
+    useEffect(() => {
+        const { offset, ...rest } = tableState;
+        updateStoredParams(rest);
+    }, [JSON.stringify(tableState)]);
+
+    return [tableState, setTableState] as const;
+};

--- a/frontend/src/utils/serializeQueryParams.ts
+++ b/frontend/src/utils/serializeQueryParams.ts
@@ -1,0 +1,30 @@
+// Custom additional serializers for query params library
+// used in `useQueryParams` hook
+
+const encodeBoolean = (
+    bool: boolean | null | undefined,
+): string | null | undefined => {
+    if (bool == null) {
+        return bool;
+    }
+
+    return bool ? 'true' : 'false';
+};
+
+const decodeBoolean = (
+    input: string | (string | null)[] | null | undefined,
+): boolean | null | undefined => {
+    if (input === 'true') {
+        return true;
+    }
+    if (input === 'false') {
+        return false;
+    }
+
+    return null;
+};
+
+export const BooleansStringParam = {
+    encode: encodeBoolean,
+    decode: decodeBoolean,
+};


### PR DESCRIPTION
## Overview
This PR introduces a significant refactor in the handling of table states in the FeatureToggleListTable component. The changes focus on enhancing the persistence of table states and improving the management of query parameters.

Key Changes
- Created a new custom hook, `usePersistentTableState`, to manage the persistent state of table parameters. This hook leverages local storage to remember the user's table state across sessions.
- Replaced the existing useQueryParams hook with usePersistentTableState in FeatureToggleListTable.tsx to enable persistent state management.
- Replaced `BooleanParam` with utilities specific to our backend convention.
