### PR TITLE
fix: Use knex whereLike instead of whereRaw to fix escaping

### DIFF
--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -167,10 +167,11 @@ export default class ClientInstanceStore implements IClientInstanceStore {
     }
 
     async getBySdkName(sdkName: string): Promise<IClientInstance[]> {
+        const sdkPrefix = `${sdkName}%`;
         const rows = await this.db
             .select()
             .from(TABLE)
-            .whereRaw(`sdk_version LIKE '??%'`, [sdkName])
+            .whereLike('sdk_version', sdkPrefix)
             .orderBy('last_seen', 'desc');
         return rows.map(mapRow);
     }


### PR DESCRIPTION
This escape with `??` double escaped the LIKE query causing no results. This updates to using whereLike, which does the correct escaping for string query.