### PR TITLE
fix: await trafficDataUsageStore.deleteAll where its being used

### DIFF
--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -62,7 +62,7 @@ test('upsert upserts', async () => {
 });
 
 test('getAll returns all', async () => {
-    trafficDataUsageStore.deleteAll();
+    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',
@@ -83,7 +83,7 @@ test('getAll returns all', async () => {
 });
 
 test('delete deletes the specified item', async () => {
-    trafficDataUsageStore.deleteAll();
+    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',
@@ -110,7 +110,7 @@ test('delete deletes the specified item', async () => {
 });
 
 test('can query for specific items', async () => {
-    trafficDataUsageStore.deleteAll();
+    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',


### PR DESCRIPTION
## About the changes

trafficDataUsageStore.deleteAll() wasn't being awaited in tests, leading to flaky tests. This PR ensures it's being awaited