### PR TITLE
fix: prevent infinite rerenders in useIncomingWebhooks

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
@@ -182,7 +182,7 @@ export const ProjectActionsTable = ({
                 disableSortBy: true,
             },
         ],
-        [actions, incomingWebhooks, serviceAccounts],
+        [incomingWebhooks, serviceAccounts],
     );
 
     const [initialState] = useState({

--- a/frontend/src/hooks/api/getters/useIncomingWebhooks/useIncomingWebhooks.ts
+++ b/frontend/src/hooks/api/getters/useIncomingWebhooks/useIncomingWebhooks.ts
@@ -8,13 +8,17 @@ import { useUiFlag } from 'hooks/useUiFlag';
 
 const ENDPOINT = 'api/admin/incoming-webhooks';
 
+const DEFAULT_DATA = {
+    incomingWebhooks: [],
+};
+
 export const useIncomingWebhooks = () => {
     const { isEnterprise } = useUiConfig();
     const incomingWebhooksEnabled = useUiFlag('incomingWebhooks');
 
     const { data, error, mutate } = useConditionalSWR(
         isEnterprise() && incomingWebhooksEnabled,
-        { incomingWebhooks: [] },
+        DEFAULT_DATA,
         formatApiPath(ENDPOINT),
         fetcher,
     );


### PR DESCRIPTION
React can sometimes be non-intuitive and behave erratically due to the way it detects changes in hook dependencies.

This prevents infinite re-renders from `useIncomingWebhooks` by using a static `DEFAULT_DATA` constant, so that its reference is always the same, so no changes are detected when there are none.

Unrelated scouting, but this PR also removes an unneeded dependency in the memoized columns in `ProjectActionsTable`.