### PR TITLE
chore: create new flag to hide insights ui

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -176,7 +176,7 @@ const Header: VFC = () => {
 
     const increaseUnleashWidth = useUiFlag('increaseUnleashWidth');
     const celebatoryUnleash = useUiFlag('celebrateUnleash');
-    const insightsDashboard = useUiFlag('executiveDashboard');
+    const insightsDashboard = useUiFlag('executiveDashboardUI');
 
     const routes = getRoutes();
     const adminRoutes = useAdminRoutes();

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`returns all baseRoutes 1`] = `
   {
     "component": [Function],
     "enterprise": false,
-    "flag": "executiveDashboard",
+    "flag": "executiveDashboardUI",
     "menu": {
       "mobile": true,
     },

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -67,7 +67,7 @@ export const routes: IRoute[] = [
         component: ExecutiveDashboard,
         type: 'protected',
         menu: { mobile: true },
-        flag: 'executiveDashboard',
+        flag: 'executiveDashboardUI',
         enterprise: false,
     },
 

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -71,7 +71,7 @@ export type UiFlags = {
     newStrategyConfigurationFeedback?: boolean;
     extendedUsageMetricsUI?: boolean;
     adminTokenKillSwitch?: boolean;
-    executiveDashboard?: boolean;
+    executiveDashboardUI?: boolean;
     feedbackComments?: Variant;
     displayUpgradeEdgeBanner?: boolean;
     showInactiveUsers?: boolean;

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -94,6 +94,7 @@ exports[`should create default config 1`] = `
       "enableLicenseChecker": false,
       "encryptEmails": false,
       "executiveDashboard": false,
+      "executiveDashboardUI": false,
       "extendedUsageMetrics": false,
       "extendedUsageMetricsUI": false,
       "featureSearchFeedback": {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -39,6 +39,7 @@ export type IFlagKey =
     | 'extendedUsageMetricsUI'
     | 'adminTokenKillSwitch'
     | 'executiveDashboard'
+    | 'executiveDashboardUI'
     | 'feedbackComments'
     | 'createdByUserIdDataMigration'
     | 'showInactiveUsers'
@@ -194,6 +195,10 @@ const flags: IFlags = {
     ),
     executiveDashboard: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EXECUTIVE_DASHBOARD,
+        false,
+    ),
+    executiveDashboardUI: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EXECUTIVE_DASHBOARD_UI,
         false,
     ),
     sdkReporting: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -48,6 +48,7 @@ process.nextTick(async () => {
                         featureSearchFeedbackPosting: true,
                         extendedUsageMetricsUI: true,
                         executiveDashboard: true,
+                        executiveDashboardUI: true,
                         userAccessUIEnabled: true,
                         sdkReporting: true,
                         outdatedSdksBanner: true,


### PR DESCRIPTION
Creates a new flag to control the executive dashboard ui

Closes # [1-2208](https://linear.app/unleash/issue/1-2208/create-separate-ui-flag-decoupled-from-the-backend-flag)