### PR TITLE
fix: normalize hours back to prevent freezing UI

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
@@ -40,12 +40,19 @@ test('Display extended daily metrics', async () => {
 
 test('Normalize invalid hours back to default value', async () => {
     const invalidHoursBack = 100000;
+    let recordedHoursBack: number | null = null;
     render(
         <FeatureMetricsHours
             hoursBack={invalidHoursBack}
-            setHoursBack={() => {}}
+            setHoursBack={(hoursBack) => {
+                recordedHoursBack = hoursBack;
+            }}
         />,
     );
 
     await screen.findByText('Last 48 hours');
+
+    await waitFor(() => {
+        expect(recordedHoursBack).toBe(48);
+    });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.test.tsx
@@ -37,3 +37,15 @@ test('Display extended daily metrics', async () => {
         expect(recordedHoursBack).toBe(7 * 24);
     });
 });
+
+test('Normalize invalid hours back to default value', async () => {
+    const invalidHoursBack = 100000;
+    render(
+        <FeatureMetricsHours
+            hoursBack={invalidHoursBack}
+            setHoursBack={() => {}}
+        />,
+    );
+
+    await screen.findByText('Last 48 hours');
+});

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -4,6 +4,7 @@ import GeneralSelect, {
 } from 'component/common/GeneralSelect/GeneralSelect';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useExtendedFeatureMetrics } from '../useExtendedFeatureMetrics';
+import { useEffect } from 'react';
 
 const StyledTitle = styled('h2')(({ theme }) => ({
     margin: 0,
@@ -25,6 +26,7 @@ export const FeatureMetricsHours = ({
     setHoursBack,
 }: IFeatureMetricsHoursProps) => {
     const { trackEvent } = usePlausibleTracker();
+
     const onChange: IGeneralSelectProps['onChange'] = (key) => {
         setHoursBack(parseInt(key));
         trackEvent('feature-metrics', {
@@ -39,6 +41,18 @@ export const FeatureMetricsHours = ({
         ? [...hourOptions, ...daysOptions]
         : hourOptions;
 
+    const normalizedHoursBack = options
+        .map((option) => Number(option.key))
+        .includes(hoursBack)
+        ? hoursBack
+        : FEATURE_METRIC_HOURS_BACK_DEFAULT;
+
+    useEffect(() => {
+        if (hoursBack != normalizedHoursBack) {
+            setHoursBack(normalizedHoursBack);
+        }
+    }, [hoursBack]);
+
     return (
         <div>
             <StyledTitle>Period</StyledTitle>
@@ -46,7 +60,7 @@ export const FeatureMetricsHours = ({
                 name='feature-metrics-period'
                 id='feature-metrics-period'
                 options={options}
-                value={String(hoursBack)}
+                value={String(normalizedHoursBack)}
                 onChange={onChange}
                 fullWidth
             />
@@ -68,8 +82,6 @@ const hourOptions: { key: `${number}`; label: string }[] = [
         label: 'Last 48 hours',
     },
 ];
-
-const now = new Date();
 
 const daysOptions: { key: `${number}`; label: string }[] = [
     {

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsHours/FeatureMetricsHours.tsx
@@ -48,7 +48,7 @@ export const FeatureMetricsHours = ({
         : FEATURE_METRIC_HOURS_BACK_DEFAULT;
 
     useEffect(() => {
-        if (hoursBack != normalizedHoursBack) {
+        if (hoursBack !== normalizedHoursBack) {
             setHoursBack(normalizedHoursBack);
         }
     }, [hoursBack]);


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

If user types invalid hoursBack into the URL it always goes back to a default value of 48 hours. It prevents UI from freezing when someone tinkers with the URL.
<img width="224" alt="Screenshot 2024-01-18 at 13 55 34" src="https://github.com/Unleash/unleash/assets/1394682/63d60650-b85b-4bd5-ae53-54cfb27dc1af">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
