### PR TITLE
task: Make Inactive users an enterprise feature (#6510)

### DIFF
--- a/frontend/src/component/admin/users/UsersAdmin.tsx
+++ b/frontend/src/component/admin/users/UsersAdmin.tsx
@@ -7,27 +7,47 @@ import EditUser from './EditUser/EditUser';
 import NotFound from 'component/common/NotFound/NotFound';
 import { InactiveUsersList } from './InactiveUsersList/InactiveUsersList';
 import { AccessMatrix } from './AccessMatrix/AccessMatrix';
+import { PremiumFeature } from '../../common/PremiumFeature/PremiumFeature';
+import { ConditionallyRender } from '../../common/ConditionallyRender/ConditionallyRender';
+import useUiConfig from '../../../hooks/api/getters/useUiConfig/useUiConfig';
 
-export const UsersAdmin = () => (
-    <div>
-        <PermissionGuard permissions={ADMIN}>
-            <Routes>
-                <Route
-                    index
-                    element={
-                        <>
-                            <InviteLinkBar />
-                            <UsersList />
-                        </>
-                    }
-                />
-                <Route path=':id/edit' element={<EditUser />} />
-                <Route path=':id/access' element={<AccessMatrix />} />
-                <Route path='inactive' element={<InactiveUsersList />} />
-                <Route path='*' element={<NotFound />} />
-            </Routes>
-        </PermissionGuard>
-    </div>
-);
+export const UsersAdmin = () => {
+    const { isEnterprise } = useUiConfig();
+    return (
+        <div>
+            <PermissionGuard permissions={ADMIN}>
+                <Routes>
+                    <Route
+                        index
+                        element={
+                            <>
+                                <InviteLinkBar />
+                                <UsersList />
+                            </>
+                        }
+                    />
+                    <Route path=':id/edit' element={<EditUser />} />
+                    <Route path=':id/access' element={<AccessMatrix />} />
+                    <Route
+                        path='inactive'
+                        element={
+                            <ConditionallyRender
+                                condition={isEnterprise()}
+                                show={<InactiveUsersList />}
+                                elseShow={
+                                    <PremiumFeature
+                                        feature='inactive-users'
+                                        page
+                                    />
+                                }
+                            />
+                        }
+                    />
+                    <Route path='*' element={<NotFound />} />
+                </Routes>
+            </PermissionGuard>
+        </div>
+    );
+};
 
 export default UsersAdmin;

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -36,9 +36,11 @@ import { useSearch } from 'hooks/useSearch';
 import { Download } from '@mui/icons-material';
 import { StyledUsersLinkDiv } from '../Users.styles';
 import { useUiFlag } from 'hooks/useUiFlag';
+import useUiConfig from '../../../../hooks/api/getters/useUiConfig/useUiConfig';
 
 const UsersList = () => {
     const navigate = useNavigate();
+    const { isEnterprise } = useUiConfig();
     const { users, roles, refetch, loading } = useUsers();
     const { setToastData, setToastApiError } = useToast();
     const { removeUser, userLoading, userApiErrors } = useAdminUsersApi();
@@ -315,9 +317,16 @@ const UsersList = () => {
             }
         >
             <UserLimitWarning />
-            <StyledUsersLinkDiv>
-                <Link to='/admin/users/inactive'>View inactive users</Link>
-            </StyledUsersLinkDiv>
+            <ConditionallyRender
+                condition={isEnterprise()}
+                show={
+                    <StyledUsersLinkDiv>
+                        <Link to='/admin/users/inactive'>
+                            View inactive users
+                        </Link>
+                    </StyledUsersLinkDiv>
+                }
+            />
             <SearchHighlightProvider value={getSearchText(searchValue)}>
                 <VirtualizedTable
                     rows={rows}

--- a/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
+++ b/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
@@ -123,6 +123,11 @@ const PremiumFeatures = {
         url: '', // FIXME: url
         label: 'Dashboard',
     },
+    'inactive-users': {
+        plan: FeaturePlan.ENTERPRISE,
+        url: '',
+        label: 'Automatic clean-up of inactive users',
+    },
 };
 
 type PremiumFeatureType = keyof typeof PremiumFeatures;


### PR DESCRIPTION
Ivar pointed out to me that this was intended as an enterprise only feature. So this PR makes it an enterprise only feature. Conditionally render the link in the normal user table, and use premium feature component if you happen to hit the route and not be running on the enterprise plan.

