### PR TITLE
fix: remove extra call to features on project load

### DIFF
--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -14,6 +14,7 @@ import {
     OnFeatureToggleSwitchArgs,
     UseFeatureToggleSwitchType,
 } from './FeatureToggleSwitch.types';
+import { ConditionallyRender } from 'comonent/common/ConditionallyRender/ConditionallyRender';
 
 type Middleware = (next: () => void) => void;
 
@@ -215,7 +216,14 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
     const modals = (
         <>
             <FeatureStrategyProdGuard {...prodGuardModalState} />
-            <EnableEnvironmentDialog {...enableEnvironmentDialogState} />
+            <ConditionallyRender
+                condition={enableEnvironmentDialogState.featureId.length !== 0}
+                show={
+                    <EnableEnvironmentDialog
+                        {...enableEnvironmentDialogState}
+                    />
+                }
+            />
             <ChangeRequestDialogue
                 isOpen={changeRequestDialogDetails.isOpen}
                 onClose={() => {
@@ -238,5 +246,8 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
         </>
     );
 
-    return { onToggle, modals };
+    return {
+        onToggle,
+        modals,
+    };
 };

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -14,7 +14,7 @@ import {
     OnFeatureToggleSwitchArgs,
     UseFeatureToggleSwitchType,
 } from './FeatureToggleSwitch.types';
-import { ConditionallyRender } from 'comonent/common/ConditionallyRender/ConditionallyRender';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 type Middleware = (next: () => void) => void;
 
@@ -213,11 +213,13 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
         [setProdGuardModalState],
     );
 
+    const featureSelected = enableEnvironmentDialogState.featureId.length !== 0;
+
     const modals = (
         <>
             <FeatureStrategyProdGuard {...prodGuardModalState} />
             <ConditionallyRender
-                condition={enableEnvironmentDialogState.featureId.length !== 0}
+                condition={featureSelected}
                 show={
                     <EnableEnvironmentDialog
                         {...enableEnvironmentDialogState}


### PR DESCRIPTION
Currently EnableEnvironmentDialog was loaded even if no feature was touched. Now it will only load, if feature toggle was selected.