### PR TITLE
chore: rename secret to token in incoming_webhook_tokens

### DIFF
--- a/src/migrations/20231218165612-inc-webhook-tokens-rename-secret-to-token.js
+++ b/src/migrations/20231218165612-inc-webhook-tokens-rename-secret-to-token.js
@@ -1,0 +1,17 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE incoming_webhook_tokens RENAME COLUMN secret TO token;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE incoming_webhook_tokens RENAME COLUMN token TO secret;
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
Renames `secret` to `token` in `incoming_webhook_tokens` for consistency. This table is not being used yet, so this should be a very safe change.