### PR TITLE
chore: avoid printing out warnings from known frontend proxies

### DIFF
--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -9,7 +9,7 @@ const AdminApi = require('./admin-api');
 const ClientApi = require('./client-api');
 const Controller = require('./controller');
 import { HealthCheckController } from './health-check';
-import ProxyController from './proxy-api';
+import FrontendAPIController from './proxy-api';
 import EdgeController from './edge-api';
 import { PublicInviteController } from './public-invite';
 import { Db } from '../db/db';
@@ -47,7 +47,7 @@ class IndexRouter extends Controller {
 
         this.use(
             '/api/frontend',
-            new ProxyController(config, services, config.flagResolver).router,
+            new FrontendAPIController(config, services).router,
         );
 
         this.use('/edge', new EdgeController(config, services).router);

--- a/src/lib/routes/proxy-api/index.ts
+++ b/src/lib/routes/proxy-api/index.ts
@@ -1,11 +1,6 @@
 import { Request, Response } from 'express';
 import Controller from '../controller';
-import {
-    IFlagResolver,
-    IUnleashConfig,
-    IUnleashServices,
-    NONE,
-} from '../../types';
+import { IUnleashConfig, IUnleashServices, NONE } from '../../types';
 import { Logger } from '../../logger';
 import { IApiUser } from '../../types/api-user';
 import {
@@ -40,22 +35,15 @@ type Services = Pick<
     'settingService' | 'proxyService' | 'openApiService'
 >;
 
-export default class ProxyController extends Controller {
+export default class FrontendAPIController extends Controller {
     private readonly logger: Logger;
 
     private services: Services;
 
-    private flagResolver: IFlagResolver;
-
-    constructor(
-        config: IUnleashConfig,
-        services: Services,
-        flagResolver: IFlagResolver,
-    ) {
+    constructor(config: IUnleashConfig, services: Services) {
         super(config);
         this.logger = config.getLogger('proxy-api/index.ts');
         this.services = services;
-        this.flagResolver = flagResolver;
 
         // Support CORS requests for the frontend endpoints.
         // Preflight requests are handled in `app.ts`.
@@ -85,14 +73,14 @@ export default class ProxyController extends Controller {
         this.route({
             method: 'post',
             path: '',
-            handler: ProxyController.endpointNotImplemented,
+            handler: FrontendAPIController.endpointNotImplemented,
             permission: NONE,
         });
 
         this.route({
             method: 'get',
             path: '/client/features',
-            handler: ProxyController.endpointNotImplemented,
+            handler: FrontendAPIController.endpointNotImplemented,
             permission: NONE,
         });
 
@@ -156,14 +144,14 @@ export default class ProxyController extends Controller {
         this.route({
             method: 'get',
             path: '/health',
-            handler: ProxyController.endpointNotImplemented,
+            handler: FrontendAPIController.endpointNotImplemented,
             permission: NONE,
         });
 
         this.route({
             method: 'get',
             path: '/internal-backstage/prometheus',
-            handler: ProxyController.endpointNotImplemented,
+            handler: FrontendAPIController.endpointNotImplemented,
             permission: NONE,
         });
     }
@@ -187,7 +175,7 @@ export default class ProxyController extends Controller {
         }
         const toggles = await this.services.proxyService.getProxyFeatures(
             req.user,
-            ProxyController.createContext(req),
+            FrontendAPIController.createContext(req),
         );
 
         res.set('Cache-control', 'no-cache');

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -125,7 +125,7 @@ export class ProxyService {
         );
 
         const client = new Unleash({
-            appName: `frontend-proxy-${token.username ?? 'unknown'}`,
+            appName: 'proxy',
             url: 'unused',
             storageProvider: new InMemStorageProvider(),
             disableMetrics: true,

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -125,12 +125,13 @@ export class ProxyService {
         );
 
         const client = new Unleash({
-            appName: 'proxy',
+            appName: `frontend-proxy-${token.username ?? 'unknown'}`,
             url: 'unused',
             storageProvider: new InMemStorageProvider(),
             disableMetrics: true,
             repository,
             disableAutoStart: true,
+            skipInstanceCountWarning: true,
         });
 
         client.on(UnleashEvents.Error, (error) => {
@@ -188,7 +189,7 @@ export class ProxyService {
         } catch (error) {
             this.logger.debug('Unable to fetch frontend settings', error);
         }
-        return this.cachedFrontendSettings;
+        return this.cachedFrontendSettings!;
     }
 
     async getFrontendSettings(useCache = true): Promise<FrontendSettings> {

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -189,7 +189,7 @@ export class ProxyService {
         } catch (error) {
             this.logger.debug('Unable to fetch frontend settings', error);
         }
-        return this.cachedFrontendSettings!;
+        return this.cachedFrontendSettings;
     }
 
     async getFrontendSettings(useCache = true): Promise<FrontendSettings> {


### PR DESCRIPTION
## About the changes
Our frontend API creates new instances of unleash-client-proxy. Because this is by-design, we don't want to log a warning that was designed to warn users about potential misconfiguration of Unleash Proxy.

As an extra, I'm renaming ProxyController to FrontendAPIController to better reflect the intent of this controller.