### PR TITLE
fix: added stronger tag validations

### DIFF
--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -303,6 +303,10 @@ test('should filter features by tag', async () => {
             { name: 'my_feature_c' },
         ],
     });
+
+    await filterFeaturesByTag('EXCLUDE_ALL:simple', 400);
+    await filterFeaturesByTag('EXCLUDE_ALL:simple,simple', 400);
+    await filterFeaturesByTag('EXCLUDE_ALL:simple,simple:jest', 400);
 });
 
 test('should filter features by environment status', async () => {
@@ -786,9 +790,18 @@ test('should filter features by segment', async () => {
 });
 
 test('should search features by state with operators', async () => {
-    await app.createFeature({ name: 'my_feature_a', stale: false });
-    await app.createFeature({ name: 'my_feature_b', stale: true });
-    await app.createFeature({ name: 'my_feature_c', stale: true });
+    await app.createFeature({
+        name: 'my_feature_a',
+        stale: false,
+    });
+    await app.createFeature({
+        name: 'my_feature_b',
+        stale: true,
+    });
+    await app.createFeature({
+        name: 'my_feature_c',
+        stale: true,
+    });
 
     const { body } = await filterFeaturesByState('IS:active');
     expect(body).toMatchObject({

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -742,6 +742,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             .joinRaw('CROSS JOIN total_features')
             .whereBetween('final_rank', [offset + 1, offset + limit]);
 
+        console.log(finalQuery.toString());
         const rows = await finalQuery;
 
         if (rows.length > 0) {

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -742,7 +742,6 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             .joinRaw('CROSS JOIN total_features')
             .whereBetween('final_rank', [offset + 1, offset + limit]);
 
-        console.log(finalQuery.toString());
         const rows = await finalQuery;
 
         if (rows.length > 0) {

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -51,7 +51,7 @@ export const featureSearchQueryParameters = [
         schema: {
             type: 'string',
             pattern:
-                '^(INCLUDE|DO_NOT_INCLUDE|INCLUDE_ALL_OF|INCLUDE_ANY_OF|EXCLUDE_IF_ANY_OF|EXCLUDE_ALL):(.*?)(,([a-zA-Z0-9_]+))*$',
+                '^(INCLUDE|DO_NOT_INCLUDE|INCLUDE_ALL_OF|INCLUDE_ANY_OF|EXCLUDE_IF_ANY_OF|EXCLUDE_ALL):(?:\\s*[^,:]+:[^,:]+\\s*)(?:,\\s*[^,:]+:[^,:]+\\s*)*$',
             example: 'INCLUDE:simple:my_tag',
         },
         description:


### PR DESCRIPTION
Now it is impossible to filter based on invalid tag syntax.