### PR TITLE
chore: re-add max listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prebuild:watch": "yarn run clean",
     "build:watch": "tsc -w --strictNullChecks false",
     "prebuild": "yarn run clean",
-    "test": "NODE_ENV=test PORT=4243 jest",
+    "test": "NODE_ENV=test PORT=4243 node --trace-warnings node_modules/.bin/jest",
     "test:unit": "NODE_ENV=test PORT=4243 jest --testPathIgnorePatterns=src/test/e2e --testPathIgnorePatterns=dist",
     "test:docker": "./scripts/docker-postgres.sh",
     "test:report": "NODE_ENV=test PORT=4243 jest --reporters=\"default\" --reporters=\"jest-junit\"",

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -80,6 +80,6 @@ export default class ConfigurationRevisionService extends EventEmitter {
     }
 
     destroy(): void {
-        ConfigurationRevisionService.instance.removeAllListeners();
+        ConfigurationRevisionService.instance?.removeAllListeners();
     }
 }

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -78,4 +78,8 @@ export default class ConfigurationRevisionService extends EventEmitter {
 
         return this.revisionId;
     }
+
+    destroy(): void {
+        ConfigurationRevisionService.instance.removeAllListeners();
+    }
 }

--- a/src/lib/middleware/response-time-metrics.test.ts
+++ b/src/lib/middleware/response-time-metrics.test.ts
@@ -52,6 +52,9 @@ describe('responseTimeMetrics old behavior', () => {
         getAppCountSnapshot: jest.fn(),
     };
     const eventBus = new EventEmitter();
+    afterEach(() => {
+        eventBus.removeAllListeners();
+    });
 
     test('uses baseUrl and route path to report metrics', async () => {
         let timeInfo: any;

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -1,6 +1,5 @@
 import supertest from 'supertest';
 
-import EventEmitter from 'events';
 import getApp from '../../../lib/app';
 import { createTestConfig } from '../../config/test-config';
 import { IAuthType, IUnleashConfig } from '../../../lib/types/option';
@@ -323,10 +322,6 @@ async function createApp(
     const unleashSession = sessionDb(config, undefined);
     const app = await getApp(config, stores, services, unleashSession, db);
     const request = supertest.agent(app);
-    // seems like this prevents the following issue in tests:
-    // MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 UPDATE_REVISION listeners added to [ConfigurationRevisionService]. Use emitter.setMaxListeners() to increase limit
-    const emitter = new EventEmitter();
-    emitter.setMaxListeners(0);
 
     const destroy = async () => {
         // iterate on the keys of services and if the services at that key has a function called destroy then call it

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -1,5 +1,6 @@
 import supertest from 'supertest';
 
+import EventEmitter from 'events';
 import getApp from '../../../lib/app';
 import { createTestConfig } from '../../config/test-config';
 import { IAuthType, IUnleashConfig } from '../../../lib/types/option';
@@ -322,6 +323,10 @@ async function createApp(
     const unleashSession = sessionDb(config, undefined);
     const app = await getApp(config, stores, services, unleashSession, db);
     const request = supertest.agent(app);
+    // seems like this prevents the following issue in tests:
+    // MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 UPDATE_REVISION listeners added to [ConfigurationRevisionService]. Use emitter.setMaxListeners() to increase limit
+    const emitter = new EventEmitter();
+    emitter.setMaxListeners(0);
 
     const destroy = async () => {
         // iterate on the keys of services and if the services at that key has a function called destroy then call it


### PR DESCRIPTION
## About the changes
Some tests are reporting this error:

`MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 UPDATE_REVISION listeners added to [ConfigurationRevisionService]. Use emitter.setMaxListeners() to increase limit`

I thought it's because of this change https://github.com/Unleash/unleash/pull/6400#discussion_r1511494201 but it was not.

I've managed to get a trace of the issue following this https://stackoverflow.com/q/62897235/239613 and now we can identify `ConfigurationRevisionService` as one explanation. The reason is that it's a singleton that should be cleaned up after tests.

E.g.: https://github.com/Unleash/unleash/actions/runs/8248332132/job/22558419656?pr=6517#step:8:15