### PR TITLE
fix: differentiated interval and initial schedule call

### DIFF
--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -17,7 +17,7 @@ export default class MaintenanceService implements IMaintenanceStatus {
 
     constructor(config: IUnleashConfig, settingService: SettingService) {
         this.config = config;
-        this.logger = config.getLogger('services/pat-service.ts');
+        this.logger = config.getLogger('services/maintenance-service.ts');
         this.settingService = settingService;
     }
 

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -177,8 +177,8 @@ test('Can handle crash of a async job', async () => {
 
     schedulerService.stop();
     expect(getRecords()).toEqual([
-        ['scheduled job failed | id: test-id-10 | async reason'],
-        ['scheduled job failed | id: test-id-10 | async reason'],
+        ['initial scheduled job failed | id: test-id-10 | async reason'],
+        ['interval scheduled job failed | id: test-id-10 | async reason'],
     ]);
 });
 
@@ -197,8 +197,8 @@ test('Can handle crash of a sync job', async () => {
 
     schedulerService.stop();
     expect(getRecords()).toEqual([
-        ['scheduled job failed | id: test-id-11 | Error: sync reason'],
-        ['scheduled job failed | id: test-id-11 | Error: sync reason'],
+        ['initial scheduled job failed | id: test-id-11 | Error: sync reason'],
+        ['interval scheduled job failed | id: test-id-11 | Error: sync reason'],
     ]);
 });
 
@@ -217,8 +217,8 @@ test('Can handle crash of a async job', async () => {
 
     schedulerService.stop();
     expect(getRecords()).toEqual([
-        ['scheduled job failed | id: test-id-10 | async reason'],
-        ['scheduled job failed | id: test-id-10 | async reason'],
+        ['initial scheduled job failed | id: test-id-10 | async reason'],
+        ['interval scheduled job failed | id: test-id-10 | async reason'],
     ]);
 });
 

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -52,7 +52,7 @@ export class SchedulerService {
                     }
                 } catch (e) {
                     this.logger.error(
-                        `scheduled job failed | id: ${id} | ${e}`,
+                        `interval scheduled job failed | id: ${id} | ${e}`,
                     );
                 }
             }, timeMs).unref(),
@@ -64,7 +64,9 @@ export class SchedulerService {
                 await runScheduledFunctionWithEvent();
             }
         } catch (e) {
-            this.logger.error(`scheduled job failed | id: ${id} | ${e}`);
+            this.logger.error(
+                `initial scheduled job failed | id: ${id} | ${e}`,
+            );
         }
     }
 

--- a/src/lib/services/scheduler-service.test.ts
+++ b/src/lib/services/scheduler-service.test.ts
@@ -101,8 +101,8 @@ test('Can handle crash of a async job', async () => {
 
     schedulerService.stop();
     expect(getRecords()).toEqual([
-        ['scheduled job failed | id: test-id-10 | async reason'],
-        ['scheduled job failed | id: test-id-10 | async reason'],
+        ['initial scheduled job failed | id: test-id-10 | async reason'],
+        ['interval scheduled job failed | id: test-id-10 | async reason'],
     ]);
 });
 
@@ -116,7 +116,7 @@ test('Can handle crash of a sync job', async () => {
 
     schedulerService.stop();
     expect(getRecords()).toEqual([
-        ['scheduled job failed | id: test-id-11 | Error: sync reason'],
-        ['scheduled job failed | id: test-id-11 | Error: sync reason'],
+        ['initial scheduled job failed | id: test-id-11 | Error: sync reason'],
+        ['interval scheduled job failed | id: test-id-11 | Error: sync reason'],
     ]);
 });


### PR DESCRIPTION
Differentiate log lines so we can see if it happens on every call, or just on the initial call.