### PR TITLE
fix: authorization header typo

### DIFF
--- a/src/lib/features/metrics/instance/register.ts
+++ b/src/lib/features/metrics/instance/register.ts
@@ -79,7 +79,7 @@ export default class RegisterController extends Controller {
     private static extractProjectFromRequest(
         req: IAuthRequest<unknown, void, ClientApplicationSchema>,
     ) {
-        const token = req.get('Authorisation');
+        const token = req.get('Authorisation') || req.headers.authorization;
         if (token) {
             return token.split(':')[0];
         }


### PR DESCRIPTION
## About the changes
There seems to be a typo in the authorization header. We're keeping the old typo as preferred just in case, but if not present we'll default to the authorization header (not authorisation).

Not sure about the impact of this bug, as all registrations might be using default project.