### PR TITLE
fix: Health tooltip when all projects should show %

### DIFF
--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -62,16 +62,19 @@ export const ProjectHealthChart: VFC<IProjectHealthChartProps> = ({
                     );
             })
             .sort((a, b) => (a.week > b.week ? 1 : -1));
-
         return {
             datasets: [
                 {
                     label: 'Health',
                     data: weeks.map((item) => ({
                         health: item.total
-                            ? ((item.total - item.stale) / item.total) * 100
+                            ? (
+                                  ((item.total - item.stale) / item.total) *
+                                  100
+                              ).toFixed(2)
                             : undefined,
                         date: item.date,
+                        total: item.total,
                     })),
                     borderColor: theme.palette.primary.light,
                     backgroundColor: fillGradientPrimary,
@@ -93,7 +96,7 @@ export const ProjectHealthChart: VFC<IProjectHealthChartProps> = ({
         <LineChart
             key={isAggregate ? 'aggregate' : 'project'}
             data={data}
-            TooltipComponent={isAggregate ? undefined : HealthTooltip}
+            TooltipComponent={HealthTooltip}
             overrideOptions={
                 notEnoughData
                     ? {}


### PR DESCRIPTION
What it says on the tin

Closes # [1-2274](https://linear.app/unleash/issue/1-2274/health-tooltip-when-all-projects-should-show-percent-values)
<img width="945" alt="Screenshot 2024-04-09 at 16 09 34" src="https://github.com/Unleash/unleash/assets/104830839/5c8fc8d3-bee6-4bf2-976d-de6f3e3013ca">
