### PR TITLE
feat: add partial index on client_applications annouced FALSE

### DIFF
--- a/src/migrations/20240207164033-client-applications-announced-index.js
+++ b/src/migrations/20240207164033-client-applications-announced-index.js
@@ -3,7 +3,7 @@
 exports.up = function(db, cb) {
     db.runSql(
         `
-            CREATE INDEX idx_client_applications_announced_false ON client_applications (announced)
+            CREATE INDEX IF NOT EXISTS idx_client_applications_announced_false ON client_applications (announced)
                 WHERE announced = FALSE;
         `,
         cb,
@@ -12,6 +12,6 @@ exports.up = function(db, cb) {
 
 exports.down = function(db, cb) {
     db.runSql(`
-        DROP INDEX idx_client_applications_announced_false;
+        DROP INDEX IF EXISTS idx_client_applications_announced_false;
     `, cb);
 };


### PR DESCRIPTION
We have customers with tens or hundreds of thousands of applications, and we have a scheduler running that sets application fields to `announced` as true. However, every time it runs, it queries the entire table, which is slow and causes database connection acquisition issues. To make it faster, we added a partial index to the table.