### PR TITLE
refactor(insights): remove unused chart property

### DIFF
--- a/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
@@ -85,7 +85,6 @@ const LineChartComponent: VFC<{
     data: ChartData<'line', unknown>;
     aspectRatio?: number;
     cover?: ReactNode;
-    isLocalTooltip?: boolean;
     overrideOptions?: ChartOptions<'line'>;
     TooltipComponent?: ({
         tooltip,
@@ -94,7 +93,6 @@ const LineChartComponent: VFC<{
     data,
     aspectRatio = 2.5,
     cover,
-    isLocalTooltip,
     overrideOptions,
     TooltipComponent,
 }) => {
@@ -109,7 +107,6 @@ const LineChartComponent: VFC<{
                 locationSettings,
                 setTooltip,
                 Boolean(cover),
-                isLocalTooltip,
             ),
             ...overrideOptions,
         }),

--- a/frontend/src/component/insights/components/LineChart/createChartOptions.ts
+++ b/frontend/src/component/insights/components/LineChart/createChartOptions.ts
@@ -9,7 +9,6 @@ export const createOptions = (
     locationSettings: ILocationSettings,
     setTooltip: React.Dispatch<React.SetStateAction<TooltipState | null>>,
     isPlaceholder?: boolean,
-    localTooltip?: boolean,
 ) =>
     ({
         responsive: true,

--- a/frontend/src/component/insights/componentsChart/FlagsProjectChart/FlagsProjectChart.tsx
+++ b/frontend/src/component/insights/componentsChart/FlagsProjectChart/FlagsProjectChart.tsx
@@ -31,7 +31,6 @@ export const FlagsProjectChart: VFC<IFlagsProjectChartProps> = ({
     return (
         <LineChart
             data={notEnoughData ? placeholderData : data}
-            isLocalTooltip
             overrideOptions={{
                 parsing: {
                     yAxisKey: 'total',

--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsSummaryChart.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsSummaryChart.tsx
@@ -63,7 +63,6 @@ export const MetricsSummaryChart: VFC<IMetricsSummaryChartProps> = ({
     return (
         <LineChart
             data={notEnoughData ? placeholderData : data}
-            isLocalTooltip
             TooltipComponent={MetricsSummaryTooltip}
             overrideOptions={
                 notEnoughData

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -93,7 +93,6 @@ export const ProjectHealthChart: VFC<IProjectHealthChartProps> = ({
         <LineChart
             key={isAggregate ? 'aggregate' : 'project'}
             data={data}
-            isLocalTooltip
             TooltipComponent={isAggregate ? undefined : HealthTooltip}
             overrideOptions={
                 notEnoughData

--- a/frontend/src/component/insights/componentsChart/TimeToProductionChart/TimeToProductionChart.tsx
+++ b/frontend/src/component/insights/componentsChart/TimeToProductionChart/TimeToProductionChart.tsx
@@ -63,7 +63,6 @@ export const TimeToProductionChart: VFC<ITimeToProductionChartProps> = ({
     return (
         <LineChart
             data={notEnoughData ? placeholderData : data}
-            isLocalTooltip
             TooltipComponent={TimeToProductionTooltip}
             overrideOptions={
                 notEnoughData

--- a/frontend/src/component/insights/componentsChart/UsersPerProjectChart/UsersPerProjectChart.tsx
+++ b/frontend/src/component/insights/componentsChart/UsersPerProjectChart/UsersPerProjectChart.tsx
@@ -31,7 +31,6 @@ export const UsersPerProjectChart: VFC<IUsersPerProjectChartProps> = ({
     return (
         <LineChart
             data={notEnoughData ? placeholderData : data}
-            isLocalTooltip
             overrideOptions={{
                 parsing: {
                     yAxisKey: 'users',


### PR DESCRIPTION
Internal ticket: https://linear.app/unleash/issue/1-2271/cleanup-of-local-tooltip-from-insights-charts