### PR TITLE
chore: add enterprise extension point to enable change requests on project creation

### DIFF
--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -3,13 +3,15 @@ import { createFakeProjectService } from './createProjectService';
 
 describe('enterprise extension: enable change requests', () => {
     test('it calls the change request enablement function', async () => {
-        const enableChangeRequests = jest.fn();
+        expect.assertions(1);
 
         const config = createTestConfig();
         const service = createFakeProjectService(config);
+
+        const projectId = 'fake-project-id';
         await service.createProject(
             {
-                id: 'fake-project-id',
+                id: projectId,
                 name: 'fake-project-name',
             },
             {
@@ -17,9 +19,13 @@ describe('enterprise extension: enable change requests', () => {
                 permissions: [],
                 isAPI: false,
             },
-            enableChangeRequests,
-        );
+            async () => {
+                // @ts-expect-error: we want to verify that the project /has/
+                // been created when calling the function.
+                const project = await service.projectStore.get(projectId);
 
-        expect(enableChangeRequests).toHaveBeenCalled();
+                expect(project).toBeTruthy();
+            },
+        );
     });
 });

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -1,0 +1,21 @@
+import { createTestConfig } from '../../../test/config/test-config';
+import { createFakeProjectService } from './createProjectService';
+
+describe('enterprise extension: enable change requests', () => {
+    test('it calls the change request enablement function', async () => {
+        const enableChangeRequests = jest.fn();
+
+        const config = createTestConfig();
+        const service = createFakeProjectService(config);
+        await service.createProject(
+            {
+                id: 'fake-project-id',
+                name: 'fake-project-name',
+            },
+            { id: 1, permissions: [], isAPI: false },
+            enableChangeRequests,
+        );
+
+        expect(enableChangeRequests).toHaveBeenCalled();
+    });
+});

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -1,4 +1,5 @@
 import { createTestConfig } from '../../../test/config/test-config';
+import { RoleName } from '../../types';
 import { createFakeProjectService } from './createProjectService';
 
 describe('enterprise extension: enable change requests', () => {
@@ -8,6 +9,13 @@ describe('enterprise extension: enable change requests', () => {
         const config = createTestConfig();
         const service = createFakeProjectService(config);
 
+        // @ts-expect-error: if we don't set this up, the test will fail due to a missing role.
+        service.accessService.createRole({
+            name: RoleName.OWNER,
+            description: 'Project owner',
+            createdByUserId: -1,
+        });
+
         const projectId = 'fake-project-id';
         await service.createProject(
             {
@@ -15,7 +23,7 @@ describe('enterprise extension: enable change requests', () => {
                 name: 'fake-project-name',
             },
             {
-                id: 1,
+                id: 5,
                 permissions: [],
                 isAPI: false,
             },

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -12,7 +12,11 @@ describe('enterprise extension: enable change requests', () => {
                 id: 'fake-project-id',
                 name: 'fake-project-name',
             },
-            { id: 1, permissions: [], isAPI: false },
+            {
+                id: 1,
+                permissions: [],
+                isAPI: false,
+            },
             enableChangeRequests,
         );
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -98,6 +98,12 @@ interface ICalculateStatus {
     updates: IProjectStats;
 }
 
+type ProjectServiceEnterpriseFunctionality = {
+    enableChangeRequestsForEnvironments: (
+        environments: string[],
+    ) => Promise<void>;
+};
+
 function includes(
     list: number[],
     {
@@ -144,6 +150,8 @@ export default class ProjectService {
 
     private isEnterprise: boolean;
 
+    private enterpriseFunctionality: ProjectServiceEnterpriseFunctionality;
+
     constructor(
         {
             projectStore,
@@ -172,6 +180,7 @@ export default class ProjectService {
         favoriteService: FavoritesService,
         eventService: EventService,
         privateProjectChecker: IPrivateProjectChecker,
+        enterpriseFunctionality?: ProjectServiceEnterpriseFunctionality,
     ) {
         this.projectStore = projectStore;
         this.environmentStore = environmentStore;
@@ -190,6 +199,9 @@ export default class ProjectService {
         this.logger = config.getLogger('services/project-service.js');
         this.flagResolver = config.flagResolver;
         this.isEnterprise = config.isEnterprise;
+        this.enterpriseFunctionality = enterpriseFunctionality ?? {
+            enableChangeRequestsForEnvironments: async () => {},
+        };
     }
 
     async getProjects(

--- a/src/test/fixtures/fake-role-store.ts
+++ b/src/test/fixtures/fake-role-store.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { RoleSchema } from '../../lib/openapi';
-import { RoleName, RoleType, type ICustomRole } from '../../lib/types/model';
+import type { ICustomRole } from '../../lib/types/model';
 import type { IRole, IUserRole } from '../../lib/types/stores/access-store';
 import type {
     ICustomRoleInsert,
@@ -21,14 +21,7 @@ export default class FakeRoleStore implements IRoleStore {
         return Promise.resolve(0);
     }
 
-    roles: ICustomRole[] = [
-        {
-            id: 5,
-            name: RoleName.OWNER,
-            type: RoleType.PROJECT,
-            description: 'A project owner',
-        },
-    ];
+    roles: ICustomRole[] = [];
 
     getGroupRolesForProject(projectId: string): Promise<IRole[]> {
         throw new Error('Method not implemented.');

--- a/src/test/fixtures/fake-role-store.ts
+++ b/src/test/fixtures/fake-role-store.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { RoleSchema } from '../../lib/openapi';
-import type { ICustomRole } from '../../lib/types/model';
+import { RoleName, RoleType, type ICustomRole } from '../../lib/types/model';
 import type { IRole, IUserRole } from '../../lib/types/stores/access-store';
 import type {
     ICustomRoleInsert,
@@ -21,7 +21,14 @@ export default class FakeRoleStore implements IRoleStore {
         return Promise.resolve(0);
     }
 
-    roles: ICustomRole[] = [];
+    roles: ICustomRole[] = [
+        {
+            id: 5,
+            name: RoleName.OWNER,
+            type: RoleType.PROJECT,
+            description: 'A project owner',
+        },
+    ];
 
     getGroupRolesForProject(projectId: string): Promise<IRole[]> {
         throw new Error('Method not implemented.');


### PR DESCRIPTION
This PR adds an optional function parameter to the `createProject` function that is intended to enable change requests for the newly created project.

The assumption is that all the logic within will be decided in the enterprise impl. The only thing we want to verify here is that it is called after the project has been created.