### PR TITLE
task: Make /edge/metrics toggleable by toggle

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -85,7 +85,7 @@ exports[`should create default config 1`] = `
       "disableBulkToggle": false,
       "disableMetrics": false,
       "disableNotifications": false,
-      "edgeBulkMetricsKillSwitch": false,
+      "edgeBulkMetrics": false,
       "embedProxy": true,
       "embedProxyFrontend": true,
       "enableLicense": false,

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -118,7 +118,7 @@ export default class EdgeController extends Controller {
         req: IAuthRequest<void, void, BulkMetricsSchema>,
         res: Response<void>,
     ): Promise<void> {
-        if (!this.flagResolver.isEnabled('edgeBulkMetricsKillSwitch')) {
+        if (this.flagResolver.isEnabled('edgeBulkMetrics')) {
             const { body, ip: clientIp } = req;
             const { metrics, applications } = body;
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -40,7 +40,7 @@ export type IFlagKey =
     | 'featureSearchFeedback'
     | 'featureSearchFeedbackPosting'
     | 'newStrategyConfigurationFeedback'
-    | 'edgeBulkMetricsKillSwitch'
+    | 'edgeBulkMetrics'
     | 'extendedUsageMetrics'
     | 'extendedUsageMetricsUI'
     | 'adminTokenKillSwitch'
@@ -185,8 +185,8 @@ const flags: IFlags = {
         process.env.UNLEASH_EXPERIMENTAL_ENCRYPT_EMAILS,
         false,
     ),
-    edgeBulkMetricsKillSwitch: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_EDGE_BULK_METRICS_KILL_SWITCH,
+    edgeBulkMetrics: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EDGE_BULK_METRICS,
         false,
     ),
     extendedUsageMetrics: parseEnvVarBoolean(


### PR DESCRIPTION
Previously we used a killswitch and returned 404 if the feature was enabled. This flips that to a default disabled toggle, that has to be turned on to handle old Edge (pre 17.0.0) posting bulk metrics