### PR TITLE
fix: show popover on empty state

### DIFF
--- a/frontend/src/component/common/FilterDateItem/FilterDateItem.test.tsx
+++ b/frontend/src/component/common/FilterDateItem/FilterDateItem.test.tsx
@@ -56,7 +56,7 @@ describe('FilterDateItem Component', () => {
 
         const recordedChanges = setup(mockState);
 
-        await screen.findByPlaceholderText('Search');
+        await screen.findByText('21');
     });
 
     it('switches operator', async () => {

--- a/frontend/src/component/common/FilterDateItem/FilterDateItem.test.tsx
+++ b/frontend/src/component/common/FilterDateItem/FilterDateItem.test.tsx
@@ -5,7 +5,7 @@ import { FilterDateItem, IFilterDateItemProps } from './FilterDateItem';
 
 const getDate = (option: string) => screen.getByText(option);
 
-const setup = (initialState: FilterItemParams) => {
+const setup = (initialState: FilterItemParams | null) => {
     const recordedChanges: FilterItemParams[] = [];
     const mockProps: IFilterDateItemProps = {
         label: 'Test Label',
@@ -49,6 +49,14 @@ describe('FilterDateItem Component', () => {
                 values: ['2015-01-22'],
             },
         ]);
+    });
+
+    it('renders initial popover when no existing value', async () => {
+        const mockState = null;
+
+        const recordedChanges = setup(mockState);
+
+        await screen.findByPlaceholderText('Search');
     });
 
     it('switches operator', async () => {

--- a/frontend/src/component/common/FilterDateItem/FilterDateItem.tsx
+++ b/frontend/src/component/common/FilterDateItem/FilterDateItem.tsx
@@ -33,7 +33,9 @@ export const FilterDateItem: FC<IFilterDateItemProps> = ({
     };
 
     useEffect(() => {
-        open();
+        if (!state) {
+            open();
+        }
     }, []);
 
     const onClose = () => {

--- a/frontend/src/component/common/FilterItem/FilterItem.test.tsx
+++ b/frontend/src/component/common/FilterItem/FilterItem.test.tsx
@@ -5,7 +5,7 @@ import { FilterItem, FilterItemParams, IFilterItemProps } from './FilterItem';
 const getOption = (option: string) =>
     screen.getByText(option).closest('li')!.querySelector('input')!;
 
-const setup = (initialState: FilterItemParams) => {
+const setup = (initialState: FilterItemParams | null) => {
     const recordedChanges: FilterItemParams[] = [];
     const mockProps: IFilterItemProps = {
         label: 'Test Label',
@@ -65,6 +65,14 @@ describe('FilterItem Component', () => {
                 values: ['1', '3', '2'],
             },
         ]);
+    });
+
+    it('renders initial popover when no existing value', async () => {
+        const mockState = null;
+
+        const recordedChanges = setup(mockState);
+
+        await screen.findByPlaceholderText('Search');
     });
 
     it('renders explicit and extra options', async () => {

--- a/frontend/src/component/common/FilterItem/FilterItem.tsx
+++ b/frontend/src/component/common/FilterItem/FilterItem.tsx
@@ -46,7 +46,9 @@ export const FilterItem: FC<IFilterItemProps> = ({
     };
 
     useEffect(() => {
-        open();
+        if (!state) {
+            open();
+        }
     }, []);
 
     const onClose = () => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Don't show open popover when there is existing state:
<img width="803" alt="Screenshot 2023-12-12 at 11 15 23" src="https://github.com/Unleash/unleash/assets/1394682/a946154a-8d9e-4f54-8319-f3e40725c1e8">



### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
