### PR TITLE
chore: add the `projectListNewCards` flag

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -139,6 +139,7 @@ exports[`should create default config 1`] = `
       "projectListFilterMyProjects": false,
       "projectOverviewRefactor": false,
       "projectOverviewRefactorFeedback": false,
+      "projectsListNewCards": false,
       "queryMissingTokens": false,
       "responseTimeMetricsFix": false,
       "responseTimeWithAppNameKillSwitch": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -304,6 +304,10 @@ const flags: IFlags = {
         process.env.UNLEASH_EXPERIMENTAL_APPLICATION_OVERVIEW_NEW_QUERY,
         false,
     ),
+    projectsListNewCards: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PROJECTS_LIST_NEW_CARDS,
+        false,
+    ),
 };
 
 export const defaultExperimentalOptions: IExperimentalOptions = {


### PR DESCRIPTION
This PR adds the `projectListNewCards` flag to the constant defined in `experimental.ts`. This should allow the API to pass that value to the front end.