### PR TITLE
fix: enabled lock check

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -141,7 +141,7 @@ async function start(opts: IUnleashOptions = {}): Promise<IUnleash> {
             logger.info('DB migration: disabled');
         } else {
             logger.debug('DB migration: start');
-            if (opts.flagResolver?.isEnabled('migrationLock')) {
+            if (config.flagResolver.isEnabled('migrationLock')) {
                 logger.info('Running migration with lock');
                 const lock = withDbLock(config.db, {
                     lockKey: defaultLockKey,


### PR DESCRIPTION
We should use the enhanced flagResolver
Tested locally:
```
9:44:13 AM - Starting compilation in watch mode...
[dev:backend] 
[dev:backend] 
[dev:backend] 9:44:26 AM - Found 0 errors. Watching for file changes.
[dev:backend] [2024-01-23T09:44:27.498] [INFO] server-impl.js - DB migration: start
[dev:backend] [2024-01-23T09:44:27.499] [INFO] server-impl.js - Running migration with lock
[dev:backend] [2024-01-23T09:44:29.884] [INFO] server-impl.js - DB migration: end
```