### PR TITLE
feat: optimize applications overview query

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -75,6 +75,7 @@ exports[`should create default config 1`] = `
     "experiments": {
       "adminTokenKillSwitch": false,
       "anonymiseEventLog": false,
+      "applicationOverviewNewQuery": false,
       "automatedActions": false,
       "bearerTokenMiddleware": false,
       "caseInsensitiveInOperators": false,

--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -326,7 +326,6 @@ export default class ClientApplicationsStore
             })
             .where('a.app_name', appName)
             .orderBy('m.environment', 'asc');
-        console.log(query.toQuery());
         const rows = await query;
         if (!rows.length) {
             throw new NotFoundError(`Could not find appName=${appName}`);

--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -298,277 +298,282 @@ export default class ClientApplicationsStore
         return mapRow(row);
     }
 
+    async getOldApplicationOverview(
+        appName: string,
+    ): Promise<IApplicationOverview> {
+        const stopTimer = this.timer('getApplicationOverviewOld');
+        const query = this.db
+            .with('metrics', (qb) => {
+                qb.distinct(
+                    'cme.app_name',
+                    'cme.environment',
+                    'cme.feature_name',
+                ).from('client_metrics_env as cme');
+            })
+            .select([
+                'f.project',
+                'cme.environment',
+                'cme.feature_name',
+                'ci.instance_id',
+                'ci.sdk_version',
+                'ci.last_seen',
+                'a.strategies',
+            ])
+            .from({ a: 'client_applications' })
+            .leftJoin('metrics as cme', 'cme.app_name', 'a.app_name')
+            .leftJoin('features as f', 'cme.feature_name', 'f.name')
+            .leftJoin('client_instances as ci', function () {
+                this.on('ci.app_name', '=', 'cme.app_name').andOn(
+                    'ci.environment',
+                    '=',
+                    'cme.environment',
+                );
+            })
+            .where('a.app_name', appName)
+            .orderBy('cme.environment', 'asc');
+        const rows = await query;
+        stopTimer();
+        if (!rows.length) {
+            throw new NotFoundError(`Could not find appName=${appName}`);
+        }
+        const existingStrategies: string[] = await this.db
+            .select('name')
+            .from('strategies')
+            .pluck('name');
+        return this.mapApplicationOverviewData(rows, existingStrategies);
+    }
+
     async getApplicationOverview(
         appName: string,
     ): Promise<IApplicationOverview> {
-        if (this.flagResolver.isEnabled('applicationOverviewNewQuery')) {
-            const stopTimer = this.timer('getApplicationOverview');
-            const query = this.db
-                .with('metrics', (qb) => {
-                    qb.select([
-                        'cme.app_name',
-                        'cme.environment',
-                        'f.project',
-                        this.db.raw(
-                            'array_agg(DISTINCT cme.feature_name) as features',
-                        ),
-                    ])
-                        .from('client_metrics_env as cme')
-                        .leftJoin('features as f', 'f.name', 'cme.feature_name')
-                        .groupBy(
-                            'cme.app_name',
-                            'cme.environment',
-                            'f.project',
-                        );
-                })
-                .select([
-                    'm.project',
-                    'm.environment',
-                    'm.features',
-                    'ci.instance_id',
-                    'ci.sdk_version',
-                    'ci.last_seen',
-                    'a.strategies',
-                ])
-                .from({ a: 'client_applications' })
-                .leftJoin('metrics as m', 'm.app_name', 'a.app_name')
-                .leftJoin('client_instances as ci', function () {
-                    this.on('ci.app_name', '=', 'm.app_name').andOn(
-                        'ci.environment',
-                        '=',
-                        'm.environment',
-                    );
-                })
-                .where('a.app_name', appName)
-                .orderBy('m.environment', 'asc');
-            const rows = await query;
-            stopTimer();
-            if (!rows.length) {
-                throw new NotFoundError(`Could not find appName=${appName}`);
-            }
-            const existingStrategies: string[] = await this.db
-                .select('name')
-                .from('strategies')
-                .pluck('name');
-            return this.mapApplicationOverviewData(rows, existingStrategies);
-        } else {
-            const stopTimer = this.timer('getApplicationOverviewOld');
-            const query = this.db
-                .with('metrics', (qb) => {
-                    qb.distinct(
-                        'cme.app_name',
-                        'cme.environment',
-                        'cme.feature_name',
-                    ).from('client_metrics_env as cme');
-                })
-                .select([
-                    'f.project',
-                    'cme.environment',
-                    'cme.feature_name',
-                    'ci.instance_id',
-                    'ci.sdk_version',
-                    'ci.last_seen',
-                    'a.strategies',
-                ])
-                .from({ a: 'client_applications' })
-                .leftJoin('metrics as cme', 'cme.app_name', 'a.app_name')
-                .leftJoin('features as f', 'cme.feature_name', 'f.name')
-                .leftJoin('client_instances as ci', function () {
-                    this.on('ci.app_name', '=', 'cme.app_name').andOn(
-                        'ci.environment',
-                        '=',
-                        'cme.environment',
-                    );
-                })
-                .where('a.app_name', appName)
-                .orderBy('cme.environment', 'asc');
-            const rows = await query;
-            stopTimer();
-            if (!rows.length) {
-                throw new NotFoundError(`Could not find appName=${appName}`);
-            }
-            const existingStrategies: string[] = await this.db
-                .select('name')
-                .from('strategies')
-                .pluck('name');
-            return this.mapApplicationOverviewData(rows, existingStrategies);
+        if (!this.flagResolver.isEnabled('applicationOverviewNewQuery')) {
+            return this.getOldApplicationOverview(appName);
         }
+        const stopTimer = this.timer('getApplicationOverview');
+        const query = this.db
+            .with('metrics', (qb) => {
+                qb.select([
+                    'cme.app_name',
+                    'cme.environment',
+                    'f.project',
+                    this.db.raw(
+                        'array_agg(DISTINCT cme.feature_name) as features',
+                    ),
+                ])
+                    .from('client_metrics_env as cme')
+                    .leftJoin('features as f', 'f.name', 'cme.feature_name')
+                    .groupBy('cme.app_name', 'cme.environment', 'f.project');
+            })
+            .select([
+                'm.project',
+                'm.environment',
+                'm.features',
+                'ci.instance_id',
+                'ci.sdk_version',
+                'ci.last_seen',
+                'a.strategies',
+            ])
+            .from({ a: 'client_applications' })
+            .leftJoin('metrics as m', 'm.app_name', 'a.app_name')
+            .leftJoin('client_instances as ci', function () {
+                this.on('ci.app_name', '=', 'm.app_name').andOn(
+                    'ci.environment',
+                    '=',
+                    'm.environment',
+                );
+            })
+            .where('a.app_name', appName)
+            .orderBy('m.environment', 'asc');
+        const rows = await query;
+        stopTimer();
+        if (!rows.length) {
+            throw new NotFoundError(`Could not find appName=${appName}`);
+        }
+        const existingStrategies: string[] = await this.db
+            .select('name')
+            .from('strategies')
+            .pluck('name');
+        return this.mapApplicationOverviewData(rows, existingStrategies);
     }
 
     mapApplicationOverviewData(
         rows: any[],
         existingStrategies: string[],
     ): IApplicationOverview {
-        if (this.flagResolver.isEnabled('applicationOverviewNewQuery')) {
-            const featureCount = new Set(rows.flatMap((row) => row.features))
-                .size;
-            const missingStrategies: Set<string> = new Set();
-
-            const environments = rows.reduce((acc, row) => {
-                const {
-                    environment,
-                    instance_id,
-                    sdk_version,
-                    last_seen,
-                    project,
-                    features,
-                    strategies,
-                } = row;
-
-                if (!environment) return acc;
-
-                strategies.forEach((strategy) => {
-                    if (
-                        !DEPRECATED_STRATEGIES.includes(strategy) &&
-                        !existingStrategies.includes(strategy)
-                    ) {
-                        missingStrategies.add(strategy);
-                    }
-                });
-
-                const featuresNotMappedToProject = !project;
-
-                let env = acc.find((e) => e.name === environment);
-                if (!env) {
-                    env = {
-                        name: environment,
-                        instanceCount: instance_id ? 1 : 0,
-                        sdks: sdk_version ? [sdk_version] : [],
-                        lastSeen: last_seen,
-                        uniqueInstanceIds: new Set(
-                            instance_id ? [instance_id] : [],
-                        ),
-                        issues: {
-                            missingFeatures: featuresNotMappedToProject
-                                ? features
-                                : [],
-                        },
-                    };
-                    acc.push(env);
-                } else {
-                    if (instance_id) {
-                        env.uniqueInstanceIds.add(instance_id);
-                        env.instanceCount = env.uniqueInstanceIds.size;
-                    }
-                    if (featuresNotMappedToProject) {
-                        env.issues.missingFeatures = features;
-                    }
-                    if (sdk_version && !env.sdks.includes(sdk_version)) {
-                        env.sdks.push(sdk_version);
-                    }
-                    if (new Date(last_seen) > new Date(env.lastSeen)) {
-                        env.lastSeen = last_seen;
-                    }
-                }
-
-                return acc;
-            }, []);
-            environments.forEach((env) => {
-                delete env.uniqueInstanceIds;
-                env.sdks.sort();
-            });
-
-            return {
-                projects: [
-                    ...new Set(
-                        rows
-                            .filter((row) => row.project != null)
-                            .map((row) => row.project),
-                    ),
-                ],
-                featureCount,
-                environments,
-                issues: {
-                    missingStrategies: [...missingStrategies],
-                },
-            };
-        } else {
-            const featureCount = new Set(rows.map((row) => row.feature_name))
-                .size;
-            const missingStrategies: Set<string> = new Set();
-
-            const environments = rows.reduce((acc, row) => {
-                const {
-                    environment,
-                    instance_id,
-                    sdk_version,
-                    last_seen,
-                    project,
-                    feature_name,
-                    strategies,
-                } = row;
-
-                if (!environment) return acc;
-
-                strategies.forEach((strategy) => {
-                    if (
-                        !DEPRECATED_STRATEGIES.includes(strategy) &&
-                        !existingStrategies.includes(strategy)
-                    ) {
-                        missingStrategies.add(strategy);
-                    }
-                });
-
-                const featureDoesNotExist = !project && feature_name;
-
-                let env = acc.find((e) => e.name === environment);
-                if (!env) {
-                    env = {
-                        name: environment,
-                        instanceCount: instance_id ? 1 : 0,
-                        sdks: sdk_version ? [sdk_version] : [],
-                        lastSeen: last_seen,
-                        uniqueInstanceIds: new Set(
-                            instance_id ? [instance_id] : [],
-                        ),
-                        issues: {
-                            missingFeatures: featureDoesNotExist
-                                ? [feature_name]
-                                : [],
-                        },
-                    };
-                    acc.push(env);
-                } else {
-                    if (instance_id) {
-                        env.uniqueInstanceIds.add(instance_id);
-                        env.instanceCount = env.uniqueInstanceIds.size;
-                    }
-                    if (
-                        featureDoesNotExist &&
-                        !env.issues.missingFeatures.includes(feature_name)
-                    ) {
-                        env.issues.missingFeatures.push(feature_name);
-                    }
-                    if (sdk_version && !env.sdks.includes(sdk_version)) {
-                        env.sdks.push(sdk_version);
-                    }
-                    if (new Date(last_seen) > new Date(env.lastSeen)) {
-                        env.lastSeen = last_seen;
-                    }
-                }
-
-                return acc;
-            }, []);
-            environments.forEach((env) => {
-                delete env.uniqueInstanceIds;
-                env.sdks.sort();
-            });
-
-            return {
-                projects: [
-                    ...new Set(
-                        rows
-                            .filter((row) => row.project != null)
-                            .map((row) => row.project),
-                    ),
-                ],
-                featureCount,
-                environments,
-                issues: {
-                    missingStrategies: [...missingStrategies],
-                },
-            };
+        if (!this.flagResolver.isEnabled('applicationOverviewNewQuery')) {
+            return this.mapOldApplicationOverviewData(rows, existingStrategies);
         }
+        const featureCount = new Set(rows.flatMap((row) => row.features)).size;
+        const missingStrategies: Set<string> = new Set();
+
+        const environments = rows.reduce((acc, row) => {
+            const {
+                environment,
+                instance_id,
+                sdk_version,
+                last_seen,
+                project,
+                features,
+                strategies,
+            } = row;
+
+            if (!environment) return acc;
+
+            strategies.forEach((strategy) => {
+                if (
+                    !DEPRECATED_STRATEGIES.includes(strategy) &&
+                    !existingStrategies.includes(strategy)
+                ) {
+                    missingStrategies.add(strategy);
+                }
+            });
+
+            const featuresNotMappedToProject = !project;
+
+            let env = acc.find((e) => e.name === environment);
+            if (!env) {
+                env = {
+                    name: environment,
+                    instanceCount: instance_id ? 1 : 0,
+                    sdks: sdk_version ? [sdk_version] : [],
+                    lastSeen: last_seen,
+                    uniqueInstanceIds: new Set(
+                        instance_id ? [instance_id] : [],
+                    ),
+                    issues: {
+                        missingFeatures: featuresNotMappedToProject
+                            ? features
+                            : [],
+                    },
+                };
+                acc.push(env);
+            } else {
+                if (instance_id) {
+                    env.uniqueInstanceIds.add(instance_id);
+                    env.instanceCount = env.uniqueInstanceIds.size;
+                }
+                if (featuresNotMappedToProject) {
+                    env.issues.missingFeatures = features;
+                }
+                if (sdk_version && !env.sdks.includes(sdk_version)) {
+                    env.sdks.push(sdk_version);
+                }
+                if (new Date(last_seen) > new Date(env.lastSeen)) {
+                    env.lastSeen = last_seen;
+                }
+            }
+
+            return acc;
+        }, []);
+        environments.forEach((env) => {
+            delete env.uniqueInstanceIds;
+            env.sdks.sort();
+        });
+
+        return {
+            projects: [
+                ...new Set(
+                    rows
+                        .filter((row) => row.project != null)
+                        .map((row) => row.project),
+                ),
+            ],
+            featureCount,
+            environments,
+            issues: {
+                missingStrategies: [...missingStrategies],
+            },
+        };
+    }
+
+    private mapOldApplicationOverviewData(
+        rows: any[],
+        existingStrategies: string[],
+    ): IApplicationOverview {
+        const featureCount = new Set(rows.map((row) => row.feature_name)).size;
+        const missingStrategies: Set<string> = new Set();
+
+        const environments = rows.reduce((acc, row) => {
+            const {
+                environment,
+                instance_id,
+                sdk_version,
+                last_seen,
+                project,
+                feature_name,
+                strategies,
+            } = row;
+
+            if (!environment) return acc;
+
+            strategies.forEach((strategy) => {
+                if (
+                    !DEPRECATED_STRATEGIES.includes(strategy) &&
+                    !existingStrategies.includes(strategy)
+                ) {
+                    missingStrategies.add(strategy);
+                }
+            });
+
+            const featureDoesNotExist = !project && feature_name;
+
+            let env = acc.find((e) => e.name === environment);
+            if (!env) {
+                env = {
+                    name: environment,
+                    instanceCount: instance_id ? 1 : 0,
+                    sdks: sdk_version ? [sdk_version] : [],
+                    lastSeen: last_seen,
+                    uniqueInstanceIds: new Set(
+                        instance_id ? [instance_id] : [],
+                    ),
+                    issues: {
+                        missingFeatures: featureDoesNotExist
+                            ? [feature_name]
+                            : [],
+                    },
+                };
+                acc.push(env);
+            } else {
+                if (instance_id) {
+                    env.uniqueInstanceIds.add(instance_id);
+                    env.instanceCount = env.uniqueInstanceIds.size;
+                }
+                if (
+                    featureDoesNotExist &&
+                    !env.issues.missingFeatures.includes(feature_name)
+                ) {
+                    env.issues.missingFeatures.push(feature_name);
+                }
+                if (sdk_version && !env.sdks.includes(sdk_version)) {
+                    env.sdks.push(sdk_version);
+                }
+                if (new Date(last_seen) > new Date(env.lastSeen)) {
+                    env.lastSeen = last_seen;
+                }
+            }
+
+            return acc;
+        }, []);
+        environments.forEach((env) => {
+            delete env.uniqueInstanceIds;
+            env.sdks.sort();
+        });
+
+        return {
+            projects: [
+                ...new Set(
+                    rows
+                        .filter((row) => row.project != null)
+                        .map((row) => row.project),
+                ),
+            ],
+            featureCount,
+            environments,
+            issues: {
+                missingStrategies: [...missingStrategies],
+            },
+        };
     }
 
     private remapUsageRow = (input) => {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -60,7 +60,8 @@ export type IFlagKey =
     | 'featureLifecycle'
     | 'projectListFilterMyProjects'
     | 'parseProjectFromSession'
-    | 'createProjectWithEnvironmentConfig';
+    | 'createProjectWithEnvironmentConfig'
+    | 'applicationOverviewNewQuery';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -295,6 +296,10 @@ const flags: IFlags = {
     ),
     createProjectWithEnvironmentConfig: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CREATE_PROJECT_WITH_ENVIRONMENT_CONFIG,
+        false,
+    ),
+    applicationOverviewNewQuery: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_APPLICATION_OVERVIEW_NEW_QUERY,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,7 +57,7 @@ process.nextTick(async () => {
                         projectListFilterMyProjects: true,
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,
-                        applicationOverviewNewQuery: true,
+                        applicationOverviewNewQuery: false,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,7 @@ process.nextTick(async () => {
                         projectListFilterMyProjects: true,
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,
+                        applicationOverviewNewQuery: true,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,7 +57,7 @@ process.nextTick(async () => {
                         projectListFilterMyProjects: true,
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,
-                        applicationOverviewNewQuery: false,
+                        applicationOverviewNewQuery: true,
                     },
                 },
                 authentication: {

--- a/src/test/e2e/api/admin/applications.e2e.test.ts
+++ b/src/test/e2e/api/admin/applications.e2e.test.ts
@@ -56,6 +56,7 @@ beforeAll(async () => {
             experimental: {
                 flags: {
                     strictSchemaValidation: true,
+                    applicationOverviewNewQuery: true,
                 },
             },
         },


### PR DESCRIPTION
We encountered an issue with a customer because this query was returning 3 million rows. The problem arose from each instance reporting approximately 100 features, with a total of 30,000 instances. The query was joining these, thus multiplying the data. This approach was fine for a reasonable number of instances, but in this extreme case, it did not perform well.

This PR modifies the logic; instead of performing outright joins, we are now grouping features by environment into an array, resulting in just one row returned per instance.

I tested locally with the same dataset. Previously, loading this large instance took about 21 seconds; now it has reduced to 2 seconds. Although this is still significant, the dataset is extensive.