### PR TITLE
docs: add image zoom to docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -776,6 +776,8 @@ module.exports = {
                 noRuntimeDownloads: true,
             },
         ],
+        'plugin-image-zoom'
+
     ],
     themes: [
         'docusaurus-theme-openapi-docs', // Allows use of @theme/ApiItem and other components

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -160,9 +160,7 @@ module.exports = {
         imageZoom: {
             // Optional medium-zoom options at
             // https://www.npmjs.com/package/medium-zoom#options
-            options: {
-                background: 'var(--unleash-img-background-color)',
-            },
+            options: {},
         }
     },
     presets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -157,6 +157,13 @@ module.exports = {
             },
         },
         image: 'img/logo.png',
+        imageZoom: {
+            // Optional medium-zoom options at
+            // https://www.npmjs.com/package/medium-zoom#options
+            options: {
+                background: 'var(--unleash-img-background-color)',
+            },
+        }
     },
     presets: [
         [
@@ -776,8 +783,7 @@ module.exports = {
                 noRuntimeDownloads: true,
             },
         ],
-        'plugin-image-zoom'
-
+        'plugin-image-zoom',
     ],
     themes: [
         'docusaurus-theme-openapi-docs', // Allows use of @theme/ApiItem and other components

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "docusaurus-theme-openapi-docs": "2.0.0-beta.2",
     "file-loader": "6.2.0",
     "immer": "^9.0.6",
+    "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "unleash-proxy-client": "2.5.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8048,6 +8048,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+medium-zoom@^1.0.8:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.1.0.tgz#6efb6bbda861a02064ee71a2617a8dc4381ecc71"
+  integrity sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==
+
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.10.tgz#4cdff7cfd21351a85e11b08aa276ebf100210a4d"
@@ -9043,6 +9048,12 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+plugin-image-zoom@flexanalytics/plugin-image-zoom:
+  version "1.1.0"
+  resolved "https://codeload.github.com/flexanalytics/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
+  dependencies:
+    medium-zoom "^1.0.8"
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This PR adds a zoom feature to the docs.

Interact with the images to blow them up to fill the screen. Still leaves the header for now, so some larger images are a bit wonky, but we can probably get around that.
