### PR TITLE
fix: schduler-service graceful shutdown

### DIFF
--- a/src/lib/features/scheduler/scheduler-service.ts
+++ b/src/lib/features/scheduler/scheduler-service.ts
@@ -93,9 +93,11 @@ export class SchedulerService {
 
             if (!maintenanceMode) {
                 if (jitter) {
-                    setTimeout(() => {
-                        runScheduledFunctionWithEvent();
-                    }, jitter);
+                    const id = setTimeout(
+                        () => runScheduledFunctionWithEvent(),
+                        jitter,
+                    );
+                    this.intervalIds.push(id);
                 } else {
                     await runScheduledFunctionWithEvent();
                 }


### PR DESCRIPTION
When a stop signal is sent to Unleash the scheduler-service should cancel any scheduled jobs. This also applies to the job scheduled for initial execution with jitter.


We observed that initial jobs was executed after the database connections are terminated. This appears after v5.9.0 of Unleash. 

```
Error: aborted
    at Object.queryBuilder (/unleash/node_modules/knex/lib/knex-builder/make-knex.js:112:26)
    at createQueryBuilder (/unleash/node_modules/knex/lib/knex-builder/make-knex.js:320:26)
    at EventStore.knex [as db] (/unleash/node_modules/knex/lib/knex-builder/make-knex.js:101:12)
    at EventStore.setUnannouncedToAnnounced (/unleash/node_modules/unleash-server/dist/lib/features/events/event-store.js:286:33)
    at EventStore.publishUnannouncedEvents (/unleash/node_modules/unleash-server/dist/lib/features/events/event-store.js:293:35)
    at EventAnnouncer.publishUnannouncedEvents (/unleash/node_modules/unleash-server/dist/lib/services/event-announcer-service.js:9:32)
    at runScheduledFunctionWithEvent (/unleash/node_modules/unleash-server/dist/lib/features/scheduler/scheduler-service.js:30:23)
    at Timeout.<anonymous> (/unleash/node_modules/unleash-server/dist/lib/features/scheduler/scheduler-service.js:50:27)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at process.processTimers (node:internal/timers:509:9)
```
