### PR TITLE
feat: add environments to project created payload

### DIFF
--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -49,6 +49,7 @@ import {
     ProjectUserUpdateRoleEvent,
     RoleName,
     SYSTEM_USER_ID,
+    type ProjectCreated,
 } from '../../types';
 import type {
     IProjectAccessModel,
@@ -284,7 +285,7 @@ export default class ProjectService {
         user: IUser,
         auditUser: IAuditUser,
         enableChangeRequestsForSpecifiedEnvironments: () => Promise<void> = async () => {},
-    ): Promise<IProject> {
+    ): Promise<ProjectCreated> {
         await this.validateProjectEnvironments(newProject.environments);
 
         const validatedData = await projectSchema.validateAsync(newProject);
@@ -321,7 +322,7 @@ export default class ProjectService {
             }),
         );
 
-        return data;
+        return { ...data, environments: envsToEnable };
     }
 
     async updateProject(

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -474,6 +474,19 @@ export type CreateProject = Pick<IProject, 'id' | 'name'> & {
     environments?: string[];
 };
 
+// Create project aligns with #/components/schemas/projectCreatedSchema
+export type ProjectCreated = Pick<
+    IProject,
+    | 'id'
+    | 'name'
+    | 'mode'
+    | 'defaultStickiness'
+    | 'description'
+    | 'featureLimit'
+> & {
+    environments: string[];
+};
+
 export interface IProject {
     id: string;
     name: string;


### PR DESCRIPTION
This commit adds an `environments` property to the project created
payload. The list contains only the projects that the project has
enabled.

The point of adding it is that it gives you a better overview over
what you have created.