### PR TITLE
fix: align privacy policy link to the center

### DIFF
--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -59,10 +59,6 @@ const StyledLink = styled(Link<typeof RouterLink | 'a'>)(({ theme }) => ({
     },
 }));
 
-const StyledLinkPrivacy = styled(StyledLink)(({ theme }) => ({
-    alignSelf: 'flex-start',
-}));
-
 const StyledLogoutButton = styled(Button)(({ theme }) => ({
     width: '100%',
     height: theme.spacing(5),
@@ -115,7 +111,7 @@ export const UserProfileContent = ({
 
                 <StyledDivider />
 
-                <StyledLinkPrivacy
+                <StyledLink
                     component='a'
                     href='https://www.getunleash.io/privacy-policy'
                     underline='hover'
@@ -123,7 +119,7 @@ export const UserProfileContent = ({
                     target='_blank'
                 >
                     Privacy Policy <OpenInNew />
-                </StyledLinkPrivacy>
+                </StyledLink>
 
                 <StyledDivider />
 


### PR DESCRIPTION
Aligns the privacy policy to the center in the profile dropdown, just like we do for the profile settings.

![image](https://github.com/Unleash/unleash/assets/14320932/0d0565eb-7b28-4b46-acb3-bbaef143fb8d)