### PR TITLE
chore: mark resource limits config type fields mandatory

### DIFF
--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -4,6 +4,16 @@ export const resourceLimitsSchema = {
     $id: '#/components/schemas/resourceLimitsSchema',
     type: 'object',
     description: 'A map of resource names and their limits.',
+    required: [
+        'segmentValues',
+        'strategySegments',
+        'actionSetActions',
+        'actionSetsPerProject',
+        'actionSetFilters',
+        'actionSetFilterValues',
+        'signalEndpoints',
+        'signalTokensPerEndpoint',
+    ],
     additionalProperties: false,
     properties: {
         segmentValues: {


### PR DESCRIPTION
## About the changes
All fields should be defined in the configuration to either a user-provided value or a sensible default