### PR TITLE
fix: Add metrics for old proxy forward

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -103,6 +103,11 @@ export default class MetricsMonitor {
             help: 'Number of times a feature toggle has been used',
             labelNames: ['toggle', 'active', 'appName'],
         });
+        const oldEmbeddedProxyForwardCounter = createCounter({
+            name: 'old_embedded_proxy_forward_total',
+            help: 'Number of times we forwarded old embedded proxy requests',
+            labelNames: ['path', 'method'],
+        });
         const featureTogglesTotal = createGauge({
             name: 'feature_toggles_total',
             help: 'Number of feature toggles',
@@ -598,6 +603,11 @@ export default class MetricsMonitor {
                     sdk_version: sdkVersion,
                 });
             }
+        });
+
+        // On purpose a hard-coded string. Will we removed when we are done migrating.
+        eventBus.on('OLD_EMBEDDED_PROXY_REQUEST', ({ path, method }) => {
+            oldEmbeddedProxyForwardCounter.labels({ path, method }).inc();
         });
 
         await this.configureDbMetrics(db, eventBus, schedulerService);


### PR DESCRIPTION
This change adds a new prometheus counter to all us to capture when we automatically forward traffic from old /proxy paths to the /api/frontend path.

![image](https://github.com/Unleash/unleash/assets/158948/639a4ade-4758-41e6-b87b-a497f00313fa)
