### PR TITLE
fix: UI changes

### DIFF
--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionView/ConstraintAccordionViewHeader/ConstraintViewHeaderOperator.tsx
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionView/ConstraintAccordionViewHeader/ConstraintViewHeaderOperator.tsx
@@ -39,16 +39,9 @@ export const ConstraintViewHeaderOperator = ({
                 condition={Boolean(constraint.inverted)}
                 show={
                     <Tooltip title={'Operator is negated'} arrow>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                paddingRight: theme.spacing(1),
-                            }}
-                        >
-                            <StyledIconWrapper>
-                                <NegatedOnIcon
-                                    color={theme.palette.primary.main}
-                                />
+                        <Box sx={{ display: 'flex' }}>
+                            <StyledIconWrapper isPrefix>
+                                <NegatedOnIcon />
                             </StyledIconWrapper>
                         </Box>
                     </Tooltip>

--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionView/ConstraintAccordionViewHeader/StyledIconWrapper.tsx
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionView/ConstraintAccordionViewHeader/StyledIconWrapper.tsx
@@ -16,7 +16,10 @@ export const StyledIconWrapperBase = styled('div')<{
     borderRadius: theme.shape.borderRadius,
 }));
 
-const StyledPrefixIconWrapper = styled(StyledIconWrapperBase)(() => ({
+const StyledPrefixIconWrapper = styled(StyledIconWrapperBase)(({ theme }) => ({
+    width: 'auto',
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
     marginLeft: 0,
     borderTopRightRadius: 0,
     borderBottomRightRadius: 0,


### PR DESCRIPTION
Includes some fixes to https://github.com/Unleash/unleash/pull/5565 after aligning with @nicolaesocaciu 

 - Keeping the `isPrefix` prop is the correct thing to do here (it's also the only place in the whole codebase where it's being used)
 - We should not add a `paddingRight` to the parent
 - We don't need to set the color on the icon, since it's inherited by `StyledIconWrapperBase`
 - After the changes above, the icon looks a bit tight in its box, so we fix that:
   - We set `width` to `auto` in `StyledPrefixIconWrapper` to override the `width: 24` on `StyledIconWrapperBase`
   - We set `paddingLeft` and `paddingRight` to `theme.spacing(1)` (8px)

![image](https://github.com/Unleash/unleash/assets/14320932/51419e6a-a658-4c70-aebe-44468f5955a9)