### PR TITLE
feat: start extracting project from session object

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -132,6 +132,7 @@ exports[`should create default config 1`] = `
       },
       "migrationLock": true,
       "outdatedSdksBanner": false,
+      "parseProjectFromSession": false,
       "personalAccessTokensKillSwitch": false,
       "projectListFilterMyProjects": false,
       "projectOverviewRefactor": false,

--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -423,7 +423,6 @@ export default class ClientApplicationsStore
     }
 
     private remapUsageRow = (input) => {
-        console.log(input);
         if (this.flagResolver.isEnabled('parseProjectFromSession')) {
             if (!input.projects || input.projects.length === 0) {
                 return [

--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -10,6 +10,7 @@ import type { Logger, LogProvider } from '../logger';
 import type { Db } from './db';
 import type { IApplicationOverview } from '../features/metrics/instance/models';
 import { applySearchFilters } from '../features/feature-search/search-utils';
+import type { IFlagResolver } from '../types';
 
 const COLUMNS = [
     'app_name',
@@ -110,14 +111,6 @@ const remapRow = (input) => {
     return temp;
 };
 
-const remapUsageRow = (input) => {
-    return {
-        app_name: input.appName,
-        project: input.project || '*',
-        environment: input.environment || '*',
-    };
-};
-
 export default class ClientApplicationsStore
     implements IClientApplicationsStore
 {
@@ -125,24 +118,32 @@ export default class ClientApplicationsStore
 
     private logger: Logger;
 
-    constructor(db: Db, eventBus: EventEmitter, getLogger: LogProvider) {
+    private flagResolver: IFlagResolver;
+
+    constructor(
+        db: Db,
+        eventBus: EventEmitter,
+        getLogger: LogProvider,
+        flagResolver: IFlagResolver,
+    ) {
         this.db = db;
+        this.flagResolver = flagResolver;
         this.logger = getLogger('client-applications-store.ts');
     }
 
     async upsert(details: Partial<IClientApplication>): Promise<void> {
         const row = remapRow(details);
         await this.db(TABLE).insert(row).onConflict('app_name').merge();
-        const usageRow = remapUsageRow(details);
+        const usageRows = this.remapUsageRow(details);
         await this.db(TABLE_USAGE)
-            .insert(usageRow)
+            .insert(usageRows)
             .onConflict(['app_name', 'project', 'environment'])
             .merge();
     }
 
     async bulkUpsert(apps: Partial<IClientApplication>[]): Promise<void> {
         const rows = apps.map(remapRow);
-        const usageRows = apps.map(remapUsageRow);
+        const usageRows = apps.flatMap(this.remapUsageRow);
         await this.db(TABLE).insert(rows).onConflict('app_name').merge();
         await this.db(TABLE_USAGE)
             .insert(usageRows)
@@ -420,4 +421,31 @@ export default class ClientApplicationsStore
             },
         };
     }
+
+    private remapUsageRow = (input) => {
+        console.log(input);
+        if (this.flagResolver.isEnabled('parseProjectFromSession')) {
+            if (!input.projects || input.projects.length === 0) {
+                return [
+                    {
+                        app_name: input.appName,
+                        project: '*',
+                        environment: input.environment || '*',
+                    },
+                ];
+            } else {
+                return input.projects.map((project) => ({
+                    app_name: input.appName,
+                    project: project,
+                    environment: input.environment || '*',
+                }));
+            }
+        } else {
+            return {
+                app_name: input.appName,
+                project: input.project || '*',
+                environment: input.environment || '*',
+            };
+        }
+    };
 }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -65,6 +65,7 @@ export const createStores = (
             db,
             eventBus,
             getLogger,
+            config.flagResolver,
         ),
         clientInstanceStore: new ClientInstanceStore(db, eventBus, getLogger),
         clientMetricsStoreV2: new ClientMetricsStoreV2(

--- a/src/lib/features/metrics/instance/models.ts
+++ b/src/lib/features/metrics/instance/models.ts
@@ -28,6 +28,7 @@ export interface IApplication {
     instances?: IClientInstance[];
     seenToggles?: Record<string, any>;
     project?: string;
+    projects?: string[];
     environment?: string;
     links?: Record<string, string>;
 }

--- a/src/lib/features/metrics/instance/register.ts
+++ b/src/lib/features/metrics/instance/register.ts
@@ -104,10 +104,8 @@ export default class RegisterController extends Controller {
         data.environment = this.resolveEnvironment(user, data);
         if (this.flagResolver.isEnabled('parseProjectFromSession')) {
             data.projects = this.resolveProject(user);
-            console.log('Project from session: ', data.projects);
         } else {
             data.project = this.extractProjectFromRequest(req);
-            console.log('Project from request: ', data.project);
         }
 
         await this.clientInstanceService.registerClient(data, clientIp);

--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -92,4 +92,5 @@ export const clientRegisterSchema = joi
         interval: joi.number().required(),
         environment: joi.string().optional(),
         project: joi.string().optional(),
+        projects: joi.array().optional().items(joi.string()),
     });

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -59,7 +59,8 @@ export type IFlagKey =
     | 'bearerTokenMiddleware'
     | 'projectOverviewRefactorFeedback'
     | 'featureLifecycle'
-    | 'projectListFilterMyProjects';
+    | 'projectListFilterMyProjects'
+    | 'parseProjectFromSession';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -291,6 +292,10 @@ const flags: IFlags = {
     ),
     projectListFilterMyProjects: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PROJECTS_LIST_MY_PROJECTS,
+        false,
+    ),
+    parseProjectFromSession: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PARSE_PROJECT_FROM_SESSION,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -56,7 +56,7 @@ process.nextTick(async () => {
                         projectOverviewRefactorFeedback: true,
                         featureLifecycle: true,
                         projectListFilterMyProjects: true,
-                        parseProjectFromSession: false,
+                        parseProjectFromSession: true,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -56,6 +56,7 @@ process.nextTick(async () => {
                         projectOverviewRefactorFeedback: true,
                         featureLifecycle: true,
                         projectListFilterMyProjects: true,
+                        parseProjectFromSession: false,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Previously, we were extracting the project from the token, but now we will retrieve it from the session, which contains the full list of projects.

This change also resolves an issue we encountered when the token was a multi-project token, formatted as []:dev:token. Previously, it was unable to display the exact list of projects. Now, it will show the exact project names.