### PR TITLE
fix: don't add project flag table state config to browser history

### DIFF
--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -42,9 +42,7 @@ export const usePersistentTableState = <T extends QueryParamConfigMap>(
 
     const [tableState, setTableStateInternal] = useQueryParams(
         queryParamsDefinition,
-        {
-            updateType: 'replace',
-        },
+        { updateType: 'replace' },
     );
 
     const [searchParams] = useSearchParams();

--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -42,6 +42,9 @@ export const usePersistentTableState = <T extends QueryParamConfigMap>(
 
     const [tableState, setTableStateInternal] = useQueryParams(
         queryParamsDefinition,
+        {
+            updateType: 'replace',
+        },
     );
 
     const [searchParams] = useSearchParams();

--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -42,7 +42,7 @@ export const usePersistentTableState = <T extends QueryParamConfigMap>(
 
     const [tableState, setTableStateInternal] = useQueryParams(
         queryParamsDefinition,
-        { updateType: 'replace' },
+        { updateType: 'replaceIn' },
     );
 
     const [searchParams] = useSearchParams();


### PR DESCRIPTION
This change specifies the update type as `replace` for the
`useQueryParams` hook used to set table state.

Primarily, this prevents the column selection from being added to the browser
history and more importantly prevents you from changing your config by
navigating through browser history.

However, this also affects other table state, such as changing sorting order etc. These will also no longer be added to the browser history.

---

Bug description:

In the project flag table, you can select which env columns to show. However, adding and removing these envs get added as steps in your browser history. This means that if you add 3 envs, you:

1. have to go back three times to get back to the previous page
2. In doing so, you also inadvertently revert the choices you mean, which can be confusing.

Steps to reproduce:

1. Navigate to the project screen
2. Use the column selector to add/remove projects. Notice that the URL changes for each selection you make.
3. After making one or more changes, use the browser's back-functionality. Notice that you stay on the same page but that the selected envs (and the URL) change.