### PR TITLE
fix: use defaults when creating gradualRollout strategies

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -120,10 +120,6 @@ const sortEnvironments = (overview: IFeatureOverview) => {
     }));
 };
 
-function mergeAll<T>(objects: Partial<T>[]): T {
-    return merge.all<T>(objects.filter((i) => i));
-}
-
 interface StrategyUpdate {
     strategy_name: string;
     parameters: object;
@@ -166,7 +162,9 @@ const defaultParameters = (featureName: string, strategyType: string) => {
         return {};
     }
 };
-
+function mergeAll<T>(objects: Partial<T>[]): T {
+    return merge.all<T>(objects.filter((i) => i));
+}
 class FeatureStrategiesStore implements IFeatureStrategiesStore {
     private db: Db;
 

--- a/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
@@ -144,3 +144,69 @@ test('Can query for features with namePrefix and tags', async () => {
     });
     expect(features).toHaveLength(1);
 });
+
+describe('strategy parameters default to sane defaults', () => {
+    test('Creating a gradualRollout strategy with no parameters uses the default for all necessary fields', async () => {
+        const toggle = await featureToggleStore.create('default', {
+            name: 'testing-strategy-parameters',
+            createdByUserId: 9999,
+        });
+        const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
+            strategyName: 'gradualRollout',
+            projectId: 'default',
+            environment: 'default',
+            featureName: toggle.name,
+            constraints: [],
+            sortOrder: 15,
+            parameters: {},
+        });
+        expect(strategy.parameters).toEqual({
+            rollout: '100',
+            groupId: toggle.name,
+            stickiness: 'default',
+        });
+    });
+    test('Creating a gradualRollout strategy with some parameters, only uses defaults for those not set', async () => {
+        const toggle = await featureToggleStore.create('default', {
+            name: 'testing-strategy-parameters-with-some-parameters',
+            createdByUserId: 9999,
+        });
+        const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
+            strategyName: 'gradualRollout',
+            projectId: 'default',
+            environment: 'default',
+            featureName: toggle.name,
+            constraints: [],
+            sortOrder: 15,
+            parameters: {
+                rollout: '60',
+                stickiness: 'userId',
+            },
+        });
+        expect(strategy.parameters).toEqual({
+            rollout: '60',
+            groupId: toggle.name,
+            stickiness: 'userId',
+        });
+    });
+    test('Creating an applicationHostname strategy does not get unnecessary parameters set', async () => {
+        const toggle = await featureToggleStore.create('default', {
+            name: 'testing-strategy-parameters-for-applicationHostname',
+            createdByUserId: 9999,
+        });
+        const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
+            strategyName: 'applicationHostname',
+            projectId: 'default',
+            environment: 'default',
+            featureName: toggle.name,
+            constraints: [],
+            sortOrder: 15,
+            parameters: {
+                hostnames: 'myfantastichost',
+            },
+        });
+        expect(strategy.parameters).toEqual({
+            hostnames: 'myfantastichost',
+        });
+    });
+});


### PR DESCRIPTION
Via the API you can currently create gradualRollout strategies without any parameters set, when visiting the UI afterwards, you can edit this, because the UI reads the parameter list from the database and sees that some parameters are required, and refuses to accept the data. This PR adds defaults for gradualRollout strategies created from the API, making sure gradual rollout strategies always have `rollout`, `groupId` and `stickiness` set.

My one worry here is if we should take the time to check if default stickiness is disabled. I think it makes sense to default to default here; but I'm open to suggestions.