### PR TITLE
fix: add keys to the features cell component

### DIFF
--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
@@ -52,6 +52,7 @@ export const FeaturesCell: VFC<FeaturesCellProps> = ({ value, project }) => {
                 condition={featureNames?.length < 3}
                 show={featureNames?.map((featureName: string) => (
                     <StyledLink
+                        key={featureName}
                         title={featureName}
                         to={`/projects/${project}/features/${featureName}`}
                     >
@@ -67,6 +68,7 @@ export const FeaturesCell: VFC<FeaturesCellProps> = ({ value, project }) => {
                             <StyledTooltipContainer>
                                 {featureNames?.map((featureName: string) => (
                                     <StyledTooltipLink
+                                        key={featureName}
                                         title={featureName}
                                         to={`/projects/${project}/features/${featureName}`}
                                     >


### PR DESCRIPTION
This PR adds the `key` property to the features cell component where it renders lists of flags. This fixes a few rendering errors we've been getting in the console.