### PR TITLE
chore: update schedule emails to handle suspensions and segment updates

### DIFF
--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -145,6 +145,38 @@ export class EmailService {
 
     async sendScheduledChangeConflictEmail(
         recipient: string,
+        conflictScope: 'flag' | 'strategy',
+        conflictingChangeRequestId: number | undefined,
+        changeRequests: {
+            id: number;
+            scheduledAt: string;
+            link: string;
+            title?: string;
+        }[],
+        flagName: string,
+        project: string,
+        strategyId?: string,
+    ) {
+        const conflictData =
+            conflictScope === 'flag'
+                ? { reason: 'flag archived' as const, flagName }
+                : {
+                      reason: 'strategy deleted' as const,
+                      flagName,
+                      strategyId: strategyId ?? '',
+                  };
+
+        return this.sendScheduledChangeConflictEmailV2(
+            recipient,
+            conflictData,
+            conflictingChangeRequestId,
+            changeRequests,
+            project,
+        );
+    }
+
+    async sendScheduledChangeConflictEmailV2(
+        recipient: string,
         conflictData:
             | { reason: 'flag archived'; flagName: string }
             | {

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -146,19 +146,19 @@ export class EmailService {
     async sendScheduledChangeConflictEmail(
         recipient: string,
         conflictData:
-            | { cause: 'flag archived'; flagName: string }
+            | { reason: 'flag archived'; flagName: string }
             | {
-                  cause: 'strategy deleted';
+                  reason: 'strategy deleted';
                   flagName: string;
                   strategyId: string;
               }
             | {
-                  cause: 'strategy updated';
+                  reason: 'strategy updated';
                   flagName: string;
                   strategyId: string;
               }
             | {
-                  cause: 'segment updated';
+                  reason: 'segment updated';
                   segment: { id: number; name: string };
               },
         conflictingChangeRequestId: number | undefined,
@@ -173,7 +173,7 @@ export class EmailService {
         if (this.configured()) {
             const year = new Date().getFullYear();
             const getConflictDetails = () => {
-                switch (conflictData.cause) {
+                switch (conflictData.reason) {
                     case 'flag archived':
                         return {
                             conflictScope: 'flag',

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -166,7 +166,7 @@ export class EmailService {
                       strategyId: strategyId ?? '',
                   };
 
-        return this.sendScheduledChangeConflictEmailV2(
+        return this.sendScheduledChangeSuspendedEmail(
             recipient,
             conflictData,
             conflictingChangeRequestId,
@@ -175,7 +175,7 @@ export class EmailService {
         );
     }
 
-    async sendScheduledChangeConflictEmailV2(
+    async sendScheduledChangeSuspendedEmail(
         recipient: string,
         conflictData:
             | { reason: 'flag archived'; flagName: string }

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -218,6 +218,7 @@ export class EmailService {
                         return {
                             conflictScope: 'strategy',
                             conflict: `The strategy with id ${conflictData.strategyId} for flag ${conflictData.flagName} in ${project} has been deleted`,
+                            canBeRescheduled: false,
                         };
                     case 'strategy updated':
                         return {

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -178,40 +178,36 @@ export class EmailService {
                         return {
                             conflictScope: 'flag',
                             conflict: `The feature flag ${conflictData.flagName} in ${project} has been archived`,
-                            conflictResolution: ' unless the flag is revived',
-                            conflictResolutionLink: `${this.config.server.unleashUrl}/projects/${project}/archive?sort=archivedAt&search=${conflictData.flagName}`,
+                            flagArchived: true,
+                            flagLink: `${this.config.server.unleashUrl}/projects/${project}/archive?sort=archivedAt&search=${conflictData.flagName}`,
+                            canBeRescheduled: false,
                         };
                     case 'strategy deleted':
                         return {
                             conflictScope: 'strategy',
                             conflict: `The strategy with id ${conflictData.strategyId} for flag ${conflictData.flagName} in ${project} has been deleted`,
-                            conflictResolution: false,
-                            conflictResolutionLink: false,
                         };
                     case 'strategy updated':
                         return {
                             conflictScope: 'strategy',
-                            conflict: `The strategy with id ${conflictData.strategyId} for flag ${conflictData.flagName} in ${project} has been updated, and your changes would overwrite some of the recent changes`,
-                            conflictResolution:
-                                'If you still want to apply your changes, you can reschedule any suspended change requests. If you no want to apply the changes, you can reject the change request',
-                            conflictResolutionLink: false,
+                            conflict: `A strategy belonging to ${conflictData.flagName} (ID: ${conflictData.strategyId}) in the project ${project} has been updated, and your changes would overwrite some of the recent changes`,
+                            canBeRescheduled: true,
                         };
                     case 'segment updated':
                         return {
                             conflictScope: 'segment',
                             conflict: `Segment ${conflictData.segment.id} ("${conflictData.segment.name}") in ${project} has been updated, and your changes would overwrite some of the recent changes`,
-                            conflictResolution:
-                                'If you still want to apply your changes, you can reschedule any suspended change requests. If you no want to apply the changes, you can reject the change request',
-                            conflictResolutionLink: false,
+                            canBeRescheduled: true,
                         };
                 }
             };
 
             const {
+                canBeRescheduled,
                 conflict,
-                conflictResolution,
                 conflictScope,
-                conflictResolutionLink,
+                flagArchived = false,
+                flagLink = false,
             } = getConflictDetails();
 
             const conflictingChangeRequestLink = conflictingChangeRequestId
@@ -224,8 +220,9 @@ export class EmailService {
                 {
                     conflict,
                     conflictScope,
-                    conflictResolution,
-                    conflictResolutionLink,
+                    canBeRescheduled,
+                    flagArchived,
+                    flagLink,
                     conflictingChangeRequestLink,
                     changeRequests,
                     year,
@@ -237,8 +234,10 @@ export class EmailService {
                 {
                     conflict,
                     conflictScope,
-                    conflictResolution,
-                    conflictResolutionLink,
+                    canBeRescheduled,
+                    flagArchived,
+                    flagLink,
+                    conflictingChangeRequestLink,
                     changeRequests,
                     year,
                 },

--- a/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.html.mustache
+++ b/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.html.mustache
@@ -363,10 +363,15 @@
                             <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateBody">
                                 <tr>
                                     <td valign="top" class="bodyContent" mc:edit="body_content">
-                                        <h1>Conflict detected in a scheduled change</h1>
+                                        <h1>Your scheduled change requests have been suspended</h1>
                                         <h3>{{ conflict }}.</h3>
-                                        <p>Scheduled change requests that use this {{ conflictScope }} can no longer be applied and their scheduled applications will fail{{#conflictResolution}}<a class="changeRequestLink" href="{{{ conflictResolutionLink }}}" target="_blank" rel="noopener noreferrer">{{.}}</a>{{/conflictResolution}}{{^conflictResolution}}.{{/conflictResolution}}</p>
-                                        <p>For you, this concerns change requests:</p>
+                                        {{#canBeRescheduled}}
+                                          <p>Scheduled change requests that contain updates to this {{ conflictScope }} have been suspended to prevent accidentally overwriting important configuration. If you still wish to go ahead with the changes, please reschedule the relevant change requests. If you no longer want the changes, you can reject the change request(s) instead.</p>
+                                        {{/canBeRescheduled}}
+                                        {{^canBeRescheduled}}
+                                          <p>Scheduled change requests that contain this {{ conflictScope }} have been suspended because they can't be applied anymore{{#flagArchived}} unless the <a class="changeRequestLink" href="{{{ flagLink }}}" target="_blank" rel="noopener noreferrer">flag is revived</a> ({{ flagLink }}). If you revive the flag, you can then reschedule any relevant change requests and they will apply as normal. Otherwise, we{{/flagArchived}}{{^flagArchived}}. We{{/flagArchived}} recommend that you clean up by rejecting the affected change requests.</p>
+                                        {{/canBeRescheduled}}
+                                        <p>For you, this concerns change these requests:</p>
                                         {{#changeRequests}}
                                         <ul style="margin-bottom:0;">
                                             <li><a class="changeRequestLink" href="{{{ link }}}" target="_blank" rel="noopener noreferrer">#{{id}} {{#title}}- {{.}}{{/title}} (scheduled for {{scheduledAt}})</a></li>

--- a/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
+++ b/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
@@ -1,8 +1,13 @@
-Your scheduled changes have been suspended
+Your scheduled change requests have been suspended
 
-{{ conflict }}. Scheduled change requests that use this {{ conflictScope }} can no longer be applied and their scheduled applications will fail{{#conflictResolution}}{{.}} ({{conflictResolutionLink}}){{/conflictResolution}}{{^conflictResolution}}.{{/conflictResolution}}
+{{#canBeRescheduled}}
+{{ conflict }}. Scheduled change requests that contain updates to this {{ conflictScope }} have been suspended to prevent accidentally overwriting important configuration. If you still wish to go ahead with the changes, please reschedule the relevant change requests. If you no longer want the changes, you can reject the change request(s) instead.
+{{/canBeRescheduled}}
+{{^canBeRescheduled}}
+{{ conflict }}. Scheduled change requests that contain this {{ conflictScope }} have been suspended because they can't be applied anymore{{#flagArchived}} unless the flag is revived ({{ flagLink }}). If you revive the flag, you can then reschedule any relevant change requests and they will apply as normal. Otherwise, we{{/flagArchived}}{{^flagArchived}}. We{{/flagArchived}} recommend that you clean up by rejecting the affected change requests.
+{{/canBeRescheduled}}
 
-For you, this concerns change requests:
+For you, this concerns these change requests:
 
 {{#changeRequests}}
     - # {{id}} - {{#title}}- {{.}}{{/title}} (scheduled for {{scheduledAt}}) ({{link}})

--- a/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
+++ b/src/mailtemplates/scheduled-change-conflict/scheduled-change-conflict.plain.mustache
@@ -1,4 +1,4 @@
-Scheduled changes can no longer be applied
+Your scheduled changes have been suspended
 
 {{ conflict }}. Scheduled change requests that use this {{ conflictScope }} can no longer be applied and their scheduled applications will fail{{#conflictResolution}}{{.}} ({{conflictResolutionLink}}){{/conflictResolution}}{{^conflictResolution}}.{{/conflictResolution}}
 


### PR DESCRIPTION
This PR updates the change request email sending method to handle the recent changes we have made. That means that the email now:
- says that change requests have been suspended instead of saying that application will fail.
- handles cases where segments or strategies have been updated causing potential conflicts.

I have updated the email templates and made some adjustments to the email sending method. To make the transition from one to the other easier, I have kept the original method as an interim solution until enterprise has switched over.   