### PR TITLE
chore: bearer token middleware

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -76,6 +76,7 @@ exports[`should create default config 1`] = `
       "adminTokenKillSwitch": false,
       "anonymiseEventLog": false,
       "automatedActions": false,
+      "bearerTokenMiddleware": false,
       "caseInsensitiveInOperators": false,
       "celebrateUnleash": false,
       "collectTrafficDataUsage": false,

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -28,6 +28,8 @@ import maintenanceMiddleware from './features/maintenance/maintenance-middleware
 import { unless } from './middleware/unless-middleware';
 import { catchAllErrorHandler } from './middleware/catch-all-error-handler';
 import NotFoundError from './error/notfound-error';
+import { bearerTokenMiddleware } from './middleware/bearer-token-middleware';
+import { conditionalMiddleware } from './middleware/conditional-middleware';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -58,6 +60,13 @@ export default async function getApp(
     }
 
     app.use(requestLogger(config));
+
+    app.use(
+        conditionalMiddleware(
+            () => config.flagResolver.isEnabled('bearerTokenMiddleware'),
+            bearerTokenMiddleware,
+        ),
+    );
 
     if (typeof config.preHook === 'function') {
         config.preHook(app, config, services, db);

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -29,7 +29,6 @@ import { unless } from './middleware/unless-middleware';
 import { catchAllErrorHandler } from './middleware/catch-all-error-handler';
 import NotFoundError from './error/notfound-error';
 import { bearerTokenMiddleware } from './middleware/bearer-token-middleware';
-import { conditionalMiddleware } from './middleware/conditional-middleware';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -61,12 +60,7 @@ export default async function getApp(
 
     app.use(requestLogger(config));
 
-    app.use(
-        conditionalMiddleware(
-            () => config.flagResolver.isEnabled('bearerTokenMiddleware'),
-            bearerTokenMiddleware,
-        ),
-    );
+    app.use(bearerTokenMiddleware(config));
 
     if (typeof config.preHook === 'function') {
         config.preHook(app, config, services, db);

--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -1,49 +1,65 @@
-import type { Request, Response, NextFunction } from 'express';
 import { bearerTokenMiddleware } from './bearer-token-middleware';
+import type { IUnleashConfig } from '../types';
+import { createTestConfig } from '../../test/config/test-config';
+import getLogger from '../../test/fixtures/no-logger';
+import type { Request, Response } from 'express';
 
 const exampleSignalToken = 'signal_tokensecret';
 
 describe('bearerTokenMiddleware', () => {
-    let req: Request;
-    let res: Response;
-    let next: NextFunction;
+    const req = { headers: {} } as Request;
+    const res = {} as Response;
+    const next = jest.fn();
+
+    let config: IUnleashConfig;
 
     beforeEach(() => {
-        req = {
-            headers: {},
-        } as Request;
-        res = {} as Response;
-        next = jest.fn();
+        config = createTestConfig({
+            getLogger,
+            experimental: {
+                flags: {
+                    bearerTokenMiddleware: true,
+                },
+            },
+        });
     });
 
     it('should call next', () => {
-        bearerTokenMiddleware(req, res, next);
+        const middleware = bearerTokenMiddleware(config);
+
+        middleware(req, res, next);
 
         expect(next).toHaveBeenCalled();
     });
 
     it('should leave Unleash tokens intact', () => {
+        const middleware = bearerTokenMiddleware(config);
+
         req.headers = { authorization: exampleSignalToken };
 
-        bearerTokenMiddleware(req, res, next);
+        middleware(req, res, next);
 
         expect(req.headers.authorization).toBe(exampleSignalToken);
     });
 
     it('should convert Bearer token to Unleash token', () => {
+        const middleware = bearerTokenMiddleware(config);
+
         const bearerToken = `Bearer ${exampleSignalToken}`;
         req.headers = { authorization: bearerToken };
 
-        bearerTokenMiddleware(req, res, next);
+        middleware(req, res, next);
 
         expect(req.headers.authorization).toBe(exampleSignalToken);
     });
 
     it('should be case insensitive in the scheme', () => {
+        const middleware = bearerTokenMiddleware(config);
+
         const bearerToken = `bEaReR ${exampleSignalToken}`;
         req.headers = { authorization: bearerToken };
 
-        bearerTokenMiddleware(req, res, next);
+        middleware(req, res, next);
 
         expect(req.headers.authorization).toBe(exampleSignalToken);
     });

--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -1,0 +1,51 @@
+import type { Request, Response, NextFunction } from 'express';
+import { bearerTokenMiddleware } from './bearer-token-middleware';
+
+const exampleSignalToken =
+    'signal_977f4473aa89da1f2823ec19bed9f5c3f0b9ab788b0bfc05a5985c994239b715';
+
+describe('bearerTokenMiddleware', () => {
+    let req: Request;
+    let res: Response;
+    let next: NextFunction;
+
+    beforeEach(() => {
+        req = {
+            headers: {},
+        } as Request;
+        res = {} as Response;
+        next = jest.fn();
+    });
+
+    it('should call next', () => {
+        bearerTokenMiddleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('should leave Unleash tokens intact', () => {
+        req.headers = { authorization: exampleSignalToken };
+
+        bearerTokenMiddleware(req, res, next);
+
+        expect(req.headers.authorization).toBe(exampleSignalToken);
+    });
+
+    it('should convert Bearer token to Unleash token', () => {
+        const bearerToken = `Bearer ${exampleSignalToken}`;
+        req.headers = { authorization: bearerToken };
+
+        bearerTokenMiddleware(req, res, next);
+
+        expect(req.headers.authorization).toBe(exampleSignalToken);
+    });
+
+    it('should be case insensitive in the scheme', () => {
+        const bearerToken = `bEaReR ${exampleSignalToken}`;
+        req.headers = { authorization: bearerToken };
+
+        bearerTokenMiddleware(req, res, next);
+
+        expect(req.headers.authorization).toBe(exampleSignalToken);
+    });
+});

--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -7,7 +7,7 @@ import type { Request, Response } from 'express';
 const exampleSignalToken = 'signal_tokensecret';
 
 describe('bearerTokenMiddleware', () => {
-    const req = { headers: {} } as Request;
+    const req = { headers: {}, path: '' } as Request;
     const res = {} as Response;
     const next = jest.fn();
 

--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -1,8 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import { bearerTokenMiddleware } from './bearer-token-middleware';
 
-const exampleSignalToken =
-    'signal_977f4473aa89da1f2823ec19bed9f5c3f0b9ab788b0bfc05a5985c994239b715';
+const exampleSignalToken = 'signal_tokensecret';
 
 describe('bearerTokenMiddleware', () => {
     let req: Request;

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -1,15 +1,24 @@
 import type { Request, Response, NextFunction } from 'express';
+import type { IUnleashConfig } from '../types';
 
-export const bearerTokenMiddleware = (
-    req: Request,
-    _: Response,
-    next: NextFunction,
-) => {
-    const authHeader = req.headers.authorization;
+export const bearerTokenMiddleware = ({
+    getLogger,
+    flagResolver,
+}: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>) => {
+    const logger = getLogger('/middleware/bearer-token-middleware.ts');
+    logger.debug('Enabling bearer token middleware');
 
-    if (authHeader) {
-        req.headers.authorization = authHeader.replace(/^Bearer\s+/i, '');
-    }
+    return (req: Request, _: Response, next: NextFunction) => {
+        if (flagResolver.isEnabled('bearerTokenMiddleware')) {
+            const authHeader = req.headers.authorization;
 
-    next();
+            if (authHeader) {
+                req.headers.authorization = authHeader.replace(
+                    /^Bearer\s+/i,
+                    '',
+                );
+            }
+        }
+        next();
+    };
 };

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -10,7 +10,7 @@ export const bearerTokenMiddleware = ({
 
     return (req: Request, _: Response, next: NextFunction) => {
         if (
-            req.path.startsWith('/api/signal-endpoint/') ||
+            req.path?.startsWith('/api/signal-endpoint/') ||
             flagResolver.isEnabled('bearerTokenMiddleware')
         ) {
             const authHeader = req.headers.authorization;

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -10,7 +10,7 @@ export const bearerTokenMiddleware = ({
 
     return (req: Request, _: Response, next: NextFunction) => {
         if (
-            req.path?.startsWith('/api/signal-endpoint/') ||
+            req.path.startsWith('/api/signal-endpoint/') ||
             flagResolver.isEnabled('bearerTokenMiddleware')
         ) {
             const authHeader = req.headers.authorization;

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export const bearerTokenMiddleware = (
+    req: Request,
+    _: Response,
+    next: NextFunction,
+) => {
+    const authHeader = req.headers.authorization;
+
+    if (authHeader) {
+        req.headers.authorization = authHeader.replace(/^Bearer\s+/i, '');
+    }
+
+    next();
+};

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -9,7 +9,10 @@ export const bearerTokenMiddleware = ({
     logger.debug('Enabling bearer token middleware');
 
     return (req: Request, _: Response, next: NextFunction) => {
-        if (flagResolver.isEnabled('bearerTokenMiddleware')) {
+        if (
+            req.path.startsWith('/api/signal-endpoint/') ||
+            flagResolver.isEnabled('bearerTokenMiddleware')
+        ) {
             const authHeader = req.headers.authorization;
 
             if (authHeader) {

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -89,13 +89,22 @@ export const createOpenApiSchema = ({
             title: 'Unleash API',
             version: apiVersion,
         },
-        security: [{ apiKey: [] }],
+        security: [{ apiKey: [] }, { bearerToken: [] }],
         components: {
             securitySchemes: {
+                // https://swagger.io/docs/specification/authentication/api-keys/
                 apiKey: {
                     type: 'apiKey',
                     in: 'header',
                     name: 'Authorization',
+                    description: 'API key needed to access this API',
+                },
+                // https://swagger.io/docs/specification/authentication/bearer-authentication/
+                bearerToken: {
+                    type: 'http',
+                    scheme: 'bearer',
+                    description:
+                        'API key needed to access this API, in Bearer token format',
                 },
             },
             schemas: mapValues(schemas, removeJsonSchemaProps),

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -56,7 +56,8 @@ export type IFlagKey =
     | 'returnGlobalFrontendApiCache'
     | 'projectOverviewRefactor'
     | 'variantDependencies'
-    | 'newContextFieldsUI';
+    | 'newContextFieldsUI'
+    | 'bearerTokenMiddleware';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -275,6 +276,10 @@ const flags: IFlags = {
     ),
     variantDependencies: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_VARIANT_DEPENDENCIES,
+        false,
+    ),
+    bearerTokenMiddleware: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_BEARER_TOKEN_MIDDLEWARE,
         false,
     ),
 };


### PR DESCRIPTION
Adds a bearer token middleware that adds support for tokens prefixed with "Bearer" scheme. Prefixing with "Bearer" is optional and the old way of authenticating still works, so we now support both ways.

Also, added as part of our OpenAPI spec which now displays authorization as follows:
![image](https://github.com/Unleash/unleash/assets/455064/77b17342-2315-4c08-bf34-4655e12a1cc3)

Related to #4630. Doesn't fully close the issue as we're still using some invalid characters for the RFC, in particular `*` and `[]`

For safety reasons this is behind a feature flag