### PR TITLE
fix: clone variants (featureEnv and strategy) when cloning an env

### DIFF
--- a/src/test/e2e/stores/feature-environment-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-environment-store.e2e.test.ts
@@ -156,19 +156,19 @@ test('Copying strategies also copies strategy variants', async () => {
     });
 
     await environmentStore.create({
-        name: 'clone',
+        name: 'clone-2',
         enabled: true,
         type: 'test',
     });
-    await featureEnvironmentStore.connectProject('clone', 'default');
+    await featureEnvironmentStore.connectProject('clone-2', 'default');
 
-    await featureEnvironmentStore.cloneStrategies(envName, 'clone');
+    await featureEnvironmentStore.cloneStrategies(envName, 'clone-2');
 
     const clonedStrategy =
         await featureStrategiesStore.getStrategiesForFeatureEnv(
             'default',
             featureName,
-            'clone',
+            'clone-2',
         );
     expect(clonedStrategy.length).toBe(1);
     expect(clonedStrategy[0].variants).toMatchObject([strategyVariant]);

--- a/src/test/e2e/stores/feature-environment-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-environment-store.e2e.test.ts
@@ -125,8 +125,8 @@ test('Copying features also copies variants', async () => {
 });
 
 test('Copying strategies also copies strategy variants', async () => {
-    const envName = 'copy-env';
-    const featureName = 'copy-env-toggle-feature';
+    const envName = 'copy-strategy';
+    const featureName = 'copy-env-strategy-feature';
     await environmentStore.create({
         name: envName,
         enabled: true,

--- a/src/test/e2e/stores/feature-environment-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-environment-store.e2e.test.ts
@@ -1,4 +1,4 @@
-import { IUnleashStores } from '../../../lib/types';
+import { IFeatureStrategiesStore, IUnleashStores } from '../../../lib/types';
 import dbInit, { ITestDb } from '../helpers/database-init';
 import getLogger from '../../fixtures/no-logger';
 import { IFeatureEnvironmentStore } from '../../../lib/types/stores/feature-environment-store';
@@ -10,6 +10,7 @@ let stores: IUnleashStores;
 let featureEnvironmentStore: IFeatureEnvironmentStore;
 let featureStore: IFeatureToggleStore;
 let environmentStore: IEnvironmentStore;
+let featureStrategiesStore: IFeatureStrategiesStore;
 
 beforeAll(async () => {
     db = await dbInit('feature_environment_store_serial', getLogger);
@@ -17,6 +18,7 @@ beforeAll(async () => {
     featureEnvironmentStore = stores.featureEnvironmentStore;
     environmentStore = stores.environmentStore;
     featureStore = stores.featureToggleStore;
+    featureStrategiesStore = stores.featureStrategiesStore;
 });
 
 afterAll(async () => {
@@ -73,4 +75,101 @@ test('Setting enabled to not existing value returns 1', async () => {
         !enabledStatus,
     );
     expect(changed).toBe(1);
+});
+
+test('Copying features also copies variants', async () => {
+    const envName = 'copy-env';
+    const featureName = 'copy-env-toggle-feature';
+    await environmentStore.create({
+        name: envName,
+        enabled: true,
+        type: 'test',
+    });
+    await featureStore.create('default', {
+        name: featureName,
+        createdByUserId: 9999,
+    });
+    await featureEnvironmentStore.connectProject(envName, 'default');
+    await featureEnvironmentStore.connectFeatures(envName, 'default');
+
+    const variant = {
+        name: 'a',
+        weight: 1,
+        stickiness: 'default',
+        weightType: 'fix' as any,
+    };
+    await featureEnvironmentStore.setVariantsToFeatureEnvironments(
+        featureName,
+        [envName],
+        [variant],
+    );
+
+    await environmentStore.create({
+        name: 'clone',
+        enabled: true,
+        type: 'test',
+    });
+    await featureEnvironmentStore.connectProject('clone', 'default');
+
+    await featureEnvironmentStore.copyEnvironmentFeaturesByProjects(
+        envName,
+        'clone',
+        ['default'],
+    );
+
+    const cloned = await featureEnvironmentStore.get({
+        featureName: featureName,
+        environment: 'clone',
+    });
+    expect(cloned.variants).toMatchObject([variant]);
+});
+
+test('Copying strategies also copies strategy variants', async () => {
+    const envName = 'copy-env';
+    const featureName = 'copy-env-toggle-feature';
+    await environmentStore.create({
+        name: envName,
+        enabled: true,
+        type: 'test',
+    });
+    await featureStore.create('default', {
+        name: featureName,
+        createdByUserId: 9999,
+    });
+    await featureEnvironmentStore.connectProject(envName, 'default');
+    await featureEnvironmentStore.connectFeatures(envName, 'default');
+
+    const strategyVariant = {
+        name: 'a',
+        weight: 1,
+        stickiness: 'default',
+        weightType: 'fix' as any,
+    };
+    await featureStrategiesStore.createStrategyFeatureEnv({
+        environment: envName,
+        projectId: 'default',
+        featureName,
+        strategyName: 'default',
+        variants: [strategyVariant],
+        parameters: {},
+        constraints: [],
+    });
+
+    await environmentStore.create({
+        name: 'clone',
+        enabled: true,
+        type: 'test',
+    });
+    await featureEnvironmentStore.connectProject('clone', 'default');
+
+    await featureEnvironmentStore.cloneStrategies(envName, 'clone');
+
+    const clonedStrategy =
+        await featureStrategiesStore.getStrategiesForFeatureEnv(
+            'default',
+            featureName,
+            'clone',
+        );
+    expect(clonedStrategy.length).toBe(1);
+    expect(clonedStrategy[0].variants).toMatchObject([strategyVariant]);
 });


### PR DESCRIPTION
Fixes 2 bugs
- Strategy variants
- Feature env variants 
not being cloned when cloning an environment

Closes # [SR-350](https://linear.app/unleash/issue/SR-350/cloning-environment-does-not-clone-variants-or-strategy-variants)

Manual test verifies the fix
<img width="1659" alt="Screenshot 2024-01-24 at 16 48 28" src="https://github.com/Unleash/unleash/assets/104830839/ba9fc9b8-e792-47bb-b6e8-660350384ea8">
<img width="1408" alt="Screenshot 2024-01-24 at 16 48 10" src="https://github.com/Unleash/unleash/assets/104830839/1e2d5287-35d0-42d2-9ab2-8caa313bd5a8">
