### PR TITLE
fix: include first day of range in the extended metrics

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -223,10 +223,12 @@ export default class ClientMetricsServiceV2 {
         let hours: HourBucket[];
         let metrics: IClientMetricsEnv[];
         if (this.flagResolver.isEnabled('extendedUsageMetrics')) {
+            const normalizedHoursBack =
+                hoursBack > 48 ? hoursBack + 24 : hoursBack;
             metrics =
                 await this.clientMetricsStoreV2.getMetricsForFeatureToggleV2(
                     featureName,
-                    hoursBack + 24,
+                    normalizedHoursBack,
                 );
             hours =
                 hoursBack > 48

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -226,7 +226,7 @@ export default class ClientMetricsServiceV2 {
             metrics =
                 await this.clientMetricsStoreV2.getMetricsForFeatureToggleV2(
                     featureName,
-                    hoursBack,
+                    hoursBack + 24,
                 );
             hours =
                 hoursBack > 48

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -223,6 +223,7 @@ export default class ClientMetricsServiceV2 {
         let hours: HourBucket[];
         let metrics: IClientMetricsEnv[];
         if (this.flagResolver.isEnabled('extendedUsageMetrics')) {
+            // if we're in the daily range we need to add one more day
             const normalizedHoursBack =
                 hoursBack > 48 ? hoursBack + 24 : hoursBack;
             metrics =


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

No matter what time of the day it is we should fetch the first date of the daily range into the result. Previously it would only return data at midnight.
<img width="1003" alt="Screenshot 2024-02-15 at 10 06 21" src="https://github.com/Unleash/unleash/assets/1394682/fa78924d-6e89-436c-b401-d683c9d247f4">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
