### PR TITLE
docs: hide the quickstart and doc nav bar links when you're on the docs pages

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -74,13 +74,13 @@ module.exports = {
                     type: 'doc',
                     position: 'right',
                     docId: 'quickstart',
-                    label: 'Quickstart',
+                    html: '<span class="hide-when-active">Quickstart</span>',
                 },
                 {
                     type: 'doc',
                     position: 'right',
                     docId: 'welcome',
-                    label: 'Docs',
+                    html: '<span class="hide-when-active">Docs</span>',
                 },
                 {
                     type: 'dropdown',
@@ -122,7 +122,7 @@ module.exports = {
                         {
                           label: 'Managing Unleash for DevOps/Admins',
                           href: 'https://docs.google.com/forms/d/1JlIqmXI3P7dj0n-OiUs2IYsYXgmqw23BChaemlSgHJA/viewform',
-                        },                     
+                        },
                   ],
                 },
                 {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -34,6 +34,10 @@
     color: var(--unleash-navbar-font-color);
 }
 
+.navbar .navbar__link--active:has(.hide-when-active) {
+    display: none;
+}
+
 .navbar button[class*='toggleButton_']:hover
 {
     background: var(--unleash-navbar-active-background-color);


### PR DESCRIPTION
This change hides the quickstart and doc nav bar links when you're on
the docs pages.

This gets around the issue of both of those links being
highlighted when you're on the docs pages.

This should work on  91.66% of browsers (according to [canIUse's data for the `:has` selector](https://caniuse.com/?search=%3Ahas)). For older browsers, the links will still be visible.