### PR TITLE
feat: simplified insights data fetching

### DIFF
--- a/frontend/src/component/executiveDashboard/FlagsProjectChart/FlagsProjectChart.tsx
+++ b/frontend/src/component/executiveDashboard/FlagsProjectChart/FlagsProjectChart.tsx
@@ -11,7 +11,18 @@ interface IFlagsProjectChartProps {
 export const FlagsProjectChart: VFC<IFlagsProjectChartProps> = ({
     projectFlagTrends,
 }) => {
-    const data = useProjectChartData(projectFlagTrends, 'total');
+    const data = useProjectChartData(projectFlagTrends);
 
-    return <LineChart data={data} isLocalTooltip />;
+    return (
+        <LineChart
+            data={data}
+            isLocalTooltip
+            overrideOptions={{
+                parsing: {
+                    yAxisKey: 'total',
+                    xAxisKey: 'date',
+                },
+            }}
+        />
+    );
 };

--- a/frontend/src/component/executiveDashboard/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/executiveDashboard/LineChart/LineChartComponent.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useMemo, useState, type VFC } from 'react';
+import {
+    type ReactNode,
+    useMemo,
+    useState,
+    type VFC,
+    ComponentProps,
+} from 'react';
 import {
     CategoryScale,
     LinearScale,
@@ -10,7 +16,6 @@ import {
     Chart,
     Filler,
     type ChartData,
-    type ScatterDataPoint,
     TooltipModel,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
@@ -223,28 +228,38 @@ const customHighlightPlugin = {
 };
 
 const LineChartComponent: VFC<{
-    data: ChartData<'line', (number | ScatterDataPoint | null)[], unknown>;
+    data: ChartData<any, unknown>;
     aspectRatio?: number;
     cover?: ReactNode;
     isLocalTooltip?: boolean;
+    overrideOptions?: ComponentProps<typeof Line>['options'];
     TooltipComponent?: ({
         tooltip,
     }: { tooltip: TooltipState | null }) => ReturnType<VFC>;
-}> = ({ data, aspectRatio, cover, isLocalTooltip, TooltipComponent }) => {
+}> = ({
+    data,
+    aspectRatio,
+    cover,
+    isLocalTooltip,
+    overrideOptions,
+    TooltipComponent,
+}) => {
     const theme = useTheme();
     const { locationSettings } = useLocationSettings();
 
     const [tooltip, setTooltip] = useState<null | TooltipState>(null);
     const options = useMemo(
-        () =>
-            createOptions(
+        () => ({
+            ...createOptions(
                 theme,
                 locationSettings,
                 setTooltip,
                 Boolean(cover),
                 isLocalTooltip,
             ),
-        [theme, locationSettings],
+            ...overrideOptions,
+        }),
+        [theme, locationSettings, overrideOptions],
     );
 
     return (

--- a/frontend/src/component/executiveDashboard/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/executiveDashboard/LineChart/LineChartComponent.tsx
@@ -1,10 +1,4 @@
-import {
-    type ReactNode,
-    useMemo,
-    useState,
-    type VFC,
-    ComponentProps,
-} from 'react';
+import { type ReactNode, useMemo, useState, type VFC } from 'react';
 import {
     CategoryScale,
     LinearScale,
@@ -17,6 +11,7 @@ import {
     Filler,
     type ChartData,
     TooltipModel,
+    ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-adapter-date-fns';
@@ -228,11 +223,11 @@ const customHighlightPlugin = {
 };
 
 const LineChartComponent: VFC<{
-    data: ChartData<any, unknown>;
+    data: ChartData<'line', unknown>;
     aspectRatio?: number;
     cover?: ReactNode;
     isLocalTooltip?: boolean;
-    overrideOptions?: ComponentProps<typeof Line>['options'];
+    overrideOptions?: ChartOptions<'line'>;
     TooltipComponent?: ({
         tooltip,
     }: { tooltip: TooltipState | null }) => ReturnType<VFC>;

--- a/frontend/src/component/executiveDashboard/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/executiveDashboard/ProjectHealthChart/ProjectHealthChart.tsx
@@ -74,13 +74,19 @@ const TooltipComponent: VFC<{ tooltip: TooltipState | null }> = ({
 export const ProjectHealthChart: VFC<IFlagsProjectChartProps> = ({
     projectFlagTrends,
 }) => {
-    const data = useProjectChartData(projectFlagTrends, 'health');
+    const data = useProjectChartData(projectFlagTrends);
 
     return (
         <LineChart
             data={data}
             isLocalTooltip
             TooltipComponent={TooltipComponent}
+            overrideOptions={{
+                parsing: {
+                    yAxisKey: 'health',
+                    xAxisKey: 'date',
+                },
+            }}
         />
     );
 };

--- a/frontend/src/component/executiveDashboard/TimeToProductionChart/TimeToProductionChart.tsx
+++ b/frontend/src/component/executiveDashboard/TimeToProductionChart/TimeToProductionChart.tsx
@@ -11,7 +11,18 @@ interface IFlagsProjectChartProps {
 export const TimeToProductionChart: VFC<IFlagsProjectChartProps> = ({
     projectFlagTrends,
 }) => {
-    const data = useProjectChartData(projectFlagTrends, 'timeToProduction');
+    const data = useProjectChartData(projectFlagTrends);
 
-    return <LineChart data={data} isLocalTooltip />;
+    return (
+        <LineChart
+            data={data}
+            isLocalTooltip
+            overrideOptions={{
+                parsing: {
+                    yAxisKey: 'timeToProduction',
+                    xAxisKey: 'date',
+                },
+            }}
+        />
+    );
 };

--- a/frontend/src/component/executiveDashboard/useProjectChartData.ts
+++ b/frontend/src/component/executiveDashboard/useProjectChartData.ts
@@ -8,10 +8,7 @@ import { useTheme } from '@mui/material';
 
 type ProjectFlagTrends = ExecutiveSummarySchema['projectFlagTrends'];
 
-export const useProjectChartData = (
-    projectFlagTrends: ProjectFlagTrends,
-    field: 'timeToProduction' | 'total' | 'health',
-) => {
+export const useProjectChartData = (projectFlagTrends: ProjectFlagTrends) => {
     const theme = useTheme();
 
     const data = useMemo(() => {
@@ -30,9 +27,7 @@ export const useProjectChartData = (
                 const color = getProjectColor(project);
                 return {
                     label: project,
-                    data: trends.map((item) => {
-                        return item[field] || 0;
-                    }),
+                    data: trends,
                     borderColor: color,
                     backgroundColor: color,
                     fill: false,
@@ -40,15 +35,7 @@ export const useProjectChartData = (
             },
         );
 
-        const objectKeys = Object.keys(groupedFlagTrends);
-
-        const firstElementTrends = groupedFlagTrends[objectKeys[0]] || [];
-        const firstElementsDates = firstElementTrends.map((item) => item.date);
-
-        return {
-            labels: firstElementsDates,
-            datasets,
-        };
+        return { datasets };
     }, [theme, projectFlagTrends]);
 
     return data;


### PR DESCRIPTION
Simplify insights data fetching - let charts pick data instead of preparing labels in hook.

This also **allows access other data-point related properties for use in a tooltip**