### PR TITLE
Feat/allow admin login using demo auth

### DIFF
--- a/frontend/src/component/user/DemoAuth/DemoAuth.tsx
+++ b/frontend/src/component/user/DemoAuth/DemoAuth.tsx
@@ -63,7 +63,7 @@ const DemoAuth: VFC<IDemoAuthProps> = ({ authDetails, redirect }) => {
                         id='email'
                         data-testid={LOGIN_EMAIL_ID}
                         required
-                        type='email'
+                        type={email === 'admin' ? 'text' : 'email'}
                     />
 
                     <Button

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -15,7 +15,7 @@ exports[`should create default config 1`] = `
     "styleSrc": [],
   },
   "authentication": {
-    "authDemoAllowAdminLogin": false,
+    "demoAllowAdminLogin": false,
     "createAdminUser": true,
     "customAuthHandler": [Function],
     "enableApiToken": true,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -15,9 +15,9 @@ exports[`should create default config 1`] = `
     "styleSrc": [],
   },
   "authentication": {
-    "demoAllowAdminLogin": false,
     "createAdminUser": true,
     "customAuthHandler": [Function],
+    "demoAllowAdminLogin": false,
     "enableApiToken": true,
     "initApiTokens": [],
     "initialAdminUser": {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -15,6 +15,7 @@ exports[`should create default config 1`] = `
     "styleSrc": [],
   },
   "authentication": {
+    "authDemoAllowAdminLogin": false,
     "createAdminUser": true,
     "customAuthHandler": [Function],
     "enableApiToken": true,

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -231,13 +231,13 @@ test('should load demo admin login flag from env var', async () => {
 
     const config = createConfig({});
 
-    expect(config.authentication.authDemoAllowAdminLogin).toBeTruthy();
+    expect(config.authentication.demoAllowAdminLogin).toBeTruthy();
     delete process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN;
 });
 
 test('should default demo admin login to false', async () => {
     const config = createConfig({});
-    expect(config.authentication.authDemoAllowAdminLogin).toBeFalsy();
+    expect(config.authentication.demoAllowAdminLogin).toBeFalsy();
 });
 
 test('should load environment overrides from env var', async () => {

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -226,6 +226,20 @@ test('should handle cases where no env var specified for tokens', async () => {
     expect(config.authentication.initApiTokens).toHaveLength(1);
 });
 
+test('should load demo admin login flag from env var', async () => {
+    process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN = 'true';
+
+    const config = createConfig({});
+
+    expect(config.authentication.authDemoAllowAdminLogin).toBeTruthy();
+    delete process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN;
+});
+
+test('should default demo admin login to false', async () => {
+    const config = createConfig({});
+    expect(config.authentication.authDemoAllowAdminLogin).toBeFalsy();
+});
+
 test('should load environment overrides from env var', async () => {
     process.env.ENABLED_ENVIRONMENTS = 'default,production';
 

--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -226,15 +226,6 @@ test('should handle cases where no env var specified for tokens', async () => {
     expect(config.authentication.initApiTokens).toHaveLength(1);
 });
 
-test('should load demo admin login flag from env var', async () => {
-    process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN = 'true';
-
-    const config = createConfig({});
-
-    expect(config.authentication.demoAllowAdminLogin).toBeTruthy();
-    delete process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN;
-});
-
 test('should default demo admin login to false', async () => {
     const config = createConfig({});
     expect(config.authentication.demoAllowAdminLogin).toBeFalsy();

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -271,7 +271,7 @@ const defaultVersionOption: IVersionOption = {
 };
 
 const defaultAuthentication: IAuthOption = {
-    authDemoAllowAdminLogin: parseEnvVarBoolean(
+    demoAllowAdminLogin: parseEnvVarBoolean(
         process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN,
         false,
     ),

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -271,6 +271,10 @@ const defaultVersionOption: IVersionOption = {
 };
 
 const defaultAuthentication: IAuthOption = {
+    authDemoAllowAdminLogin: parseEnvVarBoolean(
+        process.env.AUTH_DEMO_ALLOW_ADMIN_LOGIN,
+        false,
+    ),
     enableApiToken: parseEnvVarBoolean(process.env.AUTH_ENABLE_API_TOKEN, true),
     type: authTypeFromString(process.env.AUTH_TYPE),
     customAuthHandler: defaultCustomAuthDenyAll,

--- a/src/lib/middleware/demo-authentication.e2e.test.ts
+++ b/src/lib/middleware/demo-authentication.e2e.test.ts
@@ -1,0 +1,73 @@
+import dbInit from '../../test/e2e/helpers/database-init';
+import { IAuthType } from '../server-impl';
+import { setupAppWithCustomAuth } from '../../test/e2e/helpers/test-helper';
+import type { ITestDb } from '../../test/e2e/helpers/database-init';
+import type { IUnleashStores } from '../types';
+
+let db: ITestDb;
+let stores: IUnleashStores;
+
+beforeAll(async () => {
+    db = await dbInit('demo_auth_serial');
+    stores = db.stores;
+});
+
+afterAll(async () => {
+    await db?.destroy();
+});
+
+const getApp = (adminLoginEnabled: boolean) =>
+    setupAppWithCustomAuth(stores, () => {}, {
+        authentication: {
+            authDemoAllowAdminLogin: adminLoginEnabled,
+            type: IAuthType.DEMO,
+            createAdminUser: true,
+        },
+    });
+
+test('the authDemoAllowAdminLogin flag should not affect regular user login/creation', async () => {
+    const app = await getApp(true);
+    return app.request
+        .post(`/auth/demo/login`)
+        .send({ email: 'test@example.com' })
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.email).toBe('test@example.com');
+            expect(res.body.id).not.toBe(1);
+        });
+});
+
+test('if the authDemoAllowAdminLogin flag is disabled, using `admin` should have the same result as any other invalid email', async () => {
+    const app = await getApp(false);
+
+    const nonAdminUsername = 'not-an-email';
+    const adminUsername = 'admin';
+
+    const nonAdminUser = await app.request
+        .post(`/auth/demo/login`)
+        .send({ email: nonAdminUsername });
+
+    const adminUser = await app.request
+        .post(`/auth/demo/login`)
+        .send({ email: adminUsername });
+
+    expect(nonAdminUser.status).toBe(adminUser.status);
+
+    for (const user of [nonAdminUser, adminUser]) {
+        expect(user.body).toMatchObject({
+            error: expect.stringMatching(/^Could not sign in with /),
+        });
+    }
+});
+
+test('should allow you to login as admin if the authDemoAllowAdminLogin flag enabled', async () => {
+    const app = await getApp(true);
+    return app.request
+        .post(`/auth/demo/login`)
+        .send({ email: 'admin' })
+        .expect(200)
+        .expect((res) => {
+            expect(res.body.id).toBe(1);
+            expect(res.body.username).toBe('admin');
+        });
+});

--- a/src/lib/middleware/demo-authentication.e2e.test.ts
+++ b/src/lib/middleware/demo-authentication.e2e.test.ts
@@ -19,13 +19,13 @@ afterAll(async () => {
 const getApp = (adminLoginEnabled: boolean) =>
     setupAppWithCustomAuth(stores, () => {}, {
         authentication: {
-            authDemoAllowAdminLogin: adminLoginEnabled,
+            demoAllowAdminLogin: adminLoginEnabled,
             type: IAuthType.DEMO,
             createAdminUser: true,
         },
     });
 
-test('the authDemoAllowAdminLogin flag should not affect regular user login/creation', async () => {
+test('the demoAllowAdminLogin flag should not affect regular user login/creation', async () => {
     const app = await getApp(true);
     return app.request
         .post(`/auth/demo/login`)
@@ -37,7 +37,7 @@ test('the authDemoAllowAdminLogin flag should not affect regular user login/crea
         });
 });
 
-test('if the authDemoAllowAdminLogin flag is disabled, using `admin` should have the same result as any other invalid email', async () => {
+test('if the demoAllowAdminLogin flag is disabled, using `admin` should have the same result as any other invalid email', async () => {
     const app = await getApp(false);
 
     const nonAdminUsername = 'not-an-email';
@@ -60,7 +60,7 @@ test('if the authDemoAllowAdminLogin flag is disabled, using `admin` should have
     }
 });
 
-test('should allow you to login as admin if the authDemoAllowAdminLogin flag enabled', async () => {
+test('should allow you to login as admin if the demoAllowAdminLogin flag enabled', async () => {
     const app = await getApp(true);
     return app.request
         .post(`/auth/demo/login`)

--- a/src/lib/middleware/demo-authentication.ts
+++ b/src/lib/middleware/demo-authentication.ts
@@ -22,7 +22,7 @@ function demoAuthentication(
         let user: IUser;
 
         try {
-            if (authentication.authDemoAllowAdminLogin && email === 'admin') {
+            if (authentication.demoAllowAdminLogin && email === 'admin') {
                 user = await userService.loginDemoAuthDefaultAdmin();
             } else {
                 email = flagResolver.isEnabled('encryptEmails', { email })

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -379,6 +379,12 @@ class UserService {
         return user;
     }
 
+    async loginDemoAuthDefaultAdmin(): Promise<IUser> {
+        const user = await this.store.getByQuery({ id: 1 });
+        await this.store.successfullyLogin(user);
+        return user;
+    }
+
     async changePassword(userId: number, password: string): Promise<void> {
         this.validatePassword(password);
         const passwordHash = await bcrypt.hash(password, saltRounds);

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -67,6 +67,7 @@ export type CustomAuthHandler = (
 ) => void;
 
 export interface IAuthOption {
+    authDemoAllowAdminLogin?: boolean;
     enableApiToken: boolean;
     type: IAuthType;
     customAuthHandler?: CustomAuthHandler;

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -67,7 +67,7 @@ export type CustomAuthHandler = (
 ) => void;
 
 export interface IAuthOption {
-    authDemoAllowAdminLogin?: boolean;
+    demoAllowAdminLogin?: boolean;
     enableApiToken: boolean;
     type: IAuthType;
     customAuthHandler?: CustomAuthHandler;


### PR DESCRIPTION
## About the changes
The `admin` user currently cannot be accessed in `demo` authentication mode, as the auth mode requires only an email to log in, and the admin user is not created with an email. This change allows for logging in as the admin user only if an `AUTH_DEMO_ALLOW_ADMIN_LOGIN` is set to `true` (or the corresponding `authDemoAllowAdminLogin` config is enabled).

<!-- Does it close an issue? Multiple? -->
Closes #6398 

### Important files
[demo-authentication.ts](https://github.com/Unleash/unleash/compare/main...00Chaotic:unleash:feat/allow_admin_login_using_demo_auth?expand=1#diff-c166f00f0a8ca4425236b3bcba40a8a3bd07a98d067495a0a092eec26866c9f1R25)


## Discussion points
Can continue discussion of [this comment](https://github.com/Unleash/unleash/pull/6447#issuecomment-2042405647) in this PR.
