### PR TITLE
docs: add ADR for logging with error object

### DIFF
--- a/website/docs/contributing/ADRs/overarching/logging.md
+++ b/website/docs/contributing/ADRs/overarching/logging.md
@@ -4,12 +4,12 @@ title: "ADR: Logging errors"
 
 ## Background
 
-After debugging multiple errors over the last few years, we've consistently found that when something
+After debugging multiple errors over the last few years, we've consistently found that when something goes wrong, we
+would like as much context as possible to debug faster.
 
 ## Decision
 
-`Error` level should be reserved for events that are actually errors. That is, we need to do something about it. When we
-log at the error level, we should give the person debugging as much information as possible.
+When we log at the error level, we should give the person debugging as much information as possible.
 As such, please include the error as a second argument to `logger.error`. This will include the stacktrace in the log
 message and make it a lot easier to figure out where the error is coming from
 

--- a/website/docs/contributing/ADRs/overarching/logging.md
+++ b/website/docs/contributing/ADRs/overarching/logging.md
@@ -1,0 +1,40 @@
+---
+title: "ADR: Logging errors"
+---
+
+## Background
+
+After debugging multiple errors over the last few years, we've consistently found that when something
+
+## Decision
+
+`Error` level should be reserved for events that are actually errors. That is, we need to do something about it. When we
+log at the error level, we should give the person debugging as much information as possible.
+As such, please include the error as a second argument to `logger.error`. This will include the stacktrace in the log
+message and make it a lot easier to figure out where the error is coming from
+
+### Change
+
+#### Previously
+
+```typescript
+function errors() {
+    try {
+    } catch (e) {
+        this.logger.error(`Something went wrong {$e}`);
+    }
+}
+```
+
+to
+
+#### Now (Recommended)
+
+```typescript
+function errors() {
+    try {
+    } catch (e) {
+        this.logger.error('Something went wrong', e);
+    }
+}
+```


### PR DESCRIPTION
I've held an internal knowledge sharing session on this already. If someone can think of a better phrasing for the background, I'm all ears. I think it's just nice to have this documented, so people remember that our logging framework already has a good way to format errors when you use the API `logger.error("<message>", e)`