### PR TITLE
fix: don't show strategy change updates if the CR is closed

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -163,6 +163,7 @@ export const FeatureChange: FC<{
                         featureName={feature.name}
                         environmentName={changeRequest.environment}
                         projectId={changeRequest.project}
+                        changeRequestState={changeRequest.state}
                     />
                 ) : null}
                 {change.action === 'patchVariant' && (

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../StrategyTooltipLink/StrategyTooltipLink';
 import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution';
 import {
+    ChangeRequestState,
     IChangeRequestAddStrategy,
     IChangeRequestDeleteStrategy,
     IChangeRequestUpdateStrategy,
@@ -120,7 +121,15 @@ export const StrategyChange: VFC<{
     environmentName: string;
     featureName: string;
     projectId: string;
-}> = ({ actions, change, featureName, environmentName, projectId }) => {
+    changeRequestState: ChangeRequestState;
+}> = ({
+    actions,
+    change,
+    featureName,
+    environmentName,
+    projectId,
+    changeRequestState,
+}) => {
     const currentStrategy = useCurrentStrategy(
         change,
         projectId,
@@ -211,6 +220,7 @@ export const StrategyChange: VFC<{
             {change.action === 'updateStrategy' && (
                 <>
                     <ChangesToOverwrite
+                        changeRequestState={changeRequestState}
                         currentStrategy={currentStrategy}
                         change={change}
                     />

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChangeOverwriteWarning.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChangeOverwriteWarning.test.tsx
@@ -1,0 +1,85 @@
+import { render } from 'utils/testRenderer';
+import { screen } from '@testing-library/react';
+import { ChangesToOverwriteInternal } from './StrategyChangeOverwriteWarning';
+import { IFeatureStrategy } from 'interfaces/strategy';
+import {
+    ChangeRequestState,
+    IChangeRequestUpdateStrategy,
+} from 'component/changeRequest/changeRequest.types';
+
+const existingStrategy: IFeatureStrategy = {
+    name: 'flexibleRollout',
+    constraints: [],
+    variants: [],
+    parameters: {
+        groupId: 'aaa',
+        rollout: '71',
+        stickiness: 'default',
+    },
+    id: '31572930-2db7-461f-813b-3eedc200cb33',
+    title: '',
+    disabled: false,
+    segments: [],
+};
+
+const snapshot: IFeatureStrategy = {
+    id: '31572930-2db7-461f-813b-3eedc200cb33',
+    name: 'flexibleRollout',
+    title: '',
+    disabled: true,
+    segments: [],
+    variants: [],
+    parameters: {
+        groupId: 'aaa',
+        rollout: '72',
+        stickiness: 'default',
+    },
+    constraints: [],
+};
+
+const change: IChangeRequestUpdateStrategy = {
+    id: 39,
+    action: 'updateStrategy' as const,
+    payload: {
+        id: '31572930-2db7-461f-813b-3eedc200cb33',
+        name: 'flexibleRollout',
+        title: '',
+        disabled: false,
+        segments: [],
+        snapshot,
+        variants: [],
+        parameters: {
+            groupId: 'baa',
+            rollout: '38',
+            stickiness: 'default',
+        },
+        constraints: [],
+    },
+    createdAt: new Date('2024-01-18T07:58:36.314Z'),
+    createdBy: {
+        id: 1,
+        username: 'admin',
+        imageUrl: '',
+    },
+};
+
+test.each([
+    ['Draft', true],
+    ['Approved', true],
+    ['In review', true],
+    ['Applied', false],
+    ['Scheduled', true],
+    ['Cancelled', false],
+    ['Rejected', false],
+])('Shows warnings for CRs in the "%s" state: %s', (status, showWarning) => {
+    render(
+        <ChangesToOverwriteInternal
+            change={change}
+            currentStrategy={existingStrategy}
+            changeRequestState={status as ChangeRequestState}
+        />,
+    );
+
+    const hasRendered = screen.queryByText('Heads up!') !== null;
+    expect(hasRendered).toBe(showWarning);
+});


### PR DESCRIPTION
This PR hides the strategy changes that would be overwritten if the CR
is closed (applied, rejected, or canceled)

This should, however, be merged into the recent changes that add
support for showing this for segments too.