### PR TITLE
chore: rate limit calling inc webhooks

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -173,6 +173,7 @@ exports[`should create default config 1`] = `
   "prometheusApi": undefined,
   "publicFolder": undefined,
   "rateLimiting": {
+    "callIncomingWebhookMaxPerSecond": 1,
     "createUserMaxPerMinute": 20,
     "simpleLoginMaxPerMinute": 10,
   },

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -142,10 +142,15 @@ function loadRateLimitingConfig(options: IUnleashOptions): IRateLimiting {
         process.env.SIMPLE_LOGIN_LIMIT_PER_MINUTE,
         10,
     );
+    const callIncomingWebhookMaxPerSecond = parseEnvVarNumber(
+        process.env.INCOMING_WEBHOOK_RATE_LIMIT_PER_SECOND,
+        1,
+    );
 
     const defaultRateLimitOptions: IRateLimiting = {
         createUserMaxPerMinute,
         simpleLoginMaxPerMinute,
+        callIncomingWebhookMaxPerSecond,
     };
     return mergeAll([defaultRateLimitOptions, options.rateLimiting || {}]);
 }

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -206,6 +206,7 @@ export interface IMetricsRateLimiting {
 export interface IRateLimiting {
     createUserMaxPerMinute: number;
     simpleLoginMaxPerMinute: number;
+    callIncomingWebhookMaxPerSecond: number;
 }
 
 export interface IUnleashConfig {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1942/rate-limit-incoming-webhooks-call-endpoint

Adds a configurable rate limit to calling incoming webhooks. We're setting a 1RPS limit for now, but I'm open to suggestions.