### PR TITLE
chore: emit PROXY_REPOSITORY_CREATED event when creating new repo

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -68,6 +68,7 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
+    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -68,7 +68,6 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
-    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -3,6 +3,7 @@ const DB_TIME = 'db_time';
 const SCHEDULER_JOB_TIME = 'scheduler_job_time';
 const FEATURES_CREATED_BY_PROCESSED = 'features_created_by_processed';
 const EVENTS_CREATED_BY_PROCESSED = 'events_created_by_processed';
+const PROXY_REPOSITORY_CREATED = 'proxy_repository_created';
 
 export {
     REQUEST_TIME,
@@ -10,4 +11,5 @@ export {
     SCHEDULER_JOB_TIME,
     FEATURES_CREATED_BY_PROCESSED,
     EVENTS_CREATED_BY_PROCESSED,
+    PROXY_REPOSITORY_CREATED,
 };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -227,6 +227,10 @@ export default class MetricsMonitor {
             name: 'event_created_by_migration_count',
             help: 'Event createdBy migration count',
         });
+        const proxyRepositoriesCreated = createCounter({
+            name: 'proxy_repositories_created',
+            help: 'Proxy repositories created',
+        });
 
         async function collectStaticCounters() {
             try {
@@ -384,6 +388,10 @@ export default class MetricsMonitor {
 
         eventBus.on(events.DB_TIME, ({ store, action, time }) => {
             dbDuration.labels({ store, action }).observe(time);
+        });
+
+        eventBus.on(events.PROXY_REPOSITORY_CREATED, () => {
+            proxyRepositoriesCreated.inc();
         });
 
         eventStore.on(FEATURE_CREATED, ({ featureName, project }) => {

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -110,7 +110,7 @@ export class ProxyService {
         if (!client) {
             client = this.createClientForProxyToken(token);
             this.clients.set(token.secret, client);
-            this.config.eventBus.emit(PROXY_REPOSITORY_CREATED, {});
+            this.config.eventBus.emit(PROXY_REPOSITORY_CREATED);
         }
 
         return client;

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -16,10 +16,11 @@ import {
 } from '../types/settings/frontend-settings';
 import { validateOrigins } from '../util';
 import { BadDataError, InvalidTokenError } from '../error';
+import { PROXY_REPOSITORY_CREATED } from '../metric-events';
 
 type Config = Pick<
     IUnleashConfig,
-    'getLogger' | 'frontendApi' | 'frontendApiOrigins'
+    'getLogger' | 'frontendApi' | 'frontendApiOrigins' | 'eventBus'
 >;
 
 type Stores = Pick<IUnleashStores, 'projectStore' | 'eventStore'>;
@@ -109,6 +110,7 @@ export class ProxyService {
         if (!client) {
             client = this.createClientForProxyToken(token);
             this.clients.set(token.secret, client);
+            this.config.eventBus.emit(PROXY_REPOSITORY_CREATED, {});
         }
 
         return client;
@@ -189,9 +191,7 @@ export class ProxyService {
         return this.cachedFrontendSettings;
     }
 
-    async getFrontendSettings(
-        useCache: boolean = true,
-    ): Promise<FrontendSettings> {
+    async getFrontendSettings(useCache = true): Promise<FrontendSettings> {
         if (useCache && this.cachedFrontendSettings) {
             return this.cachedFrontendSettings;
         }


### PR DESCRIPTION
## About the changes

- Emits a new event on the eventBus when Proxy-service creates a new repository for a frontend token
- Adds a prometheus metrics counter for created proxy-repositories

![image](https://github.com/Unleash/unleash/assets/707867/85a84fa7-4f03-4dc1-b0ba-3ffd2477045b)
