### PR TITLE
chore: remove archived column from features table

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -300,10 +300,11 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             .count('type')
             .groupBy('type');
 
-        query.where({
-            project: projectId,
-            archived,
-        });
+        query
+            .where({
+                project: projectId,
+            })
+            .modify(FeatureToggleStore.filterByArchived, archived);
 
         const result = await query;
         return result.map((row) => ({
@@ -677,7 +678,8 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
                                                   WHERE feature_types.id = features.type) *
                                                  INTERVAL '1 day'))) as current_staleness
              FROM features
-             WHERE NOT stale = true AND archived_at IS NULL`,
+             WHERE NOT stale = true
+               AND archived_at IS NULL`,
             [currentTime || this.db.fn.now()],
         );
 

--- a/src/migrations/20240305094305-features-remove-archived.js
+++ b/src/migrations/20240305094305-features-remove-archived.js
@@ -6,3 +6,12 @@ exports.up = function (db, cb) {
         cb,
     );
 };
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;
+        `,
+        cb,
+    );
+};

--- a/src/migrations/20240305094305-features-remove-archived.js
+++ b/src/migrations/20240305094305-features-remove-archived.js
@@ -1,0 +1,8 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE features DROP COLUMN IF EXISTS archived;
+        `,
+        cb,
+    );
+};

--- a/src/test/e2e/services/project-service.e2e.test.ts
+++ b/src/test/e2e/services/project-service.e2e.test.ts
@@ -2070,19 +2070,15 @@ test('should get correct amount of features archived in current and past window'
     await Promise.all([
         updateFeature(toggles[0].name, {
             archived_at: new Date(),
-            archived: true,
         }),
         updateFeature(toggles[1].name, {
             archived_at: new Date(),
-            archived: true,
         }),
         updateFeature(toggles[2].name, {
             archived_at: subDays(new Date(), 31),
-            archived: true,
         }),
         updateFeature(toggles[3].name, {
             archived_at: subDays(new Date(), 31),
-            archived: true,
         }),
     ]);
 


### PR DESCRIPTION
This column has not been used for 1.5 years and was replace by **archived_at** column and people still get confused of why this is not working as name suggests. Removing this column to remove technical debt.