### PR TITLE
fix: long descriptions should have tooltips

### DIFF
--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -81,7 +81,7 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
             </StyledTitle>
             <ConditionallyRender
                 condition={Boolean(subtitle)}
-                show={renderSubtitle}
+                show={renderSubtitle()}
             />
         </StyledContainer>
     );

--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -4,7 +4,6 @@ import { useSearchHighlightContext } from 'component/common/Table/SearchHighligh
 import { Box, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
-import { StyledDescription } from '../LinkCell/LinkCell.styles';
 
 interface IHighlightCellProps {
     value: string;
@@ -47,7 +46,7 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
 }) => {
     const { searchQuery } = useSearchHighlightContext();
 
-    const renderSubtitle = () => (
+    const renderSubtitle = (
         <ConditionallyRender
             condition={Boolean(subtitle && subtitle.length > 40)}
             show={
@@ -81,7 +80,7 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
             </StyledTitle>
             <ConditionallyRender
                 condition={Boolean(subtitle)}
-                show={renderSubtitle()}
+                show={renderSubtitle}
             />
         </StyledContainer>
     );

--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -3,6 +3,7 @@ import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Box, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 
 interface IHighlightCellProps {
     value: string;
@@ -60,11 +61,17 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
             <ConditionallyRender
                 condition={Boolean(subtitle)}
                 show={() => (
-                    <StyledSubtitle data-loading title={subtitle}>
-                        <Highlighter search={searchQuery}>
-                            {subtitle}
-                        </Highlighter>
-                    </StyledSubtitle>
+                    <HtmlTooltip
+                        title={subtitle}
+                        placement='bottom-start'
+                        arrow
+                    >
+                        <StyledSubtitle data-loading>
+                            <Highlighter search={searchQuery}>
+                                {subtitle}
+                            </Highlighter>
+                        </StyledSubtitle>
+                    </HtmlTooltip>
                 )}
             />
         </StyledContainer>

--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -1,9 +1,10 @@
-import { VFC } from 'react';
+import React, { VFC } from 'react';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Box, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
+import { StyledDescription } from '../LinkCell/LinkCell.styles';
 
 interface IHighlightCellProps {
     value: string;
@@ -46,6 +47,26 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
 }) => {
     const { searchQuery } = useSearchHighlightContext();
 
+    const renderSubtitle = () => (
+        <ConditionallyRender
+            condition={Boolean(subtitle && subtitle.length > 40)}
+            show={
+                <HtmlTooltip title={subtitle} placement='bottom-start' arrow>
+                    <StyledSubtitle data-loading>
+                        <Highlighter search={searchQuery}>
+                            {subtitle}
+                        </Highlighter>
+                    </StyledSubtitle>
+                </HtmlTooltip>
+            }
+            elseShow={
+                <StyledSubtitle data-loading>
+                    <Highlighter search={searchQuery}>{subtitle}</Highlighter>
+                </StyledSubtitle>
+            }
+        />
+    );
+
     return (
         <StyledContainer>
             <StyledTitle
@@ -60,19 +81,7 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
             </StyledTitle>
             <ConditionallyRender
                 condition={Boolean(subtitle)}
-                show={() => (
-                    <HtmlTooltip
-                        title={subtitle}
-                        placement='bottom-start'
-                        arrow
-                    >
-                        <StyledSubtitle data-loading>
-                            <Highlighter search={searchQuery}>
-                                {subtitle}
-                            </Highlighter>
-                        </StyledSubtitle>
-                    </HtmlTooltip>
-                )}
+                show={renderSubtitle}
             />
         </StyledContainer>
     );

--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -60,7 +60,7 @@ export const HighlightCell: VFC<IHighlightCellProps> = ({
             <ConditionallyRender
                 condition={Boolean(subtitle)}
                 show={() => (
-                    <StyledSubtitle data-loading>
+                    <StyledSubtitle data-loading title={subtitle}>
                         <Highlighter search={searchQuery}>
                             {subtitle}
                         </Highlighter>

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.test.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import userEvent from '@testing-library/user-event';
+import { LinkCell } from './LinkCell';
+
+describe('LinkCell Component', () => {
+    it('renders the subtitle in an HtmlTooltip when length is greater than 40 characters', async () => {
+        const longSubtitle =
+            'This is a long subtitle that should trigger tooltip rendering.';
+        render(<LinkCell title='Test Title' subtitle={longSubtitle} />);
+
+        const subtitleElement = screen.getByText(longSubtitle);
+        expect(subtitleElement).toBeInTheDocument();
+
+        userEvent.hover(subtitleElement);
+
+        const tooltip = await screen.findByRole('tooltip');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).toHaveTextContent(longSubtitle);
+    });
+});

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
@@ -10,6 +10,7 @@ import {
     StyledTitle,
     StyledDescription,
 } from './LinkCell.styles';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 
 interface ILinkCellProps {
     title?: string;
@@ -43,11 +44,17 @@ export const LinkCell: FC<ILinkCellProps> = ({
                 condition={Boolean(subtitle)}
                 show={
                     <>
-                        <StyledDescription data-loading title={subtitle}>
-                            <Highlighter search={searchQuery}>
-                                {subtitle}
-                            </Highlighter>
-                        </StyledDescription>
+                        <HtmlTooltip
+                            title={subtitle}
+                            placement='bottom-start'
+                            arrow
+                        >
+                            <StyledDescription data-loading>
+                                <Highlighter search={searchQuery}>
+                                    {subtitle}
+                                </Highlighter>
+                            </StyledDescription>
+                        </HtmlTooltip>
                     </>
                 }
             />

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
@@ -43,7 +43,7 @@ export const LinkCell: FC<ILinkCellProps> = ({
                 condition={Boolean(subtitle)}
                 show={
                     <>
-                        <StyledDescription data-loading>
+                        <StyledDescription data-loading title={subtitle}>
                             <Highlighter search={searchQuery}>
                                 {subtitle}
                             </Highlighter>

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
@@ -28,7 +28,7 @@ export const LinkCell: React.FC<ILinkCellProps> = ({
 }) => {
     const { searchQuery } = useSearchHighlightContext();
 
-    const renderSubtitle = () => (
+    const renderSubtitle = (
         <ConditionallyRender
             condition={Boolean(subtitle && subtitle.length > 40)}
             show={
@@ -62,7 +62,7 @@ export const LinkCell: React.FC<ILinkCellProps> = ({
             </StyledTitle>
             <ConditionallyRender
                 condition={Boolean(subtitle)}
-                show={renderSubtitle()}
+                show={renderSubtitle}
             />
         </StyledContainer>
     );

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
@@ -1,8 +1,9 @@
-import { FC } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import {
     StyledWrapper,
     StyledLink,
@@ -10,7 +11,6 @@ import {
     StyledTitle,
     StyledDescription,
 } from './LinkCell.styles';
-import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 
 interface ILinkCellProps {
     title?: string;
@@ -19,7 +19,7 @@ interface ILinkCellProps {
     subtitle?: string;
 }
 
-export const LinkCell: FC<ILinkCellProps> = ({
+export const LinkCell: React.FC<ILinkCellProps> = ({
     title,
     to,
     onClick,
@@ -27,6 +27,26 @@ export const LinkCell: FC<ILinkCellProps> = ({
     children,
 }) => {
     const { searchQuery } = useSearchHighlightContext();
+
+    const renderSubtitle = () => (
+        <ConditionallyRender
+            condition={Boolean(subtitle && subtitle.length > 40)}
+            show={
+                <HtmlTooltip title={subtitle} placement='bottom-start' arrow>
+                    <StyledDescription data-loading>
+                        <Highlighter search={searchQuery}>
+                            {subtitle}
+                        </Highlighter>
+                    </StyledDescription>
+                </HtmlTooltip>
+            }
+            elseShow={
+                <StyledDescription data-loading>
+                    <Highlighter search={searchQuery}>{subtitle}</Highlighter>
+                </StyledDescription>
+            }
+        />
+    );
 
     const content = (
         <StyledContainer>
@@ -41,35 +61,27 @@ export const LinkCell: FC<ILinkCellProps> = ({
                 {children}
             </StyledTitle>
             <ConditionallyRender
-                condition={Boolean(subtitle)}
-                show={
-                    <>
-                        <HtmlTooltip
-                            title={subtitle}
-                            placement='bottom-start'
-                            arrow
-                        >
-                            <StyledDescription data-loading>
-                                <Highlighter search={searchQuery}>
-                                    {subtitle}
-                                </Highlighter>
-                            </StyledDescription>
-                        </HtmlTooltip>
-                    </>
-                }
+                condition={!!subtitle}
+                show={renderSubtitle()}
             />
         </StyledContainer>
     );
 
-    return to ? (
-        <StyledLink component={RouterLink} to={to} underline='hover'>
-            {content}
-        </StyledLink>
-    ) : onClick ? (
-        <StyledLink onClick={onClick} underline='hover'>
-            {content}
-        </StyledLink>
-    ) : (
-        <StyledWrapper>{content}</StyledWrapper>
-    );
+    if (to) {
+        return (
+            <StyledLink component={RouterLink} to={to} underline='hover'>
+                {content}
+            </StyledLink>
+        );
+    }
+
+    if (onClick) {
+        return (
+            <StyledLink onClick={onClick} underline='hover'>
+                {content}
+            </StyledLink>
+        );
+    }
+
+    return <StyledWrapper>{content}</StyledWrapper>;
 };

--- a/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
+++ b/frontend/src/component/common/Table/cells/LinkCell/LinkCell.tsx
@@ -61,7 +61,7 @@ export const LinkCell: React.FC<ILinkCellProps> = ({
                 {children}
             </StyledTitle>
             <ConditionallyRender
-                condition={!!subtitle}
+                condition={Boolean(subtitle)}
                 show={renderSubtitle()}
             />
         </StyledContainer>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding tooltip when title+subtitle cell has a long subtitle (40 characters threshold)

Design decisions: 
* It's difficult to get info from CSS that ellipsis was used so we decided to use a simple heuristic instead.
* Adding tooltip to the cells instead of wrapping cells at call site so that all tables get this capability without modifying code in 30+ different places

<img width="776" alt="Screenshot 2024-02-12 at 14 27 16" src="https://github.com/Unleash/unleash/assets/1394682/24b514b5-2154-4d93-ac27-7f1d2db16ba4">
<img width="890" alt="Screenshot 2024-02-12 at 14 25 34" src="https://github.com/Unleash/unleash/assets/1394682/774da7d0-7670-458f-bee8-27a15ee4255d">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
