### PR TITLE
refactor: remove client from frontend api

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -39,7 +39,6 @@ import { Notifications } from 'component/common/Notifications/Notifications';
 import { useAdminRoutes } from 'component/admin/useAdminRoutes';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { INavigationMenuItem } from '../../../interfaces/route';
 import { Badge } from '../../common/Badge/Badge';
 
 const StyledHeader = styled(AppBar)(({ theme }) => ({

--- a/src/lib/proxy/client-feature-toggle-read-model-type.ts
+++ b/src/lib/proxy/client-feature-toggle-read-model-type.ts
@@ -1,5 +1,5 @@
 import { IFeatureToggleClient } from '../types';
 
 export interface IClientFeatureToggleReadModel {
-    getClient(): Promise<Record<string, Record<string, IFeatureToggleClient>>>;
+    getAll(): Promise<Record<string, Record<string, IFeatureToggleClient>>>;
 }

--- a/src/lib/proxy/client-feature-toggle-read-model.ts
+++ b/src/lib/proxy/client-feature-toggle-read-model.ts
@@ -25,7 +25,7 @@ export default class ClientFeatureToggleReadModel
             });
     }
 
-    private async getAll(): Promise<
+    public async getAll(): Promise<
         Record<string, Record<string, IFeatureToggleClient>>
     > {
         const stopTimer = this.timer(`getAll`);
@@ -179,11 +179,5 @@ export default class ClientFeatureToggleReadModel
             row.strategy_id &&
             !feature.strategies?.find((s) => s?.id === row.strategy_id)
         );
-    }
-
-    async getClient(): Promise<
-        Record<string, Record<string, IFeatureToggleClient>>
-    > {
-        return this.getAll();
     }
 }

--- a/src/lib/proxy/fake-client-feature-toggle-read-model.ts
+++ b/src/lib/proxy/fake-client-feature-toggle-read-model.ts
@@ -11,7 +11,7 @@ export default class FakeClientFeatureToggleReadModel
         > = {},
     ) {}
 
-    getClient(): Promise<Record<string, Record<string, IFeatureToggleClient>>> {
+    getAll(): Promise<Record<string, Record<string, IFeatureToggleClient>>> {
         return Promise.resolve(this.value);
     }
 

--- a/src/lib/proxy/global-frontend-api-cache.ts
+++ b/src/lib/proxy/global-frontend-api-cache.ts
@@ -118,7 +118,7 @@ export class GlobalFrontendApiCache extends EventEmitter {
     }
 
     private async getAllFeatures(): Promise<FrontendApiFeatureCache> {
-        const features = await this.clientFeatureToggleReadModel.getClient();
+        const features = await this.clientFeatureToggleReadModel.getAll();
         return this.mapFeatures(features);
     }
 


### PR DESCRIPTION
There was extra call getClient().getAll() not needed and complicating readability.