### PR TITLE
feat: show suspended schedules in ui

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -111,7 +111,7 @@ export const ChangeRequestOverview: FC = () => {
         changeRequest.environment,
     );
 
-    const hasSchedule = Boolean(changeRequest.schedule?.scheduledAt);
+    const hasSchedule = Boolean('schedule' in changeRequest && changeRequest.schedule?.scheduledAt);
 
     const onApplyChanges = async () => {
         try {
@@ -266,8 +266,7 @@ export const ChangeRequestOverview: FC = () => {
                 <StyledAsideBox>
                     <ChangeRequestTimeline
                         state={changeRequest.state}
-                        scheduledAt={changeRequest.schedule?.scheduledAt}
-                        failureReason={changeRequest.schedule?.failureReason}
+        schedule={'schedule' in changeRequest ? changeRequest.schedule : undefined}
                     />
                     <ChangeRequestReviewers changeRequest={changeRequest} />
                 </StyledAsideBox>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.styles.ts
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.styles.ts
@@ -5,6 +5,7 @@ import {
     Schedule,
     Edit,
     Error as ErrorIcon,
+    PauseCircle,
 } from '@mui/icons-material';
 import { Box, Typography, Divider } from '@mui/material';
 
@@ -55,6 +56,14 @@ export const StyledScheduleFailedIcon = styled(ErrorIcon)(({ theme }) => ({
     width: '35px',
     marginRight: theme.spacing(1),
 }));
+
+export const StyledScheduleSuspendedIcon = styled(PauseCircle)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    height: '35px',
+    width: '35px',
+    marginRight: theme.spacing(1),
+}));
+
 export const StyledEditIcon = styled(Edit)(({ theme }) => ({
     color: theme.palette.text.secondary,
     height: '24px',

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -23,6 +23,7 @@ import {
     StyledScheduledBox,
     StyledErrorIcon,
     StyledScheduleFailedIcon,
+    StyledScheduleSuspendedIcon,
 } from './ChangeRequestReviewStatus.styles';
 import {
     ChangeRequestState,
@@ -260,7 +261,15 @@ const Scheduled = ({ schedule, onEditClick }: IScheduledProps) => {
                 <ConditionallyRender
                     condition={schedule?.status === 'pending'}
                     show={<ScheduledPending schedule={schedule} />}
-                    elseShow={<ScheduledFailed schedule={schedule} />}
+                    elseShow={
+                        <ConditionallyRender
+                            condition={schedule?.status === 'failed'}
+                            show={<ScheduledFailed schedule={schedule} />}
+                            elseShow={
+                                <ScheduledSuspended schedule={schedule} />
+                            }
+                        />
+                    }
                 />
 
                 <StyledIconButton onClick={onEditClick}>
@@ -294,6 +303,39 @@ const ScheduledFailed = ({
                 <StyledReviewTitle color={theme.palette.error.main}>
                     Changes failed to be applied on {scheduledTime} because of{' '}
                     {schedule?.failureReason}
+                </StyledReviewTitle>
+                <Typography>Your timezone is {timezone}</Typography>
+            </Box>
+        </StyledFlexAlignCenterBox>
+    );
+};
+
+const ScheduledSuspended = ({
+    schedule,
+}: { schedule: IChangeRequestSchedule }) => {
+    const theme = useTheme();
+    const timezone = getBrowserTimezone();
+    const { locationSettings } = useLocationSettings();
+
+    if (!schedule?.scheduledAt) {
+        return null;
+    }
+
+    const scheduledTime = formatDateYMDHMS(
+        new Date(schedule?.scheduledAt),
+        locationSettings?.locale,
+    );
+
+    return (
+        <StyledFlexAlignCenterBox>
+            <StyledScheduleSuspendedIcon />
+            <Box>
+                <StyledReviewTitle color={theme.palette.text.secondary}>
+                    The change request is suspended for the following reason:{' '}
+                    {(schedule as unknown as { reason: string }).reason}
+                </StyledReviewTitle>
+                <StyledReviewTitle color={theme.palette.text.secondary}>
+                    It will not be applied on {scheduledTime}.
                 </StyledReviewTitle>
                 <Typography>Your timezone is {timezone}</Typography>
             </Box>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewStatus/ChangeRequestReviewStatus.tsx
@@ -28,7 +28,7 @@ import {
 import {
     ChangeRequestState,
     IChangeRequest,
-    IChangeRequestSchedule,
+    ChangeRequestSchedule,
 } from 'component/changeRequest/changeRequest.types';
 import { getBrowserTimezone } from './utils';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
@@ -280,9 +280,7 @@ const Scheduled = ({ schedule, onEditClick }: IScheduledProps) => {
     );
 };
 
-const ScheduledFailed = ({
-    schedule,
-}: { schedule: IChangeRequestSchedule }) => {
+const ScheduledFailed = ({ schedule }: { schedule: ChangeRequestSchedule }) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
     const { locationSettings } = useLocationSettings();
@@ -312,7 +310,7 @@ const ScheduledFailed = ({
 
 const ScheduledSuspended = ({
     schedule,
-}: { schedule: IChangeRequestSchedule }) => {
+}: { schedule: ChangeRequestSchedule }) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
     const { locationSettings } = useLocationSettings();
@@ -345,7 +343,7 @@ const ScheduledSuspended = ({
 
 const ScheduledPending = ({
     schedule,
-}: { schedule: IChangeRequestSchedule }) => {
+}: { schedule: ChangeRequestSchedule }) => {
     const theme = useTheme();
     const timezone = getBrowserTimezone();
     const { locationSettings } = useLocationSettings();

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -6,18 +6,25 @@ import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
-import { ChangeRequestState } from '../../changeRequest.types';
+import {
+    ChangeRequestSchedule,
+    ChangeRequestState,
+} from '../../changeRequest.types';
 import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from '../../../common/HtmlTooltip/HtmlTooltip';
 import { Error as ErrorIcon } from '@mui/icons-material';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { formatDateYMDHMS } from 'utils/formatDate';
 
-interface ISuggestChangeTimelineProps {
-    state: ChangeRequestState;
-    scheduledAt?: string;
-    failureReason?: string;
-}
+type ISuggestChangeTimelineProps =
+    | {
+          state: Exclude<ChangeRequestState, 'Scheduled'>;
+          schedule: undefined;
+      }
+    | {
+          state: 'Scheduled';
+          schedule: ChangeRequestSchedule;
+      };
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
     marginTop: theme.spacing(2),
@@ -90,8 +97,7 @@ export const determineColor = (
 
 export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     state,
-    scheduledAt,
-    failureReason,
+    schedule,
 }) => {
     let data;
     switch (state) {
@@ -106,28 +112,39 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     }
     const activeIndex = data.findIndex((item) => item === state);
 
-    const { locationSettings } = useLocationSettings();
-
     return (
         <StyledPaper elevation={0}>
             <StyledBox>
                 <StyledTimeline>
                     {data.map((title, index) => {
-                        const subtitle =
-                            scheduledAt &&
-                            state === 'Scheduled' &&
-                            state === title
-                                ? formatDateYMDHMS(
-                                      new Date(scheduledAt),
-                                      locationSettings?.locale,
-                                  )
-                                : undefined;
+                        console.log('title and state ++', title, state);
+                        if (schedule && title === 'Scheduled') {
+                            console.log('Title for scheduled is', title, state);
+
+                            return createTimelineScheduleItem(
+                                schedule,
+                                // color,
+                                // title,
+                                // index < data.length - 1,
+                                // timelineDotProps,
+                            );
+                        }
+
+                        // const subtitle =
+                        //     scheduledAt &&
+                        //     state === 'Scheduled' &&
+                        //     state === title
+                        //         ? formatDateYMDHMS(
+                        //               new Date(scheduledAt),
+                        //               locationSettings?.locale,
+                        //           )
+                        //         : undefined;
                         const color = determineColor(
                             state,
                             activeIndex,
                             title,
                             index,
-                            failureReason,
+                            // failureReason,
                         );
                         let timelineDotProps = {};
 
@@ -142,8 +159,6 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                         return createTimelineItem(
                             color,
                             title,
-                            subtitle,
-                            failureReason,
                             index < data.length - 1,
                             timelineDotProps,
                         );
@@ -154,11 +169,96 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     );
 };
 
+const createTimelineScheduleItem = (
+    schedule: ChangeRequestSchedule,
+    // color: 'primary' | 'success' | 'grey' | 'error' | 'warning',
+    // title: string,
+    // subtitle: string | undefined,
+    // failureReason: string | undefined,
+    // shouldConnectToNextItem: boolean,
+    // timelineDotProps: { [key: string]: string | undefined } = {},
+) => {
+    const { locationSettings } = useLocationSettings();
+
+    const time = formatDateYMDHMS(
+        new Date(schedule.scheduledAt),
+        locationSettings?.locale,
+    );
+
+    const color = (() => {
+        switch (schedule.status) {
+            case 'suspended':
+                return 'grey';
+            case 'failed':
+                return 'error';
+            case 'pending':
+            default:
+                return 'warning';
+        }
+    })();
+
+    const title = `Schedule ${schedule.status}`;
+
+    const subtitle = (() => {
+        switch (schedule.status) {
+            case 'suspended':
+                return `was ${time}`;
+            case 'failed':
+                return `at ${time}`;
+            case 'pending':
+            default:
+                return `for ${time}`;
+        }
+    })();
+
+    const reason = (() => {
+        switch (schedule.status) {
+            case 'suspended':
+                return (
+                    <HtmlTooltip title={schedule.reason} arrow>
+                        <ErrorIcon color={'error'} fontSize={'small'} />
+                    </HtmlTooltip>
+                );
+            case 'failed':
+                return (
+                    <HtmlTooltip
+                        title={`Schedule failed because of ${
+                            schedule.reason || schedule.failureReason
+                        }`}
+                        arrow
+                    >
+                        <ErrorIcon color={'error'} fontSize={'small'} />
+                    </HtmlTooltip>
+                );
+            case 'pending':
+            default:
+                return <></>;
+        }
+    })();
+
+    return (
+        <TimelineItem key={title}>
+            <TimelineSeparator>
+                <TimelineDot color={color} />
+                <TimelineConnector />
+            </TimelineSeparator>
+            <TimelineContent>
+                {title}
+                <StyledSubtitle>
+                    <Typography
+                        color={'text.secondary'}
+                        sx={{ mr: 1 }}
+                    >{`(${subtitle})`}</Typography>
+                    {reason}
+                </StyledSubtitle>
+            </TimelineContent>
+        </TimelineItem>
+    );
+};
+
 const createTimelineItem = (
     color: 'primary' | 'success' | 'grey' | 'error' | 'warning',
     title: string,
-    subtitle: string | undefined,
-    failureReason: string | undefined,
     shouldConnectToNextItem: boolean,
     timelineDotProps: { [key: string]: string | undefined } = {},
 ) => (
@@ -167,33 +267,6 @@ const createTimelineItem = (
             <TimelineDot color={color} {...timelineDotProps} />
             {shouldConnectToNextItem && <TimelineConnector />}
         </TimelineSeparator>
-        <TimelineContent>
-            {title}
-            <ConditionallyRender
-                condition={Boolean(subtitle)}
-                show={
-                    <StyledSubtitle>
-                        <Typography
-                            color={'text.secondary'}
-                            sx={{ mr: 1 }}
-                        >{`(for ${subtitle})`}</Typography>
-                        <ConditionallyRender
-                            condition={Boolean(failureReason)}
-                            show={
-                                <HtmlTooltip
-                                    title={`Schedule failed because of ${failureReason}`}
-                                    arrow
-                                >
-                                    <ErrorIcon
-                                        color={'error'}
-                                        fontSize={'small'}
-                                    />
-                                </HtmlTooltip>
-                            }
-                        />
-                    </StyledSubtitle>
-                }
-            />
-        </TimelineContent>
+        <TimelineContent>{title}</TimelineContent>
     </TimelineItem>
 );

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -165,7 +165,7 @@ const createTimelineScheduleItem = (schedule: ChangeRequestSchedule) => {
                     `was ${time}`,
                     'grey' as const,
                     <HtmlTooltip title={schedule.reason} arrow>
-                        <ErrorIcon color={'error'} fontSize={'small'} />
+                        <ErrorIcon color={'disabled'} fontSize={'small'} />
                     </HtmlTooltip>,
                 ];
             case 'failed':

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -69,7 +69,6 @@ export const determineColor = (
     changeRequestStateIndex: number,
     displayStage: ChangeRequestState,
     displayStageIndex: number,
-    failureReason?: string,
 ) => {
     if (changeRequestState === 'Cancelled') return 'grey';
 
@@ -117,34 +116,15 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
             <StyledBox>
                 <StyledTimeline>
                     {data.map((title, index) => {
-                        console.log('title and state ++', title, state);
                         if (schedule && title === 'Scheduled') {
-                            console.log('Title for scheduled is', title, state);
-
-                            return createTimelineScheduleItem(
-                                schedule,
-                                // color,
-                                // title,
-                                // index < data.length - 1,
-                                // timelineDotProps,
-                            );
+                            return createTimelineScheduleItem(schedule);
                         }
 
-                        // const subtitle =
-                        //     scheduledAt &&
-                        //     state === 'Scheduled' &&
-                        //     state === title
-                        //         ? formatDateYMDHMS(
-                        //               new Date(scheduledAt),
-                        //               locationSettings?.locale,
-                        //           )
-                        //         : undefined;
                         const color = determineColor(
                             state,
                             activeIndex,
                             title,
                             index,
-                            // failureReason,
                         );
                         let timelineDotProps = {};
 
@@ -169,15 +149,7 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
     );
 };
 
-const createTimelineScheduleItem = (
-    schedule: ChangeRequestSchedule,
-    // color: 'primary' | 'success' | 'grey' | 'error' | 'warning',
-    // title: string,
-    // subtitle: string | undefined,
-    // failureReason: string | undefined,
-    // shouldConnectToNextItem: boolean,
-    // timelineDotProps: { [key: string]: string | undefined } = {},
-) => {
+const createTimelineScheduleItem = (schedule: ChangeRequestSchedule) => {
     const { locationSettings } = useLocationSettings();
 
     const time = formatDateYMDHMS(

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -157,42 +157,22 @@ const createTimelineScheduleItem = (schedule: ChangeRequestSchedule) => {
         locationSettings?.locale,
     );
 
-    const color = (() => {
+    const [title, subtitle, color, reason] = (() => {
         switch (schedule.status) {
             case 'suspended':
-                return 'grey';
-            case 'failed':
-                return 'error';
-            case 'pending':
-            default:
-                return 'warning';
-        }
-    })();
-
-    const title = `Schedule ${schedule.status}`;
-
-    const subtitle = (() => {
-        switch (schedule.status) {
-            case 'suspended':
-                return `was ${time}`;
-            case 'failed':
-                return `at ${time}`;
-            case 'pending':
-            default:
-                return `for ${time}`;
-        }
-    })();
-
-    const reason = (() => {
-        switch (schedule.status) {
-            case 'suspended':
-                return (
+                return [
+                    'Schedule suspended',
+                    `was ${time}`,
+                    'grey' as const,
                     <HtmlTooltip title={schedule.reason} arrow>
                         <ErrorIcon color={'error'} fontSize={'small'} />
-                    </HtmlTooltip>
-                );
+                    </HtmlTooltip>,
+                ];
             case 'failed':
-                return (
+                return [
+                    'Schedule failed',
+                    `at ${time}`,
+                    'error' as const,
                     <HtmlTooltip
                         title={`Schedule failed because of ${
                             schedule.reason || schedule.failureReason
@@ -200,11 +180,11 @@ const createTimelineScheduleItem = (schedule: ChangeRequestSchedule) => {
                         arrow
                     >
                         <ErrorIcon color={'error'} fontSize={'small'} />
-                    </HtmlTooltip>
-                );
+                    </HtmlTooltip>,
+                ];
             case 'pending':
             default:
-                return <></>;
+                return ['Scheduled', `for ${time}`, 'warning' as const, <></>];
         }
     })();
 

--- a/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
@@ -7,6 +7,7 @@ import {
     CircleOutlined,
     Close,
     Error as ErrorIcon,
+    PauseCircle,
 } from '@mui/icons-material';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 
@@ -60,23 +61,39 @@ export const ChangeRequestStatusBadge: VFC<IChangeRequestStatusBadgeProps> = ({
             );
         case 'Scheduled': {
             const { schedule } = changeRequest;
-            const color = schedule!.status === 'pending' ? 'warning' : 'error';
-            const icon =
-                schedule?.status === 'pending' ? (
-                    <AccessTime fontSize={'small'} />
-                ) : (
-                    <ErrorIcon fontSize={'small'} />
-                );
             const scheduledAt = new Date(
                 schedule!.scheduledAt,
             ).toLocaleString();
 
-            const tooltipTitle =
-                schedule?.status === 'pending'
-                    ? `Scheduled for ${scheduledAt}`
-                    : `Failed on ${scheduledAt} because of ${
-                          schedule!.failureReason
-                      }`;
+            const { color, icon, tooltipTitle } = (() => {
+                switch (schedule!.status) {
+                    case 'pending':
+                        return {
+                            color: 'warning' as const,
+                            icon: <AccessTime fontSize={'small'} />,
+                            tooltipTitle: `Scheduled for ${scheduledAt}`,
+                        };
+                    case 'failed':
+                        return {
+                            color: 'error' as const,
+                            icon: <ErrorIcon fontSize={'small'} />,
+                            tooltipTitle: `Failed on ${scheduledAt} because of ${
+                                // @ts-ignore
+                                schedule!.reason ?? schedule!.failureReason
+                            }`,
+                        };
+                    // @ts-ignore
+                    case 'suspended':
+                        return {
+                            color: 'disabled' as const,
+                            icon: <PauseCircle fontSize={'small'} />,
+                            tooltipTitle: `Suspended  because: ${
+                                // @ts-ignore
+                                schedule!.reason
+                            }`,
+                        };
+                }
+            })();
 
             return (
                 <HtmlTooltip title={tooltipTitle} arrow>

--- a/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
@@ -66,31 +66,29 @@ export const ChangeRequestStatusBadge: VFC<IChangeRequestStatusBadgeProps> = ({
             ).toLocaleString();
 
             const { color, icon, tooltipTitle } = (() => {
-                switch (schedule!.status) {
-                    case 'pending':
-                        return {
-                            color: 'warning' as const,
-                            icon: <AccessTime fontSize={'small'} />,
-                            tooltipTitle: `Scheduled for ${scheduledAt}`,
-                        };
+                switch (schedule?.status) {
                     case 'failed':
                         return {
                             color: 'error' as const,
                             icon: <ErrorIcon fontSize={'small'} />,
                             tooltipTitle: `Failed on ${scheduledAt} because of ${
-                                // @ts-ignore
                                 schedule!.reason ?? schedule!.failureReason
                             }`,
                         };
-                    // @ts-ignore
                     case 'suspended':
                         return {
                             color: 'disabled' as const,
                             icon: <PauseCircle fontSize={'small'} />,
                             tooltipTitle: `Suspended  because: ${
-                                // @ts-ignore
                                 schedule!.reason
                             }`,
+                        };
+                    case 'pending':
+                    default:
+                        return {
+                            color: 'warning' as const,
+                            icon: <AccessTime fontSize={'small'} />,
+                            tooltipTitle: `Scheduled for ${scheduledAt}`,
                         };
                 }
             })();

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -18,10 +18,10 @@ export interface IChangeRequest {
     comments: IChangeRequestComment[];
     conflict?: string;
     state: ChangeRequestState;
-    schedule?: IChangeRequestSchedule;
+    schedule?: ChangeRequestSchedule;
 }
 
-export type IChangeRequestSchedule =
+export type ChangeRequestSchedule =
     | {
           status: 'pending';
           scheduledAt: string;

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -21,11 +21,22 @@ export interface IChangeRequest {
     schedule?: IChangeRequestSchedule;
 }
 
-export interface IChangeRequestSchedule {
-    scheduledAt: string;
-    status: 'pending' | 'failed';
-    failureReason?: string;
-}
+export type IChangeRequestSchedule =
+    | {
+          status: 'pending';
+          scheduledAt: string;
+      }
+    | {
+          status: 'failed';
+          scheduledAt: string;
+          failureReason?: string | null;
+          reason: string;
+      }
+    | {
+          status: 'suspended';
+          scheduledAt: string;
+          reason: string;
+      };
 
 export interface IChangeRequestEnvironmentConfig {
     environment: string;

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -3,7 +3,7 @@ import { IFeatureStrategy } from '../../interfaces/strategy';
 import { IUser } from '../../interfaces/user';
 import { SetStrategySortOrderSchema } from '../../openapi';
 
-export interface IChangeRequest {
+export type IChangeRequest = {
     id: number;
     title: string;
     project: string;
@@ -17,9 +17,15 @@ export interface IChangeRequest {
     rejections: IChangeRequestApproval[];
     comments: IChangeRequestComment[];
     conflict?: string;
-    state: ChangeRequestState;
-    schedule?: ChangeRequestSchedule;
-}
+} & (
+    | {
+          state: Exclude<ChangeRequestState, 'Scheduled'>;
+      }
+    | {
+          state: 'Scheduled';
+          schedule: ChangeRequestSchedule;
+      }
+);
 
 export type ChangeRequestSchedule =
     | {


### PR DESCRIPTION
This PR updates the UI to display suspended schedules correctly. 

It:

- uses a standard "pause" icon for the new suspended state
- uses a grey / disabled color for icons text
- mentions why the CR was suspended in the review box at the bottom (and when hovering over the badge / icon)
- updates the timeline to say "schedule suspended" (or "failed") when it is in that state.

In doing this, it also does a little bit of refactoring to use types that are more accurate and to avoid too many "maybe undefined" variables.

It looks a bit like this now:

![image](https://github.com/Unleash/unleash/assets/17786332/974454d8-8a56-4fb2-a7f3-0382728e5bcf)
