### PR TITLE
feat: frontend api observability

### DIFF
--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -1,6 +1,7 @@
 const REQUEST_TIME = 'request_time';
 const DB_TIME = 'db_time';
 const SCHEDULER_JOB_TIME = 'scheduler_job_time';
+const FRONTEND_API_TIME = 'frontend_api_time';
 const FEATURES_CREATED_BY_PROCESSED = 'features_created_by_processed';
 const EVENTS_CREATED_BY_PROCESSED = 'events_created_by_processed';
 const PROXY_REPOSITORY_CREATED = 'proxy_repository_created';
@@ -10,6 +11,7 @@ export {
     REQUEST_TIME,
     DB_TIME,
     SCHEDULER_JOB_TIME,
+    FRONTEND_API_TIME,
     FEATURES_CREATED_BY_PROCESSED,
     EVENTS_CREATED_BY_PROCESSED,
     PROXY_REPOSITORY_CREATED,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -77,6 +77,14 @@ export default class MetricsMonitor {
             maxAgeSeconds: 600,
             ageBuckets: 5,
         });
+        const frontendApiEvaluationDuration = createSummary({
+            name: 'frontend_api_duration_seconds',
+            help: 'Frontend API evaluation duration time',
+            labelNames: ['action'],
+            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+            maxAgeSeconds: 600,
+            ageBuckets: 5,
+        });
         const dbDuration = createSummary({
             name: 'db_query_duration_seconds',
             help: 'DB query duration time',
@@ -399,6 +407,10 @@ export default class MetricsMonitor {
 
         eventBus.on(events.SCHEDULER_JOB_TIME, ({ jobId, time }) => {
             schedulerDuration.labels(jobId).observe(time);
+        });
+
+        eventBus.on(events.FRONTEND_API_TIME, ({ action, time }) => {
+            frontendApiEvaluationDuration.labels(action).observe(time);
         });
 
         eventBus.on(events.EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We want to measure execution time of the frontend API evaluation. Similar measurement to scheduler execution and store execution time. 

Design decisions:
* high level event FRONTEND_API_TIME with one lower level action evaluateEnabledFeatures. Adding space for more actions in the FRONTEND_API_TIME timeline. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I wanted to correlate the time with the number of all features and enabled features after filtering. However our abstraction doesn't allow for this. Also I'm not sure if it's a good idea to mix time metrics with number of results metrics. For other time based metrics we only add actual time not the number of results in a query. 