### PR TITLE
fix: prevent banner from crashing with invalid variant

### DIFF
--- a/frontend/src/component/banners/Banner/Banner.test.tsx
+++ b/frontend/src/component/banners/Banner/Banner.test.tsx
@@ -6,20 +6,24 @@ test('should render correctly when using basic options', () => {
     render(
         <Banner
             banner={{
-                message: 'This is a banner message.',
+                message: 'This is a simple banner message.',
+                variant: 'warning',
             }}
         />,
     );
 
-    expect(screen.getByText('This is a banner message.')).toBeInTheDocument();
+    expect(
+        screen.getByText('This is a simple banner message.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
 });
 
 test('should render correctly when using advanced options', () => {
     render(
         <Banner
             banner={{
-                message: 'This is another banner message.',
-                variant: 'info',
+                message: 'This is a more advanced banner message.',
+                variant: 'success',
                 sticky: false,
                 icon: 'star',
                 link: 'dialog',
@@ -31,7 +35,7 @@ test('should render correctly when using advanced options', () => {
     );
 
     expect(
-        screen.getByText('This is another banner message.'),
+        screen.getByText('This is a more advanced banner message.'),
     ).toBeInTheDocument();
 
     const link = screen.getByText('Click me');
@@ -46,7 +50,7 @@ test('should default to info variant when an invalid variant is provided', () =>
     render(
         <Banner
             banner={{
-                message: 'This is an info banner message.',
+                message: 'This defaulted to an info banner message.',
                 // @ts-expect-error
                 variant: 'invalid',
             }}
@@ -54,7 +58,7 @@ test('should default to info variant when an invalid variant is provided', () =>
     );
 
     expect(
-        screen.getByText('This is an info banner message.'),
+        screen.getByText('This defaulted to an info banner message.'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
 });

--- a/frontend/src/component/banners/Banner/Banner.test.tsx
+++ b/frontend/src/component/banners/Banner/Banner.test.tsx
@@ -1,0 +1,60 @@
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { Banner } from './Banner';
+
+test('should render correctly when using basic options', () => {
+    render(
+        <Banner
+            banner={{
+                message: 'This is a banner message.',
+            }}
+        />,
+    );
+
+    expect(screen.getByText('This is a banner message.')).toBeInTheDocument();
+});
+
+test('should render correctly when using advanced options', () => {
+    render(
+        <Banner
+            banner={{
+                message: 'This is another banner message.',
+                variant: 'info',
+                sticky: false,
+                icon: 'star',
+                link: 'dialog',
+                linkText: 'Click me',
+                dialogTitle: 'Dialog title',
+                dialog: 'Dialog content',
+            }}
+        />,
+    );
+
+    expect(
+        screen.getByText('This is another banner message.'),
+    ).toBeInTheDocument();
+
+    const link = screen.getByText('Click me');
+    expect(link).toBeInTheDocument();
+    link.click();
+
+    expect(screen.getByText('Dialog title')).toBeInTheDocument();
+    expect(screen.getByText('Dialog content')).toBeInTheDocument();
+});
+
+test('should default to info variant when an invalid variant is provided', () => {
+    render(
+        <Banner
+            banner={{
+                message: 'This is an info banner message.',
+                // @ts-expect-error
+                variant: 'invalid',
+            }}
+        />,
+    );
+
+    expect(
+        screen.getByText('This is an info banner message.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
+});

--- a/frontend/src/component/banners/Banner/Banner.tsx
+++ b/frontend/src/component/banners/Banner/Banner.tsx
@@ -13,6 +13,8 @@ import ReactMarkdown from 'react-markdown';
 import { BannerVariant, IBanner } from 'interfaces/banner';
 import { Sticky } from 'component/common/Sticky/Sticky';
 
+const DEFAULT_VARIANT = 'info';
+
 const StyledBar = styled('aside', {
     shouldForwardProp: (prop) =>
         prop !== 'variant' && prop !== 'inline' && prop !== 'maxHeight',
@@ -36,9 +38,14 @@ const StyledBar = styled('aside', {
             maxHeight: maxHeight,
             overflow: 'auto',
         }),
-        borderColor: theme.palette[variant].border,
-        background: theme.palette[variant].light,
-        color: theme.palette[variant].dark,
+        borderColor:
+            theme.palette[variant]?.border ??
+            theme.palette[DEFAULT_VARIANT].border,
+        background:
+            theme.palette[variant]?.light ??
+            theme.palette[DEFAULT_VARIANT].light,
+        color:
+            theme.palette[variant]?.dark ?? theme.palette[DEFAULT_VARIANT].dark,
         fontSize: theme.fontSizes.smallBody,
     }),
 );
@@ -48,7 +55,7 @@ const StyledIcon = styled('div', {
 })<{ variant: BannerVariant }>(({ theme, variant }) => ({
     display: 'flex',
     alignItems: 'center',
-    color: theme.palette[variant].main,
+    color: theme.palette[variant]?.main ?? theme.palette[DEFAULT_VARIANT].main,
 }));
 
 interface IBannerProps {
@@ -62,7 +69,7 @@ export const Banner = ({ banner, inline, maxHeight }: IBannerProps) => {
 
     const {
         message,
-        variant = 'info',
+        variant = DEFAULT_VARIANT,
         sticky,
         icon,
         link,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1760/prevent-banner-from-crashing-when-set-with-an-invalid-variant

This prevents the banner from crashing when set with an invalid variant. Instead, it default its styles to the default variant, which is `info`.

Also adds tests to validate our assumptions.