### PR TITLE
fix: Insights placement in drawer nav

### DIFF
--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -11,17 +11,6 @@ exports[`returns all baseRoutes 1`] = `
     "type": "protected",
   },
   {
-    "component": [Function],
-    "enterprise": false,
-    "flag": "executiveDashboardUI",
-    "menu": {
-      "mobile": true,
-    },
-    "path": "/insights",
-    "title": "Insights",
-    "type": "protected",
-  },
-  {
     "component": {
       "$$typeof": Symbol(react.lazy),
       "_init": [Function],
@@ -149,6 +138,17 @@ exports[`returns all baseRoutes 1`] = `
     },
     "path": "/playground",
     "title": "Playground",
+    "type": "protected",
+  },
+  {
+    "component": [Function],
+    "enterprise": false,
+    "flag": "executiveDashboardUI",
+    "menu": {
+      "mobile": true,
+    },
+    "path": "/insights",
+    "title": "Insights",
     "type": "protected",
   },
   {

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -162,7 +162,7 @@ export const routes: IRoute[] = [
         menu: { mobile: true },
     },
 
-    // Insights - previously "Executive dashboard"
+    // Insights
     {
         path: '/insights',
         title: 'Insights',

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -60,17 +60,6 @@ export const routes: IRoute[] = [
         isStandalone: true,
     },
 
-    // Insights - previously "Executive dashboard"
-    {
-        path: '/insights',
-        title: 'Insights',
-        component: Insights,
-        type: 'protected',
-        menu: { mobile: true },
-        flag: 'executiveDashboardUI',
-        enterprise: false,
-    },
-
     // Project
     {
         path: '/projects/create',
@@ -171,6 +160,17 @@ export const routes: IRoute[] = [
         hidden: false,
         type: 'protected',
         menu: { mobile: true },
+    },
+
+    // Insights - previously "Executive dashboard"
+    {
+        path: '/insights',
+        title: 'Insights',
+        component: Insights,
+        type: 'protected',
+        menu: { mobile: true },
+        flag: 'executiveDashboardUI',
+        enterprise: false,
     },
 
     // Applications


### PR DESCRIPTION
Moves the Insights nav menu item down to match desktop ordering

Closes # [1-2290](https://linear.app/unleash/issue/1-2290/mobile-menu-insights-pops-up-as-the-first-item)
<img width="951" alt="Screenshot 2024-04-12 at 13 12 25" src="https://github.com/Unleash/unleash/assets/104830839/c4222912-2fb9-4d01-8c82-e3288738f52c">
