### PR TITLE
fix: return 400 when enabling env of archived toggle

### DIFF
--- a/src/lib/error/archivedfeature-error.ts
+++ b/src/lib/error/archivedfeature-error.ts
@@ -1,0 +1,13 @@
+import { UnleashError } from './unleash-error';
+
+class ArchivedFeatureError extends UnleashError {
+    statusCode = 400;
+
+    constructor(
+        message: string = 'Cannot perform this operation on archived features',
+    ) {
+        super(message);
+    }
+}
+export default ArchivedFeatureError;
+module.exports = ArchivedFeatureError;


### PR DESCRIPTION
Creates a new ArchivedFeatureError.
Throw this error when trying to toggle a feature environment for an archived feature.  

Closes https://github.com/orgs/Unleash/projects/8/views/1?pane=issue&itemId=51242922