### PR TITLE
feat: support null created_by_user_id

### DIFF
--- a/src/migrations/20240102142100-incoming-webhooks-created-by.js
+++ b/src/migrations/20240102142100-incoming-webhooks-created-by.js
@@ -1,0 +1,13 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE incoming_webhooks ALTER COLUMN created_by_user_id DROP NOT NULL;
+        ALTER TABLE incoming_webhook_tokens ALTER COLUMN created_by_user_id DROP NOT NULL;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, callback) {
+    callback();
+};


### PR DESCRIPTION
## About the changes
Creating an incoming webhook with an admin token means we can't correlate the action with a real user. In this case we should support null.