### PR TITLE
fix: insights navigation

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -152,7 +152,7 @@ const StyledLinkWithBetaBagde = ({
     title,
     to,
 }: { title: string; to: string }) => (
-    <StyledLink to={path} sx={{ margin: 0 }}>
+    <StyledLink to={to} sx={{ margin: 0 }}>
         <div>
             <span>{title}</span>{' '}
             <StyledSpan>

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -148,6 +148,20 @@ const styledIconProps = (theme: Theme) => ({
 
 const StyledLink = styled(Link)(({ theme }) => focusable(theme));
 
+const StyledLinkWithBetaBagde = ({
+    title,
+    to,
+}: { title: string; to: string }) => (
+    <StyledLink to={path} sx={{ margin: 0 }}>
+        <div>
+            <span>{title}</span>{' '}
+            <StyledSpan>
+                <StyledBadge color='success'>Beta</StyledBadge>
+            </StyledSpan>
+        </div>
+    </StyledLink>
+);
+
 const StyledIconButton = styled(IconButton)<{
     component?: 'a' | 'button';
     href?: string;
@@ -268,16 +282,10 @@ const Header: VFC = () => {
                         <ConditionallyRender
                             condition={insightsDashboard}
                             show={
-                                <StyledLink to='/insights' sx={{ margin: 0 }}>
-                                    <div>
-                                        <span>Insights</span>{' '}
-                                        <StyledSpan>
-                                            <StyledBadge color='success'>
-                                                Beta
-                                            </StyledBadge>
-                                        </StyledSpan>
-                                    </div>
-                                </StyledLink>
+                                <StyledLinkWithBetaBagde
+                                    to={'/insights'}
+                                    title={'Insights'}
+                                />
                             }
                         />
                         <StyledAdvancedNavButton

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -39,6 +39,7 @@ import { Notifications } from 'component/common/Notifications/Notifications';
 import { useAdminRoutes } from 'component/admin/useAdminRoutes';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { INavigationMenuItem } from "../../../interfaces/route";
 
 const StyledHeader = styled(AppBar)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -171,12 +172,16 @@ const Header: VFC = () => {
     const routes = getRoutes();
     const adminRoutes = useAdminRoutes();
 
+    const excludeInsights = (r: INavigationMenuItem) => !r.title.includes('Insights')
+
     const filteredMainRoutes = {
         mainNavRoutes: getCondensedRoutes(routes.mainNavRoutes)
             .filter(filterByConfig(uiConfig))
+            .filter(excludeInsights)
             .map(mapRouteLink),
         mobileRoutes: getCondensedRoutes(routes.mobileRoutes)
             .filter(filterByConfig(uiConfig))
+            .filter(excludeInsights)
             .map(mapRouteLink),
         adminRoutes,
     };
@@ -248,15 +253,15 @@ const Header: VFC = () => {
 
                 <StyledNav>
                     <StyledLinks>
+                        <StyledLink to='/projects'>Projects</StyledLink>
+                        <StyledLink to={'/search'}>Search</StyledLink>
+                        <StyledLink to='/playground'>Playground</StyledLink>
                         <ConditionallyRender
                             condition={insightsDashboard}
                             show={
                                 <StyledLink to='/insights'>Insights</StyledLink>
                             }
                         />
-                        <StyledLink to='/projects'>Projects</StyledLink>
-                        <StyledLink to={'/search'}>Search</StyledLink>
-                        <StyledLink to='/playground'>Playground</StyledLink>
                         <StyledAdvancedNavButton
                             onClick={(e) => setConfigRef(e.currentTarget)}
                             aria-controls={configRef ? configId : undefined}

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -172,17 +172,12 @@ const Header: VFC = () => {
     const routes = getRoutes();
     const adminRoutes = useAdminRoutes();
 
-    const excludeInsights = (r: INavigationMenuItem) =>
-        !r.title.includes('Insights');
-
     const filteredMainRoutes = {
         mainNavRoutes: getCondensedRoutes(routes.mainNavRoutes)
             .filter(filterByConfig(uiConfig))
-            .filter(excludeInsights)
             .map(mapRouteLink),
         mobileRoutes: getCondensedRoutes(routes.mobileRoutes)
             .filter(filterByConfig(uiConfig))
-            .filter(excludeInsights)
             .map(mapRouteLink),
         adminRoutes,
     };

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -40,6 +40,7 @@ import { useAdminRoutes } from 'component/admin/useAdminRoutes';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { INavigationMenuItem } from '../../../interfaces/route';
+import { Badge } from '../../common/Badge/Badge';
 
 const StyledHeader = styled(AppBar)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -128,6 +129,18 @@ const StyledAdvancedNavButton = styled('button')(({ theme }) => ({
     color: 'inherit',
     cursor: 'pointer',
 }));
+
+const StyledSpan = styled('span')({
+    height: '16px',
+    paddingBottom: 16,
+});
+
+const StyledBadge = styled(Badge)({
+    height: '16px',
+    maxHeight: '16px',
+    padding: 0.25,
+    marginBottom: 0,
+});
 
 const styledIconProps = (theme: Theme) => ({
     color: theme.palette.neutral.main,
@@ -255,7 +268,16 @@ const Header: VFC = () => {
                         <ConditionallyRender
                             condition={insightsDashboard}
                             show={
-                                <StyledLink to='/insights'>Insights</StyledLink>
+                                <StyledLink to='/insights' sx={{ margin: 0 }}>
+                                    <div>
+                                        <span>Insights</span>{' '}
+                                        <StyledSpan>
+                                            <StyledBadge color='success'>
+                                                Beta
+                                            </StyledBadge>
+                                        </StyledSpan>
+                                    </div>
+                                </StyledLink>
                             }
                         />
                         <StyledAdvancedNavButton

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -39,7 +39,7 @@ import { Notifications } from 'component/common/Notifications/Notifications';
 import { useAdminRoutes } from 'component/admin/useAdminRoutes';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { INavigationMenuItem } from "../../../interfaces/route";
+import { INavigationMenuItem } from '../../../interfaces/route';
 
 const StyledHeader = styled(AppBar)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -172,7 +172,8 @@ const Header: VFC = () => {
     const routes = getRoutes();
     const adminRoutes = useAdminRoutes();
 
-    const excludeInsights = (r: INavigationMenuItem) => !r.title.includes('Insights')
+    const excludeInsights = (r: INavigationMenuItem) =>
+        !r.title.includes('Insights');
 
     const filteredMainRoutes = {
         mainNavRoutes: getCondensedRoutes(routes.mainNavRoutes)

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`returns all baseRoutes 1`] = `
     "enterprise": false,
     "flag": "executiveDashboard",
     "menu": {
-      "advanced": true,
       "mobile": true,
     },
     "path": "/insights",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -66,7 +66,7 @@ export const routes: IRoute[] = [
         title: 'Insights',
         component: ExecutiveDashboard,
         type: 'protected',
-        menu: { mobile: true, advanced: true },
+        menu: { mobile: true },
         flag: 'executiveDashboard',
         enterprise: false,
     },

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
@@ -53,7 +53,7 @@ export const CreateProjectApiTokenForm = () => {
 
     usePageTitle(pageTitle);
 
-    const PATH = `api/admin/project/${projectId}/api-tokens`;
+    const PATH = `api/admin/projects/${projectId}/api-tokens`;
     const permission = CREATE_PROJECT_API_TOKEN;
 
     const handleSubmit = async (e: Event) => {


### PR DESCRIPTION
What it says on the tin

Also adds the beta badge

Closes # [1-2152](https://linear.app/unleash/issue/1-2152/adjust-insights-placement-in-navigation)

<img width="902" alt="Screenshot 2024-03-08 at 16 14 59" src="https://github.com/Unleash/unleash/assets/104830839/3e67cba3-fb0f-438c-9e53-e51d923a373e">
