### PR TITLE
chore: remove logs for secret and change invalid token query logic

### DIFF
--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -78,9 +78,7 @@ const apiAccessMiddleware = (
                     // If we're here, we know that api token middleware was enabled, otherwise we'd returned a no-op middleware
                     // We explicitly only protect client and proxy apis, since admin apis are protected by our permission checker
                     // Reject with 401
-                    logger.warn(
-                        `Client api request without valid token (${apiToken}), rejecting`,
-                    );
+                    logger.warn(`No user found for token, rejecting`);
                     res.status(401).send({
                         message: NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
                     });

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -263,15 +263,7 @@ describe('API token getTokenWithCache', () => {
     });
 
     test('should not return the token if it has expired and shoud perform only one db query', async () => {
-        const { apiTokenService, apiTokenStore } = setup({
-            getLogger: () => ({
-                debug: console.log,
-                fatal: console.log,
-                info: console.log,
-                warn: console.log,
-                error: console.log,
-            }),
-        });
+        const { apiTokenService, apiTokenStore } = setup();
         const apiTokenStoreGet = jest.spyOn(apiTokenStore, 'get');
 
         // valid token not present in cache but expired

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -163,6 +163,7 @@ export class ApiTokenService {
                         this.logger.info('Token has expired');
                         // prevent querying the same invalid secret multiple times. Expire after 5 minutes
                         this.queryAfter.set(secret, addMinutes(new Date(), 5));
+                        token = undefined;
                     } else {
                         this.activeTokens.push(token);
                     }

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -159,7 +159,13 @@ export class ApiTokenService {
                 const stopCacheTimer = this.timer('getTokenWithCache.query');
                 token = await this.store.get(secret);
                 if (token) {
-                    this.activeTokens.push(token);
+                    if (token?.expiresAt && isPast(token.expiresAt)) {
+                        this.logger.info('Token has expired');
+                        // prevent querying the same invalid secret multiple times. Expire after 5 minutes
+                        this.queryAfter.set(secret, addMinutes(new Date(), 5));
+                    } else {
+                        this.activeTokens.push(token);
+                    }
                 } else {
                     // prevent querying the same invalid secret multiple times. Expire after 5 minutes
                     this.queryAfter.set(secret, addMinutes(new Date(), 5));


### PR DESCRIPTION
## About the changes
What's going on is the following:
1. When a token is not found in the token's cache we try to find it in the db
2. To prevent a denial of service attack using invalid tokens, we cache the invalid tokens so we don't hit the db.
3. The issue is that we stored this token in the cache regardless we found it or not. And if the token was valid the first time we'd add a timestamp to avoid querying this token again the next time. 
4. The next iteration the token should be in the cache: https://github.com/Unleash/unleash/blob/54383a6578c221bdacdd1b9f14a108a1eb256e7c/src/lib/services/api-token-service.ts#L162 but for some reason it is not and therefore we have to make a query. But this is where the query prevention mechanism kicks in because it finds the token in the cache and kicks us out. This PR fixes this by only storing in the cache for misses if not found: https://github.com/Unleash/unleash/blob/54383a6578c221bdacdd1b9f14a108a1eb256e7c/src/lib/services/api-token-service.ts#L164-L165

The token was added to the cache because we were not checking if it had expired. Now we added a check and we also have a log for expired tokens. Some improvement opportunities:
- I don't think we display that a token has expired in the UI which probably led to this issue
- When a token expired we don't display a specific error message or error response saying that which is not very helpful for users