### PR TITLE
chore: support full path schemas

### DIFF
--- a/src/lib/openapi/util/create-request-schema.ts
+++ b/src/lib/openapi/util/create-request-schema.ts
@@ -9,7 +9,9 @@ export const createRequestSchema = (
         content: {
             'application/json': {
                 schema: {
-                    $ref: `#/components/schemas/${schemaName}`,
+                    $ref: schemaName.startsWith('#')
+                        ? schemaName
+                        : `#/components/schemas/${schemaName}`,
                 },
             },
         },

--- a/src/lib/openapi/util/create-response-schema.ts
+++ b/src/lib/openapi/util/create-response-schema.ts
@@ -13,7 +13,9 @@ export const createResponseSchemas = (
 export const schemaNamed = (schemaName: string): OpenAPIV3.MediaTypeObject => {
     return {
         schema: {
-            $ref: `#/components/schemas/${schemaName}`,
+            $ref: schemaName.startsWith('#')
+                ? schemaName
+                : `#/components/schemas/${schemaName}`,
         },
     };
 };
@@ -62,7 +64,9 @@ export const resourceCreatedResponseSchema = (
         content: {
             'application/json': {
                 schema: {
-                    $ref: `#/components/schemas/${schemaName}`,
+                    $ref: schemaName.startsWith('#')
+                        ? schemaName
+                        : `#/components/schemas/${schemaName}`,
                 },
             },
         },


### PR DESCRIPTION
This backwards compatible change allows us to specify a schema `id` (full path) which to me feels a bit better than specifying the schema name as a string, since a literal string is prone to typos.

### Before

```ts
requestBody: createRequestSchema(
    'createResourceSchema',
),
responses: {
    ...getStandardResponses(400, 401, 403, 415),
    201: resourceCreatedResponseSchema(
        'resourceSchema',
    ),
},
```

### After

```ts
requestBody: createRequestSchema(
    createResourceSchema.$id,
),
responses: {
    ...getStandardResponses(400, 401, 403, 415),
    201: resourceCreatedResponseSchema(
        resourceSchema.$id,
    ),
},
```