### PR TITLE
fix: revert archived column for backwards migration compatibility

### DIFF
--- a/src/migrations/20240329064629-revert-feature-archived.js
+++ b/src/migrations/20240329064629-revert-feature-archived.js
@@ -1,0 +1,18 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;
+            UPDATE features SET archived = (archived_at IS NOT NULL);
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE features DROP COLUMN IF EXISTS archived;
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When downgrading to 5.10 we had one query impacted because of the missing legacy archived column (used in getFeatureTypeCounts). Bringing it back so that we keep our rule of being backwards compat for 2 versions ([from our db changes ADR](https://github.com/Unleash/unleash/blob/main/website/docs/contributing/ADRs/back-end/breaking-db-changes.md)).

It reverts this change: https://github.com/Unleash/unleash/pull/6431

