### PR TITLE
fix: metrics apps should be selected from the longest time span

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
@@ -3,6 +3,7 @@ import { PageContent } from 'component/common/PageContent/PageContent';
 import { useEffect, useMemo, useState } from 'react';
 import {
     FEATURE_METRIC_HOURS_BACK_DEFAULT,
+    FEATURE_METRIC_HOURS_BACK_MAX,
     FeatureMetricsHours,
 } from './FeatureMetricsHours/FeatureMetricsHours';
 import { IFeatureMetricsRaw } from 'interfaces/featureToggle';
@@ -165,7 +166,7 @@ const useFeatureMetricsEnvironments = (
 const useFeatureMetricsApplications = (featureId: string): Set<string> => {
     const { featureMetrics = [] } = useFeatureMetricsRaw(
         featureId,
-        FEATURE_METRIC_HOURS_BACK_DEFAULT,
+        FEATURE_METRIC_HOURS_BACK_MAX,
     );
 
     const applications = featureMetrics.map((metric) => {

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
@@ -22,6 +22,7 @@ import {
     withDefault,
 } from 'use-query-params';
 import { aggregateFeatureMetrics } from './aggregateFeatureMetrics';
+import { useExtendedFeatureMetrics } from './useExtendedFeatureMetrics';
 
 export const FeatureMetrics = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -164,9 +165,12 @@ const useFeatureMetricsEnvironments = (
 // Get all application names for a feature. Fetch apps for the max time range
 // so that the list of apps doesn't change when selecting a shorter range.
 const useFeatureMetricsApplications = (featureId: string): Set<string> => {
+    const extendedOptions = useExtendedFeatureMetrics();
     const { featureMetrics = [] } = useFeatureMetricsRaw(
         featureId,
-        FEATURE_METRIC_HOURS_BACK_MAX,
+        extendedOptions
+            ? FEATURE_METRIC_HOURS_BACK_MAX
+            : FEATURE_METRIC_HOURS_BACK_DEFAULT,
     );
 
     const applications = featureMetrics.map((metric) => {

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -6,6 +6,7 @@ import { subWeeks, subMonths, differenceInHours } from 'date-fns';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useExtendedFeatureMetrics } from '../useExtendedFeatureMetrics';
 
 const StyledTitle = styled('h2')(({ theme }) => ({
     margin: 0,
@@ -36,9 +37,7 @@ export const FeatureMetricsHours = ({
             },
         });
     };
-    const { isEnterprise } = useUiConfig();
-    const extendedUsageMetrics = useUiFlag('extendedUsageMetricsUI');
-    const extendedOptions = isEnterprise() && extendedUsageMetrics;
+    const extendedOptions = useExtendedFeatureMetrics();
     const options = extendedOptions
         ? [...hourOptions, ...daysOptions]
         : hourOptions;

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -89,3 +89,8 @@ const daysOptions: { key: `${number}`; label: string }[] = [
         label: 'Last 3 months',
     },
 ];
+
+export const FEATURE_METRIC_HOURS_BACK_MAX = differenceInHours(
+    now,
+    subMonths(now, 3),
+);

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/useExtendedFeatureMetrics.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/useExtendedFeatureMetrics.ts
@@ -1,0 +1,10 @@
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useUiFlag } from 'hooks/useUiFlag';
+
+export const useExtendedFeatureMetrics = () => {
+    const { isEnterprise } = useUiConfig();
+    const extendedUsageMetrics = useUiFlag('extendedUsageMetricsUI');
+    const extendedOptions = isEnterprise() && extendedUsageMetrics;
+
+    return extendedOptions;
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Select applications from the longest time span. Previously it was 48 hours. Now it's 3 months. Without this fix we're not showing all app names for longer time spans.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
