### PR TITLE
refactor: allow user events to take in only what they need

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -105,14 +105,14 @@ export default class EventService {
     }
 
     /**
-     * @deprecated use storeUserEvent instead
+     * For events arising from user actions you should prefer to use storeUserEvents instead
      */
     async storeEvent(event: IBaseEvent): Promise<void> {
         return this.storeEvents([event]);
     }
 
     /**
-     * @deprecated use storeUserEvents instead
+     * For events arising from user actions you should prefer to use storeUserEvents instead
      */
     async storeEvents(events: IBaseEvent[]): Promise<void> {
         let enhancedEvents = events;

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -1304,11 +1304,11 @@ export class PotentiallyStaleOnEvent extends BaseEvent {
 }
 
 export class UserCreatedEvent extends BaseEvent {
-    readonly data: IUserWithRootRole;
+    readonly data: IUserEventData;
 
     constructor(eventData: {
         createdBy: string | IUser;
-        userCreated: IUserWithRootRole;
+        userCreated: IUserEventData;
         createdByUserId: number;
     }) {
         super(USER_CREATED, eventData.createdBy, eventData.createdByUserId);
@@ -1317,13 +1317,13 @@ export class UserCreatedEvent extends BaseEvent {
 }
 
 export class UserUpdatedEvent extends BaseEvent {
-    readonly data: IUserWithRootRole;
-    readonly preData: IUserWithRootRole;
+    readonly data: IUserEventData;
+    readonly preData: IUserEventData;
 
     constructor(eventData: {
         createdBy: string | IUser;
-        preUser: IUserWithRootRole;
-        postUser: IUserWithRootRole;
+        preUser: IUserEventData;
+        postUser: IUserEventData;
         createdByUserId: number;
     }) {
         super(USER_UPDATED, eventData.createdBy, eventData.createdByUserId);
@@ -1333,11 +1333,11 @@ export class UserUpdatedEvent extends BaseEvent {
 }
 
 export class UserDeletedEvent extends BaseEvent {
-    readonly preData: IUserWithRootRole;
+    readonly preData: IUserEventData;
 
     constructor(eventData: {
         createdBy: string | IUser;
-        deletedUser: IUserWithRootRole;
+        deletedUser: IUserEventData;
         createdByUserId: number;
     }) {
         super(USER_DELETED, eventData.createdBy, eventData.createdByUserId);
@@ -1345,7 +1345,15 @@ export class UserDeletedEvent extends BaseEvent {
     }
 }
 
-function mapUserToData(user: IUserWithRootRole): any {
+interface IUserEventData extends Partial<IUserWithRootRole> {
+    id: number;
+    name: string;
+    username: string;
+    email: string;
+    rootRole: number;
+}
+
+function mapUserToData(user: IUserEventData): any {
     return {
         id: user.id,
         name: user.name,


### PR DESCRIPTION
This changes the user event system type to ingest a partial IUserWithRootRole interface rather than the whole interface. 

This also undeprecates the storeEvent(s) methods.

**Why the new interface**

Usually when creating users we can just sling around the entire User object. That's absolutely fine in cases where we have the entire object including all its permissions. But we certainly don't have all those permissions in an easily accessible way in the SSO/SCIM code.

Luckily, that event object doesn't need or care about those properties. It explicitly extracts only the fields the new interface provides and discards everything else. So we're depending on a wider type than we need. 

**Why the undeprecation**

Some things don't get made by real users. Some things get made by the system user, which both doesn't and probably shouldn't have an email. I can't find the breadcrumbs for why we deprecated that method. There's no explanation in the deprecation warning and the PR that makes the change has no reasoning either

The old deprecated method is used extensively throughout the code and it's hard to know if that code is now broken or why it should be considered broken if it is

Completely open to being told this is wrong and bad, but then I think we need that deprecation warning to have useful details on what danger it causes