### PR TITLE
fix: replace true on important create screens

### DIFF
--- a/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
+++ b/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
@@ -67,7 +67,9 @@ const CreateFeature = () => {
             const payload = getTogglePayload();
             try {
                 await createFeatureToggle(project, payload);
-                navigate(`/projects/${project}/features/${name}`);
+                navigate(`/projects/${project}/features/${name}`, {
+                    replace: true,
+                });
                 setToastData({
                     title: 'Toggle created successfully',
                     text: 'Now you can start using your toggle.',

--- a/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
@@ -58,7 +58,7 @@ const CreateProject = () => {
             try {
                 await createProject(payload);
                 refetchUser();
-                navigate(`/projects/${projectId}`);
+                navigate(`/projects/${projectId}`, { replace: true });
                 setToastData({
                     title: 'Project created',
                     text: 'Now you can add toggles to this project',


### PR DESCRIPTION
This adds replace: true to navigate on the create feature toggle screen and create project screen. This will make it so you don't go back to the form after you have created the resource, replacing the entry in the history with the new url. We can do this in more places, but some of them require a bit more thought. For example when creating a user, you navigate from the admin screen to the user page, and then back to the same screen. Adding `{ replace: true }` in this context makes it so that when you press back you end up on the same screen, because it's recorded twice in history. 

Another discussion point: 
* Would you expect the edit screens to also replace the history?