### PR TITLE
feat: show failure reason for scheduled requests in timeline

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -241,6 +241,7 @@ export const ChangeRequestOverview: FC = () => {
                     <ChangeRequestTimeline
                         state={changeRequest.state}
                         scheduledAt={changeRequest.schedule?.scheduledAt}
+                        failureReason={changeRequest.schedule?.failureReason}
                     />
                     <ChangeRequestReviewers changeRequest={changeRequest} />
                 </StyledAsideBox>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
@@ -109,7 +109,6 @@ test('returns warning for Scheduled stage in Scheduled state', () => {
             irrelevantIndex,
             'Scheduled',
             irrelevantIndex,
-
         ),
     ).toBe('warning');
 });
@@ -121,8 +120,7 @@ test('returns error for Scheduled stage in Scheduled state with failure reason',
             irrelevantIndex,
             'Scheduled',
             irrelevantIndex,
-            'conflicts'
-
+            'conflicts',
         ),
     ).toBe('error');
 });

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
@@ -109,8 +109,22 @@ test('returns warning for Scheduled stage in Scheduled state', () => {
             irrelevantIndex,
             'Scheduled',
             irrelevantIndex,
+
         ),
     ).toBe('warning');
+});
+
+test('returns error for Scheduled stage in Scheduled state with failure reason', () => {
+    expect(
+        determineColor(
+            'Scheduled',
+            irrelevantIndex,
+            'Scheduled',
+            irrelevantIndex,
+            'conflicts'
+
+        ),
+    ).toBe('error');
 });
 
 test('returns success for stages at or before activeIndex', () => {

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Box, Paper, styled, Tooltip, Typography } from "@mui/material";
+import { Box, Paper, styled, Tooltip, Typography } from '@mui/material';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem, { timelineItemClasses } from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -8,8 +8,8 @@ import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import { ChangeRequestState } from '../../changeRequest.types';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
-import { HtmlTooltip } from "../../../common/HtmlTooltip/HtmlTooltip";
-import { Info } from "@mui/icons-material";
+import { HtmlTooltip } from '../../../common/HtmlTooltip/HtmlTooltip';
+import { Info } from '@mui/icons-material';
 
 interface ISuggestChangeTimelineProps {
     state: ChangeRequestState;
@@ -29,7 +29,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
 
 const StyledSubtitle = styled(Box)(({ theme }) => ({
     display: 'flex',
-    flexDirection: 'row'
+    flexDirection: 'row',
 }));
 
 const StyledTimeline = styled(Timeline)(() => ({
@@ -59,7 +59,7 @@ export const determineColor = (
     changeRequestStateIndex: number,
     displayStage: ChangeRequestState,
     displayStageIndex: number,
-    failureReason?: string
+    failureReason?: string,
 ) => {
     if (changeRequestState === 'Cancelled') return 'grey';
 
@@ -74,7 +74,11 @@ export const determineColor = (
         changeRequestStateIndex !== -1 &&
         changeRequestStateIndex === displayStageIndex
     ) {
-        return changeRequestState === 'Scheduled' ? failureReason ? 'error': 'warning' : 'success';
+        return changeRequestState === 'Scheduled'
+            ? failureReason
+                ? 'error'
+                : 'warning'
+            : 'success';
     }
 
     if (changeRequestStateIndex + 1 === displayStageIndex) return 'primary';
@@ -115,7 +119,7 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                             activeIndex,
                             title,
                             index,
-                            failureReason
+                            failureReason,
                         );
                         let timelineDotProps = {};
 
@@ -161,17 +165,23 @@ const createTimelineItem = (
             <ConditionallyRender
                 condition={Boolean(subtitle)}
                 show={
-                <StyledSubtitle>
-                    <Typography
-                        color={'text.secondary'}
-                        sx={{mr: 1}}
-                    >{`(for ${subtitle})`}</Typography>
-                    <ConditionallyRender condition={Boolean(failureReason)} show={
-                        <HtmlTooltip title={`Schedule failed because of ${failureReason}`} arrow >
-                            <Info color={'error'} fontSize={'small'}/>
-                        </HtmlTooltip>
-                    } />
-                </StyledSubtitle>
+                    <StyledSubtitle>
+                        <Typography
+                            color={'text.secondary'}
+                            sx={{ mr: 1 }}
+                        >{`(for ${subtitle})`}</Typography>
+                        <ConditionallyRender
+                            condition={Boolean(failureReason)}
+                            show={
+                                <HtmlTooltip
+                                    title={`Schedule failed because of ${failureReason}`}
+                                    arrow
+                                >
+                                    <Info color={'error'} fontSize={'small'} />
+                                </HtmlTooltip>
+                            }
+                        />
+                    </StyledSubtitle>
                 }
             />
         </TimelineContent>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Box, Paper, styled, Typography } from '@mui/material';
+import { Box, Paper, styled, Tooltip, Typography } from "@mui/material";
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem, { timelineItemClasses } from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -8,10 +8,13 @@ import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import { ChangeRequestState } from '../../changeRequest.types';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
+import { HtmlTooltip } from "../../../common/HtmlTooltip/HtmlTooltip";
+import { Info } from "@mui/icons-material";
 
 interface ISuggestChangeTimelineProps {
     state: ChangeRequestState;
     scheduledAt?: string;
+    failureReason?: string;
 }
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
@@ -22,6 +25,11 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
 const StyledBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(2),
     marginBottom: `-${theme.spacing(4)}`,
+}));
+
+const StyledSubtitle = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row'
 }));
 
 const StyledTimeline = styled(Timeline)(() => ({
@@ -51,6 +59,7 @@ export const determineColor = (
     changeRequestStateIndex: number,
     displayStage: ChangeRequestState,
     displayStageIndex: number,
+    failureReason?: string
 ) => {
     if (changeRequestState === 'Cancelled') return 'grey';
 
@@ -65,7 +74,7 @@ export const determineColor = (
         changeRequestStateIndex !== -1 &&
         changeRequestStateIndex === displayStageIndex
     ) {
-        return changeRequestState === 'Scheduled' ? 'warning' : 'success';
+        return changeRequestState === 'Scheduled' ? failureReason ? 'error': 'warning' : 'success';
     }
 
     if (changeRequestStateIndex + 1 === displayStageIndex) return 'primary';
@@ -75,6 +84,7 @@ export const determineColor = (
 export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     state,
     scheduledAt,
+    failureReason,
 }) => {
     let data;
     switch (state) {
@@ -105,6 +115,7 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                             activeIndex,
                             title,
                             index,
+                            failureReason
                         );
                         let timelineDotProps = {};
 
@@ -120,6 +131,7 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                             color,
                             title,
                             subtitle,
+                            failureReason,
                             index < data.length - 1,
                             timelineDotProps,
                         );
@@ -134,6 +146,7 @@ const createTimelineItem = (
     color: 'primary' | 'success' | 'grey' | 'error' | 'warning',
     title: string,
     subtitle: string | undefined,
+    failureReason: string | undefined,
     shouldConnectToNextItem: boolean,
     timelineDotProps: { [key: string]: string | undefined } = {},
 ) => (
@@ -148,9 +161,17 @@ const createTimelineItem = (
             <ConditionallyRender
                 condition={Boolean(subtitle)}
                 show={
+                <StyledSubtitle>
                     <Typography
                         color={'text.secondary'}
+                        sx={{mr: 1}}
                     >{`(for ${subtitle})`}</Typography>
+                    <ConditionallyRender condition={Boolean(failureReason)} show={
+                        <HtmlTooltip title={`Schedule failed because of ${failureReason}`} arrow >
+                            <Info color={'error'} fontSize={'small'}/>
+                        </HtmlTooltip>
+                    } />
+                </StyledSubtitle>
                 }
             />
         </TimelineContent>

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -24,6 +24,7 @@ export interface IChangeRequest {
 export interface IChangeRequestSchedule {
     scheduledAt: string;
     status: 'pending' | 'failed';
+    failureReason?: string;
 }
 
 export interface IChangeRequestEnvironmentConfig {


### PR DESCRIPTION
Adds an icon with a tooltip and changes the dot color to red for scheduled change requests 

Closes # [1-1768](https://linear.app/unleash/issue/1-1768/add-reason-and-icon-to-timeline)
<img width="1668" alt="Screenshot 2023-12-14 at 10 20 27" src="https://github.com/Unleash/unleash/assets/104830839/dcf54834-ea9f-4e78-b69d-15d6179ffce3">
