### PR TITLE
Feat/rm new strategy config button

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEdit.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEdit.tsx
@@ -225,10 +225,7 @@ export const ConstraintAccordionEdit = ({
                 expanded={expanded}
                 TransitionProps={{
                     onExited: () => {
-                        if (action === CANCEL) {
-                            setAction('');
-                            onCancel();
-                        } else if (action === SAVE) {
+                        if (action === SAVE) {
                             setAction('');
                             onSave(localConstraint);
                         }

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ConstraintAccordionEditBody.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ConstraintAccordionEditBody.tsx
@@ -69,14 +69,6 @@ export const ConstraintAccordionEditBody: React.FC<IConstraintAccordionBody> =
                         >
                             Done
                         </StyledLeftButton>
-                        <StyledRightButton
-                            onClick={() => {
-                                setAction(CANCEL);
-                                triggerTransition();
-                            }}
-                        >
-                            Cancel
-                        </StyledRightButton>
                     </StyledInputButtonContainer>
                 </StyledButtonContainer>
             </>


### PR DESCRIPTION
This PR removes the cancel button from the new constraint accordion. Since we now do autosave when the constraint updates, cancel is no longer needed, the done button and delete button is enough.