### PR TITLE
fix: handle objects in top-level context in playground

### DIFF
--- a/src/lib/features/playground/clean-context.test.ts
+++ b/src/lib/features/playground/clean-context.test.ts
@@ -1,0 +1,35 @@
+import { cleanContext } from './clean-context';
+
+test('strips invalid context properties from the context', async () => {
+    const invalidJsonTypes = {
+        object: {},
+        array: [],
+        true: true,
+        false: false,
+        number: 123,
+        null: null,
+    };
+
+    const validValues = {
+        appName: 'test',
+    };
+
+    const inputContext = {
+        ...invalidJsonTypes,
+        ...validValues,
+    };
+
+    const cleanedContext = cleanContext(inputContext);
+
+    expect(cleanedContext).toStrictEqual(validValues);
+});
+
+test("doesn't add non-existing properties", async () => {
+    const input = {
+        appName: 'test',
+    };
+
+    const output = cleanContext(input);
+
+    expect(output).toStrictEqual(input);
+});

--- a/src/lib/features/playground/clean-context.ts
+++ b/src/lib/features/playground/clean-context.ts
@@ -1,23 +1,16 @@
 import type { SdkContextSchema } from '../../openapi';
 
 export const cleanContext = (context: SdkContextSchema): SdkContextSchema => {
-    const { appName, properties, ...otherContextFields } = context;
+    const { appName, ...otherContextFields } = context;
 
-    const removedContextFields: string[] = [];
     const cleanedContextFields = Object.fromEntries(
-        Object.entries(otherContextFields).filter(([key, value]) => {
-            if (typeof value === 'string') {
-                return true;
-            } else {
-                removedContextFields.push(key);
-                return false;
-            }
-        }),
+        Object.entries(otherContextFields).filter(
+            ([key, value]) => key === 'properties' || typeof value === 'string',
+        ),
     );
 
     return {
         ...cleanedContextFields,
         appName,
-        properties,
     };
 };

--- a/src/lib/features/playground/clean-context.ts
+++ b/src/lib/features/playground/clean-context.ts
@@ -1,0 +1,23 @@
+import type { SdkContextSchema } from '../../openapi';
+
+export const cleanContext = (context: SdkContextSchema): SdkContextSchema => {
+    const { appName, properties, ...otherContextFields } = context;
+
+    const removedContextFields: string[] = [];
+    const cleanedContextFields = Object.fromEntries(
+        Object.entries(otherContextFields).filter(([key, value]) => {
+            if (typeof value === 'string') {
+                return true;
+            } else {
+                removedContextFields.push(key);
+                return false;
+            }
+        }),
+    );
+
+    return {
+        ...cleanedContextFields,
+        appName,
+        properties,
+    };
+};

--- a/src/lib/features/playground/playground-api.e2e.test.ts
+++ b/src/lib/features/playground/playground-api.e2e.test.ts
@@ -31,16 +31,12 @@ afterAll(async () => {
 });
 
 test('strips invalid context properties from input before using it', async () => {
-    const invalidData = {
-        invalid: {},
-    };
-
     const validData = {
         appName: 'test',
     };
 
     const inputContext = {
-        ...invalidData,
+        invalid: {},
         ...validData,
     };
 
@@ -53,10 +49,30 @@ test('strips invalid context properties from input before using it', async () =>
         })
         .expect(200);
 
-    expect(body.input.context).toMatchObject(inputContext);
-
     const evaluatedContext =
         body.features[0].environments.production[0].context;
 
     expect(evaluatedContext).toStrictEqual(validData);
+});
+
+test('returns the input context exactly as it came in, even if invalid values have been removed for the evaluation', async () => {
+    const invalidData = {
+        invalid: {},
+    };
+
+    const inputContext = {
+        ...invalidData,
+        appName: 'test',
+    };
+
+    const { body } = await app.request
+        .post('/api/admin/playground/advanced')
+        .send({
+            context: inputContext,
+            environments: ['production'],
+            projects: '*',
+        })
+        .expect(200);
+
+    expect(body.input.context).toMatchObject(inputContext);
 });

--- a/src/lib/features/playground/playground-api.e2e.test.ts
+++ b/src/lib/features/playground/playground-api.e2e.test.ts
@@ -1,7 +1,10 @@
-import type { IUnleashStores } from '../../../../lib/types';
-import dbInit, { type ITestDb } from '../../helpers/database-init';
-import { type IUnleashTest, setupApp } from '../../helpers/test-helper';
-import getLogger from '../../../fixtures/no-logger';
+import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
+import {
+    type IUnleashTest,
+    setupApp,
+} from '../../../test/e2e/helpers/test-helper';
+import type { IUnleashStores } from '../../types';
+import getLogger from '../../../test/fixtures/no-logger';
 
 let stores: IUnleashStores;
 let db: ITestDb;

--- a/src/lib/features/playground/playground-api.e2e.test.ts
+++ b/src/lib/features/playground/playground-api.e2e.test.ts
@@ -31,22 +31,17 @@ afterAll(async () => {
 });
 
 test('strips invalid context properties from input before using it', async () => {
-    const invalidJsonTypes = {
-        object: {},
-        array: [],
-        true: true,
-        false: false,
-        number: 123,
-        null: null,
+    const invalidData = {
+        invalid: {},
     };
 
-    const validValues = {
+    const validData = {
         appName: 'test',
     };
 
     const inputContext = {
-        ...invalidJsonTypes,
-        ...validValues,
+        ...invalidData,
+        ...validData,
     };
 
     const { body } = await app.request
@@ -63,9 +58,5 @@ test('strips invalid context properties from input before using it', async () =>
     const evaluatedContext =
         body.features[0].environments.production[0].context;
 
-    expect(
-        ['array', 'true', 'false', 'number', 'null'].every(
-            (property) => !evaluatedContext.hasOwnProperty(property),
-        ),
-    ).toBeTruthy();
+    expect(evaluatedContext).toStrictEqual(validData);
 });

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -28,6 +28,7 @@ import type { AdvancedPlaygroundEnvironmentFeatureSchema } from '../../openapi/s
 import { validateQueryComplexity } from './validateQueryComplexity';
 import type { IPrivateProjectChecker } from '../private-project/privateProjectCheckerType';
 import { getDefaultVariant } from './feature-evaluator/variant';
+import { cleanContext } from './clean-context';
 
 type EvaluationInput = {
     features: FeatureConfigurationClient[];
@@ -125,19 +126,7 @@ export class PlaygroundService {
             ),
         );
 
-        const { appName, properties, ...otherContextFields } = context;
-
-        const cleanedContextFields = Object.fromEntries(
-            Object.entries(otherContextFields).filter(([_, value]) => {
-                return typeof value === 'string';
-            }),
-        );
-
-        const contexts = generateObjectCombinations({
-            ...cleanedContextFields,
-            appName,
-            properties,
-        });
+        const contexts = generateObjectCombinations(cleanContext(context));
 
         validateQueryComplexity(
             environments.length,

--- a/src/lib/features/playground/playground-service.ts
+++ b/src/lib/features/playground/playground-service.ts
@@ -124,7 +124,20 @@ export class PlaygroundService {
                 this.resolveFeatures(filteredProjects, env),
             ),
         );
-        const contexts = generateObjectCombinations(context);
+
+        const { appName, properties, ...otherContextFields } = context;
+
+        const cleanedContextFields = Object.fromEntries(
+            Object.entries(otherContextFields).filter(([_, value]) => {
+                return typeof value === 'string';
+            }),
+        );
+
+        const contexts = generateObjectCombinations({
+            ...cleanedContextFields,
+            appName,
+            properties,
+        });
 
         validateQueryComplexity(
             environments.length,

--- a/src/test/e2e/api/admin/playground-api.e2e.test.ts
+++ b/src/test/e2e/api/admin/playground-api.e2e.test.ts
@@ -1,0 +1,67 @@
+import type { IUnleashStores } from '../../../../lib/types';
+import dbInit, { type ITestDb } from '../../helpers/database-init';
+import { type IUnleashTest, setupApp } from '../../helpers/test-helper';
+import getLogger from '../../../fixtures/no-logger';
+
+let stores: IUnleashStores;
+let db: ITestDb;
+let app: IUnleashTest;
+
+const flag = {
+    name: 'test-flag',
+    enabled: true,
+    strategies: [{ name: 'default' }],
+    createdByUserId: 9999,
+};
+
+beforeAll(async () => {
+    db = await dbInit('playground_api', getLogger);
+    stores = db.stores;
+
+    await stores.featureToggleStore.create('default', flag);
+
+    app = await setupApp(stores);
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+test('strips invalid context properties from input before using it', async () => {
+    const invalidJsonTypes = {
+        array: [],
+        true: true,
+        false: false,
+        number: 123,
+        null: null,
+    };
+
+    const validValues = {
+        appName: 'test',
+    };
+
+    const inputContext = {
+        ...invalidJsonTypes,
+        ...validValues,
+    };
+
+    const { body } = await app.request
+        .post('/api/admin/playground/advanced')
+        .send({
+            context: inputContext,
+            environments: ['production'],
+            projects: '*',
+        })
+        .expect(200);
+
+    expect(body.input.context).toMatchObject(inputContext);
+
+    const evaluatedContext =
+        body.features[0].environments.production[0].context;
+
+    expect(
+        ['array', 'true', 'false', 'number', 'null'].every(
+            (property) => !evaluatedContext.hasOwnProperty(property),
+        ),
+    ).toBeTruthy();
+});

--- a/src/test/e2e/api/admin/playground-api.e2e.test.ts
+++ b/src/test/e2e/api/admin/playground-api.e2e.test.ts
@@ -29,6 +29,7 @@ afterAll(async () => {
 
 test('strips invalid context properties from input before using it', async () => {
     const invalidJsonTypes = {
+        object: {},
         array: [],
         true: true,
         false: false,


### PR DESCRIPTION
Don't include invalid context properties in the contexts that we evaluate. 

This PR removes any non-`properties` fields that have a non-string value. 

This prevents the front end from crashing when trying to render an object.

Expect follow-up PRs to include more warnings/diagnostics we can show to the end user to inform them of what fields have been removed and why.