### PR TITLE
fix: minimum pagination size

### DIFF
--- a/frontend/src/component/common/Table/PaginatedTable/PaginatedTable.tsx
+++ b/frontend/src/component/common/Table/PaginatedTable/PaginatedTable.tsx
@@ -103,7 +103,7 @@ export const PaginatedTable = <T extends object>({
             <ConditionallyRender
                 condition={
                     tableInstance.getRowModel().rows.length > 0 &&
-                    (totalItems || 0) > pagination.pageSize
+                    (totalItems || 0) > 25
                 }
                 show={
                     <StickyPaginationBar


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When all paginated table results fit into a table (e.g. 65 items with 75 rows selected) we still need to show the pagination because someone may change rows size to 25. Out new heuristic for showing pagination is more than 25 results.
<img width="818" alt="Screenshot 2024-02-22 at 19 12 26" src="https://github.com/Unleash/unleash/assets/1394682/150a6a89-f12d-4d2c-9a42-0486192de706">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
