### PR TITLE
fix: separate concerns for ConstraintAccordionList

### DIFF
--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -107,9 +107,9 @@ export const AutocompleteBox = ({
                         },
                     },
                 }}
-                placeholder={placeHolder}
+                placeholder={label}
                 onFocus={() => setPlaceholder('')}
-                onBlur={() => setPlaceholder('Add Segments')}
+                onBlur={() => setPlaceholder(label)}
             />
         );
     };

--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionList/ConstraintAccordionList.tsx
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionList/ConstraintAccordionList.tsx
@@ -5,8 +5,8 @@ import React, {
     RefObject,
     useImperativeHandle,
 } from 'react';
-import { Box, Button, styled, Tooltip, Typography } from '@mui/material';
-import { Add, HelpOutline } from '@mui/icons-material';
+import { Box, Button, styled, Tooltip } from '@mui/material';
+import { HelpOutline } from '@mui/icons-material';
 import { IConstraint } from 'interfaces/strategy';
 import { ConstraintAccordion } from 'component/common/ConstraintAccordion/ConstraintAccordion';
 import produce from 'immer';
@@ -16,8 +16,6 @@ import { objectId } from 'utils/objectId';
 import { createEmptyConstraint } from 'component/common/ConstraintAccordion/ConstraintAccordionList/createEmptyConstraint';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
-import { useUiFlag } from 'hooks/useUiFlag';
-import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 
 export interface IConstraintAccordionListProps {
     constraints: IConstraint[];
@@ -70,13 +68,6 @@ const StyledAddCustomLabel = styled('div')(({ theme }) => ({
     marginBottom: theme.spacing(1),
     color: theme.palette.text.primary,
     display: 'flex',
-}));
-
-const StyledHelpIconBox = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
 }));
 
 export const useConstraintAccordionList = (

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
@@ -20,15 +20,6 @@ interface IConstraintAccordionListProps {
     /* Add "constraints" title on the top - default `true` */
     showLabel?: boolean;
 }
-
-// Extra form state for each constraint.
-interface IConstraintAccordionListItemState {
-    // Is the constraint new (never been saved)?
-    new?: boolean;
-    // Is the constraint currently being edited?
-    editing?: boolean;
-}
-
 export const constraintAccordionListId = 'constraintAccordionListId';
 
 const StyledContainer = styled('div')({

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
@@ -71,12 +71,11 @@ export const FeatureStrategyConstraintAccordionList = forwardRef<
             setConstraints,
             ref as RefObject<IConstraintAccordionListRef>,
         );
+        const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
 
         if (context.length === 0) {
             return null;
         }
-
-        const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
 
         if (newStrategyConfiguration) {
             return (

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList.tsx
@@ -1,35 +1,24 @@
-import React, {
-    forwardRef,
-    Fragment,
-    Ref,
-    RefObject,
-    useImperativeHandle,
-} from 'react';
+import React, { forwardRef, RefObject } from 'react';
 import { Box, Button, styled, Tooltip, Typography } from '@mui/material';
 import { Add, HelpOutline } from '@mui/icons-material';
 import { IConstraint } from 'interfaces/strategy';
-import { ConstraintAccordion } from 'component/common/ConstraintAccordion/ConstraintAccordion';
-import produce from 'immer';
-import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
-import { IUseWeakMap, useWeakMap } from 'hooks/useWeakMap';
-import { objectId } from 'utils/objectId';
-import { createEmptyConstraint } from 'component/common/ConstraintAccordion/ConstraintAccordionList/createEmptyConstraint';
+
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
+
 import { useUiFlag } from 'hooks/useUiFlag';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import {
+    ConstraintList,
+    IConstraintAccordionListRef,
+    useConstraintAccordionList,
+} from 'component/common/ConstraintAccordion/ConstraintAccordionList/ConstraintAccordionList';
 
-export interface IConstraintAccordionListProps {
+interface IConstraintAccordionListProps {
     constraints: IConstraint[];
     setConstraints?: React.Dispatch<React.SetStateAction<IConstraint[]>>;
     showCreateButton?: boolean;
     /* Add "constraints" title on the top - default `true` */
     showLabel?: boolean;
-}
-
-// Ref methods exposed by this component.
-export interface IConstraintAccordionListRef {
-    addConstraint?: (contextName: string) => void;
 }
 
 // Extra form state for each constraint.
@@ -79,37 +68,7 @@ const StyledHelpIconBox = styled(Box)(({ theme }) => ({
     marginBottom: theme.spacing(1),
 }));
 
-export const useConstraintAccordionList = (
-    setConstraints:
-        | React.Dispatch<React.SetStateAction<IConstraint[]>>
-        | undefined,
-    ref: React.RefObject<IConstraintAccordionListRef>,
-) => {
-    const state = useWeakMap<IConstraint, IConstraintAccordionListItemState>();
-    const { context } = useUnleashContext();
-
-    const addConstraint =
-        setConstraints &&
-        ((contextName: string) => {
-            const constraint = createEmptyConstraint(contextName);
-            state.set(constraint, { editing: true, new: true });
-            setConstraints((prev) => [...prev, constraint]);
-        });
-
-    useImperativeHandle(ref, () => ({
-        addConstraint,
-    }));
-
-    const onAdd =
-        addConstraint &&
-        (() => {
-            addConstraint(context[0].name);
-        });
-
-    return { onAdd, state, context };
-};
-
-export const ConstraintAccordionList = forwardRef<
+export const FeatureStrategyConstraintAccordionList = forwardRef<
     IConstraintAccordionListRef | undefined,
     IConstraintAccordionListProps
 >(
@@ -124,6 +83,64 @@ export const ConstraintAccordionList = forwardRef<
 
         if (context.length === 0) {
             return null;
+        }
+
+        const newStrategyConfiguration = useUiFlag('newStrategyConfiguration');
+
+        if (newStrategyConfiguration) {
+            return (
+                <StyledContainer id={constraintAccordionListId}>
+                    <ConditionallyRender
+                        condition={Boolean(showCreateButton && onAdd)}
+                        show={
+                            <div>
+                                <StyledHelpIconBox>
+                                    <Typography>Constraints</Typography>
+                                    <HelpIcon
+                                        htmlTooltip
+                                        tooltip={
+                                            <Box>
+                                                <Typography variant='body2'>
+                                                    Constraints are advanced
+                                                    targeting rules that you can
+                                                    use to enable a feature
+                                                    toggle for a subset of your
+                                                    users. Read more about
+                                                    constraints{' '}
+                                                    <a
+                                                        href='https://docs.getunleash.io/reference/strategy-constraints'
+                                                        target='_blank'
+                                                        rel='noopener noreferrer'
+                                                    >
+                                                        here
+                                                    </a>
+                                                </Typography>
+                                            </Box>
+                                        }
+                                    />
+                                </StyledHelpIconBox>
+                                <ConstraintList
+                                    ref={ref}
+                                    setConstraints={setConstraints}
+                                    constraints={constraints}
+                                    state={state}
+                                />
+                                <Button
+                                    sx={{ marginTop: '1rem' }}
+                                    type='button'
+                                    onClick={onAdd}
+                                    startIcon={<Add />}
+                                    variant='outlined'
+                                    color='primary'
+                                    data-testid='ADD_CONSTRAINT_BUTTON'
+                                >
+                                    Add constraint
+                                </Button>
+                            </div>
+                        }
+                    />
+                </StyledContainer>
+            );
         }
 
         return (
@@ -181,78 +198,3 @@ export const ConstraintAccordionList = forwardRef<
         );
     },
 );
-
-interface IConstraintList {
-    constraints: IConstraint[];
-    setConstraints?: React.Dispatch<React.SetStateAction<IConstraint[]>>;
-    state: IUseWeakMap<IConstraint, IConstraintAccordionListItemState>;
-}
-
-export const ConstraintList = forwardRef<
-    IConstraintAccordionListRef | undefined,
-    IConstraintList
->(({ constraints, setConstraints, state }, ref) => {
-    const { context } = useUnleashContext();
-
-    const onEdit =
-        setConstraints &&
-        ((constraint: IConstraint) => {
-            state.set(constraint, { editing: true });
-        });
-
-    const onRemove =
-        setConstraints &&
-        ((index: number) => {
-            const constraint = constraints[index];
-            state.set(constraint, {});
-            setConstraints(
-                produce((draft) => {
-                    draft.splice(index, 1);
-                }),
-            );
-        });
-
-    const onSave =
-        setConstraints &&
-        ((index: number, constraint: IConstraint) => {
-            state.set(constraint, {});
-            setConstraints(
-                produce((draft) => {
-                    draft[index] = constraint;
-                }),
-            );
-        });
-
-    const onCancel = (index: number) => {
-        const constraint = constraints[index];
-        state.get(constraint)?.new && onRemove?.(index);
-        state.set(constraint, {});
-    };
-
-    if (context.length === 0) {
-        return null;
-    }
-
-    return (
-        <StyledContainer id={constraintAccordionListId}>
-            {constraints.map((constraint, index) => (
-                <Fragment key={objectId(constraint)}>
-                    {console.log(state.get(constraint))}
-                    <ConditionallyRender
-                        condition={index > 0}
-                        show={<StrategySeparator text='AND' />}
-                    />
-                    <ConstraintAccordion
-                        constraint={constraint}
-                        onEdit={onEdit?.bind(null, constraint)}
-                        onCancel={onCancel.bind(null, index)}
-                        onDelete={onRemove?.bind(null, index)}
-                        onSave={onSave?.bind(null, index)}
-                        editing={Boolean(state.get(constraint)?.editing)}
-                        compact
-                    />
-                </Fragment>
-            ))}
-        </StyledContainer>
-    );
-});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
@@ -1,11 +1,11 @@
 import { IConstraint, IFeatureStrategy } from 'interfaces/strategy';
 import React, { useMemo } from 'react';
-import { ConstraintAccordionList } from 'component/common/ConstraintAccordion/ConstraintAccordionList/ConstraintAccordionList';
 import {
     UPDATE_FEATURE_STRATEGY,
     CREATE_FEATURE_STRATEGY,
 } from 'component/providers/AccessProvider/permissions';
 import { useHasProjectEnvironmentAccess } from 'hooks/useHasAccess';
+import { FeatureStrategyConstraintAccordionList } from './FeatureStrategyConstraintAccordionList/FeatureStrategyConstraintAccordionList';
 
 interface IFeatureStrategyConstraintsProps {
     projectId: string;
@@ -46,7 +46,7 @@ export const FeatureStrategyConstraints = ({
     );
 
     return (
-        <ConstraintAccordionList
+        <FeatureStrategyConstraintAccordionList
             constraints={constraints}
             setConstraints={allowEditAndDelete ? setConstraints : undefined}
             showCreateButton={showCreateButton}

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
@@ -238,7 +238,7 @@ describe('NewFeatureStrategyCreate', () => {
         const doneEl = screen.getByText('Done');
         fireEvent.click(doneEl);
 
-        const selectElement = screen.getByPlaceholderText('Add Segments');
+        const selectElement = screen.getByPlaceholderText('Select segments');
         fireEvent.mouseDown(selectElement);
 
         const optionElement = await screen.findByText(expectedSegmentName);

--- a/frontend/src/hooks/useWeakMap.ts
+++ b/frontend/src/hooks/useWeakMap.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useMemo } from 'react';
 
-interface IUseWeakMap<K, V> {
+export interface IUseWeakMap<K, V> {
     set: (k: K, v: V) => void;
     get: (k: K) => V | undefined;
 }


### PR DESCRIPTION
## Problem

The ConstraintAccordionList component was used in multiple places: 
* Playground
* Segment form
* StrategyExecution
* Change requests
* Create strategy
* Edit strategy

This is problematic because some of the views are just pure visual representations, and other views allow you to interact with and edit the constraints. This causes a situation where the visual representation needs to be aware of the implementation details of editing and mutating constraints. In addition the ConstraintAccordionList is not just a pure rendering of the list, it also keeps internal state on when to show the create button and optional headers. This is makes it hard to make changes when stylings need to be subtly different across components. 

## Solution

Taking on the full refactor for this is out of scope, but it's unfortunate that the ConstraintAccordionList needs all this internal state. For now I split out the list into it's own component called ConstraintList. I gathered the functions needed for editing and mutating the constraints in a reusable hook and isolated the version of the list used in the new feature strategy edit / create components into it's own component so that the changes in layout will not affect anything else. 

Ideally we should try to move towards a future where the components don't keep internal state like this but clear boundaries and purposes for the use.