### PR TITLE
chore: remove flagResolver option

### DIFF
--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -127,7 +127,6 @@ export interface IUnleashOptions {
     enterpriseVersion?: string;
     inlineSegmentConstraints?: boolean;
     clientFeatureCaching?: Partial<IClientCachingOption>;
-    flagResolver?: IFlagResolver;
     accessControlMaxAge?: number;
     prometheusApi?: string;
     publicFolder?: string;


### PR DESCRIPTION
## About the changes
This option is not referenced in the code

I believe its original intent was to be able to override flagResolver, but it's currently not being used:
https://github.com/Unleash/unleash/blob/a46f54f48afffdaf06126fa2998e61280dee03a3/src/lib/create-config.ts#L490-L491

Instead, we're using `experimental`, `flags`, and `externalResolver`

https://github.com/Unleash/unleash/blob/a46f54f48afffdaf06126fa2998e61280dee03a3/src/lib/create-config.ts#L64-L73

https://github.com/Unleash/unleash/blob/f63581c03a3bd2d520f26c900876f88246fe88d2/src/lib/util/flag-resolver.ts#L12-L20


