### PR TITLE
Update publish-new-version.yaml

### DIFF
--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: What version would you like to use?
+        description: What version would you like to use? Prepend the version number with a `v`, e.g. `v5.7.1`.
 
 jobs:
   build:

--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: What version would you like to use? Prepend the version number with a `v`, e.g. `v5.7.1`.
+        description: What version number would you like to use? The version number should be **without** a leading `v`, e.g. `5.7.1` or `6.2.4`.
 
 jobs:
   build:


### PR DESCRIPTION
Add more details about the how the version should be formatted. 

When trying to run this workflow, I'm always very unsure whether the version should be prepended with a `v` or not. This should be clearly stated in the description.  If it doesn't matter, that should also be stated explicitly.

Updated the texts after talking to @chriswk and making a release.