### PR TITLE
feat: add configurable event for banner goto action

### DIFF
--- a/frontend/src/component/banners/Banner/Banner.tsx
+++ b/frontend/src/component/banners/Banner/Banner.tsx
@@ -72,10 +72,16 @@ export const Banner = ({ banner, inline, maxHeight }: IBannerProps) => {
         icon,
         link,
         linkText = 'More info',
+        linkClicked,
         plausibleEvent,
         dialogTitle,
         dialog,
     } = banner;
+
+    const openDialog = () => {
+        setOpen(true);
+        linkClicked?.();
+    };
 
     const bannerBar = (
         <StyledBar variant={variant} inline={inline} maxHeight={maxHeight}>
@@ -86,7 +92,7 @@ export const Banner = ({ banner, inline, maxHeight }: IBannerProps) => {
             <BannerButton
                 link={link}
                 plausibleEvent={plausibleEvent}
-                openDialog={() => setOpen(true)}
+                openDialog={openDialog}
             >
                 {linkText}
             </BannerButton>

--- a/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
+++ b/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
@@ -5,6 +5,7 @@ import { useOutdatedSdks } from 'hooks/api/getters/useOutdatedSdks/useOutdatedSd
 import { useUiFlag } from 'hooks/useUiFlag';
 import { Link } from 'react-router-dom';
 import { styled } from '@mui/material';
+import { usePlausibleTracker } from '../../../hooks/usePlausibleTracker';
 
 const StyledList = styled('ul')({ margin: 0 });
 
@@ -13,12 +14,30 @@ export const OutdatedSdksBanner = () => {
         data: { sdks },
     } = useOutdatedSdks();
     const flagEnabled = useUiFlag('outdatedSdksBanner');
+    const { trackEvent } = usePlausibleTracker();
+
+    const bannerClicked = () => {
+        trackEvent('sdk-reporting', {
+            props: {
+                eventType: 'banner application clicked',
+            },
+        });
+    };
+
+    const linkClicked = () => {
+        trackEvent('sdk-reporting', {
+            props: {
+                eventType: 'banner clicked',
+            },
+        });
+    };
 
     const outdatedSdksBanner: IBanner = {
         message: `We noticed that you're using outdated SDKs. `,
         variant: 'warning',
         link: 'dialog',
         linkText: 'Please update those versions',
+        linkClicked,
         dialogTitle: 'Outdated SDKs',
         dialog: (
             <>
@@ -27,7 +46,11 @@ export const OutdatedSdksBanner = () => {
                         <span>{item.sdkVersion}</span>
                         <StyledList>
                             {item.applications.map((application) => (
-                                <li key={application}>
+                                <li
+                                    key={application}
+                                    onClick={bannerClicked}
+                                    onKeyDown={bannerClicked}
+                                >
                                     <Link to={`/applications/${application}`}>
                                         {application}
                                     </Link>
@@ -42,7 +65,7 @@ export const OutdatedSdksBanner = () => {
     return (
         <>
             <ConditionallyRender
-                condition={flagEnabled && sdks.length > 0}
+                condition={flagEnabled && sdks.length > -1}
                 show={<Banner banner={outdatedSdksBanner} />}
             />
         </>

--- a/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
+++ b/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
@@ -17,7 +17,7 @@ export const OutdatedSdksBanner = () => {
     const { trackEvent } = usePlausibleTracker();
 
     const applicationClickedWithVersion = (sdkVersion: string) => {
-        trackEvent('sdk-reporting', {
+        trackEvent('sdk-banner', {
             props: {
                 eventType: `banner application clicked`,
                 sdkVersion: sdkVersion,
@@ -26,7 +26,7 @@ export const OutdatedSdksBanner = () => {
     };
 
     const bannerClicked = () => {
-        trackEvent('sdk-reporting', {
+        trackEvent('sdk-banner', {
             props: {
                 eventType: 'banner clicked',
             },

--- a/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
+++ b/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
@@ -16,10 +16,11 @@ export const OutdatedSdksBanner = () => {
     const flagEnabled = useUiFlag('outdatedSdksBanner');
     const { trackEvent } = usePlausibleTracker();
 
-    const applicationClicked = () => {
+    const applicationClickedWithVersion = (sdkVersion: string) => {
         trackEvent('sdk-reporting', {
             props: {
-                eventType: 'banner application clicked',
+                eventType: `banner application clicked`,
+                sdkVersion: sdkVersion,
             },
         });
     };
@@ -48,8 +49,16 @@ export const OutdatedSdksBanner = () => {
                             {item.applications.map((application) => (
                                 <li
                                     key={application}
-                                    onClick={applicationClicked}
-                                    onKeyDown={applicationClicked}
+                                    onClick={() => {
+                                        applicationClickedWithVersion(
+                                            item.sdkVersion,
+                                        );
+                                    }}
+                                    onKeyDown={() => {
+                                        applicationClickedWithVersion(
+                                            item.sdkVersion,
+                                        );
+                                    }}
                                 >
                                     <Link to={`/applications/${application}`}>
                                         {application}

--- a/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
+++ b/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
@@ -16,7 +16,7 @@ export const OutdatedSdksBanner = () => {
     const flagEnabled = useUiFlag('outdatedSdksBanner');
     const { trackEvent } = usePlausibleTracker();
 
-    const bannerClicked = () => {
+    const applicationClicked = () => {
         trackEvent('sdk-reporting', {
             props: {
                 eventType: 'banner application clicked',
@@ -24,7 +24,7 @@ export const OutdatedSdksBanner = () => {
         });
     };
 
-    const linkClicked = () => {
+    const bannerClicked = () => {
         trackEvent('sdk-reporting', {
             props: {
                 eventType: 'banner clicked',
@@ -37,7 +37,7 @@ export const OutdatedSdksBanner = () => {
         variant: 'warning',
         link: 'dialog',
         linkText: 'Please update those versions',
-        linkClicked,
+        linkClicked: bannerClicked,
         dialogTitle: 'Outdated SDKs',
         dialog: (
             <>
@@ -48,8 +48,8 @@ export const OutdatedSdksBanner = () => {
                             {item.applications.map((application) => (
                                 <li
                                     key={application}
-                                    onClick={bannerClicked}
-                                    onKeyDown={bannerClicked}
+                                    onClick={applicationClicked}
+                                    onKeyDown={applicationClicked}
                                 >
                                     <Link to={`/applications/${application}`}>
                                         {application}
@@ -65,7 +65,7 @@ export const OutdatedSdksBanner = () => {
     return (
         <>
             <ConditionallyRender
-                condition={flagEnabled && sdks.length > -1}
+                condition={flagEnabled && sdks.length > 0}
                 show={<Banner banner={outdatedSdksBanner} />}
             />
         </>

--- a/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
+++ b/frontend/src/component/banners/OutdatedSdksBanner/OutdatedSdksBanner.tsx
@@ -1,11 +1,11 @@
-import { ConditionallyRender } from '../../common/ConditionallyRender/ConditionallyRender';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Banner } from '../Banner/Banner';
 import type { IBanner } from 'interfaces/banner';
 import { useOutdatedSdks } from 'hooks/api/getters/useOutdatedSdks/useOutdatedSdks';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { Link } from 'react-router-dom';
 import { styled } from '@mui/material';
-import { usePlausibleTracker } from '../../../hooks/usePlausibleTracker';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 const StyledList = styled('ul')({ margin: 0 });
 

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -58,7 +58,8 @@ export type CustomEvents =
     | 'feature-metrics'
     | 'search-bar'
     | 'sdk-reporting'
-    | 'insights-share';
+    | 'insights-share'
+    | 'sdk-banner';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);

--- a/frontend/src/interfaces/banner.ts
+++ b/frontend/src/interfaces/banner.ts
@@ -8,6 +8,7 @@ export interface IBanner {
     sticky?: boolean;
     icon?: string;
     link?: string;
+    linkClicked?: () => void;
     linkText?: string;
     plausibleEvent?: string;
     dialogTitle?: string;

--- a/frontend/src/themes/themeTypes.ts
+++ b/frontend/src/themes/themeTypes.ts
@@ -1,5 +1,3 @@
-import { FormHelperTextOwnProps } from '@mui/material/FormHelperText';
-
 declare module '@mui/material/styles' {
     interface CustomTheme {
         /**

--- a/frontend/src/themes/themeTypes.ts
+++ b/frontend/src/themes/themeTypes.ts
@@ -1,3 +1,5 @@
+import { FormHelperTextOwnProps } from '@mui/material/FormHelperText';
+
 declare module '@mui/material/styles' {
     interface CustomTheme {
         /**


### PR DESCRIPTION
We added banner to get attention of customer, but we are not tracking its usage.
Added a way to track the **goto action** button.