### PR TITLE
fix: prevent non-string properties from being passed as context values

### DIFF
--- a/src/lib/openapi/spec/sdk-context-schema.test.ts
+++ b/src/lib/openapi/spec/sdk-context-schema.test.ts
@@ -25,3 +25,43 @@ test('sdkContextSchema', () =>
                 validateSchema(sdkContextSchema.$id, data) === undefined,
         ),
     ));
+
+test('using objects as values (outside of the `properties` property) is invalid', () => {
+    const input = {
+        appName: 'test',
+        object: {},
+        array: [],
+        properties: {
+            object: {},
+            array: [],
+        },
+    };
+
+    const inputs = [
+        {
+            appName: 'test',
+            array: [],
+        },
+        {
+            appName: 'test',
+            object: {},
+        },
+        {
+            appName: 'test',
+            properties: {
+                array: [],
+            },
+        },
+        {
+            appName: 'test',
+            properties: {
+                object: {},
+            },
+        },
+    ];
+
+    const errors = inputs.map((input) =>
+        validateSchema(sdkContextSchema.$id, input),
+    );
+    expect(errors.every((error) => error !== undefined)).toBe(true);
+});

--- a/src/lib/openapi/spec/sdk-context-schema.test.ts
+++ b/src/lib/openapi/spec/sdk-context-schema.test.ts
@@ -27,16 +27,6 @@ test('sdkContextSchema', () =>
     ));
 
 test('using objects as values (outside of the `properties` property) is invalid', () => {
-    const input = {
-        appName: 'test',
-        object: {},
-        array: [],
-        properties: {
-            object: {},
-            array: [],
-        },
-    };
-
     const inputs = [
         {
             appName: 'test',
@@ -60,8 +50,8 @@ test('using objects as values (outside of the `properties` property) is invalid'
         },
     ];
 
-    const errors = inputs.map((input) =>
+    const validationResults = inputs.map((input) =>
         validateSchema(sdkContextSchema.$id, input),
     );
-    expect(errors.every((error) => error !== undefined)).toBe(true);
+    expect(validationResults.every((error) => error !== undefined)).toBe(true);
 });

--- a/src/lib/openapi/spec/sdk-context-schema.ts
+++ b/src/lib/openapi/spec/sdk-context-schema.ts
@@ -5,7 +5,9 @@ export const sdkContextSchema = {
     description: 'The Unleash context as modeled in client SDKs',
     type: 'object',
     required: ['appName'],
-    additionalProperties: true,
+    additionalProperties: {
+        type: 'string',
+    },
     properties: {
         appName: {
             type: 'string',


### PR DESCRIPTION
This change fixes the OpenAPI schema to disallow non-string properties
on the top level of the context (except, of course, the `properties` object).

This means that we'll no longer be seeing issues with rendering
invalid contexts, because we don't accept them in the first place.