### PR TITLE
test: specify custom config in dbm

### DIFF
--- a/src/test/e2e/dedupe-permissions.e2e.test.ts
+++ b/src/test/e2e/dedupe-permissions.e2e.test.ts
@@ -28,7 +28,7 @@ test('Dedupe permissions migration correctly dedupes permissions', async () => {
 
     await initSchema(config.db);
 
-    const e2e = {
+    const custom = {
         ...config.db,
         connectionTimeoutMillis: 2000,
     };
@@ -37,9 +37,11 @@ test('Dedupe permissions migration correctly dedupes permissions', async () => {
     process.argv = process.argv.filter((it) => !it.includes('--verbose'));
     const dbm = getInstance(true, {
         cwd: `${__dirname}/../../`, // relative to src/test/e2e
-        config: { e2e },
-        env: 'e2e',
+        config: { custom },
+        env: 'custom',
     });
+
+    dbm.config.custom = custom;
 
     // Run all migrations up to, and including, this one, the last one before the dedupe migration
     await dbm.up('20231121153304-add-permission-create-tag-type.js');

--- a/src/test/e2e/favor-permission-name-over-id.e2e.test.ts
+++ b/src/test/e2e/favor-permission-name-over-id.e2e.test.ts
@@ -28,7 +28,7 @@ test('Favor permission name over id migration correctly assigns permissions by n
 
     await initSchema(config.db);
 
-    const e2e = {
+    const custom = {
         ...config.db,
         connectionTimeoutMillis: 2000,
     };
@@ -37,9 +37,11 @@ test('Favor permission name over id migration correctly assigns permissions by n
     process.argv = process.argv.filter((it) => !it.includes('--verbose'));
     const dbm = getInstance(true, {
         cwd: `${__dirname}/../../`, // relative to src/test/e2e
-        config: { e2e },
-        env: 'e2e',
+        config: { custom },
+        env: 'custom',
     });
+
+    dbm.config.custom = custom;
 
     // Run all migrations up to, and including, this one, the last one before the favor permission name over id migration
     await dbm.up('20231123100052-drop-last-seen-foreign-key.js');


### PR DESCRIPTION
Was having some trouble running these migration tests locally due to `dbm` not correctly picking up the passed in config. This fixes it by setting the custom config property after it has been initialized, always overriding any wrong values.

PS: I think I found the issue. `dbm` was prioritizing my `DATABASE_URL` for some reason, as I started having issues when it was set, and stopped having issues when I unset it. 

I still think this is a good change, as it prevents similar hard-to-debug issues in the future.

To help clarify this, running this locally:
 - `export DATABASE_URL=postgres://unleash_user:passord@localhost:5432/unleash`
 - `yarn test dedupe-permissions`

Fails on `main`, but passes on this branch. For some reason the `dbm` instance prioritizes whatever is set in `DATABASE_URL` instead of the options that are passed in `getInstance`.