### PR TITLE
chore: centralize events service creation

### DIFF
--- a/src/lib/features/access/createAccessService.ts
+++ b/src/lib/features/access/createAccessService.ts
@@ -1,5 +1,4 @@
 import { Db, IUnleashConfig } from 'lib/server-impl';
-import EventStore from '../../db/event-store';
 import GroupStore from '../../db/group-store';
 import { AccountStore } from '../../db/account-store';
 import RoleStore from '../../db/role-store';
@@ -12,26 +11,21 @@ import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
 import FakeRoleStore from '../../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../project-environments/fake-environment-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
-import FeatureTagStore from '../../db/feature-tag-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import { IEventStore } from '../../types';
+import { createEventsService } from '../events/createEventsService';
 
 export const createAccessService = (
     db: Db,
     config: IUnleashConfig,
 ): AccessService => {
     const { eventBus, getLogger, flagResolver } = config;
-    const eventStore = new EventStore(db, getLogger);
     const groupStore = new GroupStore(db);
     const accountStore = new AccountStore(db, getLogger);
     const roleStore = new RoleStore(db, eventBus, getLogger);
     const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
     const accessStore = new AccessStore(db, eventBus, getLogger);
-    const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
-    const eventService = new EventService(
-        { eventStore, featureTagStore },
-        config,
-    );
+    const eventService = createEventsService(db, config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/dependent-features/createDependentFeaturesService.ts
+++ b/src/lib/features/dependent-features/createDependentFeaturesService.ts
@@ -4,32 +4,22 @@ import { DependentFeaturesStore } from './dependent-features-store';
 import { DependentFeaturesReadModel } from './dependent-features-read-model';
 import { FakeDependentFeaturesStore } from './fake-dependent-features-store';
 import { FakeDependentFeaturesReadModel } from './fake-dependent-features-read-model';
-import EventStore from '../../db/event-store';
 import { IUnleashConfig } from '../../types';
-import { EventService } from '../../services';
-import FeatureTagStore from '../../db/feature-tag-store';
-import FakeEventStore from '../../../test/fixtures/fake-event-store';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import {
     createChangeRequestAccessReadModel,
     createFakeChangeRequestAccessService,
 } from '../change-request-access-service/createChangeRequestAccessReadModel';
 import { FeaturesReadModel } from '../feature-toggle/features-read-model';
 import { FakeFeaturesReadModel } from '../feature-toggle/fakes/fake-features-read-model';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createDependentFeaturesService =
     (config: IUnleashConfig) =>
     (db: Db): DependentFeaturesService => {
-        const { getLogger, eventBus } = config;
-        const eventStore = new EventStore(db, getLogger);
-        const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
-        const eventService = new EventService(
-            {
-                eventStore,
-                featureTagStore,
-            },
-            config,
-        );
+        const eventService = createEventsService(db, config);
         const dependentFeaturesStore = new DependentFeaturesStore(db);
         const dependentFeaturesReadModel = new DependentFeaturesReadModel(db);
         const changeRequestAccessReadModel = createChangeRequestAccessReadModel(
@@ -49,15 +39,7 @@ export const createDependentFeaturesService =
 export const createFakeDependentFeaturesService = (
     config: IUnleashConfig,
 ): DependentFeaturesService => {
-    const eventStore = new FakeEventStore();
-    const featureTagStore = new FakeFeatureTagStore();
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore,
-        },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const dependentFeaturesStore = new FakeDependentFeaturesStore();
     const dependentFeaturesReadModel = new FakeDependentFeaturesReadModel();
     const changeRequestAccessReadModel = createFakeChangeRequestAccessService();

--- a/src/lib/features/events/createEventsService.ts
+++ b/src/lib/features/events/createEventsService.ts
@@ -1,0 +1,27 @@
+import FakeEventStore from '../../../test/fixtures/fake-event-store';
+import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
+import { Db } from '../../db/db';
+import EventStore from '../../db/event-store';
+import FeatureTagStore from '../../db/feature-tag-store';
+import { EventService } from '../../services';
+import { IUnleashConfig } from '../../types';
+
+export const createEventsService: (
+    db: Db,
+    config: IUnleashConfig,
+) => EventService = (db, config) => {
+    const eventStore = new EventStore(db, config.getLogger);
+    const featureTagStore = new FeatureTagStore(
+        db,
+        config.eventBus,
+        config.getLogger,
+    );
+    return new EventService({ eventStore, featureTagStore }, config);
+};
+
+export const createFakeEventsService: (config: IUnleashConfig) => EventService =
+    (config) => {
+        const eventStore = new FakeEventStore();
+        const featureTagStore = new FakeFeatureTagStore();
+        return new EventService({ eventStore, featureTagStore }, config);
+    };

--- a/src/lib/features/export-import-toggles/createExportImportService.ts
+++ b/src/lib/features/export-import-toggles/createExportImportService.ts
@@ -54,6 +54,7 @@ import {
     createDependentFeaturesService,
     createFakeDependentFeaturesService,
 } from '../dependent-features/createDependentFeaturesService';
+import { createEventsService } from '../events/createEventsService';
 
 export const createFakeExportImportTogglesService = (
     config: IUnleashConfig,
@@ -196,13 +197,7 @@ export const deferredExportImportTogglesService = (
         const featureToggleService = createFeatureToggleService(db, config);
         const privateProjectChecker = createPrivateProjectChecker(db, config);
 
-        const eventService = new EventService(
-            {
-                eventStore,
-                featureTagStore,
-            },
-            config,
-        );
+        const eventService = createEventsService(db, config);
 
         const featureTagService = new FeatureTagService(
             {

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -29,7 +29,6 @@ import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
 import FakeRoleStore from '../../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../project-environments/fake-environment-store';
-import EventStore from '../../db/event-store';
 import {
     createChangeRequestAccessReadModel,
     createFakeChangeRequestAccessService,
@@ -52,6 +51,7 @@ import {
     createDependentFeaturesService,
     createFakeDependentFeaturesService,
 } from '../dependent-features/createDependentFeaturesService';
+import { createEventsService } from '../events/createEventsService';
 
 export const createFeatureToggleService = (
     db: Db,
@@ -99,11 +99,7 @@ export const createFeatureToggleService = (
     const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
     const roleStore = new RoleStore(db, eventBus, getLogger);
     const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
-    const eventStore = new EventStore(db, getLogger);
-    const eventService = new EventService(
-        { eventStore, featureTagStore },
-        { getLogger },
-    );
+    const eventService = createEventsService(db, config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/group/createGroupService.ts
+++ b/src/lib/features/group/createGroupService.ts
@@ -1,24 +1,18 @@
 import { IUnleashConfig } from '../../types';
-import { EventService, GroupService } from '../../services';
+import { GroupService } from '../../services';
 import { Db } from '../../db/db';
 import GroupStore from '../../db/group-store';
 import { AccountStore } from '../../db/account-store';
-import EventStore from '../../db/event-store';
-import FeatureTagStore from '../../db/feature-tag-store';
+import { createEventsService } from '../events/createEventsService';
 
 export const createGroupService = (
     db: Db,
     config: IUnleashConfig,
 ): GroupService => {
-    const { getLogger, eventBus } = config;
+    const { getLogger } = config;
     const groupStore = new GroupStore(db);
     const accountStore = new AccountStore(db, getLogger);
-    const eventStore = new EventStore(db, getLogger);
-    const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
-    const eventService = new EventService(
-        { eventStore, featureTagStore },
-        { getLogger },
-    );
+    const eventService = createEventsService(db, config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/project-environments/createEnvironmentService.ts
+++ b/src/lib/features/project-environments/createEnvironmentService.ts
@@ -1,8 +1,6 @@
 import { Db } from '../../db/db';
-import EventStore from '../../db/event-store';
 import { IUnleashConfig } from '../../types';
 import { EventService } from '../../services';
-import FeatureTagStore from '../../db/feature-tag-store';
 import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import EnvironmentService from './environment-service';
@@ -14,13 +12,12 @@ import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-env
 import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 import FakeFeatureStrategiesStore from '../feature-toggle/fakes/fake-feature-strategies-store';
 import FakeEnvironmentStore from './fake-environment-store';
+import { createEventsService } from '../events/createEventsService';
 
 export const createEnvironmentService =
     (config: IUnleashConfig) =>
     (db: Db): EnvironmentService => {
         const { getLogger, eventBus, flagResolver } = config;
-        const eventStore = new EventStore(db, getLogger);
-        const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
         const featureEnvironmentStore = new FeatureEnvironmentStore(
             db,
             eventBus,
@@ -39,13 +36,7 @@ export const createEnvironmentService =
             flagResolver,
         );
         const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
-        const eventService = new EventService(
-            {
-                eventStore,
-                featureTagStore,
-            },
-            config,
-        );
+        const eventService = createEventsService(db, config);
         return new EnvironmentService(
             {
                 environmentStore,

--- a/src/lib/features/segment/createSegmentService.ts
+++ b/src/lib/features/segment/createSegmentService.ts
@@ -1,5 +1,4 @@
 import { Db, IUnleashConfig } from 'lib/server-impl';
-import EventStore from '../../db/event-store';
 import { EventService, SegmentService } from '../../services';
 import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import { ISegmentService } from '../../segments/segment-service-interface';
@@ -19,15 +18,14 @@ import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
-import FeatureTagStore from '../../db/feature-tag-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
+import { createEventsService } from '../events/createEventsService';
 
 export const createSegmentService = (
     db: Db,
     config: IUnleashConfig,
 ): SegmentService => {
     const { eventBus, getLogger, flagResolver } = config;
-    const eventStore = new EventStore(db, getLogger);
     const segmentStore = new SegmentStore(
         db,
         eventBus,
@@ -50,13 +48,7 @@ export const createSegmentService = (
 
     const privateProjectChecker = createPrivateProjectChecker(db, config);
 
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore: new FeatureTagStore(db, eventBus, getLogger),
-        },
-        config,
-    );
+    const eventService = createEventsService(db, config);
 
     return new SegmentService(
         { segmentStore, featureStrategiesStore },

--- a/src/lib/features/tag-type/createTagTypeService.ts
+++ b/src/lib/features/tag-type/createTagTypeService.ts
@@ -1,27 +1,18 @@
 import { Db } from '../../db/db';
-import EventStore from '../../db/event-store';
 import { IUnleashConfig } from '../../types';
-import { EventService } from '../../services';
-import FeatureTagStore from '../../db/feature-tag-store';
-import FakeEventStore from '../../../test/fixtures/fake-event-store';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import TagTypeService from './tag-type-service';
 import TagTypeStore from './tag-type-store';
 import FakeTagTypeStore from './fake-tag-type-store';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createTagTypeService =
     (config: IUnleashConfig) =>
     (db: Db): TagTypeService => {
         const { getLogger, eventBus } = config;
-        const eventStore = new EventStore(db, getLogger);
-        const featureTagStore = new FeatureTagStore(db, eventBus, getLogger);
-        const eventService = new EventService(
-            {
-                eventStore,
-                featureTagStore,
-            },
-            config,
-        );
+        const eventService = createEventsService(db, config);
         const tagTypeStore = new TagTypeStore(db, eventBus, getLogger);
         return new TagTypeService({ tagTypeStore }, config, eventService);
     };
@@ -29,15 +20,7 @@ export const createTagTypeService =
 export const createFakeTagTypeService = (
     config: IUnleashConfig,
 ): TagTypeService => {
-    const eventStore = new FakeEventStore();
-    const featureTagStore = new FakeFeatureTagStore();
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore,
-        },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const tagTypeStore = new FakeTagTypeStore();
 
     return new TagTypeService({ tagTypeStore }, config, eventService);

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -17,7 +17,7 @@ import { GroupService } from '../services/group-service';
 import { IRole } from '../../lib/types/stores/access-store';
 import { IGroup, ROLE_CREATED, SYSTEM_USER } from '../../lib/types';
 import BadDataError from '../../lib/error/bad-data-error';
-import { createFakeEventsService } from 'lib/features/events/createEventsService';
+import { createFakeEventsService } from '../../lib/features/events/createEventsService';
 
 function getSetup(customRootRolesKillSwitch: boolean = true) {
     const config = createTestConfig({

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -14,12 +14,10 @@ import FakeRoleStore from '../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../features/project-environments/fake-environment-store';
 import AccessStoreMock from '../../test/fixtures/fake-access-store';
 import { GroupService } from '../services/group-service';
-import FakeEventStore from '../../test/fixtures/fake-event-store';
 import { IRole } from '../../lib/types/stores/access-store';
 import { IGroup, ROLE_CREATED, SYSTEM_USER } from '../../lib/types';
-import EventService from './event-service';
-import FakeFeatureTagStore from '../../test/fixtures/fake-feature-tag-store';
 import BadDataError from '../../lib/error/bad-data-error';
+import { createFakeEventsService } from 'lib/features/events/createEventsService';
 
 function getSetup(customRootRolesKillSwitch: boolean = true) {
     const config = createTestConfig({
@@ -223,7 +221,6 @@ test('throws error when trying to delete a project role in use by group', async 
         getLogger,
     });
 
-    const eventStore = new FakeEventStore();
     const groupStore = new FakeGroupStore();
     groupStore.getAllWithId = async (): Promise<IGroup[]> => {
         return [{ id: 1, name: 'group' }];
@@ -239,10 +236,7 @@ test('throws error when trying to delete a project role in use by group', async 
     accessStore.get = async (): Promise<IRole> => {
         return { id: 1, type: 'custom', name: 'project role' };
     };
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },


### PR DESCRIPTION
## About the changes
EventsService is a dependency in most of our services. This creates helper methods to create them easily and replace a few places where we're creating them manually