### PR TITLE
fix: review status title color

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -301,7 +301,7 @@ const ScheduledPending = ({
         <StyledFlexAlignCenterBox>
             <StyledScheduledIcon />
             <Box>
-                <StyledReviewTitle color={theme.palette.warning.main}>
+                <StyledReviewTitle color={theme.palette.warning.dark}>
                     Changes are scheduled to be applied on:{' '}
                     {new Date(schedule?.scheduledAt).toLocaleString()}
                 </StyledReviewTitle>


### PR DESCRIPTION
Closes # [1-1825](https://linear.app/unleash/issue/1-1825/change-the-color-of-the-scheduled-and-pending-state-to-warningdark)