### PR TITLE
Fix: strategy import

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -347,20 +347,11 @@ export default class ExportImportService
         await Promise.all(
             dto.data.featureStrategies
                 ?.filter(hasFeatureName)
-                .map((featureStrategy) =>
+                .map(({ featureName, ...restOfFeatureStrategy }) =>
                     this.featureToggleService.createStrategy(
+                        restOfFeatureStrategy,
                         {
-                            name: featureStrategy.name,
-                            constraints: featureStrategy.constraints,
-                            parameters: featureStrategy.parameters,
-                            segments: featureStrategy.segments,
-                            sortOrder: featureStrategy.sortOrder,
-                            title: featureStrategy.title,
-                            variants: featureStrategy.variants,
-                            disabled: featureStrategy.disabled,
-                        },
-                        {
-                            featureName: featureStrategy.featureName,
+                            featureName,
                             environment: dto.environment,
                             projectId: dto.project,
                         },

--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -355,6 +355,9 @@ export default class ExportImportService
                             parameters: featureStrategy.parameters,
                             segments: featureStrategy.segments,
                             sortOrder: featureStrategy.sortOrder,
+                            title: featureStrategy.title,
+                            variants: featureStrategy.variants,
+                            disabled: featureStrategy.disabled,
                         },
                         {
                             featureName: featureStrategy.featureName,


### PR DESCRIPTION
## About the changes
Some optional properties of `strategy` where not included after importing.

Internal issue: [SR-284](https://linear.app/unleash/issue/SR-284/wayfair-import-didnt-copy-title-of-strategies)