### PR TITLE
feat: project list frontend filter

### DIFF
--- a/frontend/cypress/integration/projects/list.spec.ts
+++ b/frontend/cypress/integration/projects/list.spec.ts
@@ -1,0 +1,36 @@
+///<reference path="../../global.d.ts" />
+import {
+    SEARCH_INPUT,
+    //@ts-ignore
+} from '../../../src/utils/testIds';
+
+describe('project overview', () => {
+    const randomId = String(Math.random()).split('.')[1];
+    const projectName = `unleash-e2e-projects-list-${randomId}`;
+
+    before(() => {
+        cy.runBefore();
+        cy.login_UI();
+        cy.createProject_API(projectName);
+    });
+
+    after(() => {
+        cy.deleteProject_API(projectName);
+    });
+
+    it('allows for searching and persists search query', () => {
+        cy.login_UI();
+        cy.visit(`/projects`);
+        cy.get(`[data-testid="${SEARCH_INPUT}"]`).as('search').click();
+        cy.get('@search').type(projectName);
+        cy.url().should('include', `search=${projectName}`);
+        cy.get('h1').contains('Projects (1 of');
+
+        cy.get('[data-testid=PROJECT_CARD_LINK]').contains(projectName).click();
+        cy.get('nav').contains('Projects').click();
+
+        cy.url().should('include', `search=${projectName}`);
+        cy.get('@search').clear();
+        cy.url().should('not.include', `search=${projectName}`);
+    });
+});

--- a/frontend/cypress/integration/projects/list.spec.ts
+++ b/frontend/cypress/integration/projects/list.spec.ts
@@ -1,8 +1,5 @@
 ///<reference path="../../global.d.ts" />
-import {
-    SEARCH_INPUT,
-    //@ts-ignore
-} from '../../../src/utils/testIds';
+import { SEARCH_INPUT } from '../../../src/utils/testIds';
 
 describe('project overview', () => {
     const randomId = String(Math.random()).split('.')[1];

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -340,6 +340,7 @@ export const ProjectListNew = () => {
                                         <StyledCardLink
                                             key={project.id}
                                             to={`/projects/${project.id}`}
+                                            data-testid='PROJECT_CARD_LINK'
                                         >
                                             <ProjectCard
                                                 onHover={() =>


### PR DESCRIPTION
## About the changes
Persist filter state in URL. This change also modifies how search phrase is used. Before we didn't persist it between visits to `/projects`. This is consistent with behavior on other pages, but it's a change that isn't behind a flag.

Internal ticket https://linear.app/unleash/issue/1-2286/front-end-store-filter-selection