### PR TITLE
fix: flag resolver get variant

### DIFF
--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -175,7 +175,7 @@ test('should expose an helper to get variant value', () => {
     });
 });
 
-test('should call external resolver getVariant when not overriden to be true, even if set as object in experimental', () => {
+test('should call external resolver getVariant when not overridden to be true, even if set as object in experimental', () => {
     const variant = {
         enabled: true,
         name: 'variant',

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -174,3 +174,44 @@ test('should expose an helper to get variant value', () => {
         foo: 'bar',
     });
 });
+
+test('should call external resolver getVariant when not overriden to be true, even if set as object in experimental', () => {
+    const variant = {
+        enabled: true,
+        name: 'variant',
+        payload: {
+            type: PayloadType.STRING,
+            value: 'variant-A',
+        },
+    };
+
+    const externalResolver = {
+        isEnabled: () => true,
+        getVariant: (name: string) => {
+            if (name === 'variantFlag') {
+                return variant;
+            }
+            return getDefaultVariant();
+        },
+    };
+
+    const config = {
+        flags: {
+            variantFlag: {
+                name: 'variant-flag',
+                enabled: false,
+                payload: {
+                    type: PayloadType.JSON,
+                    value: '',
+                },
+            },
+        },
+        externalResolver,
+    };
+
+    const resolver = new FlagResolver(config as IExperimentalOptions);
+
+    expect(resolver.getVariant('variantFlag' as IFlagKey)).toStrictEqual(
+        variant,
+    );
+});

--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -57,7 +57,7 @@ export default class FlagResolver implements IFlagResolver {
         const exp = this.experiments[expName];
         if (exp) {
             if (typeof exp === 'boolean') return getDefaultVariant();
-            else return exp;
+            else if (exp.enabled) return exp;
         }
         return this.externalResolver.getVariant(expName, context);
     }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1880/fix-flag-resolver-getvariant-behavior

Fixes the flag resolver `getVariant` behavior when there's a variant object set in `experimental` - The flag resolver should call the external resolver `getVariant` when not overridden to be true, even if set as variant object in `experimental`.

Related: https://github.com/Unleash/unleash/pull/3808