### PR TITLE
fix: add unleash to default email sender string

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -57,7 +57,7 @@ exports[`should create default config 1`] = `
     "host": undefined,
     "port": 587,
     "secure": false,
-    "sender": "noreply@getunleash.io",
+    "sender": "Unleash <noreply@getunleash.io>",
     "smtppass": undefined,
     "smtpuser": undefined,
   },

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -270,7 +270,7 @@ const defaultEmail: IEmailOption = {
     host: process.env.EMAIL_HOST,
     secure: parseEnvVarBoolean(process.env.EMAIL_SECURE, false),
     port: parseEnvVarNumber(process.env.EMAIL_PORT, 587),
-    sender: process.env.EMAIL_SENDER || 'noreply@getunleash.io',
+    sender: process.env.EMAIL_SENDER || 'Unleash <noreply@getunleash.io>',
     smtpuser: process.env.EMAIL_USER,
     smtppass: process.env.EMAIL_PASSWORD,
 };


### PR DESCRIPTION
Adds "Unleash" to the "noreply@getunleash.io" for default email sender