### PR TITLE
chore: default the data migration flag for createdbyuserid to false

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -79,7 +79,7 @@ exports[`should create default config 1`] = `
       "caseInsensitiveInOperators": false,
       "celebrateUnleash": false,
       "changeRequestConflictHandling": false,
-      "createdByUserIdDataMigration": true,
+      "createdByUserIdDataMigration": false,
       "customRootRolesKillSwitch": false,
       "demo": false,
       "detectSegmentUsageInChangeRequests": false,

--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -746,15 +746,17 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             .limit(batchSize)
             .select(['f.*', 'ev.created_by', 'u.id', 't.username']);
 
-        toUpdate
+        const updatePromises = toUpdate
             .filter((row) => row.id || row.username)
-            .forEach(async (row) => {
+            .map((row) => {
                 const id = row.id || ADMIN_TOKEN_USER.id;
 
-                await this.db(TABLE)
+                return this.db(TABLE)
                     .update({ created_by_user_id: id })
                     .where({ name: row.name });
             });
+
+        await Promise.all(updatePromises);
     }
 }
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -225,7 +225,7 @@ const flags: IFlags = {
     },
     createdByUserIdDataMigration: parseEnvVarBoolean(
         process.env.CREATED_BY_USERID_DATA_MIGRATION,
-        true,
+        false,
     ),
 };
 

--- a/src/test/config/test-config.ts
+++ b/src/test/config/test-config.ts
@@ -27,6 +27,7 @@ export function createTestConfig(config?: IUnleashOptions): IUnleashConfig {
             flags: {
                 embedProxy: true,
                 embedProxyFrontend: true,
+                createdByUserIdDataMigration: true,
             },
         },
         publicFolder: path.join(__dirname, '../examples'),


### PR DESCRIPTION
## About the changes

Sets data migration of features and events created_by_user_id to disabled by default
