### PR TITLE
fix: handle title diffing correctly in strategy change diffs

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -55,6 +55,16 @@ export const getChangesThatWouldBeOverwritten = (
                             newValue: snapshotValue,
                         };
                     }
+                } else if (key === 'title') {
+                    // the title can be defined as `null` or
+                    // `undefined`, so we fallback to an empty string
+                    if (hasJsonDiff(snapshotValue ?? '', currentValue ?? '')) {
+                        return {
+                            property: key as keyof IFeatureStrategy,
+                            oldValue: currentValue,
+                            newValue: snapshotValue,
+                        };
+                    }
                 } else if (hasChanged(snapshotValue, currentValue)) {
                     return {
                         property: key as keyof IFeatureStrategy,

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -228,7 +228,7 @@ export type ChangeRequestAddStrategy = Pick<
 
 export type ChangeRequestEditStrategy = ChangeRequestAddStrategy & {
     id: string;
-    snapshot?: IFeatureStrategy;
+    snapshot?: Omit<IFeatureStrategy, 'title'> & { title?: string | null };
 };
 
 type ChangeRequestDeleteStrategy = {


### PR DESCRIPTION
A strategy title can be either an empty string or undefined on the
type we use in the frontend. In the snapshot it can be an empty
string, null (presumably), and undefined.

This change updates the diffing logic to handle the various title diff
cases correctly. It also updates the type used for the snapshot to reflect this.