### PR TITLE
fix: unauthorized disable feature

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1732,6 +1732,10 @@ class FeatureToggleService {
         user?: IUser,
         shouldActivateDisabledStrategies = false,
     ): Promise<FeatureToggle> {
+        await this.validateFeatureBelongsToProject({
+            featureName,
+            projectId: project,
+        });
         const hasEnvironment =
             await this.featureEnvironmentStore.featureHasEnvironment(
                 environment,

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -65,6 +65,9 @@ export type IdPermissionRef = Pick<IPermission, 'id' | 'environment'>;
 export type NamePermissionRef = Pick<IPermission, 'name' | 'environment'>;
 export type PermissionRef = IdPermissionRef | NamePermissionRef;
 
+type APIUser = Pick<IUser, 'id' | 'permissions'> & { isAPI: true };
+type NonAPIUser = Pick<IUser, 'id'> & { isAPI?: false };
+
 export interface IRoleCreation {
     name: string;
     description: string;
@@ -150,7 +153,7 @@ export class AccessService {
      * @param projectId
      */
     async hasPermission(
-        user: Pick<IUser, 'id' | 'permissions' | 'isAPI'>,
+        user: APIUser | NonAPIUser,
         permission: string | string[],
         projectId?: string,
         environment?: string,
@@ -198,7 +201,7 @@ export class AccessService {
     }
 
     async getPermissionsForUser(
-        user: Pick<IUser, 'id' | 'isAPI' | 'permissions'>,
+        user: APIUser | NonAPIUser,
     ): Promise<IUserPermission[]> {
         if (user.isAPI) {
             return user.permissions?.map((p) => ({


### PR DESCRIPTION
## About the changes
This was spotted while testing automated actions. Steps to reproduce:

1. Add an editor user
2. Get a PAT for the editor user
3. As Admin create a feature in a project where the editor user is not a member and enable the feature
4. Try using the editor's PAT to modify the feature: ```$ curl -XPOST -H 'Authorization: user:editor-pat' https://sandbox.getunleash.io/enterprise/api/admin/projects/gaston-editor/features/editor-feature/environments/development/off | jq
{
  "id": "444d157c-dd85-4953-afec-781cde9d029f",
  "name": "PermissionError",
  "message": "You don't have the required permissions to perform this operation. To perform this action, you need the \"UPDATE_FEATURE_ENVIRONMENT\" permission.",
  "details": [
    {
      "message": "You don't have the required permissions to perform this operation. To perform this action, you need the \"UPDATE_FEATURE_ENVIRONMENT\" permission.",
      "description": "You don't have the required permissions to perform this operation. To perform this action, you need the \"UPDATE_FEATURE_ENVIRONMENT\" permission."
    }
  ],
  "permissions": [
    "UPDATE_FEATURE_ENVIRONMENT"
  ]
}```

5. As the editor create a project (you'd be made owner) and try the same request but just change the project name for the new project just created (don't change anything else): ```$ curl -XPOST -I -H 'Authorization: editor-pat' https://sandbox.getunleash.io/enterprise/api/admin/projects/myown/features/editor-feature/environments/development/off 
HTTP/1.1 200 OK```

This does not happen when trying to turn on a flag because during the turn-on process we do validate if the feature belongs to project when we call updateStrategy: https://github.com/Unleash/unleash/blob/c18a7c0dc226f6b32a601a8d002dcd8f94d3c9af/src/lib/features/feature-toggle/feature-toggle-service.ts#L1751-L1764
