### PR TITLE
fix: environment_type_trends table data

### DIFF
--- a/src/migrations/20240408104624-fix-environment-type-trends.js
+++ b/src/migrations/20240408104624-fix-environment-type-trends.js
@@ -68,7 +68,6 @@ ORDER BY
 exports.down = function (db, cb) {
     db.runSql(
         `
-            ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;
         `,
         cb,
     );

--- a/src/migrations/20240408104624-fix-environment-type-trends.js
+++ b/src/migrations/20240408104624-fix-environment-type-trends.js
@@ -1,0 +1,75 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+-- 1. Clear the environment_type_trends table
+TRUNCATE TABLE environment_type_trends;
+
+-- 2. Create a temporary staging table for pre-processing
+CREATE TEMPORARY TABLE staging_environment_type_trends (
+   day DATE,
+   environment_type VARCHAR,
+   total_updates INT
+);
+
+-- 3. Aggregate per day and environmentType and insert into the staging table
+INSERT INTO staging_environment_type_trends (day, environment_type, total_updates)
+SELECT
+    seu.day,
+    e.type AS environment_type,
+    SUM(seu.updates) AS total_updates
+FROM
+    stat_environment_updates AS seu
+        JOIN
+    environments AS e ON seu.environment = e.name
+GROUP BY
+    seu.day,
+    e.type
+ORDER BY
+    seu.day,
+    e.type;
+
+-- 4. Aggregate the staging table per iso-week and environmentType, setting created_at based on the week before a date from flag_trends
+INSERT INTO environment_type_trends (id, environment_type, total_updates, created_at)
+SELECT
+    CONCAT(EXTRACT(YEAR FROM set.week_start)::TEXT, '-', LPAD(EXTRACT(WEEK FROM set.week_start)::TEXT, 2, '0')) AS id,
+    set.environment_type,
+    SUM(set.total_updates) AS total_updates,
+    set.week_start AS created_at
+FROM (
+         SELECT
+             environment_type,
+             SUM(total_updates) AS total_updates,
+             date_trunc('week', day) - INTERVAL '1 week' AS week_start
+         FROM
+             staging_environment_type_trends
+         GROUP BY
+             environment_type,
+             date_trunc('week', day) - INTERVAL '1 week'
+     ) AS set
+         JOIN (
+    SELECT
+            date_trunc('week', created_at) - INTERVAL '1 week' AS week_start
+    FROM
+        flag_trends
+    GROUP BY
+            date_trunc('week', created_at) - INTERVAL '1 week'
+) AS ft ON set.week_start = ft.week_start
+GROUP BY
+    set.environment_type,
+    set.week_start
+ORDER BY
+    set.week_start;
+
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+            ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;
+        `,
+        cb,
+    );
+};

--- a/src/migrations/20240408104624-fix-environment-type-trends.js
+++ b/src/migrations/20240408104624-fix-environment-type-trends.js
@@ -1,65 +1,58 @@
 exports.up = function (db, cb) {
     db.runSql(
         `
--- 1. Clear the environment_type_trends table
-TRUNCATE TABLE environment_type_trends;
+    -- 1. Clear the environment_type_trends table
+    TRUNCATE TABLE environment_type_trends;
 
--- 2. Create a temporary staging table for pre-processing
-CREATE TEMPORARY TABLE staging_environment_type_trends (
-   day DATE,
-   environment_type VARCHAR,
-   total_updates INT
-);
-
--- 3. Aggregate per day and environmentType and insert into the staging table
-INSERT INTO staging_environment_type_trends (day, environment_type, total_updates)
-SELECT
-    seu.day,
-    e.type AS environment_type,
-    SUM(seu.updates) AS total_updates
-FROM
-    stat_environment_updates AS seu
-        JOIN
-    environments AS e ON seu.environment = e.name
-GROUP BY
-    seu.day,
-    e.type
-ORDER BY
-    seu.day,
-    e.type;
-
--- 4. Aggregate the staging table per iso-week and environmentType, setting created_at based on the week before a date from flag_trends
-INSERT INTO environment_type_trends (id, environment_type, total_updates, created_at)
-SELECT
-    CONCAT(EXTRACT(YEAR FROM set.week_start)::TEXT, '-', LPAD(EXTRACT(WEEK FROM set.week_start)::TEXT, 2, '0')) AS id,
-    set.environment_type,
-    SUM(set.total_updates) AS total_updates,
-    set.week_start AS created_at
-FROM (
-         SELECT
-             environment_type,
-             SUM(total_updates) AS total_updates,
-             date_trunc('week', day) - INTERVAL '1 week' AS week_start
-         FROM
-             staging_environment_type_trends
-         GROUP BY
-             environment_type,
-             date_trunc('week', day) - INTERVAL '1 week'
-     ) AS set
-         JOIN (
+    -- 2. Prepare staging table
+    with staging_environment_type_trends as (
+        SELECT
+            seu.day,
+            e.type AS environment_type,
+            SUM(seu.updates) AS total_updates
+        FROM
+            stat_environment_updates AS seu
+                JOIN
+            environments AS e ON seu.environment = e.name
+        GROUP BY
+            seu.day,
+            e.type
+        ORDER BY
+            seu.day,
+            e.type
+    ),
+    -- 3. Aggregate per week
+    set as (
+          SELECT
+                 environment_type,
+                 SUM(total_updates) AS total_updates,
+                 date_trunc('week', day) AS week_start,
+                 CONCAT(EXTRACT(YEAR FROM date_trunc('week', day))::TEXT, '-', LPAD(EXTRACT(WEEK FROM date_trunc('week', day))::TEXT, 2, '0')) AS id
+             FROM
+                 staging_environment_type_trends
+             GROUP BY
+                 environment_type,
+                 date_trunc('week', day)
+    ),
+    -- 4. Find correlating created dates
+    created as (
+        select distinct id, created_at from flag_trends
+    )
+    -- 5. Insert aggregated data with dates into environment_type_trends
+    INSERT INTO environment_type_trends (id, environment_type, total_updates, created_at)
     SELECT
-            date_trunc('week', created_at) - INTERVAL '1 week' AS week_start
-    FROM
-        flag_trends
+        CONCAT(EXTRACT(YEAR FROM set.week_start)::TEXT, '-', LPAD(EXTRACT(WEEK FROM set.week_start)::TEXT, 2, '0')) AS id,
+        set.environment_type,
+        SUM(set.total_updates) AS total_updates,
+        created.created_at
+    FROM set
+        JOIN created ON set.id = created.id
     GROUP BY
-            date_trunc('week', created_at) - INTERVAL '1 week'
-) AS ft ON set.week_start = ft.week_start
-GROUP BY
-    set.environment_type,
-    set.week_start
-ORDER BY
-    set.week_start;
-
+        set.environment_type,
+        set.week_start,
+        created.created_at
+    ORDER BY
+        set.week_start;
         `,
         cb,
     );


### PR DESCRIPTION
Creates a migration to fix the environment_type_trends table data.

The migration works in 4 steps:
- Clear environment_type_trends table
- Create a temporary staging table for 1st aggregation (day + environmentType)
- Aggregate the data from stat_environment_updates to the staging table
- Aggregate the data from staging to environment_type_trends 

Closes # [1-2266](https://linear.app/unleash/issue/1-2266/fix-the-environment-type-trends-table-data)