### PR TITLE
chore: enable manual testing of migrations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "fmt:check": "biome check src",
     "ts:check": "tsc",
     "e2e": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" yarn run cypress open --config baseUrl='http://localhost:3000' --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
-    "e2e:oss": "yarn --cwd frontend run cypress run --spec \"cypress/oss/**/*.spec.ts\" --config baseUrl='http://localhost:4242' --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
+    "e2e:oss": "yarn --cwd frontend run cypress run --spec \"cypress/oss/**/*.spec.ts\" --config baseUrl=\"http://localhost:${EXPOSED_PORT:-4242}\" --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
     "e2e:heroku": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" yarn run cypress open --config baseUrl='https://unleash.herokuapp.com' --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
     "gen:api": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" orval --config orval.config.js",
     "gen:api:demo": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" UNLEASH_OPENAPI_URL=https://app.unleash-hosted.com/demo/docs/openapi.json yarn run gen:api",

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -7,16 +7,19 @@ process.nextTick(async () => {
     try {
         await start(
             createConfig({
-                db: {
-                    user: 'unleash_user',
-                    password: 'password',
-                    host: 'localhost',
-                    port: 5432,
-                    database: process.env.UNLEASH_DATABASE_NAME || 'unleash',
-                    schema: process.env.UNLEASH_DATABASE_SCHEMA,
-                    ssl: false,
-                    applicationName: 'unleash',
-                },
+                db: process.env.DATABASE_URL
+                    ? undefined
+                    : {
+                          user: 'unleash_user',
+                          password: 'password',
+                          host: 'localhost',
+                          port: 5432,
+                          database:
+                              process.env.UNLEASH_DATABASE_NAME || 'unleash',
+                          schema: process.env.UNLEASH_DATABASE_SCHEMA,
+                          ssl: false,
+                          applicationName: 'unleash',
+                      },
                 server: {
                     enableRequestLogger: true,
                     baseUriPath: '',

--- a/test-migrations/Makefile
+++ b/test-migrations/Makefile
@@ -1,0 +1,85 @@
+## Use UNLEASH_DOCKER_IMAGE to override the docker image used for testing
+## Examples:
+## - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:latest
+## - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:4.12.6
+## - UNLEASH_DOCKER_IMAGE=ghcr.io/ivarconr/unleash-enterprise:latests
+## - UNLEASH_DOCKER_IMAGE=ghcr.io/ivarconr/unleash-enterprise:5.6.0
+ifndef UNLEASH_DOCKER_IMAGE
+override UNLEASH_DOCKER_IMAGE = unleashorg/unleash-server:latest
+endif
+
+ifndef EXPOSED_PORT
+override EXPOSED_PORT = 4242
+endif
+
+# default action
+.PHONY: default
+default:
+	@echo "Usage: make [command]"
+	@echo ""
+	@echo "This helps testing the impact of latest migrations into an old version of Unleash, helping us answer the following questions:"
+	@echo "  - Can we safely upgrade to the latest version from version X?"
+	@echo "  - If we need to rollback to the previous version, can we do that?"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  - UNLEASH_DOCKER_IMAGE: docker image used for start-docker command"
+	@echo "  - EXPOSED_PORT: port used for start-docker command where unleash will be exposed"
+	@echo ""
+	@echo "The most common way of using this makefile is to run 'make tests' followed by manual exploration of Unleash at http://localhost:4242"
+	@echo ""
+	@echo "You can also explore the current version running 'make run-current' and exploring the new version at http://localhost:3000"
+	@echo ""
+	@echo "Example:"
+	@echo "    - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.0 make tests"
+	@echo ""
+	@echo "If you just want to test one version and then another one you can simply run these two commands one after the other:"
+	@echo "  UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:4.12.6 make start-docker"
+	@echo "  EXPOSED_PORT=4243 UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.10 make start-docker"
+	@echo "The old version will run on http://localhost:4242 and the new one on http://localhost:4243"
+	@echo ""
+	@echo "Commands available (you can manually run them one by one in this specific order):"
+	@echo "  1. clean: clean up before or after the tests"
+	@echo "  2. start-docker: Start docker with the previous version specified by UNLEASH_DOCKER_IMAGE"
+	@echo "  3. apply-migrations: Apply migrations from HEAD"
+	@echo "  4. prepare: Install dependencies to run the tests"
+	@echo "  5. tests: Applies all the steps above and then run UI tests"
+	@echo "  6. run-current: Run the current version of unleash from this local repository"
+
+.PHONY: prepare
+prepare: 
+	@echo "Preparing the environment..."
+	@yarn --cwd .. install --frozen-lockfile --ignore-scripts
+
+
+.PHONY: apply-migrations
+apply-migrations: prepare start-docker
+	@echo "Applying migrations from HEAD... $(git rev-parse HEAD)"
+	@DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd .. db-migrate up
+
+.PHONY: run-current
+run-current: prepare start-docker
+	@yarn install --cwd ../frontend
+	@yarn build --cwd ../frontend
+	@HTTP_PORT=4243 UNLEASH_API=http://localhost:4243 DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd .. dev
+	@echo "You can manually validate current unleash at http://localhost:3000 and compare with previous version at http://localhost:4242"
+
+.PHONY: tests
+tests: clean apply-migrations
+	@echo "Running tests..."
+	@yarn --cwd ../frontend e2e:oss
+	@echo "You can manually validate unleash at http://localhost:4242"
+	@echo "If you want to test the current version (HEAD of this git repo) side-by-side, execute make run-current"
+	@echo "After all, you clean up by running 'make clean'"
+
+.PHONY: start-docker
+start-docker:
+	@echo "Starting docker..."
+	@UNLEASH_DOCKER_IMAGE=$(UNLEASH_DOCKER_IMAGE) docker compose up -d
+	@echo "Waiting for Unleash to be healthy..."
+	@while ! curl -s "http://localhost:$(EXPOSED_PORT)/health"; do sleep 0.1; done
+	@echo "\n$(UNLEASH_DOCKER_IMAGE) is now running at http://localhost:$(EXPOSED_PORT)"
+
+.PHONY: clean
+clean:
+	@echo "Cleaning up docker..."
+	@docker compose stop && docker compose rm -f

--- a/test-migrations/Makefile
+++ b/test-migrations/Makefile
@@ -2,14 +2,10 @@
 ## Examples:
 ## - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:latest
 ## - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:4.12.6
-## - UNLEASH_DOCKER_IMAGE=ghcr.io/ivarconr/unleash-enterprise:latests
+## - UNLEASH_DOCKER_IMAGE=ghcr.io/ivarconr/unleash-enterprise:latest
 ## - UNLEASH_DOCKER_IMAGE=ghcr.io/ivarconr/unleash-enterprise:5.6.0
 ifndef UNLEASH_DOCKER_IMAGE
 override UNLEASH_DOCKER_IMAGE = unleashorg/unleash-server:latest
-endif
-
-ifndef EXPOSED_PORT
-override EXPOSED_PORT = 4242
 endif
 
 # default action
@@ -22,28 +18,30 @@ default:
 	@echo "  - If we need to rollback to the previous version, can we do that?"
 	@echo ""
 	@echo "Environment variables:"
-	@echo "  - UNLEASH_DOCKER_IMAGE: docker image used for start-docker command"
-	@echo "  - EXPOSED_PORT: port used for start-docker command where unleash will be exposed"
+	@echo "  - UNLEASH_DOCKER_IMAGE: docker image used for start-unleash command"
+	@echo "  - EXPOSED_PORT: port used for start-unleash command where Unleash will be exposed. Also specifies which port will be used for the UI tests"
 	@echo ""
-	@echo "The most common way of using this makefile is to run 'make tests' followed by manual exploration of Unleash at http://localhost:4242"
+	@echo "The most common way of using this makefile is to run 'make start-unleash test' followed by manual exploration of Unleash at http://localhost:4242"
 	@echo ""
 	@echo "You can also explore the current version running 'make run-current' and exploring the new version at http://localhost:3000"
 	@echo ""
 	@echo "Example:"
-	@echo "    - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.0 make tests"
+	@echo "    - UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.0 make start-unleash test"
 	@echo ""
 	@echo "If you just want to test one version and then another one you can simply run these two commands one after the other:"
-	@echo "  UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:4.12.6 make start-docker"
-	@echo "  EXPOSED_PORT=4243 UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.10 make start-docker"
+	@echo "  UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:4.12.6 make start-unleash"
+	@echo "  UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.10 make start-another-unleash"
 	@echo "The old version will run on http://localhost:4242 and the new one on http://localhost:4243"
 	@echo ""
 	@echo "Commands available (you can manually run them one by one in this specific order):"
-	@echo "  1. clean: clean up before or after the tests"
-	@echo "  2. start-docker: Start docker with the previous version specified by UNLEASH_DOCKER_IMAGE"
-	@echo "  3. apply-migrations: Apply migrations from HEAD"
-	@echo "  4. prepare: Install dependencies to run the tests"
-	@echo "  5. tests: Applies all the steps above and then run UI tests"
-	@echo "  6. run-current: Run the current version of unleash from this local repository"
+	@echo "  1. clean: clean up before or after the test"
+	@echo "  2. start-unleash: Start docker with the previous version specified by UNLEASH_DOCKER_IMAGE"
+	@echo "  3. start-another-unleash: same as above, but runs another instance side by side"
+	@echo "  4. apply-migrations: Apply migrations from HEAD"
+	@echo "  5. prepare: Install dependencies to run the test"
+	@echo "  6. test: Run UI tests (you can specify EXPOSED_PORT to run the tests against a different port)"
+	@echo "  7. run-current: Run the current version of Unleash from this local repository"
+	@echo "  8. start-another-unleash: Starts another docker instance of Unleash with the image specified by UNLEASH_DOCKER_IMAGE"
 
 .PHONY: prepare
 prepare: 
@@ -52,32 +50,56 @@ prepare:
 
 
 .PHONY: apply-migrations
-apply-migrations: prepare start-docker
+apply-migrations: prepare
 	@echo "Applying migrations from HEAD... $(git rev-parse HEAD)"
 	@DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd .. db-migrate up
 
-.PHONY: run-current
-run-current: prepare start-docker
-	@yarn install --cwd ../frontend
-	@yarn build --cwd ../frontend
-	@HTTP_PORT=4243 UNLEASH_API=http://localhost:4243 DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd .. dev
-	@echo "You can manually validate current unleash at http://localhost:3000 and compare with previous version at http://localhost:4242"
 
-.PHONY: tests
-tests: clean apply-migrations
-	@echo "Running tests..."
-	@yarn --cwd ../frontend e2e:oss
-	@echo "You can manually validate unleash at http://localhost:4242"
+.PHONY: run-current-ui
+run-current-ui: prepare
+	@yarn install --cwd ../frontend
+	@UNLEASH_API=http://localhost:$${EXPOSED_PORT:-4244} DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd ../frontend dev
+	@echo "You can manually validate current Unleash at http://localhost:3000 and compare with previous version"
+
+.PHONY: run-current
+run-current: prepare start-db
+	@HTTP_PORT=$($${EXPOSED_PORT:-4244}) DATABASE_URL=postgres://postgres:unleash@localhost:5432/unleash DATABASE_SSL=false yarn --cwd .. dev:backend
+	@echo "You can manually validate current Unleash at http://localhost:$${EXPOSED_PORT:-4244} and compare with previous version"
+	@echo "Waiting for Unleash to be healthy at port $${EXPOSED_PORT:-4244}..."
+	@while ! curl -s "http://localhost:$${EXPOSED_PORT:-4244}/health"; do sleep 0.1; done
+	@echo "\nUnleash is now running at http://localhost:$${EXPOSED_PORT:-4244}"
+
+.PHONY: test
+test:
+	@echo "Running tests against $${EXPOSED_PORT:-4242}..."
+	@EXPOSED_PORT=$${EXPOSED_PORT:-4242} yarn --cwd ../frontend e2e:oss
+	@echo "You can manually validate Unleash at http://localhost:$${EXPOSED_PORT:-4242}"
 	@echo "If you want to test the current version (HEAD of this git repo) side-by-side, execute make run-current"
 	@echo "After all, you clean up by running 'make clean'"
 
-.PHONY: start-docker
-start-docker:
+.PHONY: start-unleash
+start-unleash:
 	@echo "Starting docker..."
-	@UNLEASH_DOCKER_IMAGE=$(UNLEASH_DOCKER_IMAGE) docker compose up -d
-	@echo "Waiting for Unleash to be healthy..."
-	@while ! curl -s "http://localhost:$(EXPOSED_PORT)/health"; do sleep 0.1; done
-	@echo "\n$(UNLEASH_DOCKER_IMAGE) is now running at http://localhost:$(EXPOSED_PORT)"
+	@UNLEASH_DOCKER_IMAGE=$(UNLEASH_DOCKER_IMAGE) docker compose up unleash -d
+	@echo "Waiting for Unleash to be healthy at port $${EXPOSED_PORT:-4242}..."
+	@while ! curl -s "http://localhost:$${EXPOSED_PORT:-4242}/health"; do sleep 0.1; done
+	@echo "\n$(UNLEASH_DOCKER_IMAGE) is now running at http://localhost:$${EXPOSED_PORT:-4242}"
+
+.PHONY: start-another-unleash
+start-another-unleash:
+	@echo "Starting docker..."
+	@EXPOSED_PORT=$${EXPOSED_PORT:-4243} UNLEASH_DOCKER_IMAGE=$(UNLEASH_DOCKER_IMAGE) docker compose up db another-unleash -d
+	@echo "Waiting for Unleash to be healthy at port $${EXPOSED_PORT:-4243}..."
+	@while ! curl -s "http://localhost:$${EXPOSED_PORT:-4243}/health"; do sleep 0.1; done
+	@echo "\n$(UNLEASH_DOCKER_IMAGE) is now running at http://localhost:$${EXPOSED_PORT:-4243}"
+
+.PHONY: start-db
+start-db:
+	@echo "Starting docker..."
+	@docker compose up db -d
+	@echo "Waiting for DB to be healthy..."
+	@sleep 3
+	@echo "\nDone waiting for DB to be healthy..."
 
 .PHONY: clean
 clean:

--- a/test-migrations/docker-compose.yml
+++ b/test-migrations/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   # The Unleash server waits for the migrations to be applied by waiting on the 
   # migrations container to be healthy.
   unleash:
-    image: unleashorg/unleash-server:latest # this is the latest stable release
+    image: ${UNLEASH_DOCKER_IMAGE:-unleashorg/unleash-server:latest} # this is the latest stable release
     pull_policy: "always"
     ports:
-      - "4242:4242"
+      - "${EXPOSED_PORT:-4242}:4242"
     environment:
       DATABASE_URL: "postgres://postgres:unleash@db/unleash"
       DATABASE_SSL: "false"

--- a/test-migrations/docker-compose.yml
+++ b/test-migrations/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.9"
 services:
-  # The Unleash server waits for the migrations to be applied by waiting on the 
-  # migrations container to be healthy.
   unleash:
     image: ${UNLEASH_DOCKER_IMAGE:-unleashorg/unleash-server:latest} # this is the latest stable release
     pull_policy: "always"
@@ -22,6 +20,25 @@ services:
       retries: 5
       start_period: 15s
 
+  another-unleash:
+    image: ${UNLEASH_DOCKER_IMAGE:-unleashorg/unleash-server:latest} # this is the latest stable release
+    pull_policy: "always"
+    ports:
+      - "${EXPOSED_PORT:-4243}:4242"
+    environment:
+      DATABASE_URL: "postgres://postgres:unleash@db/unleash"
+      DATABASE_SSL: "false"
+      LOG_LEVEL: "debug"
+      INIT_ADMIN_API_TOKENS: "*:*.unleash-insecure-admin-api-token"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1
+      interval: 1s
+      timeout: 1m
+      retries: 5
+      start_period: 15s
   db:
     ports:
       - "5432:5432"


### PR DESCRIPTION
## About the changes
This adds a Makefile to make it easy to test migrations from one version of Unleash to another. 

The script depends on [docker compose V2](https://docs.docker.com/compose/migrate/)

**Before starting**: make sure you're inside test-migrations folder and run `make clean` to be in a clean state.

We can run 2 versions of Unleash side by side with a shared database (the second version will apply migrations to the DB):
```shell
UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.10 make start-unleash # defaults to port 4242
UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:latest make start-another-unleash # defaults to port 4243
make test # run basic UI tests against port 4242 (first image)
EXPOSED_PORT=4243 make test # run basic UI tests against port 4243
```

This also enables us to test our local repository with our code of Unleash server running at port 4244 (`EXPOSE_PORT=4444 make run-current` if you want to change it):
```shell
UNLEASH_DOCKER_IMAGE=unleashorg/unleash-server:5.6.10 make start-unleash # defaults to port 4242
make run-current # exposes the current backend at 4244
```

You can also connect the latest UI to any of the ports specified above, starting the UI at port 3000:
```shell
EXPOSED_PORT=4242 make run-current-ui # exposed port defaults to 4244 which is the port of the current backend
```