### PR TITLE
idea 1: api token consistency scope using flags

### DIFF
--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -35,7 +35,7 @@ const contextFrom = (
     // req_user_agent: 'unleash-edge-16.0.4'
     return {
         req_path: req.path,
-        req_user_agent: req.get('User-Agent') ?? '',
+        req_user_agent: req.get ? req.get('User-Agent') ?? '' : '',
     };
 };
 

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -2,6 +2,7 @@ import { ApiTokenType } from '../types/models/api-token';
 import { IUnleashConfig } from '../types/option';
 import { IApiRequest, IAuthRequest } from '../routes/unleash-types';
 import { IUnleashServices } from '../server-impl';
+import { IFlagContext } from '../types';
 
 const isClientApi = ({ path }) => {
     return path && path.indexOf('/api/client') > -1;
@@ -24,6 +25,18 @@ const isProxyApi = ({ path }) => {
         path.indexOf('/api/production/proxy') > -1 ||
         path.indexOf('/api/frontend') > -1
     );
+};
+
+const contextFrom = (
+    req: IAuthRequest<any, any, any, any> | IApiRequest<any, any, any, any>,
+): IFlagContext | undefined => {
+    // this is what we'd get from edge:
+    // req_path: '/api/client/features',
+    // req_user_agent: 'unleash-edge-16.0.4'
+    return {
+        req_path: req.path,
+        req_user_agent: req.get('User-Agent') ?? '',
+    };
 };
 
 export const TOKEN_TYPE_ERROR_MESSAGE =
@@ -55,7 +68,10 @@ const apiAccessMiddleware = (
             const apiToken = req.header('authorization');
             if (!apiToken?.startsWith('user:')) {
                 const apiUser = apiToken
-                    ? await apiTokenService.getUserForToken(apiToken)
+                    ? await apiTokenService.getUserForToken(
+                          apiToken,
+                          contextFrom(req),
+                      )
                     : undefined;
                 const { CLIENT, FRONTEND } = ApiTokenType;
 

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -36,7 +36,8 @@ const contextFrom = (
     return {
         reqPath: req.path,
         reqUserAgent: req.get ? req.get('User-Agent') ?? '' : '',
-        reqAppName: req.headers['unleash-appname'] ?? req.query.appName,
+        reqAppName:
+            req.headers?.['unleash-appname'] ?? req.query?.appName ?? '',
     };
 };
 

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -34,8 +34,9 @@ const contextFrom = (
     // req_path: '/api/client/features',
     // req_user_agent: 'unleash-edge-16.0.4'
     return {
-        req_path: req.path,
-        req_user_agent: req.get ? req.get('User-Agent') ?? '' : '',
+        reqPath: req.path,
+        reqUserAgent: req.get ? req.get('User-Agent') ?? '' : '',
+        reqAppName: req.headers['unleash-appname'] ?? req.query.appName,
     };
 };
 

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -192,7 +192,7 @@ test('getUserForToken should get a user with admin token user id and token name'
 });
 
 describe('When token is added by another instance', () => {
-    const setup = async (options?: IUnleashOptions) => {
+    const setup = (options?: IUnleashOptions) => {
         const token: IApiTokenCreate = {
             environment: 'default',
             projects: ['*'],
@@ -218,7 +218,7 @@ describe('When token is added by another instance', () => {
         };
     };
     test('should not return the token when query db flag is disabled', async () => {
-        const { apiTokenService, apiTokenStore, token } = await setup();
+        const { apiTokenService, apiTokenStore, token } = setup();
 
         // simulate this token being inserted by another instance (apiTokenService does not know about it)
         apiTokenStore.insert(token);
@@ -228,7 +228,7 @@ describe('When token is added by another instance', () => {
     });
 
     test('should return the token when query db flag is enabled', async () => {
-        const { apiTokenService, apiTokenStore, token } = await setup({
+        const { apiTokenService, apiTokenStore, token } = setup({
             experimental: {
                 flags: {
                     queryMissingTokens: true,

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -209,8 +209,7 @@ describe('When token is added by another instance', () => {
         const apiTokenService = new ApiTokenService(
             { apiTokenStore, environmentStore },
             config,
-            // @ts-expect-error not using event service
-            undefined,
+            createFakeEventsService(config),
         );
         return {
             apiTokenService,

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -24,6 +24,7 @@ import {
     ApiTokenCreatedEvent,
     ApiTokenDeletedEvent,
     ApiTokenUpdatedEvent,
+    IFlagContext,
     IFlagResolver,
     IUser,
     SYSTEM_USER,
@@ -162,6 +163,7 @@ export class ApiTokenService {
 
     public async getUserForToken(
         secret: string,
+        flagContext?: IFlagContext, // temporarily added, expected from the middleware
     ): Promise<IApiUser | undefined> {
         if (!secret) {
             return undefined;
@@ -183,7 +185,11 @@ export class ApiTokenService {
             );
         }
 
-        if (!token && this.flagResolver.isEnabled('queryMissingTokens')) {
+        if (flagContext) console.log(flagContext);
+        if (
+            !token &&
+            this.flagResolver.isEnabled('queryMissingTokens', flagContext)
+        ) {
             token = await this.store.get(secret);
             if (token) {
                 this.activeTokens.push(token);

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -185,7 +185,6 @@ export class ApiTokenService {
             );
         }
 
-        if (flagContext) console.log(flagContext);
         if (
             !token &&
             this.flagResolver.isEnabled('queryMissingTokens', flagContext)


### PR DESCRIPTION
## About the changes
This PR tries to limit the scope the impact of this change to just requests from edge. This has to be configured as a constraint in the feature flag that controls the rollout of this feature.

This is an option to https://github.com/Unleash/unleash/pull/6356 which is more flexible and can be used for other purposes.