### PR TITLE
docs: proxy-hosting link to what frontend api is

### DIFF
--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -21,7 +21,7 @@ Which way is right for you will depend on your setup and your needs.
 
 In general, we recommend you use Edge over the [Frontend API](https://docs.getunleash.io/reference/front-end-api), but we do recognize that self-hosting requires some extra work on your part and that not all our customers need it.
 
-If you want Unleash to host the [Frontend API](https://docs.getunleash.io/reference/front-end-api) for you, you should be aware of the following limitations:
+If you want Unleash to host the Frontend API for you, you should be aware of the following limitations:
 
 -   This is only available to Pro and Enterprise customers who have signed up for a managed Unleash instance.
 -   We allow short spikes in traffic and our adaptive infrastructure will automatically scale to your needs.

--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -15,13 +15,13 @@ Edge is the next-gen replacement of the Unleash proxy and is recommended to be u
 
 <VideoContent videoUrls={["https://www.youtube.com/embed/6uIdF-yByWs"]}/>
 
-## Unleash-hosted Frontend API vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
+## Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api) vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
 
 Which way is right for you will depend on your setup and your needs.
 
-In general, we recommend you use Edge over the Frontend API, but we do recognize that self-hosting requires some extra work on your part and that not all our customers need it.
+In general, we recommend you use Edge over the [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api), but we do recognize that self-hosting requires some extra work on your part and that not all our customers need it.
 
-If you want Unleash to host the Frontend API for you, you should be aware of the following limitations:
+If you want Unleash to host the [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api) for you, you should be aware of the following limitations:
 
 -   This is only available to Pro and Enterprise customers who have signed up for a managed Unleash instance.
 -   We allow short spikes in traffic and our adaptive infrastructure will automatically scale to your needs.

--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -29,7 +29,7 @@ If you want Unleash to host the Frontend API for you, you should be aware of the
 -   There's no guarantee that it'll be close to your applications. This means you'll get higher response times.
 -   When we host the frontend API, we will also receive whatever end user data you put in the [Unleash context](../reference/unleash-context.md). This may or may not be an issue depending on your business requirements.
 
-Hosting Edge requires a little more setup the Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/front-end-api) does, but it offers a number of benefits over both the frontend API and Proxy:
+Hosting Edge requires a little more setup the Unleash-hosted Frontend API does, but it offers a number of benefits over both the frontend API and Proxy:
 
 -   You can scale Edge instances horizontally and automatically.
 -   There's no request cap or extra charges.

--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -15,13 +15,13 @@ Edge is the next-gen replacement of the Unleash proxy and is recommended to be u
 
 <VideoContent videoUrls={["https://www.youtube.com/embed/6uIdF-yByWs"]}/>
 
-## Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api) vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
+## Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/front-end-api) vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
 
 Which way is right for you will depend on your setup and your needs.
 
-In general, we recommend you use Edge over the [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api), but we do recognize that self-hosting requires some extra work on your part and that not all our customers need it.
+In general, we recommend you use Edge over the [Frontend API](https://docs.getunleash.io/reference/front-end-api), but we do recognize that self-hosting requires some extra work on your part and that not all our customers need it.
 
-If you want Unleash to host the [Frontend API](https://docs.getunleash.io/reference/api/unleash/frontend-api) for you, you should be aware of the following limitations:
+If you want Unleash to host the [Frontend API](https://docs.getunleash.io/reference/front-end-api) for you, you should be aware of the following limitations:
 
 -   This is only available to Pro and Enterprise customers who have signed up for a managed Unleash instance.
 -   We allow short spikes in traffic and our adaptive infrastructure will automatically scale to your needs.
@@ -29,7 +29,7 @@ If you want Unleash to host the [Frontend API](https://docs.getunleash.io/refere
 -   There's no guarantee that it'll be close to your applications. This means you'll get higher response times.
 -   When we host the frontend API, we will also receive whatever end user data you put in the [Unleash context](../reference/unleash-context.md). This may or may not be an issue depending on your business requirements.
 
-Hosting Edge requires a little more setup the Unleash-hosted frontend API does, but it offers a number of benefits over both the frontend API and Proxy:
+Hosting Edge requires a little more setup the Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/front-end-api) does, but it offers a number of benefits over both the frontend API and Proxy:
 
 -   You can scale Edge instances horizontally and automatically.
 -   There's no request cap or extra charges.

--- a/website/docs/understanding-unleash/proxy-hosting.mdx
+++ b/website/docs/understanding-unleash/proxy-hosting.mdx
@@ -15,7 +15,7 @@ Edge is the next-gen replacement of the Unleash proxy and is recommended to be u
 
 <VideoContent videoUrls={["https://www.youtube.com/embed/6uIdF-yByWs"]}/>
 
-## Unleash-hosted [Frontend API](https://docs.getunleash.io/reference/front-end-api) vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
+## Unleash-hosted Frontend API vs self-hosted Edge/Proxy {#unleash-hosted-or-self-hosted}
 
 Which way is right for you will depend on your setup and your needs.
 


### PR DESCRIPTION
Adding links to definition of what frontend api is. Can be confusing for new users to read without seing what it is.