### PR TITLE
chore: make security optional for /edge/validate endpoint

### DIFF
--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -63,6 +63,7 @@ export default class EdgeController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Edge'],
+                    security: [{}],
                     summary: 'Check which tokens are valid',
                     description:
                         'This operation accepts a list of tokens to validate. Unleash will validate each token you provide. For each valid token you provide, Unleash will return the token along with its type and which projects it has access to.',


### PR DESCRIPTION
We've had a couple of misunderstandings from people surprised that Unleash allows posts against the `/edge/validate` endpoint without an API key. It is intentional that this endpoint does not require an Authorization header, so this PR updates our OpenAPI spec to clarify that there is no security required for `/edge/validate`