### PR TITLE
fix: optimize headers we return for API calls.

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -31,7 +31,8 @@ export type IFlagKey =
     | 'scheduledConfigurationChanges'
     | 'detectSegmentUsageInChangeRequests'
     | 'stripClientHeadersOn304'
-    | 'newStrategyConfiguration';
+    | 'newStrategyConfiguration'
+    | 'stripHeadersOnAPI';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -42,6 +42,7 @@ process.nextTick(async () => {
                         featureSearchFrontend: true,
                         stripClientHeadersOn304: true,
                         newStrategyConfiguration: true,
+                        stripHeadersOnAPI: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Today we include a lot of "secutiry headers" for all API calls. Quite a lot of them are only relevent when we return a HTML document for the browser.

This PR removes and simplify these headers for API calls, so that we do not include unecessary data in the HTTP headers.

Each header have been carfully examied by following best practices from these source:

- https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
- https://owasp.org/www-project-secure-headers/

This feature is protected with feature flag named 'stripHeadersOnAPI'.