### PR TITLE
chore: add scim id migration for groups

### DIFF
--- a/src/lib/types/openapi.d.ts
+++ b/src/lib/types/openapi.d.ts
@@ -1,7 +1,6 @@
 // Partial types for "@unleash/express-openapi".
 declare module '@unleash/express-openapi' {
     import type { RequestHandler } from 'express';
-    import type { OpenAPIV3 } from 'openapi-types';
 
     export interface IExpressOpenApi extends RequestHandler {
         validPath: (operation: OpenAPIV3.OperationObject) => RequestHandler;

--- a/src/migrations/20240325081847-add-scim-id-for-groups.js
+++ b/src/migrations/20240325081847-add-scim-id-for-groups.js
@@ -1,0 +1,18 @@
+exports.up = function (db, cb) {
+	db.runSql(
+		`
+  ALTER TABLE groups ADD COLUMN scim_id TEXT;
+  CREATE UNIQUE INDEX groups_scim_id_unique_idx ON groups(scim_id) WHERE scim_id IS NOT NULL;
+`,
+		cb,
+	);
+};
+
+exports.down = function (db, cb) {
+	db.runSql(
+		`
+  DROP INDEX IF EXISTS groups_scim_id_unique_idx;
+  ALTER TABLE groups DROP COLUMN scim_id;`,
+		cb,
+	);
+};

--- a/website/package.json
+++ b/website/package.json
@@ -52,11 +52,7 @@
     "semver": "^7.5.3"
   },
   "browserslist": {
-    "production": [
-      ">0.5%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.5%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",


### PR DESCRIPTION
Adds a scim id to groups. Seemed like we could get away with the name here but unfortunately our names are not unique