### PR TITLE
fix: remove empty variants when changing tabs

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/NewEditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/NewEditChange.tsx
@@ -25,7 +25,7 @@ import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
-import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
+import { NewStrategyVariants } from 'component/feature/StrategyTypes/NewStrategyVariants';
 
 interface IEditChangeProps {
     change: IChangeRequestAddStrategy | IChangeRequestUpdateStrategy;
@@ -174,7 +174,7 @@ export const NewEditChange = ({
                             tab={tab}
                             setTab={setTab}
                             StrategyVariants={
-                                <StrategyVariants
+                                <NewStrategyVariants
                                     strategy={strategy}
                                     setStrategy={setStrategy}
                                     environment={environment}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -337,7 +337,9 @@ export const NewFeatureStrategyForm = ({
             if (newStrategyConfigurationFeedback && !hasSubmittedFeedback) {
                 createFeedbackContext();
             }
-        } catch (e) {}
+        } catch (e) {
+            console.error(e);
+        }
     };
 
     const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm.tsx
@@ -47,6 +47,7 @@ import EnvironmentIcon from 'component/common/EnvironmentIcon/EnvironmentIcon';
 import { useFeedback } from 'component/feedbackNew/useFeedback';
 import { useUserSubmittedFeedback } from 'hooks/useSubmittedFeedback';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { NewStrategyVariants } from 'component/feature/StrategyTypes/NewStrategyVariants';
 
 interface IFeatureStrategyFormProps {
     feature: IFeatureToggle;
@@ -330,11 +331,13 @@ export const NewFeatureStrategyForm = ({
     };
 
     const onSubmitWithFeedback = async () => {
-        await onSubmit();
+        try {
+            await onSubmit();
 
-        if (newStrategyConfigurationFeedback && !hasSubmittedFeedback) {
-            createFeedbackContext();
-        }
+            if (newStrategyConfigurationFeedback && !hasSubmittedFeedback) {
+                createFeedbackContext();
+            }
+        } catch (e) {}
     };
 
     const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
@@ -187,8 +187,8 @@ describe('NewFeatureStrategyCreate', () => {
         expect(screen.getByText(expectedVariantName)).toBeInTheDocument();
     });
 
-    test('should change variant name after changing tab', async () => {
-        const { expectedVariantName } = setupComponent();
+    test.only('should remove empty variants when changing tabs', async () => {
+        setupComponent();
 
         const titleEl = await screen.findByText('Gradual rollout');
         expect(titleEl).toBeInTheDocument();
@@ -207,12 +207,8 @@ describe('NewFeatureStrategyCreate', () => {
 
         fireEvent.click(variantsEl);
 
-        const inputElement = screen.getAllByRole('textbox')[0];
-        fireEvent.change(inputElement, {
-            target: { value: expectedVariantName },
-        });
-
-        expect(screen.getByText(expectedVariantName)).toBeInTheDocument();
+        const variants = screen.queryAllByTestId('VARIANT');
+        expect(variants.length).toBe(0);
     });
 
     test('Should autosave constraint settings when navigating between tabs', async () => {

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
@@ -228,6 +228,9 @@ describe('NewFeatureStrategyCreate', () => {
         const addVariantEl = await screen.findByText('Add variant');
         fireEvent.click(addVariantEl);
 
+        const variants = screen.queryAllByTestId('VARIANT');
+        expect(variants.length).toBe(1);
+
         const targetingEl = await screen.findByText('Targeting');
         fireEvent.click(targetingEl);
 
@@ -236,8 +239,8 @@ describe('NewFeatureStrategyCreate', () => {
 
         fireEvent.click(variantsEl);
 
-        const variants = screen.queryAllByTestId('VARIANT');
-        expect(variants.length).toBe(0);
+        const variants2 = screen.queryAllByTestId('VARIANT');
+        expect(variants2.length).toBe(0);
     });
 
     test('Should autosave constraint settings when navigating between tabs', async () => {

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.test.tsx
@@ -187,7 +187,36 @@ describe('NewFeatureStrategyCreate', () => {
         expect(screen.getByText(expectedVariantName)).toBeInTheDocument();
     });
 
-    test.only('should remove empty variants when changing tabs', async () => {
+    test('should change variant name after changing tab', async () => {
+        const { expectedVariantName } = setupComponent();
+
+        const titleEl = await screen.findByText('Gradual rollout');
+        expect(titleEl).toBeInTheDocument();
+
+        const variantsEl = screen.getByText('Variants');
+        fireEvent.click(variantsEl);
+
+        const addVariantEl = await screen.findByText('Add variant');
+        fireEvent.click(addVariantEl);
+
+        const inputElement = screen.getAllByRole('textbox')[0];
+        fireEvent.change(inputElement, {
+            target: { value: expectedVariantName },
+        });
+
+        const targetingEl = await screen.findByText('Targeting');
+        fireEvent.click(targetingEl);
+
+        const addConstraintEl = await screen.findByText('Add constraint');
+        expect(addConstraintEl).toBeInTheDocument();
+
+        fireEvent.click(variantsEl);
+        const inputElement2 = screen.getAllByRole('textbox')[0];
+
+        expect(inputElement2).not.toBeDisabled();
+    });
+
+    test('should remove empty variants when changing tabs', async () => {
         setupComponent();
 
         const titleEl = await screen.findByText('Gradual rollout');

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
@@ -216,6 +216,7 @@ export const NewFeatureStrategyCreate = () => {
                         setStrategy={setStrategy}
                         environment={environmentId}
                         projectId={projectId}
+                        editable
                     />
                 }
             />

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyCreate/NewFeatureStrategyCreate.tsx
@@ -34,7 +34,7 @@ import useQueryParams from 'hooks/useQueryParams';
 import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
 import { useDefaultStrategy } from '../../../project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy';
 import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
-import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
+import { NewStrategyVariants } from 'component/feature/StrategyTypes/NewStrategyVariants';
 
 export const NewFeatureStrategyCreate = () => {
     const [tab, setTab] = useState(0);
@@ -211,12 +211,11 @@ export const NewFeatureStrategyCreate = () => {
                 tab={tab}
                 setTab={setTab}
                 StrategyVariants={
-                    <StrategyVariants
+                    <NewStrategyVariants
                         strategy={strategy}
                         setStrategy={setStrategy}
                         environment={environmentId}
                         projectId={projectId}
-                        editable
                     />
                 }
             />

--- a/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/NewFeatureStrategyEdit/NewFeatureStrategyEdit.tsx
@@ -29,7 +29,7 @@ import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useCh
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { NewFeatureStrategyForm } from 'component/feature/FeatureStrategy/FeatureStrategyForm/NewFeatureStrategyForm';
-import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
+import { NewStrategyVariants } from 'component/feature/StrategyTypes/NewStrategyVariants';
 
 const useTitleTracking = () => {
     const [previousTitle, setPreviousTitle] = useState<string>('');
@@ -233,7 +233,7 @@ export const NewFeatureStrategyEdit = () => {
                 tab={tab}
                 setTab={setTab}
                 StrategyVariants={
-                    <StrategyVariants
+                    <NewStrategyVariants
                         strategy={strategy}
                         setStrategy={setStrategy}
                         environment={environmentId}

--- a/frontend/src/component/feature/StrategyTypes/NewStrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/NewStrategyVariants.tsx
@@ -6,19 +6,34 @@ import PermissionButton from '../../common/PermissionButton/PermissionButton';
 import { UPDATE_FEATURE_ENVIRONMENT_VARIANTS } from '../../providers/AccessProvider/permissions';
 import { v4 as uuidv4 } from 'uuid';
 import { WeightType } from '../../../constants/variantTypes';
-import { Link, styled, Typography, useTheme } from '@mui/material';
+import { Box, styled, Typography, useTheme } from '@mui/material';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import SplitPreviewSlider from './SplitPreviewSlider/SplitPreviewSlider';
 import { HelpIcon } from '../../common/HelpIcon/HelpIcon';
 import { StrategyVariantsUpgradeAlert } from '../../common/StrategyVariantsUpgradeAlert/StrategyVariantsUpgradeAlert';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { Add } from '@mui/icons-material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledVariantForms = styled('div')({
     display: 'flex',
     flexDirection: 'column',
 });
 
-export const StrategyVariants: FC<{
+const StyledHelpIconBox = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+}));
+
+const StyledVariantsHeader = styled('div')(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    marginTop: theme.spacing(1.5),
+}));
+
+export const NewStrategyVariants: FC<{
     setStrategy: React.Dispatch<
         React.SetStateAction<Partial<IFeatureStrategy>>
     >;
@@ -35,6 +50,17 @@ export const StrategyVariants: FC<{
         strategy?.parameters && 'stickiness' in strategy?.parameters
             ? String(strategy.parameters.stickiness)
             : 'default';
+
+    useEffect(() => {
+        return () => {
+            setStrategy((prev) => ({
+                ...prev,
+                variants: variantsEdit.filter((variant) =>
+                    Boolean(variant.name),
+                ),
+            }));
+        };
+    }, [JSON.stringify(variantsEdit)]);
 
     useEffect(() => {
         setVariantsEdit(
@@ -95,33 +121,43 @@ export const StrategyVariants: FC<{
 
     return (
         <>
-            <Typography
-                component='h3'
-                sx={{ m: 0, display: 'flex', gap: '1ch' }}
-                variant='h3'
-            >
-                Variants
+            <StyledVariantsHeader>
+                Variants enhance a feature flag by providing a version of the
+                feature to be enabled
+            </StyledVariantsHeader>
+            <StyledHelpIconBox>
+                <Typography>Variants</Typography>
                 <HelpIcon
-                    htmlTooltip={true}
+                    htmlTooltip
                     tooltip={
-                        <>
-                            <span>
-                                Variants allow to attach one or more values to
-                                this strategy. Variants at the strategy level
-                                override variants at the feature level.
-                            </span>
-                            <Link
-                                target='_blank'
-                                href='https://docs.getunleash.io/reference/strategy-variants'
-                            >
-                                Learn more
-                            </Link>
-                        </>
+                        <Box>
+                            <Typography variant='body2'>
+                                Variants in feature toggling allow you to serve
+                                different versions of a feature to different
+                                users. This can be used for A/B testing, gradual
+                                rollouts, and canary releases. Variants provide
+                                a way to control the user experience at a
+                                granular level, enabling you to test and
+                                optimize different aspects of your features.
+                                Read more about variants{' '}
+                                <a
+                                    href='https://docs.getunleash.io/reference/strategy-variants'
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                >
+                                    here
+                                </a>
+                            </Typography>
+                        </Box>
                     }
                 />
-            </Typography>
+            </StyledHelpIconBox>
             <StyledVariantForms>
-                <StrategyVariantsUpgradeAlert />
+                <ConditionallyRender
+                    condition={variantsEdit.length > 0}
+                    show={<StrategyVariantsUpgradeAlert />}
+                />
+
                 {variantsEdit.map((variant, i) => (
                     <VariantForm
                         disableOverrides={true}
@@ -156,6 +192,7 @@ export const StrategyVariants: FC<{
                 projectId={projectId}
                 environmentId={environment}
                 data-testid='ADD_STRATEGY_VARIANT_BUTTON'
+                startIcon={<Add />}
             >
                 Add variant
             </PermissionButton>


### PR DESCRIPTION
This PR makes a change to how variants work in the new setup. Variants will now:

* Be removed if you change tab or unmount the component and it has no name
* Moved StrategyVariants into a separate component to isolate this change
* Add error handling around onSubmit and only trigger feedback if it's successful