### PR TITLE
fix: strategy targeting numeric also check value field

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/FeatureStrategyConstraints.tsx
@@ -18,7 +18,10 @@ interface IFeatureStrategyConstraintsProps {
 }
 
 const filterConstraints = (constraint: any) => {
-    if (constraint.hasOwnProperty('values')) {
+    if (
+        constraint.hasOwnProperty('values') &&
+        (!constraint.hasOwnProperty('value') || constraint.value === '')
+    ) {
         return constraint.values && constraint.values.length > 0;
     }
 


### PR DESCRIPTION
## About the changes

API returns both value and values fields. Empty values array causes ui to think constraint doesnt have a value

This PR checks if value field exists and is empty before returning check on values and length

## Discussion points

Included a check on the value of the field in addition to checking if the field exists, I'll check the Open API spec but can we guarantee it doesn't exist without also having a value?
Should we check if the field is undefined? Feels like if it exists it's returned either with a value or as empty.