### PR TITLE
feat: ttp stat should show No data when exactly 0

### DIFF
--- a/frontend/src/component/insights/componentsStat/TimeToProduction/TimeToProduction.tsx
+++ b/frontend/src/component/insights/componentsStat/TimeToProduction/TimeToProduction.tsx
@@ -47,7 +47,7 @@ const resolveValue = (
     gauge: number | undefined;
     score: 'Fast' | 'Medium' | 'Slow' | undefined;
 } => {
-    if (daysToProduction === undefined) {
+    if (daysToProduction === undefined || daysToProduction === 0) {
         return {
             value: undefined,
             gauge: undefined,


### PR DESCRIPTION
Currently the TimeToProduction stat shows `Fast` for ttp = 0 which is wrong.  Absolute 0 will only happen when there are no data.

Closes [1-2281](https://linear.app/unleash/issue/1-2281/timetoproduction-stat-should-not-say-fast-when-value-is-0)

Before: 
 
<img width="321" alt="Screenshot 2024-04-10 at 14 25 48" src="https://github.com/Unleash/unleash/assets/104830839/f6d3c7af-1674-41c4-b187-ee3bf8df05ba">

After:
<img width="360" alt="Screenshot 2024-04-10 at 14 25 38" src="https://github.com/Unleash/unleash/assets/104830839/631ffbe5-475c-4c48-8790-47716e04887b">
