### PR TITLE
feat: make frontend api complexity O(n) instead of O(n2)

### DIFF
--- a/src/lib/features/playground/offline-unleash-client.ts
+++ b/src/lib/features/playground/offline-unleash-client.ts
@@ -14,7 +14,12 @@ type NonEmptyList<T> = [T, ...T[]];
 export const mapFeaturesForClient = (
     features: FeatureConfigurationClient[],
 ): FeatureInterface[] =>
-    features.map((feature) => ({
+    features.map((feature) => mapFeatureForClient(feature));
+
+export const mapFeatureForClient = (
+    feature: FeatureConfigurationClient,
+): FeatureInterface => {
+    return {
         impressionData: false,
         ...feature,
         variants: (feature.variants || []).map((variant) => ({
@@ -47,7 +52,8 @@ export const mapFeaturesForClient = (
                 })) || [],
         })),
         dependencies: feature.dependencies,
-    }));
+    };
+};
 
 export const mapSegmentsForClient = (segments: ISegment[]): Segment[] =>
     serializeDates(segments) as Segment[];

--- a/src/lib/proxy/client-feature-toggle-read-model-type.ts
+++ b/src/lib/proxy/client-feature-toggle-read-model-type.ts
@@ -1,5 +1,5 @@
 import { IFeatureToggleClient } from '../types';
 
 export interface IClientFeatureToggleReadModel {
-    getClient(): Promise<Record<string, IFeatureToggleClient[]>>;
+    getClient(): Promise<Record<string, Record<string, IFeatureToggleClient>>>;
 }

--- a/src/lib/proxy/fake-client-feature-toggle-read-model.ts
+++ b/src/lib/proxy/fake-client-feature-toggle-read-model.ts
@@ -4,13 +4,18 @@ import { IClientFeatureToggleReadModel } from './client-feature-toggle-read-mode
 export default class FakeClientFeatureToggleReadModel
     implements IClientFeatureToggleReadModel
 {
-    constructor(private value: Record<string, IFeatureToggleClient[]> = {}) {}
+    constructor(
+        private value: Record<
+            string,
+            Record<string, IFeatureToggleClient>
+        > = {},
+    ) {}
 
-    getClient(): Promise<Record<string, IFeatureToggleClient[]>> {
+    getClient(): Promise<Record<string, Record<string, IFeatureToggleClient>>> {
         return Promise.resolve(this.value);
     }
 
-    setValue(value: Record<string, IFeatureToggleClient[]>) {
+    setValue(value: Record<string, Record<string, IFeatureToggleClient>>) {
         this.value = value;
     }
 }

--- a/src/lib/proxy/frontend-api-repository.ts
+++ b/src/lib/proxy/frontend-api-repository.ts
@@ -50,9 +50,7 @@ export class FrontendApiRepository
 
     getToggle(name: string): FeatureInterface {
         //@ts-ignore (we must update the node SDK to allow undefined)
-        return this.getToggles(this.token).find(
-            (feature) => feature.name === name,
-        );
+        return this.globalFrontendApiCache.getToggle(name, this.token);
     }
 
     getToggles(): FeatureInterface[] {

--- a/src/lib/proxy/global-frontend-api-cache.test.ts
+++ b/src/lib/proxy/global-frontend-api-cache.test.ts
@@ -138,6 +138,18 @@ test('Can read initial features', async () => {
         projects: ['*'],
     } as IApiUser);
     expect(defaultProjectFeatures.length).toBe(0);
+
+    const singleToggle = cache.getToggle('featureA', {
+        environment: 'development',
+        projects: ['*'],
+    } as IApiUser);
+
+    expect(singleToggle).toMatchObject({
+        ...defaultFeature,
+        name: 'featureA',
+        enabled: true,
+        impressionData: false,
+    });
 });
 
 test('Can refresh data on revision update', async () => {

--- a/src/lib/proxy/global-frontend-api-cache.test.ts
+++ b/src/lib/proxy/global-frontend-api-cache.test.ts
@@ -46,7 +46,7 @@ const alwaysOnFlagResolver = {
 
 const createCache = (
     segment: ISegment = defaultSegment,
-    features: Record<string, IFeatureToggleClient[]> = {},
+    features: Record<string, Record<string, IFeatureToggleClient>> = {},
 ) => {
     const config = { getLogger: noLogger, flagResolver: alwaysOnFlagResolver };
     const segmentReadModel = new FakeSegmentReadModel([segment as ISegment]);
@@ -82,28 +82,28 @@ test('Can read initial segment', async () => {
 
 test('Can read initial features', async () => {
     const { cache } = createCache(defaultSegment, {
-        development: [
-            {
+        development: {
+            featureA: {
                 ...defaultFeature,
                 name: 'featureA',
                 enabled: true,
                 project: 'projectA',
             },
-            {
+            featureB: {
                 ...defaultFeature,
                 name: 'featureB',
                 enabled: true,
                 project: 'projectB',
             },
-        ],
-        production: [
-            {
+        },
+        production: {
+            featureA: {
                 ...defaultFeature,
                 name: 'featureA',
                 enabled: false,
                 project: 'projectA',
             },
-        ],
+        },
     });
 
     const featuresBeforeRead = cache.getToggles({
@@ -150,15 +150,15 @@ test('Can refresh data on revision update', async () => {
     await state(cache, 'ready');
 
     clientFeatureToggleReadModel.setValue({
-        development: [
-            {
+        development: {
+            featureA: {
                 ...defaultFeature,
                 name: 'featureA',
                 enabled: false,
                 strategies: [{ name: 'default' }],
                 project: 'projectA',
             },
-        ],
+        },
     });
     configurationRevisionService.emit(UPDATE_REVISION);
 

--- a/src/lib/proxy/global-frontend-api-cache.ts
+++ b/src/lib/proxy/global-frontend-api-cache.ts
@@ -2,18 +2,23 @@ import EventEmitter from 'events';
 import { Segment } from 'unleash-client/lib/strategy/strategy';
 import { FeatureInterface } from 'unleash-client/lib/feature';
 import { IApiUser } from '../types/api-user';
-import { ISegmentReadModel, IUnleashConfig } from '../types';
 import {
-    mapFeaturesForClient,
+    IFeatureToggleClient,
+    ISegmentReadModel,
+    IUnleashConfig,
+} from '../types';
+import {
+    mapFeatureForClient,
     mapSegmentsForClient,
 } from '../features/playground/offline-unleash-client';
 import { ALL_ENVS } from '../util/constants';
 import { Logger } from '../logger';
 import { UPDATE_REVISION } from '../features/feature-toggle/configuration-revision-service';
-import { mapValues } from '../util';
 import { IClientFeatureToggleReadModel } from './client-feature-toggle-read-model-type';
 
 type Config = Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>;
+
+type FrontendApiFeatureCache = Record<string, Record<string, FeatureInterface>>;
 
 export type GlobalFrontendApiCacheState = 'starting' | 'ready' | 'updated';
 
@@ -28,7 +33,7 @@ export class GlobalFrontendApiCache extends EventEmitter {
 
     private readonly configurationRevisionService: EventEmitter;
 
-    private featuresByEnvironment: Record<string, FeatureInterface[]> = {};
+    private featuresByEnvironment: FrontendApiFeatureCache = {};
 
     private segments: Segment[] = [];
 
@@ -58,30 +63,40 @@ export class GlobalFrontendApiCache extends EventEmitter {
         return this.segments.find((segment) => segment.id === id);
     }
 
+    getToggle(name: string, token: IApiUser): FeatureInterface {
+        const features = this.getTogglesByEnvironment(
+            this.environmentNameForToken(token),
+        );
+        return features[name];
+    }
+
     getToggles(token: IApiUser): FeatureInterface[] {
-        if (
-            this.featuresByEnvironment[this.environmentNameForToken(token)] ==
-            null
-        )
-            return [];
-        return this.featuresByEnvironment[
-            this.environmentNameForToken(token)
-        ].filter(
-            (feature) =>
-                token.projects.includes('*') ||
-                (feature.project && token.projects.includes(feature.project)),
+        const features = this.getTogglesByEnvironment(
+            this.environmentNameForToken(token),
+        );
+        return this.filterTogglesByProjects(features, token.projects);
+    }
+
+    private filterTogglesByProjects(
+        features: Record<string, FeatureInterface>,
+        projects: string[],
+    ): FeatureInterface[] {
+        if (projects.includes('*')) {
+            return Object.values(features);
+        }
+        return Object.values(features).filter(
+            (feature) => feature.project && projects.includes(feature.project),
         );
     }
 
-    private async getAllFeatures(): Promise<
-        Record<string, FeatureInterface[]>
-    > {
-        const features = await this.clientFeatureToggleReadModel.getClient();
-        return mapValues(features, mapFeaturesForClient);
-    }
+    private getTogglesByEnvironment(
+        environment: string,
+    ): Record<string, FeatureInterface> {
+        const features = this.featuresByEnvironment[environment];
 
-    private async getAllSegments(): Promise<Segment[]> {
-        return mapSegmentsForClient(await this.segmentReadModel.getAll());
+        if (features == null) return {};
+
+        return features;
     }
 
     // TODO: fetch only relevant projects/environments based on tokens
@@ -102,6 +117,15 @@ export class GlobalFrontendApiCache extends EventEmitter {
         }
     }
 
+    private async getAllFeatures(): Promise<FrontendApiFeatureCache> {
+        const features = await this.clientFeatureToggleReadModel.getClient();
+        return this.mapFeatures(features);
+    }
+
+    private async getAllSegments(): Promise<Segment[]> {
+        return mapSegmentsForClient(await this.segmentReadModel.getAll());
+    }
+
     private async onUpdateRevisionEvent() {
         if (this.config.flagResolver.isEnabled('globalFrontendApiCache')) {
             await this.refreshData();
@@ -113,5 +137,21 @@ export class GlobalFrontendApiCache extends EventEmitter {
             return 'default';
         }
         return token.environment;
+    }
+
+    private mapFeatures(
+        features: Record<string, Record<string, IFeatureToggleClient>>,
+    ): FrontendApiFeatureCache {
+        const entries = Object.entries(features).map(([key, value]) => [
+            key,
+            Object.fromEntries(
+                Object.entries(value).map(([innerKey, innerValue]) => [
+                    innerKey,
+                    mapFeatureForClient(innerValue),
+                ]),
+            ),
+        ]);
+
+        return Object.fromEntries(entries);
     }
 }

--- a/src/lib/services/proxy-service.test.ts
+++ b/src/lib/services/proxy-service.test.ts
@@ -32,6 +32,11 @@ test('proxy service fetching features from global cache', async () => {
                 },
             ];
         },
+        getToggle(name: string, token: IApiUser): FeatureInterface {
+            return this.getToggles(token).find(
+                (t) => t.name === name,
+            ) as FeatureInterface;
+        },
     } as GlobalFrontendApiCache;
     const proxyService = new ProxyService(
         { getLogger: noLogger } as unknown as Config,


### PR DESCRIPTION
Now frontend api complexity for evaluation is down from O(n²) to O(n). Because previous getToggle was filtering from the features pool, now we have hashmap, so we can find by key.