### PR TITLE
fix(insights): axis rendering after placeholder

### DIFF
--- a/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
@@ -113,7 +113,7 @@ const LineChartComponent: VFC<{
             ),
             ...overrideOptions,
         }),
-        [theme, locationSettings, overrideOptions],
+        [theme, locationSettings, overrideOptions, cover],
     );
 
     return (


### PR DESCRIPTION
Chart options should change when it stops displaying a placeholder/cover. Without this we had axis missing on some renders. 

![image](https://github.com/Unleash/unleash/assets/2625371/7655028f-1748-4f94-af65-9f5135f0594e)
