### PR TITLE
chore: split metrics by request type

### DIFF
--- a/src/lib/db/feature-tag-store.ts
+++ b/src/lib/db/feature-tag-store.ts
@@ -34,7 +34,7 @@ class FeatureTagStore implements IFeatureTagStore {
         this.logger = getLogger('feature-tag-store.ts');
         this.timer = (action) =>
             metricsHelper.wrapTimer(eventBus, DB_TIME, {
-                store: 'feature-toggle',
+                store: 'feature-tag-toggle',
                 action,
             });
     }

--- a/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
@@ -51,7 +51,7 @@ export default class FeatureToggleClientStore
         this.logger = getLogger('feature-toggle-client-store.ts');
         this.timer = (action) =>
             metricsHelper.wrapTimer(eventBus, DB_TIME, {
-                store: 'feature-toggle',
+                store: 'client-feature-toggle',
                 action,
             });
         this.flagResolver = flagResolver;
@@ -66,7 +66,7 @@ export default class FeatureToggleClientStore
         const isAdmin = requestType === 'admin';
         const isPlayground = requestType === 'playground';
         const environment = featureQuery?.environment || DEFAULT_ENV;
-        const stopTimer = this.timer('getFeatureAdmin');
+        const stopTimer = this.timer(`getFeatureAdmin${requestType}`);
 
         let selectColumns = [
             'features.name as name',


### PR DESCRIPTION
## About the changes
Queries on client-feature-toggle store have many purposes depending on the requestType, making the query more complex or not depending on the use case. Also, each use case has different frequencies (i.e. playground is expected to be used rarely).

The name for the store metrics was wrong, copy&pasted from:
https://github.com/Unleash/unleash/blob/7b04db054793a03e12bd92a53c24d5feb40c561d/src/lib/features/feature-toggle/feature-toggle-store.ts#L107

Which was also present in feature-tag metrics:
https://github.com/Unleash/unleash/blob/7b04db054793a03e12bd92a53c24d5feb40c561d/src/lib/db/feature-tag-store.ts#L37

With this, we'll have more granularity to understand the execution time and frequency of each