### PR TITLE
chore: add sdkReporting flag to front end

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -79,6 +79,7 @@ export type UiFlags = {
     displayUpgradeEdgeBanner?: boolean;
     showInactiveUsers?: boolean;
     featureSearchFeedbackPosting?: boolean;
+    sdkReporting?: boolean;
 };
 
 export interface IVersionInfo {


### PR DESCRIPTION
It's already in the back end, but wasn't declared in the front end flags.