### PR TITLE
chore: bump indicated main version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
-  "version": "5.10.0+main",
+  "version": "5.11.0+main",
   "keywords": ["unleash", "feature toggle", "feature", "toggle"],
   "files": [
     "dist",


### PR DESCRIPTION
v5.11 was released. This is updating current version indicated on main branch of open-source