### PR TITLE
chore: add a generic error for limit's exeeded

### DIFF
--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -3,7 +3,7 @@ import { GenericUnleashError } from './unleash-error';
 export class ExceedsLimitError extends GenericUnleashError {
     constructor(resource: string, limit: number) {
         super({
-            name: 'ExceedsLimitError', // it can also be 'OperationDeniedError' or we can create a new one
+            name: 'ExceedsLimitError',
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
             statusCode: 400,
         });

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -1,9 +1,9 @@
 import { GenericUnleashError } from './unleash-error';
 
-export class ExeedsLimitError extends GenericUnleashError {
+export class ExceedsLimitError extends GenericUnleashError {
     constructor(resource: string, limit: number) {
         super({
-            name: 'ValidationError', // it can also be 'OperationDeniedError' or we can create a new one
+            name: 'ExceedsLimitError', // it can also be 'OperationDeniedError' or we can create a new one
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
             statusCode: 400,
         });

--- a/src/lib/error/exeeds-limit-error.ts
+++ b/src/lib/error/exeeds-limit-error.ts
@@ -1,0 +1,11 @@
+import { GenericUnleashError } from './unleash-error';
+
+export class ExeedsLimitError extends GenericUnleashError {
+    constructor(resource: string, limit: number) {
+        super({
+            name: 'ValidationError', // it can also be 'OperationDeniedError' or we can create a new one
+            message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
+            statusCode: 400,
+        });
+    }
+}

--- a/src/lib/error/unleash-error.ts
+++ b/src/lib/error/unleash-error.ts
@@ -28,7 +28,7 @@ export const UnleashApiErrorTypes = [
     'InvalidTokenError',
     'OwaspValidationError',
     'ForbiddenError',
-
+    'ExceedsLimitError',
     // server errors; not the end user's fault
     'InternalError',
 ] as const;


### PR DESCRIPTION
## About the changes
We don't have a meaningful error for limits established by the application. This could be a good starting point.

The error code is 400 cause I couldn't find anything better. 

The name of the error was picked from UnleashApiErrorTypes: https://github.com/Unleash/unleash/blob/2d8e9f87ff96fcb2e2f84a8b4b36bf5c0e28a885/src/lib/error/unleash-error.ts#L4-L34