### PR TITLE
fix: include custom root roles in user access overview

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -918,7 +918,9 @@ export class AccessStore implements IAccessStore {
                     SELECT r.name
                     FROM   role_user ru
                     INNER JOIN roles r on ru.role_id = r.id
-                    WHERE ru.user_id = u.id and r.type='root'
+                    WHERE ru.user_id = u.id and r.type IN (${ROOT_ROLE_TYPES.map(
+                        (type) => `'${type}'`,
+                    ).join(',')})
                 ) r, LATERAL (
                 SELECT ARRAY (
                     SELECT g.name FROM group_user gu


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1844/fix-add-custom-root-roles-to-user-access-overview

I noticed our user access overview method did not take into account custom root roles, which meant only users with default root roles were being returned.

This changes the query to check for `IN ('root', 'root-custom')` instead, including both "root" and "custom root" roles.

![image](https://github.com/Unleash/unleash/assets/14320932/aa808e8f-edc0-4a94-b59f-a8b619ae54ca)