### PR TITLE
fix: adjust padding of problem detected icon

### DIFF
--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
@@ -33,7 +33,7 @@ const EnvironmentSelectionContainer = styled('div')(({ theme }) => ({
             color: theme.palette.warning.main,
             position: 'absolute',
             fontSize: theme.fontSizes.bodySize,
-            top: 'calc(var(--padding-vertical) * .7)',
+            top: 'calc(var(--padding-horizontal) * .12)',
             right: 'calc(var(--padding-horizontal) * .2)',
         },
     },


### PR DESCRIPTION
This PR adjusts the vertical position of the problem detected icon in the environment selector.

<img width="1137" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/ef961bba-6380-4849-a81a-0468fc467b5c">
