### PR TITLE
feat: add primary keys to missing tables

### DIFF
--- a/src/migrations/20240118093611-missing-primary-keys.js
+++ b/src/migrations/20240118093611-missing-primary-keys.js
@@ -4,7 +4,7 @@ exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE project_stats ADD PRIMARY KEY (project);
-        ALTER TABLE api_token_project ADD PRIMARY KEY (secret);
+        ALTER TABLE api_token_project ADD COLUMN id SERIAL PRIMARY KEY;
         ALTER TABLE role_permission ADD COLUMN id SERIAL PRIMARY KEY;
         `,
         callback,
@@ -16,6 +16,7 @@ exports.down = function (db, callback) {
         `
         ALTER TABLE project_stats DROP CONSTRAINT project_stats_pkey;
         ALTER TABLE api_token_project DROP CONSTRAINT api_token_project_pkey;
+        ALTER TABLE api_token_project DROP COLUMN id;
         ALTER TABLE role_permission DROP CONSTRAINT role_permission_pkey;
         ALTER TABLE role_permission DROP COLUMN id;
         `,

--- a/src/migrations/20240118093611-missing-primary-keys.js
+++ b/src/migrations/20240118093611-missing-primary-keys.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+        ALTER TABLE project_stats ADD PRIMARY KEY (project);
+        ALTER TABLE api_token_project ADD PRIMARY KEY (secret);
+        ALTER TABLE role_permission ADD COLUMN id SERIAL PRIMARY KEY;
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+        ALTER TABLE project_stats DROP CONSTRAINT project_stats_pkey;
+        ALTER TABLE api_token_project DROP CONSTRAINT api_token_project_pkey;
+        ALTER TABLE role_permission DROP CONSTRAINT role_permission_pkey;
+        ALTER TABLE role_permission DROP COLUMN id;
+        `,
+        callback,
+    );
+};

--- a/src/migrations/20240118093611-missing-primary-keys.js
+++ b/src/migrations/20240118093611-missing-primary-keys.js
@@ -4,7 +4,7 @@ exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE project_stats ADD PRIMARY KEY (project);
-        ALTER TABLE api_token_project ADD COLUMN id SERIAL PRIMARY KEY;
+        ALTER TABLE api_token_project ADD PRIMARY KEY (secret, project);
         ALTER TABLE role_permission ADD COLUMN id SERIAL PRIMARY KEY;
         `,
         callback,
@@ -16,7 +16,6 @@ exports.down = function (db, callback) {
         `
         ALTER TABLE project_stats DROP CONSTRAINT project_stats_pkey;
         ALTER TABLE api_token_project DROP CONSTRAINT api_token_project_pkey;
-        ALTER TABLE api_token_project DROP COLUMN id;
         ALTER TABLE role_permission DROP CONSTRAINT role_permission_pkey;
         ALTER TABLE role_permission DROP COLUMN id;
         `,


### PR DESCRIPTION
Follow up of https://github.com/Unleash/unleash/issues/4303

We are adding primary keys to all tables missing them, currently **role_permission**, **api_token_project**, and **project_stats**. 
By adding primary keys, the issue with migrations failing during upgrades in replicated database setups will be resolved.