### PR TITLE
Fix: time to production showing  NaN when no data

### DIFF
--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -63,7 +63,7 @@ export const useFilteredFlagsSummary = (
         const medianTimeToProduction = Number.isNaN(
             medianTimeToProductionCalculation,
         )
-            ? 'N/A'
+            ? 0
             : medianTimeToProductionCalculation;
 
         const flagsPerUserCalculation = sum.total / users.total;

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -48,17 +48,23 @@ export const useFilteredFlagsSummary = (
 
         const timesToProduction: number[] = lastWeekSummary
             .filter(validTimeToProduction)
-            .map((item) => item.timeToProduction!); // Non-null assertion is safe due to filter
+            .map((item) => item.timeToProduction!);
 
         // Calculate median timeToProduction for lastWeekSummary
         timesToProduction.sort((a, b) => a - b);
         const midIndex = Math.floor(timesToProduction.length / 2);
-        const medianTimeToProduction =
+        const medianTimeToProductionCalculation =
             timesToProduction.length % 2 === 0
                 ? (timesToProduction[midIndex - 1] +
                       timesToProduction[midIndex]) /
                   2
                 : timesToProduction[midIndex];
+
+        const medianTimeToProduction = Number.isNaN(
+            medianTimeToProductionCalculation,
+        )
+            ? 'N/A'
+            : medianTimeToProductionCalculation;
 
         const flagsPerUserCalculation = sum.total / users.total;
         const flagsPerUser = Number.isNaN(flagsPerUserCalculation)

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -63,7 +63,7 @@ export const useFilteredFlagsSummary = (
         const medianTimeToProduction = Number.isNaN(
             medianTimeToProductionCalculation,
         )
-            ? 0
+            ? undefined
             : medianTimeToProductionCalculation;
 
         const flagsPerUserCalculation = sum.total / users.total;


### PR DESCRIPTION
Before: 

<img width="1398" alt="Screenshot 2024-04-08 at 16 20 48" src="https://github.com/Unleash/unleash/assets/104830839/892860f8-80de-4750-bad2-0e17ac221f1f">


After: 

<img width="1243" alt="Screenshot 2024-04-08 at 16 45 47" src="https://github.com/Unleash/unleash/assets/104830839/3247c90a-f92f-4d4f-b407-275549b308bf">

