### PR TITLE
fix: make username nullable in user-schema

### DIFF
--- a/src/lib/openapi/spec/user-schema.ts
+++ b/src/lib/openapi/spec/user-schema.ts
@@ -36,6 +36,7 @@ export const userSchema = {
             description: 'A unique username for the user',
             type: 'string',
             example: 'hunter',
+            nullable: true,
         },
         imageUrl: {
             description: `URL used for the userprofile image`,


### PR DESCRIPTION
I noticed I was getting warnings logged in my local instance when
visiting the users page (`/admin/users`)

```json
{
    "schema": "#/components/schemas/publicSignupTokensSchema",
    "errors": [
        {
            "instancePath": "/tokens/0/users/0/username",
            "schemaPath": "#/components/schemas/userSchema/properties/username/type",
            "keyword": "type",
            "params": {
                "type": "string"
            },
            "message": "must be string"
        }
    ]
}
```

It was complaining because one of my users doesn't have a username, so
the value returned from the API was:

```json
{
    "users": [
        {
            "id": 2,
            "name": "2mas",
            "username": null
        }
    ]
}
```

This adjustment fixes that oversight by allowing `null` values for the username.