### PR TITLE
feat: startup tasks

### DIFF
--- a/src/lib/features/startup-tasks/startup-task-runner.ts
+++ b/src/lib/features/startup-tasks/startup-task-runner.ts
@@ -1,0 +1,30 @@
+import { IUnleashServices } from '../../server-impl';
+import { ProcessFeatureCreatedByIdTask } from './tasks/process-feature-created-by-id-task';
+
+export const scheduleStartupTasks = async (
+    services: IUnleashServices,
+): Promise<void> => {
+    const {
+        accountService,
+        schedulerService,
+        apiTokenService,
+        instanceStatsService,
+        clientInstanceService,
+        projectService,
+        projectHealthService,
+        configurationRevisionService,
+        eventAnnouncerService,
+        featureToggleService,
+        versionService,
+        lastSeenService,
+        proxyService,
+        clientMetricsServiceV2,
+        startupTaskService,
+    } = services;
+
+    startupTaskService.scheduleStart(
+        new ProcessFeatureCreatedByIdTask(services),
+        1000,
+        'processFeatureCreatedByIdTask',
+    );
+};

--- a/src/lib/features/startup-tasks/startup-task-service.ts
+++ b/src/lib/features/startup-tasks/startup-task-service.ts
@@ -1,0 +1,66 @@
+import { Logger, LogProvider } from '../../logger';
+import { IMaintenanceStatus } from '../maintenance/maintenance-service';
+
+export interface IStartupTask {
+    shouldRun(): Promise<boolean>;
+    run(): Promise<void>;
+    stop(): Promise<void>;
+}
+
+interface IScheduledTask {
+    timeout: NodeJS.Timeout;
+    task: IStartupTask;
+    id: string;
+}
+
+export class StartupTaskService {
+    private tasks: Map<string, IScheduledTask> = new Map();
+
+    private logger: Logger;
+
+    private maintenanceStatus: IMaintenanceStatus;
+
+    constructor(getLogger: LogProvider, maintenanceStatus: IMaintenanceStatus) {
+        this.logger = getLogger('/services/startup-task-service.ts');
+        this.maintenanceStatus = maintenanceStatus;
+    }
+
+    async scheduleStart(
+        scheduledTask: IStartupTask,
+        timeMs: number,
+        id: string,
+    ): Promise<void> {
+        this.logger.info('Scheduling startup task');
+
+        if (!scheduledTask.shouldRun()) {
+            this.logger.info('Startup task not needed');
+            return;
+        }
+
+        const timeoutRef = setTimeout(async () => {
+            try {
+                const maintenanceMode =
+                    await this.maintenanceStatus.isMaintenanceMode();
+                if (!maintenanceMode) {
+                    if (!scheduledTask.shouldRun()) {
+                        this.logger.info('Startup task not needed');
+                        return;
+                    }
+                    await scheduledTask.run();
+                    this.logger.info('Startup task completed');
+                }
+            } catch (e) {
+                this.logger.error(`scheduled task failed | id: ${id} | ${e}`);
+            }
+        }, timeMs).unref();
+
+        this.tasks.set(id, { timeout: timeoutRef, task: scheduledTask, id });
+    }
+
+    stop(): void {
+        this.tasks.forEach((item) => {
+            clearTimeout(item.timeout);
+            item.task.stop();
+        });
+    }
+}

--- a/src/lib/features/startup-tasks/tasks/process-feature-created-by-id-task.ts
+++ b/src/lib/features/startup-tasks/tasks/process-feature-created-by-id-task.ts
@@ -1,0 +1,16 @@
+import { IUnleashServices } from '../../../server-impl';
+import { IStartupTask } from '../startup-task-service';
+
+export class ProcessFeatureCreatedByIdTask implements IStartupTask {
+    constructor(services: IUnleashServices) {}
+
+    shouldRun(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+    run(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+    stop(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -35,6 +35,7 @@ import * as eventType from './types/events';
 import { Db } from './db/db';
 import { defaultLockKey, defaultTimeout, withDbLock } from './util/db-lock';
 import { scheduleServices } from './features/scheduler/schedule-services';
+import { scheduleStartupTasks } from './features/startup-tasks/startup-task-runner';
 
 async function createApp(
     config: IUnleashConfig,
@@ -48,6 +49,10 @@ async function createApp(
     const services = createServices(stores, config, db);
     if (!config.disableScheduler) {
         await scheduleServices(services);
+    }
+
+    if (config.flagResolver.isEnabled('startupTasks')) {
+        await scheduleStartupTasks(services);
     }
 
     const metricsMonitor = createMetricsMonitor();

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -104,6 +104,7 @@ import {
     createFakeTagTypeService,
     createTagTypeService,
 } from '../features/tag-type/createTagTypeService';
+import { StartupTaskService } from 'lib/features/startup-tasks/startup-task-service';
 
 export const createServices = (
     stores: IUnleashStores,
@@ -317,6 +318,11 @@ export const createServices = (
 
     const eventAnnouncerService = new EventAnnouncerService(stores, config);
 
+    const startupTaskService = new StartupTaskService(
+        config.getLogger,
+        maintenanceService,
+    );
+
     return {
         accessService,
         accountService,
@@ -373,6 +379,7 @@ export const createServices = (
         transactionalDependentFeaturesService,
         clientFeatureToggleService,
         featureSearchService,
+        startupTaskService,
     };
 };
 
@@ -419,4 +426,5 @@ export {
     DependentFeaturesService,
     ClientFeatureToggleService,
     FeatureSearchService,
+    StartupTaskService,
 };

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -44,7 +44,8 @@ export type IFlagKey =
     | 'extendedUsageMetrics'
     | 'extendedUsageMetricsUI'
     | 'adminTokenKillSwitch'
-    | 'changeRequestConflictHandling';
+    | 'changeRequestConflictHandling'
+    | 'startupTasks';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -201,6 +202,10 @@ const flags: IFlags = {
     ),
     changeRequestConflictHandling: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CHANGE_REQUEST_CONFLICT_HANDLING,
+        false,
+    ),
+    startupTasks: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_STARTUP_TASKS,
         false,
     ),
 };

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -51,6 +51,7 @@ import { DependentFeaturesService } from '../features/dependent-features/depende
 import { WithTransactional } from '../db/transaction';
 import { ClientFeatureToggleService } from '../features/client-feature-toggles/client-feature-toggle-service';
 import { FeatureSearchService } from '../features/feature-search/feature-search-service';
+import { StartupTaskService } from '../features/startup-tasks/startup-task-service';
 
 export interface IUnleashServices {
     accessService: AccessService;
@@ -111,4 +112,5 @@ export interface IUnleashServices {
     transactionalDependentFeaturesService: WithTransactional<DependentFeaturesService>;
     clientFeatureToggleService: ClientFeatureToggleService;
     featureSearchService: FeatureSearchService;
+    startupTaskService: StartupTaskService;
 }


### PR DESCRIPTION
## About the changes

This PR introduces the concept of a startup task to be used for purposes like processes that migrate data that might cause a timeout during a regular migration.
A startup task implements IStartupTask interface, and lives in /tasks. Tasks get scheduled to run once when the server starts, runs until it is complete, then never runs again until the server restarts.

When the task is scheduled, a method `shouldRun` gets invoked and the result of it determines if the task gets scheduled for invocation or not. This method gets checked again before the task is invoked. If you need to check something in the DB before running then this is the place for it.

When the system shuts down, task.stop() is called. If you're doing repetitive work inside your task, or have batched up your work then this is a good place to cancel that.
