### PR TITLE
fix: AuthType.None issues in frontend and client APIs

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -108,29 +108,26 @@ export default async function getApp(
     );
 
     app.use(baseUriPath, patMiddleware(config, services));
+    app.use(baseUriPath, apiTokenMiddleware(config, services));
 
     switch (config.authentication.type) {
         case IAuthType.OPEN_SOURCE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             ossAuthentication(app, config.getLogger, config.server.baseUriPath);
             break;
         }
         case IAuthType.ENTERPRISE: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
             break;
         }
         case IAuthType.HOSTED: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
             break;
         }
         case IAuthType.DEMO: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,
@@ -140,7 +137,6 @@ export default async function getApp(
             break;
         }
         case IAuthType.CUSTOM: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             if (config.authentication.customAuthHandler) {
                 config.authentication.customAuthHandler(app, config, services);
             }
@@ -151,7 +147,6 @@ export default async function getApp(
             break;
         }
         default: {
-            app.use(baseUriPath, apiTokenMiddleware(config, services));
             demoAuthentication(
                 app,
                 config.server.baseUriPath,

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -1,7 +1,7 @@
 import { ApiTokenType } from '../types/models/api-token';
 import { IUnleashConfig } from '../types/option';
 import { IApiRequest, IAuthRequest } from '../routes/unleash-types';
-import { IUnleashServices } from '../server-impl';
+import { IAuthType, IUnleashServices } from '../server-impl';
 
 const isClientApi = ({ path }) => {
     return path && path.indexOf('/api/client') > -1;
@@ -48,6 +48,13 @@ const apiAccessMiddleware = (
 
     return (req: IAuthRequest | IApiRequest, res, next) => {
         if (req.user) {
+            return next();
+        }
+
+        if (
+            !req.header('authorization') &&
+            authentication.type === IAuthType.NONE
+        ) {
             return next();
         }
 

--- a/src/lib/middleware/no-authentication.ts
+++ b/src/lib/middleware/no-authentication.ts
@@ -1,6 +1,7 @@
 import { Application } from 'express';
 import NoAuthUser from '../types/no-auth-user';
 import NoAuthFrontendAPIUser from '../types/no-auth-frontend-api-user';
+import NoAuthClientAPIUser from '../types/no-auth-client-api-user';
 
 // eslint-disable-next-line
 function noneAuthentication(basePath: string, app: Application): void {
@@ -17,6 +18,14 @@ function noneAuthentication(basePath: string, app: Application): void {
         if (!req.user) {
             // @ts-expect-error
             req.user = new NoAuthFrontendAPIUser();
+        }
+        next();
+    });
+    app.use(`${basePath || ''}/api/client`, (req, res, next) => {
+        // @ts-expect-error
+        if (!req.user) {
+            // @ts-expect-error
+            req.user = new NoAuthClientAPIUser();
         }
         next();
     });

--- a/src/lib/middleware/no-authentication.ts
+++ b/src/lib/middleware/no-authentication.ts
@@ -1,5 +1,6 @@
 import { Application } from 'express';
 import NoAuthUser from '../types/no-auth-user';
+import NoAuthFrontendAPIUser from '../types/no-auth-frontend-api-user';
 
 // eslint-disable-next-line
 function noneAuthentication(basePath: string, app: Application): void {
@@ -8,6 +9,14 @@ function noneAuthentication(basePath: string, app: Application): void {
         if (!req.user) {
             // @ts-expect-error
             req.user = new NoAuthUser();
+        }
+        next();
+    });
+    app.use(`${basePath || ''}/api/frontend/`, (req, res, next) => {
+        // @ts-expect-error
+        if (!req.user) {
+            // @ts-expect-error
+            req.user = new NoAuthFrontendAPIUser();
         }
         next();
     });

--- a/src/lib/types/no-auth-client-api-user.ts
+++ b/src/lib/types/no-auth-client-api-user.ts
@@ -1,0 +1,28 @@
+import { ApiTokenType } from './models/api-token';
+import { CLIENT } from './permissions';
+
+export default class NoAuthClientAPIUser {
+    isAPI: boolean;
+
+    username: string;
+
+    id: number;
+
+    permissions: string[];
+
+    projects: string[];
+
+    type: ApiTokenType;
+
+    constructor(
+        username: string = 'unknown',
+        permissions: string[] = [CLIENT],
+        projects: string[] = ['default'],
+    ) {
+        this.isAPI = true;
+        this.username = username;
+        this.permissions = permissions;
+        this.projects = projects;
+        this.type = ApiTokenType.CLIENT;
+    }
+}

--- a/src/lib/types/no-auth-frontend-api-user.ts
+++ b/src/lib/types/no-auth-frontend-api-user.ts
@@ -1,0 +1,28 @@
+import { ApiTokenType } from './models/api-token';
+import { FRONTEND } from './permissions';
+
+export default class NoAuthFrontendAPIUser {
+    isAPI: boolean;
+
+    username: string;
+
+    id: number;
+
+    permissions: string[];
+
+    projects: string[];
+
+    type: ApiTokenType;
+
+    constructor(
+        username: string = 'unknown',
+        permissions: string[] = [FRONTEND],
+        projects: string[] = ['default'],
+    ) {
+        this.isAPI = true;
+        this.username = username;
+        this.permissions = permissions;
+        this.projects = projects;
+        this.type = ApiTokenType.FRONTEND;
+    }
+}

--- a/src/test/e2e/api/client/metrics.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.e2e.test.ts
@@ -46,3 +46,18 @@ test('should accept empty client metrics', async () => {
         })
         .expect(202);
 });
+
+test('should tag metrics under default environment when set to authtype.none', async () => {
+    await app.request
+        .post('/api/client/metrics')
+        .send(metricsExample)
+        .expect(202);
+
+    await app.services.clientMetricsServiceV2.bulkAdd();
+    const metrics = await db.stores.clientMetricsStoreV2.getAll();
+    const toggle1 = metrics.filter((m) => m.featureName === 'toggle-name-1')[0];
+    const toggle2 = metrics.filter((m) => m.featureName === 'toggle-name-2')[0];
+
+    expect(toggle1.environment).toBe('default');
+    expect(toggle2.environment).toBe('default');
+});

--- a/src/test/e2e/api/proxy/proxy.authtype.none.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.authtype.none.e2e.test.ts
@@ -1,0 +1,53 @@
+import { IUnleashTest, setupApp } from '../../helpers/test-helper';
+import dbInit, { ITestDb } from '../../helpers/database-init';
+import getLogger from '../../../fixtures/no-logger';
+import { randomId } from '../../../../lib/util';
+import { ApiTokenType } from '../../../../lib/types/models/api-token';
+
+let app: IUnleashTest;
+let db: ITestDb;
+let appErrorLogs: string[] = [];
+
+beforeAll(async () => {
+    db = await dbInit('proxy_auth_none', getLogger);
+    const baseLogger = getLogger();
+    const appLogger = {
+        ...baseLogger,
+        error: (msg: string, ...args: any[]) => {
+            appErrorLogs.push(msg);
+            baseLogger.error(msg, ...args);
+        },
+    };
+    app = await setupApp(db.stores);
+});
+
+afterEach(() => {
+    app.services.proxyService.stopAll();
+    jest.clearAllMocks();
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+beforeEach(async () => {
+    appErrorLogs = [];
+});
+
+test('calling /frontend with a token works when AuthType=None', async () => {
+    const frontendTokenDefault =
+        await app.services.apiTokenService.createApiTokenWithProjects({
+            type: ApiTokenType.FRONTEND,
+            projects: ['default'],
+            environment: 'default',
+            tokenName: `test-token-${randomId()}`,
+        });
+
+    await app.request
+        .get('/api/frontend')
+        .set('Authorization', frontendTokenDefault.secret)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    expect(appErrorLogs).toHaveLength(0);
+});


### PR DESCRIPTION
## About the changes

- Sets a default user on request to `/api/frontend` when `AuthType` is `none` in the noAuth middleware
- Respects tokens provided to `/api/frontend` and `/api/client` also when `AuthType` is `none`

Closes #5785 

Replaces #5806 
This causes /frontend to behave mostly the same way as /client/features. It will fetch and evaluate all toggles configured on default project for default environment.