### PR TITLE
Typo fix in ChangeRequestTable.tsx

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -306,11 +306,8 @@ export const ChangeRequestTable: VFC = () => {
                     condition={!dialogState.isEnabled}
                     show={
                         <Typography variant='body2' color='text.secondary'>
-                            When enabling change request for an environment, you
-                            need to be sure that your Unleash Admin already have
-                            created the custom project roles in your Unleash
-                            instance so you can assign your project members from
-                            the project access page.
+                            To enable change requests for an environment, you need to ensure that your Unleash Admin has created the necessary custom project roles in your Unleash instance. 
+                            This will allow you to assign project members from the project access page.
                         </Typography>
                     }
                 />

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -306,8 +306,11 @@ export const ChangeRequestTable: VFC = () => {
                     condition={!dialogState.isEnabled}
                     show={
                         <Typography variant='body2' color='text.secondary'>
-                            To enable change requests for an environment, you need to ensure that your Unleash Admin has created the necessary custom project roles in your Unleash instance. 
-                            This will allow you to assign project members from the project access page.
+                            To enable change requests for an environment, you
+                            need to ensure that your Unleash Admin has created
+                            the necessary custom project roles in your Unleash
+                            instance. This will allow you to assign project
+                            members from the project access page.
                         </Typography>
                     }
                 />


### PR DESCRIPTION
There was a typo in the original message, it said "Unleash Admin already have" (either "admins already have," or "admin already has.")

Fixed it and improved the wording a little bit.