### PR TITLE
chore: add migration for traffic data collection

### DIFF
--- a/src/migrations/20240208123212-create-stat-traffic-usage-table.js
+++ b/src/migrations/20240208123212-create-stat-traffic-usage-table.js
@@ -9,6 +9,8 @@ exports.up = (db, callback) => {
             count BIGINT NOT NULL DEFAULT 0,
             PRIMARY KEY(day, traffic_group, status_code_series)
             );
+            CREATE INDEX IF NOT EXISTS stat_traffic_usage_traffic_group_idx ON stat_traffic_usage (traffic_group);
+            CREATE INDEX IF NOT EXISTS  stat_traffic_usage_status_code_series_idx ON stat_traffic_usage (status_code_series);
         `,
         callback,
     );
@@ -17,6 +19,8 @@ exports.up = (db, callback) => {
 exports.down = (db, callback) => {
     db.runSql(
         `
+        DROP INDEX IF EXISTS stat_traffic_usage_traffic_group_idx;
+        DROP INDEX IF EXISTS stat_traffic_usage_status_code_series_idx;
         DROP TABLE IF EXISTS stat_traffic_usage;
         `,
         callback,

--- a/src/migrations/20240208123212-create-stat-traffic-usage-table.js
+++ b/src/migrations/20240208123212-create-stat-traffic-usage-table.js
@@ -1,0 +1,24 @@
+
+exports.up = (db, callback) => {
+    db.runSql(
+        `
+        CREATE TABLE IF NOT EXISTS stat_traffic_usage(
+            day DATE NOT NULL,
+            traffic_group TEXT NOT NULL,
+            status_code_series INT NOT NULL,
+            count BIGINT NOT NULL DEFAULT 0,
+            PRIMARY KEY(day, traffic_group, status_code_series)
+            );
+        `,
+        callback,
+    );
+};
+
+exports.down = (db, callback) => {
+    db.runSql(
+        `
+        DROP TABLE IF EXISTS stat_traffic_usage;
+        `,
+        callback,
+    );
+};

--- a/src/migrations/20240208123212-create-stat-traffic-usage-table.js
+++ b/src/migrations/20240208123212-create-stat-traffic-usage-table.js
@@ -9,8 +9,9 @@ exports.up = (db, callback) => {
             count BIGINT NOT NULL DEFAULT 0,
             PRIMARY KEY(day, traffic_group, status_code_series)
             );
+        CREATE INDEX IF NOT EXISTS stat_traffic_usage_day_idx ON stat_traffic_usage (day);
         CREATE INDEX IF NOT EXISTS stat_traffic_usage_traffic_group_idx ON stat_traffic_usage (traffic_group);
-        CREATE INDEX IF NOT EXISTS  stat_traffic_usage_status_code_series_idx ON stat_traffic_usage (status_code_series);
+        CREATE INDEX IF NOT EXISTS stat_traffic_usage_status_code_series_idx ON stat_traffic_usage (status_code_series);
         `,
         callback,
     );
@@ -19,6 +20,7 @@ exports.up = (db, callback) => {
 exports.down = (db, callback) => {
     db.runSql(
         `
+        DROP INDEX IF EXISTS stat_traffic_usage_day_idx;
         DROP INDEX IF EXISTS stat_traffic_usage_traffic_group_idx;
         DROP INDEX IF EXISTS stat_traffic_usage_status_code_series_idx;
         DROP TABLE IF EXISTS stat_traffic_usage;

--- a/src/migrations/20240208123212-create-stat-traffic-usage-table.js
+++ b/src/migrations/20240208123212-create-stat-traffic-usage-table.js
@@ -9,8 +9,8 @@ exports.up = (db, callback) => {
             count BIGINT NOT NULL DEFAULT 0,
             PRIMARY KEY(day, traffic_group, status_code_series)
             );
-            CREATE INDEX IF NOT EXISTS stat_traffic_usage_traffic_group_idx ON stat_traffic_usage (traffic_group);
-            CREATE INDEX IF NOT EXISTS  stat_traffic_usage_status_code_series_idx ON stat_traffic_usage (status_code_series);
+        CREATE INDEX IF NOT EXISTS stat_traffic_usage_traffic_group_idx ON stat_traffic_usage (traffic_group);
+        CREATE INDEX IF NOT EXISTS  stat_traffic_usage_status_code_series_idx ON stat_traffic_usage (status_code_series);
         `,
         callback,
     );


### PR DESCRIPTION
## About the changes

Adds migration for creating table `stat_traffic_usage`.
This table primary-keys on day, traffic_group, and status_code_series.

Traffic group is the grouping for API endpoints for which traffic is counted.
status_code_series is 200/202 etc = 200, 304 etc = 300