### PR TITLE
fix: add instanceName to license display

### DIFF
--- a/frontend/src/component/admin/license/License.tsx
+++ b/frontend/src/component/admin/license/License.tsx
@@ -80,7 +80,7 @@ export const License = () => {
                                     Customer
                                 </StyledPropertyName>
                                 <StyledPropertyDetails>
-                                    {license?.customer}
+                                    {license.customer}
                                 </StyledPropertyDetails>
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>
@@ -88,19 +88,19 @@ export const License = () => {
                                     Instance Name
                                 </StyledPropertyName>
                                 <StyledPropertyDetails>
-                                    {license?.instanceName}
+                                    {license.instanceName}
                                 </StyledPropertyDetails>
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>
                                 <StyledPropertyName>Plan</StyledPropertyName>
                                 <StyledPropertyDetails>
-                                    {license?.plan}
+                                    {license.plan}
                                 </StyledPropertyDetails>
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>
                                 <StyledPropertyName>Seats</StyledPropertyName>
                                 <StyledPropertyDetails>
-                                    {license?.seats}
+                                    {license.seats}
                                 </StyledPropertyDetails>
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>

--- a/frontend/src/component/admin/license/License.tsx
+++ b/frontend/src/component/admin/license/License.tsx
@@ -84,6 +84,14 @@ export const License = () => {
                                 </StyledPropertyDetails>
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>
+                                <StyledPropertyName>
+                                    Instance Name
+                                </StyledPropertyName>
+                                <StyledPropertyDetails>
+                                    {license?.instanceName}
+                                </StyledPropertyDetails>
+                            </StyledDataCollectionPropertyRow>
+                            <StyledDataCollectionPropertyRow>
                                 <StyledPropertyName>Plan</StyledPropertyName>
                                 <StyledPropertyDetails>
                                     {license?.plan}

--- a/frontend/src/hooks/api/getters/useLicense/useLicense.ts
+++ b/frontend/src/hooks/api/getters/useLicense/useLicense.ts
@@ -21,6 +21,7 @@ export interface License {
     license?: {
         token: string;
         customer: string;
+        instanceName: string;
         plan: string;
         seats: number;
         expireAt: Date;

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -90,6 +90,7 @@ exports[`should create default config 1`] = `
       "embedProxy": true,
       "embedProxyFrontend": true,
       "enableLicense": false,
+      "enableLicenseChecker": false,
       "encryptEmails": false,
       "executiveDashboard": false,
       "extendedUsageMetrics": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -7,6 +7,7 @@ export type IFlagKey =
     | 'anonymiseEventLog'
     | 'encryptEmails'
     | 'enableLicense'
+    | 'enableLicenseChecker'
     | 'embedProxy'
     | 'embedProxyFrontend'
     | 'responseTimeWithAppNameKillSwitch'
@@ -54,6 +55,7 @@ export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 const flags: IFlags = {
     anonymiseEventLog: false,
     enableLicense: false,
+    enableLicenseChecker: false,
     embedProxy: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EMBED_PROXY,
         true,


### PR DESCRIPTION
## About the changes
- Shows the instanceName from the license
- add new feature flag `enableLicenseChecker` used to enforce a valid license. 
