### PR TITLE
chore: clean up banners feature flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -63,7 +63,6 @@ export type UiFlags = {
     doraMetrics?: boolean;
     privateProjects?: boolean;
     dependentFeatures?: boolean;
-    banners?: boolean;
     scheduledConfigurationChanges?: boolean;
     featureSearchAPI?: boolean;
     featureSearchFrontend?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -25,7 +25,6 @@ export type IFlagKey =
     | 'customRootRolesKillSwitch'
     | 'privateProjects'
     | 'disableMetrics'
-    | 'banners'
     | 'featureSearchAPI'
     | 'featureSearchFrontend'
     | 'scheduledConfigurationChanges'


### PR DESCRIPTION
Cleans up some leftover references to the `banners` feature flag. 

Related to https://github.com/Unleash/unleash/pull/5348