### PR TITLE
Feat/new strategy variants tab

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -1,30 +1,30 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
-import FormTemplate from 'component/common/FormTemplate/FormTemplate';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { formatUnknownError } from 'utils/formatUnknownError';
-import useToast from 'hooks/useToast';
-import { IFeatureStrategy } from 'interfaces/strategy';
-import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
-import { ISegment } from 'interfaces/segment';
-import { formatStrategyName } from 'utils/strategyNames';
-import { useFormErrors } from 'hooks/useFormErrors';
-import { useCollaborateData } from 'hooks/useCollaborateData';
-import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
-import { IFeatureToggle } from 'interfaces/featureToggle';
-import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
-import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
-import { comparisonModerator } from 'component/feature/FeatureStrategy/featureStrategy.utils';
+import React, { useEffect, useRef, useState } from "react";
+import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
+import FormTemplate from "component/common/FormTemplate/FormTemplate";
+import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
+import { useRequiredPathParam } from "hooks/useRequiredPathParam";
+import { formatUnknownError } from "utils/formatUnknownError";
+import useToast from "hooks/useToast";
+import { IFeatureStrategy } from "interfaces/strategy";
+import { UPDATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
+import { ISegment } from "interfaces/segment";
+import { formatStrategyName } from "utils/strategyNames";
+import { useFormErrors } from "hooks/useFormErrors";
+import { useCollaborateData } from "hooks/useCollaborateData";
+import { useFeature } from "hooks/api/getters/useFeature/useFeature";
+import { IFeatureToggle } from "interfaces/featureToggle";
+import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
+import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
+import { comparisonModerator } from "component/feature/FeatureStrategy/featureStrategy.utils";
 import {
     IChangeRequestAddStrategy,
     IChangeRequestUpdateStrategy,
-} from 'component/changeRequest/changeRequest.types';
-import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
-import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
-import { useUiFlag } from 'hooks/useUiFlag';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
+} from "component/changeRequest/changeRequest.types";
+import { SidebarModal } from "component/common/SidebarModal/SidebarModal";
+import { useSegments } from "hooks/api/getters/useSegments/useSegments";
+import { useUiFlag } from "hooks/useUiFlag";
+import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
+import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
 
 interface IEditChangeProps {
     change: IChangeRequestAddStrategy | IChangeRequestUpdateStrategy;
@@ -45,13 +45,13 @@ export const EditChange = ({
     onClose,
     featureId,
 }: IEditChangeProps) => {
-    const projectId = useRequiredPathParam('projectId');
+    const projectId = useRequiredPathParam("projectId");
     const { editChange } = useChangeRequestApi();
     const [tab, setTab] = useState(0);
-    const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
+    const newStrategyConfiguration = useUiFlag("newStrategyConfiguration");
 
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>(
-        change.payload,
+        change.payload
     );
 
     const { segments: allSegments } = useSegments();
@@ -80,19 +80,19 @@ export const EditChange = ({
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: 'feature',
-                refetchFunctionKey: 'refetchFeature',
+                dataKey: "feature",
+                refetchFunctionKey: "refetchFeature",
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator,
+            comparisonModerator
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (ref.current.name === "" && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -106,14 +106,14 @@ export const EditChange = ({
     const onInternalSubmit = async () => {
         try {
             await editChange(projectId, changeRequestId, change.id, {
-                action: strategy.id ? 'updateStrategy' : 'addStrategy',
+                action: strategy.id ? "updateStrategy" : "addStrategy",
                 feature: featureId,
                 payload,
             });
             onSubmit();
             setToastData({
-                title: 'Change updated',
-                type: 'success',
+                title: "Change updated",
+                type: "success",
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -130,14 +130,14 @@ export const EditChange = ({
         <SidebarModal
             open={open}
             onClose={onClose}
-            label='Edit change'
+            label="Edit change"
             onClick={(e) => {
                 e.stopPropagation();
             }}
         >
             <FormTemplate
                 modal
-                title={formatStrategyName(strategyDefinition.name ?? '')}
+                title={formatStrategyName(strategyDefinition.name ?? "")}
                 description={featureStrategyHelp}
                 documentationLink={featureStrategyDocsLink}
                 documentationLinkLabel={featureStrategyDocsLinkLabel}
@@ -147,7 +147,7 @@ export const EditChange = ({
                         changeRequestId,
                         change.id,
                         payload,
-                        unleashUrl,
+                        unleashUrl
                     )
                 }
             >
@@ -168,7 +168,7 @@ export const EditChange = ({
                             permission={UPDATE_FEATURE_STRATEGY}
                             errors={errors}
                             isChangeRequest={isChangeRequestConfigured(
-                                environment,
+                                environment
                             )}
                             tab={tab}
                             setTab={setTab}
@@ -189,7 +189,7 @@ export const EditChange = ({
                             permission={UPDATE_FEATURE_STRATEGY}
                             errors={errors}
                             isChangeRequest={isChangeRequestConfigured(
-                                environment,
+                                environment
                             )}
                         />
                     }
@@ -206,10 +206,10 @@ export const formatUpdateStrategyApiCode = (
     changeRequestId: number,
     changeId: number,
     strategy: Partial<IFeatureStrategy>,
-    unleashUrl?: string,
+    unleashUrl?: string
 ): string => {
     if (!unleashUrl) {
-        return '';
+        return "";
     }
 
     const url = `${unleashUrl}/api/admin/projects/${projectId}/change-requests/${changeRequestId}/changes/${changeId}`;
@@ -227,6 +227,6 @@ export const featureStrategyHelp = `
 `;
 
 export const featureStrategyDocsLink =
-    'https://docs.getunleash.io/reference/activation-strategies';
+    "https://docs.getunleash.io/reference/activation-strategies";
 
-export const featureStrategyDocsLinkLabel = 'Strategies documentation';
+export const featureStrategyDocsLinkLabel = "Strategies documentation";

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -1,30 +1,30 @@
-import React, { useEffect, useRef, useState } from "react";
-import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
-import FormTemplate from "component/common/FormTemplate/FormTemplate";
-import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
-import { useRequiredPathParam } from "hooks/useRequiredPathParam";
-import { formatUnknownError } from "utils/formatUnknownError";
-import useToast from "hooks/useToast";
-import { IFeatureStrategy } from "interfaces/strategy";
-import { UPDATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
-import { ISegment } from "interfaces/segment";
-import { formatStrategyName } from "utils/strategyNames";
-import { useFormErrors } from "hooks/useFormErrors";
-import { useCollaborateData } from "hooks/useCollaborateData";
-import { useFeature } from "hooks/api/getters/useFeature/useFeature";
-import { IFeatureToggle } from "interfaces/featureToggle";
-import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
-import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
-import { comparisonModerator } from "component/feature/FeatureStrategy/featureStrategy.utils";
+import React, { useEffect, useRef, useState } from 'react';
+import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
+import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import useToast from 'hooks/useToast';
+import { IFeatureStrategy } from 'interfaces/strategy';
+import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { ISegment } from 'interfaces/segment';
+import { formatStrategyName } from 'utils/strategyNames';
+import { useFormErrors } from 'hooks/useFormErrors';
+import { useCollaborateData } from 'hooks/useCollaborateData';
+import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
+import { IFeatureToggle } from 'interfaces/featureToggle';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
+import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import { comparisonModerator } from 'component/feature/FeatureStrategy/featureStrategy.utils';
 import {
     IChangeRequestAddStrategy,
     IChangeRequestUpdateStrategy,
-} from "component/changeRequest/changeRequest.types";
-import { SidebarModal } from "component/common/SidebarModal/SidebarModal";
-import { useSegments } from "hooks/api/getters/useSegments/useSegments";
-import { useUiFlag } from "hooks/useUiFlag";
-import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
-import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
+} from 'component/changeRequest/changeRequest.types';
+import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
+import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
 
 interface IEditChangeProps {
     change: IChangeRequestAddStrategy | IChangeRequestUpdateStrategy;
@@ -45,13 +45,13 @@ export const EditChange = ({
     onClose,
     featureId,
 }: IEditChangeProps) => {
-    const projectId = useRequiredPathParam("projectId");
+    const projectId = useRequiredPathParam('projectId');
     const { editChange } = useChangeRequestApi();
     const [tab, setTab] = useState(0);
-    const newStrategyConfiguration = useUiFlag("newStrategyConfiguration");
+    const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
 
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>(
-        change.payload
+        change.payload,
     );
 
     const { segments: allSegments } = useSegments();
@@ -80,19 +80,19 @@ export const EditChange = ({
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: "feature",
-                refetchFunctionKey: "refetchFeature",
+                dataKey: 'feature',
+                refetchFunctionKey: 'refetchFeature',
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator
+            comparisonModerator,
         );
 
     useEffect(() => {
-        if (ref.current.name === "" && feature.name) {
+        if (ref.current.name === '' && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -106,14 +106,14 @@ export const EditChange = ({
     const onInternalSubmit = async () => {
         try {
             await editChange(projectId, changeRequestId, change.id, {
-                action: strategy.id ? "updateStrategy" : "addStrategy",
+                action: strategy.id ? 'updateStrategy' : 'addStrategy',
                 feature: featureId,
                 payload,
             });
             onSubmit();
             setToastData({
-                title: "Change updated",
-                type: "success",
+                title: 'Change updated',
+                type: 'success',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -130,14 +130,14 @@ export const EditChange = ({
         <SidebarModal
             open={open}
             onClose={onClose}
-            label="Edit change"
+            label='Edit change'
             onClick={(e) => {
                 e.stopPropagation();
             }}
         >
             <FormTemplate
                 modal
-                title={formatStrategyName(strategyDefinition.name ?? "")}
+                title={formatStrategyName(strategyDefinition.name ?? '')}
                 description={featureStrategyHelp}
                 documentationLink={featureStrategyDocsLink}
                 documentationLinkLabel={featureStrategyDocsLinkLabel}
@@ -147,7 +147,7 @@ export const EditChange = ({
                         changeRequestId,
                         change.id,
                         payload,
-                        unleashUrl
+                        unleashUrl,
                     )
                 }
             >
@@ -168,7 +168,7 @@ export const EditChange = ({
                             permission={UPDATE_FEATURE_STRATEGY}
                             errors={errors}
                             isChangeRequest={isChangeRequestConfigured(
-                                environment
+                                environment,
                             )}
                             tab={tab}
                             setTab={setTab}
@@ -189,7 +189,7 @@ export const EditChange = ({
                             permission={UPDATE_FEATURE_STRATEGY}
                             errors={errors}
                             isChangeRequest={isChangeRequestConfigured(
-                                environment
+                                environment,
                             )}
                         />
                     }
@@ -206,10 +206,10 @@ export const formatUpdateStrategyApiCode = (
     changeRequestId: number,
     changeId: number,
     strategy: Partial<IFeatureStrategy>,
-    unleashUrl?: string
+    unleashUrl?: string,
 ): string => {
     if (!unleashUrl) {
-        return "";
+        return '';
     }
 
     const url = `${unleashUrl}/api/admin/projects/${projectId}/change-requests/${changeRequestId}/changes/${changeId}`;
@@ -227,6 +227,6 @@ export const featureStrategyHelp = `
 `;
 
 export const featureStrategyDocsLink =
-    "https://docs.getunleash.io/reference/activation-strategies";
+    'https://docs.getunleash.io/reference/activation-strategies';
 
-export const featureStrategyDocsLinkLabel = "Strategies documentation";
+export const featureStrategyDocsLinkLabel = 'Strategies documentation';

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
     Alert,
     Button,
@@ -9,39 +9,39 @@ import {
     Typography,
     Divider,
     Box,
-} from '@mui/material';
+} from "@mui/material";
 import {
     IFeatureStrategy,
     IFeatureStrategyParameters,
     IStrategyParameter,
-} from 'interfaces/strategy';
-import { FeatureStrategyType } from '../FeatureStrategyType/FeatureStrategyType';
-import { FeatureStrategyEnabled } from './FeatureStrategyEnabled/FeatureStrategyEnabled';
-import { FeatureStrategyConstraints } from '../FeatureStrategyConstraints/FeatureStrategyConstraints';
-import { IFeatureToggle } from 'interfaces/featureToggle';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { STRATEGY_FORM_SUBMIT_ID } from 'utils/testIds';
-import { useConstraintsValidation } from 'hooks/api/getters/useConstraintsValidation/useConstraintsValidation';
-import PermissionButton from 'component/common/PermissionButton/PermissionButton';
-import { FeatureStrategySegment } from 'component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment';
-import { ISegment } from 'interfaces/segment';
-import { IFormErrors } from 'hooks/useFormErrors';
-import { validateParameterValue } from 'utils/validateParameterValue';
-import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
-import { FeatureStrategyChangeRequestAlert } from './FeatureStrategyChangeRequestAlert/FeatureStrategyChangeRequestAlert';
+} from "interfaces/strategy";
+import { FeatureStrategyType } from "../FeatureStrategyType/FeatureStrategyType";
+import { FeatureStrategyEnabled } from "./FeatureStrategyEnabled/FeatureStrategyEnabled";
+import { FeatureStrategyConstraints } from "../FeatureStrategyConstraints/FeatureStrategyConstraints";
+import { IFeatureToggle } from "interfaces/featureToggle";
+import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
+import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
+import { STRATEGY_FORM_SUBMIT_ID } from "utils/testIds";
+import { useConstraintsValidation } from "hooks/api/getters/useConstraintsValidation/useConstraintsValidation";
+import PermissionButton from "component/common/PermissionButton/PermissionButton";
+import { FeatureStrategySegment } from "component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment";
+import { ISegment } from "interfaces/segment";
+import { IFormErrors } from "hooks/useFormErrors";
+import { validateParameterValue } from "utils/validateParameterValue";
+import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
+import { FeatureStrategyChangeRequestAlert } from "./FeatureStrategyChangeRequestAlert/FeatureStrategyChangeRequestAlert";
 import {
     FeatureStrategyProdGuard,
     useFeatureStrategyProdGuard,
-} from '../FeatureStrategyProdGuard/FeatureStrategyProdGuard';
-import { formatFeaturePath } from '../FeatureStrategyEdit/FeatureStrategyEdit';
-import { useChangeRequestInReviewWarning } from 'hooks/useChangeRequestInReviewWarning';
-import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
-import { useHasProjectEnvironmentAccess } from 'hooks/useHasAccess';
-import { FeatureStrategyTitle } from './FeatureStrategyTitle/FeatureStrategyTitle';
-import { FeatureStrategyEnabledDisabled } from './FeatureStrategyEnabledDisabled/FeatureStrategyEnabledDisabled';
-import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+} from "../FeatureStrategyProdGuard/FeatureStrategyProdGuard";
+import { formatFeaturePath } from "../FeatureStrategyEdit/FeatureStrategyEdit";
+import { useChangeRequestInReviewWarning } from "hooks/useChangeRequestInReviewWarning";
+import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
+import { useHasProjectEnvironmentAccess } from "hooks/useHasAccess";
+import { FeatureStrategyTitle } from "./FeatureStrategyTitle/FeatureStrategyTitle";
+import { FeatureStrategyEnabledDisabled } from "./FeatureStrategyEnabledDisabled/FeatureStrategyEnabledDisabled";
+import { StrategyVariants } from "component/feature/StrategyTypes/StrategyVariants";
+import { usePlausibleTracker } from "hooks/usePlausibleTracker";
 
 interface IFeatureStrategyFormProps {
     feature: IFeatureToggle;
@@ -69,44 +69,62 @@ const StyledDividerContent = styled(Box)(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
     backgroundColor: theme.palette.background.elevation2,
     borderRadius: theme.shape.borderRadius,
-    width: '45px',
-    position: 'absolute',
-    top: '-10px',
-    left: 'calc(50% - 45px)',
+    width: "45px",
+    position: "absolute",
+    top: "-10px",
+    left: "calc(50% - 45px)",
     lineHeight: 1,
 }));
 
-const StyledForm = styled('form')(({ theme }) => ({
-    display: 'grid',
+const StyledForm = styled("form")(({ theme }) => ({
+    position: "relative",
+    display: "flex",
+    flexDirection: "column",
     gap: theme.spacing(2),
+    padding: theme.spacing(6),
+    paddingBottom: theme.spacing(12),
+    overflow: "auto",
+    height: "100%",
 }));
 
-const StyledHr = styled('hr')(({ theme }) => ({
-    width: '100%',
-    height: '1px',
+const StyledHr = styled("hr")(({ theme }) => ({
+    width: "100%",
+    height: "1px",
     margin: theme.spacing(2, 0),
-    border: 'none',
+    border: "none",
     background: theme.palette.background.elevation2,
 }));
 
-const StyledButtons = styled('div')(({ theme }) => ({
-    display: 'flex',
-    justifyContent: 'end',
-    gap: theme.spacing(2),
-    paddingBottom: theme.spacing(10),
+const StyledButtons = styled("div")(({ theme }) => ({
+    bottom: 0,
+    right: 0,
+    left: 0,
+    position: "absolute",
+    display: "flex",
+    padding: theme.spacing(3),
+    backgroundColor: theme.palette.common.white,
+    justifyContent: "end",
+    borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+    borderTop: `1px solid ${theme.palette.divider}`,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    paddingLeft: theme.spacing(6),
+    paddingRight: theme.spacing(6),
 }));
 
 const StyledBox = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    position: 'relative',
+    display: "flex",
+    position: "relative",
     marginTop: theme.spacing(3.5),
 }));
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
-    width: '100%',
+    width: "100%",
 }));
 
-const StyledTargetingHeader = styled('div')(({ theme }) => ({
+const StyledTargetingHeader = styled("div")(({ theme }) => ({
     color: theme.palette.text.secondary,
     marginTop: theme.spacing(1.5),
 }));
@@ -135,7 +153,7 @@ export const NewFeatureStrategyForm = ({
     const access = useHasProjectEnvironmentAccess(
         permission,
         projectId,
-        environmentId,
+        environmentId
     );
     const { strategyDefinition } = useStrategy(strategy?.name);
 
@@ -144,11 +162,11 @@ export const NewFeatureStrategyForm = ({
         useChangeRequestInReviewWarning(data);
 
     const hasChangeRequestInReviewForEnvironment =
-        changeRequestInReviewOrApproved(environmentId || '');
+        changeRequestInReviewOrApproved(environmentId || "");
 
     const changeRequestButtonText = hasChangeRequestInReviewForEnvironment
-        ? 'Add to existing change request'
-        : 'Add change to draft';
+        ? "Add to existing change request"
+        : "Add change to draft";
 
     const navigate = useNavigate();
 
@@ -174,11 +192,11 @@ export const NewFeatureStrategyForm = ({
 
     const validateParameter = (
         name: string,
-        value: IFeatureStrategyParameters[string],
+        value: IFeatureStrategyParameters[string]
     ): boolean => {
         const parameterValueError = validateParameterValue(
             findParameterDefinition(name),
-            value,
+            value
         );
         if (parameterValueError) {
             errors.setFormError(name, parameterValueError);
@@ -202,9 +220,9 @@ export const NewFeatureStrategyForm = ({
 
     const onSubmitWithValidation = async (event: React.FormEvent) => {
         if (Array.isArray(strategy.variants) && strategy.variants?.length > 0) {
-            trackEvent('strategy-variants', {
+            trackEvent("strategy-variants", {
                 props: {
-                    eventType: 'submitted',
+                    eventType: "submitted",
                 },
             });
         }
@@ -225,173 +243,180 @@ export const NewFeatureStrategyForm = ({
     };
 
     return (
-        <StyledForm onSubmit={onSubmitWithValidation}>
-            <Tabs value={tab} onChange={handleChange}>
-                <Tab label='General' />
-                <Tab label='Targeting' />
-                <Tab label='Variants' />
-            </Tabs>
-            <ConditionallyRender
-                condition={tab === 0}
-                show={
-                    <>
-                        <ConditionallyRender
-                            condition={hasChangeRequestInReviewForEnvironment}
-                            show={alert}
-                            elseShow={
+        <>
+            <StyledTabs value={tab} onChange={handleChange}>
+                <Tab label="General" />
+                <Tab label="Targeting" />
+                <Tab label="Variants" />
+            </StyledTabs>
+            <StyledForm onSubmit={onSubmitWithValidation}>
+                <ConditionallyRender
+                    condition={tab === 0}
+                    show={
+                        <>
+                            <ConditionallyRender
+                                condition={
+                                    hasChangeRequestInReviewForEnvironment
+                                }
+                                show={alert}
+                                elseShow={
+                                    <ConditionallyRender
+                                        condition={Boolean(isChangeRequest)}
+                                        show={
+                                            <FeatureStrategyChangeRequestAlert
+                                                environment={environmentId}
+                                            />
+                                        }
+                                    />
+                                }
+                            />
+                            <FeatureStrategyEnabled
+                                projectId={feature.project}
+                                featureId={feature.name}
+                                environmentId={environmentId}
+                            >
                                 <ConditionallyRender
                                     condition={Boolean(isChangeRequest)}
                                     show={
-                                        <FeatureStrategyChangeRequestAlert
-                                            environment={environmentId}
-                                        />
+                                        <Alert severity="success">
+                                            This feature toggle is currently
+                                            enabled in the{" "}
+                                            <strong>{environmentId}</strong>{" "}
+                                            environment. Any changes made here
+                                            will be available to users as soon
+                                            as these changes are approved and
+                                            applied.
+                                        </Alert>
                                     }
+                                    elseShow={
+                                        <Alert severity="success">
+                                            This feature toggle is currently
+                                            enabled in the{" "}
+                                            <strong>{environmentId}</strong>{" "}
+                                            environment. Any changes made here
+                                            will be available to users as soon
+                                            as you hit <strong>save</strong>.
+                                        </Alert>
+                                    }
+                                />
+                            </FeatureStrategyEnabled>
+
+                            <FeatureStrategyTitle
+                                title={strategy.title || ""}
+                                setTitle={(title) => {
+                                    setStrategy((prev) => ({
+                                        ...prev,
+                                        title,
+                                    }));
+                                }}
+                            />
+                            <FeatureStrategyEnabledDisabled
+                                enabled={!strategy?.disabled}
+                                onToggleEnabled={() =>
+                                    setStrategy((strategyState) => ({
+                                        ...strategyState,
+                                        disabled: !strategyState.disabled,
+                                    }))
+                                }
+                            />
+                            <FeatureStrategyType
+                                strategy={strategy}
+                                strategyDefinition={strategyDefinition}
+                                setStrategy={setStrategy}
+                                validateParameter={validateParameter}
+                                errors={errors}
+                                hasAccess={access}
+                            />
+                        </>
+                    }
+                />
+
+                <ConditionallyRender
+                    condition={tab === 1}
+                    show={
+                        <>
+                            <StyledTargetingHeader>
+                                Segmentation and constraints allow you to set
+                                filters on your strategies, so that they will
+                                only be evaluated for users and applications
+                                that match the specified preconditions.
+                            </StyledTargetingHeader>
+                            <FeatureStrategySegment
+                                segments={segments}
+                                setSegments={setSegments}
+                                projectId={projectId}
+                            />
+
+                            <StyledBox>
+                                <StyledDivider />
+                                <StyledDividerContent>AND</StyledDividerContent>
+                            </StyledBox>
+                            <FeatureStrategyConstraints
+                                projectId={feature.project}
+                                environmentId={environmentId}
+                                strategy={strategy}
+                                setStrategy={setStrategy}
+                            />
+                        </>
+                    }
+                />
+
+                <ConditionallyRender
+                    condition={tab === 2}
+                    show={
+                        <ConditionallyRender
+                            condition={
+                                strategy.parameters != null &&
+                                "stickiness" in strategy.parameters
+                            }
+                            show={
+                                <StrategyVariants
+                                    strategy={strategy}
+                                    setStrategy={setStrategy}
+                                    environment={environmentId}
+                                    projectId={projectId}
                                 />
                             }
                         />
-                        <FeatureStrategyEnabled
-                            projectId={feature.project}
-                            featureId={feature.name}
-                            environmentId={environmentId}
-                        >
-                            <ConditionallyRender
-                                condition={Boolean(isChangeRequest)}
-                                show={
-                                    <Alert severity='success'>
-                                        This feature toggle is currently enabled
-                                        in the <strong>{environmentId}</strong>{' '}
-                                        environment. Any changes made here will
-                                        be available to users as soon as these
-                                        changes are approved and applied.
-                                    </Alert>
-                                }
-                                elseShow={
-                                    <Alert severity='success'>
-                                        This feature toggle is currently enabled
-                                        in the <strong>{environmentId}</strong>{' '}
-                                        environment. Any changes made here will
-                                        be available to users as soon as you hit{' '}
-                                        <strong>save</strong>.
-                                    </Alert>
-                                }
-                            />
-                        </FeatureStrategyEnabled>
-                        <StyledHr />
-                        <FeatureStrategyTitle
-                            title={strategy.title || ''}
-                            setTitle={(title) => {
-                                setStrategy((prev) => ({
-                                    ...prev,
-                                    title,
-                                }));
-                            }}
-                        />
-                        <FeatureStrategyEnabledDisabled
-                            enabled={!strategy?.disabled}
-                            onToggleEnabled={() =>
-                                setStrategy((strategyState) => ({
-                                    ...strategyState,
-                                    disabled: !strategyState.disabled,
-                                }))
-                            }
-                        />
-                        <FeatureStrategyType
-                            strategy={strategy}
-                            strategyDefinition={strategyDefinition}
-                            setStrategy={setStrategy}
-                            validateParameter={validateParameter}
-                            errors={errors}
-                            hasAccess={access}
-                        />
-                    </>
-                }
-            />
-
-            <ConditionallyRender
-                condition={tab === 1}
-                show={
-                    <>
-                        <StyledTargetingHeader>
-                            Segmentation and constraints allow you to set
-                            filters on your strategies, so that they will only
-                            be evaluated for users and applications that match
-                            the specified preconditions.
-                        </StyledTargetingHeader>
-                        <FeatureStrategySegment
-                            segments={segments}
-                            setSegments={setSegments}
-                            projectId={projectId}
-                        />
-
-                        <StyledBox>
-                            <StyledDivider />
-                            <StyledDividerContent>AND</StyledDividerContent>
-                        </StyledBox>
-                        <FeatureStrategyConstraints
-                            projectId={feature.project}
-                            environmentId={environmentId}
-                            strategy={strategy}
-                            setStrategy={setStrategy}
-                        />
-                    </>
-                }
-            />
-
-            <ConditionallyRender
-                condition={tab === 2}
-                show={
-                    <ConditionallyRender
-                        condition={
-                            strategy.parameters != null &&
-                            'stickiness' in strategy.parameters
-                        }
-                        show={
-                            <StrategyVariants
-                                strategy={strategy}
-                                setStrategy={setStrategy}
-                                environment={environmentId}
-                                projectId={projectId}
-                            />
-                        }
-                    />
-                }
-            />
-
-            <StyledButtons>
-                <PermissionButton
-                    permission={permission}
-                    projectId={feature.project}
-                    environmentId={environmentId}
-                    variant='contained'
-                    color='primary'
-                    type='submit'
-                    disabled={
-                        loading ||
-                        !hasValidConstraints ||
-                        errors.hasFormErrors()
                     }
-                    data-testid={STRATEGY_FORM_SUBMIT_ID}
-                >
-                    {isChangeRequest
-                        ? changeRequestButtonText
-                        : 'Save strategy'}
-                </PermissionButton>
-                <Button
-                    type='button'
-                    color='primary'
-                    onClick={onCancel ? onCancel : onDefaultCancel}
-                    disabled={loading}
-                >
-                    Cancel
-                </Button>
-                <FeatureStrategyProdGuard
-                    open={showProdGuard}
-                    onClose={() => setShowProdGuard(false)}
-                    onClick={onSubmit}
-                    loading={loading}
-                    label='Save strategy'
                 />
-            </StyledButtons>
-        </StyledForm>
+
+                <StyledButtons>
+                    <PermissionButton
+                        permission={permission}
+                        projectId={feature.project}
+                        environmentId={environmentId}
+                        variant="contained"
+                        color="primary"
+                        type="submit"
+                        disabled={
+                            loading ||
+                            !hasValidConstraints ||
+                            errors.hasFormErrors()
+                        }
+                        data-testid={STRATEGY_FORM_SUBMIT_ID}
+                    >
+                        {isChangeRequest
+                            ? changeRequestButtonText
+                            : "Save strategy"}
+                    </PermissionButton>
+                    <Button
+                        type="button"
+                        color="primary"
+                        onClick={onCancel ? onCancel : onDefaultCancel}
+                        disabled={loading}
+                    >
+                        Cancel
+                    </Button>
+                    <FeatureStrategyProdGuard
+                        open={showProdGuard}
+                        onClose={() => setShowProdGuard(false)}
+                        onClick={onSubmit}
+                        loading={loading}
+                        label="Save strategy"
+                    />
+                </StyledButtons>
+            </StyledForm>
+        </>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -130,7 +130,7 @@ const StyledTargetingHeader = styled('div')(({ theme }) => ({
     marginTop: theme.spacing(1.5),
 }));
 
-const StyledHeaderBox = styled(Tabs)(({ theme }) => ({
+const StyledHeaderBox = styled(Box)(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     paddingLeft: theme.spacing(6),

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -1,15 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-    Alert,
-    Button,
-    styled,
-    Tabs,
-    Tab,
-    Typography,
-    Divider,
-    Box,
-} from "@mui/material";
+import { Alert, Button, styled, Tabs, Tab, Box } from "@mui/material";
 import {
     IFeatureStrategy,
     IFeatureStrategyParameters,
@@ -42,6 +33,7 @@ import { FeatureStrategyTitle } from "./FeatureStrategyTitle/FeatureStrategyTitl
 import { FeatureStrategyEnabledDisabled } from "./FeatureStrategyEnabledDisabled/FeatureStrategyEnabledDisabled";
 import { StrategyVariants } from "component/feature/StrategyTypes/StrategyVariants";
 import { usePlausibleTracker } from "hooks/usePlausibleTracker";
+import { formatStrategyName } from "utils/strategyNames";
 
 interface IFeatureStrategyFormProps {
     feature: IFeatureToggle;
@@ -83,6 +75,7 @@ const StyledForm = styled("form")(({ theme }) => ({
     gap: theme.spacing(2),
     padding: theme.spacing(6),
     paddingBottom: theme.spacing(12),
+    paddingTop: theme.spacing(4),
     overflow: "auto",
     height: "100%",
 }));
@@ -95,6 +88,12 @@ const StyledHr = styled("hr")(({ theme }) => ({
     background: theme.palette.background.elevation2,
 }));
 
+const StyledTitle = styled("h1")(({ theme }) => ({
+    fontWeight: "normal",
+    display: "flex",
+    alignItems: "center",
+}));
+
 const StyledButtons = styled("div")(({ theme }) => ({
     bottom: 0,
     right: 0,
@@ -102,6 +101,8 @@ const StyledButtons = styled("div")(({ theme }) => ({
     position: "absolute",
     display: "flex",
     padding: theme.spacing(3),
+    paddingRight: theme.spacing(6),
+    paddingLeft: theme.spacing(6),
     backgroundColor: theme.palette.common.white,
     justifyContent: "end",
     borderTop: `1px solid ${theme.palette.divider}`,
@@ -127,6 +128,15 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
 const StyledTargetingHeader = styled("div")(({ theme }) => ({
     color: theme.palette.text.secondary,
     marginTop: theme.spacing(1.5),
+}));
+
+const StyledHeaderBox = styled(Tabs)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    paddingLeft: theme.spacing(6),
+    paddingRight: theme.spacing(6),
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
 }));
 
 export const NewFeatureStrategyForm = ({
@@ -244,6 +254,11 @@ export const NewFeatureStrategyForm = ({
 
     return (
         <>
+            <StyledHeaderBox>
+                <StyledTitle>
+                    {formatStrategyName(strategy.name || "")}
+                </StyledTitle>
+            </StyledHeaderBox>
             <StyledTabs value={tab} onChange={handleChange}>
                 <Tab label="General" />
                 <Tab label="Targeting" />
@@ -254,6 +269,32 @@ export const NewFeatureStrategyForm = ({
                     condition={tab === 0}
                     show={
                         <>
+                            <FeatureStrategyTitle
+                                title={strategy.title || ""}
+                                setTitle={(title) => {
+                                    setStrategy((prev) => ({
+                                        ...prev,
+                                        title,
+                                    }));
+                                }}
+                            />
+                            <FeatureStrategyEnabledDisabled
+                                enabled={!strategy?.disabled}
+                                onToggleEnabled={() =>
+                                    setStrategy((strategyState) => ({
+                                        ...strategyState,
+                                        disabled: !strategyState.disabled,
+                                    }))
+                                }
+                            />
+                            <FeatureStrategyType
+                                strategy={strategy}
+                                strategyDefinition={strategyDefinition}
+                                setStrategy={setStrategy}
+                                validateParameter={validateParameter}
+                                errors={errors}
+                                hasAccess={access}
+                            />
                             <ConditionallyRender
                                 condition={
                                     hasChangeRequestInReviewForEnvironment
@@ -270,6 +311,7 @@ export const NewFeatureStrategyForm = ({
                                     />
                                 }
                             />
+
                             <FeatureStrategyEnabled
                                 projectId={feature.project}
                                 featureId={feature.name}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -1,39 +1,39 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Alert, Button, styled, Tabs, Tab, Box } from "@mui/material";
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Alert, Button, styled, Tabs, Tab, Box, Divider } from '@mui/material';
 import {
     IFeatureStrategy,
     IFeatureStrategyParameters,
     IStrategyParameter,
-} from "interfaces/strategy";
-import { FeatureStrategyType } from "../FeatureStrategyType/FeatureStrategyType";
-import { FeatureStrategyEnabled } from "./FeatureStrategyEnabled/FeatureStrategyEnabled";
-import { FeatureStrategyConstraints } from "../FeatureStrategyConstraints/FeatureStrategyConstraints";
-import { IFeatureToggle } from "interfaces/featureToggle";
-import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
-import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
-import { STRATEGY_FORM_SUBMIT_ID } from "utils/testIds";
-import { useConstraintsValidation } from "hooks/api/getters/useConstraintsValidation/useConstraintsValidation";
-import PermissionButton from "component/common/PermissionButton/PermissionButton";
-import { FeatureStrategySegment } from "component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment";
-import { ISegment } from "interfaces/segment";
-import { IFormErrors } from "hooks/useFormErrors";
-import { validateParameterValue } from "utils/validateParameterValue";
-import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
-import { FeatureStrategyChangeRequestAlert } from "./FeatureStrategyChangeRequestAlert/FeatureStrategyChangeRequestAlert";
+} from 'interfaces/strategy';
+import { FeatureStrategyType } from '../FeatureStrategyType/FeatureStrategyType';
+import { FeatureStrategyEnabled } from './FeatureStrategyEnabled/FeatureStrategyEnabled';
+import { FeatureStrategyConstraints } from '../FeatureStrategyConstraints/FeatureStrategyConstraints';
+import { IFeatureToggle } from 'interfaces/featureToggle';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { STRATEGY_FORM_SUBMIT_ID } from 'utils/testIds';
+import { useConstraintsValidation } from 'hooks/api/getters/useConstraintsValidation/useConstraintsValidation';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
+import { FeatureStrategySegment } from 'component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment';
+import { ISegment } from 'interfaces/segment';
+import { IFormErrors } from 'hooks/useFormErrors';
+import { validateParameterValue } from 'utils/validateParameterValue';
+import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
+import { FeatureStrategyChangeRequestAlert } from './FeatureStrategyChangeRequestAlert/FeatureStrategyChangeRequestAlert';
 import {
     FeatureStrategyProdGuard,
     useFeatureStrategyProdGuard,
-} from "../FeatureStrategyProdGuard/FeatureStrategyProdGuard";
-import { formatFeaturePath } from "../FeatureStrategyEdit/FeatureStrategyEdit";
-import { useChangeRequestInReviewWarning } from "hooks/useChangeRequestInReviewWarning";
-import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
-import { useHasProjectEnvironmentAccess } from "hooks/useHasAccess";
-import { FeatureStrategyTitle } from "./FeatureStrategyTitle/FeatureStrategyTitle";
-import { FeatureStrategyEnabledDisabled } from "./FeatureStrategyEnabledDisabled/FeatureStrategyEnabledDisabled";
-import { StrategyVariants } from "component/feature/StrategyTypes/StrategyVariants";
-import { usePlausibleTracker } from "hooks/usePlausibleTracker";
-import { formatStrategyName } from "utils/strategyNames";
+} from '../FeatureStrategyProdGuard/FeatureStrategyProdGuard';
+import { formatFeaturePath } from '../FeatureStrategyEdit/FeatureStrategyEdit';
+import { useChangeRequestInReviewWarning } from 'hooks/useChangeRequestInReviewWarning';
+import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
+import { useHasProjectEnvironmentAccess } from 'hooks/useHasAccess';
+import { FeatureStrategyTitle } from './FeatureStrategyTitle/FeatureStrategyTitle';
+import { FeatureStrategyEnabledDisabled } from './FeatureStrategyEnabledDisabled/FeatureStrategyEnabledDisabled';
+import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { formatStrategyName } from 'utils/strategyNames';
 
 interface IFeatureStrategyFormProps {
     feature: IFeatureToggle;
@@ -61,50 +61,50 @@ const StyledDividerContent = styled(Box)(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
     backgroundColor: theme.palette.background.elevation2,
     borderRadius: theme.shape.borderRadius,
-    width: "45px",
-    position: "absolute",
-    top: "-10px",
-    left: "calc(50% - 45px)",
+    width: '45px',
+    position: 'absolute',
+    top: '-10px',
+    left: 'calc(50% - 45px)',
     lineHeight: 1,
 }));
 
-const StyledForm = styled("form")(({ theme }) => ({
-    position: "relative",
-    display: "flex",
-    flexDirection: "column",
+const StyledForm = styled('form')(({ theme }) => ({
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
     gap: theme.spacing(2),
     padding: theme.spacing(6),
     paddingBottom: theme.spacing(12),
     paddingTop: theme.spacing(4),
-    overflow: "auto",
-    height: "100%",
+    overflow: 'auto',
+    height: '100%',
 }));
 
-const StyledHr = styled("hr")(({ theme }) => ({
-    width: "100%",
-    height: "1px",
+const StyledHr = styled('hr')(({ theme }) => ({
+    width: '100%',
+    height: '1px',
     margin: theme.spacing(2, 0),
-    border: "none",
+    border: 'none',
     background: theme.palette.background.elevation2,
 }));
 
-const StyledTitle = styled("h1")(({ theme }) => ({
-    fontWeight: "normal",
-    display: "flex",
-    alignItems: "center",
+const StyledTitle = styled('h1')(({ theme }) => ({
+    fontWeight: 'normal',
+    display: 'flex',
+    alignItems: 'center',
 }));
 
-const StyledButtons = styled("div")(({ theme }) => ({
+const StyledButtons = styled('div')(({ theme }) => ({
     bottom: 0,
     right: 0,
     left: 0,
-    position: "absolute",
-    display: "flex",
+    position: 'absolute',
+    display: 'flex',
     padding: theme.spacing(3),
     paddingRight: theme.spacing(6),
     paddingLeft: theme.spacing(6),
     backgroundColor: theme.palette.common.white,
-    justifyContent: "end",
+    justifyContent: 'end',
     borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
@@ -116,23 +116,23 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
 }));
 
 const StyledBox = styled(Box)(({ theme }) => ({
-    display: "flex",
-    position: "relative",
+    display: 'flex',
+    position: 'relative',
     marginTop: theme.spacing(3.5),
 }));
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
-    width: "100%",
+    width: '100%',
 }));
 
-const StyledTargetingHeader = styled("div")(({ theme }) => ({
+const StyledTargetingHeader = styled('div')(({ theme }) => ({
     color: theme.palette.text.secondary,
     marginTop: theme.spacing(1.5),
 }));
 
 const StyledHeaderBox = styled(Tabs)(({ theme }) => ({
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     paddingLeft: theme.spacing(6),
     paddingRight: theme.spacing(6),
     paddingTop: theme.spacing(2),
@@ -163,7 +163,7 @@ export const NewFeatureStrategyForm = ({
     const access = useHasProjectEnvironmentAccess(
         permission,
         projectId,
-        environmentId
+        environmentId,
     );
     const { strategyDefinition } = useStrategy(strategy?.name);
 
@@ -172,11 +172,11 @@ export const NewFeatureStrategyForm = ({
         useChangeRequestInReviewWarning(data);
 
     const hasChangeRequestInReviewForEnvironment =
-        changeRequestInReviewOrApproved(environmentId || "");
+        changeRequestInReviewOrApproved(environmentId || '');
 
     const changeRequestButtonText = hasChangeRequestInReviewForEnvironment
-        ? "Add to existing change request"
-        : "Add change to draft";
+        ? 'Add to existing change request'
+        : 'Add change to draft';
 
     const navigate = useNavigate();
 
@@ -202,11 +202,11 @@ export const NewFeatureStrategyForm = ({
 
     const validateParameter = (
         name: string,
-        value: IFeatureStrategyParameters[string]
+        value: IFeatureStrategyParameters[string],
     ): boolean => {
         const parameterValueError = validateParameterValue(
             findParameterDefinition(name),
-            value
+            value,
         );
         if (parameterValueError) {
             errors.setFormError(name, parameterValueError);
@@ -230,9 +230,9 @@ export const NewFeatureStrategyForm = ({
 
     const onSubmitWithValidation = async (event: React.FormEvent) => {
         if (Array.isArray(strategy.variants) && strategy.variants?.length > 0) {
-            trackEvent("strategy-variants", {
+            trackEvent('strategy-variants', {
                 props: {
-                    eventType: "submitted",
+                    eventType: 'submitted',
                 },
             });
         }
@@ -256,13 +256,13 @@ export const NewFeatureStrategyForm = ({
         <>
             <StyledHeaderBox>
                 <StyledTitle>
-                    {formatStrategyName(strategy.name || "")}
+                    {formatStrategyName(strategy.name || '')}
                 </StyledTitle>
             </StyledHeaderBox>
             <StyledTabs value={tab} onChange={handleChange}>
-                <Tab label="General" />
-                <Tab label="Targeting" />
-                <Tab label="Variants" />
+                <Tab label='General' />
+                <Tab label='Targeting' />
+                <Tab label='Variants' />
             </StyledTabs>
             <StyledForm onSubmit={onSubmitWithValidation}>
                 <ConditionallyRender
@@ -270,7 +270,7 @@ export const NewFeatureStrategyForm = ({
                     show={
                         <>
                             <FeatureStrategyTitle
-                                title={strategy.title || ""}
+                                title={strategy.title || ''}
                                 setTitle={(title) => {
                                     setStrategy((prev) => ({
                                         ...prev,
@@ -295,6 +295,7 @@ export const NewFeatureStrategyForm = ({
                                 errors={errors}
                                 hasAccess={access}
                             />
+
                             <ConditionallyRender
                                 condition={
                                     hasChangeRequestInReviewForEnvironment
@@ -320,10 +321,10 @@ export const NewFeatureStrategyForm = ({
                                 <ConditionallyRender
                                     condition={Boolean(isChangeRequest)}
                                     show={
-                                        <Alert severity="success">
+                                        <Alert severity='success'>
                                             This feature toggle is currently
-                                            enabled in the{" "}
-                                            <strong>{environmentId}</strong>{" "}
+                                            enabled in the{' '}
+                                            <strong>{environmentId}</strong>{' '}
                                             environment. Any changes made here
                                             will be available to users as soon
                                             as these changes are approved and
@@ -331,10 +332,10 @@ export const NewFeatureStrategyForm = ({
                                         </Alert>
                                     }
                                     elseShow={
-                                        <Alert severity="success">
+                                        <Alert severity='success'>
                                             This feature toggle is currently
-                                            enabled in the{" "}
-                                            <strong>{environmentId}</strong>{" "}
+                                            enabled in the{' '}
+                                            <strong>{environmentId}</strong>{' '}
                                             environment. Any changes made here
                                             will be available to users as soon
                                             as you hit <strong>save</strong>.
@@ -342,33 +343,6 @@ export const NewFeatureStrategyForm = ({
                                     }
                                 />
                             </FeatureStrategyEnabled>
-
-                            <FeatureStrategyTitle
-                                title={strategy.title || ""}
-                                setTitle={(title) => {
-                                    setStrategy((prev) => ({
-                                        ...prev,
-                                        title,
-                                    }));
-                                }}
-                            />
-                            <FeatureStrategyEnabledDisabled
-                                enabled={!strategy?.disabled}
-                                onToggleEnabled={() =>
-                                    setStrategy((strategyState) => ({
-                                        ...strategyState,
-                                        disabled: !strategyState.disabled,
-                                    }))
-                                }
-                            />
-                            <FeatureStrategyType
-                                strategy={strategy}
-                                strategyDefinition={strategyDefinition}
-                                setStrategy={setStrategy}
-                                validateParameter={validateParameter}
-                                errors={errors}
-                                hasAccess={access}
-                            />
                         </>
                     }
                 />
@@ -409,7 +383,7 @@ export const NewFeatureStrategyForm = ({
                         <ConditionallyRender
                             condition={
                                 strategy.parameters != null &&
-                                "stickiness" in strategy.parameters
+                                'stickiness' in strategy.parameters
                             }
                             show={
                                 <StrategyVariants
@@ -428,9 +402,9 @@ export const NewFeatureStrategyForm = ({
                         permission={permission}
                         projectId={feature.project}
                         environmentId={environmentId}
-                        variant="contained"
-                        color="primary"
-                        type="submit"
+                        variant='contained'
+                        color='primary'
+                        type='submit'
                         disabled={
                             loading ||
                             !hasValidConstraints ||
@@ -440,11 +414,11 @@ export const NewFeatureStrategyForm = ({
                     >
                         {isChangeRequest
                             ? changeRequestButtonText
-                            : "Save strategy"}
+                            : 'Save strategy'}
                     </PermissionButton>
                     <Button
-                        type="button"
-                        color="primary"
+                        type='button'
+                        color='primary'
                         onClick={onCancel ? onCancel : onDefaultCancel}
                         disabled={loading}
                     >
@@ -455,7 +429,7 @@ export const NewFeatureStrategyForm = ({
                         onClose={() => setShowProdGuard(false)}
                         onClick={onSubmit}
                         loading={loading}
-                        label="Save strategy"
+                        label='Save strategy'
                     />
                 </StyledButtons>
             </StyledForm>

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
@@ -180,7 +180,6 @@ export const NewFeatureStrategyCreate = () => {
     return (
         <FormTemplate
             modal
-            title={formatStrategyName(strategyName)}
             description={featureStrategyHelp}
             documentationLink={featureStrategyDocsLink}
             documentationLinkLabel={featureStrategyDocsLinkLabel}

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
@@ -1,50 +1,50 @@
-import React, { useEffect, useRef, useState } from "react";
-import { useRequiredPathParam } from "hooks/useRequiredPathParam";
-import { useRequiredQueryParam } from "hooks/useRequiredQueryParam";
-import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
-import FormTemplate from "component/common/FormTemplate/FormTemplate";
-import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
-import useFeatureStrategyApi from "hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi";
-import { formatUnknownError } from "utils/formatUnknownError";
-import { useNavigate } from "react-router-dom";
-import useToast from "hooks/useToast";
-import { IFeatureStrategy, IFeatureStrategyPayload } from "interfaces/strategy";
+import React, { useEffect, useRef, useState } from 'react';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
+import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
+import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useNavigate } from 'react-router-dom';
+import useToast from 'hooks/useToast';
+import { IFeatureStrategy, IFeatureStrategyPayload } from 'interfaces/strategy';
 import {
     createStrategyPayload,
     featureStrategyDocsLink,
     featureStrategyDocsLinkLabel,
     featureStrategyHelp,
     formatFeaturePath,
-} from "../FeatureStrategyEdit/FeatureStrategyEdit";
-import { CREATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
-import { ISegment } from "interfaces/segment";
-import { formatStrategyName } from "utils/strategyNames";
-import { useFormErrors } from "hooks/useFormErrors";
-import { createFeatureStrategy } from "utils/createFeatureStrategy";
-import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
-import { useCollaborateData } from "hooks/useCollaborateData";
-import { useFeature } from "hooks/api/getters/useFeature/useFeature";
-import { IFeatureToggle } from "interfaces/featureToggle";
-import { comparisonModerator } from "../featureStrategy.utils";
-import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
-import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
-import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
-import { usePlausibleTracker } from "hooks/usePlausibleTracker";
-import useQueryParams from "hooks/useQueryParams";
-import { useSegments } from "hooks/api/getters/useSegments/useSegments";
-import { useDefaultStrategy } from "../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy";
-import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
+} from '../FeatureStrategyEdit/FeatureStrategyEdit';
+import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { ISegment } from 'interfaces/segment';
+import { formatStrategyName } from 'utils/strategyNames';
+import { useFormErrors } from 'hooks/useFormErrors';
+import { createFeatureStrategy } from 'utils/createFeatureStrategy';
+import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
+import { useCollaborateData } from 'hooks/useCollaborateData';
+import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
+import { IFeatureToggle } from 'interfaces/featureToggle';
+import { comparisonModerator } from '../featureStrategy.utils';
+import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
+import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import useQueryParams from 'hooks/useQueryParams';
+import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
+import { useDefaultStrategy } from '../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
+import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
 
 export const NewFeatureStrategyCreate = () => {
     const [tab, setTab] = useState(0);
-    const projectId = useRequiredPathParam("projectId");
-    const featureId = useRequiredPathParam("featureId");
-    const environmentId = useRequiredQueryParam("environmentId");
-    const strategyName = useRequiredQueryParam("strategyName");
+    const projectId = useRequiredPathParam('projectId');
+    const featureId = useRequiredPathParam('featureId');
+    const environmentId = useRequiredQueryParam('environmentId');
+    const strategyName = useRequiredQueryParam('strategyName');
     const { strategy: defaultStrategy, defaultStrategyFallback } =
         useDefaultStrategy(projectId, environmentId);
     const shouldUseDefaultStrategy: boolean = JSON.parse(
-        useQueryParams().get("defaultStrategy") || "false"
+        useQueryParams().get('defaultStrategy') || 'false',
     );
 
     const { segments: allSegments } = useSegments();
@@ -55,7 +55,7 @@ export const NewFeatureStrategyCreate = () => {
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>({});
 
     const [segments, setSegments] = useState<ISegment[]>(
-        shouldUseDefaultStrategy ? strategySegments : []
+        shouldUseDefaultStrategy ? strategySegments : [],
     );
     const { strategyDefinition } = useStrategy(strategyName);
     const errors = useFormErrors();
@@ -79,19 +79,19 @@ export const NewFeatureStrategyCreate = () => {
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: "feature",
-                refetchFunctionKey: "refetchFeature",
+                dataKey: 'feature',
+                refetchFunctionKey: 'refetchFeature',
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator
+            comparisonModerator,
         );
 
     useEffect(() => {
-        if (ref.current.name === "" && feature.name) {
+        if (ref.current.name === '' && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -100,7 +100,7 @@ export const NewFeatureStrategyCreate = () => {
     useEffect(() => {
         if (shouldUseDefaultStrategy) {
             const strategyTemplate = defaultStrategy || defaultStrategyFallback;
-            if (strategyTemplate.parameters?.groupId === "" && featureId) {
+            if (strategyTemplate.parameters?.groupId === '' && featureId) {
                 setStrategy({
                     ...strategyTemplate,
                     parameters: {
@@ -125,26 +125,26 @@ export const NewFeatureStrategyCreate = () => {
             projectId,
             featureId,
             environmentId,
-            payload
+            payload,
         );
 
         setToastData({
-            title: "Strategy created",
-            type: "success",
+            title: 'Strategy created',
+            type: 'success',
             confetti: true,
         });
     };
 
     const onStrategyRequestAdd = async (payload: IFeatureStrategyPayload) => {
         await addChange(projectId, environmentId, {
-            action: "addStrategy",
+            action: 'addStrategy',
             feature: featureId,
             payload,
         });
         // FIXME: segments in change requests
         setToastData({
-            title: "Strategy added to draft",
-            type: "success",
+            title: 'Strategy added to draft',
+            type: 'success',
             confetti: true,
         });
         refetchChangeRequests();
@@ -153,10 +153,10 @@ export const NewFeatureStrategyCreate = () => {
     const payload = createStrategyPayload(strategy, segments);
 
     const onSubmit = async () => {
-        trackEvent("strategyTitle", {
+        trackEvent('strategyTitle', {
             props: {
                 hasTitle: Boolean(strategy.title),
-                on: "create",
+                on: 'create',
             },
         });
 
@@ -190,7 +190,7 @@ export const NewFeatureStrategyCreate = () => {
                     featureId,
                     environmentId,
                     payload,
-                    unleashUrl
+                    unleashUrl,
                 )
             }
         >
@@ -220,7 +220,7 @@ export const formatCreateStrategyPath = (
     featureId: string,
     environmentId: string,
     strategyName: string,
-    defaultStrategy: boolean = false
+    defaultStrategy: boolean = false,
 ): string => {
     const params = new URLSearchParams({
         environmentId,
@@ -236,10 +236,10 @@ export const formatAddStrategyApiCode = (
     featureId: string,
     environmentId: string,
     strategy: Partial<IFeatureStrategy>,
-    unleashUrl?: string
+    unleashUrl?: string,
 ): string => {
     if (!unleashUrl) {
-        return "";
+        return '';
     }
 
     const url = `${unleashUrl}/api/admin/projects/${projectId}/features/${featureId}/environments/${environmentId}/strategies`;

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
@@ -1,50 +1,50 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
-import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
-import FormTemplate from 'component/common/FormTemplate/FormTemplate';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
-import { formatUnknownError } from 'utils/formatUnknownError';
-import { useNavigate } from 'react-router-dom';
-import useToast from 'hooks/useToast';
-import { IFeatureStrategy, IFeatureStrategyPayload } from 'interfaces/strategy';
+import React, { useEffect, useRef, useState } from "react";
+import { useRequiredPathParam } from "hooks/useRequiredPathParam";
+import { useRequiredQueryParam } from "hooks/useRequiredQueryParam";
+import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
+import FormTemplate from "component/common/FormTemplate/FormTemplate";
+import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
+import useFeatureStrategyApi from "hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi";
+import { formatUnknownError } from "utils/formatUnknownError";
+import { useNavigate } from "react-router-dom";
+import useToast from "hooks/useToast";
+import { IFeatureStrategy, IFeatureStrategyPayload } from "interfaces/strategy";
 import {
     createStrategyPayload,
     featureStrategyDocsLink,
     featureStrategyDocsLinkLabel,
     featureStrategyHelp,
     formatFeaturePath,
-} from '../FeatureStrategyEdit/FeatureStrategyEdit';
-import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
-import { ISegment } from 'interfaces/segment';
-import { formatStrategyName } from 'utils/strategyNames';
-import { useFormErrors } from 'hooks/useFormErrors';
-import { createFeatureStrategy } from 'utils/createFeatureStrategy';
-import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
-import { useCollaborateData } from 'hooks/useCollaborateData';
-import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
-import { IFeatureToggle } from 'interfaces/featureToggle';
-import { comparisonModerator } from '../featureStrategy.utils';
-import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
-import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
-import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
-import useQueryParams from 'hooks/useQueryParams';
-import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
-import { useDefaultStrategy } from '../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
-import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
+} from "../FeatureStrategyEdit/FeatureStrategyEdit";
+import { CREATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
+import { ISegment } from "interfaces/segment";
+import { formatStrategyName } from "utils/strategyNames";
+import { useFormErrors } from "hooks/useFormErrors";
+import { createFeatureStrategy } from "utils/createFeatureStrategy";
+import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
+import { useCollaborateData } from "hooks/useCollaborateData";
+import { useFeature } from "hooks/api/getters/useFeature/useFeature";
+import { IFeatureToggle } from "interfaces/featureToggle";
+import { comparisonModerator } from "../featureStrategy.utils";
+import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
+import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
+import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
+import { usePlausibleTracker } from "hooks/usePlausibleTracker";
+import useQueryParams from "hooks/useQueryParams";
+import { useSegments } from "hooks/api/getters/useSegments/useSegments";
+import { useDefaultStrategy } from "../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy";
+import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
 
 export const NewFeatureStrategyCreate = () => {
     const [tab, setTab] = useState(0);
-    const projectId = useRequiredPathParam('projectId');
-    const featureId = useRequiredPathParam('featureId');
-    const environmentId = useRequiredQueryParam('environmentId');
-    const strategyName = useRequiredQueryParam('strategyName');
+    const projectId = useRequiredPathParam("projectId");
+    const featureId = useRequiredPathParam("featureId");
+    const environmentId = useRequiredQueryParam("environmentId");
+    const strategyName = useRequiredQueryParam("strategyName");
     const { strategy: defaultStrategy, defaultStrategyFallback } =
         useDefaultStrategy(projectId, environmentId);
     const shouldUseDefaultStrategy: boolean = JSON.parse(
-        useQueryParams().get('defaultStrategy') || 'false',
+        useQueryParams().get("defaultStrategy") || "false"
     );
 
     const { segments: allSegments } = useSegments();
@@ -55,7 +55,7 @@ export const NewFeatureStrategyCreate = () => {
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>({});
 
     const [segments, setSegments] = useState<ISegment[]>(
-        shouldUseDefaultStrategy ? strategySegments : [],
+        shouldUseDefaultStrategy ? strategySegments : []
     );
     const { strategyDefinition } = useStrategy(strategyName);
     const errors = useFormErrors();
@@ -79,19 +79,19 @@ export const NewFeatureStrategyCreate = () => {
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: 'feature',
-                refetchFunctionKey: 'refetchFeature',
+                dataKey: "feature",
+                refetchFunctionKey: "refetchFeature",
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator,
+            comparisonModerator
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (ref.current.name === "" && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -100,7 +100,7 @@ export const NewFeatureStrategyCreate = () => {
     useEffect(() => {
         if (shouldUseDefaultStrategy) {
             const strategyTemplate = defaultStrategy || defaultStrategyFallback;
-            if (strategyTemplate.parameters?.groupId === '' && featureId) {
+            if (strategyTemplate.parameters?.groupId === "" && featureId) {
                 setStrategy({
                     ...strategyTemplate,
                     parameters: {
@@ -125,26 +125,26 @@ export const NewFeatureStrategyCreate = () => {
             projectId,
             featureId,
             environmentId,
-            payload,
+            payload
         );
 
         setToastData({
-            title: 'Strategy created',
-            type: 'success',
+            title: "Strategy created",
+            type: "success",
             confetti: true,
         });
     };
 
     const onStrategyRequestAdd = async (payload: IFeatureStrategyPayload) => {
         await addChange(projectId, environmentId, {
-            action: 'addStrategy',
+            action: "addStrategy",
             feature: featureId,
             payload,
         });
         // FIXME: segments in change requests
         setToastData({
-            title: 'Strategy added to draft',
-            type: 'success',
+            title: "Strategy added to draft",
+            type: "success",
             confetti: true,
         });
         refetchChangeRequests();
@@ -153,10 +153,10 @@ export const NewFeatureStrategyCreate = () => {
     const payload = createStrategyPayload(strategy, segments);
 
     const onSubmit = async () => {
-        trackEvent('strategyTitle', {
+        trackEvent("strategyTitle", {
             props: {
                 hasTitle: Boolean(strategy.title),
-                on: 'create',
+                on: "create",
             },
         });
 
@@ -184,13 +184,14 @@ export const NewFeatureStrategyCreate = () => {
             description={featureStrategyHelp}
             documentationLink={featureStrategyDocsLink}
             documentationLinkLabel={featureStrategyDocsLinkLabel}
+            disablePadding
             formatApiCode={() =>
                 formatAddStrategyApiCode(
                     projectId,
                     featureId,
                     environmentId,
                     payload,
-                    unleashUrl,
+                    unleashUrl
                 )
             }
         >
@@ -220,7 +221,7 @@ export const formatCreateStrategyPath = (
     featureId: string,
     environmentId: string,
     strategyName: string,
-    defaultStrategy: boolean = false,
+    defaultStrategy: boolean = false
 ): string => {
     const params = new URLSearchParams({
         environmentId,
@@ -236,10 +237,10 @@ export const formatAddStrategyApiCode = (
     featureId: string,
     environmentId: string,
     strategy: Partial<IFeatureStrategy>,
-    unleashUrl?: string,
+    unleashUrl?: string
 ): string => {
     if (!unleashUrl) {
-        return '';
+        return "";
     }
 
     const url = `${unleashUrl}/api/admin/projects/${projectId}/features/${featureId}/environments/${environmentId}/strategies`;

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
@@ -1,70 +1,70 @@
-import { useEffect, useRef, useState } from 'react';
-import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
-import FormTemplate from 'component/common/FormTemplate/FormTemplate';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
-import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
-import { formatUnknownError } from 'utils/formatUnknownError';
-import { useNavigate } from 'react-router-dom';
-import useToast from 'hooks/useToast';
+import { useEffect, useRef, useState } from "react";
+import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
+import FormTemplate from "component/common/FormTemplate/FormTemplate";
+import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
+import { useRequiredQueryParam } from "hooks/useRequiredQueryParam";
+import { useRequiredPathParam } from "hooks/useRequiredPathParam";
+import useFeatureStrategyApi from "hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi";
+import { formatUnknownError } from "utils/formatUnknownError";
+import { useNavigate } from "react-router-dom";
+import useToast from "hooks/useToast";
 import {
     IFeatureStrategy,
     IFeatureStrategyPayload,
     IStrategy,
-} from 'interfaces/strategy';
-import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
-import { ISegment } from 'interfaces/segment';
-import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
-import { formatStrategyName } from 'utils/strategyNames';
-import { useFormErrors } from 'hooks/useFormErrors';
-import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
-import { sortStrategyParameters } from 'utils/sortStrategyParameters';
-import { useCollaborateData } from 'hooks/useCollaborateData';
-import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
-import { IFeatureToggle } from 'interfaces/featureToggle';
-import { comparisonModerator } from '../featureStrategy.utils';
-import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
-import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
-import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
-import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
+} from "interfaces/strategy";
+import { UPDATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
+import { ISegment } from "interfaces/segment";
+import { useSegments } from "hooks/api/getters/useSegments/useSegments";
+import { formatStrategyName } from "utils/strategyNames";
+import { useFormErrors } from "hooks/useFormErrors";
+import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
+import { sortStrategyParameters } from "utils/sortStrategyParameters";
+import { useCollaborateData } from "hooks/useCollaborateData";
+import { useFeature } from "hooks/api/getters/useFeature/useFeature";
+import { IFeatureToggle } from "interfaces/featureToggle";
+import { comparisonModerator } from "../featureStrategy.utils";
+import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
+import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
+import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
+import { usePlausibleTracker } from "hooks/usePlausibleTracker";
+import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
 
 const useTitleTracking = () => {
-    const [previousTitle, setPreviousTitle] = useState<string>('');
+    const [previousTitle, setPreviousTitle] = useState<string>("");
     const { trackEvent } = usePlausibleTracker();
 
-    const trackTitle = (title: string = '') => {
+    const trackTitle = (title: string = "") => {
         // don't expose the title, just if it was added, removed, or edited
         if (title === previousTitle) {
-            trackEvent('strategyTitle', {
+            trackEvent("strategyTitle", {
                 props: {
-                    action: 'none',
-                    on: 'edit',
+                    action: "none",
+                    on: "edit",
                 },
             });
         }
-        if (previousTitle === '' && title !== '') {
-            trackEvent('strategyTitle', {
+        if (previousTitle === "" && title !== "") {
+            trackEvent("strategyTitle", {
                 props: {
-                    action: 'added',
-                    on: 'edit',
+                    action: "added",
+                    on: "edit",
                 },
             });
         }
-        if (previousTitle !== '' && title === '') {
-            trackEvent('strategyTitle', {
+        if (previousTitle !== "" && title === "") {
+            trackEvent("strategyTitle", {
                 props: {
-                    action: 'removed',
-                    on: 'edit',
+                    action: "removed",
+                    on: "edit",
                 },
             });
         }
-        if (previousTitle !== '' && title !== '' && title !== previousTitle) {
-            trackEvent('strategyTitle', {
+        if (previousTitle !== "" && title !== "" && title !== previousTitle) {
+            trackEvent("strategyTitle", {
                 props: {
-                    action: 'edited',
-                    on: 'edit',
+                    action: "edited",
+                    on: "edit",
                 },
             });
         }
@@ -77,10 +77,10 @@ const useTitleTracking = () => {
 };
 
 export const NewFeatureStrategyEdit = () => {
-    const projectId = useRequiredPathParam('projectId');
-    const featureId = useRequiredPathParam('featureId');
-    const environmentId = useRequiredQueryParam('environmentId');
-    const strategyId = useRequiredQueryParam('strategyId');
+    const projectId = useRequiredPathParam("projectId");
+    const featureId = useRequiredPathParam("featureId");
+    const environmentId = useRequiredQueryParam("environmentId");
+    const strategyId = useRequiredQueryParam("strategyId");
     const [tab, setTab] = useState(0);
 
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>({});
@@ -107,19 +107,19 @@ export const NewFeatureStrategyEdit = () => {
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: 'feature',
-                refetchFunctionKey: 'refetchFeature',
+                dataKey: "feature",
+                refetchFunctionKey: "refetchFeature",
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator,
+            comparisonModerator
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (ref.current.name === "" && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -135,7 +135,7 @@ export const NewFeatureStrategyEdit = () => {
             .flatMap((environment) => environment.strategies)
             .find((strategy) => strategy.id === strategyId);
         setStrategy((prev) => ({ ...prev, ...savedStrategy }));
-        setPreviousTitle(savedStrategy?.title || '');
+        setPreviousTitle(savedStrategy?.title || "");
     }, [strategyId, data]);
 
     useEffect(() => {
@@ -151,27 +151,27 @@ export const NewFeatureStrategyEdit = () => {
             featureId,
             environmentId,
             strategyId,
-            payload,
+            payload
         );
 
         await refetchSavedStrategySegments();
         setToastData({
-            title: 'Strategy updated',
-            type: 'success',
+            title: "Strategy updated",
+            type: "success",
             confetti: true,
         });
     };
 
     const onStrategyRequestEdit = async (payload: IFeatureStrategyPayload) => {
         await addChange(projectId, environmentId, {
-            action: 'updateStrategy',
+            action: "updateStrategy",
             feature: featureId,
             payload: { ...payload, id: strategyId },
         });
         // FIXME: segments in change requests
         setToastData({
-            title: 'Change added to draft',
-            type: 'success',
+            title: "Change added to draft",
+            type: "success",
             confetti: true,
         });
         refetchChangeRequests();
@@ -200,7 +200,8 @@ export const NewFeatureStrategyEdit = () => {
     return (
         <FormTemplate
             modal
-            title={formatStrategyName(strategy.name ?? '')}
+            disablePadding
+            title={formatStrategyName(strategy.name ?? "")}
             description={featureStrategyHelp}
             documentationLink={featureStrategyDocsLink}
             documentationLinkLabel={featureStrategyDocsLinkLabel}
@@ -212,7 +213,7 @@ export const NewFeatureStrategyEdit = () => {
                     strategyId,
                     payload,
                     strategyDefinition,
-                    unleashUrl,
+                    unleashUrl
                 )
             }
         >
@@ -239,7 +240,7 @@ export const NewFeatureStrategyEdit = () => {
 
 export const createStrategyPayload = (
     strategy: Partial<IFeatureStrategy>,
-    segments: ISegment[],
+    segments: ISegment[]
 ): IFeatureStrategyPayload => ({
     name: strategy.name,
     title: strategy.title,
@@ -252,7 +253,7 @@ export const createStrategyPayload = (
 
 export const formatFeaturePath = (
     projectId: string,
-    featureId: string,
+    featureId: string
 ): string => {
     return `/projects/${projectId}/features/${featureId}`;
 };
@@ -261,7 +262,7 @@ export const formatEditStrategyPath = (
     projectId: string,
     featureId: string,
     environmentId: string,
-    strategyId: string,
+    strategyId: string
 ): string => {
     const params = new URLSearchParams({ environmentId, strategyId });
 
@@ -275,10 +276,10 @@ export const formatUpdateStrategyApiCode = (
     strategyId: string,
     strategy: Partial<IFeatureStrategy>,
     strategyDefinition: IStrategy,
-    unleashUrl?: string,
+    unleashUrl?: string
 ): string => {
     if (!unleashUrl) {
-        return '';
+        return "";
     }
 
     // Sort the strategy parameters payload so that they match
@@ -287,7 +288,7 @@ export const formatUpdateStrategyApiCode = (
         ...strategy,
         parameters: sortStrategyParameters(
             strategy.parameters ?? {},
-            strategyDefinition,
+            strategyDefinition
         ),
     };
 
@@ -306,6 +307,6 @@ export const featureStrategyHelp = `
 `;
 
 export const featureStrategyDocsLink =
-    'https://docs.getunleash.io/reference/activation-strategies';
+    "https://docs.getunleash.io/reference/activation-strategies";
 
-export const featureStrategyDocsLinkLabel = 'Strategies documentation';
+export const featureStrategyDocsLinkLabel = "Strategies documentation";

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
@@ -1,70 +1,70 @@
-import { useEffect, useRef, useState } from "react";
-import { FeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm";
-import FormTemplate from "component/common/FormTemplate/FormTemplate";
-import useUiConfig from "hooks/api/getters/useUiConfig/useUiConfig";
-import { useRequiredQueryParam } from "hooks/useRequiredQueryParam";
-import { useRequiredPathParam } from "hooks/useRequiredPathParam";
-import useFeatureStrategyApi from "hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi";
-import { formatUnknownError } from "utils/formatUnknownError";
-import { useNavigate } from "react-router-dom";
-import useToast from "hooks/useToast";
+import { useEffect, useRef, useState } from 'react';
+import { FeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm';
+import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useNavigate } from 'react-router-dom';
+import useToast from 'hooks/useToast';
 import {
     IFeatureStrategy,
     IFeatureStrategyPayload,
     IStrategy,
-} from "interfaces/strategy";
-import { UPDATE_FEATURE_STRATEGY } from "component/providers/AccessProvider/permissions";
-import { ISegment } from "interfaces/segment";
-import { useSegments } from "hooks/api/getters/useSegments/useSegments";
-import { formatStrategyName } from "utils/strategyNames";
-import { useFormErrors } from "hooks/useFormErrors";
-import { useStrategy } from "hooks/api/getters/useStrategy/useStrategy";
-import { sortStrategyParameters } from "utils/sortStrategyParameters";
-import { useCollaborateData } from "hooks/useCollaborateData";
-import { useFeature } from "hooks/api/getters/useFeature/useFeature";
-import { IFeatureToggle } from "interfaces/featureToggle";
-import { comparisonModerator } from "../featureStrategy.utils";
-import { useChangeRequestsEnabled } from "hooks/useChangeRequestsEnabled";
-import { useChangeRequestApi } from "hooks/api/actions/useChangeRequestApi/useChangeRequestApi";
-import { usePendingChangeRequests } from "hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests";
-import { usePlausibleTracker } from "hooks/usePlausibleTracker";
-import { NewFeatureStrategyForm } from "component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm";
+} from 'interfaces/strategy';
+import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { ISegment } from 'interfaces/segment';
+import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
+import { formatStrategyName } from 'utils/strategyNames';
+import { useFormErrors } from 'hooks/useFormErrors';
+import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
+import { sortStrategyParameters } from 'utils/sortStrategyParameters';
+import { useCollaborateData } from 'hooks/useCollaborateData';
+import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
+import { IFeatureToggle } from 'interfaces/featureToggle';
+import { comparisonModerator } from '../featureStrategy.utils';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
+import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
 
 const useTitleTracking = () => {
-    const [previousTitle, setPreviousTitle] = useState<string>("");
+    const [previousTitle, setPreviousTitle] = useState<string>('');
     const { trackEvent } = usePlausibleTracker();
 
-    const trackTitle = (title: string = "") => {
+    const trackTitle = (title: string = '') => {
         // don't expose the title, just if it was added, removed, or edited
         if (title === previousTitle) {
-            trackEvent("strategyTitle", {
+            trackEvent('strategyTitle', {
                 props: {
-                    action: "none",
-                    on: "edit",
+                    action: 'none',
+                    on: 'edit',
                 },
             });
         }
-        if (previousTitle === "" && title !== "") {
-            trackEvent("strategyTitle", {
+        if (previousTitle === '' && title !== '') {
+            trackEvent('strategyTitle', {
                 props: {
-                    action: "added",
-                    on: "edit",
+                    action: 'added',
+                    on: 'edit',
                 },
             });
         }
-        if (previousTitle !== "" && title === "") {
-            trackEvent("strategyTitle", {
+        if (previousTitle !== '' && title === '') {
+            trackEvent('strategyTitle', {
                 props: {
-                    action: "removed",
-                    on: "edit",
+                    action: 'removed',
+                    on: 'edit',
                 },
             });
         }
-        if (previousTitle !== "" && title !== "" && title !== previousTitle) {
-            trackEvent("strategyTitle", {
+        if (previousTitle !== '' && title !== '' && title !== previousTitle) {
+            trackEvent('strategyTitle', {
                 props: {
-                    action: "edited",
-                    on: "edit",
+                    action: 'edited',
+                    on: 'edit',
                 },
             });
         }
@@ -77,10 +77,10 @@ const useTitleTracking = () => {
 };
 
 export const NewFeatureStrategyEdit = () => {
-    const projectId = useRequiredPathParam("projectId");
-    const featureId = useRequiredPathParam("featureId");
-    const environmentId = useRequiredQueryParam("environmentId");
-    const strategyId = useRequiredQueryParam("strategyId");
+    const projectId = useRequiredPathParam('projectId');
+    const featureId = useRequiredPathParam('featureId');
+    const environmentId = useRequiredQueryParam('environmentId');
+    const strategyId = useRequiredQueryParam('strategyId');
     const [tab, setTab] = useState(0);
 
     const [strategy, setStrategy] = useState<Partial<IFeatureStrategy>>({});
@@ -107,19 +107,19 @@ export const NewFeatureStrategyEdit = () => {
             {
                 unleashGetter: useFeature,
                 params: [projectId, featureId],
-                dataKey: "feature",
-                refetchFunctionKey: "refetchFeature",
+                dataKey: 'feature',
+                refetchFunctionKey: 'refetchFeature',
                 options: {},
             },
             feature,
             {
                 afterSubmitAction: refetchFeature,
             },
-            comparisonModerator
+            comparisonModerator,
         );
 
     useEffect(() => {
-        if (ref.current.name === "" && feature.name) {
+        if (ref.current.name === '' && feature.name) {
             forceRefreshCache(feature);
             ref.current = feature;
         }
@@ -135,7 +135,7 @@ export const NewFeatureStrategyEdit = () => {
             .flatMap((environment) => environment.strategies)
             .find((strategy) => strategy.id === strategyId);
         setStrategy((prev) => ({ ...prev, ...savedStrategy }));
-        setPreviousTitle(savedStrategy?.title || "");
+        setPreviousTitle(savedStrategy?.title || '');
     }, [strategyId, data]);
 
     useEffect(() => {
@@ -151,27 +151,27 @@ export const NewFeatureStrategyEdit = () => {
             featureId,
             environmentId,
             strategyId,
-            payload
+            payload,
         );
 
         await refetchSavedStrategySegments();
         setToastData({
-            title: "Strategy updated",
-            type: "success",
+            title: 'Strategy updated',
+            type: 'success',
             confetti: true,
         });
     };
 
     const onStrategyRequestEdit = async (payload: IFeatureStrategyPayload) => {
         await addChange(projectId, environmentId, {
-            action: "updateStrategy",
+            action: 'updateStrategy',
             feature: featureId,
             payload: { ...payload, id: strategyId },
         });
         // FIXME: segments in change requests
         setToastData({
-            title: "Change added to draft",
-            type: "success",
+            title: 'Change added to draft',
+            type: 'success',
             confetti: true,
         });
         refetchChangeRequests();
@@ -212,7 +212,7 @@ export const NewFeatureStrategyEdit = () => {
                     strategyId,
                     payload,
                     strategyDefinition,
-                    unleashUrl
+                    unleashUrl,
                 )
             }
         >
@@ -239,7 +239,7 @@ export const NewFeatureStrategyEdit = () => {
 
 export const createStrategyPayload = (
     strategy: Partial<IFeatureStrategy>,
-    segments: ISegment[]
+    segments: ISegment[],
 ): IFeatureStrategyPayload => ({
     name: strategy.name,
     title: strategy.title,
@@ -252,7 +252,7 @@ export const createStrategyPayload = (
 
 export const formatFeaturePath = (
     projectId: string,
-    featureId: string
+    featureId: string,
 ): string => {
     return `/projects/${projectId}/features/${featureId}`;
 };
@@ -261,7 +261,7 @@ export const formatEditStrategyPath = (
     projectId: string,
     featureId: string,
     environmentId: string,
-    strategyId: string
+    strategyId: string,
 ): string => {
     const params = new URLSearchParams({ environmentId, strategyId });
 
@@ -275,10 +275,10 @@ export const formatUpdateStrategyApiCode = (
     strategyId: string,
     strategy: Partial<IFeatureStrategy>,
     strategyDefinition: IStrategy,
-    unleashUrl?: string
+    unleashUrl?: string,
 ): string => {
     if (!unleashUrl) {
-        return "";
+        return '';
     }
 
     // Sort the strategy parameters payload so that they match
@@ -287,7 +287,7 @@ export const formatUpdateStrategyApiCode = (
         ...strategy,
         parameters: sortStrategyParameters(
             strategy.parameters ?? {},
-            strategyDefinition
+            strategyDefinition,
         ),
     };
 
@@ -306,6 +306,6 @@ export const featureStrategyHelp = `
 `;
 
 export const featureStrategyDocsLink =
-    "https://docs.getunleash.io/reference/activation-strategies";
+    'https://docs.getunleash.io/reference/activation-strategies';
 
-export const featureStrategyDocsLinkLabel = "Strategies documentation";
+export const featureStrategyDocsLinkLabel = 'Strategies documentation';

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
@@ -201,7 +201,6 @@ export const NewFeatureStrategyEdit = () => {
         <FormTemplate
             modal
             disablePadding
-            title={formatStrategyName(strategy.name ?? "")}
             description={featureStrategyHelp}
             documentationLink={featureStrategyDocsLink}
             documentationLinkLabel={featureStrategyDocsLinkLabel}

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -1,22 +1,36 @@
-import { VariantForm } from '../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm';
-import { updateWeightEdit } from '../../common/util';
-import React, { FC, useEffect, useState } from 'react';
-import { IFeatureVariantEdit } from '../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal';
-import PermissionButton from '../../common/PermissionButton/PermissionButton';
-import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from '../../providers/AccessProvider/permissions';
-import { v4 as uuidv4 } from 'uuid';
-import { WeightType } from '../../../constants/variantTypes';
-import { Link, styled, Typography, useTheme } from '@mui/material';
-import { IFeatureStrategy } from 'interfaces/strategy';
-import SplitPreviewSlider from './SplitPreviewSlider/SplitPreviewSlider';
-import { HelpIcon } from '../../common/HelpIcon/HelpIcon';
-import { StrategyVariantsUpgradeAlert } from '../../common/StrategyVariantsUpgradeAlert/StrategyVariantsUpgradeAlert';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { VariantForm } from "../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm";
+import { updateWeightEdit } from "../../common/util";
+import React, { FC, useEffect, useState } from "react";
+import { IFeatureVariantEdit } from "../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal";
+import PermissionButton from "../../common/PermissionButton/PermissionButton";
+import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from "../../providers/AccessProvider/permissions";
+import { v4 as uuidv4 } from "uuid";
+import { WeightType } from "../../../constants/variantTypes";
+import { Box, Link, styled, Typography, useTheme } from "@mui/material";
+import { IFeatureStrategy } from "interfaces/strategy";
+import SplitPreviewSlider from "./SplitPreviewSlider/SplitPreviewSlider";
+import { HelpIcon } from "../../common/HelpIcon/HelpIcon";
+import { StrategyVariantsUpgradeAlert } from "../../common/StrategyVariantsUpgradeAlert/StrategyVariantsUpgradeAlert";
+import { usePlausibleTracker } from "hooks/usePlausibleTracker";
+import { useUiFlag } from "hooks/useUiFlag";
+import { Add } from "@mui/icons-material";
 
-const StyledVariantForms = styled('div')({
-    display: 'flex',
-    flexDirection: 'column',
+const StyledVariantForms = styled("div")({
+    display: "flex",
+    flexDirection: "column",
 });
+
+const StyledHelpIconBox = styled(Box)(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+}));
+
+const StyledVariantsHeader = styled("div")(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    marginTop: theme.spacing(1.5),
+}));
 
 export const StrategyVariants: FC<{
     setStrategy: React.Dispatch<
@@ -29,10 +43,12 @@ export const StrategyVariants: FC<{
     const { trackEvent } = usePlausibleTracker();
     const [variantsEdit, setVariantsEdit] = useState<IFeatureVariantEdit[]>([]);
     const theme = useTheme();
+    const newStrategyConfiguration = useUiFlag("newStrategyConfiguration");
+
     const stickiness =
-        strategy?.parameters && 'stickiness' in strategy?.parameters
+        strategy?.parameters && "stickiness" in strategy?.parameters
             ? String(strategy.parameters.stickiness)
-            : 'default';
+            : "default";
 
     useEffect(() => {
         setVariantsEdit(
@@ -42,7 +58,7 @@ export const StrategyVariants: FC<{
                 isValid: true,
                 id: uuidv4(),
                 overrides: [],
-            })),
+            }))
         );
     }, []);
 
@@ -63,10 +79,10 @@ export const StrategyVariants: FC<{
         setVariantsEdit((prevVariants) =>
             updateWeightEdit(
                 prevVariants.map((prevVariant) =>
-                    prevVariant.id === id ? updatedVariant : prevVariant,
+                    prevVariant.id === id ? updatedVariant : prevVariant
                 ),
-                1000,
-            ),
+                1000
+            )
         );
     };
 
@@ -75,7 +91,7 @@ export const StrategyVariants: FC<{
         setVariantsEdit((variantsEdit) => [
             ...variantsEdit,
             {
-                name: '',
+                name: "",
                 weightType: WeightType.VARIABLE,
                 weight: 0,
                 stickiness,
@@ -84,19 +100,99 @@ export const StrategyVariants: FC<{
                 id,
             },
         ]);
-        trackEvent('strategy-variants', {
+        trackEvent("strategy-variants", {
             props: {
-                eventType: 'variant added',
+                eventType: "variant added",
             },
         });
     };
 
+    if (newStrategyConfiguration) {
+        return (
+            <>
+                <StyledVariantsHeader>
+                    Variants enhance a feature flag by providing a version of
+                    the feature to be enabled
+                </StyledVariantsHeader>
+                <StyledHelpIconBox>
+                    <Typography>Variants</Typography>
+                    <HelpIcon
+                        htmlTooltip
+                        tooltip={
+                            <Box>
+                                <Typography variant="body2">
+                                    Variants in feature toggling allow you to
+                                    serve different versions of a feature to
+                                    different users. This can be used for A/B
+                                    testing, gradual rollouts, and canary
+                                    releases. Variants provide a way to control
+                                    the user experience at a granular level,
+                                    enabling you to test and optimize different
+                                    aspects of your features. Read more about
+                                    variants{" "}
+                                    <a
+                                        href="https://docs.getunleash.io/reference/strategy-variants"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        here
+                                    </a>
+                                </Typography>
+                            </Box>
+                        }
+                    />
+                </StyledHelpIconBox>
+                <StyledVariantForms>
+                    <StrategyVariantsUpgradeAlert />
+                    {variantsEdit.map((variant, i) => (
+                        <VariantForm
+                            disableOverrides={true}
+                            key={variant.id}
+                            variant={variant}
+                            variants={variantsEdit}
+                            updateVariant={(updatedVariant) =>
+                                updateVariant(updatedVariant, variant.id)
+                            }
+                            removeVariant={() =>
+                                setVariantsEdit((variantsEdit) =>
+                                    updateWeightEdit(
+                                        variantsEdit.filter(
+                                            (v) => v.id !== variant.id
+                                        ),
+                                        1000
+                                    )
+                                )
+                            }
+                            decorationColor={
+                                theme.palette.variants[
+                                    i % theme.palette.variants.length
+                                ]
+                            }
+                        />
+                    ))}
+                </StyledVariantForms>
+                <PermissionButton
+                    onClick={addVariant}
+                    variant="outlined"
+                    permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
+                    projectId={projectId}
+                    environmentId={environment}
+                    data-testid="ADD_STRATEGY_VARIANT_BUTTON"
+                    startIcon={<Add />}
+                >
+                    Add variant
+                </PermissionButton>
+                <SplitPreviewSlider variants={variantsEdit} />
+            </>
+        );
+    }
+
     return (
         <>
             <Typography
-                component='h3'
-                sx={{ m: 0, display: 'flex', gap: '1ch' }}
-                variant='h3'
+                component="h3"
+                sx={{ m: 0, display: "flex", gap: "1ch" }}
+                variant="h3"
             >
                 Variants
                 <HelpIcon
@@ -109,8 +205,8 @@ export const StrategyVariants: FC<{
                                 override variants at the feature level.
                             </span>
                             <Link
-                                target='_blank'
-                                href='https://docs.getunleash.io/reference/strategy-variants'
+                                target="_blank"
+                                href="https://docs.getunleash.io/reference/strategy-variants"
                             >
                                 Learn more
                             </Link>
@@ -133,10 +229,10 @@ export const StrategyVariants: FC<{
                             setVariantsEdit((variantsEdit) =>
                                 updateWeightEdit(
                                     variantsEdit.filter(
-                                        (v) => v.id !== variant.id,
+                                        (v) => v.id !== variant.id
                                     ),
-                                    1000,
-                                ),
+                                    1000
+                                )
                             )
                         }
                         decorationColor={
@@ -149,11 +245,11 @@ export const StrategyVariants: FC<{
             </StyledVariantForms>
             <PermissionButton
                 onClick={addVariant}
-                variant='outlined'
+                variant="outlined"
                 permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
                 projectId={projectId}
                 environmentId={environment}
-                data-testid='ADD_STRATEGY_VARIANT_BUTTON'
+                data-testid="ADD_STRATEGY_VARIANT_BUTTON"
             >
                 Add variant
             </PermissionButton>

--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -1,33 +1,33 @@
-import { VariantForm } from "../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm";
-import { updateWeightEdit } from "../../common/util";
-import React, { FC, useEffect, useState } from "react";
-import { IFeatureVariantEdit } from "../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal";
-import PermissionButton from "../../common/PermissionButton/PermissionButton";
-import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from "../../providers/AccessProvider/permissions";
-import { v4 as uuidv4 } from "uuid";
-import { WeightType } from "../../../constants/variantTypes";
-import { Box, Link, styled, Typography, useTheme } from "@mui/material";
-import { IFeatureStrategy } from "interfaces/strategy";
-import SplitPreviewSlider from "./SplitPreviewSlider/SplitPreviewSlider";
-import { HelpIcon } from "../../common/HelpIcon/HelpIcon";
-import { StrategyVariantsUpgradeAlert } from "../../common/StrategyVariantsUpgradeAlert/StrategyVariantsUpgradeAlert";
-import { usePlausibleTracker } from "hooks/usePlausibleTracker";
-import { useUiFlag } from "hooks/useUiFlag";
-import { Add } from "@mui/icons-material";
+import { VariantForm } from '../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm';
+import { updateWeightEdit } from '../../common/util';
+import React, { FC, useEffect, useState } from 'react';
+import { IFeatureVariantEdit } from '../FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/EnvironmentVariantsModal';
+import PermissionButton from '../../common/PermissionButton/PermissionButton';
+import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from '../../providers/AccessProvider/permissions';
+import { v4 as uuidv4 } from 'uuid';
+import { WeightType } from '../../../constants/variantTypes';
+import { Box, Link, styled, Typography, useTheme } from '@mui/material';
+import { IFeatureStrategy } from 'interfaces/strategy';
+import SplitPreviewSlider from './SplitPreviewSlider/SplitPreviewSlider';
+import { HelpIcon } from '../../common/HelpIcon/HelpIcon';
+import { StrategyVariantsUpgradeAlert } from '../../common/StrategyVariantsUpgradeAlert/StrategyVariantsUpgradeAlert';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { Add } from '@mui/icons-material';
 
-const StyledVariantForms = styled("div")({
-    display: "flex",
-    flexDirection: "column",
+const StyledVariantForms = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
 });
 
 const StyledHelpIconBox = styled(Box)(({ theme }) => ({
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(1),
 }));
 
-const StyledVariantsHeader = styled("div")(({ theme }) => ({
+const StyledVariantsHeader = styled('div')(({ theme }) => ({
     color: theme.palette.text.secondary,
     marginTop: theme.spacing(1.5),
 }));
@@ -43,12 +43,12 @@ export const StrategyVariants: FC<{
     const { trackEvent } = usePlausibleTracker();
     const [variantsEdit, setVariantsEdit] = useState<IFeatureVariantEdit[]>([]);
     const theme = useTheme();
-    const newStrategyConfiguration = useUiFlag("newStrategyConfiguration");
+    const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
 
     const stickiness =
-        strategy?.parameters && "stickiness" in strategy?.parameters
+        strategy?.parameters && 'stickiness' in strategy?.parameters
             ? String(strategy.parameters.stickiness)
-            : "default";
+            : 'default';
 
     useEffect(() => {
         setVariantsEdit(
@@ -58,7 +58,7 @@ export const StrategyVariants: FC<{
                 isValid: true,
                 id: uuidv4(),
                 overrides: [],
-            }))
+            })),
         );
     }, []);
 
@@ -79,10 +79,10 @@ export const StrategyVariants: FC<{
         setVariantsEdit((prevVariants) =>
             updateWeightEdit(
                 prevVariants.map((prevVariant) =>
-                    prevVariant.id === id ? updatedVariant : prevVariant
+                    prevVariant.id === id ? updatedVariant : prevVariant,
                 ),
-                1000
-            )
+                1000,
+            ),
         );
     };
 
@@ -91,7 +91,7 @@ export const StrategyVariants: FC<{
         setVariantsEdit((variantsEdit) => [
             ...variantsEdit,
             {
-                name: "",
+                name: '',
                 weightType: WeightType.VARIABLE,
                 weight: 0,
                 stickiness,
@@ -100,9 +100,9 @@ export const StrategyVariants: FC<{
                 id,
             },
         ]);
-        trackEvent("strategy-variants", {
+        trackEvent('strategy-variants', {
             props: {
-                eventType: "variant added",
+                eventType: 'variant added',
             },
         });
     };
@@ -120,7 +120,7 @@ export const StrategyVariants: FC<{
                         htmlTooltip
                         tooltip={
                             <Box>
-                                <Typography variant="body2">
+                                <Typography variant='body2'>
                                     Variants in feature toggling allow you to
                                     serve different versions of a feature to
                                     different users. This can be used for A/B
@@ -129,11 +129,11 @@ export const StrategyVariants: FC<{
                                     the user experience at a granular level,
                                     enabling you to test and optimize different
                                     aspects of your features. Read more about
-                                    variants{" "}
+                                    variants{' '}
                                     <a
-                                        href="https://docs.getunleash.io/reference/strategy-variants"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
+                                        href='https://docs.getunleash.io/reference/strategy-variants'
+                                        target='_blank'
+                                        rel='noopener noreferrer'
                                     >
                                         here
                                     </a>
@@ -157,10 +157,10 @@ export const StrategyVariants: FC<{
                                 setVariantsEdit((variantsEdit) =>
                                     updateWeightEdit(
                                         variantsEdit.filter(
-                                            (v) => v.id !== variant.id
+                                            (v) => v.id !== variant.id,
                                         ),
-                                        1000
-                                    )
+                                        1000,
+                                    ),
                                 )
                             }
                             decorationColor={
@@ -173,11 +173,11 @@ export const StrategyVariants: FC<{
                 </StyledVariantForms>
                 <PermissionButton
                     onClick={addVariant}
-                    variant="outlined"
+                    variant='outlined'
                     permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
                     projectId={projectId}
                     environmentId={environment}
-                    data-testid="ADD_STRATEGY_VARIANT_BUTTON"
+                    data-testid='ADD_STRATEGY_VARIANT_BUTTON'
                     startIcon={<Add />}
                 >
                     Add variant
@@ -190,9 +190,9 @@ export const StrategyVariants: FC<{
     return (
         <>
             <Typography
-                component="h3"
-                sx={{ m: 0, display: "flex", gap: "1ch" }}
-                variant="h3"
+                component='h3'
+                sx={{ m: 0, display: 'flex', gap: '1ch' }}
+                variant='h3'
             >
                 Variants
                 <HelpIcon
@@ -205,8 +205,8 @@ export const StrategyVariants: FC<{
                                 override variants at the feature level.
                             </span>
                             <Link
-                                target="_blank"
-                                href="https://docs.getunleash.io/reference/strategy-variants"
+                                target='_blank'
+                                href='https://docs.getunleash.io/reference/strategy-variants'
                             >
                                 Learn more
                             </Link>
@@ -229,10 +229,10 @@ export const StrategyVariants: FC<{
                             setVariantsEdit((variantsEdit) =>
                                 updateWeightEdit(
                                     variantsEdit.filter(
-                                        (v) => v.id !== variant.id
+                                        (v) => v.id !== variant.id,
                                     ),
-                                    1000
-                                )
+                                    1000,
+                                ),
                             )
                         }
                         decorationColor={
@@ -245,11 +245,11 @@ export const StrategyVariants: FC<{
             </StyledVariantForms>
             <PermissionButton
                 onClick={addVariant}
-                variant="outlined"
+                variant='outlined'
                 permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
                 projectId={projectId}
                 environmentId={environment}
-                data-testid="ADD_STRATEGY_VARIANT_BUTTON"
+                data-testid='ADD_STRATEGY_VARIANT_BUTTON'
             >
                 Add variant
             </PermissionButton>


### PR DESCRIPTION
This PR sets up the variants tab for the new strategy configuration. Also some minor adjustments to the new form:

* Change where padding is controlled to allow us to have more granular control over how the buttons width and border should look and have the tabs have full-width borders across the form
* Move the buttons to be absolutely positioned at the bottom of the page
* Move where we display banners to avoid clutter

<img width="1284" alt="Skjermbilde 2023-12-14 kl  21 17 53" src="https://github.com/Unleash/unleash/assets/16081982/45e6a364-e4aa-47ac-b420-f3be9b39a15e">
