### PR TITLE
chore: upgrade typescript in frontend to 5.4.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -113,7 +113,7 @@
     "semver": "7.6.0",
     "swr": "2.2.5",
     "tss-react": "4.9.4",
-    "typescript": "4.8.4",
+    "typescript": "5.4.2",
     "use-query-params": "^2.2.1",
     "vanilla-jsoneditor": "^0.23.0",
     "vite": "5.1.6",

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/change-request-conflict-data.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/change-request-conflict-data.test.ts
@@ -3,6 +3,7 @@ import {
     getChangeRequestConflictCreatedData,
     getChangeRequestConflictCreatedDataFromScheduleData,
 } from './change-request-conflict-data';
+import type { ChangeRequestType } from 'component/changeRequest/changeRequest.types';
 
 const uiConfig: Pick<IUiConfig, 'baseUriPath' | 'versionInfo'> = {
     baseUriPath: '/some-base-uri',
@@ -58,7 +59,7 @@ const changeRequestWithoutStrategy = {
 
 test('it finds crs that update a strategy', () => {
     const results = getChangeRequestConflictCreatedData(
-        [changeRequestWithStrategy],
+        [changeRequestWithStrategy] as ChangeRequestType[],
         featureId,
         strategyId,
         uiConfig,
@@ -74,7 +75,7 @@ test('it finds crs that update a strategy', () => {
 
 test('it does not return crs that do not update a strategy', () => {
     const results = getChangeRequestConflictCreatedData(
-        [changeRequestWithoutStrategy],
+        [changeRequestWithoutStrategy] as ChangeRequestType[],
         featureId,
         strategyId,
         uiConfig,

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/change-request-conflict-data.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/change-request-conflict-data.ts
@@ -1,8 +1,6 @@
 import type {
     ChangeRequestState,
     ChangeRequestType,
-    IChangeRequestFeature,
-    IFeatureChange,
 } from 'component/changeRequest/changeRequest.types';
 import type { ScheduledChangeRequestViewModel } from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
 import type { IUiConfig } from 'interfaces/uiConfig';
@@ -14,18 +12,7 @@ type ChangeRequestConflictCreatedData = {
 };
 
 export const getChangeRequestConflictCreatedData = (
-    changeRequests:
-        | {
-              state: ChangeRequestType['state'];
-              id: ChangeRequestType['id'];
-              features: {
-                  name: IChangeRequestFeature['name'];
-                  changes: (Pick<IFeatureChange, 'action'> & {
-                      payload: { id?: number | string };
-                  })[];
-              }[];
-          }[]
-        | undefined,
+    changeRequests: ChangeRequestType[] | undefined,
     featureId: string,
     strategyId: string,
     uiConfig: Pick<IUiConfig, 'baseUriPath' | 'versionInfo'>,

--- a/frontend/src/utils/strategyNames.tsx
+++ b/frontend/src/utils/strategyNames.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, SVGProps } from 'react';
 import { SvgIcon, useTheme } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import PeopleIcon from '@mui/icons-material/People';
@@ -14,7 +14,7 @@ export const formatStrategyName = (strategyName: string): string => {
 const RolloutSvgIcon: FC = (props) => (
     <SvgIcon
         {...props}
-        component={(rest) => <RolloutIcon {...rest} />}
+        component={(rest: SVGProps<SVGSVGElement>) => <RolloutIcon {...rest} />}
         inheritViewBox
     />
 );

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7002,10 +7002,10 @@ typed-array-length@^1.0.5:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 uc.micro@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
Follow up to https://github.com/Unleash/unleash/pull/6605

This upgrades TypeScript in frontend to `5.4.2`, matching the version we have on the server.
Only 2 things broke with this upgrade, so the changes are related to fixing the types in those places.

This fixes https://github.com/Unleash/unleash/pull/6659