### PR TITLE
fix: set log level to error for db migrate

### DIFF
--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -3,7 +3,7 @@ import { getInstance } from 'db-migrate';
 import type { IUnleashConfig } from './lib/types/option';
 import { secondsToMilliseconds } from 'date-fns';
 
-log.setLogLevel('info');
+log.setLogLevel('error');
 
 export async function migrateDb({ db }: IUnleashConfig): Promise<void> {
     const custom = {


### PR DESCRIPTION
This PR sets the log level of db-migrate to error, because it interferes with the indexing of our logs in Loki when the logs are not in JSON format.