### PR TITLE
chore: remove drew as a codeowner for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # docs
-/website/ @thomasheartman @dgorton
+/website/ @thomasheartman


### PR DESCRIPTION
Now that Drew isn't at Unleash anymore, he probably doesn't want to get review requests for docs stuff anymore 💁