### PR TITLE
fix: network tab active state

### DIFF
--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -2,7 +2,7 @@ import { lazy } from 'react';
 
 import { Tab, Tabs } from '@mui/material';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { CenteredNavLink } from '../menu/CenteredNavLink';
+import { TabLink } from 'component/common/TabNav/TabLink';
 import { PageContent } from 'component/common/PageContent/PageContent';
 
 const NetworkOverview = lazy(() => import('./NetworkOverview/NetworkOverview'));
@@ -39,9 +39,9 @@ export const Network = () => {
                                 key={label}
                                 value={path}
                                 label={
-                                    <CenteredNavLink to={path}>
+                                    <TabLink to={path}>
                                         <span>{label}</span>
-                                    </CenteredNavLink>
+                                    </TabLink>
                                 }
                                 sx={{ padding: 0 }}
                             />


### PR DESCRIPTION
https://linear.app/unleash/issue/UNL-335/network-active-tab-state

Fixes the tab active state in Network by using the new `TabLink` component.

![image](https://github.com/Unleash/unleash/assets/14320932/d8d4cc1e-9554-4b20-9991-b66e49663ae5)