### PR TITLE
fix: add padding to warning banner

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -51,7 +51,7 @@ const StyledSingleChangeBox = styled(Box, {
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     borderRadius: 0,
-    padding: theme.spacing(0, 2),
+    padding: theme.spacing(1, 2),
     '&.MuiAlert-standardWarning': {
         borderStyle: 'none none solid none',
     },


### PR DESCRIPTION
Closes # [1-1830](https://linear.app/unleash/issue/1-1830/potential-conflict-warning-add-padding-8px)