### PR TITLE
chore: db drop action_states

### DIFF
--- a/src/migrations/20240221115502-drop-action-states.js
+++ b/src/migrations/20240221115502-drop-action-states.js
@@ -1,0 +1,35 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        DROP INDEX IF EXISTS idx_action_states_action_id;
+        DROP INDEX IF EXISTS idx_action_states_observable_event_id;
+        DROP INDEX IF EXISTS idx_action_states_action_observable;
+
+        DROP TABLE IF EXISTS action_states;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        CREATE TABLE IF NOT EXISTS action_states
+        (
+            id SERIAL PRIMARY KEY NOT NULL,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            state VARCHAR(255) NOT NULL,
+            details VARCHAR(255),
+            action_id INTEGER NOT NULL,
+            observable_event_id INTEGER NOT NULL,
+            FOREIGN KEY (observable_event_id) references observable_events(id),
+            FOREIGN KEY (action_id) references actions(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_action_states_action_id ON action_states(action_id);
+        CREATE INDEX IF NOT EXISTS idx_action_states_observable_event_id ON action_states(observable_event_id);
+        CREATE INDEX IF NOT EXISTS idx_action_states_action_observable ON action_states(action_id, observable_event_id);
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
Follow up to: https://github.com/Unleash/unleash/pull/6298

We no longer need this table, since it was superseded by `action_events` and is no longer used.
I believe it's safe to drop this table right away since the feature is not being used yet.