### PR TITLE
chore: fix bearer token middleware signal endpoint logic

### DIFF
--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -63,4 +63,55 @@ describe('bearerTokenMiddleware', () => {
 
         expect(req.headers.authorization).toBe(exampleSignalToken);
     });
+
+    it('should always run for signal endpoint, regardless of the flag', () => {
+        const configWithBearerTokenMiddlewareFlagDisabled = createTestConfig({
+            getLogger,
+            experimental: {
+                flags: {
+                    bearerTokenMiddleware: false,
+                },
+            },
+        });
+
+        const middleware = bearerTokenMiddleware(
+            configWithBearerTokenMiddlewareFlagDisabled,
+        );
+
+        req.path = '/api/signal-endpoint/';
+
+        const bearerToken = `Bearer ${exampleSignalToken}`;
+        req.headers = { authorization: bearerToken };
+
+        middleware(req, res, next);
+
+        expect(req.headers.authorization).toBe(exampleSignalToken);
+    });
+
+    it('should always run for signal endpoint, regardless of the flag, supporting instance path', () => {
+        const configWithBearerTokenMiddlewareFlagDisabled = createTestConfig({
+            getLogger,
+            server: {
+                baseUriPath: '/some-test-instance',
+            },
+            experimental: {
+                flags: {
+                    bearerTokenMiddleware: false,
+                },
+            },
+        });
+
+        const middleware = bearerTokenMiddleware(
+            configWithBearerTokenMiddlewareFlagDisabled,
+        );
+
+        req.path = '/some-test-instance/api/signal-endpoint/';
+
+        const bearerToken = `Bearer ${exampleSignalToken}`;
+        req.headers = { authorization: bearerToken };
+
+        middleware(req, res, next);
+
+        expect(req.headers.authorization).toBe(exampleSignalToken);
+    });
 });

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -10,7 +10,7 @@ export const bearerTokenMiddleware = ({
 
     return (req: Request, _: Response, next: NextFunction) => {
         if (
-            req.path.startsWith('/api/signal-endpoint/') ||
+            req.path.includes('/signal-endpoint/') ||
             flagResolver.isEnabled('bearerTokenMiddleware')
         ) {
             const authHeader = req.headers.authorization;

--- a/src/lib/middleware/bearer-token-middleware.ts
+++ b/src/lib/middleware/bearer-token-middleware.ts
@@ -2,15 +2,17 @@ import type { Request, Response, NextFunction } from 'express';
 import type { IUnleashConfig } from '../types';
 
 export const bearerTokenMiddleware = ({
+    server,
     getLogger,
     flagResolver,
-}: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>) => {
+}: Pick<IUnleashConfig, 'server' | 'getLogger' | 'flagResolver'>) => {
     const logger = getLogger('/middleware/bearer-token-middleware.ts');
     logger.debug('Enabling bearer token middleware');
+    const baseUriPath = server.baseUriPath || '';
 
     return (req: Request, _: Response, next: NextFunction) => {
         if (
-            req.path.includes('/signal-endpoint/') ||
+            req.path.startsWith(`${baseUriPath}/api/signal-endpoint/`) ||
             flagResolver.isEnabled('bearerTokenMiddleware')
         ) {
             const authHeader = req.headers.authorization;


### PR DESCRIPTION
This should make it so that the `signal-endpoint` route match is slightly less strict.