### PR TITLE
Fix/check maintenance flag once per minute

### DIFF
--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -53,6 +53,8 @@ export default class MaintenanceService implements IMaintenanceStatus {
         user: string,
         toggledByUserId: number,
     ): Promise<void> {
+        //@ts-ignore
+        this.resolveMaintenance.clear();
         return this.settingService.insert(
             maintenanceSettingsKey,
             setting,


### PR DESCRIPTION
## About the changes
Every schedule job will now check if maintenance is enabled. This ends up querying the settings table in the db at least once per second per running unleash instance. This small fix caches this query for 60 seconds to reduce the load somewhat. 

We should reconsider this solution for the long term, but this will be a great improvement on the short term. 


**Logs after this fix running locally.** 
We can observe that we resolve settings from the DB once per minute. 
![image](https://github.com/Unleash/unleash/assets/158948/c313cf38-8d86-4b86-a0ba-4f4df60d50d6)


Also we should consider giving a warning in section where you enable maintenance mode that it can take up to a minute to propagate. 