### PR TITLE
chore: add incomingWebhooks feature flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -68,6 +68,7 @@ export type UiFlags = {
     featureSearchAPI?: boolean;
     featureSearchFrontend?: boolean;
     newStrategyConfiguration?: boolean;
+    incomingWebhooks?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -86,6 +86,7 @@ exports[`should create default config 1`] = `
       "featuresExportImport": true,
       "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
+      "incomingWebhooks": false,
       "maintenanceMode": false,
       "messageBanner": {
         "enabled": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -32,7 +32,8 @@ export type IFlagKey =
     | 'detectSegmentUsageInChangeRequests'
     | 'stripClientHeadersOn304'
     | 'newStrategyConfiguration'
-    | 'stripHeadersOnAPI';
+    | 'stripHeadersOnAPI'
+    | 'incomingWebhooks';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -140,6 +141,10 @@ const flags: IFlags = {
     ),
     newStrategyConfiguration: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_STRATEGY_CONFIGURATION,
+        false,
+    ),
+    incomingWebhooks: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_INCOMING_WEBHOOKS,
         false,
     ),
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1683/feature-flag-add-a-new-incomingwebhooks-feature-flag-for-this-feature

Adds a new `incomingWebhooks` feature flag.