### PR TITLE
chore: suggest nested properties in action filters

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFormStepSource.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFormStepSource.tsx
@@ -13,6 +13,7 @@ import Add from '@mui/icons-material/Add';
 import { ProjectActionsPreviewPayload } from './ProjectActionsPreviewPayload';
 import { useSignalEndpointSignals } from 'hooks/api/getters/useSignalEndpointSignals/useSignalEndpointSignals';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { flattenPayload } from '@server/util/flattenPayload';
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
     margin: theme.spacing(2, 0),
@@ -86,7 +87,9 @@ export const ProjectActionsFormStepSource = ({
         const lastSourcePayload = signalEndpointSignals[0]?.payload;
         return {
             lastSourcePayload,
-            filterSuggestions: Object.keys(lastSourcePayload || {}),
+            filterSuggestions: Object.keys(
+                flattenPayload(lastSourcePayload) || {},
+            ).sort(),
         };
     }, [signalEndpointSignals]);
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2029/support-filtering-on-nested-properties

Suggests nested properties in action filters. Also sorts them alphabetically.

Follow up to https://github.com/Unleash/unleash/pull/6531

<img width="381" alt="image" src="https://github.com/Unleash/unleash/assets/14320932/4e2c900d-335b-4360-8be4-186f3887e42b">
