### PR TITLE
task: add kill-switch for edge bulk metrics

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -81,6 +81,7 @@ exports[`should create default config 1`] = `
       "disableBulkToggle": false,
       "disableMetrics": false,
       "disableNotifications": false,
+      "edgeBulkMetricsKillSwitch": false,
       "embedProxy": true,
       "embedProxyFrontend": true,
       "enableLicense": false,

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -143,7 +143,12 @@ export default class EdgeController extends Controller {
                 res.status(400).end();
             }
         } else {
-            res.status(202).end();
+            // @ts-expect-error Expected result here is void, but since we want to communicate extra information in our 404, we allow this to avoid type-checking
+            res.status(404).json({
+                status: 'disabled',
+                reason: 'disabled by killswitch',
+                help: 'You should upgrade Edge to the most recent version to not lose metrics',
+            });
         }
     }
 }

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -37,7 +37,8 @@ export type IFlagKey =
     | 'increaseUnleashWidth'
     | 'featureSearchFeedback'
     | 'featureSearchFeedbackPosting'
-    | 'newStrategyConfigurationFeedback';
+    | 'newStrategyConfigurationFeedback'
+    | 'edgeBulkMetricsKillSwitch';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -166,6 +167,10 @@ const flags: IFlags = {
     ),
     newStrategyConfigurationFeedback: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_STRATEGY_CONFIGURATION_FEEDBACK,
+        false,
+    ),
+    edgeBulkMetricsKillSwitch: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EDGE_BULK_METRICS_KILL_SWITCH,
         false,
     ),
 };


### PR DESCRIPTION
As the title says. This adds a kill switch for the processing of Edge bulk metrics.

I was wondering if we should even add a kill switch fully around the router configuration as well, so that if the kill switch is already on when you start up you don't even map the route. WDYT?