### PR TITLE
chore: set proxy-repo interval to 45mins instead of 20secs

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -148,7 +148,7 @@ exports[`should create default config 1`] = `
     },
   },
   "frontendApi": {
-    "refreshIntervalInMs": 20000,
+    "refreshIntervalInMs": 2700000,
   },
   "frontendApiOrigins": [
     "*",

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -24,7 +24,11 @@ import {
 import { getDefaultLogProvider, LogLevel, validateLogProvider } from './logger';
 import { defaultCustomAuthDenyAll } from './default-custom-auth-deny-all';
 import { formatBaseUri } from './util/format-base-uri';
-import { hoursToMilliseconds, secondsToMilliseconds } from 'date-fns';
+import {
+    hoursToMilliseconds,
+    minutesToMilliseconds,
+    secondsToMilliseconds,
+} from 'date-fns';
 import EventEmitter from 'events';
 import {
     ApiTokenType,
@@ -514,7 +518,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     const frontendApi = options.frontendApi || {
         refreshIntervalInMs: parseEnvVarNumber(
             process.env.FRONTEND_API_REFRESH_INTERVAL_MS,
-            20000,
+            minutesToMilliseconds(45),
         ),
     };
 


### PR DESCRIPTION
## About the changes

Since we're polling for updates to max revision id every second, and listening for update events for revision id in the proxy repository then running a refresh interval of 20secs in the proxy repo refresh seems excessive.

This PR changes the frequency of the refresh to once per 45mins.