### PR TITLE
fix: generalize multi action button

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ApplyButton/ApplyButton.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ApplyButton/ApplyButton.tsx
@@ -2,34 +2,45 @@ import { FC } from 'react';
 
 import CheckBox from '@mui/icons-material/Check';
 import Today from '@mui/icons-material/Today';
-import { MultiActionButton } from '../MultiActionButton/MultiActionButton';
 import { APPLY_CHANGE_REQUEST } from 'component/providers/AccessProvider/permissions';
+import { MultiActionButton } from 'component/common/MultiActionButton/MultiActionButton';
+import { useChangeRequest } from 'hooks/api/getters/useChangeRequest/useChangeRequest';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 
 export const ApplyButton: FC<{
     disabled: boolean;
     onSchedule: () => void;
     onApply: () => void;
     variant?: 'create' | 'update';
-}> = ({ disabled, onSchedule, onApply, variant = 'create', children }) => (
-    <MultiActionButton
-        permission={APPLY_CHANGE_REQUEST}
-        disabled={disabled}
-        actions={[
-            {
-                label: 'Apply changes',
-                onSelect: onApply,
-                icon: <CheckBox fontSize='small' />,
-            },
-            {
-                label:
-                    variant === 'create'
-                        ? 'Schedule changes'
-                        : 'Update schedule',
-                onSelect: onSchedule,
-                icon: <Today fontSize='small' />,
-            },
-        ]}
-    >
-        {children}
-    </MultiActionButton>
-);
+}> = ({ disabled, onSchedule, onApply, variant = 'create', children }) => {
+    const projectId = useRequiredPathParam('projectId');
+    const id = useRequiredPathParam('id');
+    const { data } = useChangeRequest(projectId, id);
+
+    return (
+        <MultiActionButton
+            permission={APPLY_CHANGE_REQUEST}
+            disabled={disabled}
+            actions={[
+                {
+                    label: 'Apply changes',
+                    onSelect: onApply,
+                    icon: <CheckBox fontSize='small' />,
+                },
+                {
+                    label:
+                        variant === 'create'
+                            ? 'Schedule changes'
+                            : 'Update schedule',
+                    onSelect: onSchedule,
+                    icon: <Today fontSize='small' />,
+                },
+            ]}
+            environmentId={data?.environment}
+            projectId={projectId}
+            ariaLabel='apply or schedule changes'
+        >
+            {children}
+        </MultiActionButton>
+    );
+};

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
@@ -1,31 +1,49 @@
-import { FC } from 'react';
+import { FC, useContext } from 'react';
 
 import CheckBox from '@mui/icons-material/Check';
 import Clear from '@mui/icons-material/Clear';
-import { MultiActionButton } from '../MultiActionButton/MultiActionButton';
+import { MultiActionButton } from 'component/common/MultiActionButton/MultiActionButton';
 import { APPROVE_CHANGE_REQUEST } from 'component/providers/AccessProvider/permissions';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+import AccessContext from 'contexts/AccessContext';
+import { useChangeRequest } from 'hooks/api/getters/useChangeRequest/useChangeRequest';
 
 export const ReviewButton: FC<{
     disabled: boolean;
     onReject: () => void;
     onApprove: () => void;
-}> = ({ disabled, onReject, onApprove, children }) => (
-    <MultiActionButton
-        permission={APPROVE_CHANGE_REQUEST}
-        disabled={disabled}
-        actions={[
-            {
-                label: 'Approve',
-                onSelect: onApprove,
-                icon: <CheckBox fontSize='small' />,
-            },
-            {
-                label: 'Reject',
-                onSelect: onReject,
-                icon: <Clear fontSize='small' />,
-            },
-        ]}
-    >
-        {children}
-    </MultiActionButton>
-);
+}> = ({ disabled, onReject, onApprove, children }) => {
+    const { isAdmin } = useContext(AccessContext);
+    const projectId = useRequiredPathParam('projectId');
+    const id = useRequiredPathParam('id');
+    const { user } = useAuthUser();
+    const { data } = useChangeRequest(projectId, id);
+
+    const approverIsCreator = data?.createdBy.id === user?.id;
+    const canApprove = disabled || (approverIsCreator && !isAdmin);
+
+    return (
+        <MultiActionButton
+            permission={APPROVE_CHANGE_REQUEST}
+            disabled={canApprove}
+            actions={[
+                {
+                    label: 'Approve',
+                    onSelect: onApprove,
+                    icon: <CheckBox fontSize='small' />,
+                },
+                {
+                    label: 'Reject',
+                    onSelect: onReject,
+                    icon: <Clear fontSize='small' />,
+                },
+            ]}
+            environmentId={data?.environment}
+            projectId={projectId}
+            ariaLabel='review or reject changes'
+        >
+            {children}
+        </MultiActionButton>
+    );
+};

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ReviewButton/ReviewButton.tsx
@@ -21,12 +21,12 @@ export const ReviewButton: FC<{
     const { data } = useChangeRequest(projectId, id);
 
     const approverIsCreator = data?.createdBy.id === user?.id;
-    const canApprove = disabled || (approverIsCreator && !isAdmin);
+    const disableApprove = disabled || (approverIsCreator && !isAdmin);
 
     return (
         <MultiActionButton
             permission={APPROVE_CHANGE_REQUEST}
-            disabled={canApprove}
+            disabled={disableApprove}
             actions={[
                 {
                     label: 'Approve',

--- a/frontend/src/component/common/MultiActionButton/MultiActionButton.tsx
+++ b/frontend/src/component/common/MultiActionButton/MultiActionButton.tsx
@@ -15,8 +15,6 @@ import {
 
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import PermissionButton from 'component/common/PermissionButton/PermissionButton';
-import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
-import AccessContext from 'contexts/AccessContext';
 
 type Action = {
     label: string;
@@ -28,13 +26,18 @@ export const MultiActionButton: FC<{
     disabled: boolean;
     actions: Action[];
     permission: string;
-}> = ({ disabled, children, actions, permission }) => {
-    const { isAdmin } = useContext(AccessContext);
-    const projectId = useRequiredPathParam('projectId');
-    const id = useRequiredPathParam('id');
-    const { user } = useAuthUser();
-    const { data } = useChangeRequest(projectId, id);
-
+    projectId?: string;
+    environmentId?: string;
+    ariaLabel?: string;
+}> = ({
+    disabled,
+    children,
+    actions,
+    permission,
+    projectId,
+    ariaLabel,
+    environmentId,
+}) => {
     const [open, setOpen] = React.useState(false);
     const anchorRef = React.useRef<HTMLButtonElement>(null);
 
@@ -57,9 +60,7 @@ export const MultiActionButton: FC<{
         <React.Fragment>
             <PermissionButton
                 variant='contained'
-                disabled={
-                    disabled || (data?.createdBy.id === user?.id && !isAdmin)
-                }
+                disabled={disabled}
                 aria-controls={open ? 'review-options-menu' : undefined}
                 aria-expanded={open ? 'true' : undefined}
                 aria-label='review changes'
@@ -69,7 +70,7 @@ export const MultiActionButton: FC<{
                 endIcon={<ArrowDropDownIcon />}
                 permission={permission}
                 projectId={projectId}
-                environmentId={data?.environment}
+                environmentId={environmentId}
             >
                 {children}
             </PermissionButton>

--- a/frontend/src/component/common/MultiActionButton/MultiActionButton.tsx
+++ b/frontend/src/component/common/MultiActionButton/MultiActionButton.tsx
@@ -63,7 +63,7 @@ export const MultiActionButton: FC<{
                 disabled={disabled}
                 aria-controls={open ? 'review-options-menu' : undefined}
                 aria-expanded={open ? 'true' : undefined}
-                aria-label='review changes'
+                aria-label={ariaLabel}
                 aria-haspopup='menu'
                 onClick={onToggle}
                 ref={anchorRef}


### PR DESCRIPTION
This PR moves the CR specific logic out of the MultiActionButton and generalises so that we can re-use it across the application. The CR specific logic is moved into:

* ApplyButton.tsx
* ReviewButton.tsx

This fixes a bug where multi action button would be disabled if you tried to apply an approved change request that you had created yourself. 