### PR TITLE
fix: only show visible environments for that project in actions

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsActionItem.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsActionItem.tsx
@@ -1,11 +1,11 @@
 import { IconButton, Tooltip, styled } from '@mui/material';
 import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
 import { Delete } from '@mui/icons-material';
-import { useProjectEnvironments } from 'hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import { ActionsActionState } from './useProjectActionsForm';
 import { ProjectActionsFormItem } from './ProjectActionsFormItem';
+import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 const StyledItemRow = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -31,7 +31,12 @@ export const ProjectActionsActionItem = ({
 }) => {
     const { action: actionName } = action;
     const projectId = useRequiredPathParam('projectId');
-    const environments = useProjectEnvironments(projectId);
+    const { project } = useProjectOverview(projectId);
+
+    const environments = project.environments.map(
+        ({ environment }) => environment,
+    );
+
     const { features } = useFeatureSearch({ project: `IS:${projectId}` });
 
     const header = (
@@ -78,9 +83,9 @@ export const ProjectActionsActionItem = ({
                     <GeneralSelect
                         label='Environment'
                         name='environment'
-                        options={environments.environments.map((env) => ({
-                            label: env.name,
-                            key: env.name,
+                        options={environments.map((environment) => ({
+                            label: environment,
+                            key: environment,
                         }))}
                         value={action.executionParams.environment as string}
                         onChange={(selected) =>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-1969/actions-form-only-show-environments-scoped-to-the-current-project

Filters the environment options in actions to only show environments that are currently visible for that project, safeguarding users from configuring actions for invalid environments.

![image](https://github.com/Unleash/unleash/assets/14320932/115cc9cd-99a2-4863-aec0-8264459ef18a)