### PR TITLE
chore: add migration that renames new created_by columns

### DIFF
--- a/src/migrations/20231219100343-rename-new-columns-to-created-by-user-id.js
+++ b/src/migrations/20231219100343-rename-new-columns-to-created-by-user-id.js
@@ -1,0 +1,35 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+        ALTER TABLE features RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE feature_types RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE feature_tag RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE feature_strategies RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE role_permission RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE role_user RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE roles RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE users RENAME COLUMN created_by TO created_by_user_id;
+        ALTER TABLE api_tokens RENAME COLUMN created_by TO created_by_user_id;
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+        ALTER TABLE features RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE feature_types RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE feature_tag RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE feature_strategies RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE role_permission RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE role_user RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE roles RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE users RENAME COLUMN created_by_user_id TO created_by;
+        ALTER TABLE api_tokens RENAME COLUMN created_by_user_id TO created_by;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
## About the changes

Replaces #5616

Renamed newly added `created_by` columns to `created_by_user_id` for these tables:
features
feature_tag
feature_strategies
feature_types
role_permission
role_user
roles
users
api_tokens
