### PR TITLE
fix: show the updated value instead of the snapshot value

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
@@ -1,4 +1,7 @@
-import { IChangeRequestUpdateStrategy } from 'component/changeRequest/changeRequest.types';
+import {
+    ChangeRequestEditStrategy,
+    IChangeRequestUpdateStrategy,
+} from 'component/changeRequest/changeRequest.types';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import omit from 'lodash.omit';
 import { getChangesThatWouldBeOverwritten } from './strategy-change-diff-calculation';
@@ -181,7 +184,6 @@ describe('Strategy change conflict detection', () => {
                 property,
                 oldValue,
                 newValue:
-                    // @ts-expect-error Some
                     change.payload[property as keyof ChangeRequestEditStrategy],
             }),
         );

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
@@ -181,9 +181,8 @@ describe('Strategy change conflict detection', () => {
                 property,
                 oldValue,
                 newValue:
-                    change.payload.snapshot![
-                        property as keyof IFeatureStrategy
-                    ],
+                    // @ts-expect-error Some
+                    change.payload[property as keyof ChangeRequestEditStrategy],
             }),
         );
 

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
@@ -343,4 +343,68 @@ describe('Strategy change conflict detection', () => {
 
         expect(cases.every((result) => result === null)).toBeTruthy();
     });
+
+    test('it shows a diff for a property if the snapshot and live version differ for that property and the changed value is different from the live version', () => {
+        const liveVersion = {
+            ...existingStrategy,
+            title: 'new-title',
+        };
+
+        const changedVersion = {
+            ...change,
+            payload: {
+                ...change.payload,
+                title: 'other-new-title',
+            },
+        };
+        const result = getChangesThatWouldBeOverwritten(
+            liveVersion,
+            changedVersion,
+        );
+
+        expect(result).toStrictEqual([
+            {
+                property: 'title',
+                oldValue: liveVersion.title,
+                newValue: changedVersion.payload.title,
+            },
+        ]);
+    });
+
+    test('it does not show a diff for a property if the live version and the change have the same value, even if the snapshot differs from the live version', () => {
+        const liveVersion = {
+            ...existingStrategy,
+            title: 'new-title',
+        };
+
+        const changedVersion = {
+            ...change,
+            payload: {
+                ...change.payload,
+                title: liveVersion.title,
+            },
+        };
+        const result = getChangesThatWouldBeOverwritten(
+            liveVersion,
+            changedVersion,
+        );
+
+        expect(result).toBeNull();
+    });
+
+    test('it does not show a diff for a property if the snapshot and the live version are the same', () => {
+        const changedVersion = {
+            ...change,
+            payload: {
+                ...change.payload,
+                title: 'new-title',
+            },
+        };
+        const result = getChangesThatWouldBeOverwritten(
+            existingStrategy,
+            changedVersion,
+        );
+
+        expect(result).toBeNull();
+    });
 });

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.test.ts
@@ -269,7 +269,7 @@ describe('Strategy change conflict detection', () => {
             {
                 property: 'variants',
                 oldValue: existingStrategyWithVariants.variants,
-                newValue: undefined,
+                newValue: [],
             },
         ]);
     });

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -8,17 +8,17 @@ import omit from 'lodash.omit';
 
 type JsonDiffProps = {
     snapshotValue: unknown;
-    liveValue: unknown;
+    currentValue: unknown;
     changeValue: unknown;
     fallback?: unknown;
 };
 const hasJsonDiff = ({
     snapshotValue,
-    liveValue,
+    currentValue,
     changeValue,
     fallback,
 }: JsonDiffProps) => {
-    const liveJson = JSON.stringify(liveValue ?? fallback);
+    const liveJson = JSON.stringify(currentValue ?? fallback);
     return (
         JSON.stringify(snapshotValue ?? fallback) !== liveJson &&
         JSON.stringify(changeValue ?? fallback) !== liveJson
@@ -27,16 +27,16 @@ const hasJsonDiff = ({
 
 const hasChanged = (
     snapshotValue: unknown,
-    liveValue: unknown,
+    currentValue: unknown,
     changeValue: unknown,
 ) => {
     if (typeof snapshotValue === 'object') {
         return (
-            !isEqual(snapshotValue, liveValue) &&
-            !isEqual(liveValue, changeValue)
+            !isEqual(snapshotValue, currentValue) &&
+            !isEqual(currentValue, changeValue)
         );
     }
-    return hasJsonDiff({ snapshotValue, liveValue, changeValue });
+    return hasJsonDiff({ snapshotValue, currentValue, changeValue });
 };
 
 type DataToOverwrite<Prop extends keyof ChangeRequestEditStrategy> = {
@@ -69,7 +69,7 @@ export const getChangesThatWouldBeOverwritten = (
                 const hasJsonDiffWithFallback = (fallback: unknown) =>
                     hasJsonDiff({
                         snapshotValue,
-                        liveValue: currentValue,
+                        currentValue,
                         changeValue,
                         fallback,
                     });

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -63,18 +63,19 @@ export const getChangesThatWouldBeOverwritten = (
                 const changeValue =
                     change.payload[key as keyof ChangeRequestEditStrategy];
 
+                const jsonDiff = (fallback: unknown = undefined) =>
+                    hasJsonDiff({
+                        snapshotValue,
+                        liveValue: currentValue,
+                        changeValue,
+                        fallback,
+                    });
+
                 // compare, assuming that order never changes
                 if (key === 'segments') {
                     // segments can be undefined on the original
                     // object, but that doesn't mean it has changed
-                    if (
-                        hasJsonDiff({
-                            snapshotValue,
-                            liveValue: currentValue,
-                            changeValue,
-                            fallback: [],
-                        })
-                    ) {
+                    if (jsonDiff([])) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,
@@ -84,14 +85,7 @@ export const getChangesThatWouldBeOverwritten = (
                 } else if (key === 'variants') {
                     // strategy variants might not be defined, so use
                     // fallback values
-                    if (
-                        hasJsonDiff({
-                            snapshotValue: snapshotValue,
-                            liveValue: currentValue,
-                            changeValue,
-                            fallback: [],
-                        })
-                    ) {
+                    if (jsonDiff([])) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,
@@ -101,14 +95,7 @@ export const getChangesThatWouldBeOverwritten = (
                 } else if (key === 'title') {
                     // the title can be defined as `null` or
                     // `undefined`, so we fallback to an empty string
-                    if (
-                        hasJsonDiff({
-                            snapshotValue: snapshotValue,
-                            liveValue: currentValue,
-                            changeValue,
-                            fallback: '',
-                        })
-                    ) {
+                    if (jsonDiff('')) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -25,6 +25,20 @@ const hasJsonDiff = ({
     );
 };
 
+const hasChanged = (
+    snapshotValue: unknown,
+    liveValue: unknown,
+    changeValue: unknown,
+) => {
+    if (typeof snapshotValue === 'object') {
+        return (
+            !isEqual(snapshotValue, liveValue) &&
+            !isEqual(snapshotValue, changeValue)
+        );
+    }
+    return hasJsonDiff({ snapshotValue, liveValue, changeValue });
+};
+
 type DataToOverwrite<Prop extends keyof IFeatureStrategy> = {
     property: Prop;
     oldValue: IFeatureStrategy[Prop];
@@ -38,20 +52,6 @@ export const getChangesThatWouldBeOverwritten = (
 ): ChangesThatWouldBeOverwritten | null => {
     const { snapshot } = change.payload;
     if (snapshot && currentStrategyConfig) {
-        const hasChanged = (
-            snapshotValue: unknown,
-            liveValue: unknown,
-            changeValue: unknown,
-        ) => {
-            if (typeof snapshotValue === 'object') {
-                return (
-                    !isEqual(snapshotValue, liveValue) &&
-                    !isEqual(snapshotValue, changeValue)
-                );
-            }
-            return hasJsonDiff({ snapshotValue, liveValue, changeValue });
-        };
-
         // compare each property in the snapshot. The property order
         // might differ, so using JSON.stringify to compare them
         // doesn't work.

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -33,7 +33,7 @@ const hasChanged = (
     if (typeof snapshotValue === 'object') {
         return (
             !isEqual(snapshotValue, liveValue) &&
-            !isEqual(snapshotValue, changeValue)
+            !isEqual(liveValue, changeValue)
         );
     }
     return hasJsonDiff({ snapshotValue, liveValue, changeValue });
@@ -53,6 +53,7 @@ export const getChangesThatWouldBeOverwritten = (
     change: IChangeRequestUpdateStrategy,
 ): ChangesThatWouldBeOverwritten | null => {
     const { snapshot } = change.payload;
+
     if (snapshot && currentStrategyConfig) {
         // compare each property in the snapshot. The property order
         // might differ, so using JSON.stringify to compare them
@@ -65,9 +66,7 @@ export const getChangesThatWouldBeOverwritten = (
                 const changeValue =
                     change.payload[key as keyof ChangeRequestEditStrategy];
 
-                const hasJsonDiffWithFallback = (
-                    fallback: unknown = undefined,
-                ) =>
+                const hasJsonDiffWithFallback = (fallback: unknown) =>
                     hasJsonDiff({
                         snapshotValue,
                         liveValue: currentValue,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -18,10 +18,10 @@ const hasJsonDiff = ({
     changeValue,
     fallback,
 }: JsonDiffProps) => {
-    const liveJson = JSON.stringify(currentValue ?? fallback);
+    const currentJson = JSON.stringify(currentValue ?? fallback);
     return (
-        JSON.stringify(snapshotValue ?? fallback) !== liveJson &&
-        JSON.stringify(changeValue ?? fallback) !== liveJson
+        JSON.stringify(snapshotValue ?? fallback) !== currentJson &&
+        JSON.stringify(changeValue ?? fallback) !== currentJson
     );
 };
 

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -39,12 +39,14 @@ const hasChanged = (
     return hasJsonDiff({ snapshotValue, liveValue, changeValue });
 };
 
-type DataToOverwrite<Prop extends keyof IFeatureStrategy> = {
+type DataToOverwrite<Prop extends keyof ChangeRequestEditStrategy> = {
     property: Prop;
-    oldValue: IFeatureStrategy[Prop];
-    newValue: IFeatureStrategy[Prop];
+    oldValue: ChangeRequestEditStrategy[Prop];
+    newValue: ChangeRequestEditStrategy[Prop];
 };
-type ChangesThatWouldBeOverwritten = DataToOverwrite<keyof IFeatureStrategy>[];
+type ChangesThatWouldBeOverwritten = DataToOverwrite<
+    keyof ChangeRequestEditStrategy
+>[];
 
 export const getChangesThatWouldBeOverwritten = (
     currentStrategyConfig: IFeatureStrategy | undefined,
@@ -63,7 +65,9 @@ export const getChangesThatWouldBeOverwritten = (
                 const changeValue =
                     change.payload[key as keyof ChangeRequestEditStrategy];
 
-                const jsonDiff = (fallback: unknown = undefined) =>
+                const hasJsonDiffWithFallback = (
+                    fallback: unknown = undefined,
+                ) =>
                     hasJsonDiff({
                         snapshotValue,
                         liveValue: currentValue,
@@ -75,9 +79,9 @@ export const getChangesThatWouldBeOverwritten = (
                 if (key === 'segments') {
                     // segments can be undefined on the original
                     // object, but that doesn't mean it has changed
-                    if (jsonDiff([])) {
+                    if (hasJsonDiffWithFallback([])) {
                         return {
-                            property: key as keyof IFeatureStrategy,
+                            property: key as keyof ChangeRequestEditStrategy,
                             oldValue: currentValue,
                             newValue: changeValue,
                         };
@@ -85,9 +89,9 @@ export const getChangesThatWouldBeOverwritten = (
                 } else if (key === 'variants') {
                     // strategy variants might not be defined, so use
                     // fallback values
-                    if (jsonDiff([])) {
+                    if (hasJsonDiffWithFallback([])) {
                         return {
-                            property: key as keyof IFeatureStrategy,
+                            property: key as keyof ChangeRequestEditStrategy,
                             oldValue: currentValue,
                             newValue: changeValue,
                         };
@@ -95,9 +99,9 @@ export const getChangesThatWouldBeOverwritten = (
                 } else if (key === 'title') {
                     // the title can be defined as `null` or
                     // `undefined`, so we fallback to an empty string
-                    if (jsonDiff('')) {
+                    if (hasJsonDiffWithFallback('')) {
                         return {
-                            property: key as keyof IFeatureStrategy,
+                            property: key as keyof ChangeRequestEditStrategy,
                             oldValue: currentValue,
                             newValue: changeValue,
                         };
@@ -106,14 +110,16 @@ export const getChangesThatWouldBeOverwritten = (
                     hasChanged(snapshotValue, currentValue, changeValue)
                 ) {
                     return {
-                        property: key as keyof IFeatureStrategy,
+                        property: key as keyof ChangeRequestEditStrategy,
                         oldValue: currentValue,
                         newValue: changeValue,
                     };
                 }
             })
             .filter(
-                (change): change is DataToOverwrite<keyof IFeatureStrategy> =>
+                (
+                    change,
+                ): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
                     Boolean(change),
             );
 

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -1,9 +1,29 @@
-import { IChangeRequestUpdateStrategy } from 'component/changeRequest/changeRequest.types';
+import {
+    ChangeRequestEditStrategy,
+    IChangeRequestUpdateStrategy,
+} from 'component/changeRequest/changeRequest.types';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import isEqual from 'lodash.isequal';
+import omit from 'lodash.omit';
 
-const hasJsonDiff = (object: unknown, objectToCompare: unknown) =>
-    JSON.stringify(object) !== JSON.stringify(objectToCompare);
+type JsonDiffProps = {
+    snapshotValue: unknown;
+    liveValue: unknown;
+    changeValue: unknown;
+    fallback?: unknown;
+};
+const hasJsonDiff = ({
+    snapshotValue,
+    liveValue,
+    changeValue,
+    fallback,
+}: JsonDiffProps) => {
+    const liveJson = JSON.stringify(liveValue ?? fallback);
+    return (
+        JSON.stringify(snapshotValue ?? fallback) !== liveJson &&
+        JSON.stringify(changeValue ?? fallback) !== liveJson
+    );
+};
 
 type DataToOverwrite<Prop extends keyof IFeatureStrategy> = {
     property: Prop;
@@ -18,58 +38,90 @@ export const getChangesThatWouldBeOverwritten = (
 ): ChangesThatWouldBeOverwritten | null => {
     const { snapshot } = change.payload;
     if (snapshot && currentStrategyConfig) {
-        const hasChanged = (a: unknown, b: unknown) => {
-            if (typeof a === 'object') {
-                return !isEqual(a, b);
+        const hasChanged = (
+            snapshotValue: unknown,
+            liveValue: unknown,
+            changeValue: unknown,
+        ) => {
+            if (typeof snapshotValue === 'object') {
+                return (
+                    !isEqual(snapshotValue, liveValue) &&
+                    !isEqual(snapshotValue, changeValue)
+                );
             }
-            return hasJsonDiff(a, b);
+            return hasJsonDiff({ snapshotValue, liveValue, changeValue });
         };
 
         // compare each property in the snapshot. The property order
         // might differ, so using JSON.stringify to compare them
         // doesn't work.
         const changes: ChangesThatWouldBeOverwritten = Object.entries(
-            currentStrategyConfig,
+            omit(currentStrategyConfig, 'strategyName'),
         )
             .map(([key, currentValue]: [string, unknown]) => {
                 const snapshotValue = snapshot[key as keyof IFeatureStrategy];
+                const changeValue =
+                    change.payload[key as keyof ChangeRequestEditStrategy];
 
                 // compare, assuming that order never changes
                 if (key === 'segments') {
                     // segments can be undefined on the original
                     // object, but that doesn't mean it has changed
-                    if (hasJsonDiff(snapshotValue, currentValue ?? [])) {
+                    if (
+                        hasJsonDiff({
+                            snapshotValue,
+                            liveValue: currentValue,
+                            changeValue,
+                            fallback: [],
+                        })
+                    ) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,
-                            newValue: snapshotValue,
+                            newValue: changeValue,
                         };
                     }
                 } else if (key === 'variants') {
                     // strategy variants might not be defined, so use
                     // fallback values
-                    if (hasJsonDiff(snapshotValue ?? [], currentValue ?? [])) {
+                    if (
+                        hasJsonDiff({
+                            snapshotValue: snapshotValue,
+                            liveValue: currentValue,
+                            changeValue,
+                            fallback: [],
+                        })
+                    ) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,
-                            newValue: snapshotValue,
+                            newValue: changeValue,
                         };
                     }
                 } else if (key === 'title') {
                     // the title can be defined as `null` or
                     // `undefined`, so we fallback to an empty string
-                    if (hasJsonDiff(snapshotValue ?? '', currentValue ?? '')) {
+                    if (
+                        hasJsonDiff({
+                            snapshotValue: snapshotValue,
+                            liveValue: currentValue,
+                            changeValue,
+                            fallback: '',
+                        })
+                    ) {
                         return {
                             property: key as keyof IFeatureStrategy,
                             oldValue: currentValue,
-                            newValue: snapshotValue,
+                            newValue: changeValue,
                         };
                     }
-                } else if (hasChanged(snapshotValue, currentValue)) {
+                } else if (
+                    hasChanged(snapshotValue, currentValue, changeValue)
+                ) {
                     return {
                         property: key as keyof IFeatureStrategy,
                         oldValue: currentValue,
-                        newValue: snapshotValue,
+                        newValue: changeValue,
                     };
                 }
             })


### PR DESCRIPTION
This PR fixes a bug in the displayed value of the conflict list so that it shows the value it would update to instead of the snapshot value.

In doing so, it updates the logic of the algorithm to:

1. if the snapshot value and the current value are the same, it's not a conflict (it's an intended change)
2. If the snapshot value differs from the current value, it is a conflict if and only if the value in the change differs from the current value. Otherwise, it's not a conflict.

The new test cases are:
- it shows a diff for a property if the snapshot and live version differ for that property and the changed value is different from the live version
- it does not show a diff for a property if the live version and the change have the same value, even if the snapshot differs from the live version
- it does not show a diff for a property if the snapshot and the live version are the same