### PR TITLE
fix: align timeline icon for schedule failures

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -32,6 +32,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
 const StyledSubtitle = styled(Box)(({ theme }) => ({
     display: 'flex',
     flexDirection: 'row',
+    alignItems: 'flex-end',
 }));
 
 const StyledTimeline = styled(Timeline)(() => ({

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -169,7 +169,6 @@ const createTimelineItem = (
         </TimelineSeparator>
         <TimelineContent>
             {title}
-            <br />
             <ConditionallyRender
                 condition={Boolean(subtitle)}
                 show={


### PR DESCRIPTION
Aligns the icon to the end of the end of the box to make it match the text.

Also removes a redundant br element.