### PR TITLE
fix: Project select should not expand when selecting multiple projects

### DIFF
--- a/frontend/src/component/common/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/component/common/ProjectSelect/ProjectSelect.tsx
@@ -5,7 +5,7 @@ import {
     type SetStateAction,
     type VFC,
 } from 'react';
-import { Autocomplete, type SxProps, TextField } from '@mui/material';
+import { Autocomplete, Chip, type SxProps, TextField } from '@mui/material';
 import { renderOption } from 'component/playground/Playground/PlaygroundForm/renderOption';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 
@@ -116,6 +116,24 @@ export const ProjectSelect: VFC<IProjectSelectProps> = forwardRef(
                 }
                 onChange={onProjectsChange}
                 data-testid={dataTestId ? dataTestId : 'PROJECT_SELECT'}
+                renderTags={(value, getTagProps) => {
+                    const numTags = value.length;
+                    const limitTags = 1;
+
+                    return (
+                        <>
+                            {value.slice(0, limitTags).map((option, index) => (
+                                <Chip
+                                    {...getTagProps({ index })}
+                                    key={index}
+                                    label={option.label}
+                                />
+                            ))}
+
+                            {numTags > limitTags && ` +${numTags - limitTags}`}
+                        </>
+                    );
+                }}
             />
         );
     },


### PR DESCRIPTION
Currently when you are selecting multiple projects, the autocomplete expands indefinitely when focused.

This fixes that behaviour by limiting the project select to 1 visible tag (even when focused)

Closes [1-2276](https://linear.app/unleash/issue/1-2276/limit-the-project-select-height-or-expand-its-length)


https://github.com/Unleash/unleash/assets/104830839/bf42a06e-8d30-49df-ac5b-a4a4f2685fa9

