### PR TITLE
fix: last seen now sorts nulls last

### DIFF
--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -284,7 +284,6 @@ class FeatureSearchStore implements IFeatureSearchStore {
             .joinRaw('CROSS JOIN total_features')
             .whereBetween('final_rank', [offset + 1, offset + limit]);
 
-        console.log(finalQuery.toQuery());
         const rows = await finalQuery;
         stopTimer();
         if (rows.length > 0) {

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1,5 +1,6 @@
 import dbInit, { ITestDb } from '../../../test/e2e/helpers/database-init';
 import {
+    insertLastSeenAt,
     IUnleashTest,
     setupAppWithAuth,
 } from '../../../test/e2e/helpers/test-helper';
@@ -392,6 +393,8 @@ test('should sort features', async () => {
     await app.enableFeature('my_feature_c', 'default');
     await app.favoriteFeature('my_feature_b');
 
+    await insertLastSeenAt('my_feature_c', db.rawDatabase, 'default');
+
     const { body: ascName } = await sortFeatures({
         sortBy: 'name',
         sortOrder: 'asc',
@@ -476,6 +479,20 @@ test('should sort features', async () => {
         ],
         total: 3,
     });
+
+    const { body: lastSeenDescSort } = await sortFeatures({
+        sortBy: 'lastSeenAt',
+        sortOrder: 'asc',
+    });
+
+    expect(lastSeenDescSort).toMatchObject({
+        features: [
+            { name: 'my_feature_c' },
+            { name: 'my_feature_a' },
+            { name: 'my_feature_b' },
+        ],
+        total: 3,
+    });
 });
 
 test('should sort features when feature names are numbers', async () => {
@@ -541,7 +558,7 @@ test('should paginate correctly when using tags', async () => {
     });
 });
 
-test('should not return duplicate entries when sorting by last seen', async () => {
+test('should not return duplicate entries when sorting by environments', async () => {
     await app.createFeature('my_feature_a');
     await app.createFeature('my_feature_b');
     await app.createFeature('my_feature_c');

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -480,7 +480,7 @@ test('should sort features', async () => {
         total: 3,
     });
 
-    const { body: lastSeenDescSort } = await sortFeatures({
+    const { body: lastSeenAscSort } = await sortFeatures({
         sortBy: 'lastSeenAt',
         sortOrder: 'asc',
     });

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -485,7 +485,7 @@ test('should sort features', async () => {
         sortOrder: 'asc',
     });
 
-    expect(lastSeenDescSort).toMatchObject({
+    expect(lastSeenAscSort).toMatchObject({
         features: [
             { name: 'my_feature_c' },
             { name: 'my_feature_a' },


### PR DESCRIPTION
Two changes were needed to sort better

1. Since we are still using `last seen` from `features` table for backwards compatibility, we needed to add it to sort condition.
2. Nulls break the order, so now sorting nulls as last.