### PR TITLE
feat: datadog integration - link to valid source type names

### DIFF
--- a/src/lib/addons/datadog-definition.ts
+++ b/src/lib/addons/datadog-definition.ts
@@ -46,7 +46,7 @@ const dataDogDefinition: IAddonDefinition = {
             name: 'sourceTypeName',
             displayName: 'Datadog Source Type Name',
             description:
-                '(Optional) source_type_name parameter to be included in Datadog events.',
+                '(Optional) source_type_name parameter to be included in Datadog events. Valid values: https://docs.datadoghq.com/integrations/faq/list-of-api-source-attribute-value/',
             type: 'text',
             required: false,
             sensitive: false,

--- a/website/docs/reference/integrations/datadog.md
+++ b/website/docs/reference/integrations/datadog.md
@@ -46,7 +46,7 @@ Unleash Datadog integration takes the following parameters.
 
 - **Datadog API key** - This is a required property. The API key to use to authenticate with Datadog.
 
-- **Datadog Source Type Name** - This is an optional property. Sets `source_type_name` parameter to be included in Datadog events.
+- **Datadog Source Type Name** - This is an optional property. Sets `source_type_name` parameter to be included in Datadog events. [List of valid api source values](https://docs.datadoghq.com/integrations/faq/list-of-api-source-attribute-value/)
 
 - **Extra HTTP Headers** - This is an optional property. Used to set the additional headers when Unleash communicates with Datadog.
 


### PR DESCRIPTION
Datadog only supports know source_type_names, lets make that easy to figure out for the user.