### PR TITLE
chore: make Alvin and Nnenna CODEOWNERs for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # docs
-/website/ @alvinometric
+/website/ @alvinometric @nnennandukwe

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # docs
-/website/ @thomasheartman
+/website/ @alvinometric


### PR DESCRIPTION
This PR updates the codeowners file, setting @alvinometric and @nnennandukwe as the code owners for docs, removing @thomasheartman .