### PR TITLE
chore: remove redundant check for project names in db

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
@@ -11,7 +11,12 @@ import {
     ITag,
     PartialDeep,
 } from '../../types';
-import { DEFAULT_ENV, ensureStringValue, mapValues } from '../../util';
+import {
+    ALL_PROJECTS,
+    DEFAULT_ENV,
+    ensureStringValue,
+    mapValues,
+} from '../../util';
 import EventEmitter from 'events';
 import FeatureToggleStore from '../feature-toggle/feature-toggle-store';
 import { Db } from '../../db/db';
@@ -166,7 +171,10 @@ export default class FeatureToggleClientStore
                     .whereIn(['tag_type', 'tag_value'], featureQuery.tag);
                 query = query.whereIn('features.name', tagQuery);
             }
-            if (featureQuery.project) {
+            if (
+                featureQuery.project &&
+                !featureQuery.project.includes(ALL_PROJECTS)
+            ) {
                 query = query.whereIn('project', featureQuery.project);
             }
             if (featureQuery.namePrefix) {

--- a/src/lib/features/feature-toggle/fakes/fake-feature-strategies-store.ts
+++ b/src/lib/features/feature-toggle/fakes/fake-feature-strategies-store.ts
@@ -10,6 +10,7 @@ import {
 import NotFoundError from '../../../error/notfound-error';
 import { IFeatureStrategiesStore } from '../types/feature-toggle-strategies-store-type';
 import { IFeatureProjectUserParams } from '../feature-toggle-controller';
+import { ALL_PROJECTS } from '../../../util';
 
 interface ProjectEnvironment {
     projectName: string;
@@ -182,17 +183,20 @@ export default class FakeFeatureStrategiesStore
             if (featureQuery.namePrefix) {
                 if (featureQuery.project) {
                     return (
-                        toggle.name.startsWith(featureQuery.namePrefix) &&
-                        featureQuery.project.some((project) =>
-                            project.includes(toggle.project),
-                        )
+                        (toggle.name.startsWith(featureQuery.namePrefix) &&
+                            featureQuery.project.some((project) =>
+                                project.includes(toggle.project),
+                            )) ||
+                        featureQuery.project.includes(ALL_PROJECTS)
                     );
                 }
                 return toggle.name.startsWith(featureQuery.namePrefix);
             }
             if (featureQuery.project) {
-                return featureQuery.project.some((project) =>
-                    project.includes(toggle.project),
+                return (
+                    featureQuery.project.some((project) =>
+                        project.includes(toggle.project),
+                    ) || featureQuery.project.includes(ALL_PROJECTS)
                 );
             }
             return toggle.archived === archived;

--- a/src/lib/proxy/proxy-repository.ts
+++ b/src/lib/proxy/proxy-repository.ts
@@ -11,7 +11,7 @@ import {
     mapFeaturesForClient,
     mapSegmentsForClient,
 } from '../features/playground/offline-unleash-client';
-import { ALL_ENVS, ALL_PROJECTS } from '../util/constants';
+import { ALL_ENVS } from '../util/constants';
 import { UnleashEvents } from 'unleash-client';
 import { Logger } from '../logger';
 import ConfigurationRevisionService, {
@@ -151,7 +151,7 @@ export class ProxyRepository
     private async featuresForToken(): Promise<FeatureInterface[]> {
         return mapFeaturesForClient(
             await this.services.featureToggleServiceV2.getClientFeatures({
-                project: await this.projectIdsForToken(),
+                project: this.token.projects,
                 environment: this.environmentNameForToken(),
             }),
         );
@@ -161,15 +161,6 @@ export class ProxyRepository
         return mapSegmentsForClient(
             await this.services.segmentService.getAll(),
         );
-    }
-
-    private async projectIdsForToken(): Promise<string[]> {
-        if (this.token.projects.includes(ALL_PROJECTS)) {
-            const allProjects = await this.stores.projectStore.getAll();
-            return allProjects.map((project) => project.id);
-        }
-
-        return this.token.projects;
     }
 
     private environmentNameForToken(): string {

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -915,6 +915,7 @@ test('Should sync proxy for keys on an interval', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 5000 },
+            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -946,6 +947,7 @@ test('Should change fetch interval', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 1000 },
+            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -974,6 +976,7 @@ test('Should not recursively set off timers on events', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 5000 },
+            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -1030,6 +1033,7 @@ test('should terminate data polling when stop is called', async () => {
         {
             getLogger: getDebugLogger,
             frontendApi: { refreshIntervalInMs: 1 },
+            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,

--- a/src/test/e2e/api/proxy/proxy.e2e.test.ts
+++ b/src/test/e2e/api/proxy/proxy.e2e.test.ts
@@ -915,7 +915,6 @@ test('Should sync proxy for keys on an interval', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 5000 },
-            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -947,7 +946,6 @@ test('Should change fetch interval', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 1000 },
-            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -976,7 +974,6 @@ test('Should not recursively set off timers on events', async () => {
         {
             getLogger,
             frontendApi: { refreshIntervalInMs: 5000 },
-            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,
@@ -1033,7 +1030,6 @@ test('should terminate data polling when stop is called', async () => {
         {
             getLogger: getDebugLogger,
             frontendApi: { refreshIntervalInMs: 1 },
-            eventBus: <any>{ emit: jest.fn() },
         },
         db.stores,
         app.services,


### PR DESCRIPTION
## About the changes

skips the fetching project names from db part in the proxy-repository that was done when the token had ALL_PROJECTS