### PR TITLE
feat: add disabled state handling on slow network

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Alert, Typography } from '@mui/material';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
@@ -13,10 +13,12 @@ interface IChangeRequestDialogueProps {
     environment?: string;
     showBanner?: boolean;
     messageComponent: JSX.Element;
+    disabled?: boolean;
 }
 
 export const ChangeRequestDialogue: FC<IChangeRequestDialogueProps> = ({
     isOpen,
+    disabled = false,
     onConfirm,
     onClose,
     showBanner,
@@ -40,6 +42,7 @@ export const ChangeRequestDialogue: FC<IChangeRequestDialogueProps> = ({
             open={isOpen}
             primaryButtonText={primaryButtonText}
             secondaryButtonText='Cancel'
+            disabledPrimaryButton={disabled}
             onClick={onConfirm}
             onClose={onClose}
             title='Request changes'

--- a/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestConfirmDialog/ChangeRequestConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 import { Alert, Typography } from '@mui/material';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRejectDialog/ChangeRequestRejectDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRejectDialog/ChangeRequestRejectDialog.tsx
@@ -6,7 +6,7 @@ interface IChangeRequestDialogueProps {
     open: boolean;
     onConfirm: (comment?: string) => void;
     onClose: () => void;
-    disabled: boolean;
+    disabled?: boolean;
 }
 
 export const ChangeRequestRejectDialogue: FC<IChangeRequestDialogueProps> = ({

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRejectDialog/ChangeRequestRejectDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRejectDialog/ChangeRequestRejectDialog.tsx
@@ -6,12 +6,14 @@ interface IChangeRequestDialogueProps {
     open: boolean;
     onConfirm: (comment?: string) => void;
     onClose: () => void;
+    disabled: boolean;
 }
 
 export const ChangeRequestRejectDialogue: FC<IChangeRequestDialogueProps> = ({
     open,
     onConfirm,
     onClose,
+    disabled = false,
 }) => {
     const [commentText, setCommentText] = useState('');
 
@@ -21,6 +23,7 @@ export const ChangeRequestRejectDialogue: FC<IChangeRequestDialogueProps> = ({
             primaryButtonText='Reject changes'
             secondaryButtonText='Cancel'
             onClick={() => onConfirm(commentText)}
+            disabledPrimaryButton={disabled}
             onClose={onClose}
             title='Reject changes'
             fullWidth

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ChangeRequestScheduledDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ChangeRequestScheduledDialog.tsx
@@ -29,6 +29,7 @@ export const ChangeRequestScheduledDialog: FC<
     onClose,
     title,
     primaryButtonText,
+    disabled,
     message,
     scheduledTime,
     permissionButton,
@@ -39,6 +40,7 @@ export const ChangeRequestScheduledDialog: FC<
         <Dialogue
             title={title}
             primaryButtonText={primaryButtonText}
+            disabledPrimaryButton={disabled}
             secondaryButtonText='Cancel'
             open={open}
             onClose={onClose}

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestScheduledDialogs/ScheduleChangeRequestDialog.tsx
@@ -48,6 +48,7 @@ export const ScheduleChangeRequestDialog: FC<ScheduleChangeRequestDialogProps> =
             <Dialogue
                 title={title}
                 primaryButtonText={primaryButtonText}
+                disabledPrimaryButton={disabled}
                 secondaryButtonText='Cancel'
                 open={open}
                 onClose={() => onClose()}

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/MultiActionButton/MultiActionButton.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/MultiActionButton/MultiActionButton.tsx
@@ -102,6 +102,7 @@ export const MultiActionButton: FC<{
                                     {actions.map(
                                         ({ label, onSelect, icon }) => (
                                             <MenuItem
+                                                disabled={disabled}
                                                 onClick={onSelect}
                                                 key={`MenuItem-${label}`}
                                             >

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
@@ -25,11 +25,17 @@ import { ChangeRequestTitle } from './ChangeRequestTitle';
 import { UpdateCount } from 'component/changeRequest/UpdateCount';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 
-const SubmitChangeRequestButton: FC<{ onClick: () => void; count: number }> = ({
-    onClick,
-    count,
-}) => (
-    <Button sx={{ ml: 'auto' }} variant='contained' onClick={onClick}>
+const SubmitChangeRequestButton: FC<{
+    onClick: () => void;
+    count: number;
+    disabled?: boolean;
+}> = ({ onClick, count, disabled = false }) => (
+    <Button
+        sx={{ ml: 'auto' }}
+        variant='contained'
+        onClick={onClick}
+        disabled={disabled}
+    >
         Submit change request ({count})
     </Button>
 );
@@ -66,11 +72,18 @@ export const EnvironmentChangeRequest: FC<{
     const { user } = useAuthUser();
     const [title, setTitle] = useState(environmentChangeRequest.title);
     const { changeState } = useChangeRequestApi();
-    const sendToReview = async (project: string) =>
-        changeState(project, environmentChangeRequest.id, 'Draft', {
-            state: 'In review',
-            comment: commentText,
-        });
+    const [disabled, setDisabled] = useState(false);
+    const sendToReview = async (project: string) => {
+        setDisabled(true);
+        try {
+            await changeState(project, environmentChangeRequest.id, 'Draft', {
+                state: 'In review',
+                comment: commentText,
+            });
+        } catch (e) {
+            setDisabled(false);
+        }
+    };
 
     return (
         <Box key={environmentChangeRequest.id}>
@@ -152,14 +165,17 @@ export const EnvironmentChangeRequest: FC<{
                                     count={changesCount(
                                         environmentChangeRequest,
                                     )}
+                                    disabled={disabled}
                                 />
 
                                 <Button
                                     sx={{ ml: 2 }}
                                     variant='outlined'
-                                    onClick={() =>
-                                        onDiscard(environmentChangeRequest.id)
-                                    }
+                                    disabled={disabled}
+                                    onClick={() => {
+                                        setDisabled(true);
+                                        onDiscard(environmentChangeRequest.id);
+                                    }}
                                 >
                                     Discard changes
                                 </Button>

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -53,6 +53,7 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
             onAddDefaultStrategy: () => {},
         });
     const {
+        pending,
         onChangeRequestToggle,
         onChangeRequestToggleClose,
         onChangeRequestToggleConfirm,
@@ -233,6 +234,7 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     onChangeRequestToggleClose();
                 }}
                 environment={changeRequestDialogDetails?.environment}
+                disabled={pending}
                 onConfirm={() => {
                     changeRequestDialogCallback?.();
                     onChangeRequestToggleConfirm();

--- a/frontend/src/hooks/useChangeRequestToggle.ts
+++ b/frontend/src/hooks/useChangeRequestToggle.ts
@@ -9,6 +9,7 @@ export const useChangeRequestToggle = (project: string) => {
     const { addChange } = useChangeRequestApi();
     const { refetch: refetchChangeRequests } =
         usePendingChangeRequests(project);
+    const [pending, setPending] = useState(false);
 
     const [changeRequestDialogDetails, setChangeRequestDialogDetails] =
         useState<{
@@ -43,6 +44,7 @@ export const useChangeRequestToggle = (project: string) => {
 
     const onChangeRequestToggleConfirm = useCallback(async () => {
         try {
+            setPending(true);
             await addChange(project, changeRequestDialogDetails.environment!, {
                 feature: changeRequestDialogDetails.featureName!,
                 action: 'updateEnabled',
@@ -68,10 +70,13 @@ export const useChangeRequestToggle = (project: string) => {
                 ...prev,
                 isOpen: false,
             }));
+        } finally {
+            setPending(false);
         }
     }, [addChange]);
 
     return {
+        pending,
         onChangeRequestToggle,
         onChangeRequestToggleClose,
         onChangeRequestToggleConfirm,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Simulation on Slow 3G:

https://github.com/Unleash/unleash/assets/1394682/a32df02b-a28e-4bea-891d-a62148673fb3



Design decisions:
* low on abstraction (disabled state close to the async workflow that can set state changes)
* mark async steps that matter for the disabled state with await. disabled can stay disabled for a duration of a few async operations (e.g. update CR state and read new CR state)
* keep the disabled state handling close to the async operations that affect it and pass the operations and disabled state to components that need them
* async operations are only for the internal operations ordering within the long running operation. We should keep passing void returning functions to components so that they're not tempted to await on the actions.
So async action used for orchestration of operations `async () => { await op1(); await op2(); }` from the component perspective is still perceived as  `() => void;`
* we can't use `loading` state from SWR because it's always true after first CR fetch and all the updates don't change the state. Also I tried `validating` state from SWR but it was disabling buttons during regular re-fetch cycle and buttons were disabled every 15 seconds without user action


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
