### PR TITLE
fix: make the conflcit email template button conditionally render

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
@@ -1,5 +1,5 @@
 import { IConstraint, IFeatureStrategy } from 'interfaces/strategy';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import {
     UPDATE_FEATURE_STRATEGY,
     CREATE_FEATURE_STRATEGY,

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -3,8 +3,6 @@ import GeneralSelect, {
     IGeneralSelectProps,
 } from 'component/common/GeneralSelect/GeneralSelect';
 import { subWeeks, subMonths, differenceInHours } from 'date-fns';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { useUiFlag } from 'hooks/useUiFlag';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useExtendedFeatureMetrics } from '../useExtendedFeatureMetrics';
 

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -146,7 +146,7 @@ export class EmailService {
     async sendScheduledChangeConflictEmail(
         recipient: string,
         conflictScope: 'flag' | 'strategy',
-        conflictingChangeRequestId: number,
+        conflictingChangeRequestId: number | undefined,
         changeRequests: {
             id: number;
             scheduledAt: string;
@@ -173,7 +173,9 @@ export class EmailService {
                 ? `${this.config.server.unleashUrl}/projects/${project}/archive?sort=archivedAt&search=${flagName}`
                 : false;
 
-            const conflictingChangeRequestLink = `${this.config.server.unleashUrl}/projects/${project}/change-requests/${conflictingChangeRequestId}`;
+            const conflictingChangeRequestLink = conflictingChangeRequestId
+                ? `${this.config.server.unleashUrl}/projects/${project}/change-requests/${conflictingChangeRequestId}`
+                : false;
 
             const bodyHtml = await this.compileTemplate(
                 'scheduled-change-conflict',

--- a/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.html.mustache
+++ b/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.html.mustache
@@ -442,7 +442,9 @@
                                             <li><a class="changeRequestLink" href="{{{ link }}}" target="_blank" rel="noopener noreferrer">#{{id}} {{#title}}- {{.}}{{/title}} (scheduled for {{scheduledAt}})</a></li>
                                         </ul>
                                         {{/changeRequests}}
-                                        <a class="buttonStyle" href="{{{ conflictingChangeRequestLink }}} target="_blank" rel="noopener noreferrer">Open change request</a>
+                                        {{#conflictingChangeRequestLink}}
+                                            <a class="buttonStyle" href="{{{ conflictingChangeRequestLink }}}" target="_blank" rel="noopener noreferrer">Open change request</a>
+                                        {{/conflictingChangeRequestLink}}
                                     </td>
                                 </tr>
                             </table>

--- a/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
+++ b/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
@@ -8,4 +8,6 @@ For you, this concerns change requests:
     - # {{id}} - {{#title}}- {{.}}{{/title}} (scheduled for {{scheduledAt}}) ({{link}})
 {{/changeRequests}}
 
-Open Change request: {{conflictingChangeRequestLink}}
+{{#conflictingChangeRequestLink}}
+    Open Change request: {{conflictingChangeRequestLink}}
+{{/conflictingChangeRequestLink}}


### PR DESCRIPTION
Makes the schedule conflict email button conditional to having the link present.

Closes # [1-1950](https://linear.app/unleash/issue/1-1950/modify-the-template-to-make-the-new-button-conditional)