### PR TITLE
feat: set apiTokenMiddleware for all AuthTypes.

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -109,29 +109,26 @@ export default async function getApp(
     );
 
     app.use(baseUriPath, patMiddleware(config, services));
+    app.use(baseUriPath, apiTokenMiddleware(config, services));
 
     switch (config.authentication.type) {
         case IAuthType.OPEN_SOURCE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             ossAuthentication(app, config.getLogger, config.server.baseUriPath);
             break;
         }
         case IAuthType.ENTERPRISE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
             break;
         }
         case IAuthType.HOSTED: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
             break;
         }
         case IAuthType.DEMO: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,
@@ -141,7 +138,6 @@ export default async function getApp(
             break;
         }
         case IAuthType.CUSTOM: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
@@ -152,7 +148,6 @@ export default async function getApp(
             break;
         }
         default: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,

--- a/src/test/e2e/api/proxy/proxy.authtype.none.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.authtype.none.e2e.test.ts
@@ -1,0 +1,53 @@
+import { IUnleashTest, setupApp } from '../../helpers/test-helper';
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import { randomId } from '../../../../lib/util';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
+
+let app: IUnleashTest;
+let db: ITestDb;
+let appErrorLogs: string[] = [];
+
+beforeAll(async () => {
+    db = await dbInit('proxy_auth_none', getLogger);
+    const baseLogger = getLogger();
+    const appLogger = {
+        ...baseLogger,
+        error: (msg: string, ...args: any[]) => {
+            appErrorLogs.push(msg);
+            baseLogger.error(msg, ...args);
+        },
+    };
+    app = await setupApp(db.stores);
+});
+
+afterEach(() => {
+    app.services.proxyService.stopAll();
+    jest.clearAllMocks();
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+beforeEach(async () => {
+    appErrorLogs = [];
+});
+
+test('calling /frontend with a token works when AuthType=None', async () => {
+    const frontendTokenDefault =
+        await app.services.apiTokenService.createApiTokenWithProjects({
+            type: ApiTokenType.FRONTEND,
+            projects: ['default'],
+            environment: 'default',
+            tokenName: `test-token-${randomId()}`,
+        });
+
+    await app.request
+        .get('/api/frontend')
+        .set('Authorization', frontendTokenDefault.secret)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    expect(appErrorLogs).toHaveLength(0);
+});


### PR DESCRIPTION
## About the changes

Fixes an issue where setting AuthType=None on the instance caused /frontend to crash regardless if there's a correct token or not.

This is a redo of this PR: https://github.com/Unleash/unleash/pull/3031
Adds an end 2 end test to verify
