### PR TITLE
fix: dark mode background

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/LegalValueLabel/LegalValueLabel.styles.ts
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/LegalValueLabel/LegalValueLabel.styles.ts
@@ -4,7 +4,7 @@ export const StyledContainer = styled('div')(({ theme }) => ({
     display: 'inline-block',
     wordBreak: 'break-word',
     padding: theme.spacing(0.5, 1),
-    background: theme.palette.common.white,
+    background: theme.palette.background.paper,
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
 


### PR DESCRIPTION
Fixes a bug where the background of Legal values was white for dark mode


<img width="758" alt="Screenshot 2024-04-09 at 10 10 16" src="https://github.com/Unleash/unleash/assets/104830839/6936be0f-fc60-49a3-b414-dbb32012f8be">
