### PR TITLE
fix: date filter item missing key

### DIFF
--- a/frontend/src/component/filter/Filters/Filters.tsx
+++ b/frontend/src/component/filter/Filters/Filters.tsx
@@ -130,6 +130,7 @@ export const Filters: VFC<IFilterProps> = ({
                 if ('dateOperators' in filter) {
                     return (
                         <FilterDateItem
+                            key={filter.label}
                             label={label}
                             name={filter.label}
                             state={state[filter.filterKey]}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When filters list is re-rendered a filter date item was always treated as a new element because of a missing key. New elements alway open on creation. This fix makes the identify of the date filter stable by adding a key.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
