### PR TITLE
fix: change insights icon to award star

### DIFF
--- a/frontend/src/component/executiveDashboard/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/executiveDashboard/componentsStat/FlagStats/FlagStats.tsx
@@ -1,4 +1,4 @@
-import Settings from '@mui/icons-material/Settings';
+import Icon from '@mui/material/Icon';
 import { Box, Typography, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
@@ -57,11 +57,12 @@ const StyledFlagCountPerUser = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.mainHeader,
 }));
 
-const StyledSettingsIcon = styled(Settings)(({ theme }) => ({
+const StyledIcon = styled(Icon)(({ theme }) => ({
     color: theme.palette.primary.main,
     width: '15px',
     height: '15px',
     marginRight: theme.spacing(0.5),
+    fontSize: '15px!important',
 }));
 
 interface IFlagStatsProps {
@@ -87,7 +88,7 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
                     <StyledInsightsContainer>
                         <StyledTextContainer>
                             <StyledHeaderContainer>
-                                <StyledSettingsIcon />
+                                <StyledIcon>award_star</StyledIcon>
                                 <Typography
                                     fontWeight='bold'
                                     variant='body2'


### PR DESCRIPTION
Changes the insights icon to award_star.  

Closes # [1-2180](https://linear.app/unleash/issue/1-2180/change-icon-to-award-star)

<img width="320" alt="Screenshot 2024-03-13 at 13 59 21" src="https://github.com/Unleash/unleash/assets/104830839/9bece091-23c3-4ebf-beda-31a81c1f75e4">

