### PR TITLE
docs: document the new `demoAllowAdminLogin` option

### DIFF
--- a/website/docs/using-unleash/deploy/configuring-unleash.md
+++ b/website/docs/using-unleash/deploy/configuring-unleash.md
@@ -82,7 +82,8 @@ unleash.start(unleashOptions);
     - `initialAdminUser`: `{ username: string, password: string} | null` — whether to create an admin user with default
       password - Defaults to using `admin` and `unleash4all` as the username and password. Can not be overridden by
       setting the `UNLEASH_DEFAULT_ADMIN_USERNAME` and `UNLEASH_DEFAULT_ADMIN_PASSWORD` environment variables.
-        - `initApiTokens` / `INIT_ADMIN_API_TOKENS`, `INIT_CLIENT_API_TOKENS`,
+    -  `demoAllowAdminLogin` / `AUTH_DEMO_ALLOW_ADMIN_LOGIN`: `boolean` — Allows you to log in as the admin user when running Unleash with the `demo` auth type. To log in as the admin user, use `admin` as your email. Defaults to `false`.
+    - `initApiTokens` / `INIT_ADMIN_API_TOKENS`, `INIT_CLIENT_API_TOKENS`,
           and `INIT_FRONTEND_API_TOKENS`: `ApiTokens[]` — Array of API tokens to create on startup. The tokens will only
           be created if the database doesn't already contain any API tokens. Example:
 

--- a/website/docs/using-unleash/deploy/configuring-unleash.md
+++ b/website/docs/using-unleash/deploy/configuring-unleash.md
@@ -82,7 +82,6 @@ unleash.start(unleashOptions);
     - `initialAdminUser`: `{ username: string, password: string} | null` — whether to create an admin user with default
       password - Defaults to using `admin` and `unleash4all` as the username and password. Can not be overridden by
       setting the `UNLEASH_DEFAULT_ADMIN_USERNAME` and `UNLEASH_DEFAULT_ADMIN_PASSWORD` environment variables.
-    -  `demoAllowAdminLogin` / `AUTH_DEMO_ALLOW_ADMIN_LOGIN`: `boolean` — Allows you to log in as the admin user when running Unleash with the `demo` auth type. To log in as the admin user, use `admin` as your email. Defaults to `false`.
     - `initApiTokens` / `INIT_ADMIN_API_TOKENS`, `INIT_CLIENT_API_TOKENS`,
           and `INIT_FRONTEND_API_TOKENS`: `ApiTokens[]` — Array of API tokens to create on startup. The tokens will only
           be created if the database doesn't already contain any API tokens. Example:
@@ -107,6 +106,8 @@ unleash.start(unleashOptions);
       instance `*:*.some-random-string, *:*.some-other-token`). The tokens found
       in `INIT_ADMIN_API_TOKENS`, `INIT_CLIENT_API_TOKENS`, and `INIT_FRONTEND_API_TOKENS` will be created as admin,
       client, and frontend tokens respectively, and Unleash will assign usernames automatically.
+
+    -  `demoAllowAdminLogin` / `AUTH_DEMO_ALLOW_ADMIN_LOGIN`: `boolean` — Allows you to log in as the admin user when running Unleash with the `demo` auth type. To log in as the admin user, use `admin` as your email. Defaults to `false`.
 
 - **databaseUrl** - (_deprecated_) the postgres database url to connect to. Only used if _db_ object is not specified,
   and overrides the _db_ object and any environment variables that change parts of it (like `DATABASE_SSL`). Should


### PR DESCRIPTION
This PR adds docs for the new `demoAllowAdminLogin` option, including how to use it and what it does.