### PR TITLE
chore: add a script that validates that we don't use prohibited mui material-icons import

### DIFF
--- a/.github/workflows/build_frontend_prs.yml
+++ b/.github/workflows/build_frontend_prs.yml
@@ -25,4 +25,3 @@ jobs:
       - run: yarn run lint:check
       - run: yarn run test
       - run: yarn run ts:check # TODO: optimize
-      - run: yarn build

--- a/.github/workflows/build_frontend_prs.yml
+++ b/.github/workflows/build_frontend_prs.yml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: yarn run lint:material:icons
       - run: yarn --frozen-lockfile
       - run: yarn run lint:check
       - run: yarn run test
       - run: yarn run ts:check # TODO: optimize
+      - run: yarn build

--- a/frontend/check-imports.rc
+++ b/frontend/check-imports.rc
@@ -1,5 +1,6 @@
 if grep -R --include="*.js" --include="*.jsx" --include="*.ts" --include="*.tsx" "from '@mui/icons-material'" src; then
-  echo "Prohibited import from '@mui/icons-material' found."
+  echo "Prohibited import from '@mui/icons-material' found. Use default imports referencing the file instead of the 
+  global package. Example: import Delete from '@mui/icons-material/Delete';'"
   exit 1
 else
   echo "No prohibited imports from '@mui/icons-material' found."

--- a/frontend/check-imports.rc
+++ b/frontend/check-imports.rc
@@ -1,0 +1,6 @@
+if grep -R --include="*.js" --include="*.jsx" --include="*.ts" --include="*.tsx" "from '@mui/icons-material'" src; then
+  echo "Prohibited import from '@mui/icons-material' found."
+  exit 1
+else
+  echo "No prohibited imports from '@mui/icons-material' found."
+fi

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,12 +2,15 @@
   "name": "unleash-frontend-local",
   "version": "0.0.0",
   "private": true,
-  "files": ["index.js", "build"],
+  "files": [
+    "index.js",
+    "build"
+  ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "./check-imports.rc && vite build",
     "dev": "vite",
     "start": "vite",
     "start:prod": "vite build && vite preview",
@@ -142,7 +145,11 @@
     }
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "./check-imports.rc && vite build",
+    "build": "yarn run lint:material:icons && vite build",
     "dev": "vite",
     "start": "vite",
     "start:prod": "vite build && vite preview",
@@ -22,6 +22,7 @@
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest run",
     "test:snapshot": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" yarn test -u",
     "test:watch": "NODE_OPTIONS=\"${NODE_OPTIONS} --no-experimental-fetch\" vitest watch",
+    "lint:material:icons": "./check-imports.rc",
     "lint": "biome lint src --apply",
     "lint:check": "biome check src",
     "fmt": "biome format src --write",

--- a/frontend/src/component/admin/banners/BannerModal/BannerForm.tsx
+++ b/frontend/src/component/admin/banners/BannerModal/BannerForm.tsx
@@ -7,8 +7,9 @@ import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import Input from 'component/common/Input/Input';
 import { BannerVariant } from 'interfaces/banner';
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
-import Visibility from '@mui/icons-material/Visibility';
+//import Visibility from '@mui/icons-material/Visibility';
 import { BannerDialog } from 'component/banners/Banner/BannerDialog/BannerDialog';
+import { Visibility } from '@mui/icons-material';
 
 const StyledForm = styled('div')(({ theme }) => ({
     display: 'flex',

--- a/frontend/src/component/admin/banners/BannerModal/BannerForm.tsx
+++ b/frontend/src/component/admin/banners/BannerModal/BannerForm.tsx
@@ -7,9 +7,8 @@ import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import Input from 'component/common/Input/Input';
 import { BannerVariant } from 'interfaces/banner';
 import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
-//import Visibility from '@mui/icons-material/Visibility';
+import Visibility from '@mui/icons-material/Visibility';
 import { BannerDialog } from 'component/banners/Banner/BannerDialog/BannerDialog';
-import { Visibility } from '@mui/icons-material';
 
 const StyledForm = styled('div')(({ theme }) => ({
     display: 'flex',


### PR DESCRIPTION
This PR adds a check that should fail the build if we use disallowed imports from `@mui/icons-material`