### PR TITLE
Fix: insights beta badge

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -139,8 +139,7 @@ const StyledLinkWithBetaBadge = ({
 }: { title: string; to: string }) => (
     <StyledLink to={to} sx={{ margin: 0 }}>
         <div>
-            <span>{title}</span>{' '}
-            <Badge color='success'>Beta</Badge>
+            <span>{title}</span> <Badge color='success'>Beta</Badge>
         </div>
     </StyledLink>
 );

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -127,18 +127,6 @@ const StyledAdvancedNavButton = styled('button')(({ theme }) => ({
     cursor: 'pointer',
 }));
 
-const StyledSpan = styled('span')({
-    height: '16px',
-    paddingBottom: 16,
-});
-
-const StyledBadge = styled(Badge)({
-    height: '16px',
-    maxHeight: '16px',
-    padding: 0.25,
-    marginBottom: 0,
-});
-
 const styledIconProps = (theme: Theme) => ({
     color: theme.palette.neutral.main,
 });

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -145,16 +145,14 @@ const styledIconProps = (theme: Theme) => ({
 
 const StyledLink = styled(Link)(({ theme }) => focusable(theme));
 
-const StyledLinkWithBetaBagde = ({
+const StyledLinkWithBetaBadge = ({
     title,
     to,
 }: { title: string; to: string }) => (
     <StyledLink to={to} sx={{ margin: 0 }}>
         <div>
             <span>{title}</span>{' '}
-            <StyledSpan>
-                <StyledBadge color='success'>Beta</StyledBadge>
-            </StyledSpan>
+            <Badge color='success'>Beta</Badge>
         </div>
     </StyledLink>
 );
@@ -279,7 +277,7 @@ const Header: VFC = () => {
                         <ConditionallyRender
                             condition={insightsDashboard}
                             show={
-                                <StyledLinkWithBetaBagde
+                                <StyledLinkWithBetaBadge
                                     to={'/insights'}
                                     title={'Insights'}
                                 />


### PR DESCRIPTION
Reuses the beta badge from insights
<img width="1448" alt="Screenshot 2024-03-14 at 18 01 42" src="https://github.com/Unleash/unleash/assets/104830839/c85b6838-c120-471b-9ff3-440c4208dc53">
