### PR TITLE
chore: log error properly

### DIFF
--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -158,7 +158,10 @@ class EventStore implements IEventStore {
         try {
             await this.db(TABLE).insert(events.map(this.eventToDbRow));
         } catch (error: unknown) {
-            this.logger.warn(`Failed to store events: ${error}`);
+            this.logger.warn(
+                `Failed to store events: ${JSON.stringify(events)}`,
+                error,
+            );
         }
     }
 


### PR DESCRIPTION
## About the changes
We see some logs with: `Failed to store events: Error: The query is empty` which suggests we're not sending events to batchStore. This will help us confirm that and will give us better insights