### PR TITLE
chore: list users and groups under each role in projectaccessadded event

### DIFF
--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -120,6 +120,8 @@ test('should anonymise any PII fields, no matter the depth', async () => {
                     {
                         roleId: 1,
                         groupIds: [1, 2],
+                        // Doesn't reflect the real data structure for event here, normally a number array.
+                        // Testing PII anonymisation
                         users: [{ id: 1, username: testUsername }],
                     },
                 ],

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -120,7 +120,7 @@ test('should anonymise any PII fields, no matter the depth', async () => {
                     {
                         roleId: 1,
                         groupIds: [1, 2],
-                        users: [1],
+                        users: [{ id: 1, username: testUsername }],
                     },
                 ],
             },
@@ -133,7 +133,7 @@ test('should anonymise any PII fields, no matter the depth', async () => {
         .expect(200);
 
     expect(body.events.length).toBe(1);
-    expect(body.events[0].data.groups[0].users[0].username).not.toBe(
+    expect(body.events[0].data.roles[0].users[0].username).not.toBe(
         testUsername,
     );
 });

--- a/src/lib/routes/admin-api/events.test.ts
+++ b/src/lib/routes/admin-api/events.test.ts
@@ -116,11 +116,11 @@ test('should anonymise any PII fields, no matter the depth', async () => {
         new ProjectAccessAddedEvent({
             createdBy: 'some@email.com',
             data: {
-                groups: [
+                roles: [
                     {
-                        name: 'test',
-                        project: 'default',
-                        users: [{ username: testUsername }],
+                        roleId: 1,
+                        groupIds: [1, 2],
+                        users: [1],
                     },
                 ],
             },

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -661,9 +661,11 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 data: {
-                    roleId,
-                    groups: usersAndGroups.groups.map(({ id }) => id),
-                    users: usersAndGroups.users.map(({ id }) => id),
+                    roles: {
+                        roleId,
+                        groupIds: usersAndGroups.groups.map(({ id }) => id),
+                        userIds: usersAndGroups.users.map(({ id }) => id),
+                    },
                 },
             }),
         );
@@ -689,9 +691,13 @@ export default class ProjectService {
                 project: projectId,
                 createdBy,
                 data: {
-                    roles,
-                    groups,
-                    users,
+                    roles: roles.map((roleId) => {
+                        return {
+                            roleId,
+                            groupIds: groups,
+                            userIds: users,
+                        };
+                    }),
                 },
             }),
         );


### PR DESCRIPTION
## About the changes

Replaces #5509 
Changes the project access added event to list all users and groups added to each role instead of in root event.

<img width="900" alt="Skjermbilde 2023-12-11 kl  08 38 12" src="https://github.com/Unleash/unleash/assets/707867/1c0b1a16-3829-479c-9035-0190ab7c5d59">


## Discussion points
- There are separate events that demonstrate access added, removed, etc for single instances of user and group, but none batched like this.
- Should this event be split up into one per instance of roleId? It kind of loses it's tie to a specific operation..