### PR TITLE
chore: add call incoming webhook rate limit metric

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -351,6 +351,12 @@ export default class MetricsMonitor {
                 rateLimits
                     .labels({ endpoint: '/auth/simple', method: 'POST' })
                     .set(config.rateLimiting.simpleLoginMaxPerMinute);
+                rateLimits
+                    .labels({
+                        endpoint: '/api/incoming-webhook/:name',
+                        method: 'POST',
+                    })
+                    .set(config.rateLimiting.callIncomingWebhookMaxPerSecond);
             } catch (e) {}
         }
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -356,7 +356,10 @@ export default class MetricsMonitor {
                         endpoint: '/api/incoming-webhook/:name',
                         method: 'POST',
                     })
-                    .set(config.rateLimiting.callIncomingWebhookMaxPerSecond);
+                    .set(
+                        config.rateLimiting.callIncomingWebhookMaxPerSecond /
+                            60,
+                    );
             } catch (e) {}
         }
 


### PR DESCRIPTION
Follow up to https://github.com/Unleash/unleash/pull/6248 - Monitor this rate limit in metrics.