### PR TITLE
chore: bump OSS main version to 5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
-  "version": "5.9.0+main",
+  "version": "5.10.0+main",
   "keywords": ["unleash", "feature toggle", "feature", "toggle"],
   "files": [
     "dist",


### PR DESCRIPTION
## About the changes

Bumps OSS main package.json version to 5.10.0+main as that's what is shown to Pro
