### PR TITLE
fix: show Changes scheduled badge for strategies even if change reque…

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
@@ -313,8 +313,8 @@ describe('Change request badges for strategies', () => {
     test('should render a "Changes scheduled" badge when "updateStrategy" action exists in "Scheduled" change request', async () => {
         testServerRoute(
             server,
-            '/api/admin/projects/default/change-requests/pending/feature1',
-            [scheduledRequest('updateStrategy')],
+            '/api/admin/projects/default/change-requests/scheduled',
+            [{ id: 1 }],
         );
 
         render(<Component />, {
@@ -335,6 +335,11 @@ describe('Change request badges for strategies', () => {
             server,
             '/api/admin/projects/default/change-requests/pending/feature1',
             [scheduledRequest('deleteStrategy')],
+        );
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/scheduled',
+            [{ id: 1 }],
         );
 
         render(<Component />, {
@@ -359,6 +364,11 @@ describe('Change request badges for strategies', () => {
                 draftRequest('updateStrategy', 1),
             ],
         );
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/scheduled',
+            [{ id: 1 }],
+        );
 
         render(<Component />, {
             route: '/projects/default/features/feature1',
@@ -381,6 +391,11 @@ describe('Change request badges for strategies', () => {
                 scheduledRequest('deleteStrategy'),
                 draftRequest('deleteStrategy', 1),
             ],
+        );
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/scheduled',
+            [{ id: 1 }],
         );
 
         render(<Component />, {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
@@ -313,6 +313,12 @@ describe('Change request badges for strategies', () => {
     test('should render a "Changes scheduled" badge when "updateStrategy" action exists in "Scheduled" change request', async () => {
         testServerRoute(
             server,
+            '/api/admin/projects/default/change-requests/pending/feature1',
+            [],
+        );
+
+        testServerRoute(
+            server,
             '/api/admin/projects/default/change-requests/scheduled',
             [{ id: 1 }],
         );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
@@ -416,4 +416,45 @@ describe('Change request badges for strategies', () => {
         await screen.findByText('Changes Scheduled');
         await screen.findByText('Deleted in draft');
     });
+
+    test('should render "Changes scheduled" badge if strategy is modified in a scheduled request event if change requests are disabled', async () => {
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/config',
+            [
+                {
+                    environment: 'development',
+                    type: 'development',
+                    changeRequestEnabled: false,
+                },
+                {
+                    environment: 'production',
+                    type: 'production',
+                    changeRequestEnabled: false,
+                },
+            ],
+            'get',
+        );
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/pending/feature1',
+            [],
+        );
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/scheduled',
+            [{ id: 1 }],
+        );
+
+        render(<Component />, {
+            route: '/projects/default/features/feature1',
+            permissions: [
+                {
+                    permission: ADMIN,
+                },
+            ],
+        });
+
+        await screen.findByText('Changes Scheduled');
+    });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -15,8 +15,8 @@ import { IFeatureChange } from 'component/changeRequest/changeRequest.types';
 import { Badge } from 'component/common/Badge/Badge';
 import {
     ChangeRequestIdentityData,
-    useScheduledChangeRequestsWithStrategy
-} from "hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
+    useScheduledChangeRequestsWithStrategy,
+} from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 interface IStrategyDraggableItemProps {
     strategy: IFeatureStrategy;
@@ -55,7 +55,8 @@ export const StrategyDraggableItem = ({
         strategy.id,
     );
 
-    const { changeRequests: scheduledChangesUsingStrategy } = useScheduledChangeRequestsWithStrategy(projectId, strategy.id);
+    const { changeRequests: scheduledChangesUsingStrategy } =
+        useScheduledChangeRequestsWithStrategy(projectId, strategy.id);
 
     return (
         <Box
@@ -78,7 +79,7 @@ export const StrategyDraggableItem = ({
                 orderNumber={index + 1}
                 headerChildren={renderHeaderChildren(
                     strategyChangesFromRequest,
-                    scheduledChangesUsingStrategy
+                    scheduledChangesUsingStrategy,
                 )}
             />
         </Box>
@@ -113,7 +114,7 @@ const ChangeRequestStatusBadge = ({
 
 const renderHeaderChildren = (
     changes: UseStrategyChangeFromRequestResult,
-    scheduledChanges?: ChangeRequestIdentityData[]
+    scheduledChanges?: ChangeRequestIdentityData[],
 ): JSX.Element[] => {
     const badges: JSX.Element[] = [];
     if (changes.length === 0 && scheduledChanges?.length === 0) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -13,6 +13,10 @@ import {
 import { ChangesScheduledBadge } from 'component/changeRequest/ModifiedInChangeRequestStatusBadge/ChangesScheduledBadge';
 import { IFeatureChange } from 'component/changeRequest/changeRequest.types';
 import { Badge } from 'component/common/Badge/Badge';
+import {
+    ChangeRequestIdentityData,
+    useScheduledChangeRequestsWithStrategy
+} from "hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
 
 interface IStrategyDraggableItemProps {
     strategy: IFeatureStrategy;
@@ -51,6 +55,8 @@ export const StrategyDraggableItem = ({
         strategy.id,
     );
 
+    const { changeRequests: scheduledChangesUsingStrategy } = useScheduledChangeRequestsWithStrategy(projectId, strategy.id);
+
     return (
         <Box
             key={strategy.id}
@@ -72,6 +78,7 @@ export const StrategyDraggableItem = ({
                 orderNumber={index + 1}
                 headerChildren={renderHeaderChildren(
                     strategyChangesFromRequest,
+                    scheduledChangesUsingStrategy
                 )}
             />
         </Box>
@@ -106,9 +113,10 @@ const ChangeRequestStatusBadge = ({
 
 const renderHeaderChildren = (
     changes: UseStrategyChangeFromRequestResult,
+    scheduledChanges?: ChangeRequestIdentityData[]
 ): JSX.Element[] => {
     const badges: JSX.Element[] = [];
-    if (changes.length === 0) {
+    if (changes.length === 0 && scheduledChanges?.length === 0) {
         return [];
     }
 
@@ -125,16 +133,12 @@ const renderHeaderChildren = (
         );
     }
 
-    const scheduledChanges = changes.filter(
-        ({ isScheduledChange }) => isScheduledChange,
-    );
-
-    if (scheduledChanges.length > 0) {
+    if (scheduledChanges && scheduledChanges.length > 0) {
         badges.push(
             <ChangesScheduledBadge
                 key='scheduled-changes'
                 scheduledChangeRequestIds={scheduledChanges.map(
-                    (scheduledChange) => scheduledChange.changeRequestId,
+                    (scheduledChange) => scheduledChange.id,
                 )}
             />,
         );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -113,15 +113,15 @@ const ChangeRequestStatusBadge = ({
 };
 
 const renderHeaderChildren = (
-    changes: UseStrategyChangeFromRequestResult,
+    changes?: UseStrategyChangeFromRequestResult,
     scheduledChanges?: ChangeRequestIdentityData[],
 ): JSX.Element[] => {
     const badges: JSX.Element[] = [];
-    if (changes.length === 0 && scheduledChanges?.length === 0) {
+    if (changes?.length === 0 && scheduledChanges?.length === 0) {
         return [];
     }
 
-    const draftChange = changes.find(
+    const draftChange = changes?.find(
         ({ isScheduledChange }) => !isScheduledChange,
     );
 

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy.ts
@@ -8,7 +8,7 @@ const fetcher = (path: string) => {
         .then((res) => res.json());
 };
 
-type ChangeRequestIdentityData = {
+export type ChangeRequestIdentityData = {
     id: number;
     title?: string;
 };


### PR DESCRIPTION
show Changes scheduled badge for strategies even if change requests are disabled

Closes # [1-1745](https://linear.app/unleash/issue/1-1745/show-changes-scheduled-badge-in-strategy-item-even-if-change-requests)