### PR TITLE
chore: add new keywords to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
   "version": "5.11.0+main",
-  "keywords": ["unleash", "feature toggle", "feature", "toggle"],
+  "keywords": [
+    "unleash",
+    "feature toggle",
+    "feature",
+    "toggle",
+    "feature flag",
+    "flag"
+  ],
   "files": [
     "dist",
     "docs",


### PR DESCRIPTION
This change adds "feature flag" and "flag" to the keywords in the package.json file. We've started moving towards using that over feature toggle, so it makes sense to add it to the keywords.