### PR TITLE
fix: fix assets not showing up

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -31,6 +31,7 @@ export default mergeConfig(
         build: {
             outDir: 'build',
             assetsDir: 'static',
+            assetsInlineLimit: 0,
             modulePreload: false,
             cssCodeSplit: false,
         },


### PR DESCRIPTION
After upgrading vite https://github.com/Unleash/unleash/pull/5703, small icons are not popping up anymore. Disabling inlining assets to make it work again.

![image](https://github.com/Unleash/unleash/assets/964450/54d33a22-5eaf-4a79-ac67-34092549803d)
