### PR TITLE
Feat: add metrics summary columns to flag trends

### DIFF
--- a/src/migrations/20240304160659-add-environment-type-trends.js
+++ b/src/migrations/20240304160659-add-environment-type-trends.js
@@ -3,13 +3,16 @@
 exports.up = function(db, cb) {
     db.runSql(
         `
-        ALTER TABLE IF EXISTS environment_type_trends
-            ADD COLUMN created_at timestamp default now();
-        `,
+        CREATE TABLE IF NOT EXISTS environment_type_trends (
+            id VARCHAR(255) NOT NULL,
+            environment_type VARCHAR(255) NOT NULL,
+            total_updates INTEGER NOT NULL,
+            PRIMARY KEY (id, environment_type)
+        );`,
         cb,
     );
 };
 
 exports.down = function(db, cb) {
-    db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN created_at;', cb);
+    db.runSql('DROP TABLE IF EXISTS environment_type_trends;', cb);
 };

--- a/src/migrations/20240304160659-add-environment-type-trends.js
+++ b/src/migrations/20240304160659-add-environment-type-trends.js
@@ -3,16 +3,13 @@
 exports.up = function(db, cb) {
     db.runSql(
         `
-        CREATE TABLE IF NOT EXISTS environment_type_trends (
-            id VARCHAR(255) NOT NULL,
-            environment_type VARCHAR(255) NOT NULL,
-            total_updates INTEGER NOT NULL,
-            PRIMARY KEY (id, environment_type)
-        );`,
+        ALTER TABLE IF EXISTS environment_type_trends
+            ADD COLUMN created_at timestamp default now();
+        `,
         cb,
     );
 };
 
 exports.down = function(db, cb) {
-    db.runSql('DROP TABLE IF EXISTS environment_type_trends;', cb);
+    db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN created_at;', cb);
 };

--- a/src/migrations/20240305121426-add-created-at-environment-type-trends.js
+++ b/src/migrations/20240305121426-add-created-at-environment-type-trends.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE IF EXISTS environment_type_trends
+            ADD COLUMN created_at timestamp default now();
+        `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN created_at;', cb);
+};

--- a/src/migrations/20240305121426-add-created-at-environment-type-trends.js
+++ b/src/migrations/20240305121426-add-created-at-environment-type-trends.js
@@ -11,5 +11,5 @@ exports.up = function(db, cb) {
 };
 
 exports.down = function(db, cb) {
-    db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN created_at;', cb);
+    db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN IF EXISTS created_at;', cb);
 };

--- a/src/migrations/20240305121702-add-metrics-summary-columns-to-flag-trends.js
+++ b/src/migrations/20240305121702-add-metrics-summary-columns-to-flag-trends.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE IF EXISTS flag_trends
+           ADD COLUMN total_yes integer,
+           ADD COLUMN  total_no integer,
+           ADD COLUMN  total_apps integer,
+           ADD COLUMN  total_environments integer;
+        `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql(`ALTER TABLE IF EXISTS flag_trends
+        DROP COLUMN IF EXISTS total_no,
+        DROP COLUMN IF EXISTS total_apps,
+        DROP COLUMN IF EXISTS total_environments,
+        DROP COLUMN IF EXISTS total_yes;`
+        ,
+        cb
+    );
+};


### PR DESCRIPTION
Adds the metrics summary trend columns to flag_trends table.
These will be populated with the rest of the weekly aggregations

Closes [1-2139](https://linear.app/unleash/issue/1-2139/add-the-summary-columns-to-flag-trends-table)