### PR TITLE
feat: add reset password to user manager

### DIFF
--- a/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
@@ -50,7 +50,9 @@ const ResetPassword = ({
             if (token) {
                 setResetLink(token.resetPasswordUrl);
             } else {
-                setToastApiError('Could not reset password');
+                setToastApiError(
+                    'Could not reset password. If you made another request in less than a minute, wait for one minute and try again.',
+                );
             }
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
@@ -36,7 +36,9 @@ const ResetPassword = ({
     const submit = async (event: React.SyntheticEvent) => {
         event.preventDefault();
         if (!user.email) {
-            setToastApiError('User without email cannot reset password');
+            setToastApiError(
+                "You can't reset the password of a user who doesn't have an email address.",
+            );
             return;
         }
 
@@ -48,7 +50,7 @@ const ResetPassword = ({
             if (token) {
                 setResetLink(token.resetPasswordUrl);
             } else {
-                setToastApiError("Could not reset password");
+                setToastApiError('Could not reset password');
             }
         } catch (error) {
             setToastApiError(formatUnknownError(error));
@@ -84,7 +86,7 @@ const ResetPassword = ({
                 )}
             >
                 <Typography variant='subtitle1'>
-                    Reseting password for user
+                    Resetting password for user
                 </Typography>
                 <div className={themeStyles.flexRow}>
                     <StyledUserAvatar user={user} variant='rounded' />
@@ -104,13 +106,10 @@ const ResetPassword = ({
                 title='Reset password link created'
             >
                 <Box>
-                    <Typography variant='body1' sx={{ mb: 2 }}>
-                        Using this link the user can reset the password.
-                    </Typography>
                     <Typography variant='body1'>
-                        Provide them with the following link to reset their
-                        password. This will allow them to set up a new password
-                        and get back to using their Unleash account.
+                        The user can use this link to reset their password. You
+                        should not share this link with anyone but the user in
+                        question.
                     </Typography>
                     <LinkField inviteLink={resetLink} />
                 </Box>

--- a/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import { Box, styled, TextField, Typography } from '@mui/material';
+import { modalStyles } from 'component/admin/users/util';
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+import { useThemeStyles } from 'themes/themeStyles';
+import { IUser } from 'interfaces/user';
+import useAdminUsersApi from 'hooks/api/actions/useAdminUsersApi/useAdminUsersApi';
+import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
+import useToast from 'hooks/useToast';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { LinkField } from '../../LinkField/LinkField';
+
+const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
+    width: theme.spacing(5),
+    height: theme.spacing(5),
+    margin: 0,
+}));
+
+interface IChangePasswordProps {
+    showDialog: boolean;
+    closeDialog: () => void;
+    user: IUser;
+}
+
+const ResetPassword = ({
+    showDialog,
+    closeDialog,
+    user,
+}: IChangePasswordProps) => {
+    const { classes: themeStyles } = useThemeStyles();
+    const { resetPassword } = useAdminUsersApi();
+    const { setToastApiError } = useToast();
+    const [resetLink, setResetLink] = useState('');
+
+    const submit = async (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        if (!user.email) {
+            setToastApiError('User without email cannot reset password');
+            return;
+        }
+
+        try {
+            const token = await resetPassword(user.email).then((res) =>
+                res.ok ? res.json() : undefined,
+            );
+
+            if (token) {
+                console.log(token);
+                setResetLink(token.resetPasswordUrl);
+            } else {
+                setToastApiError("Could not reset password");
+            }
+        } catch (error) {
+            console.warn(error);
+            setToastApiError(formatUnknownError(error));
+        }
+    };
+
+    const onCancel = (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        closeDialog();
+    };
+
+    const closeConfirm = () => {
+        setResetLink('');
+        closeDialog();
+    };
+
+    return (
+        <Dialogue
+            open={showDialog}
+            onClick={submit}
+            style={modalStyles}
+            onClose={onCancel}
+            primaryButtonText='Generate Link'
+            title='Reset password'
+            secondaryButtonText='Cancel'
+            maxWidth='xs'
+        >
+            <form
+                onSubmit={submit}
+                className={classnames(
+                    themeStyles.contentSpacingY,
+                    themeStyles.flexColumn,
+                )}
+            >
+                <Typography variant='subtitle1'>
+                    Reseting password for user
+                </Typography>
+                <div className={themeStyles.flexRow}>
+                    <StyledUserAvatar user={user} variant='rounded' />
+                    <Typography
+                        variant='subtitle1'
+                        style={{ marginLeft: '1rem' }}
+                    >
+                        {user.username || user.email}
+                    </Typography>
+                </div>
+            </form>
+
+            <Dialogue
+                open={Boolean(resetLink)}
+                onClick={closeConfirm}
+                primaryButtonText='Close'
+                title='Reset password link created'
+            >
+                <Box>
+                    <Typography variant='body1' sx={{ mb: 2 }}>
+                        Using this link the user can reset the password.
+                    </Typography>
+                    <Typography variant='body1'>
+                        Provide them with the following link to reset their
+                        password. This will allow them to set up a new password
+                        and get back to using their Unleash account.
+                    </Typography>
+                    <LinkField inviteLink={resetLink} />
+                </Box>
+            </Dialogue>
+        </Dialogue>
+    );
+};
+
+export default ResetPassword;

--- a/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
@@ -51,7 +51,7 @@ const ResetPassword = ({
                 setResetLink(token.resetPasswordUrl);
             } else {
                 setToastApiError(
-                    'Could not reset password. If you made another request in less than a minute, wait for one minute and try again.',
+                    'Could not reset password. This may be to prevent too many resets. Try again in a minute.',
                 );
             }
         } catch (error) {

--- a/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ResetPassword/ResetPassword.tsx
@@ -46,13 +46,11 @@ const ResetPassword = ({
             );
 
             if (token) {
-                console.log(token);
                 setResetLink(token.resetPasswordUrl);
             } else {
                 setToastApiError("Could not reset password");
             }
         } catch (error) {
-            console.warn(error);
             setToastApiError(formatUnknownError(error));
         }
     };

--- a/frontend/src/component/admin/users/UsersList/UsersActionsCell/UsersActionsCell.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersActionsCell/UsersActionsCell.tsx
@@ -1,4 +1,4 @@
-import { Delete, Edit, Lock } from '@mui/icons-material';
+import { Delete, Edit, Lock, LockReset } from '@mui/icons-material';
 import { Box, styled } from '@mui/material';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { ADMIN } from 'component/providers/AccessProvider/permissions';
@@ -12,12 +12,14 @@ const StyledBox = styled(Box)(() => ({
 interface IUsersActionsCellProps {
     onEdit: (event: React.SyntheticEvent) => void;
     onChangePassword: (event: React.SyntheticEvent) => void;
+    onResetPassword: (event: React.SyntheticEvent) => void;
     onDelete: (event: React.SyntheticEvent) => void;
 }
 
 export const UsersActionsCell: VFC<IUsersActionsCellProps> = ({
     onEdit,
     onChangePassword,
+    onResetPassword,
     onDelete,
 }) => {
     return (
@@ -41,6 +43,16 @@ export const UsersActionsCell: VFC<IUsersActionsCellProps> = ({
                 }}
             >
                 <Lock />
+            </PermissionIconButton>
+            <PermissionIconButton
+                data-loading
+                onClick={onResetPassword}
+                permission={ADMIN}
+                tooltipProps={{
+                    title: 'Reset password',
+                }}
+            >
+                <LockReset />
             </PermissionIconButton>
             <PermissionIconButton
                 data-loading

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
 import ChangePassword from './ChangePassword/ChangePassword';
+import ResetPassword from './ResetPassword/ResetPassword';
 import DeleteUser from './DeleteUser/DeleteUser';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import ConfirmUserAdded from '../ConfirmUserAdded/ConfirmUserAdded';
@@ -45,6 +46,12 @@ const UsersList = () => {
     const [pwDialog, setPwDialog] = useState<{ open: boolean; user?: IUser }>({
         open: false,
     });
+    const [resetPwDialog, setResetPwDialog] = useState<{
+        open: boolean;
+        user?: IUser;
+    }>({
+        open: false,
+    });
     const { isEnterprise } = useUiConfig();
     const [delDialog, setDelDialog] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
@@ -75,8 +82,18 @@ const UsersList = () => {
             setPwDialog({ open: true, user });
         };
 
+    const openResetPwDialog =
+        (user: IUser) => (e: React.SyntheticEvent<Element, Event>) => {
+            e.preventDefault();
+            setResetPwDialog({ open: true, user });
+        };
+
     const closePwDialog = () => {
         setPwDialog({ open: false });
+    };
+
+    const closeResetPwDialog = () => {
+        setResetPwDialog({ open: false });
     };
 
     const onDeleteUser = async (user: IUser) => {
@@ -180,10 +197,11 @@ const UsersList = () => {
                             navigate(`/admin/users/${user.id}/edit`);
                         }}
                         onChangePassword={openPwDialog(user)}
+                        onResetPassword={openResetPwDialog(user)}
                         onDelete={openDelDialog(user)}
                     />
                 ),
-                width: 150,
+                width: 200,
                 disableSortBy: true,
             },
             // Always hidden -- for search
@@ -334,6 +352,18 @@ const UsersList = () => {
                     />
                 )}
             />
+
+            <ConditionallyRender
+                condition={Boolean(resetPwDialog.user)}
+                show={() => (
+                    <ResetPassword
+                        showDialog={resetPwDialog.open}
+                        closeDialog={closeResetPwDialog}
+                        user={resetPwDialog.user!}
+                    />
+                )}
+            />
+
             <ConditionallyRender
                 condition={Boolean(delUser)}
                 show={

--- a/frontend/src/hooks/api/actions/useAdminUsersApi/useAdminUsersApi.ts
+++ b/frontend/src/hooks/api/actions/useAdminUsersApi/useAdminUsersApi.ts
@@ -89,12 +89,27 @@ const useAdminUsersApi = () => {
         return makeRequest(req.caller, req.id);
     };
 
+    const resetPassword = async (email: string) => {
+        const requestId = 'resetPassword';
+        const req = createRequest(
+            'api/admin/user-admin/reset-password',
+            {
+                method: 'POST',
+                body: JSON.stringify({ id: email }),
+            },
+            requestId,
+        );
+
+        return makeRequest(req.caller, req.id);
+    };
+
     return {
         addUser,
         updateUser,
         removeUser,
         changePassword,
         validatePassword,
+        resetPassword,
         userApiErrors: errors,
         userLoading: loading,
     };


### PR DESCRIPTION
## About the changes
This PR aims to add reset password to user manager. This will help those who do not intend to configure the email system.

![Screenshot from 2023-12-10 20-41-22](https://github.com/Unleash/unleash/assets/32435715/0209525a-4f3a-4998-b9de-7299469e1a68)

![Screenshot from 2023-12-16 16-40-36](https://github.com/Unleash/unleash/assets/32435715/556e324c-c0b0-4bb9-b2b5-3bd653f4d329)

![Screenshot from 2023-12-16 16-40-48](https://github.com/Unleash/unleash/assets/32435715/b0249e9d-9e1a-4cfe-a5ee-0ab22f45ce28)


## Discussion points
I didn't find a test for this part of user management in the frontend. Do I need to do automated testing for this implementation?