### PR TITLE
task: added scim id to user

### DIFF
--- a/src/migrations/20240305131822-add-scim-id-column-to-user.js
+++ b/src/migrations/20240305131822-add-scim-id-column-to-user.js
@@ -1,0 +1,13 @@
+exports.up = function(db, cb) {
+  db.runSql(`
+    ALTER TABLE users ADD COLUMN scim_id TEXT;
+    CREATE INDEX users_scim_id_uniq_idx ON users (scim_id) WHERE scim_id IS NOT NULL;
+  `, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`
+    DROP INDEX users_scim_id_uniq_idx;
+    ALTER TABLE users DROP COLUMN scim_id;
+  `, cb);
+};


### PR DESCRIPTION
SCIM synchronizations requires a stable id no matter how many changes are made to username and email (our other unique fields). In addition, exposing internal incremented database ids to an external service (our current id field) feels insecure. Our plan is to create either a uuidv7 or ulid when scim operations are performed against the user, so the external scim provisioner has a stable globally unique id to use to refer to the users they're modifying.