### PR TITLE
refactor: playground uses segment read model

### DIFF
--- a/src/lib/features/segment/fake-segment-read-model.ts
+++ b/src/lib/features/segment/fake-segment-read-model.ts
@@ -1,4 +1,4 @@
-import { IFeatureStrategySegment, ISegment } from '../../types';
+import { IClientSegment, IFeatureStrategySegment, ISegment } from '../../types';
 import { ISegmentReadModel } from './segment-read-model-type';
 
 export class FakeSegmentReadModel implements ISegmentReadModel {
@@ -7,6 +7,14 @@ export class FakeSegmentReadModel implements ISegmentReadModel {
     }
 
     async getAllFeatureStrategySegments(): Promise<IFeatureStrategySegment[]> {
+        return [];
+    }
+
+    async getActive(): Promise<ISegment[]> {
+        return [];
+    }
+
+    async getActiveForClient(): Promise<IClientSegment[]> {
         return [];
     }
 }

--- a/src/lib/features/segment/segment-read-model-type.ts
+++ b/src/lib/features/segment/segment-read-model-type.ts
@@ -1,6 +1,8 @@
-import { IFeatureStrategySegment, ISegment } from '../../types';
+import { IClientSegment, IFeatureStrategySegment, ISegment } from '../../types';
 
 export interface ISegmentReadModel {
     getAll(): Promise<ISegment[]>;
     getAllFeatureStrategySegments(): Promise<IFeatureStrategySegment[]>;
+    getActive(): Promise<ISegment[]>;
+    getActiveForClient(): Promise<IClientSegment[]>;
 }

--- a/src/lib/segments/segment-service-interface.ts
+++ b/src/lib/segments/segment-service-interface.ts
@@ -33,8 +33,6 @@ export interface ISegmentService {
 
     validateName(name: string): Promise<void>;
 
-    getActive(): Promise<ISegment[]>;
-
     getActiveForClient(): Promise<IClientSegment[]>;
 
     getAll(): Promise<ISegment[]>;

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -109,6 +109,8 @@ import {
     createInstanceStatsService,
 } from '../features/instance-stats/createInstanceStatsService';
 import { InactiveUsersService } from '../users/inactive/inactive-users-service';
+import { SegmentReadModel } from '../features/segment/segment-read-model';
+import { FakeSegmentReadModel } from '../features/segment/fake-segment-read-model';
 
 export const createServices = (
     stores: IUnleashStores,
@@ -138,6 +140,9 @@ export const createServices = (
     const dependentFeaturesReadModel = db
         ? new DependentFeaturesReadModel(db)
         : new FakeDependentFeaturesReadModel();
+    const segmentReadModel = db
+        ? new SegmentReadModel(db)
+        : new FakeSegmentReadModel();
 
     const contextService = new ContextService(
         stores,
@@ -270,11 +275,14 @@ export const createServices = (
     const userSplashService = new UserSplashService(stores, config);
     const openApiService = new OpenApiService(config);
     const clientSpecService = new ClientSpecService(config);
-    const playgroundService = new PlaygroundService(config, {
-        featureToggleServiceV2,
-        segmentService,
-        privateProjectChecker,
-    });
+    const playgroundService = new PlaygroundService(
+        config,
+        {
+            featureToggleServiceV2,
+            privateProjectChecker,
+        },
+        segmentReadModel,
+    );
 
     const configurationRevisionService = new ConfigurationRevisionService(
         stores,

--- a/src/lib/services/segment-service.ts
+++ b/src/lib/services/segment-service.ts
@@ -79,10 +79,6 @@ export class SegmentService implements ISegmentService {
         return this.segmentStore.getAll(this.config.isEnterprise);
     }
 
-    async getActive(): Promise<ISegment[]> {
-        return this.segmentStore.getActive();
-    }
-
     async getActiveForClient(): Promise<IClientSegment[]> {
         return this.segmentStore.getActiveForClient();
     }

--- a/src/test/e2e/api/admin/state.e2e.test.ts
+++ b/src/test/e2e/api/admin/state.e2e.test.ts
@@ -377,7 +377,7 @@ test(`should import segments and connect them to feature strategies`, async () =
         .expect(202);
 
     const allSegments = await app.services.segmentService.getAll();
-    const activeSegments = await app.services.segmentService.getActive();
+    const activeSegments = await db.stores.segmentReadModel.getActive();
 
     expect(allSegments.length).toEqual(2);
     expect(collectIds(allSegments)).toEqual([1, 2]);

--- a/src/test/e2e/services/playground-service.test.ts
+++ b/src/test/e2e/services/playground-service.test.ts
@@ -20,18 +20,14 @@ import { SdkContextSchema } from '../../../lib/openapi/spec/sdk-context-schema';
 import { SegmentSchema } from '../../../lib/openapi/spec/segment-schema';
 import { playgroundStrategyEvaluation } from '../../../lib/openapi/spec/playground-strategy-schema';
 import { PlaygroundSegmentSchema } from '../../../lib/openapi/spec/playground-segment-schema';
-import { ISegmentService } from '../../../lib/segments/segment-service-interface';
 import { createPrivateProjectChecker } from '../../../lib/features/private-project/createPrivateProjectChecker';
-import {
-    createFeatureToggleService,
-    createSegmentService,
-} from '../../../lib/features';
+import { createFeatureToggleService } from '../../../lib/features';
+import { SegmentReadModel } from '../../../lib/features/segment/segment-read-model';
 
 let stores: IUnleashStores;
 let db: ITestDb;
 let service: PlaygroundService;
 let featureToggleService: FeatureToggleService;
-let segmentService: ISegmentService;
 
 beforeAll(async () => {
     const config = createTestConfig();
@@ -41,14 +37,17 @@ beforeAll(async () => {
         db.rawDatabase,
         config,
     );
-    segmentService = createSegmentService(db.rawDatabase, config);
+    const segmentReadModel = new SegmentReadModel(db.rawDatabase);
 
     featureToggleService = createFeatureToggleService(db.rawDatabase, config);
-    service = new PlaygroundService(config, {
-        featureToggleServiceV2: featureToggleService,
-        segmentService,
-        privateProjectChecker,
-    });
+    service = new PlaygroundService(
+        config,
+        {
+            featureToggleServiceV2: featureToggleService,
+            privateProjectChecker,
+        },
+        segmentReadModel,
+    );
 });
 
 afterAll(async () => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Playground service uses segment read model since we don't need write model.

<img width="801" alt="Screenshot 2024-03-04 at 16 26 37" src="https://github.com/Unleash/unleash/assets/1394682/e62ddf2d-00e4-47a0-b12b-b201dafaf829">

In the next refactoring I will do the same with the getActiveForClient and remove getActive and getActiveForClient from the store.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
