### PR TITLE
test: log all query times

### DIFF
--- a/src/lib/db/db-pool.ts
+++ b/src/lib/db/db-pool.ts
@@ -1,12 +1,13 @@
 import { knex, Knex } from 'knex';
 import { IUnleashConfig } from '../types/option';
+import timer from '../util/timer';
 
 export function createDb({
     db,
     getLogger,
 }: Pick<IUnleashConfig, 'db' | 'getLogger'>): Knex {
     const logger = getLogger('db-pool.js');
-    return knex({
+    const conn = knex({
         client: 'pg',
         version: db.version,
         connection: {
@@ -22,6 +23,23 @@ export function createDb({
             error: (msg) => logger.error(msg),
         },
     });
+
+    // Object to store the start times of queries
+    const queryTimes = {};
+
+    conn.on('query', (query) => {
+        const { __knexQueryUid } = query;
+        queryTimes[__knexQueryUid] = timer.new();
+    });
+
+    conn.on('query-response', (response, query) => {
+        const { __knexQueryUid } = query;
+        const durationInSeconds = queryTimes[__knexQueryUid]();
+        console.log(`Query ${query.sql} took ${durationInSeconds * 1000}ms`);
+        // Clean up the start time record
+        delete queryTimes[__knexQueryUid];
+    });
+    return conn;
 }
 
 // for backward compatibility


### PR DESCRIPTION
This logs all query times into console. The idea is to discuss whether this can be used to have all execution times as metrics in a way that's valuable for us.

This is a sample output:
```shell
[2024-02-13T09:58:46.324] [INFO] server-impl.js - DB migration: start
[2024-02-13T09:58:46.325] [INFO] server-impl.js - Running migration with lock
[INFO] No migrations to run
[INFO] Done
[2024-02-13T09:58:46.383] [INFO] server-impl.js - DB migration: end
[2024-02-13T09:58:46.409] [DEBUG] services/maintenance-service.ts - getMaintenanceSetting called
[2024-02-13T09:58:46.413] [DEBUG] /middleware/pat-middleware.ts - Enabling PAT middleware
[2024-02-13T09:58:46.414] [DEBUG] /middleware/api-token.ts - Enabling api-token middleware
[2024-02-13T09:58:46.414] [DEBUG] /middleware/authorization-middleware.ts - Enabling Authorization middleware
[2024-02-13T09:58:46.414] [DEBUG] /middleware/authorization-middleware.ts - Enabling Authorization middleware
[2024-02-13T09:58:46.414] [DEBUG] /middleware/rbac-middleware.ts - Enabling RBAC middleware
[2024-02-13T09:58:46.414] [DEBUG] /middleware/maintenance-middleware.ts - Enabling Maintenance middleware
Query select "tokens"."secret", "username", "token_name", "type", "expires_at", "created_at", "alias", "seen_at", "environment", "token_project_link"."project" from "api_tokens" as "tokens" left join "api_token_project" as "token_project_link" on "tokens"."secret" = "token_project_link"."secret" where "expires_at" is null or "expires_at" > $1 took 2.109833ms
Query select * from "settings" where "name" = $1 limit $2 took 2.152283ms
Query select count(*) from "users" where "deleted_at" is null and "is_service" = $1 and "is_system" = $2 took 1.889659ms
Query select count(*) from "api_tokens" took 3.5988890000000002ms
Query select * from information_schema.tables where table_name = $1 and table_schema = current_schema() took 4.633397ms
Query update "events" set "announced" = $1 where "announced" = $2 returning "id", "type", "created_by", "created_at", "created_by_user_id", "data", "pre_data", "tags", "feature_name", "project", "environment" took 2.137578ms
Query select * from "settings" where "name" = $1 limit $2 took 1.785502ms
Query select max("id") from "events" where ("feature_name" is not null or "type" in ($1, $2, $3)) and "id" >= $4 limit $5 took 5.784859ms
[2024-02-13T09:58:46.448] [DEBUG] configuration-revision-service.ts - Updating feature configuration with new revision Id 11
Query select count(*) from "users" where "deleted_at" is null and "is_service" = $1 and "is_system" = $2 took 1.123005ms
Query select count(*) from "features" where "archived_at" is null took 1.85228ms
Query delete from "unleash_session" where expired < CAST($1 as timestamp with time zone) took 4.814274999999999ms
Query select "type", count(*) from "api_tokens" group by "type" took 1.100389ms
Query select count(*) from "context_fields" took 1.1898360000000001ms
Query select count(*) from "users" where "deleted_at" is null and "is_service" = $1 took 2.567821ms
Query select count(*) from "roles" took 1.3674659999999998ms
Query select count(*) from "roles" where "type" = $1 took 1.313227ms
Query select count(*) from "groups" took 2.473401ms
Query select count(*) from "environments" took 0.810043ms
Query select count(*) from "segments" took 0.9973339999999999ms
Query select count(distinct "roles"."id") from "roles" left join "role_user" as "ru" on "roles"."id" = "ru"."role_id" left join "groups" as "g" on "roles"."id" = "g"."root_role_id" where "type" = $1 and ("ru"."role_id" is not null or "g"."root_role_id" is not null) took 2.196643ms
Query select count(distinct "app_name") from "client_instances" where "last_seen" > $1 took 1.056884ms
Query select count(distinct "app_name") from "client_instances" where "last_seen" > $1 took 1.121749ms
Query select count(*) from "strategies" took 2.4181250000000003ms
Query with "Combined" as (select "id" as "user_id", "seen_at" from "users" union all select "user_id", "seen_at" from "personal_access_tokens") select COUNT(DISTINCT CASE WHEN seen_at > NOW() - INTERVAL '1 week' THEN user_id END) as "last_week", COUNT(DISTINCT CASE WHEN seen_at > NOW() - INTERVAL '1 month' THEN user_id END) as "last_month", COUNT(DISTINCT CASE WHEN seen_at > NOW() - INTERVAL '2 months' THEN user_id END) as "last_two_months", COUNT(DISTINCT CASE WHEN seen_at > NOW() - INTERVAL '3 months' THEN user_id END) as "last_quarter" from "Combined" took 0.95004ms
Query select count(distinct "app_name") from "client_instances" took 1.88296ms
Query select * from "settings" where "name" = $1 limit $2 took 0.567667ms
Query select COALESCE(project_settings.project_mode, 'open') as mode, count("projects"."id") as "count" from "projects" left join "project_settings" on "projects"."id" = "project_settings"."project" group by COALESCE(project_settings.project_mode, 'open') took 1.5682719999999999ms
Query select * from "settings" where "name" = $1 limit $2 took 1.681961ms
Query select count(*) from "events" where "type" = $1 limit $2 took 0.968442ms
Query select count(*) from "events" where "type" = $1 limit $2 took 1.6905679999999998ms
Query SELECT SUM(CASE WHEN seu.day > NOW() - INTERVAL '30 days' THEN seu.updates END) AS last_month,
                         SUM(CASE WHEN seu.day > NOW() - INTERVAL '60 days' THEN seu.updates END) AS last_two_months,
                         SUM(CASE WHEN seu.day > NOW() - INTERVAL '90 days' THEN seu.updates END) AS last_quarter
                  FROM stat_environment_updates seu
                  LEFT JOIN environments e
                    ON e.name = seu.environment
                  WHERE e.type = 'production'; took 1.047402ms
Query select count(*) from "client_metrics_env" where timestamp >= CURRENT_DATE - INTERVAL '1 day' and timestamp < CURRENT_DATE limit $1 took 0.719751ms
Query select count(*) from "client_metrics_env_variants" where timestamp >= CURRENT_DATE - INTERVAL '1 day' and timestamp < CURRENT_DATE limit $1 took 0.41865199999999997ms
[2024-02-13T09:58:46.459] [INFO] server-impl.js - Unleash has started. { address: '::', family: 'IPv6', port: 4242 }
[2024-02-13T09:58:46.460] [DEBUG] server-impl.js - Registering graceful shutdown
Query select max("id") from "events" where ("feature_name" is not null or "type" in ($1, $2, $3)) and "id" >= $4 limit $5 took 2.8200600000000002ms
Query update "events" set "announced" = $1 where "announced" = $2 returning "id", "type", "created_by", "created_at", "created_by_user_id", "data", "pre_data", "tags", "feature_name", "project", "environment" took 2.537565ms
Query select max("id") from "events" where ("feature_name" is not null or "type" in ($1, $2, $3)) and "id" >= $4 limit $5 took 1.262479ms
Query update "events" set "announced" = $1 where "announced" = $2 returning "id", "type", "created_by", "created_at", "created_by_user_id", "data", "pre_data", "tags", "feature_name", "project", "environment" took 0.6970000000000001ms
Query select max("id") from "events" where ("feature_name" is not null or "type" in ($1, $2, $3)) and "id" >= $4 limit $5 took 2.005874ms
Query update "events" set "announced" = $1 where "announced" = $2 returning "id", "type", "created_by", "created_at", "created_by_user_id", "data", "pre_data", "tags", "feature_name", "project", "environment" took 1.770432ms
Query select max("id") from "events" where ("feature_name" is not null or "type" in ($1, $2, $3)) and "id" >= $4 limit $5 took 2.991405ms
Query update "events" set "announced" = $1 where "announced" = $2 returning "id", "type", "created_by", "created_at", "created_by_user_id", "data", "pre_data", "tags", "feature_name", "project", "environment" took 0.692814ms
```
