### PR TITLE
fix: render small values in project health

### DIFF
--- a/frontend/src/component/project/Project/ProjectInsights/ProjectHealth/ProjectHealthChart.test.tsx
+++ b/frontend/src/component/project/Project/ProjectInsights/ProjectHealth/ProjectHealthChart.test.tsx
@@ -109,4 +109,35 @@ describe('ProjectHealthChart', () => {
         expect(screen.queryByText('3 flags')).toBeInTheDocument();
         expect(screen.queryByText('50%')).toBeInTheDocument();
     });
+
+    test('renders small values without negative stroke dasharray', () => {
+        const { container } = render(
+            <ProjectHealthChart
+                active={1000}
+                stale={1}
+                potentiallyStale={1}
+                health={50}
+            />,
+        );
+
+        const activeCircle = container.querySelector(
+            'circle[data-testid="active-circle"]',
+        );
+        const staleCircle = container.querySelector(
+            'circle[data-testid="stale-circle"]',
+        );
+        const potentiallyStaleCircle = container.querySelector(
+            'circle[data-testid="potentially-stale-circle"]',
+        );
+
+        expect(
+            activeCircle?.getAttribute('stroke-dasharray')?.charAt(0),
+        ).not.toBe('-');
+        expect(
+            staleCircle?.getAttribute('stroke-dasharray')?.charAt(0),
+        ).not.toBe('-');
+        expect(
+            potentiallyStaleCircle?.getAttribute('stroke-dasharray')?.charAt(0),
+        ).not.toBe('-');
+    });
 });

--- a/frontend/src/component/project/Project/ProjectInsights/ProjectHealth/ProjectHealthChart.tsx
+++ b/frontend/src/component/project/Project/ProjectInsights/ProjectHealth/ProjectHealthChart.tsx
@@ -29,8 +29,14 @@ export const ProjectHealthChart: React.FC<ProgressComponentProps> = ({
     const potentiallyStalePercentage =
         active === 0 ? 0 : (potentiallyStale / active) * 100;
 
-    const activeLength = (activePercentage / 100) * circumference - gap;
-    const staleLength = (stalePercentage / 100) * circumference - gap;
+    const activeLength = Math.max(
+        (activePercentage / 100) * circumference - gap,
+        1,
+    );
+    const staleLength = Math.max(
+        (stalePercentage / 100) * circumference - gap,
+        1,
+    );
     const potentiallyStaleLength =
         (potentiallyStalePercentage / 100) * activeLength;
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

For very small values we were getting negative stroke dasharray (due to a required gap). This fix prevents negative values in stroke dasharray.
<img width="452" alt="Screenshot 2024-03-21 at 15 40 06" src="https://github.com/Unleash/unleash/assets/1394682/89e6cf04-4f63-4836-a827-5ca0aaf5a8c6">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
