### PR TITLE
feat: count frontend api requests 

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
@@ -25,7 +25,7 @@ import Raw = Knex.Raw;
 export interface IGetAllFeatures {
     featureQuery?: IFeatureToggleQuery;
     archived: boolean;
-    requestType: 'client' | 'admin' | 'playground';
+    requestType: 'client' | 'admin' | 'playground' | 'frontend';
     userId?: number;
 }
 
@@ -71,7 +71,7 @@ export default class FeatureToggleClientStore
         const isAdmin = requestType === 'admin';
         const isPlayground = requestType === 'playground';
         const environment = featureQuery?.environment || DEFAULT_ENV;
-        const stopTimer = this.timer(`getFeatureAdmin${requestType}`);
+        const stopTimer = this.timer(`getAllBy${requestType}`);
 
         let selectColumns = [
             'features.name as name',
@@ -351,6 +351,16 @@ export default class FeatureToggleClientStore
             featureQuery,
             archived: false,
             requestType: 'client',
+        });
+    }
+
+    async getFrontendApiClient(
+        featureQuery?: IFeatureToggleQuery,
+    ): Promise<IFeatureToggleClient[]> {
+        return this.getAll({
+            featureQuery,
+            archived: false,
+            requestType: 'frontend',
         });
     }
 

--- a/src/lib/features/client-feature-toggles/types/client-feature-toggle-store-type.ts
+++ b/src/lib/features/client-feature-toggles/types/client-feature-toggle-store-type.ts
@@ -9,6 +9,10 @@ export interface IFeatureToggleClientStore {
         featureQuery: Partial<IFeatureToggleQuery>,
     ): Promise<IFeatureToggleClient[]>;
 
+    getFrontendApiClient(
+        featureQuery: Partial<IFeatureToggleQuery>,
+    ): Promise<IFeatureToggleClient[]>;
+
     getPlayground(
         featureQuery: Partial<IFeatureToggleQuery>,
     ): Promise<IFeatureToggleClient[]>;

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1064,7 +1064,7 @@ class FeatureToggleService {
     async getClientFeatures(
         query?: IFeatureToggleQuery,
     ): Promise<FeatureConfigurationClient[]> {
-        const result = await this.clientFeatureToggleStore.getClient(
+        const result = await this.clientFeatureToggleStore.getFrontendApiClient(
             query || {},
         );
         return result.map(


### PR DESCRIPTION
Now frontend API requests will be counted separately under getAllByfrontend. We are already tracking new FE db calls, so we can build grafana dashboard.
