### PR TITLE
chore: incoming webhook events UI

### DIFF
--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -32,6 +32,7 @@ interface ICreateProps {
     formatApiCode?: () => string;
     footer?: ReactNode;
     compact?: boolean;
+    showGuidance?: boolean;
 }
 
 const StyledContainer = styled('section', {
@@ -202,6 +203,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
     showLink = true,
     footer,
     compact,
+    showGuidance = true,
 }) => {
     const { setToastData } = useToast();
     const smallScreen = useMediaQuery(`(max-width:${1099}px)`);
@@ -252,7 +254,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
     return (
         <StyledContainer modal={modal} compact={compact}>
             <ConditionallyRender
-                condition={smallScreen}
+                condition={showGuidance && smallScreen}
                 show={
                     <StyledRelativeDiv>
                         <MobileGuidance
@@ -293,7 +295,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
                 />
             </StyledMain>
             <ConditionallyRender
-                condition={!smallScreen}
+                condition={showGuidance && !smallScreen}
                 show={
                     <Guidance
                         description={description}

--- a/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
+++ b/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
@@ -4,7 +4,11 @@ import 'vanilla-jsoneditor/themes/jse-theme-dark.css';
 import { styled } from '@mui/material';
 import UIContext from 'contexts/UIContext';
 
-const JSONEditorThemeWrapper = styled('div')(({ theme }) => ({
+type EditorStyle = 'default' | 'sidePanel';
+
+const JSONEditorThemeWrapper = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'editorStyle',
+})<{ editorStyle?: EditorStyle }>(({ theme, editorStyle = 'default' }) => ({
     '&.jse-theme-dark': {
         '--jse-background-color': theme.palette.background.default,
         '--jse-panel-background': theme.palette.background.default,
@@ -24,9 +28,34 @@ const JSONEditorThemeWrapper = styled('div')(({ theme }) => ({
         borderBottomLeftRadius: theme.shape.borderRadius,
         borderBottomRightRadius: theme.shape.borderRadius,
     },
+    ...(editorStyle === 'sidePanel' && {
+        '&&&': {
+            '--jse-main-border': 0,
+            '& > div': {
+                height: '100%',
+            },
+            '& .jse-focus': {
+                '--jse-main-border': 0,
+            },
+            '& .cm-gutters': {
+                '--jse-panel-background': 'transparent',
+                '--jse-panel-border': 'transparent',
+            },
+            '& .cm-gutter-lint': {
+                width: 0,
+            },
+            '& .jse-text-mode': {
+                borderBottomRightRadius: theme.shape.borderRadiusMedium,
+            },
+        },
+    }),
 }));
 
-const VanillaJSONEditor: React.FC<JSONEditorPropsOptional> = (props) => {
+interface IReactJSONEditorProps extends JSONEditorPropsOptional {
+    editorStyle?: EditorStyle;
+}
+
+const VanillaJSONEditor: React.FC<IReactJSONEditorProps> = (props) => {
     const refContainer = useRef<HTMLDivElement | null>(null);
     const refEditor = useRef<JSONEditor | null>(null);
 
@@ -58,11 +87,12 @@ const VanillaJSONEditor: React.FC<JSONEditorPropsOptional> = (props) => {
     return <div ref={refContainer} />;
 };
 
-const ReactJSONEditor: React.FC<JSONEditorPropsOptional> = (props) => {
+const ReactJSONEditor: React.FC<IReactJSONEditorProps> = (props) => {
     const { themeMode } = useContext(UIContext);
     return (
         <JSONEditorThemeWrapper
             className={themeMode === 'dark' ? 'jse-theme-dark' : ''}
+            editorStyle={props.editorStyle}
         >
             <VanillaJSONEditor
                 mainMenuBar={false}

--- a/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
+++ b/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
@@ -30,6 +30,9 @@ const JSONEditorThemeWrapper = styled('div', {
     },
     ...(editorStyle === 'sidePanel' && {
         '&&&': {
+            '& .jse-main': {
+                minHeight: 0,
+            },
             '--jse-main-border': 0,
             '& > div': {
                 height: '100%',
@@ -46,6 +49,9 @@ const JSONEditorThemeWrapper = styled('div', {
             },
             '& .jse-text-mode': {
                 borderBottomRightRadius: theme.shape.borderRadiusMedium,
+            },
+            '& .cm-scroller': {
+                '--jse-delimiter-color': theme.palette.text.primary,
             },
         },
     }),

--- a/frontend/src/component/common/SidePanelList/SidePanelList.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelList.tsx
@@ -1,3 +1,54 @@
-export const SidePanelList = () => {
-    return <span>TODO: Implement</span>;
+import { styled } from '@mui/material';
+import { ReactNode, useState } from 'react';
+
+const StyledSidePanelListWrapper = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
+});
+
+const StyledSidePanelListBody = styled('div')({
+    display: 'flex',
+    flexDirection: 'row',
+});
+
+interface ISidePanelListProps<T> {
+    items: T[];
+    header: ReactNode;
+    renderItem: (
+        item: T,
+        isSelected: boolean,
+        selectItem: (item: T) => void,
+    ) => ReactNode;
+    renderContent: (item: T) => ReactNode;
+}
+
+export const SidePanelList = <T,>({
+    items,
+    header,
+    renderItem,
+    renderContent,
+}: ISidePanelListProps<T>) => {
+    const [selectedItem, setSelectedItem] = useState<T>(items[0]);
+
+    return (
+        <StyledSidePanelListWrapper>
+            {header}
+            <StyledSidePanelListBody>
+                <div className='side-panel-list'>
+                    {items.map((item) =>
+                        renderItem(
+                            item,
+                            item === selectedItem,
+                            setSelectedItem,
+                        ),
+                    )}
+                </div>
+                <div className='side-panel-content'>
+                    {renderContent(selectedItem)}
+                </div>
+            </StyledSidePanelListBody>
+        </StyledSidePanelListWrapper>
+    );
 };

--- a/frontend/src/component/common/SidePanelList/SidePanelList.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelList.tsx
@@ -6,7 +6,6 @@ import { SidePanelListItem } from './SidePanelListItem';
 const StyledSidePanelListWrapper = styled('div')({
     display: 'flex',
     flexDirection: 'column',
-    height: '100%',
     width: '100%',
 });
 
@@ -19,10 +18,24 @@ const StyledSidePanelHalf = styled('div')({
     display: 'flex',
     flexDirection: 'column',
     flex: 1,
-    '& > *': {
-        flex: 1,
-    },
 });
+
+const StyledSidePanelHalfLeft = styled(StyledSidePanelHalf, {
+    shouldForwardProp: (prop) => prop !== 'maxHeight',
+})<{ maxHeight?: number }>(({ theme, maxHeight }) => ({
+    border: `1px solid ${theme.palette.divider}`,
+    borderTop: 0,
+    borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+    overflow: 'auto',
+    ...(maxHeight && { maxHeight }),
+}));
+
+const StyledSidePanelHalfRight = styled(StyledSidePanelHalf)(({ theme }) => ({
+    border: `1px solid ${theme.palette.divider}`,
+    borderTop: 0,
+    borderLeft: 0,
+    borderBottomRightRadius: theme.shape.borderRadiusMedium,
+}));
 
 type ColumnAlignment = 'start' | 'end' | 'center';
 
@@ -35,6 +48,7 @@ export const StyledSidePanelListColumn = styled('div', {
         fontSize: theme.fontSizes.smallBody,
         justifyContent: align,
         ...(maxWidth && { maxWidth }),
+        textAlign: align,
     }),
 );
 
@@ -50,6 +64,7 @@ interface ISidePanelListProps<T> {
     columns: SidePanelListColumn<T>[];
     sidePanelHeader: string;
     renderContent: (item: T) => ReactNode;
+    maxHeight?: number;
 }
 
 export const SidePanelList = <T extends { id: string | number }>({
@@ -57,8 +72,13 @@ export const SidePanelList = <T extends { id: string | number }>({
     columns,
     sidePanelHeader,
     renderContent,
+    maxHeight,
 }: ISidePanelListProps<T>) => {
     const [selectedItem, setSelectedItem] = useState<T>(items[0]);
+
+    if (items.length === 0) {
+        return null;
+    }
 
     return (
         <StyledSidePanelListWrapper>
@@ -67,7 +87,7 @@ export const SidePanelList = <T extends { id: string | number }>({
                 sidePanelHeader={sidePanelHeader}
             />
             <StyledSidePanelListBody>
-                <StyledSidePanelHalf>
+                <StyledSidePanelHalfLeft maxHeight={maxHeight}>
                     {items.map((item) => (
                         <SidePanelListItem
                             key={item.id}
@@ -87,10 +107,10 @@ export const SidePanelList = <T extends { id: string | number }>({
                             )}
                         </SidePanelListItem>
                     ))}
-                </StyledSidePanelHalf>
-                <StyledSidePanelHalf>
+                </StyledSidePanelHalfLeft>
+                <StyledSidePanelHalfRight>
                     {renderContent(selectedItem)}
-                </StyledSidePanelHalf>
+                </StyledSidePanelHalfRight>
             </StyledSidePanelListBody>
         </StyledSidePanelListWrapper>
     );

--- a/frontend/src/component/common/SidePanelList/SidePanelList.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelList.tsx
@@ -1,5 +1,7 @@
 import { styled } from '@mui/material';
 import { ReactNode, useState } from 'react';
+import { SidePanelListHeader } from './SidePanelListHeader';
+import { SidePanelListItem } from './SidePanelListItem';
 
 const StyledSidePanelListWrapper = styled('div')({
     display: 'flex',
@@ -13,41 +15,82 @@ const StyledSidePanelListBody = styled('div')({
     flexDirection: 'row',
 });
 
+const StyledSidePanelHalf = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    '& > *': {
+        flex: 1,
+    },
+});
+
+type ColumnAlignment = 'start' | 'end' | 'center';
+
+export const StyledSidePanelListColumn = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'maxWidth' && prop !== 'align',
+})<{ maxWidth?: number; align?: ColumnAlignment }>(
+    ({ theme, maxWidth, align = 'start' }) => ({
+        flex: 1,
+        padding: theme.spacing(2),
+        fontSize: theme.fontSizes.smallBody,
+        justifyContent: align,
+        ...(maxWidth && { maxWidth }),
+    }),
+);
+
+export type SidePanelListColumn<T> = {
+    header: string;
+    maxWidth?: number;
+    align?: ColumnAlignment;
+    cell: (item: T) => ReactNode;
+};
+
 interface ISidePanelListProps<T> {
     items: T[];
-    header: ReactNode;
-    renderItem: (
-        item: T,
-        isSelected: boolean,
-        selectItem: (item: T) => void,
-    ) => ReactNode;
+    columns: SidePanelListColumn<T>[];
+    sidePanelHeader: string;
     renderContent: (item: T) => ReactNode;
 }
 
-export const SidePanelList = <T,>({
+export const SidePanelList = <T extends { id: string | number }>({
     items,
-    header,
-    renderItem,
+    columns,
+    sidePanelHeader,
     renderContent,
 }: ISidePanelListProps<T>) => {
     const [selectedItem, setSelectedItem] = useState<T>(items[0]);
 
     return (
         <StyledSidePanelListWrapper>
-            {header}
+            <SidePanelListHeader
+                columns={columns}
+                sidePanelHeader={sidePanelHeader}
+            />
             <StyledSidePanelListBody>
-                <div className='side-panel-list'>
-                    {items.map((item) =>
-                        renderItem(
-                            item,
-                            item === selectedItem,
-                            setSelectedItem,
-                        ),
-                    )}
-                </div>
-                <div className='side-panel-content'>
+                <StyledSidePanelHalf>
+                    {items.map((item) => (
+                        <SidePanelListItem
+                            key={item.id}
+                            selected={selectedItem.id === item.id}
+                            onClick={() => setSelectedItem(item)}
+                        >
+                            {columns.map(
+                                ({ header, maxWidth, align, cell }) => (
+                                    <StyledSidePanelListColumn
+                                        key={header}
+                                        maxWidth={maxWidth}
+                                        align={align}
+                                    >
+                                        {cell(item)}
+                                    </StyledSidePanelListColumn>
+                                ),
+                            )}
+                        </SidePanelListItem>
+                    ))}
+                </StyledSidePanelHalf>
+                <StyledSidePanelHalf>
                     {renderContent(selectedItem)}
-                </div>
+                </StyledSidePanelHalf>
             </StyledSidePanelListBody>
         </StyledSidePanelListWrapper>
     );

--- a/frontend/src/component/common/SidePanelList/SidePanelList.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelList.tsx
@@ -1,0 +1,3 @@
+export const SidePanelList = () => {
+    return <span>TODO: Implement</span>;
+};

--- a/frontend/src/component/common/SidePanelList/SidePanelList.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelList.tsx
@@ -21,13 +21,13 @@ const StyledSidePanelHalf = styled('div')({
 });
 
 const StyledSidePanelHalfLeft = styled(StyledSidePanelHalf, {
-    shouldForwardProp: (prop) => prop !== 'maxHeight',
-})<{ maxHeight?: number }>(({ theme, maxHeight }) => ({
+    shouldForwardProp: (prop) => prop !== 'height',
+})<{ height?: number }>(({ theme, height }) => ({
     border: `1px solid ${theme.palette.divider}`,
     borderTop: 0,
     borderBottomLeftRadius: theme.shape.borderRadiusMedium,
     overflow: 'auto',
-    ...(maxHeight && { maxHeight }),
+    ...(height && { height }),
 }));
 
 const StyledSidePanelHalfRight = styled(StyledSidePanelHalf)(({ theme }) => ({
@@ -64,7 +64,8 @@ interface ISidePanelListProps<T> {
     columns: SidePanelListColumn<T>[];
     sidePanelHeader: string;
     renderContent: (item: T) => ReactNode;
-    maxHeight?: number;
+    height?: number;
+    listEnd?: ReactNode;
 }
 
 export const SidePanelList = <T extends { id: string | number }>({
@@ -72,13 +73,16 @@ export const SidePanelList = <T extends { id: string | number }>({
     columns,
     sidePanelHeader,
     renderContent,
-    maxHeight,
+    height,
+    listEnd,
 }: ISidePanelListProps<T>) => {
     const [selectedItem, setSelectedItem] = useState<T>(items[0]);
 
     if (items.length === 0) {
         return null;
     }
+
+    const activeItem = selectedItem || items[0];
 
     return (
         <StyledSidePanelListWrapper>
@@ -87,11 +91,11 @@ export const SidePanelList = <T extends { id: string | number }>({
                 sidePanelHeader={sidePanelHeader}
             />
             <StyledSidePanelListBody>
-                <StyledSidePanelHalfLeft maxHeight={maxHeight}>
+                <StyledSidePanelHalfLeft height={height}>
                     {items.map((item) => (
                         <SidePanelListItem
                             key={item.id}
-                            selected={selectedItem.id === item.id}
+                            selected={activeItem.id === item.id}
                             onClick={() => setSelectedItem(item)}
                         >
                             {columns.map(
@@ -107,9 +111,10 @@ export const SidePanelList = <T extends { id: string | number }>({
                             )}
                         </SidePanelListItem>
                     ))}
+                    {listEnd}
                 </StyledSidePanelHalfLeft>
                 <StyledSidePanelHalfRight>
-                    {renderContent(selectedItem)}
+                    {renderContent(activeItem)}
                 </StyledSidePanelHalfRight>
             </StyledSidePanelListBody>
         </StyledSidePanelListWrapper>

--- a/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
@@ -1,29 +1,47 @@
 import { styled } from '@mui/material';
-import { ReactNode } from 'react';
+import {
+    SidePanelListColumn,
+    StyledSidePanelListColumn,
+} from './SidePanelList';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'row',
-    borderRadius: theme.shape.borderRadius,
+    alignItems: 'center',
+    borderRadius: theme.shape.borderRadiusMedium,
     backgroundColor: theme.palette.table.headerBackground,
 }));
 
-const StyledHeaderHalf = styled('div')(({ theme }) => ({
+const StyledHeaderHalf = styled('div')({
     display: 'flex',
     flex: 1,
-}));
+});
 
-interface ISidePanelListHeaderProps {
+interface ISidePanelListHeaderProps<T> {
+    columns: SidePanelListColumn<T>[];
     sidePanelHeader: string;
-    children: ReactNode[];
 }
 
-export const SidePanelListHeader = ({
+export const SidePanelListHeader = <T,>({
+    columns,
     sidePanelHeader,
-    children,
-}: ISidePanelListHeaderProps) => (
+}: ISidePanelListHeaderProps<T>) => (
     <StyledHeader>
-        <StyledHeaderHalf>{children}</StyledHeaderHalf>
-        <StyledHeaderHalf>{sidePanelHeader}</StyledHeaderHalf>
+        <StyledHeaderHalf>
+            {columns.map(({ header, maxWidth, align }) => (
+                <StyledSidePanelListColumn
+                    key={header}
+                    maxWidth={maxWidth}
+                    align={align}
+                >
+                    {header}
+                </StyledSidePanelListColumn>
+            ))}
+        </StyledHeaderHalf>
+        <StyledHeaderHalf>
+            <StyledSidePanelListColumn>
+                {sidePanelHeader}
+            </StyledSidePanelListColumn>
+        </StyledHeaderHalf>
     </StyledHeader>
 );

--- a/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
@@ -8,7 +8,8 @@ const StyledHeader = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: theme.shape.borderRadiusMedium,
+    borderTopLeftRadius: theme.shape.borderRadiusMedium,
+    borderTopRightRadius: theme.shape.borderRadiusMedium,
     backgroundColor: theme.palette.table.headerBackground,
 }));
 

--- a/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelListHeader.tsx
@@ -1,0 +1,29 @@
+import { styled } from '@mui/material';
+import { ReactNode } from 'react';
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.table.headerBackground,
+}));
+
+const StyledHeaderHalf = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flex: 1,
+}));
+
+interface ISidePanelListHeaderProps {
+    sidePanelHeader: string;
+    children: ReactNode[];
+}
+
+export const SidePanelListHeader = ({
+    sidePanelHeader,
+    children,
+}: ISidePanelListHeaderProps) => (
+    <StyledHeader>
+        <StyledHeaderHalf>{children}</StyledHeaderHalf>
+        <StyledHeaderHalf>{sidePanelHeader}</StyledHeaderHalf>
+    </StyledHeader>
+);

--- a/frontend/src/component/common/SidePanelList/SidePanelListItem.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelListItem.tsx
@@ -24,6 +24,7 @@ const StyledItem = styled(Button, {
         textAlign: 'left',
         fontWeight: selected ? theme.fontWeight.bold : theme.fontWeight.medium,
         fontSize: theme.fontSizes.smallBody,
+        overflow: 'auto',
     },
     '&:hover': {
         backgroundColor: selected

--- a/frontend/src/component/common/SidePanelList/SidePanelListItem.tsx
+++ b/frontend/src/component/common/SidePanelList/SidePanelListItem.tsx
@@ -1,0 +1,57 @@
+import { Button, styled } from '@mui/material';
+import { ReactNode } from 'react';
+
+const StyledItemRow = styled('div')(({ theme }) => ({
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledItem = styled(Button, {
+    shouldForwardProp: (prop) => prop !== 'selected',
+})<{ selected: boolean }>(({ theme, selected }) => ({
+    '&.MuiButton-root': {
+        width: '100%',
+        backgroundColor: selected
+            ? theme.palette.secondary.light
+            : 'transparent',
+        borderRight: `${theme.spacing(0.5)} solid ${
+            selected ? theme.palette.background.alternative : 'transparent'
+        }`,
+        padding: 0,
+        borderRadius: 0,
+        justifyContent: 'start',
+        transition: 'background-color 0.2s ease',
+        color: theme.palette.text.primary,
+        textAlign: 'left',
+        fontWeight: selected ? theme.fontWeight.bold : theme.fontWeight.medium,
+        fontSize: theme.fontSizes.smallBody,
+    },
+    '&:hover': {
+        backgroundColor: selected
+            ? theme.palette.secondary.light
+            : theme.palette.neutral.light,
+    },
+    '&.Mui-disabled': {
+        pointerEvents: 'auto',
+    },
+    '&:focus-visible': {
+        outline: `2px solid ${theme.palette.primary.main}`,
+    },
+}));
+
+interface ISidePanelListItemProps<T> {
+    selected: boolean;
+    onClick: () => void;
+    children: ReactNode;
+}
+
+export const SidePanelListItem = <T,>({
+    selected,
+    onClick,
+    children,
+}: ISidePanelListItemProps<T>) => (
+    <StyledItemRow>
+        <StyledItem selected={selected} onClick={onClick}>
+            {children}
+        </StyledItem>
+    </StyledItemRow>
+);

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -20,7 +20,9 @@ import { WeightType } from 'constants/variantTypes';
 import { IFeatureVariantEdit } from '../EnvironmentVariantsModal';
 import { Delete } from '@mui/icons-material';
 
-const LazyReactJSONEditor = React.lazy(() => import('./ReactJSONEditor'));
+const LazyReactJSONEditor = React.lazy(
+    () => import('component/common/ReactJSONEditor/ReactJSONEditor'),
+);
 
 const StyledVariantForm = styled('div')(({ theme }) => ({
     position: 'relative',

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
@@ -92,7 +92,6 @@ export const IncomingWebhooksEventsModal = ({
             <FormTemplate
                 loading={loading && incomingWebhookEvents.length === 0}
                 modal
-                title=''
                 description='Incoming Webhooks allow third-party services to send observable events to Unleash.'
                 documentationLink='https://docs.getunleash.io/reference/incoming-webhooks'
                 documentationLinkLabel='Incoming webhooks documentation'

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { SidePanelList } from 'component/common/SidePanelList/SidePanelList';
+import { SidePanelListHeader } from 'component/common/SidePanelList/SidePanelListHeader';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -35,11 +36,11 @@ const StyledTitle = styled('h1')({
     fontWeight: 'normal',
 });
 
-const StyledForm = styled('form')(() => ({
+const StyledForm = styled('form')({
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-}));
+});
 
 const StyledButtonContainer = styled('div')(({ theme }) => ({
     marginTop: 'auto',
@@ -112,7 +113,19 @@ export const IncomingWebhooksEventsModal = ({
                     </StyledHeaderSubtitle>
                 </StyledHeader>
                 <StyledForm>
-                    <SidePanelList />
+                    <SidePanelList
+                        items={incomingWebhookEvents}
+                        header={
+                            <SidePanelListHeader sidePanelHeader='Payload'>
+                                <div>Date</div>
+                                <div>Token</div>
+                            </SidePanelListHeader>
+                        }
+                        renderItem={(event) => <div>{event.createdAt}</div>}
+                        renderContent={(event) => (
+                            <div>{JSON.stringify(event.payload)}</div>
+                        )}
+                    />
                     <StyledButtonContainer>
                         <Button
                             onClick={() => {

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
@@ -1,0 +1,129 @@
+import { Button, Link, styled } from '@mui/material';
+import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
+import { IIncomingWebhook } from 'interfaces/incomingWebhook';
+import { useIncomingWebhookEvents } from 'hooks/api/getters/useIncomingWebhookEvents/useIncomingWebhookEvents';
+import { useState } from 'react';
+import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { SidePanelList } from 'component/common/SidePanelList/SidePanelList';
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    marginBottom: theme.fontSizes.mainHeader,
+}));
+
+const StyledHeaderRow = styled('div')({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+});
+
+const StyledHeaderSubtitle = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    marginTop: theme.spacing(2),
+    fontSize: theme.fontSizes.smallBody,
+}));
+
+const StyledDescription = styled('p')(({ theme }) => ({
+    color: theme.palette.text.secondary,
+}));
+
+const StyledTitle = styled('h1')({
+    fontWeight: 'normal',
+});
+
+const StyledForm = styled('form')(() => ({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+}));
+
+const StyledButtonContainer = styled('div')(({ theme }) => ({
+    marginTop: 'auto',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    paddingTop: theme.spacing(4),
+}));
+
+const LIMIT = 50;
+
+interface IIncomingWebhooksEventsModalProps {
+    incomingWebhook?: IIncomingWebhook;
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    onOpenConfiguration: () => void;
+}
+
+export const IncomingWebhooksEventsModal = ({
+    incomingWebhook,
+    open,
+    setOpen,
+    onOpenConfiguration,
+}: IIncomingWebhooksEventsModalProps) => {
+    const { uiConfig } = useUiConfig();
+    const [page, setPage] = useState(0);
+    const { incomingWebhookEvents, loading } = useIncomingWebhookEvents(
+        incomingWebhook?.id,
+        LIMIT,
+        page * LIMIT,
+    );
+
+    if (!incomingWebhook) {
+        return null;
+    }
+
+    const title = `Events: ${incomingWebhook.name}`;
+
+    return (
+        <SidebarModal
+            open={open}
+            onClose={() => {
+                setOpen(false);
+            }}
+            label={title}
+        >
+            <FormTemplate
+                loading={loading}
+                modal
+                title=''
+                description='Incoming Webhooks allow third-party services to send observable events to Unleash.'
+                documentationLink='https://docs.getunleash.io/reference/incoming-webhooks'
+                documentationLinkLabel='Incoming webhooks documentation'
+                showGuidance={false}
+            >
+                <StyledHeader>
+                    <StyledHeaderRow>
+                        <StyledTitle>{title}</StyledTitle>
+                        <Link onClick={onOpenConfiguration}>
+                            View configuration
+                        </Link>
+                    </StyledHeaderRow>
+                    <StyledHeaderSubtitle>
+                        <p>
+                            {uiConfig.unleashUrl}/api/incoming-webhook/
+                            {incomingWebhook.name}
+                        </p>
+                        <StyledDescription>
+                            {incomingWebhook.description}
+                        </StyledDescription>
+                    </StyledHeaderSubtitle>
+                </StyledHeader>
+                <StyledForm>
+                    <SidePanelList />
+                    <StyledButtonContainer>
+                        <Button
+                            onClick={() => {
+                                setOpen(false);
+                            }}
+                        >
+                            Close
+                        </Button>
+                    </StyledButtonContainer>
+                </StyledForm>
+            </FormTemplate>
+        </SidebarModal>
+    );
+};

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
@@ -2,7 +2,7 @@ import { Button, Link, styled } from '@mui/material';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { IIncomingWebhook } from 'interfaces/incomingWebhook';
 import { useIncomingWebhookEvents } from 'hooks/api/getters/useIncomingWebhookEvents/useIncomingWebhookEvents';
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, lazy } from 'react';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { SidePanelList } from 'component/common/SidePanelList/SidePanelList';
@@ -55,8 +55,6 @@ const StyledButtonContainer = styled('div')(({ theme }) => ({
     paddingTop: theme.spacing(4),
 }));
 
-const LIMIT = 50;
-
 interface IIncomingWebhooksEventsModalProps {
     incomingWebhook?: IIncomingWebhook;
     open: boolean;
@@ -72,12 +70,10 @@ export const IncomingWebhooksEventsModal = ({
 }: IIncomingWebhooksEventsModalProps) => {
     const { uiConfig } = useUiConfig();
     const { locationSettings } = useLocationSettings();
-    const [page, setPage] = useState(0);
-    const { incomingWebhookEvents, loading } = useIncomingWebhookEvents(
-        incomingWebhook?.id,
-        LIMIT,
-        page * LIMIT,
-    );
+    const { incomingWebhookEvents, hasMore, loadMore, loading } =
+        useIncomingWebhookEvents(incomingWebhook?.id, 20, {
+            refreshInterval: 5000,
+        });
 
     if (!incomingWebhook) {
         return null;
@@ -94,7 +90,7 @@ export const IncomingWebhooksEventsModal = ({
             label={title}
         >
             <FormTemplate
-                loading={loading}
+                loading={loading && incomingWebhookEvents.length === 0}
                 modal
                 title=''
                 description='Incoming Webhooks allow third-party services to send observable events to Unleash.'
@@ -121,7 +117,7 @@ export const IncomingWebhooksEventsModal = ({
                 </StyledHeader>
                 <StyledForm>
                     <SidePanelList
-                        maxHeight={960}
+                        height={960}
                         items={incomingWebhookEvents}
                         columns={[
                             {
@@ -148,6 +144,16 @@ export const IncomingWebhooksEventsModal = ({
                                 />
                             </Suspense>
                         )}
+                        listEnd={
+                            <ConditionallyRender
+                                condition={hasMore}
+                                show={
+                                    <Button onClick={loadMore}>
+                                        Load more
+                                    </Button>
+                                }
+                            />
+                        }
                     />
                     <ConditionallyRender
                         condition={incomingWebhookEvents.length === 0}

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksEvents/IncomingWebhooksEventsModal.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { SidePanelList } from 'component/common/SidePanelList/SidePanelList';
-import { SidePanelListHeader } from 'component/common/SidePanelList/SidePanelListHeader';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -115,13 +114,17 @@ export const IncomingWebhooksEventsModal = ({
                 <StyledForm>
                     <SidePanelList
                         items={incomingWebhookEvents}
-                        header={
-                            <SidePanelListHeader sidePanelHeader='Payload'>
-                                <div>Date</div>
-                                <div>Token</div>
-                            </SidePanelListHeader>
-                        }
-                        renderItem={(event) => <div>{event.createdAt}</div>}
+                        columns={[
+                            {
+                                header: 'Date',
+                                cell: (event) => event.createdAt,
+                            },
+                            {
+                                header: 'Token',
+                                cell: (event) => event.tokenName,
+                            },
+                        ]}
+                        sidePanelHeader='Payload'
                         renderContent={(event) => (
                             <div>{JSON.stringify(event.payload)}</div>
                         )}

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksModal/IncomingWebhooksModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksModal/IncomingWebhooksModal.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect } from 'react';
-import { Button, styled } from '@mui/material';
+import { Button, Link, styled } from '@mui/material';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
@@ -17,6 +17,18 @@ import {
     TokenGeneration,
     useIncomingWebhooksForm,
 } from './IncomingWebhooksForm/useIncomingWebhooksForm';
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    marginBottom: theme.fontSizes.mainHeader,
+}));
+
+const StyledTitle = styled('h1')({
+    fontWeight: 'normal',
+});
 
 const StyledForm = styled('form')(() => ({
     display: 'flex',
@@ -40,6 +52,7 @@ interface IIncomingWebhooksModalProps {
     open: boolean;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
     newToken: (token: string) => void;
+    onOpenEvents: () => void;
 }
 
 export const IncomingWebhooksModal = ({
@@ -47,6 +60,7 @@ export const IncomingWebhooksModal = ({
     open,
     setOpen,
     newToken,
+    onOpenEvents,
 }: IIncomingWebhooksModalProps) => {
     const { refetch } = useIncomingWebhooks();
     const { addIncomingWebhook, updateIncomingWebhook, loading } =
@@ -137,12 +151,16 @@ export const IncomingWebhooksModal = ({
             <FormTemplate
                 loading={loading}
                 modal
-                title={title}
+                title=''
                 description='Incoming Webhooks allow third-party services to send observable events to Unleash.'
                 documentationLink='https://docs.getunleash.io/reference/incoming-webhooks'
                 documentationLinkLabel='Incoming webhooks documentation'
                 formatApiCode={formatApiCode}
             >
+                <StyledHeader>
+                    <StyledTitle>{title}</StyledTitle>
+                    <Link onClick={onOpenEvents}>View events</Link>
+                </StyledHeader>
                 <StyledForm onSubmit={onSubmit}>
                     <IncomingWebhooksForm
                         incomingWebhook={incomingWebhook}

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksModal/IncomingWebhooksModal.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksModal/IncomingWebhooksModal.tsx
@@ -151,7 +151,6 @@ export const IncomingWebhooksModal = ({
             <FormTemplate
                 loading={loading}
                 modal
-                title=''
                 description='Incoming Webhooks allow third-party services to send observable events to Unleash.'
                 documentationLink='https://docs.getunleash.io/reference/incoming-webhooks'
                 documentationLinkLabel='Incoming webhooks documentation'

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksTable/IncomingWebhooksActionsCell.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksTable/IncomingWebhooksActionsCell.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
-import { Delete, Edit } from '@mui/icons-material';
+import { Delete, Edit, Visibility } from '@mui/icons-material';
 import { PermissionHOC } from 'component/common/PermissionHOC/PermissionHOC';
 import { ADMIN } from 'component/providers/AccessProvider/permissions';
 import { defaultBorderRadius } from 'themes/themeStyles';
@@ -26,6 +26,7 @@ const StyledBoxCell = styled(Box)({
 interface IIncomingWebhooksActionsCellProps {
     incomingWebhookId: number;
     onCopyToClipboard: (event: React.SyntheticEvent) => void;
+    onOpenEvents: (event: React.SyntheticEvent) => void;
     onEdit: (event: React.SyntheticEvent) => void;
     onDelete: (event: React.SyntheticEvent) => void;
 }
@@ -33,6 +34,7 @@ interface IIncomingWebhooksActionsCellProps {
 export const IncomingWebhooksActionsCell = ({
     incomingWebhookId,
     onCopyToClipboard,
+    onOpenEvents,
     onEdit,
     onDelete,
 }: IIncomingWebhooksActionsCellProps) => {
@@ -94,6 +96,24 @@ export const IncomingWebhooksActionsCell = ({
                             <Typography variant='body2'>Copy URL</Typography>
                         </ListItemText>
                     </MenuItem>
+                    <PermissionHOC permission={ADMIN}>
+                        {({ hasAccess }) => (
+                            <MenuItem
+                                sx={defaultBorderRadius}
+                                onClick={onOpenEvents}
+                                disabled={!hasAccess}
+                            >
+                                <ListItemIcon>
+                                    <Visibility />
+                                </ListItemIcon>
+                                <ListItemText>
+                                    <Typography variant='body2'>
+                                        View events
+                                    </Typography>
+                                </ListItemText>
+                            </MenuItem>
+                        )}
+                    </PermissionHOC>
                     <PermissionHOC permission={ADMIN}>
                         {({ hasAccess }) => (
                             <MenuItem

--- a/frontend/src/component/incomingWebhooks/IncomingWebhooksTable/IncomingWebhooksTable.tsx
+++ b/frontend/src/component/incomingWebhooks/IncomingWebhooksTable/IncomingWebhooksTable.tsx
@@ -22,6 +22,7 @@ import { IncomingWebhookTokensCell } from './IncomingWebhooksTokensCell';
 import { IncomingWebhooksModal } from '../IncomingWebhooksModal/IncomingWebhooksModal';
 import { IncomingWebhooksTokensDialog } from '../IncomingWebhooksModal/IncomingWebhooksForm/IncomingWebhooksTokens/IncomingWebhooksTokensDialog';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
+import { IncomingWebhooksEventsModal } from '../IncomingWebhooksEvents/IncomingWebhooksEventsModal';
 
 interface IIncomingWebhooksTableProps {
     modalOpen: boolean;
@@ -48,6 +49,8 @@ export const IncomingWebhooksTable = ({
     const [tokenDialog, setTokenDialog] = useState(false);
     const [newToken, setNewToken] = useState('');
     const [deleteOpen, setDeleteOpen] = useState(false);
+
+    const [eventsModalOpen, setEventsModalOpen] = useState(false);
 
     const onToggleIncomingWebhook = async (
         incomingWebhook: IIncomingWebhook,
@@ -174,6 +177,10 @@ export const IncomingWebhooksTable = ({
                                 title: 'Copied to clipboard',
                             });
                         }}
+                        onOpenEvents={() => {
+                            setSelectedIncomingWebhook(incomingWebhook);
+                            setEventsModalOpen(true);
+                        }}
                         onEdit={() => {
                             setSelectedIncomingWebhook(incomingWebhook);
                             setModalOpen(true);
@@ -247,6 +254,19 @@ export const IncomingWebhooksTable = ({
                 newToken={(token: string) => {
                     setNewToken(token);
                     setTokenDialog(true);
+                }}
+                onOpenEvents={() => {
+                    setModalOpen(false);
+                    setEventsModalOpen(true);
+                }}
+            />
+            <IncomingWebhooksEventsModal
+                incomingWebhook={selectedIncomingWebhook}
+                open={eventsModalOpen}
+                setOpen={setEventsModalOpen}
+                onOpenConfiguration={() => {
+                    setEventsModalOpen(false);
+                    setModalOpen(true);
                 }}
             />
             <IncomingWebhooksTokensDialog

--- a/frontend/src/hooks/api/getters/useIncomingWebhookEvents/useIncomingWebhookEvents.ts
+++ b/frontend/src/hooks/api/getters/useIncomingWebhookEvents/useIncomingWebhookEvents.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { formatApiPath } from 'utils/formatPath';
+import handleErrorResponses from '../httpErrorResponseHandler';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
+import useUiConfig from '../useUiConfig/useUiConfig';
+import { IIncomingWebhookEvent } from 'interfaces/incomingWebhook';
+import { useUiFlag } from 'hooks/useUiFlag';
+
+const ENDPOINT = 'api/admin/incoming-webhooks';
+
+const DEFAULT_DATA = {
+    incomingWebhookEvents: [],
+};
+
+export const useIncomingWebhookEvents = (
+    incomingWebhookId?: number,
+    limit = 50,
+    offset = 0,
+) => {
+    const { isEnterprise } = useUiConfig();
+    const incomingWebhooksEnabled = useUiFlag('incomingWebhooks');
+
+    const { data, error, mutate } = useConditionalSWR<{
+        incomingWebhookEvents: IIncomingWebhookEvent[];
+    }>(
+        Boolean(incomingWebhookId) && isEnterprise() && incomingWebhooksEnabled,
+        DEFAULT_DATA,
+        formatApiPath(
+            `${ENDPOINT}/${incomingWebhookId}/events?limit=${limit}&offset=${offset}`,
+        ),
+        fetcher,
+    );
+
+    return useMemo(
+        () => ({
+            incomingWebhookEvents: data?.incomingWebhookEvents ?? [],
+            loading: !error && !data,
+            refetch: () => mutate(),
+            error,
+        }),
+        [data, error, mutate],
+    );
+};
+
+const fetcher = (path: string) => {
+    return fetch(path)
+        .then(handleErrorResponses('Incoming webhook events'))
+        .then((res) => res.json());
+};

--- a/frontend/src/interfaces/incomingWebhook.ts
+++ b/frontend/src/interfaces/incomingWebhook.ts
@@ -15,3 +15,14 @@ export interface IIncomingWebhookToken {
     createdAt: string;
     createdByUserId: number;
 }
+
+type EventSource = 'incoming-webhook';
+
+export interface IIncomingWebhookEvent {
+    id: number;
+    payload: Record<string, unknown>;
+    createdAt: string;
+    source: EventSource;
+    sourceId: number;
+    tokenName: string;
+}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1937/incoming-webhook-events-ui

This PR implements the UI for incoming webhook events.

We're also introducing a new `SidePanelList` component that we'll be able to reuse when we tackle action set events. This PR also promotes `ReactJSONEditor` to a common component and adapts it slightly for this use case.

![image](https://github.com/Unleash/unleash/assets/14320932/b1abc2e0-3971-4882-b6f6-0ae48d1523d5)

![image](https://github.com/Unleash/unleash/assets/14320932/ce5c31e4-650a-4df5-a966-2ce06fd6baa8)

We're refreshing the events view every 5s, so if you're monitoring events for a specific incoming webhook you can see the latest ones coming in.
We load 20 (configurable through the hook) events by default. Everytime you reach the end of the list you can load 20 more events until you reach the end of the event list.

![image](https://github.com/Unleash/unleash/assets/14320932/94f187a1-8b0f-4138-8dbc-d3ebc9914bfd)
