### PR TITLE
chore: observable events db migration

### DIFF
--- a/src/migrations/20240102205517-observable-events.js
+++ b/src/migrations/20240102205517-observable-events.js
@@ -1,0 +1,32 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        CREATE TABLE IF NOT EXISTS observable_events
+            (
+                id SERIAL PRIMARY KEY NOT NULL,
+                payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                source TEXT NOT NULL,
+                source_id INTEGER NOT NULL,
+                created_by_incoming_webhook_token_id INTEGER,
+                announced BOOLEAN DEFAULT false NOT NULL
+            );
+        CREATE INDEX observable_events_source_and_source_id_idx ON observable_events(source, source_id);
+        CREATE INDEX observable_events_created_by_incoming_webhook_token_id_idx ON observable_events(created_by_incoming_webhook_token_id);
+        CREATE INDEX observable_events_unannounced_idx ON observable_events(announced) WHERE announced = false;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DROP INDEX IF EXISTS observable_events_source_and_source_id_idx;
+        DROP INDEX IF EXISTS observable_events_created_by_incoming_webhook_token_id_idx;
+        DROP INDEX IF EXISTS observable_events_unannounced_idx;
+        DROP TABLE IF EXISTS observable_events;
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1773/db-create-migration-for-a-new-observable-events-table

Adds a new DB migration to create a new `observable_events` table. Even though we are thinking long term with the `source` columns, the short term purpose of this table will be to store incoming webhook calls.