### PR TITLE
fix: remove unsued metric 'optimal304DiffingCounter'

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -185,12 +185,6 @@ export default class MetricsMonitor {
             labelNames: ['sdk_name', 'sdk_version'],
         });
 
-        const optimal304DiffingCounter = new client.Counter({
-            name: 'optimal_304_diffing',
-            help: 'Count the Optimal 304 diffing with status',
-            labelNames: ['status'],
-        });
-
         const productionChanges30 = new client.Gauge({
             name: 'production_changes_30',
             help: 'Changes made to production environment last 30 days',
@@ -349,10 +343,6 @@ export default class MetricsMonitor {
 
         eventBus.on(events.SCHEDULER_JOB_TIME, ({ jobId, time }) => {
             schedulerDuration.labels(jobId).observe(time);
-        });
-
-        eventBus.on('optimal304Differ', ({ status }) => {
-            optimal304DiffingCounter.labels(status).inc();
         });
 
         eventBus.on(events.DB_TIME, ({ store, action, time }) => {


### PR DESCRIPTION
This metric was used while developing the optimal304 feature. The feature flag has been removed and this data is not longer being collected and this will remove the metric from Prometheus. 