### PR TITLE
fix: fix skeleton not appearing on feature toggle list

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -312,6 +312,7 @@ export const FeatureToggleListTable: VFC = () => {
 
     return (
         <PageContent
+            disableLoading={true}
             bodyClass='no-padding'
             header={
                 <PageHeader


### PR DESCRIPTION
The `FeatureToggleListTable` is nested directly within `PageContent`. `PageContent` was cause for removing the skeleton from the table. However, this is unnecessary because the table has its own loader that manages the skeletons. Therefore, `PageContent` does not require a loader.