### PR TITLE
fix: admin token should be passed forward from controllers 

### DIFF
--- a/src/lib/features/feature-toggle/archive-feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/archive-feature-toggle-controller.ts
@@ -2,7 +2,10 @@ import { Request, Response } from 'express';
 import { IUnleashConfig } from '../../types/option';
 import { IUnleashServices } from '../../types';
 import Controller from '../../routes/controller';
-import { extractUsername } from '../../util/extract-user';
+import {
+    extractUserIdFromUser,
+    extractUsername,
+} from '../../util/extract-user';
 import { DELETE_FEATURE, NONE, UPDATE_FEATURE } from '../../types/permissions';
 import FeatureToggleService from './feature-toggle-service';
 import { IAuthRequest } from '../../routes/unleash-types';
@@ -142,7 +145,7 @@ export default class ArchiveController extends Controller {
         const { user } = req;
         const features = await this.featureService.getAllArchivedFeatures(
             true,
-            user.id,
+            extractUserIdFromUser(user),
         );
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -2078,20 +2078,15 @@ class FeatureToggleService {
     ): Promise<FeatureToggle[]> {
         const features = await this.featureToggleStore.getArchivedFeatures();
 
-        if (userId) {
-            const projectAccess =
-                await this.privateProjectChecker.getUserAccessibleProjects(
-                    userId,
-                );
-            if (projectAccess.mode === 'all') {
-                return features;
-            } else {
-                return features.filter((f) =>
-                    projectAccess.projects.includes(f.project),
-                );
-            }
+        const projectAccess =
+            await this.privateProjectChecker.getUserAccessibleProjects(userId);
+        if (projectAccess.mode === 'all') {
+            return features;
+        } else {
+            return features.filter((f) =>
+                projectAccess.projects.includes(f.project),
+            );
         }
-        return features;
     }
 
     async getArchivedFeaturesByProjectId(

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -123,7 +123,9 @@ export interface IGetFeatureParams {
 }
 
 export type FeatureNameCheckResultWithFeaturePattern =
-    | { state: 'valid' }
+    | {
+          state: 'valid';
+      }
     | {
           state: 'invalid';
           invalidNames: Set<string>;
@@ -996,7 +998,11 @@ class FeatureToggleService {
                     userId,
                     archived,
                 );
-            return { ...result, dependencies, children };
+            return {
+                ...result,
+                dependencies,
+                children,
+            };
         } else {
             const result =
                 await this.featureStrategiesStore.getFeatureToggleWithEnvs(
@@ -1004,7 +1010,11 @@ class FeatureToggleService {
                     userId,
                     archived,
                 );
-            return { ...result, dependencies, children };
+            return {
+                ...result,
+                dependencies,
+                children,
+            };
         }
     }
 
@@ -1215,7 +1225,10 @@ class FeatureToggleService {
                 );
 
                 if (result.state === 'invalid') {
-                    return { ...result, featureNaming: patternData };
+                    return {
+                        ...result,
+                        featureNaming: patternData,
+                    };
                 }
             }
         } catch (error) {
@@ -1329,7 +1342,11 @@ class FeatureToggleService {
 
         const cloneDependencies =
             this.dependentFeaturesService.cloneDependencies(
-                { featureName, newFeatureName, projectId },
+                {
+                    featureName,
+                    newFeatureName,
+                    projectId,
+                },
                 userName,
                 userId,
             );
@@ -1350,7 +1367,10 @@ class FeatureToggleService {
         featureName: string,
         userId: number,
     ): Promise<FeatureToggle> {
-        await this.validateFeatureBelongsToProject({ featureName, projectId });
+        await this.validateFeatureBelongsToProject({
+            featureName,
+            projectId,
+        });
 
         this.logger.info(`${userName} updates feature toggle ${featureName}`);
 
@@ -1883,7 +1903,11 @@ class FeatureToggleService {
         const defaultEnv = environments.find((e) => e.name === DEFAULT_ENV);
         const strategies = defaultEnv?.strategies || [];
         const enabled = defaultEnv?.enabled || false;
-        return { ...legacyFeature, enabled, strategies };
+        return {
+            ...legacyFeature,
+            enabled,
+            strategies,
+        };
     }
 
     async changeProject(
@@ -2054,15 +2078,20 @@ class FeatureToggleService {
     ): Promise<FeatureToggle[]> {
         const features = await this.featureToggleStore.getArchivedFeatures();
 
-        const projectAccess =
-            await this.privateProjectChecker.getUserAccessibleProjects(userId);
-        if (projectAccess.mode === 'all') {
-            return features;
-        } else {
-            return features.filter((f) =>
-                projectAccess.projects.includes(f.project),
-            );
+        if (userId) {
+            const projectAccess =
+                await this.privateProjectChecker.getUserAccessibleProjects(
+                    userId,
+                );
+            if (projectAccess.mode === 'all') {
+                return features;
+            } else {
+                return features.filter((f) =>
+                    projectAccess.projects.includes(f.project),
+                );
+            }
         }
+        return features;
     }
 
     async getArchivedFeaturesByProjectId(
@@ -2253,7 +2282,9 @@ class FeatureToggleService {
     ): Promise<IVariant[]> {
         await variantsArraySchema.validateAsync(newVariants);
         const fixedVariants = this.fixVariantWeights(newVariants);
-        const oldVariants: { [env: string]: IVariant[] } = {};
+        const oldVariants: {
+            [env: string]: IVariant[];
+        } = {};
         for (const env of environments) {
             const featureEnv = await this.featureEnvironmentStore.get({
                 featureName,

--- a/src/lib/features/playground/playground.ts
+++ b/src/lib/features/playground/playground.ts
@@ -21,6 +21,7 @@ import {
     playgroundViewModel,
 } from './playground-view-model';
 import { IAuthRequest } from '../../routes/unleash-types';
+import { extractUserIdFromUser } from '../../util';
 
 export default class PlaygroundController extends Controller {
     private openApiService: OpenApiService;
@@ -129,7 +130,7 @@ export default class PlaygroundController extends Controller {
             req.body.environments,
             req.body.context,
             limit,
-            user.id,
+            extractUserIdFromUser(user),
         );
 
         const response: AdvancedPlaygroundResponseSchema =

--- a/src/lib/features/private-project/privateProjectStore.ts
+++ b/src/lib/features/private-project/privateProjectStore.ts
@@ -1,7 +1,7 @@
 import { Db } from '../../db/db';
 import { Logger, LogProvider } from '../../logger';
 import { IPrivateProjectStore } from './privateProjectStoreType';
-import { ADMIN_TOKEN_ID } from '../../types';
+import { ADMIN_TOKEN_USER } from '../../types';
 
 export type ProjectAccess =
     | {
@@ -29,7 +29,7 @@ class PrivateProjectStore implements IPrivateProjectStore {
     destroy(): void {}
 
     async getUserAccessibleProjects(userId: number): Promise<ProjectAccess> {
-        if (userId === ADMIN_TOKEN_ID) {
+        if (userId === ADMIN_TOKEN_USER.id) {
             return ALL_PROJECT_ACCESS;
         }
         const isViewer = await this.db('role_user')

--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -39,7 +39,7 @@ import {
     SegmentsSchema,
 } from '../../openapi/spec/segments-schema';
 
-import { anonymiseKeys } from '../../util';
+import { anonymiseKeys, extractUserIdFromUser } from '../../util';
 import { BadDataError } from '../../error';
 
 type IUpdateFeatureStrategySegmentsRequest = IAuthRequest<
@@ -351,7 +351,7 @@ export class SegmentsController extends Controller {
         const { user } = req;
         const strategies = await this.segmentService.getVisibleStrategies(
             id,
-            user.id,
+            extractUserIdFromUser(user),
         );
 
         const segmentStrategies = strategies.strategies.map((strategy) => ({

--- a/src/lib/routes/admin-api/context.ts
+++ b/src/lib/routes/admin-api/context.ts
@@ -2,7 +2,10 @@ import { Request, Response } from 'express';
 
 import Controller from '../controller';
 
-import { extractUsername } from '../../util/extract-user';
+import {
+    extractUserIdFromUser,
+    extractUsername,
+} from '../../util/extract-user';
 
 import {
     CREATE_CONTEXT_FIELD,
@@ -310,7 +313,7 @@ export class ContextController extends Controller {
         const contextFields =
             await this.contextService.getStrategiesByContextField(
                 contextField,
-                user.id,
+                extractUserIdFromUser(user),
             );
 
         this.openApiService.respondWithValidation(

--- a/src/lib/routes/admin-api/metrics.ts
+++ b/src/lib/routes/admin-api/metrics.ts
@@ -15,6 +15,7 @@ import {
 } from '../../openapi/util/standard-responses';
 import { CreateApplicationSchema } from '../../openapi/spec/create-application-schema';
 import { IAuthRequest } from '../unleash-types';
+import { extractUserIdFromUser } from '../../util';
 
 class MetricsController extends Controller {
     private logger: Logger;
@@ -158,7 +159,7 @@ class MetricsController extends Controller {
             : {};
         const applications = await this.clientInstanceService.getApplications(
             query,
-            user.id,
+            extractUserIdFromUser(user),
         );
         res.json({ applications });
     }

--- a/src/lib/types/no-auth-user.ts
+++ b/src/lib/types/no-auth-user.ts
@@ -1,6 +1,4 @@
 import { ADMIN } from './permissions';
-
-export const ADMIN_TOKEN_ID = -1;
 export default class NoAuthUser {
     isAPI: boolean;
 
@@ -12,7 +10,7 @@ export default class NoAuthUser {
 
     constructor(
         username: string = 'unknown',
-        id: number = ADMIN_TOKEN_ID,
+        id: number = -1,
         permissions: string[] = [ADMIN],
     ) {
         this.isAPI = true;


### PR DESCRIPTION
We were sending `user.id` to the service, but if an admin token is used, there is no `user.id.` Instead, there is `user.internalAdminTokenUserId`. so we need to use the special method `extractUserIdFromUser`.

This PR adds this implementation, and now the service correctly retrieves the appropriate ID for admins.

Related to: https://github.com/Unleash/unleash/pull/5924