### PR TITLE
feat: scheduler init jitter

### DIFF
--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -4,13 +4,13 @@ import { IMaintenanceStatus } from '../maintenance/maintenance-service';
 import { SCHEDULER_JOB_TIME } from '../../metric-events';
 
 // returns between min and max seconds in ms
-// when schedule interval is smaller than min jitter then no jitter
+// when schedule interval is smaller than max jitter then no jitter
 function randomJitter(
     minMs: number,
     maxMs: number,
     scheduleIntervalMs: number,
 ): number {
-    if (scheduleIntervalMs < minMs) {
+    if (scheduleIntervalMs < maxMs) {
         return 0;
     }
     return Math.random() * (maxMs - minMs + 1) + minMs;

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -13,7 +13,7 @@ function randomJitter(
     if (scheduleIntervalMs < maxMs) {
         return 0;
     }
-    return Math.random() * (maxMs - minMs + 1) + minMs;
+    return Math.random() * (maxMs - minMs) + minMs;
 }
 
 export class SchedulerService {

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -10,7 +10,7 @@ function randomJitter(
     maxMs: number,
     scheduleIntervalMs: number,
 ): number {
-    if (scheduleIntervalMs < maxMs) {
+    if (scheduleIntervalMs < minMs) {
         return 0;
     }
     return Math.random() * (maxMs - minMs + 1) + minMs;

--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -4,7 +4,7 @@ import { IMaintenanceStatus } from '../maintenance/maintenance-service';
 import { SCHEDULER_JOB_TIME } from '../../metric-events';
 
 // returns between min and max seconds in ms
-// when schedule interval is smaller than max then no jitter
+// when schedule interval is smaller than min jitter then no jitter
 function randomJitter(
     minMs: number,
     maxMs: number,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding scheduler init jitter to avoid too many DB operations running at once. Subsequent runs are not affected.

Design decisions:
* default jitter calculated so that we don't need to change code using scheduler
* default jitter is 2s-30s
* if any scheduler runs more often than max jitter time (30 seconds) then no jitter is applied
* you can explicitly opt-out of jitter by passing 0ms jitter

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
