### PR TITLE
feat: add tabs

### DIFF
--- a/frontend/src/component/application/Application.tsx
+++ b/frontend/src/component/application/Application.tsx
@@ -29,6 +29,8 @@ import PermissionButton from 'component/common/PermissionButton/PermissionButton
 import { formatDateYMD } from 'utils/formatDate';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { ApplicationEdit } from './ApplicationEdit/ApplicationEdit';
 
 type Tab = {
     title: string;
@@ -67,6 +69,7 @@ const StyledTab = styled(Tab)(({ theme }) => ({
 }));
 
 export const Application = () => {
+    const useOldApplicationScreen = !useUiFlag('sdkReporting');
     const navigate = useNavigate();
     const name = useRequiredPathParam('name');
     const { application, loading } = useApplication(name);
@@ -75,9 +78,13 @@ export const Application = () => {
     const { deleteApplication } = useApplicationsApi();
     const { locationSettings } = useLocationSettings();
     const { setToastData, setToastApiError } = useToast();
-    const basePath = `/applications/${name}`;
-
     const { pathname } = useLocation();
+
+    if (useOldApplicationScreen) {
+        return <ApplicationEdit />;
+    }
+
+    const basePath = `/applications/${name}`;
 
     const [showDialog, setShowDialog] = useState(false);
 

--- a/frontend/src/component/application/Application.tsx
+++ b/frontend/src/component/application/Application.tsx
@@ -66,7 +66,7 @@ const StyledTab = styled(Tab)(({ theme }) => ({
     },
 }));
 
-export const ApplicationEdit = () => {
+export const Application = () => {
     const navigate = useNavigate();
     const name = useRequiredPathParam('name');
     const { application, loading } = useApplication(name);

--- a/frontend/src/component/application/Application.tsx
+++ b/frontend/src/component/application/Application.tsx
@@ -15,7 +15,7 @@ import {
 import { Link as LinkIcon } from '@mui/icons-material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { UPDATE_APPLICATION } from 'component/providers/AccessProvider/permissions';
-import { ConnectedInstances } from '../ConnectedInstances/ConnectedInstances';
+import { ConnectedInstances } from './ConnectedInstances/ConnectedInstances';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';

--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -31,10 +31,8 @@ import { formatDateYMD } from 'utils/formatDate';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 export const ApplicationEdit = () => {
-    const showAdvancedApplicationMetrics = useUiFlag('sdkReporting');
     const navigate = useNavigate();
     const name = useRequiredPathParam('name');
     const { application, loading } = useApplication(name);
@@ -86,13 +84,6 @@ export const ApplicationEdit = () => {
             component: <ApplicationUpdate application={application} />,
         },
     ];
-
-    if (showAdvancedApplicationMetrics) {
-        tabData.push({
-            label: 'Connected instances',
-            component: <ConnectedInstances />,
-        });
-    }
 
     if (loading) {
         return (

--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -15,8 +15,6 @@ import {
 import { Link as LinkIcon } from '@mui/icons-material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { UPDATE_APPLICATION } from 'component/providers/AccessProvider/permissions';
-import { ApplicationView } from '../ApplicationView/ApplicationView';
-import { ApplicationUpdate } from '../ApplicationUpdate/ApplicationUpdate';
 import { ConnectedInstances } from '../ConnectedInstances/ConnectedInstances';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import { PageContent } from 'component/common/PageContent/PageContent';
@@ -70,7 +68,6 @@ const StyledTab = styled(Tab)(({ theme }) => ({
 }));
 
 export const ApplicationEdit = () => {
-    const showAdvancedApplicationMetrics = useUiFlag('sdkReporting');
     const navigate = useNavigate();
     const name = useRequiredPathParam('name');
     const { application, loading } = useApplication(name);
@@ -210,7 +207,6 @@ export const ApplicationEdit = () => {
                         {tabs.map((tab) => {
                             return (
                                 <StyledTab
-                                    data-loading-project
                                     key={tab.title}
                                     label={tab.title}
                                     value={tab.path}

--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -29,7 +29,6 @@ import PermissionButton from 'component/common/PermissionButton/PermissionButton
 import { formatDateYMD } from 'utils/formatDate';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 type Tab = {
     title: string;
@@ -79,7 +78,6 @@ export const ApplicationEdit = () => {
     const basePath = `/applications/${name}`;
 
     const { pathname } = useLocation();
-    console.log('pathname is', pathname);
 
     const [showDialog, setShowDialog] = useState(false);
 
@@ -224,7 +222,7 @@ export const ApplicationEdit = () => {
                     show={<div>{renderModal()}</div>}
                 />
                 <Routes>
-                    <Route path='/instances' element={<ConnectedInstances />} />
+                    <Route path='instances' element={<ConnectedInstances />} />
                     <Route path='*' element={<p>This is a placeholder</p>} />
                 </Routes>
             </PageContent>

--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -24,14 +24,13 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import AccessContext from 'contexts/AccessContext';
 import useApplicationsApi from 'hooks/api/actions/useApplicationsApi/useApplicationsApi';
 import useApplication from 'hooks/api/getters/useApplication/useApplication';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import useToast from 'hooks/useToast';
 import PermissionButton from 'component/common/PermissionButton/PermissionButton';
 import { formatDateYMD } from 'utils/formatDate';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
 import { useUiFlag } from 'hooks/useUiFlag';
 
 type Tab = {
@@ -43,7 +42,7 @@ type Tab = {
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadiusLarge,
-    marginBottom: theme.spacing(2),
+    marginBottom: theme.spacing(3),
 }));
 
 const TabContainer = styled('div')(({ theme }) => ({
@@ -80,7 +79,6 @@ export const ApplicationEdit = () => {
     const { deleteApplication } = useApplicationsApi();
     const { locationSettings } = useLocationSettings();
     const { setToastData, setToastApiError } = useToast();
-    const [activeTab, setActiveTab] = useState(0);
     const basePath = `/applications/${name}`;
 
     const { pathname } = useLocation();
@@ -117,23 +115,6 @@ export const ApplicationEdit = () => {
             title='Are you sure you want to delete this application?'
         />
     );
-    const tabData = [
-        {
-            label: 'Application overview',
-            component: <ApplicationView />,
-        },
-        {
-            label: 'Edit application',
-            component: <ApplicationUpdate application={application} />,
-        },
-    ];
-
-    if (showAdvancedApplicationMetrics) {
-        tabData.push({
-            label: 'Connected instances',
-            component: <ConnectedInstances />,
-        });
-    }
 
     if (loading) {
         return (
@@ -241,52 +222,15 @@ export const ApplicationEdit = () => {
                     </Tabs>
                 </TabContainer>
             </StyledHeader>
-            <br />
-            <PageContent
-                withTabs
-                header={
-                    <Tabs
-                        value={activeTab}
-                        onChange={(_, tabId) => {
-                            setActiveTab(tabId);
-                        }}
-                        indicatorColor='primary'
-                        textColor='primary'
-                    >
-                        {tabData.map((tab, index) => (
-                            <Tab
-                                key={`${tab.label}_${index}`}
-                                label={tab.label}
-                                id={`tab-${index}`}
-                                aria-controls={`tabpanel-${index}`}
-                                sx={{
-                                    minWidth: {
-                                        lg: 160,
-                                    },
-                                }}
-                            />
-                        ))}
-                    </Tabs>
-                }
-            >
+            <PageContent>
                 <ConditionallyRender
                     condition={hasAccess(UPDATE_APPLICATION)}
-                    show={
-                        <div>
-                            {renderModal()}
-                            {tabData.map((tab, index) => (
-                                <TabPanel
-                                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-                                    key={index}
-                                    value={activeTab}
-                                    index={index}
-                                >
-                                    {tab.component}
-                                </TabPanel>
-                            ))}
-                        </div>
-                    }
+                    show={<div>{renderModal()}</div>}
                 />
+                <Routes>
+                    <Route path='/instances' element={<ConnectedInstances />} />
+                    <Route path='*' element={<p>This is a placeholder</p>} />
+                </Routes>
             </PageContent>
         </>
     );

--- a/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
+++ b/frontend/src/component/application/ApplicationEdit/ApplicationEdit.tsx
@@ -1,0 +1,207 @@
+/* eslint react/no-multi-comp:off */
+import React, { useContext, useState } from 'react';
+import {
+    Box,
+    Avatar,
+    Icon,
+    IconButton,
+    LinearProgress,
+    Link,
+    Tab,
+    Tabs,
+    Typography,
+} from '@mui/material';
+import { Link as LinkIcon } from '@mui/icons-material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { UPDATE_APPLICATION } from 'component/providers/AccessProvider/permissions';
+import { ApplicationView } from '../ApplicationView/ApplicationView';
+import { ApplicationUpdate } from '../ApplicationUpdate/ApplicationUpdate';
+import { ConnectedInstances } from '../ConnectedInstances/ConnectedInstances';
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+import { PageContent } from 'component/common/PageContent/PageContent';
+import { PageHeader } from 'component/common/PageHeader/PageHeader';
+import AccessContext from 'contexts/AccessContext';
+import useApplicationsApi from 'hooks/api/actions/useApplicationsApi/useApplicationsApi';
+import useApplication from 'hooks/api/getters/useApplication/useApplication';
+import { useNavigate } from 'react-router-dom';
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import useToast from 'hooks/useToast';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
+import { formatDateYMD } from 'utils/formatDate';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
+import { useUiFlag } from 'hooks/useUiFlag';
+
+export const ApplicationEdit = () => {
+    const showAdvancedApplicationMetrics = useUiFlag('sdkReporting');
+    const navigate = useNavigate();
+    const name = useRequiredPathParam('name');
+    const { application, loading } = useApplication(name);
+    const { appName, url, description, icon = 'apps', createdAt } = application;
+    const { hasAccess } = useContext(AccessContext);
+    const { deleteApplication } = useApplicationsApi();
+    const { locationSettings } = useLocationSettings();
+    const { setToastData, setToastApiError } = useToast();
+    const [activeTab, setActiveTab] = useState(0);
+
+    const [showDialog, setShowDialog] = useState(false);
+
+    const toggleModal = () => {
+        setShowDialog(!showDialog);
+    };
+
+    const formatDate = (v: string) => formatDateYMD(v, locationSettings.locale);
+
+    const onDeleteApplication = async (evt: React.SyntheticEvent) => {
+        evt.preventDefault();
+        try {
+            await deleteApplication(appName);
+            setToastData({
+                title: 'Deleted Successfully',
+                text: 'Application deleted successfully',
+                type: 'success',
+            });
+            navigate('/applications');
+        } catch (error: unknown) {
+            setToastApiError(formatUnknownError(error));
+        }
+    };
+
+    const renderModal = () => (
+        <Dialogue
+            open={showDialog}
+            onClose={toggleModal}
+            onClick={onDeleteApplication}
+            title='Are you sure you want to delete this application?'
+        />
+    );
+    const tabData = [
+        {
+            label: 'Application overview',
+            component: <ApplicationView />,
+        },
+        {
+            label: 'Edit application',
+            component: <ApplicationUpdate application={application} />,
+        },
+    ];
+
+    if (showAdvancedApplicationMetrics) {
+        tabData.push({
+            label: 'Connected instances',
+            component: <ConnectedInstances />,
+        });
+    }
+
+    if (loading) {
+        return (
+            <div>
+                <p>Loading...</p>
+                <LinearProgress />
+            </div>
+        );
+    } else if (!application) {
+        return <p>Application ({appName}) not found</p>;
+    }
+
+    return (
+        <>
+            <PageContent>
+                <PageHeader
+                    titleElement={
+                        <span
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Avatar style={{ marginRight: '8px' }}>
+                                <Icon>{icon || 'apps'}</Icon>
+                            </Avatar>
+                            {appName}
+                        </span>
+                    }
+                    title={appName}
+                    actions={
+                        <>
+                            <ConditionallyRender
+                                condition={Boolean(url)}
+                                show={
+                                    <IconButton
+                                        component={Link}
+                                        href={url}
+                                        size='large'
+                                    >
+                                        <LinkIcon titleAccess={url} />
+                                    </IconButton>
+                                }
+                            />
+
+                            <PermissionButton
+                                tooltipProps={{ title: 'Delete application' }}
+                                onClick={toggleModal}
+                                permission={UPDATE_APPLICATION}
+                            >
+                                Delete
+                            </PermissionButton>
+                        </>
+                    }
+                />
+                <Box sx={(theme) => ({ marginTop: theme.spacing(1) })}>
+                    <Typography variant='body1'>{description || ''}</Typography>
+                    <Typography variant='body2'>
+                        Created: <strong>{formatDate(createdAt)}</strong>
+                    </Typography>
+                </Box>
+            </PageContent>
+            <br />
+            <PageContent
+                withTabs
+                header={
+                    <Tabs
+                        value={activeTab}
+                        onChange={(_, tabId) => {
+                            setActiveTab(tabId);
+                        }}
+                        indicatorColor='primary'
+                        textColor='primary'
+                    >
+                        {tabData.map((tab, index) => (
+                            <Tab
+                                key={`${tab.label}_${index}`}
+                                label={tab.label}
+                                id={`tab-${index}`}
+                                aria-controls={`tabpanel-${index}`}
+                                sx={{
+                                    minWidth: {
+                                        lg: 160,
+                                    },
+                                }}
+                            />
+                        ))}
+                    </Tabs>
+                }
+            >
+                <ConditionallyRender
+                    condition={hasAccess(UPDATE_APPLICATION)}
+                    show={
+                        <div>
+                            {renderModal()}
+                            {tabData.map((tab, index) => (
+                                <TabPanel
+                                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                                    key={index}
+                                    value={activeTab}
+                                    index={index}
+                                >
+                                    {tab.component}
+                                </TabPanel>
+                            ))}
+                        </div>
+                    }
+                />
+            </PageContent>
+        </>
+    );
+};

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`returns all baseRoutes 1`] = `
     "component": [Function],
     "menu": {},
     "parent": "/applications",
-    "path": "/applications/:name",
+    "path": "/applications/:name/*",
     "title": ":name",
     "type": "protected",
   },

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -17,7 +17,6 @@ import EditTagType from 'component/tags/EditTagType/EditTagType';
 import CreateTagType from 'component/tags/CreateTagType/CreateTagType';
 import CreateFeature from 'component/feature/CreateFeature/CreateFeature';
 import EditFeature from 'component/feature/EditFeature/EditFeature';
-import { ApplicationEdit } from 'component/application/ApplicationEdit/ApplicationEdit';
 import ContextList from 'component/context/ContextList/ContextList/ContextList';
 import RedirectFeatureView from 'component/feature/RedirectFeatureView/RedirectFeatureView';
 import { CreateIntegration } from 'component/integrations/CreateIntegration/CreateIntegration';
@@ -171,15 +170,6 @@ export const routes: IRoute[] = [
         type: 'protected',
         menu: {},
         flag: 'sdkReporting',
-    },
-    {
-        path: '/applications/:name',
-        title: ':name',
-        parent: '/applications',
-        component: ApplicationEdit,
-        type: 'protected',
-        menu: {},
-        notFlag: 'sdkReporting',
     },
     {
         path: '/applications',

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -163,7 +163,7 @@ export const routes: IRoute[] = [
 
     // Applications
     {
-        path: '/applications/:name',
+        path: '/applications/:name/*',
         title: ':name',
         parent: '/applications',
         component: ApplicationEdit,

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -169,7 +169,6 @@ export const routes: IRoute[] = [
         component: Application,
         type: 'protected',
         menu: {},
-        flag: 'sdkReporting',
     },
     {
         path: '/applications',

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -47,6 +47,7 @@ import { ApplicationList } from '../application/ApplicationList/ApplicationList'
 import { AddonRedirect } from 'component/integrations/AddonRedirect/AddonRedirect';
 import { ExecutiveDashboard } from 'component/executiveDashboard/ExecutiveDashboard';
 import { FeedbackList } from '../feedbackNew/FeedbackList';
+import { Application } from 'component/application/Application';
 
 export const routes: IRoute[] = [
     // Splash
@@ -166,9 +167,19 @@ export const routes: IRoute[] = [
         path: '/applications/:name/*',
         title: ':name',
         parent: '/applications',
+        component: Application,
+        type: 'protected',
+        menu: {},
+        flag: 'sdkReporting',
+    },
+    {
+        path: '/applications/:name',
+        title: ':name',
+        parent: '/applications',
         component: ApplicationEdit,
         type: 'protected',
         menu: {},
+        notFlag: 'sdkReporting',
     },
     {
         path: '/applications',


### PR DESCRIPTION
This PR adds a new file "Application.tsx", which is analogous to the existing Project.tsx file in that it contains the base layout for the application page, as well as tabs pointing to sub pages. Currently, the overview tab uses a paragraph with some fallback text, while the connected instances table displays the instances table. 

I have mostly copied the existing ApplicationEdit component and used that as a base, assuming that we'll delete that component when we're done with this.

<img width="1449" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/ac574a83-3cf4-4de5-a4de-188575074ecb">
