### PR TITLE
chore: create new flag to hide insights ui (#6638)

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -166,7 +166,7 @@ const Header: VFC = () => {
 
     const increaseUnleashWidth = useUiFlag('increaseUnleashWidth');
     const celebatoryUnleash = useUiFlag('celebrateUnleash');
-    const insightsDashboard = useUiFlag('executiveDashboard');
+    const insightsDashboard = useUiFlag('executiveDashboardUI');
 
     const routes = getRoutes();
     const adminRoutes = useAdminRoutes();

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`returns all baseRoutes 1`] = `
   {
     "component": [Function],
     "enterprise": false,
-    "flag": "executiveDashboard",
+    "flag": "executiveDashboardUI",
     "menu": {
       "advanced": true,
       "mobile": true,

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`returns all baseRoutes 1`] = `
     "enterprise": false,
     "flag": "executiveDashboardUI",
     "menu": {
-      "advanced": true,
       "mobile": true,
     },
     "path": "/insights",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -66,8 +66,8 @@ export const routes: IRoute[] = [
         title: 'Insights',
         component: ExecutiveDashboard,
         type: 'protected',
-        menu: { mobile: true, advanced: true },
-        flag: 'executiveDashboard',
+        menu: { mobile: true },
+        flag: 'executiveDashboardUI',
         enterprise: false,
     },
 

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -72,7 +72,7 @@ export type UiFlags = {
     newStrategyConfigurationFeedback?: boolean;
     extendedUsageMetricsUI?: boolean;
     adminTokenKillSwitch?: boolean;
-    executiveDashboard?: boolean;
+    executiveDashboardUI?: boolean;
     feedbackComments?: Variant;
     displayUpgradeEdgeBanner?: boolean;
     showInactiveUsers?: boolean;

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -94,6 +94,7 @@ exports[`should create default config 1`] = `
       "enableLicenseChecker": false,
       "encryptEmails": false,
       "executiveDashboard": false,
+      "executiveDashboardUI": false,
       "extendedUsageMetrics": false,
       "extendedUsageMetricsUI": false,
       "featureSearchFeedback": {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -40,6 +40,7 @@ export type IFlagKey =
     | 'extendedUsageMetricsUI'
     | 'adminTokenKillSwitch'
     | 'executiveDashboard'
+    | 'executiveDashboardUI'
     | 'feedbackComments'
     | 'createdByUserIdDataMigration'
     | 'showInactiveUsers'
@@ -195,6 +196,10 @@ const flags: IFlags = {
     ),
     executiveDashboard: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EXECUTIVE_DASHBOARD,
+        false,
+    ),
+    executiveDashboardUI: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EXECUTIVE_DASHBOARD_UI,
         false,
     ),
     sdkReporting: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -48,6 +48,7 @@ process.nextTick(async () => {
                         featureSearchFeedbackPosting: true,
                         extendedUsageMetricsUI: true,
                         executiveDashboard: true,
+                        executiveDashboardUI: true,
                         userAccessUIEnabled: true,
                         sdkReporting: true,
                     },


### PR DESCRIPTION
Creates a new flag to control the executive dashboard ui

Closes #
[1-2208](https://linear.app/unleash/issue/1-2208/create-separate-ui-flag-decoupled-from-the-backend-flag)

---------



(cherry picked from commit 84707e2bf3aa2241a60c92aa4fd40f5b6b6e34c2)

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
