### PR TITLE
docs: show links to other sidebars when the navbar is collapsed

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -29,6 +29,12 @@ module.exports = {
                 'unleash-academy/managing-unleash-for-devops',
             ],
         },
+        {
+            type: 'ref',
+            id:'welcome',
+            label: 'Docs',
+            className: 'show-when-collapsed',
+        }
     ],
     documentation: [
         'welcome',
@@ -488,5 +494,11 @@ module.exports = {
                 },
             ],
         },
+        {
+            type: 'ref',
+            id:'unleash-academy/introduction',
+            label: 'Unleash Academy',
+            className: 'show-when-collapsed',
+        }
     ],
 };

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -58,6 +58,12 @@
     }
 }
 
+@media (min-width: 997px) {
+    .show-when-collapsed {
+        display: none;
+    }
+}
+
 footer {
     --ifm-footer-link-hover-color: var(--ifm-footer-link-color);
 }


### PR DESCRIPTION
This change adds links to Unleash Academy from the docs sidebar and
vice versa when the nav bar is collapsed (on narrow screens).