### PR TITLE
feat: track search bar events

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.test.tsx
@@ -1,5 +1,5 @@
 import { render } from 'utils/testRenderer';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { StrategyDiff } from './StrategyTooltipLink';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import { IChangeRequestUpdateStrategy } from 'component/changeRequest/changeRequest.types';

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -286,7 +286,14 @@ const FeatureToggleListTableComponent: VFC = () => {
         }
     }, [isSmallScreen, isMediumScreen]);
 
-    const setSearchValue = (query = '') => setTableState({ query });
+    const setSearchValue = (query = '') => {
+        setTableState({ query });
+        trackEvent('search-bar', {
+            props: {
+                screen: 'features',
+            },
+        });
+    };
 
     const rows = table.getRowModel().rows;
 

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -291,6 +291,7 @@ const FeatureToggleListTableComponent: VFC = () => {
         trackEvent('search-bar', {
             props: {
                 screen: 'features',
+                length: query.length,
             },
         });
     };

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -20,6 +20,7 @@ import { getCreateTogglePath } from 'utils/routePathHelpers';
 import { CREATE_FEATURE } from 'component/providers/AccessProvider/permissions';
 import { ExportDialog } from 'component/feature/FeatureToggleList/ExportDialog';
 import { FeatureSchema } from 'openapi';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 interface IProjectFeatureTogglesHeaderProps {
     isLoading?: boolean;
@@ -53,8 +54,14 @@ export const ProjectFeatureTogglesHeader: VFC<
     const featuresExportImportFlag = useUiFlag('featuresExportImport');
     const [showExportDialog, setShowExportDialog] = useState(false);
     const navigate = useNavigate();
+    const { trackEvent } = usePlausibleTracker();
     const handleSearch = (query: string) => {
         onChangeSearchQuery?.(query);
+        trackEvent('search-bar', {
+            props: {
+                screen: 'project',
+            },
+        });
     };
 
     return (

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -60,6 +60,7 @@ export const ProjectFeatureTogglesHeader: VFC<
         trackEvent('search-bar', {
             props: {
                 screen: 'project',
+                length: query.length,
             },
         });
     };

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -56,7 +56,8 @@ export type CustomEvents =
     | 'search-feature-buttons'
     | 'new-strategy-form'
     | 'feedback'
-    | 'feature-metrics';
+    | 'feature-metrics'
+    | 'search-bar';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);


### PR DESCRIPTION
Adding tracking for 2 views, when users use the new search. 

For features view and project view.