### PR TITLE
fix: insights menu point alignment

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -9,7 +9,6 @@ import {
     styled,
     type Theme,
     Box,
-    Typography,
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -118,21 +117,20 @@ const styledIconProps = (theme: Theme) => ({
 
 const StyledLink = styled(Link)(({ theme }) => focusable(theme));
 
+const StyledText = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+}));
+
 const StyledLinkWithBetaBadge = ({
     title,
     to,
 }: { title: string; to: string }) => (
     <StyledLink to={to} sx={{ margin: 0 }}>
-        <Typography
-            component='div'
-            sx={(theme) => ({
-                display: 'flex',
-                alignItems: 'center',
-                gap: theme.spacing(1),
-            })}
-        >
+        <StyledText>
             <span>{title}</span> <Badge color='success'>Beta</Badge>
-        </Typography>
+        </StyledText>
     </StyledLink>
 );
 

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -9,6 +9,7 @@ import {
     styled,
     type Theme,
     Box,
+    Typography,
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -122,9 +123,16 @@ const StyledLinkWithBetaBadge = ({
     to,
 }: { title: string; to: string }) => (
     <StyledLink to={to} sx={{ margin: 0 }}>
-        <div>
+        <Typography
+            component='div'
+            sx={(theme) => ({
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing(1),
+            })}
+        >
             <span>{title}</span> <Badge color='success'>Beta</Badge>
-        </div>
+        </Typography>
     </StyledLink>
 );
 


### PR DESCRIPTION
What is says on the tin

Closes [1-2288](https://linear.app/unleash/issue/1-2288/misalignment-insights-beta-menu-item)

<img width="1429" alt="Screenshot 2024-04-12 at 14 42 28" src="https://github.com/Unleash/unleash/assets/104830839/6b428e6f-e3b7-42e5-aa6b-c807338f5231">
