### PR TITLE
fix: show segment details in targetting

### DIFF
--- a/frontend/src/component/common/SegmentItem/SegmentItem.tsx
+++ b/frontend/src/component/common/SegmentItem/SegmentItem.tsx
@@ -72,7 +72,11 @@ export const SegmentItem: VFC<ISegmentItemProps> = ({
     const [isOpen, setIsOpen] = useState(isExpanded || false);
 
     return (
-        <StyledAccordion className='segment-accordion' isDisabled={disabled}>
+        <StyledAccordion
+            className='segment-accordion'
+            isDisabled={disabled}
+            expanded={isOpen}
+        >
             <StyledAccordionSummary id={`segment-accordion-${segment.id}`}>
                 <DonutLarge
                     sx={(theme) => ({


### PR DESCRIPTION
Preview (eye icon) on a segment in "targetting" when creating or editing a strategy now corectly shows details of a segment.

![image](https://github.com/Unleash/unleash/assets/2625371/9ca47ef6-882d-4093-be8b-90116ed404f1)


Previously it was not showing constraints present in this segment