### PR TITLE
fix: hide variant diff if no change in ChangeRequestOverview

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -169,7 +169,7 @@ export const StrategyChange: VFC<{
                     </ChangeItemCreateEditWrapper>
                     <StrategyExecution strategy={change.payload} />
                     <ConditionallyRender
-                        condition={Boolean(change.payload.variants)}
+                        condition={hasVariantDiff}
                         show={
                             change.payload.variants && (
                                 <StyledBox>


### PR DESCRIPTION
Closes # [1-1813](https://linear.app/unleash/issue/1-1813/do-not-show-variants-table-in-change-request-when-no-variant-change)