### PR TITLE
chore: scheduled created-by migrations metrics

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -141,7 +141,7 @@ export default class EventService {
 
     async setEventCreatedByUserId(): Promise<void> {
         const updated = await this.eventStore.setCreatedByUserId(100);
-        if (updated > -1) {
+        if (updated !== undefined) {
             this.eventBus.emit(EVENTS_CREATED_BY_PROCESSED, {
                 updated,
             });

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -136,6 +136,6 @@ export default class EventService {
     }
 
     async setEventCreatedByUserId(): Promise<void> {
-        return this.eventStore.setCreatedByUserId(100);
+        const updated = await this.eventStore.setCreatedByUserId(100);
     }
 }

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -143,7 +143,6 @@ export default class EventService {
         const updated = await this.eventStore.setCreatedByUserId(100);
         if (updated > -1) {
             this.eventBus.emit(EVENTS_CREATED_BY_PROCESSED, {
-                jobId: 'setEventCreatedByUserId',
                 updated,
             });
         }

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -433,16 +433,16 @@ class EventStore implements IEventStore {
         events.forEach((e) => this.eventEmitter.emit(e.type, e));
     }
 
-    async setCreatedByUserId(batchSize: number): Promise<void> {
+    async setCreatedByUserId(batchSize: number): Promise<number> {
         const API_TOKEN_TABLE = 'api_tokens';
 
         if (!this.flagResolver.isEnabled('createdByUserIdDataMigration')) {
-            return;
+            return -1;
         }
 
         const toUpdate = await this.db(`${TABLE} as e`)
             .joinRaw(
-                `LEFT OUTER JOIN users AS u ON e.created_by = u.username OR e.created_by = u.email`,
+                'LEFT OUTER JOIN users AS u ON e.created_by = u.username OR e.created_by = u.email',
             )
             .joinRaw(
                 `LEFT OUTER JOIN ${API_TOKEN_TABLE} AS t on e.created_by = t.username`,
@@ -469,21 +469,23 @@ class EventStore implements IEventStore {
                 return this.db(TABLE)
                     .update({ created_by_user_id: SYSTEM_USER_ID })
                     .where({ id: row.id });
-            } else if (row.userid) {
+            }
+            if (row.userid) {
                 return this.db(TABLE)
                     .update({ created_by_user_id: row.userid })
                     .where({ id: row.id });
-            } else if (row.username) {
+            }
+            if (row.username) {
                 return this.db(TABLE)
                     .update({ created_by_user_id: ADMIN_TOKEN_USER.id })
                     .where({ id: row.id });
-            } else {
-                this.logger.warn(`Could not find user for event ${row.id}`);
-                return Promise.resolve();
             }
+            this.logger.warn(`Could not find user for event ${row.id}`);
+            return Promise.resolve();
         });
 
         await Promise.all(updatePromises);
+        return toUpdate.length;
     }
 }
 

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -433,11 +433,11 @@ class EventStore implements IEventStore {
         events.forEach((e) => this.eventEmitter.emit(e.type, e));
     }
 
-    async setCreatedByUserId(batchSize: number): Promise<number> {
+    async setCreatedByUserId(batchSize: number): Promise<number | undefined> {
         const API_TOKEN_TABLE = 'api_tokens';
 
         if (!this.flagResolver.isEnabled('createdByUserIdDataMigration')) {
-            return -1;
+            return undefined;
         }
 
         const toUpdate = await this.db(`${TABLE} as e`)

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -52,6 +52,7 @@ import {
     createFakeDependentFeaturesService,
 } from '../dependent-features/createDependentFeaturesService';
 import { createEventsService } from '../events/createEventsService';
+import { EventEmitter } from 'stream';
 
 export const createFeatureToggleService = (
     db: Db,
@@ -134,7 +135,7 @@ export const createFeatureToggleService = (
             contextFieldStore,
             strategyStore,
         },
-        { getLogger, flagResolver },
+        { getLogger, flagResolver, eventBus },
         segmentService,
         accessService,
         eventService,
@@ -166,7 +167,7 @@ export const createFakeFeatureToggleService = (
     const environmentStore = new FakeEnvironmentStore();
     const eventService = new EventService(
         { eventStore, featureTagStore },
-        { getLogger },
+        { getLogger, eventBus: new EventEmitter() },
     );
     const groupService = new GroupService(
         { groupStore, accountStore },
@@ -195,7 +196,7 @@ export const createFakeFeatureToggleService = (
             contextFieldStore,
             strategyStore,
         },
-        { getLogger, flagResolver },
+        { getLogger, flagResolver, eventBus: new EventEmitter() },
         segmentService,
         accessService,
         eventService,

--- a/src/lib/features/feature-toggle/fakes/fake-feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/fakes/fake-feature-toggle-store.ts
@@ -329,7 +329,7 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
         throw new Error('Method not implemented.');
     }
 
-    setCreatedByUserId(batchSize: number): Promise<number> {
+    setCreatedByUserId(batchSize: number): Promise<number | undefined> {
         throw new Error('Method not implemented.');
     }
 }

--- a/src/lib/features/feature-toggle/fakes/fake-feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/fakes/fake-feature-toggle-store.ts
@@ -166,7 +166,7 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
     async getFeatureToggleList(
         query?: IFeatureToggleQuery,
         userId?: number,
-        archived: boolean = false,
+        archived = false,
     ): Promise<FeatureToggle[]> {
         return this.features.filter((feature) => feature.archived !== archived);
     }
@@ -329,7 +329,7 @@ export default class FakeFeatureToggleStore implements IFeatureToggleStore {
         throw new Error('Method not implemented.');
     }
 
-    setCreatedByUserId(batchSize: number): Promise<void> {
+    setCreatedByUserId(batchSize: number): Promise<number> {
         throw new Error('Method not implemented.');
     }
 }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -2451,7 +2451,7 @@ class FeatureToggleService {
 
     async setFeatureCreatedByUserIdFromEvents(): Promise<void> {
         const updated = await this.featureToggleStore.setCreatedByUserId(100);
-        if (updated > -1) {
+        if (updated !== undefined) {
             this.eventBus.emit(FEATURES_CREATED_BY_PROCESSED, {
                 updated,
             });

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -2453,7 +2453,6 @@ class FeatureToggleService {
         const updated = await this.featureToggleStore.setCreatedByUserId(100);
         if (updated > -1) {
             this.eventBus.emit(FEATURES_CREATED_BY_PROCESSED, {
-                jobId: 'setFeatureCreatedByUserIdFromEvents',
                 updated,
             });
         }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -2444,7 +2444,7 @@ class FeatureToggleService {
     }
 
     async setFeatureCreatedByUserIdFromEvents(): Promise<void> {
-        await this.featureToggleStore.setCreatedByUserId(100);
+        const updated = await this.featureToggleStore.setCreatedByUserId(100);
     }
 }
 

--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -723,13 +723,13 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         return result?.potentially_stale ?? false;
     }
 
-    async setCreatedByUserId(batchSize: number): Promise<number> {
+    async setCreatedByUserId(batchSize: number): Promise<number | undefined> {
         const EVENTS_TABLE = 'events';
         const USERS_TABLE = 'users';
         const API_TOKEN_TABLE = 'api_tokens';
 
         if (!this.flagResolver.isEnabled('createdByUserIdDataMigration')) {
-            return -1;
+            return undefined;
         }
         const toUpdate = await this.db(`${TABLE} as f`)
             .joinRaw(`JOIN ${EVENTS_TABLE} AS ev ON ev.feature_name = f.name`)

--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -723,13 +723,13 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         return result?.potentially_stale ?? false;
     }
 
-    async setCreatedByUserId(batchSize: number): Promise<void> {
+    async setCreatedByUserId(batchSize: number): Promise<number> {
         const EVENTS_TABLE = 'events';
         const USERS_TABLE = 'users';
         const API_TOKEN_TABLE = 'api_tokens';
 
         if (!this.flagResolver.isEnabled('createdByUserIdDataMigration')) {
-            return;
+            return -1;
         }
         const toUpdate = await this.db(`${TABLE} as f`)
             .joinRaw(`JOIN ${EVENTS_TABLE} AS ev ON ev.feature_name = f.name`)
@@ -757,6 +757,7 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
         });
 
         await Promise.all(updatePromises);
+        return toUpdate.length;
     }
 }
 

--- a/src/lib/features/feature-toggle/types/feature-toggle-store-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-toggle-store-type.ts
@@ -104,5 +104,5 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
         params: IFeatureProjectUserParams,
     ): Promise<IFeatureTypeCount[]>;
 
-    setCreatedByUserId(batchSize: number): Promise<void>;
+    setCreatedByUserId(batchSize: number): Promise<number>;
 }

--- a/src/lib/features/feature-toggle/types/feature-toggle-store-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-toggle-store-type.ts
@@ -104,5 +104,5 @@ export interface IFeatureToggleStore extends Store<FeatureToggle, string> {
         params: IFeatureProjectUserParams,
     ): Promise<IFeatureTypeCount[]>;
 
-    setCreatedByUserId(batchSize: number): Promise<number>;
+    setCreatedByUserId(batchSize: number): Promise<number | undefined>;
 }

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -1,5 +1,13 @@
 const REQUEST_TIME = 'request_time';
 const DB_TIME = 'db_time';
 const SCHEDULER_JOB_TIME = 'scheduler_job_time';
+const FEATURES_CREATED_BY_PROCESSED = 'features_created_by_processed';
+const EVENTS_CREATED_BY_PROCESSED = 'events_created_by_processed';
 
-export { REQUEST_TIME, DB_TIME, SCHEDULER_JOB_TIME };
+export {
+    REQUEST_TIME,
+    DB_TIME,
+    SCHEDULER_JOB_TIME,
+    FEATURES_CREATED_BY_PROCESSED,
+    EVENTS_CREATED_BY_PROCESSED,
+};

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -374,6 +374,20 @@ export default class MetricsMonitor {
             schedulerDuration.labels(jobId).observe(time);
         });
 
+        eventBus.on(
+            events.EVENTS_CREATED_BY_PROCESSED,
+            ({ jobId, updated }) => {
+                schedulerDuration.labels(jobId).observe(updated);
+            },
+        );
+
+        eventBus.on(
+            events.FEATURES_CREATED_BY_PROCESSED,
+            ({ jobId, updated }) => {
+                schedulerDuration.labels(jobId).observe(updated);
+            },
+        );
+
         eventBus.on(events.DB_TIME, ({ store, action, time }) => {
             dbDuration.labels({ store, action }).observe(time);
         });

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -224,6 +224,14 @@ export default class MetricsMonitor {
             help: 'Rate limits (per minute) for METHOD/ENDPOINT pairs',
             labelNames: ['endpoint', 'method'],
         });
+        const featureCreatedByMigration = createGauge({
+            name: 'feature_created_by_migration_count',
+            help: 'Feature createdBy migration count',
+        });
+        const eventCreatedByMigration = createGauge({
+            name: 'event_created_by_migration_count',
+            help: 'Event createdBy migration count',
+        });
 
         async function collectStaticCounters() {
             try {
@@ -374,19 +382,15 @@ export default class MetricsMonitor {
             schedulerDuration.labels(jobId).observe(time);
         });
 
-        eventBus.on(
-            events.EVENTS_CREATED_BY_PROCESSED,
-            ({ jobId, updated }) => {
-                schedulerDuration.labels(jobId).observe(updated);
-            },
-        );
+        eventBus.on(events.EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {
+            eventCreatedByMigration.reset();
+            eventCreatedByMigration.set(updated);
+        });
 
-        eventBus.on(
-            events.FEATURES_CREATED_BY_PROCESSED,
-            ({ jobId, updated }) => {
-                schedulerDuration.labels(jobId).observe(updated);
-            },
-        );
+        eventBus.on(events.FEATURES_CREATED_BY_PROCESSED, ({ updated }) => {
+            featureCreatedByMigration.reset();
+            featureCreatedByMigration.set(updated);
+        });
 
         eventBus.on(events.DB_TIME, ({ store, action, time }) => {
             dbDuration.labels({ store, action }).observe(time);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -224,11 +224,11 @@ export default class MetricsMonitor {
             help: 'Rate limits (per minute) for METHOD/ENDPOINT pairs',
             labelNames: ['endpoint', 'method'],
         });
-        const featureCreatedByMigration = createGauge({
+        const featureCreatedByMigration = createCounter({
             name: 'feature_created_by_migration_count',
             help: 'Feature createdBy migration count',
         });
-        const eventCreatedByMigration = createGauge({
+        const eventCreatedByMigration = createCounter({
             name: 'event_created_by_migration_count',
             help: 'Event createdBy migration count',
         });
@@ -383,13 +383,11 @@ export default class MetricsMonitor {
         });
 
         eventBus.on(events.EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {
-            eventCreatedByMigration.reset();
-            eventCreatedByMigration.set(updated);
+            eventCreatedByMigration.inc(updated);
         });
 
         eventBus.on(events.FEATURES_CREATED_BY_PROCESSED, ({ updated }) => {
-            featureCreatedByMigration.reset();
-            featureCreatedByMigration.set(updated);
+            featureCreatedByMigration.inc(updated);
         });
 
         eventBus.on(events.DB_TIME, ({ store, action, time }) => {

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -16,6 +16,7 @@ import SimpleAddon from './addon-service-test-simple-addon';
 import { IAddonProviders } from '../addons';
 import EventService from '../features/events/event-service';
 import { SYSTEM_USER } from '../types';
+import { EventEmitter } from 'stream';
 
 const MASKED_VALUE = '*****';
 
@@ -25,7 +26,10 @@ let addonProvider: IAddonProviders;
 
 function getSetup() {
     const stores = createStores();
-    const eventService = new EventService(stores, { getLogger });
+    const eventService = new EventService(stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
     const tagTypeService = new TagTypeService(
         stores,
         { getLogger },

--- a/src/lib/services/state-service.test.ts
+++ b/src/lib/services/state-service.test.ts
@@ -15,12 +15,16 @@ import { GLOBAL_ENV } from '../types/environment';
 import variantsExportV3 from '../../test/examples/variantsexport_v3.json';
 import EventService from '../features/events/event-service';
 import { SYSTEM_USER_ID } from '../types';
+import { EventEmitter } from 'stream';
 const oldExportExample = require('./state-service-export-v1.json');
 const TESTUSERID = 3333;
 
 function getSetup() {
     const stores = createStores();
-    const eventService = new EventService(stores, { getLogger });
+    const eventService = new EventService(stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
     return {
         stateService: new StateService(
             stores,
@@ -70,7 +74,10 @@ async function setupV3VariantsCompatibilityScenario(
             ],
         );
     });
-    const eventService = new EventService(stores, { getLogger });
+    const eventService = new EventService(stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
     return {
         stateService: new StateService(
             stores,
@@ -645,7 +652,10 @@ test('Should export projects', async () => {
 
 test('exporting to new format works', async () => {
     const stores = createStores();
-    const eventService = new EventService(stores, { getLogger });
+    const eventService = new EventService(stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
     const stateService = new StateService(
         stores,
         {

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -17,5 +17,5 @@ export interface IEventStore
     getMaxRevisionId(currentMax?: number): Promise<number>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;
     queryCount(operations: IQueryOperations[]): Promise<number>;
-    setCreatedByUserId(batchSize: number): Promise<void>;
+    setCreatedByUserId(batchSize: number): Promise<number>;
 }

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -17,5 +17,5 @@ export interface IEventStore
     getMaxRevisionId(currentMax?: number): Promise<number>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;
     queryCount(operations: IQueryOperations[]): Promise<number>;
-    setCreatedByUserId(batchSize: number): Promise<number>;
+    setCreatedByUserId(batchSize: number): Promise<number | undefined>;
 }

--- a/src/test/e2e/api/admin/event.e2e.test.ts
+++ b/src/test/e2e/api/admin/event.e2e.test.ts
@@ -7,6 +7,7 @@ import getLogger from '../../../fixtures/no-logger';
 import { FEATURE_CREATED, IBaseEvent } from '../../../../lib/types/events';
 import { randomId } from '../../../../lib/util/random-id';
 import { EventService } from '../../../../lib/services';
+import { EventEmitter } from 'stream';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -21,7 +22,10 @@ beforeAll(async () => {
             },
         },
     });
-    eventService = new EventService(db.stores, { getLogger });
+    eventService = new EventService(db.stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
 });
 
 beforeEach(async () => {

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -126,7 +126,7 @@ class FakeEventStore implements IEventStore {
         throw new Error('Method not implemented.');
     }
 
-    setCreatedByUserId(batchSize: number): Promise<number> {
+    setCreatedByUserId(batchSize: number): Promise<number | undefined> {
         throw new Error('Method not implemented.');
     }
 }

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -126,7 +126,7 @@ class FakeEventStore implements IEventStore {
         throw new Error('Method not implemented.');
     }
 
-    setCreatedByUserId(batchSize: number): Promise<void> {
+    setCreatedByUserId(batchSize: number): Promise<number> {
         throw new Error('Method not implemented.');
     }
 }


### PR DESCRIPTION
## About the changes

the created_by_user_id data migration from resolving events.created_by (for both events and features) now emits events on how many rows were updated.

Adds listeners for these events that records these metrics with prometheus

![image](https://github.com/Unleash/unleash/assets/707867/3bb02645-0919-4a9a-83fe-a07383ac0be1)
