### PR TITLE
refactor: take chatgpt's suggestions for diff calc algorithm

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -56,11 +56,10 @@ export const getChangesThatWouldBeOverwritten = (
     const { snapshot } = change.payload;
     if (!snapshot || !currentStrategyConfig) return null;
 
-    // @ts-ignore
     const changes: ChangesThatWouldBeOverwritten = Object.entries(
         omit(currentStrategyConfig, 'strategyName'),
     )
-        .map(([key, currentValue]) => {
+        .map(([key, currentValue]: [string, unknown]) => {
             const snapshotValue = snapshot[key as keyof IFeatureStrategy];
             const changeValue =
                 change.payload[key as keyof ChangeRequestEditStrategy];
@@ -86,7 +85,6 @@ export const getChangesThatWouldBeOverwritten = (
         .filter(
             (
                 change,
-                // @ts-ignore
             ): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
                 Boolean(change),
         );

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -12,16 +12,20 @@ type JsonDiffProps = {
     changeValue: unknown;
     fallback?: unknown;
 };
+
+const stringifyWithFallback = (value: unknown, fallback: unknown) =>
+    JSON.stringify(value ?? fallback);
+
 const hasJsonDiff = ({
     snapshotValue,
     currentValue,
     changeValue,
     fallback,
 }: JsonDiffProps) => {
-    const currentJson = JSON.stringify(currentValue ?? fallback);
+    const currentJson = stringifyWithFallback(currentValue, fallback);
     return (
-        JSON.stringify(snapshotValue ?? fallback) !== currentJson &&
-        JSON.stringify(changeValue ?? fallback) !== currentJson
+        stringifyWithFallback(snapshotValue, fallback) !== currentJson &&
+        stringifyWithFallback(changeValue, fallback) !== currentJson
     );
 };
 
@@ -29,21 +33,18 @@ const hasChanged = (
     snapshotValue: unknown,
     currentValue: unknown,
     changeValue: unknown,
-) => {
-    if (typeof snapshotValue === 'object') {
-        return (
-            !isEqual(snapshotValue, currentValue) &&
-            !isEqual(currentValue, changeValue)
-        );
-    }
-    return hasJsonDiff({ snapshotValue, currentValue, changeValue });
-};
+) =>
+    typeof snapshotValue === 'object'
+        ? !isEqual(snapshotValue, currentValue) ||
+          !isEqual(currentValue, changeValue)
+        : hasJsonDiff({ snapshotValue, currentValue, changeValue });
 
 type DataToOverwrite<Prop extends keyof ChangeRequestEditStrategy> = {
     property: Prop;
     oldValue: ChangeRequestEditStrategy[Prop];
     newValue: ChangeRequestEditStrategy[Prop];
 };
+
 type ChangesThatWouldBeOverwritten = DataToOverwrite<
     keyof ChangeRequestEditStrategy
 >[];
@@ -53,80 +54,46 @@ export const getChangesThatWouldBeOverwritten = (
     change: IChangeRequestUpdateStrategy,
 ): ChangesThatWouldBeOverwritten | null => {
     const { snapshot } = change.payload;
+    if (!snapshot || !currentStrategyConfig) return null;
 
-    if (snapshot && currentStrategyConfig) {
-        // compare each property in the snapshot. The property order
-        // might differ, so using JSON.stringify to compare them
-        // doesn't work.
-        const changes: ChangesThatWouldBeOverwritten = Object.entries(
-            omit(currentStrategyConfig, 'strategyName'),
-        )
-            .map(([key, currentValue]: [string, unknown]) => {
-                const snapshotValue = snapshot[key as keyof IFeatureStrategy];
-                const changeValue =
-                    change.payload[key as keyof ChangeRequestEditStrategy];
+    // @ts-ignore
+    const changes: ChangesThatWouldBeOverwritten = Object.entries(
+        omit(currentStrategyConfig, 'strategyName'),
+    )
+        .map(([key, currentValue]) => {
+            const snapshotValue = snapshot[key as keyof IFeatureStrategy];
+            const changeValue =
+                change.payload[key as keyof ChangeRequestEditStrategy];
+            const fallbacks = { segments: [], variants: [], title: '' };
+            const fallback =
+                fallbacks[key as keyof typeof fallbacks] ?? undefined;
 
-                const hasJsonDiffWithFallback = (fallback: unknown) =>
-                    hasJsonDiff({
-                        snapshotValue,
-                        currentValue,
-                        changeValue,
-                        fallback,
-                    });
+            if (
+                hasJsonDiff({
+                    snapshotValue,
+                    currentValue,
+                    changeValue,
+                    fallback,
+                })
+            ) {
+                return {
+                    property: key as keyof ChangeRequestEditStrategy,
+                    oldValue: currentValue,
+                    newValue: changeValue,
+                };
+            }
+        })
+        .filter(
+            (
+                change,
+                // @ts-ignore
+            ): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
+                Boolean(change),
+        );
 
-                // compare, assuming that order never changes
-                if (key === 'segments') {
-                    // segments can be undefined on the original
-                    // object, but that doesn't mean it has changed
-                    if (hasJsonDiffWithFallback([])) {
-                        return {
-                            property: key as keyof ChangeRequestEditStrategy,
-                            oldValue: currentValue,
-                            newValue: changeValue,
-                        };
-                    }
-                } else if (key === 'variants') {
-                    // strategy variants might not be defined, so use
-                    // fallback values
-                    if (hasJsonDiffWithFallback([])) {
-                        return {
-                            property: key as keyof ChangeRequestEditStrategy,
-                            oldValue: currentValue,
-                            newValue: changeValue,
-                        };
-                    }
-                } else if (key === 'title') {
-                    // the title can be defined as `null` or
-                    // `undefined`, so we fallback to an empty string
-                    if (hasJsonDiffWithFallback('')) {
-                        return {
-                            property: key as keyof ChangeRequestEditStrategy,
-                            oldValue: currentValue,
-                            newValue: changeValue,
-                        };
-                    }
-                } else if (
-                    hasChanged(snapshotValue, currentValue, changeValue)
-                ) {
-                    return {
-                        property: key as keyof ChangeRequestEditStrategy,
-                        oldValue: currentValue,
-                        newValue: changeValue,
-                    };
-                }
-            })
-            .filter(
-                (
-                    change,
-                ): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
-                    Boolean(change),
-            );
-
-        if (changes.length) {
-            // we have changes that would be overwritten
-            changes.sort((a, b) => a.property.localeCompare(b.property));
-            return changes;
-        }
+    if (changes.length) {
+        changes.sort((a, b) => a.property.localeCompare(b.property));
+        return changes;
     }
 
     return null;

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/strategy-change-diff-calculation.ts
@@ -53,6 +53,11 @@ type ChangesThatWouldBeOverwritten = DataToOverwrite<
     keyof ChangeRequestEditStrategy
 >[];
 
+const removeEmptyEntries = (
+    change: unknown,
+): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
+    Boolean(change);
+
 export const getChangesThatWouldBeOverwritten = (
     currentStrategyConfig: IFeatureStrategy | undefined,
     change: IChangeRequestUpdateStrategy,
@@ -90,12 +95,7 @@ export const getChangesThatWouldBeOverwritten = (
                 return changeInfo;
             }
         })
-        .filter(
-            (
-                change,
-            ): change is DataToOverwrite<keyof ChangeRequestEditStrategy> =>
-                Boolean(change),
-        );
+        .filter(removeEmptyEntries);
 
     if (changes.length) {
         changes.sort((a, b) => a.property.localeCompare(b.property));


### PR DESCRIPTION
We had to make some updates to let the compiler know about the types and fix an issue with nested objects not being compared as objects (instead as strings), but this saves us a few lines and is hopefully more readable.