### PR TITLE
fix: default strategy ui update fix

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -19,6 +19,7 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { ProjectDefaultStrategyForm } from './ProjectDefaultStrategyForm';
 import type { CreateFeatureStrategySchema } from 'openapi';
 import useProject from 'hooks/api/getters/useProject/useProject';
+import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const useDefaultStrategy = (
     projectId: string,
@@ -46,6 +47,7 @@ export const useDefaultStrategy = (
 const EditDefaultStrategy = () => {
     const projectId = useRequiredPathParam('projectId');
     const environmentId = useRequiredQueryParam('environmentId');
+    const { refetch: refetchProjectOverview } = useProjectOverview(projectId);
 
     const {
         defaultStrategyFallback,
@@ -102,7 +104,8 @@ const EditDefaultStrategy = () => {
             },
         });
 
-        await refetchSavedStrategySegments();
+        refetchSavedStrategySegments();
+        refetchProjectOverview();
         setToastData({
             title: 'Default Strategy updated',
             type: 'success',


### PR DESCRIPTION
This PR fixes a bug where editing the default strategy would not refresh the resource it was depending on to display the data. This also surfaces another issue, which is that project settings is using data from the getProjectOverview hook to display the default strategies in each environment. This should be it's own resource, but that is beyond the scope of this PR.