### PR TITLE
feat: add plausible tracking to scheduling

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -31,7 +31,7 @@ import {
     ChangeRequestRejectScheduledDialogue,
 } from './ChangeRequestScheduledDialogs/changeRequestScheduledDialogs';
 import { ScheduleChangeRequestDialog } from './ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog';
-import { usePlausibleTracker } from '../../../hooks/usePlausibleTracker';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 const StyledAsideBox = styled(Box)(({ theme }) => ({
     width: '30%',

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -31,7 +31,7 @@ import {
     ChangeRequestRejectScheduledDialogue,
 } from './ChangeRequestScheduledDialogs/changeRequestScheduledDialogs';
 import { ScheduleChangeRequestDialog } from './ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog';
-import { usePlausibleTracker } from "../../../hooks/usePlausibleTracker";
+import { usePlausibleTracker } from '../../../hooks/usePlausibleTracker';
 
 const StyledAsideBox = styled(Box)(({ theme }) => ({
     width: '30%',
@@ -129,9 +129,9 @@ export const ChangeRequestOverview: FC = () => {
             if (hasSchedule) {
                 trackEvent('scheduled-configuration-changes', {
                     props: {
-                        action: 'schedule-applied'
-                    }
-                })
+                        action: 'scheduled-applied',
+                    },
+                });
             }
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -139,7 +139,9 @@ export const ChangeRequestOverview: FC = () => {
     };
 
     const onScheduleChangeRequest = async (scheduledDate: Date) => {
-        const plausibleAction = hasSchedule ? 'schedule-updated': 'schedule-created';
+        const plausibleAction = hasSchedule
+            ? 'scheduled-updated'
+            : 'scheduled-created';
         try {
             await changeState(projectId, Number(id), {
                 state: 'Scheduled',
@@ -155,9 +157,9 @@ export const ChangeRequestOverview: FC = () => {
             });
             trackEvent('scheduled-configuration-changes', {
                 props: {
-                    action: plausibleAction
-                }
-            })
+                    action: plausibleAction,
+                },
+            });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
         }
@@ -213,9 +215,10 @@ export const ChangeRequestOverview: FC = () => {
             if (hasSchedule) {
                 trackEvent('scheduled-configuration-changes', {
                     props: {
-                        action: 'schedule-rejected'
-                    }
-                })}
+                        action: 'scheduled-rejected',
+                    },
+                });
+            }
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
         }

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -51,7 +51,8 @@ export type CustomEvents =
     | 'project-mode'
     | 'dependent_features'
     | 'playground_token_input_used'
-    | 'search-filter';
+    | 'search-filter'
+    | 'scheduled-configuration-changes';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);


### PR DESCRIPTION
Adds plausible tracking with actions:
- scheduled-created
- scheduled-updated
- scheduled-rejected
- scheduled-applied

Closes # [1-1630](https://linear.app/unleash/issue/1-1630/add-plausible-metrics)