### PR TITLE
docs: Clarify edge proximity to users

### DIFF
--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -26,7 +26,7 @@ If you want Unleash to host the Frontend API for you, you should be aware of the
 -   This is only available to Pro and Enterprise customers who have signed up for a managed Unleash instance.
 -   We allow short spikes in traffic and our adaptive infrastructure will automatically scale to your needs.
 -   Please check the [Fair Use Policy](https://www.getunleash.io/fair-use-policy) to see the limits of the Unleash-hosted Frontend API.
--   There's no guarantee that it'll be geographically close to your end users, this means your end users might be getting slower response times on feature toggle evaluations.
+-   There's no guarantee that it'll be geographically close to your end users, this means your end users might be getting slower response times on feature flag evaluations.
 -   When we host the frontend API, we will also receive whatever end user data you put in the [Unleash context](../reference/unleash-context.md). This may or may not be an issue depending on your business requirements.
 
 Hosting Edge requires a little more setup the Unleash-hosted frontend API does, but it offers a number of benefits over both the frontend API and Proxy:

--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -26,7 +26,7 @@ If you want Unleash to host the Frontend API for you, you should be aware of the
 -   This is only available to Pro and Enterprise customers who have signed up for a managed Unleash instance.
 -   We allow short spikes in traffic and our adaptive infrastructure will automatically scale to your needs.
 -   Please check the [Fair Use Policy](https://www.getunleash.io/fair-use-policy) to see the limits of the Unleash-hosted Frontend API.
--   There's no guarantee that it'll be close to your applications. This means you'll get higher response times.
+-   There's no guarantee that it'll be geographically close to your end users, this means your end users might be getting slower response times on feature toggle evaluations.
 -   When we host the frontend API, we will also receive whatever end user data you put in the [Unleash context](../reference/unleash-context.md). This may or may not be an issue depending on your business requirements.
 
 Hosting Edge requires a little more setup the Unleash-hosted frontend API does, but it offers a number of benefits over both the frontend API and Proxy:


### PR DESCRIPTION
A benefit of hosting your own edge instance is that it will be as close to end users as you are.