### PR TITLE
fix: adapts react markdown to open links in new tab

### DIFF
--- a/frontend/src/component/banners/Banner/Banner.tsx
+++ b/frontend/src/component/banners/Banner/Banner.tsx
@@ -84,7 +84,7 @@ export const Banner = ({ banner, inline, maxHeight }: IBannerProps) => {
             <StyledIcon variant={variant}>
                 <BannerIcon icon={icon} variant={variant} />
             </StyledIcon>
-            <ReactMarkdown>{message}</ReactMarkdown>
+            <ReactMarkdown linkTarget='_blank'>{message}</ReactMarkdown>
             <BannerButton
                 link={link}
                 plausibleEvent={plausibleEvent}

--- a/frontend/src/component/banners/Banner/BannerDialog/BannerDialog.tsx
+++ b/frontend/src/component/banners/Banner/BannerDialog/BannerDialog.tsx
@@ -30,7 +30,9 @@ export const BannerDialog = ({
                 setOpen(false);
             }}
         >
-            <StyledReactMarkdown>{children}</StyledReactMarkdown>
+            <StyledReactMarkdown linkTarget='_blank'>
+                {children}
+            </StyledReactMarkdown>
         </Dialogue>
     );
 };

--- a/frontend/src/component/integrations/IntegrationHowToSection/IntegrationHowToSection.tsx
+++ b/frontend/src/component/integrations/IntegrationHowToSection/IntegrationHowToSection.tsx
@@ -34,7 +34,9 @@ export const IntegrationHowToSection: VFC<IIntegrationHowToSectionProps> = ({
             >
                 <IntegrationIcon name={provider.name} /> {title}
             </Typography>
-            <ReactMarkdown>{provider!.howTo || ''}</ReactMarkdown>
+            <ReactMarkdown linkTarget='_blank'>
+                {provider!.howTo || ''}
+            </ReactMarkdown>
         </StyledHowDoesItWorkSection>
     );
 };


### PR DESCRIPTION
Adapts our current implementations of `ReactMarkdown` to always open markdown links in new tabs.