### PR TITLE
fix: move paginated table into isolation context

### DIFF
--- a/frontend/src/component/common/Table/PaginatedTable/PaginatedTable.tsx
+++ b/frontend/src/component/common/Table/PaginatedTable/PaginatedTable.tsx
@@ -45,6 +45,7 @@ const HeaderCell = <T extends object>(header: Header<T, unknown>) => {
 
 const TableContainer = styled('div')(({ theme }) => ({
     overflowX: 'auto',
+    isolation: 'isolate',
 }));
 
 /**


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Table loaders were overflowing the sticky bar and footer. I moved the parent table into its own isolation context so that high z-index children don't escape it.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
