### PR TITLE
chore: remove log

### DIFF
--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -78,7 +78,6 @@ const apiAccessMiddleware = (
                     // If we're here, we know that api token middleware was enabled, otherwise we'd returned a no-op middleware
                     // We explicitly only protect client and proxy apis, since admin apis are protected by our permission checker
                     // Reject with 401
-                    logger.warn(`No user found for token, rejecting`);
                     res.status(401).send({
                         message: NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
                     });


### PR DESCRIPTION
This log is also not needed because we have the API status code 401 that shows the same data