### PR TITLE
fix: project settings selected tab bug

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
@@ -93,7 +93,8 @@ export const ProjectSettings = () => {
             tabs={tabs}
             value={
                 tabs.find(
-                    ({ id }) => id && location.pathname?.includes(`/${id}`),
+                    ({ id }) =>
+                        id && location.pathname?.includes(`/settings/${id}`),
                 )?.id || tabs[0].id
             }
             onChange={onChange}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2034/project-settings-url-bug

This prevents a bug where the wrong tab would show as selected, only present in an edge case where the project has the name of a settings tab.