### PR TITLE
fix: NotEnoughData hiding the header

### DIFF
--- a/frontend/src/component/insights/Insights.tsx
+++ b/frontend/src/component/insights/Insights.tsx
@@ -16,7 +16,7 @@ const StickyWrapper = styled(Box, {
 })<{ scrolled?: boolean }>(({ theme, scrolled }) => ({
     position: 'sticky',
     top: 0,
-    zIndex: 1000,
+    zIndex: theme.zIndex.sticky,
     padding: scrolled ? theme.spacing(2, 0) : theme.spacing(0, 0, 2),
     background: theme.palette.background.application,
     transition: 'padding 0.3s ease',


### PR DESCRIPTION
Before: 
<img width="884" alt="Screenshot 2024-04-08 at 15 52 41" src="https://github.com/Unleash/unleash/assets/104830839/3784a1db-83a8-4414-bda8-3eed698476a2">


After:
<img width="879" alt="Screenshot 2024-04-08 at 16 04 54" src="https://github.com/Unleash/unleash/assets/104830839/117dec8e-6419-448d-89b7-9f6640e59500">

Closes # [1-2267](https://linear.app/unleash/issue/1-2267/fix-zindex-of-notenoughdata-component)