### PR TITLE
fix: table loader

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -64,7 +64,7 @@ export const Project = () => {
     const projectId = useRequiredPathParam('projectId');
     const params = useQueryParams();
     const { project, loading, error, refetch } = useProject(projectId);
-    const ref = useLoading(loading);
+    const ref = useLoading(loading, '[data-loading-project=true]');
     const { setToastData, setToastApiError } = useToast();
     const [modalOpen, setModalOpen] = useState(false);
     const navigate = useNavigate();
@@ -193,7 +193,7 @@ export const Project = () => {
                                     condition={project?.mode === 'private'}
                                     show={<HiddenProjectIconWithTooltip />}
                                 />
-                                <StyledName data-loading>
+                                <StyledName data-loading-project>
                                     {projectName}
                                 </StyledName>
                             </StyledProjectTitle>
@@ -210,7 +210,7 @@ export const Project = () => {
                                         onClick={() => setModalOpen(true)}
                                         tooltipProps={{ title: 'Import' }}
                                         data-testid={IMPORT_BUTTON}
-                                        data-loading
+                                        data-loading-project
                                     >
                                         <FileUpload />
                                     </PermissionIconButton>
@@ -232,7 +232,7 @@ export const Project = () => {
                         {filteredTabs.map((tab) => {
                             return (
                                 <StyledTab
-                                    data-loading
+                                    data-loading-project
                                     key={tab.title}
                                     label={tab.title}
                                     value={tab.path}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Bug: loaders in the table were cancelled before data arrived

Root cause:
<img width="955" alt="Screenshot 2024-01-17 at 16 14 38" src="https://github.com/Unleash/unleash/assets/1394682/b5d55d4b-cf14-43c2-b1f3-40c6f6968766">

Solution:
Give a loader at the top level (in Project) a very specific identifier for things it should load so that very deeply nested loaders are not affected and can have their local loading hooks.


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
