### PR TITLE
Api token consistency scope to edge

### DIFF
--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -26,6 +26,13 @@ const isProxyApi = ({ path }) => {
     );
 };
 
+const isEdgeClientFeaturesRequest = (req: IAuthRequest | IApiRequest) => {
+    return (
+        req.path.endsWith('/api/client/features') &&
+        (req.get('User-Agent') ?? '').startsWith('unleash-edge')
+    );
+};
+
 export const TOKEN_TYPE_ERROR_MESSAGE =
     'invalid token: expected a different token type for this endpoint';
 
@@ -55,7 +62,10 @@ const apiAccessMiddleware = (
             const apiToken = req.header('authorization');
             if (!apiToken?.startsWith('user:')) {
                 const apiUser = apiToken
-                    ? await apiTokenService.getUserForToken(apiToken)
+                    ? await apiTokenService.getUserForToken(
+                          apiToken,
+                          isEdgeClientFeaturesRequest(req),
+                      )
                     : undefined;
                 const { CLIENT, FRONTEND } = ApiTokenType;
 

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -162,6 +162,7 @@ export class ApiTokenService {
 
     public async getUserForToken(
         secret: string,
+        edgeRequest = false,
     ): Promise<IApiUser | undefined> {
         if (!secret) {
             return undefined;
@@ -183,7 +184,11 @@ export class ApiTokenService {
             );
         }
 
-        if (!token && this.flagResolver.isEnabled('queryMissingTokens')) {
+        if (
+            !token &&
+            edgeRequest &&
+            this.flagResolver.isEnabled('queryMissingTokens')
+        ) {
             token = await this.store.get(secret);
             if (token) {
                 this.activeTokens.push(token);


### PR DESCRIPTION
## About the changes
Alternative to https://github.com/Unleash/unleash/pull/6354 this is more specific and less flexible. The reason why this is valid is because we don't want this to become a feature. A least not because of the problem with edge, as we **may** have documentation explaining that tokens are eventually consistent.