### PR TITLE
feat: make edge use token's cache

### DIFF
--- a/src/lib/db/api-token-store.ts
+++ b/src/lib/db/api-token-store.ts
@@ -194,10 +194,12 @@ export class ApiTokenStore implements IApiTokenStore {
     }
 
     async get(key: string): Promise<IApiToken> {
+        const stopTimer = this.timer('get-by-secret');
         const row = await this.makeTokenProjectQuery().where(
             'tokens.secret',
             key,
         );
+        stopTimer();
         return toTokens(row)[0];
     }
 

--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -49,7 +49,7 @@ export const scheduleServices = async (
         apiTokenService.fetchActiveTokens.bind(apiTokenService),
         minutesToMilliseconds(1),
         'fetchActiveTokens',
-        0,
+        0, // no jitter, we need tokens at startup
     );
 
     schedulerService.schedule(

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -2,7 +2,6 @@ import { ApiTokenType } from '../types/models/api-token';
 import type { IUnleashConfig } from '../types/option';
 import type { IApiRequest, IAuthRequest } from '../routes/unleash-types';
 import type { IUnleashServices } from '../server-impl';
-import type { IFlagContext } from '../types';
 
 const isClientApi = ({ path }) => {
     return path && path.indexOf('/api/client') > -1;
@@ -25,20 +24,6 @@ const isProxyApi = ({ path }) => {
         path.indexOf('/api/production/proxy') > -1 ||
         path.indexOf('/api/frontend') > -1
     );
-};
-
-const contextFrom = (
-    req: IAuthRequest<any, any, any, any> | IApiRequest<any, any, any, any>,
-): IFlagContext | undefined => {
-    // this is what we'd get from edge:
-    // req_path: '/api/client/features',
-    // req_user_agent: 'unleash-edge-16.0.4'
-    return {
-        reqPath: req.path,
-        reqUserAgent: req.get ? req.get('User-Agent') ?? '' : '',
-        reqAppName:
-            req.headers?.['unleash-appname'] ?? req.query?.appName ?? '',
-    };
 };
 
 export const TOKEN_TYPE_ERROR_MESSAGE =
@@ -70,10 +55,7 @@ const apiAccessMiddleware = (
             const apiToken = req.header('authorization');
             if (!apiToken?.startsWith('user:')) {
                 const apiUser = apiToken
-                    ? await apiTokenService.getUserForToken(
-                          apiToken,
-                          contextFrom(req),
-                      )
+                    ? await apiTokenService.getUserForToken(apiToken)
                     : undefined;
                 const { CLIENT, FRONTEND } = ApiTokenType;
 

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -18,31 +18,6 @@ import FakeFeatureTagStore from '../../test/fixtures/fake-feature-tag-store';
 import { createFakeEventsService } from '../../lib/features';
 import { extractAuditInfoFromUser } from '../util';
 
-const token: IApiTokenCreate = {
-    environment: 'default',
-    projects: ['*'],
-    secret: '*:*:some-random-string',
-    type: ApiTokenType.CLIENT,
-    tokenName: 'new-token-by-another-instance',
-    expiresAt: undefined,
-};
-
-const setup = (options?: IUnleashOptions) => {
-    const config: IUnleashConfig = createTestConfig(options);
-    const apiTokenStore = new FakeApiTokenStore();
-    const environmentStore = new FakeEnvironmentStore();
-
-    const apiTokenService = new ApiTokenService(
-        { apiTokenStore, environmentStore },
-        config,
-        createFakeEventsService(config),
-    );
-    return {
-        apiTokenService,
-        apiTokenStore,
-    };
-};
-
 test('Should init api token', async () => {
     const token = {
         environment: '*',
@@ -223,6 +198,31 @@ test('getUserForToken should get a user with admin token user id and token name'
 });
 
 describe('API token getTokenWithCache', () => {
+    const token: IApiTokenCreate = {
+        environment: 'default',
+        projects: ['*'],
+        secret: '*:*:some-random-string',
+        type: ApiTokenType.CLIENT,
+        tokenName: 'new-token-by-another-instance',
+        expiresAt: undefined,
+    };
+
+    const setup = (options?: IUnleashOptions) => {
+        const config: IUnleashConfig = createTestConfig(options);
+        const apiTokenStore = new FakeApiTokenStore();
+        const environmentStore = new FakeEnvironmentStore();
+
+        const apiTokenService = new ApiTokenService(
+            { apiTokenStore, environmentStore },
+            config,
+            createFakeEventsService(config),
+        );
+        return {
+            apiTokenService,
+            apiTokenStore,
+        };
+    };
+
     test('should return the token and perform only one db query', async () => {
         const { apiTokenService, apiTokenStore } = setup();
         const apiTokenStoreGet = jest.spyOn(apiTokenStore, 'get');

--- a/src/lib/services/edge-service.ts
+++ b/src/lib/services/edge-service.ts
@@ -1,4 +1,4 @@
-import type { IUnleashConfig } from '../types';
+import type { IFlagResolver, IUnleashConfig } from '../types';
 import type { Logger } from '../logger';
 import type { EdgeTokenSchema } from '../openapi/spec/edge-token-schema';
 import { constantTimeCompare } from '../util/constantTimeCompare';
@@ -10,30 +10,60 @@ export default class EdgeService {
 
     private apiTokenService: ApiTokenService;
 
+    private flagResolver: IFlagResolver;
+
     constructor(
         { apiTokenService }: { apiTokenService: ApiTokenService },
-        { getLogger }: Pick<IUnleashConfig, 'getLogger'>,
+        {
+            getLogger,
+            flagResolver,
+        }: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>,
     ) {
         this.logger = getLogger('lib/services/edge-service.ts');
         this.apiTokenService = apiTokenService;
+        this.flagResolver = flagResolver;
     }
 
     async getValidTokens(tokens: string[]): Promise<ValidatedEdgeTokensSchema> {
-        const activeTokens = await this.apiTokenService.getAllActiveTokens();
-        const edgeTokens = tokens.reduce((result: EdgeTokenSchema[], token) => {
-            const dbToken = activeTokens.find((activeToken) =>
-                constantTimeCompare(activeToken.secret, token),
-            );
-            if (dbToken) {
-                result.push({
-                    token: token,
-                    type: dbToken.type,
-                    projects: dbToken.projects,
-                });
+        if (this.flagResolver.isEnabled('checkEdgeValidTokensFromCache')) {
+            // new behavior: use cached tokens when possible
+            // use the db to fetch the missing ones
+            // cache stores both missing and active so we don't hammer the db
+            const validatedTokens: EdgeTokenSchema[] = [];
+            for (const token of tokens) {
+                const found =
+                    await this.apiTokenService.getTokenWithCache(token);
+                if (found) {
+                    validatedTokens.push({
+                        token: token,
+                        type: found.type,
+                        projects: found.projects,
+                    });
+                }
             }
-            return result;
-        }, []);
-        return { tokens: edgeTokens };
+            return { tokens: validatedTokens };
+        } else {
+            // old behavior: go to the db to fetch all tokens and then filter in memory
+            const activeTokens =
+                await this.apiTokenService.getAllActiveTokens();
+            const edgeTokens = tokens.reduce(
+                (result: EdgeTokenSchema[], token) => {
+                    const dbToken = activeTokens.find((activeToken) =>
+                        constantTimeCompare(activeToken.secret, token),
+                    );
+                    if (dbToken) {
+                        result.push({
+                            token: token,
+                            type: dbToken.type,
+                            projects: dbToken.projects,
+                        });
+                    }
+                    return result;
+                },
+                [],
+            );
+            return { tokens: edgeTokens };
+        }
     }
 }
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -43,6 +43,7 @@ export type IFlagKey =
     | 'displayTrafficDataUsage'
     | 'useMemoizedActiveTokens'
     | 'queryMissingTokens'
+    | 'checkEdgeValidTokensFromCache'
     | 'userAccessUIEnabled'
     | 'disableUpdateMaxRevisionId'
     | 'disablePublishUnannouncedEvents'


### PR DESCRIPTION
## About the changes
This PR removes the feature flag `queryMissingTokens` that was fully rolled out.
It introduces a new way of checking edgeValidTokens controlled by the flag `checkEdgeValidTokensFromCache` that relies in the cached data but hits the DB if needed. 

The assumption is that most of the times edge will find tokens in the cache, except for a few cases in which a new token is queried. From all tokens we expect at most one to hit the DB and in this case querying a single token should be better than querying all the tokens.