### PR TITLE
chore: format schedule information according to user preferences

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -70,10 +70,6 @@ const resolveIconColors = (state: ChangeRequestState, theme: Theme) => {
     };
 };
 
-const formatScheduledDate = (date: Date, locale?: string) => {
-        return formatDateYMDHMS(date, locale);
-};
-
 export const ChangeRequestReviewStatus: FC<ISuggestChangeReviewsStatusProps> =
     ({ changeRequest, onEditClick }) => {
         const theme = useTheme();
@@ -286,7 +282,7 @@ const ScheduledFailed = ({
         return null;
     }
 
-    const scheduledTime = formatScheduledDate(
+    const scheduledTime = formatDateYMDHMS(
         new Date(schedule?.scheduledAt),
         locationSettings?.locale
     );
@@ -318,7 +314,7 @@ const ScheduledPending = ({
         return null;
     }
 
-    const scheduledTime = formatScheduledDate(
+    const scheduledTime = formatDateYMDHMS(
         new Date(schedule?.scheduledAt),
         locationSettings?.locale
     );

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -8,6 +8,7 @@ import {
     useTheme,
 } from '@mui/material';
 import { ReactComponent as ChangesAppliedIcon } from 'assets/icons/merge.svg';
+import { useLocationSettings } from 'hooks/useLocationSettings';
 import {
     StyledOuterContainer,
     StyledButtonContainer,
@@ -30,6 +31,7 @@ import {
 } from 'component/changeRequest/changeRequest.types';
 import { getBrowserTimezone } from './utils';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
+import { formatDateYMDHMS } from 'utils/formatDate';
 
 interface ISuggestChangeReviewsStatusProps {
     changeRequest: IChangeRequest;
@@ -66,6 +68,10 @@ const resolveIconColors = (state: ChangeRequestState, theme: Theme) => {
         bgColor: theme.palette.background.elevation2,
         svgColor: theme.palette.neutral.main!,
     };
+};
+
+const formatScheduledDate = (date: Date, locale?: string) => {
+        return formatDateYMDHMS(date, locale);
 };
 
 export const ChangeRequestReviewStatus: FC<ISuggestChangeReviewsStatusProps> =
@@ -232,6 +238,7 @@ interface IScheduledProps {
 const Scheduled = ({ schedule, onEditClick }: IScheduledProps) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
+    const { locationSettings } = useLocationSettings();
 
     if (!schedule?.scheduledAt) {
         return null;
@@ -273,17 +280,25 @@ const ScheduledFailed = ({
 }: { schedule: IChangeRequestSchedule }) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
+    const { locationSettings } = useLocationSettings();
 
     if (!schedule?.scheduledAt) {
         return null;
     }
+
+    const scheduledTime = formatScheduledDate(
+        new Date(schedule?.scheduledAt),
+        locationSettings?.locale
+    );
+
+
     return (
         <StyledFlexAlignCenterBox>
             <StyledInfoIcon />
             <Box>
                 <StyledReviewTitle color={theme.palette.error.main}>
                     Changes failed to be applied on{' '}
-                    {new Date(schedule?.scheduledAt).toLocaleString()} because
+                    {scheduledTime} because
                     of {schedule?.failureReason}
                 </StyledReviewTitle>
                 <Typography>Your timezone is {timezone}</Typography>
@@ -297,13 +312,24 @@ const ScheduledPending = ({
 }: { schedule: IChangeRequestSchedule }) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
+    const { locationSettings } = useLocationSettings();
+
+    if (!schedule?.scheduledAt) {
+        return null;
+    }
+
+    const scheduledTime = formatScheduledDate(
+        new Date(schedule?.scheduledAt),
+        locationSettings?.locale
+    );
+
     return (
         <StyledFlexAlignCenterBox>
             <StyledScheduledIcon />
             <Box>
                 <StyledReviewTitle color={theme.palette.warning.dark}>
                     Changes are scheduled to be applied on:{' '}
-                    {new Date(schedule?.scheduledAt).toLocaleString()}
+                    {scheduledTime}
                 </StyledReviewTitle>
                 <Typography>Your timezone is {timezone}</Typography>
             </Box>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -284,18 +284,16 @@ const ScheduledFailed = ({
 
     const scheduledTime = formatDateYMDHMS(
         new Date(schedule?.scheduledAt),
-        locationSettings?.locale
+        locationSettings?.locale,
     );
-
 
     return (
         <StyledFlexAlignCenterBox>
             <StyledInfoIcon />
             <Box>
                 <StyledReviewTitle color={theme.palette.error.main}>
-                    Changes failed to be applied on{' '}
-                    {scheduledTime} because
-                    of {schedule?.failureReason}
+                    Changes failed to be applied on {scheduledTime} because of{' '}
+                    {schedule?.failureReason}
                 </StyledReviewTitle>
                 <Typography>Your timezone is {timezone}</Typography>
             </Box>
@@ -316,7 +314,7 @@ const ScheduledPending = ({
 
     const scheduledTime = formatDateYMDHMS(
         new Date(schedule?.scheduledAt),
-        locationSettings?.locale
+        locationSettings?.locale,
     );
 
     return (
@@ -324,8 +322,7 @@ const ScheduledPending = ({
             <StyledScheduledIcon />
             <Box>
                 <StyledReviewTitle color={theme.palette.warning.dark}>
-                    Changes are scheduled to be applied on:{' '}
-                    {scheduledTime}
+                    Changes are scheduled to be applied on: {scheduledTime}
                 </StyledReviewTitle>
                 <Typography>Your timezone is {timezone}</Typography>
             </Box>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -10,6 +10,8 @@ import { ChangeRequestState } from '../../changeRequest.types';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from '../../../common/HtmlTooltip/HtmlTooltip';
 import { Info } from '@mui/icons-material';
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import { formatDateYMDHMS } from 'utils/formatDate';
 
 interface ISuggestChangeTimelineProps {
     state: ChangeRequestState;
@@ -103,6 +105,8 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     }
     const activeIndex = data.findIndex((item) => item === state);
 
+    const { locationSettings } = useLocationSettings();
+
     return (
         <StyledPaper elevation={0}>
             <StyledBox>
@@ -112,7 +116,10 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                             scheduledAt &&
                             state === 'Scheduled' &&
                             state === title
-                                ? new Date(scheduledAt).toLocaleString()
+                                ? formatDateYMDHMS(
+                                      new Date(scheduledAt),
+                                      locationSettings?.locale,
+                                  )
                                 : undefined;
                         const color = determineColor(
                             state,

--- a/frontend/src/utils/formatDate.ts
+++ b/frontend/src/utils/formatDate.ts
@@ -1,6 +1,6 @@
 export const formatDateYMDHMS = (
     date: number | string | Date,
-    locale: string,
+    locale?: string,
 ): string => {
     return new Date(date).toLocaleString(locale, {
         day: '2-digit',


### PR DESCRIPTION
This pr uses the user's preferred timezone to display the scheduled times. If the user has no preferences, the default will be used.

With norwegian locale set as preference: 

<img width="1529" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/0072432c-e470-4edc-91fb-864a86bc8f30">

With nothing set (falls back to my system setting):
<img width="1529" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/adf3d95f-4015-4302-ac09-e3ba511090db">
