### PR TITLE
fix: update text in scheduling components

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog.tsx
@@ -78,7 +78,7 @@ export const ScheduleChangeRequestDialog: FC<ScheduleChangeRequestDialogProps> =
                 >
                     Select the date and time when these changes should be
                     applied. If you change your mind later, you can reschedule
-                    the changes or apply the immediately.
+                    the changes or apply them immediately.
                 </Typography>
                 <StyledContainer>
                     <DateTimePicker

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/changeRequestScheduledDialogs.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/changeRequestScheduledDialogs.tsx
@@ -47,7 +47,7 @@ export const ChangeRequestRejectScheduledDialogue: FC<
     >
 > = ({ ...rest }) => {
     const message =
-        'Rejecting the changes now means the scheduled time will be ignored';
+        'Rejecting this change request will delete its schedule and it can no longer be rescheduled or applied.';
     const title = 'Reject changes';
     const primaryButtonText = 'Reject changes';
 


### PR DESCRIPTION
This pr updates the text in some of the scheduling components to be more clear and consistent.