### PR TITLE
chore: remove response time metrics fix

### DIFF
--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -46,19 +46,14 @@ export function responseTimeMetrics(
 ): RequestHandler {
     return _responseTime((req, res, time) => {
         const { statusCode } = res;
-        const responseTimeMetricsFix = flagResolver.isEnabled(
-            'responseTimeMetricsFix',
-        );
         let pathname: string | undefined = undefined;
-        if (responseTimeMetricsFix && res.locals.route) {
+        if (res.locals.route) {
             pathname = res.locals.route;
         } else if (req.route) {
             pathname = req.baseUrl + req.route.path;
         }
         // when pathname is undefined use a fallback
-        pathname =
-            pathname ??
-            (responseTimeMetricsFix ? collapse(req.path) : '(hidden)');
+        pathname = pathname ?? collapse(req.path);
         let appName: string | undefined;
         if (
             !flagResolver.isEnabled('responseTimeWithAppNameKillSwitch') &&


### PR DESCRIPTION
## About the changes
The feature `responseTimeMetricsFix` has been enabled for a while. Since it's released in 5.11 this prepares the removal for the next major version.

![image](https://github.com/Unleash/unleash/assets/455064/cc49ba3f-f775-45b2-998c-ef7a02c537b4)
