### PR TITLE
feat: daily metrics db migration

### DIFF
--- a/src/migrations/20240108151652-add-daily-metrics.js
+++ b/src/migrations/20240108151652-add-daily-metrics.js
@@ -1,7 +1,7 @@
 exports.up = function (db, cb) {
     db.runSql(
         `
-      CREATE TABLE IF NOT EXISTS client_metrics_env_daily(
+      CREATE TABLE IF NOT EXISTS client_metrics_env_daily (
                feature_name  VARCHAR(255),
                app_name      VARCHAR(255),
                environment   VARCHAR(100),

--- a/src/migrations/20240108151652-add-daily-metrics.js
+++ b/src/migrations/20240108151652-add-daily-metrics.js
@@ -1,0 +1,45 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+      CREATE TABLE IF NOT EXISTS client_metrics_env_daily(
+               feature_name  VARCHAR(255),
+               app_name      VARCHAR(255),
+               environment   VARCHAR(100),
+               timestamp     TIMESTAMP WITH TIME ZONE,
+               yes           INTEGER DEFAULT 0,
+               no            INTEGER DEFAULT 0,
+               PRIMARY KEY (feature_name, app_name, environment, timestamp)
+      );
+      CREATE TABLE IF NOT EXISTS client_metrics_env_variants_daily (
+               feature_name  VARCHAR(255),
+               app_name      VARCHAR(255),
+               environment   VARCHAR(100),
+               timestamp     TIMESTAMP WITH TIME ZONE,
+               variant       TEXT,
+               count         INTEGER DEFAULT 0,
+               FOREIGN KEY (
+                            feature_name, app_name, environment,
+                            timestamp
+                   ) REFERENCES client_metrics_env_daily (
+                                                    feature_name, app_name, environment,
+                                                    timestamp
+                   ) ON UPDATE CASCADE ON DELETE CASCADE,
+               PRIMARY KEY(
+                           feature_name, app_name, environment,
+                           timestamp, variant
+                   )
+            );
+  `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DROP TABLE client_metrics_env_daily;
+        DROP TABLE client_metrics_env_variants_daily;
+        `,
+        cb,
+    );
+};

--- a/src/migrations/20240108151652-add-daily-metrics.js
+++ b/src/migrations/20240108151652-add-daily-metrics.js
@@ -37,8 +37,8 @@ exports.up = function (db, cb) {
 exports.down = function (db, cb) {
     db.runSql(
         `
-        DROP TABLE client_metrics_env_daily;
         DROP TABLE client_metrics_env_variants_daily;
+        DROP TABLE client_metrics_env_daily;
         `,
         cb,
     );

--- a/src/migrations/20240108151652-add-daily-metrics.js
+++ b/src/migrations/20240108151652-add-daily-metrics.js
@@ -5,28 +5,28 @@ exports.up = function (db, cb) {
                feature_name  VARCHAR(255),
                app_name      VARCHAR(255),
                environment   VARCHAR(100),
-               timestamp     TIMESTAMP WITH TIME ZONE,
+               date          DATE,
                yes           INTEGER DEFAULT 0,
                no            INTEGER DEFAULT 0,
-               PRIMARY KEY (feature_name, app_name, environment, timestamp)
+               PRIMARY KEY (feature_name, app_name, environment, date)
       );
       CREATE TABLE IF NOT EXISTS client_metrics_env_variants_daily (
                feature_name  VARCHAR(255),
                app_name      VARCHAR(255),
                environment   VARCHAR(100),
-               timestamp     TIMESTAMP WITH TIME ZONE,
+               date          DATE,
                variant       TEXT,
                count         INTEGER DEFAULT 0,
                FOREIGN KEY (
                             feature_name, app_name, environment,
-                            timestamp
+                            date
                    ) REFERENCES client_metrics_env_daily (
                                                     feature_name, app_name, environment,
-                                                    timestamp
+                                                    date
                    ) ON UPDATE CASCADE ON DELETE CASCADE,
                PRIMARY KEY(
                            feature_name, app_name, environment,
-                           timestamp, variant
+                           date, variant
                    )
             );
   `,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Business problem: we want to store up to 3 months of metrics data. Hourly storage is not feasible, so we go for the daily storage above 2 days.

Technical solution:
Adding 2 new tables to simulate time series DB in postgres. The idea is to store data in high resolution initially (the original tables) and then aggregate it to a lower resolution as it ages (2 new tables). 
The original metrics tables contain hourly data, the new tables will contain daily data. The structure is the same except from the timestamp column changing to date column.

Calculations for 90 days of data: https://gist.github.com/kwasniew/864bb6e5111b7de516b6e4454963d2d4#data-requirements-for-the-extended-90-days-scenario. New table should take twice as much space as the hourly table.

In the next PR I will create a scheduler that uses those tables for aggregation: https://github.com/Unleash/unleash/pull/5804


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
