### PR TITLE
feat: add connected instances table

### DIFF
--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -16,6 +16,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { UPDATE_APPLICATION } from 'component/providers/AccessProvider/permissions';
 import { ApplicationView } from '../ApplicationView/ApplicationView';
 import { ApplicationUpdate } from '../ApplicationUpdate/ApplicationUpdate';
+import { ConnectedInstances } from '../ConnectedInstances/ConnectedInstances';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
@@ -30,8 +31,10 @@ import { formatDateYMD } from 'utils/formatDate';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 export const ApplicationEdit = () => {
+    const showAdvancedApplicationMetrics = useUiFlag('sdkReporting');
     const navigate = useNavigate();
     const name = useRequiredPathParam('name');
     const { application, loading } = useApplication(name);
@@ -83,6 +86,13 @@ export const ApplicationEdit = () => {
             component: <ApplicationUpdate application={application} />,
         },
     ];
+
+    if (showAdvancedApplicationMetrics) {
+        tabData.push({
+            label: 'Connected instances',
+            component: <ConnectedInstances />,
+        });
+    }
 
     if (loading) {
         return (

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
@@ -1,28 +1,7 @@
-import { useContext, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import {
-    Grid,
-    List,
-    ListItem,
-    ListItemAvatar,
-    ListItemText,
-    Typography,
-    Divider,
-} from '@mui/material';
-import {
-    Extension,
-    FlagRounded,
-    Report,
-    SvgIconComponent,
-    Timeline,
-} from '@mui/icons-material';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useMemo } from 'react';
 import useApplication from 'hooks/api/getters/useApplication/useApplication';
-import AccessContext from 'contexts/AccessContext';
 import { formatDateYMDHMS } from 'utils/formatDate';
-import { useLocationSettings } from 'hooks/useLocationSettings';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { MemoizedRowSelectCell } from 'component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell';
 import { useConnectedInstancesTable } from './useConnectedInstancesTable';
 import { ConnectedInstancesTable } from './ConnectedInstancesTable';
 
@@ -54,35 +33,21 @@ export const ConnectedInstances = () => {
         rows,
         prepareRow,
         state: { globalFilter },
-        setGlobalFilter,
         setHiddenColumns,
         columns,
     } = useConnectedInstancesTable(tableData);
 
     return (
-        <>
-            <ConnectedInstancesTable
-                loading={false}
-                headerGroups={headerGroups}
-                setHiddenColumns={setHiddenColumns}
-                prepareRow={prepareRow}
-                getTableBodyProps={getTableBodyProps}
-                getTableProps={getTableProps}
-                rows={rows}
-                columns={columns}
-                globalFilter={globalFilter}
-            />
-            <p>Got some table data for you!</p>
-            <ul>
-                {tableData.map((instance) => (
-                    <li key={instance.instanceId}>
-                        <p>Instance ID: {instance.instanceId}</p>
-                        <p>IP: {instance.ip}</p>
-                        <p>SDK Version: {instance.sdkVersion}</p>
-                        <p>Last seen: {instance.lastSeen}</p>
-                    </li>
-                ))}
-            </ul>
-        </>
+        <ConnectedInstancesTable
+            loading={false}
+            headerGroups={headerGroups}
+            setHiddenColumns={setHiddenColumns}
+            prepareRow={prepareRow}
+            getTableBodyProps={getTableBodyProps}
+            getTableProps={getTableProps}
+            rows={rows}
+            columns={columns}
+            globalFilter={globalFilter}
+        />
     );
 };

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
@@ -1,0 +1,88 @@
+import { useContext, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import {
+    Grid,
+    List,
+    ListItem,
+    ListItemAvatar,
+    ListItemText,
+    Typography,
+    Divider,
+} from '@mui/material';
+import {
+    Extension,
+    FlagRounded,
+    Report,
+    SvgIconComponent,
+    Timeline,
+} from '@mui/icons-material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import useApplication from 'hooks/api/getters/useApplication/useApplication';
+import AccessContext from 'contexts/AccessContext';
+import { formatDateYMDHMS } from 'utils/formatDate';
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { MemoizedRowSelectCell } from 'component/project/Project/ProjectFeatureToggles/RowSelectCell/RowSelectCell';
+import { useConnectedInstancesTable } from './useConnectedInstancesTable';
+import { ConnectedInstancesTable } from './ConnectedInstancesTable';
+
+export const ConnectedInstances = () => {
+    const name = useRequiredPathParam('name');
+    const { application } = useApplication(name);
+
+    const tableData = useMemo(() => {
+        return (
+            application.instances
+                // @ts-expect-error: the type definition here is incomplete. It
+                // should be updated as part of this project.
+                .filter((instance) => instance.environment === 'production')
+                .map(({ instanceId, sdkVersion, clientIp, lastSeen }) => {
+                    return {
+                        instanceId,
+                        ip: clientIp,
+                        sdkVersion,
+                        lastSeen: formatDateYMDHMS(lastSeen),
+                    };
+                })
+        );
+    }, [application]);
+
+    const {
+        getTableProps,
+        getTableBodyProps,
+        headerGroups,
+        rows,
+        prepareRow,
+        state: { globalFilter },
+        setGlobalFilter,
+        setHiddenColumns,
+        columns,
+    } = useConnectedInstancesTable(tableData);
+
+    return (
+        <>
+            <ConnectedInstancesTable
+                loading={false}
+                headerGroups={headerGroups}
+                setHiddenColumns={setHiddenColumns}
+                prepareRow={prepareRow}
+                getTableBodyProps={getTableBodyProps}
+                getTableProps={getTableProps}
+                rows={rows}
+                columns={columns}
+                globalFilter={globalFilter}
+            />
+            <p>Got some table data for you!</p>
+            <ul>
+                {tableData.map((instance) => (
+                    <li key={instance.instanceId}>
+                        <p>Instance ID: {instance.instanceId}</p>
+                        <p>IP: {instance.ip}</p>
+                        <p>SDK Version: {instance.sdkVersion}</p>
+                        <p>Last seen: {instance.lastSeen}</p>
+                    </li>
+                ))}
+            </ul>
+        </>
+    );
+};

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
@@ -100,17 +100,10 @@ export const ConnectedInstancesTable = ({
                 condition={rows.length === 0 && !loading}
                 show={
                     <TablePlaceholder>
-                        <span>
-                            {'No tokens available. Read '}
-                            <Link
-                                href='https://docs.getunleash.io/how-to/api'
-                                target='_blank'
-                                rel='noreferrer'
-                            >
-                                API How-to guides
-                            </Link>{' '}
-                            {' to learn more.'}
-                        </span>
+                        <p>
+                            There's no data for any connected instances to
+                            display. Have you configured your clients correctly?
+                        </p>
                     </TablePlaceholder>
                 }
             />

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
@@ -24,12 +24,8 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 
 import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
 
-const hiddenColumnsSmall = ['Icon', 'createdAt'];
-const hiddenColumnsCompact = ['Icon', 'project', 'seenAt'];
-
-const StyledTable = styled(Table)(({ theme }) => ({
-    tableDisplay: 'fixed',
-}));
+const hiddenColumnsSmall = ['ip', 'sdkVersion'];
+const hiddenColumnsCompact = ['ip', 'sdkVersion', 'lastSeen'];
 
 type ConnectedInstancesTableProps = {
     compact?: boolean;
@@ -79,7 +75,7 @@ export const ConnectedInstancesTable = ({
     return (
         <>
             <Box sx={{ overflowX: 'auto' }}>
-                <StyledTable {...getTableProps()}>
+                <Table {...getTableProps()}>
                     <SortableTableHeader headerGroups={headerGroups as any} />
                     <TableBody {...getTableBodyProps()}>
                         {rows.map((row) => {
@@ -95,7 +91,7 @@ export const ConnectedInstancesTable = ({
                             );
                         })}
                     </TableBody>
-                </StyledTable>
+                </Table>
             </Box>
             <ConditionallyRender
                 condition={rows.length === 0 && !loading}

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
@@ -1,0 +1,119 @@
+import {
+    Row,
+    TablePropGetter,
+    TableProps,
+    TableBodyPropGetter,
+    TableBodyProps,
+    HeaderGroup,
+} from 'react-table';
+import {
+    SortableTableHeader,
+    TableCell,
+    TablePlaceholder,
+} from 'component/common/Table';
+import {
+    Box,
+    Table,
+    TableBody,
+    TableRow,
+    useMediaQuery,
+    Link,
+} from '@mui/material';
+import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
+import { ApiTokenDocs } from 'component/admin/apiToken/ApiTokenDocs/ApiTokenDocs';
+
+import theme from 'themes/theme';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+
+import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+
+const hiddenColumnsSmall = ['Icon', 'createdAt'];
+const hiddenColumnsCompact = ['Icon', 'project', 'seenAt'];
+
+type ConnectedInstancesTableProps = {
+    compact?: boolean;
+    loading: boolean;
+    setHiddenColumns: (param: any) => void;
+    columns: any[];
+    rows: Row<object>[];
+    prepareRow: (row: Row<object>) => void;
+    getTableProps: (
+        propGetter?: TablePropGetter<object> | undefined,
+    ) => TableProps;
+    getTableBodyProps: (
+        propGetter?: TableBodyPropGetter<object> | undefined,
+    ) => TableBodyProps;
+    headerGroups: HeaderGroup<object>[];
+    globalFilter: any;
+};
+export const ConnectedInstancesTable = ({
+    compact = false,
+    setHiddenColumns,
+    columns,
+    loading,
+    rows,
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    globalFilter,
+    prepareRow,
+}: ConnectedInstancesTableProps) => {
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+    useConditionallyHiddenColumns(
+        [
+            {
+                condition: isSmallScreen,
+                columns: hiddenColumnsSmall,
+            },
+            {
+                condition: compact,
+                columns: hiddenColumnsCompact,
+            },
+        ],
+        setHiddenColumns,
+        columns,
+    );
+
+    return (
+        <>
+            <Box sx={{ overflowX: 'auto' }}>
+                <Table {...getTableProps()}>
+                    <SortableTableHeader headerGroups={headerGroups as any} />
+                    <TableBody {...getTableBodyProps()}>
+                        {rows.map((row) => {
+                            prepareRow(row);
+                            return (
+                                <TableRow hover {...row.getRowProps()}>
+                                    {row.cells.map((cell) => (
+                                        <TableCell {...cell.getCellProps()}>
+                                            {cell.render('Cell')}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </Box>
+            <ConditionallyRender
+                condition={rows.length === 0 && !loading}
+                show={
+                    <TablePlaceholder>
+                        <span>
+                            {'No tokens available. Read '}
+                            <Link
+                                href='https://docs.getunleash.io/how-to/api'
+                                target='_blank'
+                                rel='noreferrer'
+                            >
+                                API How-to guides
+                            </Link>{' '}
+                            {' to learn more.'}
+                        </span>
+                    </TablePlaceholder>
+                }
+            />
+        </>
+    );
+};

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
@@ -13,15 +13,12 @@ import {
 } from 'component/common/Table';
 import {
     Box,
+    styled,
     Table,
     TableBody,
     TableRow,
     useMediaQuery,
-    Link,
 } from '@mui/material';
-import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { ApiTokenDocs } from 'component/admin/apiToken/ApiTokenDocs/ApiTokenDocs';
-
 import theme from 'themes/theme';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
@@ -29,6 +26,10 @@ import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColum
 
 const hiddenColumnsSmall = ['Icon', 'createdAt'];
 const hiddenColumnsCompact = ['Icon', 'project', 'seenAt'];
+
+const StyledTable = styled(Table)(({ theme }) => ({
+    tableDisplay: 'fixed',
+}));
 
 type ConnectedInstancesTableProps = {
     compact?: boolean;
@@ -78,7 +79,7 @@ export const ConnectedInstancesTable = ({
     return (
         <>
             <Box sx={{ overflowX: 'auto' }}>
-                <Table {...getTableProps()}>
+                <StyledTable {...getTableProps()}>
                     <SortableTableHeader headerGroups={headerGroups as any} />
                     <TableBody {...getTableBodyProps()}>
                         {rows.map((row) => {
@@ -94,7 +95,7 @@ export const ConnectedInstancesTable = ({
                             );
                         })}
                     </TableBody>
-                </Table>
+                </StyledTable>
             </Box>
             <ConditionallyRender
                 condition={rows.length === 0 && !loading}

--- a/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
@@ -30,21 +30,33 @@ export const useConnectedInstancesTable = (
                 Header: 'Instances',
                 accessor: 'instanceId',
                 Cell: HighlightCell,
+                styles: {
+                    width: '45%',
+                },
             },
             {
                 Header: 'SDK',
                 accessor: 'sdkVersion',
                 Cell: HighlightCell,
+                styles: {
+                    width: '20%',
+                },
             },
             {
                 Header: 'Last seen',
                 accessor: 'lastSeen',
                 Cell: HighlightCell,
+                styles: {
+                    width: '20%',
+                },
             },
             {
                 Header: 'IP',
                 accessor: 'ip',
                 Cell: HighlightCell,
+                styles: {
+                    width: '15%',
+                },
             },
         ];
     }, []);

--- a/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import { IApiToken } from 'hooks/api/getters/useApiTokens/useApiTokens';
+import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
+import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
+import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
+import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
+import { useTable, useGlobalFilter, useSortBy } from 'react-table';
+import { sortTypes } from 'utils/sortTypes';
+import { ProjectsList } from 'component/admin/apiToken/ProjectsList/ProjectsList';
+import { Key } from '@mui/icons-material';
+
+type ConnectedInstancesTableData = {
+    instanceId: string;
+    ip: string;
+    sdkVersion: string;
+    lastSeen: string;
+};
+
+export const useConnectedInstancesTable = (
+    instanceData: ConnectedInstancesTableData[],
+) => {
+    const initialState = useMemo(
+        () => ({ sortBy: [{ id: 'instanceId' }] }),
+        [],
+    );
+
+    const COLUMNS = useMemo(() => {
+        return [
+            {
+                Header: 'Instances',
+                accessor: 'instanceId',
+                Cell: HighlightCell,
+            },
+            {
+                Header: 'SDK',
+                accessor: 'sdkVersion',
+                Cell: HighlightCell,
+            },
+            {
+                Header: 'Last seen',
+                accessor: 'lastSeen',
+                Cell: HighlightCell,
+            },
+            {
+                Header: 'IP',
+                accessor: 'ip',
+                Cell: HighlightCell,
+            },
+        ];
+    }, []);
+
+    const {
+        getTableProps,
+        getTableBodyProps,
+        headerGroups,
+        rows,
+        prepareRow,
+        state,
+        setGlobalFilter,
+        setHiddenColumns,
+    } = useTable(
+        {
+            columns: COLUMNS as any,
+            data: instanceData as any,
+            initialState,
+            sortTypes,
+            autoResetHiddenColumns: false,
+            disableSortRemove: true,
+        },
+        useGlobalFilter,
+        useSortBy,
+    );
+
+    return {
+        getTableProps,
+        getTableBodyProps,
+        headerGroups,
+        rows,
+        prepareRow,
+        state,
+        setGlobalFilter,
+        setHiddenColumns,
+        columns: COLUMNS,
+    };
+};


### PR DESCRIPTION
This PR adds a first iteration of the connected instances table on a new connected instances tab of the application page (hidden behind a flag).

As a first version, it only uses data that we currently return for each application (so no "connected through" or "last synchronized"). 

It also uses the existing version of the application data and just filters it for the "production" environment right now.

Adding query parameters (and potentially a new URL?) to the applications page (to save state and fetch data) will be done in a follow-up. This should lay the groundwork for adding a new API too.

<img width="1485" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/4fb68456-d0f5-4f82-9246-5333a273df9c">
