### PR TITLE
chore: remove unused event

### DIFF
--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -143,8 +143,6 @@ export const CHANGE_REQUEST_CANCELLED = 'change-request-cancelled' as const;
 export const CHANGE_REQUEST_SENT_TO_REVIEW =
     'change-request-sent-to-review' as const;
 export const CHANGE_REQUEST_APPLIED = 'change-request-applied' as const;
-export const SCHEDULED_CHANGE_REQUEST_EXECUTED =
-    'scheduled-change-request-executed' as const; //This will be removed in follow up PR
 export const CHANGE_REQUEST_SCHEDULE_SUSPENDED =
     'change-request-schedule-suspended' as const;
 export const CHANGE_REQUEST_SCHEDULED = 'change-request-scheduled' as const;
@@ -293,7 +291,6 @@ export const IEventTypes = [
     CHANGE_REQUEST_APPROVAL_ADDED,
     CHANGE_REQUEST_CANCELLED,
     CHANGE_REQUEST_SENT_TO_REVIEW,
-    SCHEDULED_CHANGE_REQUEST_EXECUTED,
     CHANGE_REQUEST_SCHEDULE_SUSPENDED,
     CHANGE_REQUEST_APPLIED,
     CHANGE_REQUEST_SCHEDULED,


### PR DESCRIPTION
Removes the SCHEDULED_CHANGE_REQUEST_EXECUTED event - replaced with CHANGE_REQUEST_SCHEDULED_APPLICATION_FAILURE, CHANGE_REQUEST_SCHEDULED_APPLICATION_SUCCESS events

Closes # [1-1900](https://linear.app/unleash/issue/1-1900/remove-old-schedule-executed-event)