### PR TITLE
chore: when some promise fails others might hang and leave open conns

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -107,6 +107,7 @@ import type { FeatureToggleInsert } from './feature-toggle-store';
 import ArchivedFeatureError from '../../error/archivedfeature-error';
 import { FEATURES_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { EventEmitter } from 'stream';
+import { allSettledWithRejection } from '../../util/allSettledWithRejection';
 
 interface IFeatureContext {
     featureName: string;
@@ -1717,7 +1718,7 @@ class FeatureToggleService {
         user?: IUser,
         shouldActivateDisabledStrategies = false,
     ): Promise<void> {
-        await Promise.all(
+        await allSettledWithRejection(
             featureNames.map((featureName) =>
                 this.updateEnabled(
                     project,


### PR DESCRIPTION
This was identified during some tests where we noticed jest did not complete properly (notice how after linking unleash-server to this commit it didn't have that issue):
![image](https://github.com/Unleash/unleash/assets/455064/306e57b8-6473-459a-8104-7223d1de40c3)
