### PR TITLE
feat: add index on group name

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,8 +217,8 @@
     "tough-cookie": "4.1.3"
   },
   "lint-staged": {
-    "*.{js,ts}": ["biome check --apply"],
-    "*.{jsx,tsx}": ["biome check --apply"],
+    "*.{js,ts}": ["biome check --apply --no-errors-on-unmatched"],
+    "*.{jsx,tsx}": ["biome check --apply --no-errors-on-unmatched"],
     "*.json": ["biome format --write --no-errors-on-unmatched"]
   }
 }

--- a/src/migrations/20240326122126-add-index-on-group-name.js
+++ b/src/migrations/20240326122126-add-index-on-group-name.js
@@ -1,6 +1,6 @@
 exports.up = function (db, cb) {
     db.runSql(
-        `CREATE INDEX IF NOT EXISTS groups_group_name_idx ON groups.name`,
+        `CREATE INDEX IF NOT EXISTS groups_group_name_idx ON groups(name)`,
         cb,
     );
 };

--- a/src/migrations/20240326122126-add-index-on-group-name.js
+++ b/src/migrations/20240326122126-add-index-on-group-name.js
@@ -1,0 +1,10 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `CREATE INDEX IF NOT EXISTS groups_group_name_idx ON groups.name`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(`DROP INDEX IF EXISTS groups_group_name_idx`, cb);
+};


### PR DESCRIPTION
As the title says, adds an index on the group name. Scim (in particular Azure) uses group names to find correct group to sync.