### PR TITLE
fix: project tokens path typo

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
@@ -53,7 +53,7 @@ export const CreateProjectApiTokenForm = () => {
 
     usePageTitle(pageTitle);
 
-    const PATH = `api/admin/project/${projectId}/api-tokens`;
+    const PATH = `api/admin/projects/${projectId}/api-tokens`;
     const permission = CREATE_PROJECT_API_TOKEN;
 
     const handleSubmit = async (e: Event) => {


### PR DESCRIPTION
Noticed a small typo in the path shown in the project API access side panel.