### PR TITLE
task: Add an X-Unleash-Version header to register response

### DIFF
--- a/src/lib/routes/client-api/register.test.ts
+++ b/src/lib/routes/client-api/register.test.ts
@@ -102,3 +102,19 @@ test('should allow an empty instanceId field', () => {
         })
         .expect(202);
 });
+
+test('Includes an X-Unleash-Version header in the response', () => {
+    return request
+        .post('/api/client/register')
+        .send({
+            appName: 'demo',
+            instanceId: '',
+            strategies: ['default'],
+            started: Date.now(),
+            interval: 10,
+        })
+        .expect(202)
+        .expect((res) => {
+            expect(res.headers['x-unleash-version']).toBeTruthy();
+        });
+});

--- a/src/lib/routes/client-api/register.ts
+++ b/src/lib/routes/client-api/register.ts
@@ -15,6 +15,7 @@ import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import { ClientApplicationSchema } from '../../openapi/spec/client-application-schema';
 import rateLimit from 'express-rate-limit';
 import { minutesToMilliseconds } from 'date-fns';
+import version from '../../util/version';
 
 export default class RegisterController extends Controller {
     logger: Logger;
@@ -93,6 +94,6 @@ export default class RegisterController extends Controller {
         data.environment = RegisterController.resolveEnvironment(user, data);
         data.project = RegisterController.extractProjectFromRequest(req);
         await this.clientInstanceService.registerClient(data, clientIp);
-        res.status(202).end();
+        res.header('X-Unleash-Version', version).status(202).end();
     }
 }


### PR DESCRIPTION
Related to our work for making Edge bulk metrics a 1st class citizen of Unleash, this PR adds an X-Unleash-Version header to the response from client registration.

Based on when we add the new `/api/client/metrics/bulk` endpoint, Edge can use the response header from upstream to decide whether to post metrics to `/edge/metrics` or `/api/client/metrics/bulk`.