### PR TITLE
fix: email link

### DIFF
--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -169,7 +169,7 @@ export class EmailService {
                     : false;
 
             const conflictResolutionLink = conflictResolution
-                ? `${this.config.server.baseUriPath}/projects/${project}/archive?sort=archivedAt&search=${flagName}`
+                ? `${this.config.server.unleashUrl}/projects/${project}/archive?sort=archivedAt&search=${flagName}`
                 : false;
 
             const bodyHtml = await this.compileTemplate(


### PR DESCRIPTION
Fixes missing base url 

Relates to #[1-1827](https://linear.app/unleash/issue/1-1827/email-link-to-revive-feature-is-wrong)