### PR TITLE
chore: add support for project and environment in PermissionGuard

### DIFF
--- a/frontend/src/component/common/PermissionGuard/PermissionGuard.tsx
+++ b/frontend/src/component/common/PermissionGuard/PermissionGuard.tsx
@@ -9,11 +9,15 @@ const StyledList = styled('ul')(({ theme }) => ({
 
 interface IPermissionGuardProps {
     permissions: string | string[];
+    project?: string;
+    environment?: string;
     children: JSX.Element;
 }
 
 export const PermissionGuard = ({
     permissions,
+    project,
+    environment,
     children,
 }: IPermissionGuardProps) => {
     const { hasAccess } = useContext(AccessContext);
@@ -26,7 +30,7 @@ export const PermissionGuard = ({
         permissionsArray.push(ADMIN);
     }
 
-    if (hasAccess(permissionsArray)) {
+    if (hasAccess(permissionsArray, project, environment)) {
         return children;
     }
 


### PR DESCRIPTION
I noticed some manual `hasAccess` usages in permission guards due to the fact that `PermissionGuard` does not accept `project` and `environment`. This PR adds this support to `PermissionGuard` so we can adapt these `hasAccess` checks to use it instead, adding consistency and cleaning things up.

This PR does not include these adaptations however, it only adds the optional properties to the component. We can address these at a later point.