### PR TITLE
docs: add notes about how Unleash deals with string context values and conversion

### DIFF
--- a/website/docs/reference/strategy-constraints.md
+++ b/website/docs/reference/strategy-constraints.md
@@ -30,7 +30,7 @@ Strategy constraints use fields from the [Unleash Context](../reference/unleash-
 You can constrain both on [standard context fields](../reference/unleash-context#structure) and on [custom context fields](../reference/unleash-context#custom-context-fields).
 
 :::info
-Unleash SDK expect all context values to be strings. If you use an operator that acts on non-string values, such as [numeric operators](#numeric-operators) or [date and time operators](#date-and-time-operators), the SDK will attempt to convert the string into the expected type. If the conversion fails, the constraint will evaluate to `false`.
+Unleash SDKs expect all context values to be strings. If you use an operator that acts on non-string values, such as [numeric operators](#numeric-operators) or [date and time operators](#date-and-time-operators), the SDK will attempt to convert the string into the expected type. If the conversion fails, the constraint will evaluate to `false`.
 :::
 
 This page explains what strategy constraints are in Unleash and how they work. If you want to know *how you add* strategy constraints to an activation strategy, see [the corresponding how-to guide](../how-to/how-to-add-strategy-constraints.md "how to add strategy constraints").

--- a/website/docs/reference/strategy-constraints.md
+++ b/website/docs/reference/strategy-constraints.md
@@ -29,6 +29,10 @@ With strategy constraints, you can:
 Strategy constraints use fields from the [Unleash Context](../reference/unleash-context) to determine whether a strategy should apply or not.
 You can constrain both on [standard context fields](../reference/unleash-context#structure) and on [custom context fields](../reference/unleash-context#custom-context-fields).
 
+:::info
+Unleash SDK expect all context values to be strings. If you use an operator that acts on non-string values, such as [numeric operators](#numeric-operators) or [date and time operators](#date-and-time-operators), the SDK will attempt to convert the string into the expected type. If the conversion fails, the constraint will evaluate to `false`.
+:::
+
 This page explains what strategy constraints are in Unleash and how they work. If you want to know *how you add* strategy constraints to an activation strategy, see [the corresponding how-to guide](../how-to/how-to-add-strategy-constraints.md "how to add strategy constraints").
 
 <VideoContent videoUrls={["https://www.youtube.com/embed/kqtqMFhLRBE"]}/>

--- a/website/docs/reference/unleash-context.md
+++ b/website/docs/reference/unleash-context.md
@@ -38,7 +38,7 @@ Some SDK implementations of the Unleash Context allow for the values in the `pro
 
 As an example: You've created a custom field called `groupId`. You know group IDs will always be numeric. You then create a constraint on a strategy that says the user must be in group `123456`. If you were to set the property `groupId` to the number `123456` in the `properties` field on the SDK side, the constraint check would fail, because in most languages the number `123456` is not equal to the string `123456` (i.e. `123456 != "123456"`).
 
-
+For operators that work on non-string types, such as numeric and date time operators, these will convert the string value to the appropriate type before performing the comparison. This means that if you use a numeric greater than operator for the value `"5"`, it will convert that value to the number `5` before doing the comparison. If the value can't be converted, the constraint will fail.
 
 ## Custom context fields
 


### PR DESCRIPTION
This change addresses the question in #6542 about using non-string
operators on string values by clarifying that Unleash SDK converts the
string values before performing the comparison.