### PR TITLE
feat: show Changes scheduled in feature variants even when CR are dis…

### DIFF
--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -11,12 +11,8 @@ import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
 import { useHighestPermissionChangeRequestEnvironment } from 'hooks/useHighestPermissionChangeRequestEnvironment';
-import {
-    useScheduledChangeRequestsWithFlags,
-} from 'hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags';
-import {
-    ScheduledChangeRequestViewModel
-} from "hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
+import { useScheduledChangeRequestsWithFlags } from 'hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags';
+import { ScheduledChangeRequestViewModel } from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 interface IFeatureArchiveDialogProps {
     isOpen: boolean;

--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -12,9 +12,11 @@ import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useCh
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
 import { useHighestPermissionChangeRequestEnvironment } from 'hooks/useHighestPermissionChangeRequestEnvironment';
 import {
-    ScheduledChangeRequestViewModel,
     useScheduledChangeRequestsWithFlags,
 } from 'hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags';
+import {
+    ScheduledChangeRequestViewModel
+} from "../../../hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
 
 interface IFeatureArchiveDialogProps {
     isOpen: boolean;
@@ -128,7 +130,7 @@ const ArchiveParentError = ({
 };
 
 const ScheduledChangeRequestAlert: VFC<{
-    changeRequests?: ChangeRequestIdentityData[];
+    changeRequests?: ScheduledChangeRequestViewModel[];
     projectId: string;
 }> = ({ changeRequests, projectId }) => {
     if (changeRequests && changeRequests.length > 0) {

--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -16,7 +16,7 @@ import {
 } from 'hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags';
 import {
     ScheduledChangeRequestViewModel
-} from "../../../hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
+} from "hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy";
 
 interface IFeatureArchiveDialogProps {
     isOpen: boolean;

--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -12,7 +12,7 @@ import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useCh
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
 import { useHighestPermissionChangeRequestEnvironment } from 'hooks/useHighestPermissionChangeRequestEnvironment';
 import {
-    ChangeRequestIdentityData,
+    ScheduledChangeRequestViewModel,
     useScheduledChangeRequestsWithFlags,
 } from 'hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags';
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -14,7 +14,7 @@ import { ChangesScheduledBadge } from 'component/changeRequest/ModifiedInChangeR
 import { IFeatureChange } from 'component/changeRequest/changeRequest.types';
 import { Badge } from 'component/common/Badge/Badge';
 import {
-    ChangeRequestIdentityData,
+    ScheduledChangeRequestViewModel,
     useScheduledChangeRequestsWithStrategy,
 } from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
@@ -114,7 +114,7 @@ const ChangeRequestStatusBadge = ({
 
 const renderHeaderChildren = (
     changes?: UseStrategyChangeFromRequestResult,
-    scheduledChanges?: ChangeRequestIdentityData[],
+    scheduledChanges?: ScheduledChangeRequestViewModel[],
 ): JSX.Element[] => {
     const badges: JSX.Element[] = [];
     if (changes?.length === 0 && scheduledChanges?.length === 0) {

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsCard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsCard.test.tsx
@@ -136,6 +136,25 @@ const changeRequestConfig = () =>
         'get',
     );
 
+const disableChangeRequests = () =>
+    testServerRoute(
+        server,
+        '/api/admin/projects/default/change-requests/config',
+        [
+            {
+                environment: 'development',
+                type: 'development',
+                changeRequestEnabled: false,
+            },
+            {
+                environment: 'production',
+                type: 'production',
+                changeRequestEnabled: false,
+            },
+        ],
+        'get',
+    );
+
 const feature = () => {
     testServerRoute(server, '/api/admin/projects/default/features/feature1', {
         environments: [
@@ -246,9 +265,31 @@ describe('Change request badges for variants', () => {
 
         testServerRoute(
             server,
-            '/api/admin/projects/default/change-requests/pending/feature1',
+            '/api/admin/projects/default/change-requests/scheduled',
             [changeRequest],
         );
+
+        render(<Component />, {
+            route: '/projects/default/features/feature1/variants',
+            permissions: [
+                {
+                    permission: ADMIN,
+                },
+            ],
+        });
+        await screen.findByText('Changes Scheduled');
+    });
+
+    test('should render the badge when scheduled request with "patchVariant" action when change requests are disabled', async () => {
+        disableChangeRequests();
+        const changeRequest = scheduledRequest('patchVariant', 1);
+
+        testServerRoute(
+            server,
+            '/api/admin/projects/default/change-requests/scheduled',
+            [changeRequest],
+        );
+
 
         render(<Component />, {
             route: '/projects/default/features/feature1/variants',

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsCard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsCard.test.tsx
@@ -290,7 +290,6 @@ describe('Change request badges for variants', () => {
             [changeRequest],
         );
 
-
         render(<Component />, {
             route: '/projects/default/features/feature1/variants',
             permissions: [

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/useVariantsFromScheduledRequests.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/useVariantsFromScheduledRequests.ts
@@ -1,39 +1,25 @@
-import { usePendingChangeRequestsForFeature } from 'hooks/api/getters/usePendingChangeRequestsForFeature/usePendingChangeRequestsForFeature';
+import { useScheduledChangeRequestsWithVariant } from 'hooks/api/getters/useScheduledChangeRequestsWithVariants/useScheduledChangeRequestsWithVariant';
 
 export const useVariantsFromScheduledRequests = (
     projectId: string,
     featureId: string,
     environment: string,
 ): number[] => {
-    const { changeRequests } = usePendingChangeRequestsForFeature(
+    const { changeRequests } = useScheduledChangeRequestsWithVariant(
         projectId,
         featureId,
     );
 
-    const scheduledEnvironmentRequests =
-        changeRequests?.filter(
-            (request) =>
-                request.environment === environment &&
-                request.state === 'Scheduled',
-        ) || [];
+    const filtered = changeRequests?.filter(
+        (changeRequestIdentity) =>
+            changeRequestIdentity.environment === environment,
+    );
 
-    const result: number[] = [];
-    if (scheduledEnvironmentRequests.length === 0) {
-        return result;
+    if (filtered) {
+        return filtered.map(
+            (changeRequestIdentity) => changeRequestIdentity.id,
+        );
     }
 
-    scheduledEnvironmentRequests.forEach((scheduledRequest) => {
-        const feature = scheduledRequest?.features.find(
-            (feature) => feature.name === featureId,
-        );
-        const change = feature?.changes.find((change) => {
-            return change.action === 'patchVariant';
-        });
-
-        if (change) {
-            result.push(scheduledRequest.id);
-        }
-    });
-
-    return result;
+    return [];
 };

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags.ts
@@ -1,7 +1,7 @@
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
-import { ChangeRequestIdentityData } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
+import { ScheduledChangeRequestViewModel } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 const fetcher = (path: string) => {
     return fetch(path)
@@ -16,7 +16,7 @@ export const useScheduledChangeRequestsWithFlags = (
     const queryString = flags.map((flag) => `feature=${flag}`).join('&');
 
     const { data, error, mutate } = useEnterpriseSWR<
-        ChangeRequestIdentityData[]
+        ScheduledChangeRequestViewModel[]
     >(
         [],
         formatApiPath(

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithFlags/useScheduledChangeRequestsWithFlags.ts
@@ -1,16 +1,12 @@
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
+import { ChangeRequestIdentityData } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 const fetcher = (path: string) => {
     return fetch(path)
         .then(handleErrorResponses('ChangeRequest'))
         .then((res) => res.json());
-};
-
-export type ChangeRequestIdentityData = {
-    id: number;
-    title?: string;
 };
 
 export const useScheduledChangeRequestsWithFlags = (

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy.ts
@@ -8,7 +8,7 @@ const fetcher = (path: string) => {
         .then((res) => res.json());
 };
 
-export type ChangeRequestIdentityData = {
+export type ScheduledChangeRequestViewModel = {
     id: number;
     environment: string;
     title?: string;
@@ -19,7 +19,7 @@ export const useScheduledChangeRequestsWithStrategy = (
     strategyId: string,
 ) => {
     const { data, error, mutate } = useEnterpriseSWR<
-        ChangeRequestIdentityData[]
+        ScheduledChangeRequestViewModel[]
     >(
         [],
         formatApiPath(

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithVariants/useScheduledChangeRequestsWithVariant.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithVariants/useScheduledChangeRequestsWithVariant.ts
@@ -1,7 +1,7 @@
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
-import { ChangeRequestIdentityData } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
+import { ScheduledChangeRequestViewModel } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 const fetcher = (path: string) => {
     return fetch(path)
@@ -14,7 +14,7 @@ export const useScheduledChangeRequestsWithVariant = (
     feature: string,
 ) => {
     const { data, error, mutate } = useEnterpriseSWR<
-        ChangeRequestIdentityData[]
+        ScheduledChangeRequestViewModel[]
     >(
         [],
         formatApiPath(

--- a/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithVariants/useScheduledChangeRequestsWithVariant.ts
+++ b/frontend/src/hooks/api/getters/useScheduledChangeRequestsWithVariants/useScheduledChangeRequestsWithVariant.ts
@@ -1,6 +1,7 @@
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
+import { ChangeRequestIdentityData } from '../useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 
 const fetcher = (path: string) => {
     return fetch(path)
@@ -8,22 +9,16 @@ const fetcher = (path: string) => {
         .then((res) => res.json());
 };
 
-export type ChangeRequestIdentityData = {
-    id: number;
-    environment: string;
-    title?: string;
-};
-
-export const useScheduledChangeRequestsWithStrategy = (
+export const useScheduledChangeRequestsWithVariant = (
     project: string,
-    strategyId: string,
+    feature: string,
 ) => {
     const { data, error, mutate } = useEnterpriseSWR<
         ChangeRequestIdentityData[]
     >(
         [],
         formatApiPath(
-            `api/admin/projects/${project}/change-requests/scheduled?strategyId=${strategyId}`,
+            `api/admin/projects/${project}/change-requests/scheduled?variantForFlag=${feature}`,
         ),
         fetcher,
     );


### PR DESCRIPTION
show Changes scheduled in feature variants even when CR are disabled

Modifies existing hook to call the new `change-requests/scheduled` endpoint that returns the relevant scheduled change requests even when change requests are disabled

Rename the ChangeRequestIdentityData to ScheduledChangeRequestViewModel for consistency (finalised schemas will replace the BE and FE types in a follow up PR)

Closes # [1-1746](https://linear.app/unleash/issue/1-1746/show-change-scheduled-badge-in-feature-environment-variants-even-if)

<img width="1486" alt="Screenshot 2023-12-12 at 14 24 44" src="https://github.com/Unleash/unleash/assets/104830839/7c4e92ef-81d8-423e-8b78-9015ede59952">
