### PR TITLE
chore: fix duplicate use of placeholder name

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -297,7 +297,7 @@ export const ProjectFeatureToggles = ({
                     stale: false,
                     environments: [
                         {
-                            name: 'production',
+                            name: 'development',
                             enabled: false,
                         },
                         {


### PR DESCRIPTION
Instead of using two placeholders both called "production", we rename
one of them to "development"