### PR TITLE
fix: default featureSearchFeedback to false

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -95,7 +95,7 @@ exports[`should create default config 1`] = `
       "extendedUsageMetrics": false,
       "extendedUsageMetricsUI": false,
       "featureSearchFeedback": {
-        "enabled": true,
+        "enabled": false,
         "name": "withText",
         "payload": {
           "type": "json",

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -161,7 +161,7 @@ const flags: IFlags = {
         name: 'withText',
         enabled: parseEnvVarBoolean(
             process.env.UNLEASH_EXPERIMENTAL_FEATURE_SEARCH_FEEDBACK,
-            true,
+            false,
         ),
         payload: {
             type: PayloadType.JSON,


### PR DESCRIPTION
We need to turn it false, because if it is true, it will not get any variants.

This solution is hacky, but good for now. 