### PR TITLE
fix: context updated event now does stores correct fields

### DIFF
--- a/src/lib/services/context-service.ts
+++ b/src/lib/services/context-service.ts
@@ -140,11 +140,13 @@ class ContextService {
 
         // update
         await this.contextFieldStore.update(value);
+
+        const { createdAt, sortOrder, ...previousContextField } = contextField;
         await this.eventService.storeEvent({
             type: CONTEXT_FIELD_UPDATED,
             createdBy: userName,
             createdByUserId: updatedByUserId,
-            preData: contextField,
+            preData: previousContextField,
             data: value,
         });
     }


### PR DESCRIPTION
Now sortOrder and createdAt are not displayed on update.
![image](https://github.com/Unleash/unleash/assets/964450/2711086e-317a-4b8b-b16b-a7b270c08ca5)
