### PR TITLE
Chore: add zendesk btn to error dialog

### DIFF
--- a/frontend/src/component/common/Dialogue/Dialogue.tsx
+++ b/frontend/src/component/common/Dialogue/Dialogue.tsx
@@ -55,6 +55,7 @@ interface IDialogue {
     disabledPrimaryButton?: boolean;
     formId?: string;
     permissionButton?: React.JSX.Element;
+    customButton?: React.JSX.Element;
 }
 
 export const Dialogue: React.FC<IDialogue> = ({
@@ -71,6 +72,7 @@ export const Dialogue: React.FC<IDialogue> = ({
     fullWidth = false,
     formId,
     permissionButton,
+    customButton,
 }) => {
     const handleClick = formId
         ? (e: React.SyntheticEvent) => {
@@ -135,6 +137,11 @@ export const Dialogue: React.FC<IDialogue> = ({
                                 {secondaryButtonText || 'No, take me back'}
                             </Button>
                         }
+                    />
+
+                    <ConditionallyRender
+                        condition={Boolean(customButton)}
+                        show={customButton}
                     />
                 </StyledDialogActions>
             </StyledDialogBody>

--- a/frontend/src/component/layout/Error/Error.tsx
+++ b/frontend/src/component/layout/Error/Error.tsx
@@ -12,7 +12,7 @@ interface IErrorProps {
 
 const ZendeskButton = () => {
     const openZendeskSupport = () => {
-        window.open('https://getunleash.zendesk.com', '_blank');
+        window?.open('https://getunleash.zendesk.com', '_blank');
     };
     return <Button onClick={openZendeskSupport}>Open a ticket</Button>;
 };

--- a/frontend/src/component/layout/Error/Error.tsx
+++ b/frontend/src/component/layout/Error/Error.tsx
@@ -1,18 +1,28 @@
-import { useEffect, VFC } from 'react';
+import React, { useEffect, VFC } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import useUiConfig from '../../../hooks/api/getters/useUiConfig/useUiConfig';
 
 interface IErrorProps {
     error: Error;
 }
 
+const ZendeskButton = () => {
+    const openZendeskSupport = () => {
+        window.open('https://getunleash.zendesk.com', '_blank');
+    };
+    return <Button onClick={openZendeskSupport}>Open a ticket</Button>;
+};
+
 // biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
 export const Error: VFC<IErrorProps> = ({ error }) => {
     const navigate = useNavigate();
     const { trackEvent } = usePlausibleTracker();
+    const { isOss } = useUiConfig();
+    const showZendeskButton = !isOss();
 
     useEffect(() => {
         const { message, stack = 'unknown' } = error;
@@ -41,6 +51,12 @@ export const Error: VFC<IErrorProps> = ({ error }) => {
                     window?.location?.reload();
                 }}
                 maxWidth='xl'
+                customButton={
+                    <ConditionallyRender
+                        condition={showZendeskButton}
+                        show={<ZendeskButton />}
+                    />
+                }
             >
                 <Box component='pre' sx={{ color: 'error.main' }}>
                     {error.message}


### PR DESCRIPTION
Adds the option for a 3rd button in the Dialogue component
Adds a button to open our zendesk support page

Closes # [1-2024](https://linear.app/unleash/issue/1-2024/review-the-ui-error-dialog)
<img width="1677" alt="Screenshot 2024-02-09 at 11 18 20" src="https://github.com/Unleash/unleash/assets/104830839/bf69c9c2-456f-4b83-b80e-d72f0d678331">
