### PR TITLE
Fix/segments can not be deleted when archived

### DIFF
--- a/frontend/src/component/segments/SegmentDelete/SegmentDeleteConfirm/SegmentDeleteConfirm.tsx
+++ b/frontend/src/component/segments/SegmentDelete/SegmentDeleteConfirm/SegmentDeleteConfirm.tsx
@@ -3,7 +3,7 @@ import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import Input from 'component/common/Input/Input';
 import { ISegment } from 'interfaces/segment';
 import { SEGMENT_DIALOG_NAME_ID } from 'utils/testIds';
-import { styled } from '@mui/material';
+import { Alert, styled } from '@mui/material';
 
 const StyledInput = styled(Input)(({ theme }) => ({
     marginTop: theme.spacing(2),
@@ -46,6 +46,11 @@ export const SegmentDeleteConfirm = ({
             onClose={handleCancel}
             formId={formId}
         >
+            <Alert sx={{ marginBottom: 2 }} severity='warning'>
+                Deleted segments may be referenced in strategies if the feature
+                flag is archived. Removing the segment will also remove the
+                segments from strategies of archived flags.
+            </Alert>
             <p>
                 In order to delete this segment, please enter the name of the
                 segment in the field below: <strong>{segment?.name}</strong>

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -814,7 +814,14 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 `${T.featureStrategySegment}.feature_strategy_id`,
                 `${T.featureStrategies}.id`,
             )
-            .where(`${T.featureStrategySegment}.segment_id`, '=', segmentId);
+            .join(
+                T.features,
+                `${T.features}.name`,
+                `${T.featureStrategies}.feature_name`,
+            )
+            .where(`${T.featureStrategySegment}.segment_id`, '=', segmentId)
+            .andWhere(`${T.features}.archived_at`, 'IS', null);
+
         stopTimer();
         return rows.map(mapRow);
     }

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -583,6 +583,35 @@ test('Should show usage in features and projects', async () => {
     ]);
 });
 
+test.only('Should not show usage in features and and projects when toggle is archived', async () => {
+    await app.createSegment({
+        name: 'a',
+        constraints: [],
+    });
+    const toggle = mockFeatureToggle();
+    await createFeatureToggle(app, toggle);
+    const [segment] = await fetchSegments();
+    await addStrategyToFeatureEnv(
+        app,
+        { ...toggle.strategies[0] },
+        'default',
+        toggle.name,
+    );
+    const [feature] = await fetchFeatures();
+    //@ts-ignore
+    await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
+
+    await app.archiveFeature(toggle.name);
+
+    const segments = await fetchSegments();
+    expect(segments).toMatchObject([
+        {
+            usedInFeatures: 0,
+            usedInProjects: 0,
+        },
+    ]);
+});
+
 describe('detect strategy usage in change requests', () => {
     const CR_TITLE = 'My change request';
     const CR_ID = 54321;

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -583,6 +583,33 @@ test('Should show usage in features and projects', async () => {
     ]);
 });
 
+test('Should return all segments when feature toggle using segment is archived', async () => {
+    for (let i = 0; i < 5; i++) {
+        await app.createSegment({
+            name: i,
+            constraints: [],
+        });
+    }
+
+    const toggle = mockFeatureToggle();
+    await createFeatureToggle(app, toggle);
+
+    const [segment] = await fetchSegments();
+    await addStrategyToFeatureEnv(
+        app,
+        { ...toggle.strategies[0] },
+        'default',
+        toggle.name,
+    );
+    const [feature] = await fetchFeatures();
+    //@ts-ignore
+    await addSegmentsToStrategy([segment.id], feature.strategies[0].id);
+    await app.archiveFeature(toggle.name);
+
+    const segments = await fetchSegments();
+    expect(segments.length).toBe(5);
+});
+
 test('Should not show usage in features and and projects when toggle is archived', async () => {
     await app.createSegment({
         name: 'a',

--- a/src/test/e2e/api/admin/segment.e2e.test.ts
+++ b/src/test/e2e/api/admin/segment.e2e.test.ts
@@ -583,7 +583,7 @@ test('Should show usage in features and projects', async () => {
     ]);
 });
 
-test.only('Should not show usage in features and and projects when toggle is archived', async () => {
+test('Should not show usage in features and and projects when toggle is archived', async () => {
     await app.createSegment({
         name: 'a',
         constraints: [],


### PR DESCRIPTION
This PR makes a change to the logic of segments: 

(1) You can now delete segments that are being referenced in strategies on archived toggles
(2) We will no longer show "used in project" and "used in feature" when the toggle referencing it is archived

<img width="1475" alt="Skjermbilde 2024-02-29 kl  13 58 55" src="https://github.com/Unleash/unleash/assets/16081982/1a455fbc-cd2c-4902-abb9-52bc6b8fdf5a">

Also added a warning when deleting: 
<img width="862" alt="Skjermbilde 2024-02-29 kl  13 59 21" src="https://github.com/Unleash/unleash/assets/16081982/2120356b-8852-48ac-9051-ec81b296cf0f">

Discussion points: 
* I have added tests to verify the behavior, and we should only be touching the usage metrics with these added queries. But I see that one of the methods that calls getAll is used in the proxy repository, which makes me wary of making this change.

I've tried to map out the impact of my changes here:
<img width="921" alt="Skjermbilde 2024-02-29 kl  14 21 06" src="https://github.com/Unleash/unleash/assets/16081982/220b5074-97c4-4d08-8840-fd8830e35d44">

