### PR TITLE
chore: add a migration that removes incorrectly set sysuserid

### DIFF
--- a/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
+++ b/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
@@ -4,8 +4,12 @@ exports.up = function (db, cb) {
       UPDATE events SET created_by_user_id = null
       WHERE
           created_by_user_id = -1337 AND
-          created_by = 'unleash_system_user' OR
-          created_by = 'systemuser@getunleash.io';
+          created_by NOT IN (
+              'unknown',
+              'migration',
+              'init-api-tokens',
+              'unleash_system_user',
+              'systemuser@getunleash.io')
       `,
       cb,
   );

--- a/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
+++ b/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
@@ -9,7 +9,7 @@ exports.up = function (db, cb) {
               'migration',
               'init-api-tokens',
               'unleash_system_user',
-              'systemuser@getunleash.io')
+              'systemuser@getunleash.io');
       `,
       cb,
   );

--- a/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
+++ b/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
@@ -1,0 +1,16 @@
+exports.up = function (db, cb) {
+  db.runSql(
+      `
+      UPDATE events SET created_by_user_id = null
+      WHERE
+          created_by_user_id = -1337 AND
+          created_by = 'unleash_system_user' OR
+          created_by = 'systemuser@getunleash.io';
+      `,
+      cb,
+  );
+};
+
+exports.down = function (db, cb) {
+    cb();
+};


### PR DESCRIPTION
## About the changes

We had a bug that would set created_by_user_id = -1337 even for some events that had an actual user, and the created_by would be the users email. To fix the data this PR introduces a migration that simply sets created_by_user_id to null when created_by is not the unleash system user but the created_by_user_id is. The other scheduled jobs should pick this up and assign the correct user id

## Discussion points

The EXPLAIN of the previous version of this query with the created_by filter looking like this: `created_by NOT IN ('system_user', 'unleash_system_user', 'system@getunleash.io')` indicated that it would scan indexes and be fairly efficient