### PR TITLE
Revert "chore(deps): update dependency husky to v9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "faker": "5.5.3",
     "fast-check": "3.15.1",
     "fetch-mock": "9.11.0",
-    "husky": "9.0.11",
+    "husky": "8.0.3",
     "jest": "29.7.0",
     "jest-junit": "^16.0.0",
     "lint-staged": "13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3632,10 +3632,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@9.0.11:
-  version "9.0.11"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
-  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+husky@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
Reverts Unleash/unleash#6232

Husky 
-   Transitioned to `ESM` for module usage.
-   Dropped support for Node 14 and 16.

I believe the first is causing an issue with our build. I tried fixing this but didn't succeed, so I'm reverting