### PR TITLE
fix: maintenance mode should assume disable if db call fails.

### DIFF
--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -33,19 +33,22 @@ export default class MaintenanceService implements IMaintenanceStatus {
     }
 
     async isMaintenanceMode(): Promise<boolean> {
-        return (
-            this.config.flagResolver.isEnabled('maintenanceMode') ||
-            (await this.resolveMaintenance())
-        );
+        try {
+            return (
+                this.config.flagResolver.isEnabled('maintenanceMode') ||
+                (await this.resolveMaintenance())
+            );
+        } catch (e) {
+            this.logger.warn('Error checking maintenance mode', e);
+            return false;
+        }
     }
 
     async getMaintenanceSetting(): Promise<MaintenanceSchema> {
         this.logger.debug('getMaintenanceSetting called');
-        return (
-            (await this.settingService.get(maintenanceSettingsKey)) || {
-                enabled: false,
-            }
-        );
+        return this.settingService.getWithDefault(maintenanceSettingsKey, {
+            enabled: false,
+        });
     }
 
     async toggleMaintenanceMode(

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -193,7 +193,7 @@ export default class VersionService {
             )) ?? { id: undefined };
             this.instanceId = id;
         } catch (err) {
-            this.logger.warn('Could not find instanceInfo');
+            this.logger.warn('Could not find instanceInfo', err);
         }
     }
 


### PR DESCRIPTION
Usually maintenance mode is disabled. If the call throws, which we see a lot of when a unleash instance is in terminating state, we should return a default value.

By having it throw inside of the memoizee function, the response is not cached, and it will trigger new calls until it return a cachable result.