### PR TITLE
feat: add created_by to role_permission table

### DIFF
--- a/src/migrations/20231211132341-add-created-by-to-role-permission.js
+++ b/src/migrations/20231211132341-add-created-by-to-role-permission.js
@@ -1,0 +1,7 @@
+exports.up = function(db, cb) {
+  db.runSql(`ALTER TABLE role_permission ADD COLUMN created_by INTEGER`, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`ALTER TABLE role_permission DROP COLUMN created_by`, cb);
+};


### PR DESCRIPTION
As it says on the tin. In an attempt to make all operations in Unleash traceable to an originator. This PR adds created_by to role_permission, which will show which user assigned a permission to a role.