### PR TITLE
feat: keep parent selection in edit dependency dialogue

### DIFF
--- a/frontend/src/component/feature/Dependencies/AddDependencyDialogue.test.tsx
+++ b/frontend/src/component/feature/Dependencies/AddDependencyDialogue.test.tsx
@@ -81,13 +81,14 @@ test('Delete dependency', async () => {
     });
 });
 
-test('Add dependency', async () => {
+test('Edit dependency', async () => {
     let closed = false;
     setupApi();
     render(
         <AddDependencyDialogue
             project='default'
             featureId='child'
+            parentFeatureId='parentB'
             showDependencyDialogue={true}
             onClose={() => {
                 closed = true;
@@ -95,7 +96,7 @@ test('Add dependency', async () => {
         />,
     );
 
-    const removeDependency = await screen.findByText('Remove');
+    const removeDependency = await screen.findByText('Add');
 
     await waitFor(() => {
         expect(removeDependency).not.toBeDisabled();
@@ -103,6 +104,7 @@ test('Add dependency', async () => {
 
     // Open the dropdown by selecting the role.
     const dropdown = screen.queryAllByRole('combobox')[0];
+    expect(dropdown.innerHTML).toBe('parentB');
     userEvent.click(dropdown);
 
     const parentAOption = await screen.findByText('parentA');

--- a/frontend/src/component/feature/Dependencies/AddDependencyDialogue.tsx
+++ b/frontend/src/component/feature/Dependencies/AddDependencyDialogue.tsx
@@ -18,6 +18,7 @@ import { DependenciesUpgradeAlert } from './DependenciesUpgradeAlert';
 interface IAddDependencyDialogueProps {
     project: string;
     featureId: string;
+    parentFeatureId?: string;
     showDependencyDialogue: boolean;
     onClose: () => void;
 }
@@ -161,10 +162,13 @@ const useManageDependency = (
 export const AddDependencyDialogue = ({
     project,
     featureId,
+    parentFeatureId,
     showDependencyDialogue,
     onClose,
 }: IAddDependencyDialogueProps) => {
-    const [parent, setParent] = useState(REMOVE_DEPENDENCY_OPTION.key);
+    const [parent, setParent] = useState(
+        parentFeatureId || REMOVE_DEPENDENCY_OPTION.key,
+    );
     const handleClick = useManageDependency(
         project,
         featureId,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/DependencyRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/DependencyRow.tsx
@@ -164,6 +164,7 @@ export const DependencyRow: FC<{ feature: IFeatureToggle }> = ({ feature }) => {
                     <AddDependencyDialogue
                         project={feature.project}
                         featureId={feature.name}
+                        parentFeatureId={feature.dependencies[0]?.feature}
                         onClose={() => setShowDependencyDialogue(false)}
                         showDependencyDialogue={showDependencyDialogue}
                     />

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelDetails/FeatureOverviewSidePanelDetails.test.tsx
@@ -18,7 +18,7 @@ const setupApi = () => {
     testServerRoute(
         server,
         '/api/admin/projects/default/features/feature/parents',
-        [],
+        ['some_parent'],
     );
     testServerRoute(
         server,
@@ -243,6 +243,7 @@ test('delete dependency with change request', async () => {
 });
 
 test('edit dependency', async () => {
+    setupChangeRequestApi();
     render(
         <FeatureOverviewSidePanelDetails
             feature={


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Before: remove dependency option always selected by default
<img width="688" alt="Screenshot 2024-03-28 at 10 29 51" src="https://github.com/Unleash/unleash/assets/1394682/e621251d-d782-4b82-8104-c88b2e618f88">

After: if there's existing parent dependency it gets auto-selected by default
<img width="690" alt="Screenshot 2024-03-28 at 10 29 42" src="https://github.com/Unleash/unleash/assets/1394682/574ebe89-809b-4dc6-88ca-191d2db3970a">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
