### PR TITLE
fix: state now persist to filters

### DIFF
--- a/frontend/src/component/common/FilterItem/FilterItem.test.tsx
+++ b/frontend/src/component/common/FilterItem/FilterItem.test.tsx
@@ -88,12 +88,12 @@ describe('FilterItem Component', () => {
         const operatorsElement = await screen.findByText('is any of');
 
         operatorsElement.click();
-        const newOperator = await screen.findByText('is not any of');
+        const newOperator = await screen.findByText('is none of');
 
         newOperator.click();
 
         expect(recordedChanges).toEqual([
-            { operator: 'IS_NOT_ANY_OF', values: ['1', '3'] },
+            { operator: 'IS_NONE_OF', values: ['1', '3'] },
         ]);
     });
 

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
@@ -47,15 +47,9 @@ export const FeatureToggleFilters: VFC<IFeatureToggleFiltersProps> = ({
             value: 'stale',
         },
     ];
-    const defaultFilterItems: IFilterItem[] = [
-        {
-            label: 'State',
-            options: stateOptions,
-            filterKey: 'state',
-        },
-    ];
+
     const [availableFilters, setAvailableFilters] =
-        useState<IFilterItem[]>(defaultFilterItems);
+        useState<IFilterItem[]>([]);
     const removeFilter = (label: string) => {
         const filters = availableFilters.map((filter) =>
             filter.label === label
@@ -74,17 +68,24 @@ export const FeatureToggleFilters: VFC<IFeatureToggleFiltersProps> = ({
             value: project.id,
         }));
 
-        const newFilterItems = [
-            ...defaultFilterItems,
+        const newFilterItems : IFilterItem[] = [
+            {
+                label: 'State',
+                options: stateOptions,
+                filterKey: 'state',
+                enabled: Boolean(state.state)
+            },
             {
                 label: 'Project',
                 options: projectsOptions,
                 filterKey: 'project',
+                enabled: Boolean(state.project)
             } as const,
         ];
 
         setAvailableFilters(newFilterItems);
-    }, [JSON.stringify(projects)]);
+    }, [JSON.stringify(projects), JSON.stringify(state)]);
+
     return (
         <StyledBox>
             {availableFilters.map(

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
@@ -48,8 +48,7 @@ export const FeatureToggleFilters: VFC<IFeatureToggleFiltersProps> = ({
         },
     ];
 
-    const [availableFilters, setAvailableFilters] =
-        useState<IFilterItem[]>([]);
+    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
     const removeFilter = (label: string) => {
         const filters = availableFilters.map((filter) =>
             filter.label === label
@@ -68,18 +67,18 @@ export const FeatureToggleFilters: VFC<IFeatureToggleFiltersProps> = ({
             value: project.id,
         }));
 
-        const newFilterItems : IFilterItem[] = [
+        const newFilterItems: IFilterItem[] = [
             {
                 label: 'State',
                 options: stateOptions,
                 filterKey: 'state',
-                enabled: Boolean(state.state)
+                enabled: Boolean(state.state),
             },
             {
                 label: 'Project',
                 options: projectsOptions,
                 filterKey: 'project',
-                enabled: Boolean(state.project)
+                enabled: Boolean(state.project),
             } as const,
         ];
 


### PR DESCRIPTION
When navigating to features list, now it will respect the query params.