### PR TITLE
fix: render values that are N/A

### DIFF
--- a/frontend/src/component/executiveDashboard/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip-InfoSummary.test.tsx
+++ b/frontend/src/component/executiveDashboard/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip-InfoSummary.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { InfoSummary } from './MetricsChartTooltip';
+
+test('Renders apps, flags, and environments, even when their data is `N/A`', () => {
+    render(
+        <InfoSummary
+            data={[
+                { key: 'Flags', value: 'N/A' },
+                { key: 'Environments', value: 'N/A' },
+                { key: 'Apps', value: 'N/A' },
+            ]}
+        />,
+    );
+
+    screen.getByText('Environments');
+    screen.getByText('Apps');
+    screen.getByText('Flags');
+});

--- a/frontend/src/component/executiveDashboard/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
+++ b/frontend/src/component/executiveDashboard/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
@@ -35,28 +35,26 @@ const InfoLine = ({
     </Typography>
 );
 
-const InfoSummary = ({
+export const InfoSummary = ({
     data,
 }: { data: { key: string; value: string | number }[] }) => (
     <Box display={'flex'} flexDirection={'row'}>
-        {data
-            .filter(({ value }) => value !== 'N/A')
-            .map(({ key, value }) => (
-                <div style={{ flex: 1, flexDirection: 'column' }} key={key}>
-                    <div
-                        style={{
-                            flex: 1,
-                            textAlign: 'center',
-                            marginBottom: '4px',
-                        }}
-                    >
-                        <Typography variant={'body1'} component={'p'}>
-                            {key}
-                        </Typography>
-                    </div>
-                    <div style={{ flex: 1, textAlign: 'center' }}>{value}</div>
+        {data.map(({ key, value }) => (
+            <div style={{ flex: 1, flexDirection: 'column' }} key={key}>
+                <div
+                    style={{
+                        flex: 1,
+                        textAlign: 'center',
+                        marginBottom: '4px',
+                    }}
+                >
+                    <Typography variant={'body1'} component={'p'}>
+                        {key}
+                    </Typography>
                 </div>
-            ))}
+                <div style={{ flex: 1, textAlign: 'center' }}>{value}</div>
+            </div>
+        ))}
     </Box>
 );
 


### PR DESCRIPTION
This change makes the tooltip still render values and headers that are
`N/A` (instead of not rendering them at all).

This makes the tooltip more consistent and predictable. At least to
me, it was confusing that some of the values were just hidden sometimes.

I've also added a test to make sure that the tooltip renders the N/A values.

This is what it looks like now:

![image](https://github.com/Unleash/unleash/assets/17786332/46cb9250-6ce2-4567-a02d-b186f86c1de5)
