### PR TITLE
Added a check that allows posting edge bulk metrics with a client token

### DIFF
--- a/src/lib/middleware/api-token-middleware.test.ts
+++ b/src/lib/middleware/api-token-middleware.test.ts
@@ -243,3 +243,34 @@ test('should call next if apiTokenService throws x2', async () => {
 
     expect(cb).toHaveBeenCalled();
 });
+
+test('should add user if client token and /edge/metrics', async () => {
+    const apiUser = new ApiUser({
+        tokenName: 'default',
+        permissions: [CLIENT],
+        project: ALL,
+        environment: ALL,
+        type: ApiTokenType.CLIENT,
+        secret: 'a',
+    });
+    const apiTokenService = {
+        getUserForToken: jest.fn().mockReturnValue(apiUser),
+    } as unknown as ApiTokenService;
+
+    const func = apiTokenMiddleware(config, { apiTokenService });
+
+    const cb = jest.fn();
+
+    const req = {
+        header: jest.fn().mockReturnValue('some-known-token'),
+        user: undefined,
+        path: '/edge/metrics',
+        method: 'POST',
+    };
+
+    await func(req, undefined, cb);
+
+    expect(cb).toHaveBeenCalled();
+    expect(req.header).toHaveBeenCalled();
+    expect(req.user).toBe(apiUser);
+});

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -7,6 +7,10 @@ const isClientApi = ({ path }) => {
     return path && path.indexOf('/api/client') > -1;
 };
 
+const isEdgeMetricsApi = ({ path }) => {
+    return path && path.indexOf('/edge/metrics') > -1;
+};
+
 const isProxyApi = ({ path }) => {
     if (!path) {
         return;
@@ -57,7 +61,9 @@ const apiAccessMiddleware = (
 
                 if (apiUser) {
                     if (
-                        (apiUser.type === CLIENT && !isClientApi(req)) ||
+                        (apiUser.type === CLIENT &&
+                            !isClientApi(req) &&
+                            !isEdgeMetricsApi(req)) ||
                         (apiUser.type === FRONTEND && !isProxyApi(req)) ||
                         (apiUser.type === FRONTEND &&
                             !flagResolver.isEnabled('embedProxy'))


### PR DESCRIPTION
This allows bulk metrics posted with a Client token to be accepted. Previously you needed an admin token to have bulk metrics accepted