### PR TITLE
chore: add another system user for admin tokens

### DIFF
--- a/src/lib/types/core.ts
+++ b/src/lib/types/core.ts
@@ -30,4 +30,14 @@ export const SYSTEM_USER: Omit<IUser, 'email'> = {
     permissions: [],
     username: 'unleash_system_user',
 };
+
+export const ADMIN_TOKEN_USER: Omit<IUser, 'email'> = {
+    id: -42,
+    imageUrl: '',
+    isAPI: true,
+    name: 'Unleash Admin Token',
+    permissions: [],
+    username: 'unleash_admin_token',
+};
+
 export const SYSTEM_USER_ID: number = SYSTEM_USER.id;

--- a/src/migrations/20240116154700-unleash-admin-token-user.js
+++ b/src/migrations/20240116154700-unleash-admin-token-user.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+        INSERT INTO users
+          (id, name, username, created_by_user_id, is_system) 
+        VALUES
+          (-42, 'Unleash Admin Token User', 'unleash_admin_token', -1337, true);
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+        DELETE FROM users WHERE id = -42;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
## About the changes
This admin token user will help us differentiate actions performed by the system from actions performed with an admin token.

Events created with an admin token should have the id of this user as createdByUserId property and the username of the token used as the createdBy property. i.e.
```json
{
  "id": 11,
  "type": "pat-created",
  "createdBy": "admin-token",
  "createdAt": "2024-01-16T13:16:27.887Z",
  "createdByUserId": -42,
  "data": {
    "description": "admin-pat",
    "expiresAt": "2024-02-15T13:16:25.586Z",
    "secret": "***",
    "userId": 1
  },
  "preData": null,
  "tags": [],
  "featureName": null,
  "project": null,
  "environment": null
}
```