### PR TITLE
chore: align the system user defined in `core.ts` with the one created in the migration

### DIFF
--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -25,7 +25,7 @@ export interface IUnleash {
 // Used by unleash internally for performing system actions that have
 // no user
 export const SYSTEM_USER: IUser = {
-    email: 'systemuser@getunleash.io',
+    email: '',
     id: -1337,
     imageUrl: '',
     isAPI: false,

--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -25,7 +25,7 @@ export interface IUnleash {
 // Used by unleash internally for performing system actions that have
 // no user
 export const SYSTEM_USER: IUser = {
-    email: 'system@getunleash.io',
+    email: 'systemuser@getunleash.io',
     id: -1337,
     imageUrl: '',
     isAPI: false,

--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -22,12 +22,14 @@ export interface IUnleash {
     version: string;
 }
 
+// Used by unleash internally for performing system actions that have
+// no user
 export const SYSTEM_USER: IUser = {
-    email: 'systemuser@getunleash.io',
+    email: 'system@getunleash.io',
     id: -1337,
     imageUrl: '',
     isAPI: false,
-    name: 'Used by unleash internally for performing system actions that have no user',
+    name: 'Unleash System',
     permissions: [],
     username: 'unleash_system_user',
 };


### PR DESCRIPTION
This change adjusts the exported `SYSTEM_USER` constant in `core.ts` to
match the one created in the migration in `src/migrations/20231222071533-unleash-system-user.js`

The slight discrepancy between these two caused me some minor headache
when trying to write a test in enterprise. 

It also removes the email because we have no inbox at that address (and we probably don't want one).

For reference, the migration looks like this:

``` sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE;
INSERT INTO users
    (id, name, username, email, created_by_user_id, is_system)
VALUES
    (-1337, 'Unleash System', 'unleash_system_user', 'system@getunleash.io', -1337, true);

```