### PR TITLE
feat: separate UI flag and backend flag for extended metrics

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
@@ -9,7 +9,7 @@ const server = testServerSetup();
 test('Display extended daily metrics', async () => {
     testServerRoute(server, '/api/admin/ui-config', {
         flags: {
-            extendedUsageMetrics: true,
+            extendedUsageMetricsUI: true,
         },
         versionInfo: {
             current: { oss: 'irrelevant', enterprise: 'some value' },

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -29,7 +29,7 @@ export const FeatureMetricsHours = ({
         setHoursBack(parseInt(key));
     };
     const { isEnterprise } = useUiConfig();
-    const extendedUsageMetrics = useUiFlag('extendedUsageMetrics');
+    const extendedUsageMetrics = useUiFlag('extendedUsageMetricsUI');
     const extendedOptions = isEnterprise() && extendedUsageMetrics;
     const options = extendedOptions
         ? [...hourOptions, ...daysOptions]

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -73,7 +73,7 @@ export type UiFlags = {
     featureSearchFeedback?: boolean;
     enableLicense?: boolean;
     newStrategyConfigurationFeedback?: boolean;
-    extendedUsageMetrics?: boolean;
+    extendedUsageMetricsUI?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -88,6 +88,7 @@ exports[`should create default config 1`] = `
       "enableLicense": false,
       "encryptEmails": false,
       "extendedUsageMetrics": false,
+      "extendedUsageMetricsUI": false,
       "featureSearchAPI": false,
       "featureSearchFeedback": false,
       "featureSearchFeedbackPosting": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -41,7 +41,8 @@ export type IFlagKey =
     | 'featureSearchFeedbackPosting'
     | 'newStrategyConfigurationFeedback'
     | 'edgeBulkMetricsKillSwitch'
-    | 'extendedUsageMetrics';
+    | 'extendedUsageMetrics'
+    | 'extendedUsageMetricsUI';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -186,6 +187,10 @@ const flags: IFlags = {
     ),
     extendedUsageMetrics: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EXTENDED_USAGE_METRICS,
+        false,
+    ),
+    extendedUsageMetricsUI: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EXTENDED_USAGE_METRICS_UI,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -49,6 +49,7 @@ process.nextTick(async () => {
                         increaseUnleashWidth: true,
                         featureSearchFeedback: true,
                         newStrategyConfigurationFeedback: true,
+                        extendedUsageMetricsUI: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes


<img width="205" alt="Screenshot 2024-01-12 at 08 54 07" src="https://github.com/Unleash/unleash/assets/1394682/6b5d3b13-564c-4d62-9910-e6118dcbca1c">

Introducing a new UI flag to control when to show old metrics. Separate backend flag will be used to start collecting metrics before we can show them.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
