### PR TITLE
fix: select default application based on timespan

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetrics.tsx
@@ -176,8 +176,8 @@ const useFeatureMetricsEnvironments = (
     return new Set(environments);
 };
 
-// Get all application names for a feature. Fetch apps for the max time range
-// so that the list of apps doesn't change when selecting a shorter range.
+// Get all application names for a feature. Respect current hoursBack since
+// we can have different apps in hourly time spans and daily time spans
 const useFeatureMetricsApplications = (
     featureId: string,
     hoursBack = FEATURE_METRIC_HOURS_BACK_DEFAULT,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We cannot select apps from the longest timespan (3 months) since we may have new app names in the last 24h that are not present in the longer timespan yet. So I decided to recalculate default application when the list of available applications changes.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
