### PR TITLE
feat: share context between both frontend apis

### DIFF
--- a/src/lib/features/frontend-api/create-context.ts
+++ b/src/lib/features/frontend-api/create-context.ts
@@ -36,5 +36,6 @@ export function createContext(value: any): Context {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const enrichContextWithIp = (query: any, ip: string): Context => {
     query.remoteAddress = query.remoteAddress || ip;
+    query.sessionId = query.sessionId || String(Math.random());
     return createContext(query);
 };

--- a/src/lib/features/frontend-api/frontend-api-controller.ts
+++ b/src/lib/features/frontend-api/frontend-api-controller.ts
@@ -179,14 +179,15 @@ export default class FrontendAPIController extends Controller {
         let toggles: FrontendApiFeatureSchema[];
         let newToggles: FrontendApiFeatureSchema[] = [];
         if (this.config.flagResolver.isEnabled('globalFrontendApiCache')) {
+            const context = FrontendAPIController.createContext(req);
             [toggles, newToggles] = await Promise.all([
                 this.services.frontendApiService.getFrontendApiFeatures(
                     req.user,
-                    FrontendAPIController.createContext(req),
+                    context,
                 ),
                 this.services.frontendApiService.getNewFrontendApiFeatures(
                     req.user,
-                    FrontendAPIController.createContext(req),
+                    context,
                 ),
             ]);
             const sortedToggles = toggles.sort((a, b) =>
@@ -201,9 +202,10 @@ export default class FrontendAPIController extends Controller {
                         toggles.length
                     }, new count ${newToggles.length}, projects ${
                         req.user.projects
-                    }, environment ${req.user.environment}, diff ${diff(
-                        sortedToggles,
-                        sortedNewToggles,
+                    }, environment ${
+                        req.user.environment
+                    }, diff ${JSON.stringify(
+                        diff(sortedToggles, sortedNewToggles),
                     )}`,
                 );
             }


### PR DESCRIPTION
We are sharing contexts because we want both clients to use same session ID.