### PR TITLE
Compare old results with new frontend api

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -115,6 +115,7 @@ exports[`should create default config 1`] = `
         },
       },
       "filterInvalidClientMetrics": false,
+      "globalFrontendApiCache": false,
       "googleAuthEnabled": false,
       "inMemoryScheduledChangeRequests": false,
       "increaseUnleashWidth": false,

--- a/src/lib/proxy/fake-client-feature-toggle-read-model.ts
+++ b/src/lib/proxy/fake-client-feature-toggle-read-model.ts
@@ -4,7 +4,7 @@ import { IClientFeatureToggleReadModel } from './client-feature-toggle-read-mode
 export default class FakeClientFeatureToggleReadModel
     implements IClientFeatureToggleReadModel
 {
-    constructor(private value: Record<string, IFeatureToggleClient[]>) {}
+    constructor(private value: Record<string, IFeatureToggleClient[]> = {}) {}
 
     getClient(): Promise<Record<string, IFeatureToggleClient[]>> {
         return Promise.resolve(this.value);

--- a/src/lib/proxy/frontend-api-repository.ts
+++ b/src/lib/proxy/frontend-api-repository.ts
@@ -23,20 +23,20 @@ export class FrontendApiRepository
 
     private readonly token: IApiUser;
 
-    private globalFrontendApiRepository: GlobalFrontendApiCache;
+    private globalFrontendApiCache: GlobalFrontendApiCache;
 
     private running: boolean;
 
     constructor(
         config: Config,
-        globalFrontendApiRepository: GlobalFrontendApiCache,
+        globalFrontendApiCache: GlobalFrontendApiCache,
         token: IApiUser,
     ) {
         super();
         this.config = config;
         this.logger = config.getLogger('frontend-api-repository.ts');
         this.token = token;
-        this.globalFrontendApiRepository = globalFrontendApiRepository;
+        this.globalFrontendApiCache = globalFrontendApiCache;
     }
 
     getTogglesWithSegmentData(): EnhancedFeatureInterface[] {
@@ -45,18 +45,18 @@ export class FrontendApiRepository
     }
 
     getSegment(id: number): Segment | undefined {
-        return this.globalFrontendApiRepository.getSegment(id);
+        return this.globalFrontendApiCache.getSegment(id);
     }
 
     getToggle(name: string): FeatureInterface {
         //@ts-ignore (we must update the node SDK to allow undefined)
-        return this.globalFrontendApiRepository
-            .getToggles(this.token)
-            .find((feature) => feature.name);
+        return this.getToggles(this.token).find(
+            (feature) => feature.name === name,
+        );
     }
 
     getToggles(): FeatureInterface[] {
-        return this.globalFrontendApiRepository.getToggles(this.token);
+        return this.globalFrontendApiCache.getToggles(this.token);
     }
 
     async start(): Promise<void> {

--- a/src/lib/proxy/global-frontend-api-cache.test.ts
+++ b/src/lib/proxy/global-frontend-api-cache.test.ts
@@ -6,7 +6,12 @@ import noLogger from '../../test/fixtures/no-logger';
 import { FakeSegmentReadModel } from '../features/segment/fake-segment-read-model';
 import FakeClientFeatureToggleReadModel from './fake-client-feature-toggle-read-model';
 import EventEmitter from 'events';
-import { IApiUser, IFeatureToggleClient, ISegment } from '../types';
+import {
+    IApiUser,
+    IFeatureToggleClient,
+    IFlagResolver,
+    ISegment,
+} from '../types';
 import { UPDATE_REVISION } from '../features/feature-toggle/configuration-revision-service';
 
 const state = async (
@@ -33,11 +38,17 @@ const defaultFeature: IFeatureToggleClient = {
 };
 const defaultSegment = { name: 'segment', id: 1 } as ISegment;
 
+const alwaysOnFlagResolver = {
+    isEnabled() {
+        return true;
+    },
+} as unknown as IFlagResolver;
+
 const createCache = (
     segment: ISegment = defaultSegment,
     features: Record<string, IFeatureToggleClient[]> = {},
 ) => {
-    const config = { getLogger: noLogger };
+    const config = { getLogger: noLogger, flagResolver: alwaysOnFlagResolver };
     const segmentReadModel = new FakeSegmentReadModel([segment as ISegment]);
     const clientFeatureToggleReadModel = new FakeClientFeatureToggleReadModel(
         features,

--- a/src/lib/proxy/global-frontend-api-cache.ts
+++ b/src/lib/proxy/global-frontend-api-cache.ts
@@ -13,7 +13,7 @@ import { UPDATE_REVISION } from '../features/feature-toggle/configuration-revisi
 import { mapValues } from '../util';
 import { IClientFeatureToggleReadModel } from './client-feature-toggle-read-model-type';
 
-type Config = Pick<IUnleashConfig, 'getLogger'>;
+type Config = Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>;
 
 export type GlobalFrontendApiCacheState = 'starting' | 'ready' | 'updated';
 
@@ -92,6 +92,7 @@ export class GlobalFrontendApiCache extends EventEmitter {
             this.segments = await this.getAllSegments();
             if (this.status === 'starting') {
                 this.status = 'ready';
+                this.status = 'ready';
                 this.emit('ready');
             } else if (this.status === 'ready' || this.status === 'updated') {
                 this.status = 'updated';
@@ -103,7 +104,9 @@ export class GlobalFrontendApiCache extends EventEmitter {
     }
 
     private async onUpdateRevisionEvent() {
-        await this.refreshData();
+        if (this.config.flagResolver.isEnabled('globalFrontendApiCache')) {
+            await this.refreshData();
+        }
     }
 
     private environmentNameForToken(token: IApiUser): string {

--- a/src/lib/proxy/global-frontend-api-cache.ts
+++ b/src/lib/proxy/global-frontend-api-cache.ts
@@ -92,7 +92,6 @@ export class GlobalFrontendApiCache extends EventEmitter {
             this.segments = await this.getAllSegments();
             if (this.status === 'starting') {
                 this.status = 'ready';
-                this.status = 'ready';
                 this.emit('ready');
             } else if (this.status === 'ready' || this.status === 'updated') {
                 this.status = 'updated';

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -111,6 +111,9 @@ import {
 import { InactiveUsersService } from '../users/inactive/inactive-users-service';
 import { SegmentReadModel } from '../features/segment/segment-read-model';
 import { FakeSegmentReadModel } from '../features/segment/fake-segment-read-model';
+import { GlobalFrontendApiCache } from '../proxy/global-frontend-api-cache';
+import ClientFeatureToggleReadModel from '../proxy/client-feature-toggle-read-model';
+import FakeClientFeatureToggleReadModel from '../proxy/fake-client-feature-toggle-read-model';
 
 export const createServices = (
     stores: IUnleashStores,
@@ -293,12 +296,27 @@ export const createServices = (
         ? createClientFeatureToggleService(db, config)
         : createFakeClientFeatureToggleService(config);
 
-    const proxyService = new ProxyService(config, stores, {
-        featureToggleServiceV2,
-        clientMetricsServiceV2,
-        settingService,
+    const clientFeatureToggleReadModel = db
+        ? new ClientFeatureToggleReadModel(db, config.eventBus)
+        : new FakeClientFeatureToggleReadModel();
+    const globalFrontendApiCache = new GlobalFrontendApiCache(
+        config,
+        segmentReadModel,
+        clientFeatureToggleReadModel,
         configurationRevisionService,
-    });
+    );
+
+    const proxyService = new ProxyService(
+        config,
+        stores,
+        {
+            featureToggleServiceV2,
+            clientMetricsServiceV2,
+            settingService,
+            configurationRevisionService,
+        },
+        globalFrontendApiCache,
+    );
 
     const edgeService = new EdgeService({ apiTokenService }, config);
 

--- a/src/lib/services/proxy-service.test.ts
+++ b/src/lib/services/proxy-service.test.ts
@@ -1,0 +1,57 @@
+import { ProxyService } from './proxy-service';
+import { GlobalFrontendApiCache } from '../proxy/global-frontend-api-cache';
+import { IApiUser } from '../types';
+import { FeatureInterface } from 'unleash-client/lib/feature';
+import noLogger from '../../test/fixtures/no-logger';
+import { ApiTokenType } from '../types/models/api-token';
+
+test('proxy service fetching features from global cache', async () => {
+    const irrelevant = {} as any;
+    const globalFrontendApiCache = {
+        getToggles(token: IApiUser): FeatureInterface[] {
+            return [
+                {
+                    name: 'toggleA',
+                    enabled: true,
+                    project: 'projectA',
+                    type: 'release',
+                    variants: [],
+                    strategies: [
+                        { name: 'default', parameters: [], constraints: [] },
+                    ],
+                },
+                {
+                    name: 'toggleB',
+                    enabled: false,
+                    project: 'projectA',
+                    type: 'release',
+                    variants: [],
+                    strategies: [
+                        { name: 'default', parameters: [], constraints: [] },
+                    ],
+                },
+            ];
+        },
+        getSegment(id: number) {
+            return undefined;
+        },
+    } as GlobalFrontendApiCache;
+    const proxyService = new ProxyService(
+        { getLogger: noLogger } as any,
+        irrelevant,
+        irrelevant,
+        globalFrontendApiCache,
+    );
+
+    const features = await proxyService.getNewProxyFeatures(
+        {
+            projects: ['irrelevant'],
+            environment: 'irrelevant',
+            type: ApiTokenType.FRONTEND,
+        } as unknown as IApiUser,
+        {},
+    );
+
+    expect(features).toMatchObject([{ name: 'toggleA' }]);
+    expect(features).toHaveLength(1);
+});

--- a/src/lib/services/proxy-service.test.ts
+++ b/src/lib/services/proxy-service.test.ts
@@ -1,4 +1,4 @@
-import { ProxyService } from './proxy-service';
+import { ProxyService, Config } from './proxy-service';
 import { GlobalFrontendApiCache } from '../proxy/global-frontend-api-cache';
 import { IApiUser } from '../types';
 import { FeatureInterface } from 'unleash-client/lib/feature';
@@ -8,7 +8,7 @@ import { ApiTokenType } from '../types/models/api-token';
 test('proxy service fetching features from global cache', async () => {
     const irrelevant = {} as any;
     const globalFrontendApiCache = {
-        getToggles(token: IApiUser): FeatureInterface[] {
+        getToggles(_: IApiUser): FeatureInterface[] {
             return [
                 {
                     name: 'toggleA',
@@ -32,12 +32,9 @@ test('proxy service fetching features from global cache', async () => {
                 },
             ];
         },
-        getSegment(id: number) {
-            return undefined;
-        },
     } as GlobalFrontendApiCache;
     const proxyService = new ProxyService(
-        { getLogger: noLogger } as any,
+        { getLogger: noLogger } as unknown as Config,
         irrelevant,
         irrelevant,
         globalFrontendApiCache,

--- a/src/lib/services/proxy-service.ts
+++ b/src/lib/services/proxy-service.ts
@@ -20,17 +20,17 @@ import { ProxyRepository } from '../proxy';
 import { FrontendApiRepository } from '../proxy/frontend-api-repository';
 import { GlobalFrontendApiCache } from '../proxy/global-frontend-api-cache';
 
-type Config = Pick<
+export type Config = Pick<
     IUnleashConfig,
     'getLogger' | 'frontendApi' | 'frontendApiOrigins' | 'eventBus'
 >;
 
-type Stores = Pick<
+export type Stores = Pick<
     IUnleashStores,
     'projectStore' | 'eventStore' | 'segmentReadModel'
 >;
 
-type Services = Pick<
+export type Services = Pick<
     IUnleashServices,
     | 'featureToggleServiceV2'
     | 'clientMetricsServiceV2'

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -53,7 +53,8 @@ export type IFlagKey =
     | 'sdkReporting'
     | 'responseTimeMetricsFix'
     | 'scimApi'
-    | 'displayEdgeBanner';
+    | 'displayEdgeBanner'
+    | 'globalFrontendApiCache';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -260,6 +261,10 @@ const flags: IFlags = {
     ),
     responseTimeMetricsFix: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_RESPONSE_TIME_METRICS_FIX,
+        false,
+    ),
+    globalFrontendApiCache: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_GLOBAL_FRONTEND_API_CACHE,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -50,6 +50,7 @@ process.nextTick(async () => {
                         executiveDashboard: true,
                         userAccessUIEnabled: true,
                         sdkReporting: true,
+                        globalFrontendApiCache: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Running old frontend API and new frontend API side by side and comparing results.

Details:
* comparison only on when flag enabled
* always returning old results and warning if new results are different
* global cache is updated only when the flag is on
* copy pasted most of the old code with minor tweak so it's easy to delete old code after the migration
* sticking to the existing naming (separate PR will remove proxy and replace it with frontend API naming)
* next PR will create a composition root for the proxy service

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
