### PR TITLE
chore: drop action definition required

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepActions/ProjectActionsActionItem.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepActions/ProjectActionsActionItem.tsx
@@ -87,11 +87,13 @@ export const ProjectActionsActionItem = ({
             ...action,
             error: undefined,
         });
-        if (
-            actionDefinition?.required.some(
-                (required) => !executionParams[required],
-            )
-        ) {
+
+        const requiredParameters =
+            actionDefinition?.parameters
+                .filter(({ optional }) => !optional)
+                .map(({ name }) => name) || [];
+
+        if (requiredParameters.some((required) => !executionParams[required])) {
             stateChanged({
                 ...action,
                 error: 'Please fill all required fields.',

--- a/src/lib/util/constants/actions.ts
+++ b/src/lib/util/constants/actions.ts
@@ -9,8 +9,6 @@ export type ActionDefinition = {
     category?: string;
     permissions: string[];
     parameters: ActionDefinitionParameter[];
-    // TODO: Remove this in favor of parameters (filter by !optional)
-    required: string[];
 };
 
 export const ACTIONS = new Map<string, ActionDefinition>([
@@ -22,7 +20,6 @@ export const ACTIONS = new Map<string, ActionDefinition>([
             category: 'Feature toggles',
             permissions: ['UPDATE_FEATURE_ENVIRONMENT'],
             parameters: toggleFeatureParameters,
-            required: ['project', 'environment', 'featureName'],
         },
     ],
     [
@@ -34,7 +31,6 @@ export const ACTIONS = new Map<string, ActionDefinition>([
             category: 'Feature toggles',
             permissions: ['UPDATE_FEATURE_ENVIRONMENT'],
             parameters: toggleFeatureParameters,
-            required: ['project', 'environment', 'featureName'],
         },
     ],
 ]);


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2046/implement-dynamic-action-parameters

Follow up to https://github.com/Unleash/unleash/pull/6554

Cleans up the `required` property in action definitions after adapting to using the `parameters` property instead.