### PR TITLE
fix: ttp stat show latest date

### DIFF
--- a/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.test.ts
+++ b/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.test.ts
@@ -10,25 +10,39 @@ describe('useAvgTimeToProduction', () => {
         expect(result.current).toBe(0);
     });
 
-    test('calculates result.current time to production correctly', () => {
+    test('calculates average time to production based on the latest date correctly', () => {
         const projectsData = {
-            project1: [{ timeToProduction: 10 }, { timeToProduction: 20 }],
-            project2: [{ timeToProduction: 15 }, { timeToProduction: 25 }],
+            project1: [
+                { timeToProduction: 10, date: '2023-01-01' },
+                { timeToProduction: 20, date: '2023-02-01' }, // Latest for project1
+            ],
+            project2: [
+                { timeToProduction: 15, date: '2023-01-15' },
+                { timeToProduction: 25, date: '2023-02-15' }, // Latest for project2
+            ],
         } as any;
         const { result } = renderHook(() =>
             useAvgTimeToProduction(projectsData),
         );
-        expect(result.current).toBe(17.5);
+        // Expect average of the latest timeToProductions (20 from project1 and 25 from project2)
+        expect(result.current).toBe(22.5);
     });
 
-    test('ignores projects without time to production data', () => {
+    test('ignores projects without time to production data in their latest entries', () => {
         const projectsData = {
-            project1: [{ timeToProduction: 10 }, { timeToProduction: 20 }],
-            project2: [],
+            project1: [
+                { timeToProduction: 10, date: '2023-01-01' },
+                { timeToProduction: 20, date: '2023-02-01' }, // Latest and valid for project1
+            ],
+            project2: [
+                { date: '2023-01-15' }, // Latest but no timeToProduction
+                { timeToProduction: 25, date: '2023-01-10' },
+            ],
         } as any;
         const { result } = renderHook(() =>
             useAvgTimeToProduction(projectsData),
         );
-        expect(result.current).toBe(7.5);
+        // Since project2's latest entry doesn't have timeToProduction, only project1's latest is considered
+        expect(result.current).toBe(20);
     });
 });

--- a/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.test.ts
+++ b/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.test.ts
@@ -14,11 +14,11 @@ describe('useAvgTimeToProduction', () => {
         const projectsData = {
             project1: [
                 { timeToProduction: 10, date: '2023-01-01' },
-                { timeToProduction: 20, date: '2023-02-01' }, // Latest for project1
+                { timeToProduction: 20, date: '2023-02-01' },
             ],
             project2: [
                 { timeToProduction: 15, date: '2023-01-15' },
-                { timeToProduction: 25, date: '2023-02-15' }, // Latest for project2
+                { timeToProduction: 25, date: '2023-02-15' },
             ],
         } as any;
         const { result } = renderHook(() =>
@@ -32,10 +32,10 @@ describe('useAvgTimeToProduction', () => {
         const projectsData = {
             project1: [
                 { timeToProduction: 10, date: '2023-01-01' },
-                { timeToProduction: 20, date: '2023-02-01' }, // Latest and valid for project1
+                { timeToProduction: 20, date: '2023-02-01' },
             ],
             project2: [
-                { date: '2023-01-15' }, // Latest but no timeToProduction
+                { date: '2023-01-15' },
                 { timeToProduction: 25, date: '2023-01-10' },
             ],
         } as any;

--- a/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.ts
+++ b/frontend/src/component/executiveDashboard/hooks/useAvgTimeToProduction.ts
@@ -16,16 +16,28 @@ export const useAvgTimeToProduction = (
 
         const totalAvgTimeToProduction = Object.entries(projectsData).reduce(
             (acc, [_, trends]) => {
-                const validTrends = trends.filter(
-                    (trend) => trend.timeToProduction !== undefined,
-                );
-                const avgTimeToProduction =
-                    validTrends.reduce(
-                        (sum, item) => sum + (item.timeToProduction || 0),
-                        0,
-                    ) / (validTrends.length || 1);
+                // Assuming trends are not sorted and there's a `date` property to determine the latest
+                const latestTrend = trends
+                    .filter(
+                        (trend) =>
+                            trend.timeToProduction !== undefined &&
+                            trend.date !== undefined,
+                    )
+                    .reduce(
+                        (latest, current) =>
+                            new Date(latest.date) < new Date(current.date)
+                                ? current
+                                : latest,
+                        trends[0],
+                    );
 
-                return acc + (validTrends.length > 0 ? avgTimeToProduction : 0);
+                // If there's no valid latest trend, this project won't contribute to the average
+                if (!latestTrend) {
+                    return acc;
+                }
+
+                const timeToProduction = latestTrend.timeToProduction || 0;
+                return acc + timeToProduction;
             },
             0,
         );


### PR DESCRIPTION
Makes the time to production stats show the current value (latest date).  This aligns it with other stats on the page.

Closes # [1-2203](https://linear.app/unleash/issue/1-2203/make-the-time-to-production-stats-show-the-latest-current-data)