### PR TITLE
feat: Added shutdown hook option

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -12,13 +12,13 @@ import { createDb } from './db/db-pool';
 import sessionDb from './middleware/session-db';
 // Types
 import {
+    CustomAuthHandler,
     IAuthType,
     IUnleash,
     IUnleashConfig,
     IUnleashOptions,
     IUnleashServices,
     RoleName,
-    CustomAuthHandler,
     SYSTEM_USER,
 } from './types';
 
@@ -58,6 +58,13 @@ async function createApp(
         if (server) {
             const stopServer = promisify(server.stop);
             await stopServer();
+        }
+        if (typeof config.shutdownHook === 'function') {
+            try {
+                await config.shutdownHook();
+            } catch (e) {
+                logger.error('Failure when executing shutdown hook', e);
+            }
         }
         services.schedulerService.stop();
         services.addonService.destroy();

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -2,7 +2,7 @@ import { Express } from 'express';
 import EventEmitter from 'events';
 import { LogLevel, LogProvider } from '../logger';
 import { ILegacyApiTokenCreate } from './models/api-token';
-import { IFlagResolver, IExperimentalOptions, IFlags } from './experimental';
+import { IExperimentalOptions, IFlagResolver, IFlags } from './experimental';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import { IUnleashServices } from './services';
 import { ResourceLimitsSchema } from '../openapi/spec/resource-limits-schema';
@@ -231,6 +231,7 @@ export interface IUnleashConfig {
     enableOAS: boolean;
     preHook?: Function;
     preRouterHook?: Function;
+    shutdownHook?: Function;
     enterpriseVersion?: string;
     eventBus: EventEmitter;
     environmentEnableOverrides?: string[];


### PR DESCRIPTION
An entrypoint for enterprise to register a hook which will be called before the database and scheduler services are torn down. That way enterprise can also perform graceful shutdown.

