### PR TITLE
chore: add `reason` column to change request schedule table

### DIFF
--- a/src/migrations/20240109095348-add-reason-column-to-schedule.js
+++ b/src/migrations/20240109095348-add-reason-column-to-schedule.js
@@ -1,0 +1,16 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE change_request_schedule ADD COLUMN reason TEXT;
+         UPDATE change_request_schedule SET reason = failure_reason;`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE change_request_schedule DROP COLUMN failure_reason;`,
+        cb,
+    );
+};

--- a/src/migrations/20240109095348-add-reason-column-to-schedule.js
+++ b/src/migrations/20240109095348-add-reason-column-to-schedule.js
@@ -10,7 +10,7 @@ exports.up = function (db, cb) {
 
 exports.down = function (db, cb) {
     db.runSql(
-        `ALTER TABLE change_request_schedule DROP COLUMN failure_reason;`,
+        `ALTER TABLE change_request_schedule DROP COLUMN reason;`,
         cb,
     );
 };


### PR DESCRIPTION
This PR adds a new `reason` column to the change request schedules table and populates it with the data that is in the `failure_reason` column. 

This is the expand phase of the expand/contract pattern. The code in enterprise will be updated to try and use the new column name, but fall back to the old one if no value is present.

The old column can be removed later.