### PR TITLE
feat: add CR id to plausible events

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -113,10 +113,6 @@ export const ChangeRequestOverview: FC = () => {
         changeRequest.environment,
     );
 
-    const conflictCount = changeRequest.features.filter(
-        (feature) => feature.conflict,
-    ).length;
-
     const getCurrentState = (): PlausibleChangeRequestState => {
         switch (changeRequest.state) {
             case 'Scheduled':
@@ -128,15 +124,9 @@ export const ChangeRequestOverview: FC = () => {
 
     const onApplyChanges = async () => {
         try {
-            await changeState(
-                projectId,
-                Number(id),
-                getCurrentState(),
-                conflictCount,
-                {
-                    state: 'Applied',
-                },
-            );
+            await changeState(projectId, Number(id), getCurrentState(), {
+                state: 'Applied',
+            });
             setShowApplyScheduledDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -152,16 +142,10 @@ export const ChangeRequestOverview: FC = () => {
 
     const onScheduleChangeRequest = async (scheduledDate: Date) => {
         try {
-            await changeState(
-                projectId,
-                Number(id),
-                getCurrentState(),
-                conflictCount,
-                {
-                    state: 'Scheduled',
-                    scheduledAt: scheduledDate.toISOString(),
-                },
-            );
+            await changeState(projectId, Number(id), getCurrentState(), {
+                state: 'Scheduled',
+                scheduledAt: scheduledDate.toISOString(),
+            });
             setShowScheduleChangeDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -192,15 +176,9 @@ export const ChangeRequestOverview: FC = () => {
 
     const onCancelChanges = async () => {
         try {
-            await changeState(
-                projectId,
-                Number(id),
-                getCurrentState(),
-                conflictCount,
-                {
-                    state: 'Cancelled',
-                },
-            );
+            await changeState(projectId, Number(id), getCurrentState(), {
+                state: 'Cancelled',
+            });
             setShowCancelDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -216,16 +194,10 @@ export const ChangeRequestOverview: FC = () => {
 
     const onReject = async (comment?: string) => {
         try {
-            await changeState(
-                projectId,
-                Number(id),
-                getCurrentState(),
-                conflictCount,
-                {
-                    state: 'Rejected',
-                    comment,
-                },
-            );
+            await changeState(projectId, Number(id), getCurrentState(), {
+                state: 'Rejected',
+                comment,
+            });
             setShowRejectDialog(false);
             setToastData({
                 type: 'success',
@@ -241,15 +213,9 @@ export const ChangeRequestOverview: FC = () => {
 
     const onApprove = async () => {
         try {
-            await changeState(
-                projectId,
-                Number(id),
-                getCurrentState(),
-                conflictCount,
-                {
-                    state: 'Approved',
-                },
-            );
+            await changeState(projectId, Number(id), getCurrentState(), {
+                state: 'Approved',
+            });
             refetchChangeRequest();
             refetchChangeRequestOpen();
             setToastData({

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -34,7 +34,6 @@ import {
     ChangeRequestRejectScheduledDialogue,
 } from './ChangeRequestScheduledDialogs/changeRequestScheduledDialogs';
 import { ScheduleChangeRequestDialog } from './ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { PlausibleChangeRequestState } from '../changeRequest.types';
 
 const StyledAsideBox = styled(Box)(({ theme }) => ({
@@ -105,7 +104,6 @@ export const ChangeRequestOverview: FC = () => {
     const { isChangeRequestConfiguredForReview } =
         useChangeRequestsEnabled(projectId);
     const scheduleChangeRequests = useUiFlag('scheduledConfigurationChanges');
-    const { trackEvent } = usePlausibleTracker();
 
     if (!changeRequest) {
         return null;
@@ -114,6 +112,10 @@ export const ChangeRequestOverview: FC = () => {
     const allowChangeRequestActions = isChangeRequestConfiguredForReview(
         changeRequest.environment,
     );
+
+    const conflictCount = changeRequest.features.filter(
+        (feature) => feature.conflict,
+    ).length;
 
     const getCurrentState = (): PlausibleChangeRequestState => {
         switch (changeRequest.state) {
@@ -126,9 +128,15 @@ export const ChangeRequestOverview: FC = () => {
 
     const onApplyChanges = async () => {
         try {
-            await changeState(projectId, Number(id), getCurrentState(), {
-                state: 'Applied',
-            });
+            await changeState(
+                projectId,
+                Number(id),
+                getCurrentState(),
+                conflictCount,
+                {
+                    state: 'Applied',
+                },
+            );
             setShowApplyScheduledDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -144,10 +152,16 @@ export const ChangeRequestOverview: FC = () => {
 
     const onScheduleChangeRequest = async (scheduledDate: Date) => {
         try {
-            await changeState(projectId, Number(id), getCurrentState(), {
-                state: 'Scheduled',
-                scheduledAt: scheduledDate.toISOString(),
-            });
+            await changeState(
+                projectId,
+                Number(id),
+                getCurrentState(),
+                conflictCount,
+                {
+                    state: 'Scheduled',
+                    scheduledAt: scheduledDate.toISOString(),
+                },
+            );
             setShowScheduleChangeDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -178,9 +192,15 @@ export const ChangeRequestOverview: FC = () => {
 
     const onCancelChanges = async () => {
         try {
-            await changeState(projectId, Number(id), getCurrentState(), {
-                state: 'Cancelled',
-            });
+            await changeState(
+                projectId,
+                Number(id),
+                getCurrentState(),
+                conflictCount,
+                {
+                    state: 'Cancelled',
+                },
+            );
             setShowCancelDialog(false);
             refetchChangeRequest();
             refetchChangeRequestOpen();
@@ -196,10 +216,16 @@ export const ChangeRequestOverview: FC = () => {
 
     const onReject = async (comment?: string) => {
         try {
-            await changeState(projectId, Number(id), getCurrentState(), {
-                state: 'Rejected',
-                comment,
-            });
+            await changeState(
+                projectId,
+                Number(id),
+                getCurrentState(),
+                conflictCount,
+                {
+                    state: 'Rejected',
+                    comment,
+                },
+            );
             setShowRejectDialog(false);
             setToastData({
                 type: 'success',
@@ -215,9 +241,15 @@ export const ChangeRequestOverview: FC = () => {
 
     const onApprove = async () => {
         try {
-            await changeState(projectId, Number(id), getCurrentState(), {
-                state: 'Approved',
-            });
+            await changeState(
+                projectId,
+                Number(id),
+                getCurrentState(),
+                conflictCount,
+                {
+                    state: 'Approved',
+                },
+            );
             refetchChangeRequest();
             refetchChangeRequestOpen();
             setToastData({

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -81,7 +81,7 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
 
     const onReview = async (draftId: number, comment?: string) => {
         try {
-            await changeState(project, draftId, 'Draft', {
+            await changeState(project, draftId, 'Draft', 0, {
                 state: 'In review',
                 comment,
             });

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -81,7 +81,7 @@ export const ChangeRequestSidebar: VFC<IChangeRequestSidebarProps> = ({
 
     const onReview = async (draftId: number, comment?: string) => {
         try {
-            await changeState(project, draftId, 'Draft', 0, {
+            await changeState(project, draftId, 'Draft', {
                 state: 'In review',
                 comment,
             });

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -59,7 +59,6 @@ export const useChangeRequestApi = () => {
         project: string,
         changeRequestId: number,
         previousState: PlausibleChangeRequestState,
-        conflictCount: number,
         payload: {
             state:
                 | 'Approved'
@@ -77,7 +76,6 @@ export const useChangeRequestApi = () => {
                 eventType: payload.state,
                 previousState,
                 id: getUniqueChangeRequestId(uiConfig, changeRequestId),
-                conflictCount,
             },
         });
 

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -1,6 +1,7 @@
 import useAPI from '../useApi/useApi';
 import { usePlausibleTracker } from '../../../usePlausibleTracker';
 import { PlausibleChangeRequestState } from 'component/changeRequest/changeRequest.types';
+import { getUniqueChangeRequestId } from 'utils/unique-change-request-id';
 
 export interface IChangeSchema {
     feature: string | null;
@@ -30,6 +31,7 @@ export const useChangeRequestApi = () => {
     const { makeRequest, createRequest, errors, loading } = useAPI({
         propagateErrors: true,
     });
+    const { uiConfig } = useUiConfig();
 
     const addChange = async (
         project: string,
@@ -73,7 +75,7 @@ export const useChangeRequestApi = () => {
             props: {
                 eventType: payload.state,
                 previousState,
-                id: changeRequestId,
+                id: getUniqueChangeRequestId(uiConfig, changeRequestId),
                 conflictCount,
             },
         });

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -56,6 +56,7 @@ export const useChangeRequestApi = () => {
         project: string,
         changeRequestId: number,
         previousState: PlausibleChangeRequestState,
+        conflictCount: number,
         payload: {
             state:
                 | 'Approved'
@@ -68,10 +69,18 @@ export const useChangeRequestApi = () => {
             scheduledAt?: string;
         },
     ) => {
+        console.log({
+            eventType: payload.state,
+            previousState,
+            id: changeRequestId,
+            conflictCount,
+        });
         trackEvent('change_request', {
             props: {
                 eventType: payload.state,
                 previousState,
+                id: changeRequestId,
+                conflictCount,
             },
         });
 

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -2,6 +2,7 @@ import useAPI from '../useApi/useApi';
 import { usePlausibleTracker } from '../../../usePlausibleTracker';
 import { PlausibleChangeRequestState } from 'component/changeRequest/changeRequest.types';
 import { getUniqueChangeRequestId } from 'utils/unique-change-request-id';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 export interface IChangeSchema {
     feature: string | null;

--- a/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
+++ b/frontend/src/hooks/api/actions/useChangeRequestApi/useChangeRequestApi.ts
@@ -69,12 +69,6 @@ export const useChangeRequestApi = () => {
             scheduledAt?: string;
         },
     ) => {
-        console.log({
-            eventType: payload.state,
-            previousState,
-            id: changeRequestId,
-            conflictCount,
-        });
         trackEvent('change_request', {
             props: {
                 eventType: payload.state,

--- a/frontend/src/utils/unique-change-request-id.ts
+++ b/frontend/src/utils/unique-change-request-id.ts
@@ -1,0 +1,10 @@
+import { IUiConfig } from 'interfaces/uiConfig';
+
+export const getUniqueChangeRequestId = (
+    uiConfig: Pick<IUiConfig, 'baseUriPath' | 'versionInfo'>,
+    changeRequestId: number,
+) => {
+    return `${
+        uiConfig.baseUriPath || uiConfig.versionInfo?.instanceId
+    }/change-requests/${changeRequestId}?version=${uiConfig.versionInfo}`;
+};


### PR DESCRIPTION
Added conflict count to CR metrics and CR id.

Something to think about:
There was idea that we can aggregate this data based on CR id, but CR id is just a number from 0 to x. So it will not be unique across instances. 