### PR TITLE
feat: migration for health and time_to_production in flag trends

### DIFF
--- a/src/migrations/20240130104757-flag-trends-health-time-to-production.js
+++ b/src/migrations/20240130104757-flag-trends-health-time-to-production.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE flag_trends ADD COLUMN IF NOT EXISTS health INTEGER DEFAULT 100;
+        ALTER TABLE flag_trends ADD COLUMN IF NOT EXISTS time_to_production FLOAT DEFAULT 0;
+        `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql(`
+        ALTER TABLE flag_trends DROP COLUMN IF EXISTS health;
+        ALTER TABLE flag_trends DROP COLUMN IF EXISTS time_to_production;
+    `, cb);
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding health and time_to_production columns to long term flag trends. Types are derived from the project and project_stats tables.  time_to_production is derived from the project_stats average time to production in the current window. Since in the context of trends we don't distinguish between current, previous and time_to_production is always avg for a project I decided to use a simple name.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
