### PR TITLE
Project owners read model - db read

### DIFF
--- a/src/lib/features/project/project-controller.ts
+++ b/src/lib/features/project/project-controller.ts
@@ -197,7 +197,9 @@ export default class ProjectController extends Controller {
             user.id,
         );
 
-        // const projectsWithOwners = projectOwnersReadModel(projects);
+        if (this.flagResolver.isEnabled('projectsListNewCards')) {
+            // const projectsWithOwners = projectOwnersReadModel(projects);
+        }
 
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/features/project/project-controller.ts
+++ b/src/lib/features/project/project-controller.ts
@@ -197,6 +197,8 @@ export default class ProjectController extends Controller {
             user.id,
         );
 
+        // const projectsWithOwners = projectOwnersReadModel(projects);
+
         this.openApiService.respondWithValidation(
             200,
             res,

--- a/src/lib/features/project/project-controller.ts
+++ b/src/lib/features/project/project-controller.ts
@@ -197,9 +197,9 @@ export default class ProjectController extends Controller {
             user.id,
         );
 
-        if (this.flagResolver.isEnabled('projectsListNewCards')) {
-            // const projectsWithOwners = projectOwnersReadModel(projects);
-        }
+        // if (this.flagResolver.isEnabled('projectsListNewCards')) {
+        //   TODO: get project owners and add to response
+        // }
 
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -6,6 +6,9 @@ import { ProjectOwnersReadModel } from './project-owners-read-model';
 
 describe('unit tests', () => {
     test('maps owners to projects', () => {});
+    test('returns "system" when a project has no owners', async () => {
+        // this is a mapping test; not an integration test
+    });
 });
 
 let db: ITestDb;
@@ -107,18 +110,6 @@ describe('integration tests', () => {
         });
     });
 
-    test('returns "system" when a project has no owners', async () => {
-        const projectId = randomId();
-
-        await db.stores.projectStore.create({ id: projectId, name: projectId });
-
-        // fetch project owners
-        const owners = await readModel.getAllProjectOwners();
-
-        expect(owners).toMatchObject({
-            [projectId]: [{ type: 'system' }],
-        });
-    });
     test('gets project group owners', async () => {});
     test('users are listed before groups', async () => {});
     test('owners (users and groups) are sorted by when they were added; oldest first', async () => {});

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,6 +1,6 @@
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import getLogger from '../../../test/fixtures/no-logger';
-import { RoleName } from '../../types';
+import { type IUser, RoleName } from '../../types';
 import { randomId } from '../../util';
 import { ProjectOwnersReadModel } from './project-owners-read-model';
 
@@ -11,9 +11,29 @@ describe('unit tests', () => {
 let db: ITestDb;
 let readModel: ProjectOwnersReadModel;
 
+let owner: IUser;
+let member: IUser;
+
 beforeAll(async () => {
     db = await dbInit('project_owners_read_model_serial', getLogger);
     readModel = new ProjectOwnersReadModel(db.rawDatabase);
+
+    const ownerData = {
+        name: 'owner',
+        username: 'owner',
+        email: 'owner@email.com',
+        imageUrl: 'image-url-1',
+    };
+    const memberData = {
+        name: 'member',
+        username: 'member',
+        email: 'member@email.com',
+        imageUrl: 'image-url-2',
+    };
+
+    // create users
+    owner = await db.stores.userStore.insert(ownerData);
+    member = await db.stores.userStore.insert(memberData);
 });
 
 afterAll(async () => {
@@ -36,35 +56,13 @@ describe('integration tests', () => {
     test('gets project user owners', async () => {
         const projectId = randomId();
 
-        const owner1create = {
-            name: 'owner1',
-            username: 'owner1',
-            email: 'email1@email.com',
-            imageUrl: 'image-url-1',
-        };
-        const owner2create = {
-            name: 'owner2',
-            username: 'owner2',
-            email: 'email2@email.com',
-            imageUrl: 'image-url-2',
-        };
-
-        // create users
-        const owner1 = await db.stores.userStore.insert(owner1create);
-        const owner2 = await db.stores.userStore.insert(owner2create);
-
         await db.stores.projectStore.create({ id: projectId, name: projectId });
 
         const ownerRole = await db.stores.roleStore.getRoleByName(
             RoleName.OWNER,
         );
         await db.stores.accessStore.addUserToRole(
-            owner1.id,
-            ownerRole.id,
-            projectId,
-        );
-        await db.stores.accessStore.addUserToRole(
-            owner2.id,
+            owner.id,
             ownerRole.id,
             projectId,
         );
@@ -73,13 +71,57 @@ describe('integration tests', () => {
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({
-            [projectId]: [{ name: 'owner1' }, { name: 'owner2' }],
+            [projectId]: [{ name: 'owner' }],
         });
     });
-    test('does not get regular project members', () => {});
-    test('gets project group owners', () => {});
-    test('users are listed before groups', () => {});
-    test('owners (users and groups) are sorted by when they were added; oldest first', () => {});
+
+    test('does not get regular project members', async () => {
+        const projectId = randomId();
+
+        await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+        const ownerRole = await db.stores.roleStore.getRoleByName(
+            RoleName.OWNER,
+        );
+
+        const memberRole = await db.stores.roleStore.getRoleByName(
+            RoleName.MEMBER,
+        );
+        await db.stores.accessStore.addUserToRole(
+            owner.id,
+            ownerRole.id,
+            projectId,
+        );
+
+        await db.stores.accessStore.addUserToRole(
+            member.id,
+            memberRole.id,
+            projectId,
+        );
+
+        // fetch project owners
+        const owners = await readModel.getAllProjectOwners();
+
+        expect(owners).toMatchObject({
+            [projectId]: [{ name: 'owner' }],
+        });
+    });
+
+    test('returns "system" when a project has no owners', async () => {
+        const projectId = randomId();
+
+        await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+        // fetch project owners
+        const owners = await readModel.getAllProjectOwners();
+
+        expect(owners).toMatchObject({
+            [projectId]: [{ type: 'system' }],
+        });
+    });
+    test('gets project group owners', async () => {});
+    test('users are listed before groups', async () => {});
+    test('owners (users and groups) are sorted by when they were added; oldest first', async () => {});
     test('returns the system owner for the default project', () => {});
     test('returns an empty list if there are no projects', async () => {
         const owners = await readModel.getAllProjectOwners();

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -21,7 +21,10 @@ afterAll(async () => {
 });
 
 describe('integration tests', () => {
-    test('gets project owners', () => {});
+    test('gets project user owners', () => {});
+    test('gets project group owners', () => {});
+    test('users are listed before groups', () => {});
+    test('owners (users and groups) are sorted by when they were added; oldest first', () => {});
     test('returns the system owner for the default project', () => {});
     test('returns an empty list if there are no projects', async () => {
         const owners = await readModel.getAllProjectOwners();

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,0 +1,25 @@
+// describe.only('get projects owners', () => {
+//     test('returns empty list if there is no project with an owner', async () => {
+//         const owners = await projectOwnersReadModel();
+//         expect(owners).toHaveLength(0);
+//     })
+
+//     test('returns an user who created a project as an owner', async () => {
+//         const project = {
+//             id: 'project-owners',
+//             name: 'Project Owners',
+//             mode: 'open' as const,
+//             defaultStickiness: 'clientId',
+//         };
+
+//         const owner = await stores.userStore.insert({
+//             name: 'Owner',
+//             email: 'owner-test@example.com'
+//         });
+
+//         await projectService.createProject(project, owner, auditUser);
+
+//         const owners = await projectService.getProjectsOwners();
+//         expect(owners).toHaveLength(1);
+//     })
+// });

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -47,6 +47,11 @@ afterAll(async () => {
 
 afterEach(async () => {
     if (db) {
+        const projects = await db.stores.projectStore.getAll();
+        for (const project of projects) {
+            // Clean only project roles, not all roles
+            await db.stores.roleStore.removeRolesForProject(project.id);
+        }
         await db.stores.projectStore.deleteAll();
     }
 });

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -92,7 +92,6 @@ describe('integration tests', () => {
             projectId,
         );
 
-        // fetch project owners
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({
@@ -111,10 +110,6 @@ describe('integration tests', () => {
         const projectId = randomId();
         await db.stores.projectStore.create({ id: projectId, name: projectId });
 
-        const ownerRole = await db.stores.roleStore.getRoleByName(
-            RoleName.OWNER,
-        );
-
         const memberRole = await db.stores.roleStore.getRoleByName(
             RoleName.MEMBER,
         );
@@ -130,7 +125,6 @@ describe('integration tests', () => {
             projectId,
         );
 
-        // fetch project owners
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({
@@ -149,7 +143,6 @@ describe('integration tests', () => {
             projectId,
         );
 
-        // fetch project owners
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,9 +1,37 @@
+import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
+import getLogger from '../../../test/fixtures/no-logger';
+import { ProjectOwnersReadModel } from './project-owners-read-model';
+
 describe('unit tests', () => {
     test('maps owners to projects', () => {});
+});
+
+let db: ITestDb;
+let readModel: ProjectOwnersReadModel;
+
+beforeAll(async () => {
+    db = await dbInit('project_owners_read_model_serial', getLogger);
+    readModel = new ProjectOwnersReadModel(db.rawDatabase);
+});
+
+afterAll(async () => {
+    if (db) {
+        await db.destroy();
+    }
 });
 
 describe('integration tests', () => {
     test('gets project owners', () => {});
     test('returns the system owner for the default project', () => {});
-    test('returns an empty list if there are no projects', () => {});
+    test('returns an empty list if there are no projects', async () => {
+        const owners = await readModel.getAllProjectOwners();
+
+        expect(owners).toStrictEqual({});
+    });
+
+    test('enriches fully', async () => {
+        const owners = await readModel.enrichWithOwners([]);
+
+        expect(owners).toStrictEqual([]);
+    });
 });

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,5 +1,7 @@
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import getLogger from '../../../test/fixtures/no-logger';
+import { RoleName } from '../../types';
+import { randomId } from '../../util';
 import { ProjectOwnersReadModel } from './project-owners-read-model';
 
 describe('unit tests', () => {
@@ -20,8 +22,61 @@ afterAll(async () => {
     }
 });
 
+afterEach(async () => {
+    if (db) {
+        await db.stores.projectStore.deleteAll();
+    }
+});
+
 describe('integration tests', () => {
-    test('gets project user owners', () => {});
+    test('name takes precedence over username', () => {
+        // import { extractUsername } from '../../../util/extract-user';
+    });
+
+    test('gets project user owners', async () => {
+        const projectId = randomId();
+
+        const owner1create = {
+            name: 'owner1',
+            username: 'owner1',
+            email: 'email1@email.com',
+            imageUrl: 'image-url-1',
+        };
+        const owner2create = {
+            name: 'owner2',
+            username: 'owner2',
+            email: 'email2@email.com',
+            imageUrl: 'image-url-2',
+        };
+
+        // create users
+        const owner1 = await db.stores.userStore.insert(owner1create);
+        const owner2 = await db.stores.userStore.insert(owner2create);
+
+        await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+        const ownerRole = await db.stores.roleStore.getRoleByName(
+            RoleName.OWNER,
+        );
+        await db.stores.accessStore.addUserToRole(
+            owner1.id,
+            ownerRole.id,
+            projectId,
+        );
+        await db.stores.accessStore.addUserToRole(
+            owner2.id,
+            ownerRole.id,
+            projectId,
+        );
+
+        // fetch project owners
+        const owners = await readModel.getAllProjectOwners();
+
+        expect(owners).toMatchObject({
+            [projectId]: [{ name: 'owner1' }, { name: 'owner2' }],
+        });
+    });
+    test('does not get regular project members', () => {});
     test('gets project group owners', () => {});
     test('users are listed before groups', () => {});
     test('owners (users and groups) are sorted by when they were added; oldest first', () => {});

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -16,7 +16,7 @@ let member: IUser;
 
 beforeAll(async () => {
     db = await dbInit('project_owners_read_model_serial', getLogger);
-    readModel = new ProjectOwnersReadModel(db.rawDatabase);
+    readModel = new ProjectOwnersReadModel(db.rawDatabase, db.stores.roleStore);
 
     const ownerData = {
         name: 'owner',

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,6 +1,6 @@
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import getLogger from '../../../test/fixtures/no-logger';
-import { type IUser, RoleName } from '../../types';
+import { type IUser, RoleName, type IGroup } from '../../types';
 import { randomId } from '../../util';
 import { ProjectOwnersReadModel } from './project-owners-read-model';
 
@@ -14,21 +14,24 @@ describe('unit tests', () => {
 let db: ITestDb;
 let readModel: ProjectOwnersReadModel;
 
+let ownerRoleId: number;
 let owner: IUser;
 let member: IUser;
+let group: IGroup;
 
 beforeAll(async () => {
     db = await dbInit('project_owners_read_model_serial', getLogger);
     readModel = new ProjectOwnersReadModel(db.rawDatabase, db.stores.roleStore);
+    ownerRoleId = (await db.stores.roleStore.getRoleByName(RoleName.OWNER)).id;
 
     const ownerData = {
-        name: 'owner',
+        name: 'Owner User',
         username: 'owner',
         email: 'owner@email.com',
         imageUrl: 'image-url-1',
     };
     const memberData = {
-        name: 'member',
+        name: 'Member Name',
         username: 'member',
         email: 'member@email.com',
         imageUrl: 'image-url-2',
@@ -37,6 +40,10 @@ beforeAll(async () => {
     // create users
     owner = await db.stores.userStore.insert(ownerData);
     member = await db.stores.userStore.insert(memberData);
+
+    // create groups
+    group = await db.stores.groupStore.create({ name: 'Group Name' });
+    await db.stores.groupStore.addUserToGroups(owner.id, [group.id]);
 });
 
 afterAll(async () => {
@@ -57,21 +64,31 @@ afterEach(async () => {
 });
 
 describe('integration tests', () => {
-    test('name takes precedence over username', () => {
-        // import { extractUsername } from '../../../util/extract-user';
+    test('name takes precedence over username', async () => {
+        const projectId = randomId();
+        await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+        await db.stores.accessStore.addUserToRole(
+            owner.id,
+            ownerRoleId,
+            projectId,
+        );
+
+        const owners = await readModel.getAllProjectOwners();
+        expect(owners).toMatchObject({
+            [projectId]: expect.arrayContaining([
+                expect.objectContaining({ name: 'Owner User' }),
+            ]),
+        });
     });
 
     test('gets project user owners', async () => {
         const projectId = randomId();
-
         await db.stores.projectStore.create({ id: projectId, name: projectId });
 
-        const ownerRole = await db.stores.roleStore.getRoleByName(
-            RoleName.OWNER,
-        );
         await db.stores.accessStore.addUserToRole(
             owner.id,
-            ownerRole.id,
+            ownerRoleId,
             projectId,
         );
 
@@ -79,13 +96,19 @@ describe('integration tests', () => {
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({
-            [projectId]: [{ name: 'owner' }],
+            [projectId]: [
+                {
+                    ownerType: 'user',
+                    name: 'Owner User',
+                    email: 'owner@email.com',
+                    imageUrl: 'image-url-1',
+                },
+            ],
         });
     });
 
     test('does not get regular project members', async () => {
         const projectId = randomId();
-
         await db.stores.projectStore.create({ id: projectId, name: projectId });
 
         const ownerRole = await db.stores.roleStore.getRoleByName(
@@ -97,7 +120,7 @@ describe('integration tests', () => {
         );
         await db.stores.accessStore.addUserToRole(
             owner.id,
-            ownerRole.id,
+            ownerRoleId,
             projectId,
         );
 
@@ -111,14 +134,40 @@ describe('integration tests', () => {
         const owners = await readModel.getAllProjectOwners();
 
         expect(owners).toMatchObject({
-            [projectId]: [{ name: 'owner' }],
+            [projectId]: [{ name: 'Owner User' }],
         });
     });
 
-    test('gets project group owners', async () => {});
+    test('gets project group owners', async () => {
+        const projectId = randomId();
+        await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+        await db.stores.accessStore.addGroupToRole(
+            group.id,
+            ownerRoleId,
+            '',
+            projectId,
+        );
+
+        // fetch project owners
+        const owners = await readModel.getAllProjectOwners();
+
+        expect(owners).toMatchObject({
+            [projectId]: [
+                {
+                    ownerType: 'group',
+                    name: 'Group Name',
+                },
+            ],
+        });
+    });
+
     test('users are listed before groups', async () => {});
+
     test('owners (users and groups) are sorted by when they were added; oldest first', async () => {});
-    test('returns the system owner for the default project', () => {});
+
+    test('returns the system owner for the default project', async () => {});
+
     test('returns an empty list if there are no projects', async () => {
         const owners = await readModel.getAllProjectOwners();
 

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -1,25 +1,9 @@
-// describe.only('get projects owners', () => {
-//     test('returns empty list if there is no project with an owner', async () => {
-//         const owners = await projectOwnersReadModel();
-//         expect(owners).toHaveLength(0);
-//     })
+describe('unit tests', () => {
+    test('maps owners to projects', () => {});
+});
 
-//     test('returns an user who created a project as an owner', async () => {
-//         const project = {
-//             id: 'project-owners',
-//             name: 'Project Owners',
-//             mode: 'open' as const,
-//             defaultStickiness: 'clientId',
-//         };
-
-//         const owner = await stores.userStore.insert({
-//             name: 'Owner',
-//             email: 'owner-test@example.com'
-//         });
-
-//         await projectService.createProject(project, owner, auditUser);
-
-//         const owners = await projectService.getProjectsOwners();
-//         expect(owners).toHaveLength(1);
-//     })
-// });
+describe('integration tests', () => {
+    test('gets project owners', () => {});
+    test('returns the system owner for the default project', () => {});
+    test('returns an empty list if there are no projects', () => {});
+});

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -1,3 +1,4 @@
+import type { Db } from '../../db/db';
 import type { IProjectWithCount } from '../../types';
 
 export type ProjectOwner =
@@ -14,45 +15,60 @@ export type ProjectOwner =
 
 export type ProjectOwnersDictionary = Record<string, ProjectOwner[]>;
 
-//   const ownerRole = await this.accessService.getRoleByName(
-//     RoleName.OWNER,
-//    );
-//   const ownerRoleId = ownerRole.id;
-
-// async getAllProjectsUsersForRole(roleId: number): Promise<IUserWithProjectRoles[]> {
-//     const rows = await this.db
-//         .select(['user_id', 'ru.created_at', 'ru.project'])
-//         .from<IRole>(`${T.ROLE_USER} AS ru`)
-//         .join(`${T.ROLES} as r`, 'ru.role_id', 'id')
-//         .where('r.id', roleId);
-
-//     return rows.map((r) => ({
-//         id: r.user_id,
-//         addedAt: r.created_at,
-//         projectId: r.project,
-//         roleId,
-//     }));
-// }
-
-// async getAllProjectsGroupsForRole(roleId: number): Promise<any[]> {
-//     throw new Error('Method not implemented');
-// }
-
 type IProjectWithCountAndOwners = IProjectWithCount & {
     owners: ProjectOwner[];
 };
 
-const getAllProjectOwners = () => {};
+export class ProjectOwnersReadModel {
+    private db: Db;
 
-const enrichWithOwners = (
-    projects: IProjectWithCount[],
-): IProjectWithCountAndOwners[] => {
-    // const projectOwners: ProjectOwnersDictionary = getAllProjectOwners();
+    constructor(db: Db) {
+        this.db = db;
+    }
 
-    // const projectsWithOwners = projects.map((p) => ({
-    //     ...p,
-    //     owners: projectOwners[p.id] || [],
-    // }));
+    addOwnerData(
+        projects: IProjectWithCount[],
+        owners: ProjectOwnersDictionary,
+    ): IProjectWithCountAndOwners[] {
+        // const projectsWithOwners = projects.map((p) => ({
+        //     ...p,
+        //     owners: projectOwners[p.id] || [],
+        // }));
+        return [];
+    }
+    async getAllProjectOwners(): Promise<ProjectOwnersDictionary> {
+        //   const ownerRole = await this.accessService.getRoleByName(
+        //     RoleName.OWNER,
+        //    );
+        //   const ownerRoleId = ownerRole.id;
 
-    return [];
-};
+        // async getAllProjectsUsersForRole(roleId: number): Promise<IUserWithProjectRoles[]> {
+        //     const rows = await this.db
+        //         .select(['user_id', 'ru.created_at', 'ru.project'])
+        //         .from<IRole>(`${T.ROLE_USER} AS ru`)
+        //         .join(`${T.ROLES} as r`, 'ru.role_id', 'id')
+        //         .where('r.id', roleId);
+
+        //     return rows.map((r) => ({
+        //         id: r.user_id,
+        //         addedAt: r.created_at,
+        //         projectId: r.project,
+        //         roleId,
+        //     }));
+        // }
+
+        // async getAllProjectsGroupsForRole(roleId: number): Promise<any[]> {
+        //     throw new Error('Method not implemented');
+        // }
+
+        return {};
+    }
+
+    async enrichWithOwners(
+        projects: IProjectWithCount[],
+    ): Promise<IProjectWithCountAndOwners[]> {
+        const owners = await this.getAllProjectOwners();
+
+        return this.addOwnerData(projects, owners);
+    }
+}

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -1,0 +1,37 @@
+export type ProjectOwner =
+    | {
+          ownerType: 'user';
+          name: string;
+          email?: string;
+          imageUrl?: string;
+      }
+    | {
+          ownerType: 'group';
+          name: string;
+      };
+
+export type ProjectOwnersDictionary = Record<string, ProjectOwner[]>;
+
+//   const ownerRole = await this.accessService.getRoleByName(
+//     RoleName.OWNER,
+//    );
+//   const ownerRoleId = ownerRole.id;
+
+// async getAllProjectsUsersForRole(roleId: number): Promise<IUserWithProjectRoles[]> {
+//     const rows = await this.db
+//         .select(['user_id', 'ru.created_at', 'ru.project'])
+//         .from<IRole>(`${T.ROLE_USER} AS ru`)
+//         .join(`${T.ROLES} as r`, 'ru.role_id', 'id')
+//         .where('r.id', roleId);
+
+//     return rows.map((r) => ({
+//         id: r.user_id,
+//         addedAt: r.created_at,
+//         projectId: r.project,
+//         roleId,
+//     }));
+// }
+
+// async getAllProjectsGroupsForRole(roleId: number): Promise<any[]> {
+//     throw new Error('Method not implemented');
+// }

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -1,6 +1,5 @@
 import type { Db } from '../../db/db';
 import { RoleName, type IProjectWithCount, type IRoleStore } from '../../types';
-import { extractUsernameFromUser } from '../../util';
 
 export type SystemOwner = { ownerType: 'system' };
 export type NonSystemProjectOwner =
@@ -68,22 +67,12 @@ export class ProjectOwnersReadModel {
 
         const result = await query;
 
-        console.log(result);
-
         const dict = result.reduce((acc, next) => {
             const { project } = next;
-            const userCanonicalName = extractUsernameFromUser({
-                id: next.id,
-                name: next.name,
-                email: next.email,
-                username: next.username,
-                permissions: [],
-                isAPI: false,
-            });
 
             const userData = {
                 ownerType: 'user',
-                name: userCanonicalName,
+                name: next.name || next.username,
                 email: next.email,
                 imageUrl: next.image_url,
             };
@@ -91,7 +80,7 @@ export class ProjectOwnersReadModel {
             if (project in acc) {
                 acc[project].push(userData);
             } else {
-                acc[project] = { userData };
+                acc[project] = [userData];
             }
             return acc;
         }, {});

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -1,3 +1,5 @@
+import type { IProjectWithCount } from '../../types';
+
 export type ProjectOwner =
     | {
           ownerType: 'user';
@@ -35,3 +37,20 @@ export type ProjectOwnersDictionary = Record<string, ProjectOwner[]>;
 // async getAllProjectsGroupsForRole(roleId: number): Promise<any[]> {
 //     throw new Error('Method not implemented');
 // }
+
+type IProjectWithCountAndOwners = IProjectWithCount & {
+    owners: ProjectOwner[];
+};
+
+const enrichWithOwners = (
+    projects: IProjectWithCount[],
+): IProjectWithCountAndOwners[] => {
+    const projectOwners: ProjectOwnersDictionary = getAllProjectOwners();
+
+    const projectsWithOwners = projects.map((p) => ({
+        ...p,
+        owners: projectOwners[p.id] || [],
+    }));
+
+    return [];
+};

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -41,6 +41,7 @@ export class ProjectOwnersReadModel {
         // }));
         return [];
     }
+
     async getAllProjectOwners(): Promise<ProjectOwnersDictionary> {
         const T = {
             ROLE_USER: 'role_user',
@@ -72,9 +73,9 @@ export class ProjectOwnersReadModel {
 
             const userData = {
                 ownerType: 'user',
-                name: next.name || next.username,
-                email: next.email,
-                imageUrl: next.image_url,
+                name: next?.name || next?.username,
+                email: next?.email,
+                imageUrl: next?.image_url,
             };
 
             if (project in acc) {

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -42,15 +42,17 @@ type IProjectWithCountAndOwners = IProjectWithCount & {
     owners: ProjectOwner[];
 };
 
+const getAllProjectOwners = () => {};
+
 const enrichWithOwners = (
     projects: IProjectWithCount[],
 ): IProjectWithCountAndOwners[] => {
-    const projectOwners: ProjectOwnersDictionary = getAllProjectOwners();
+    // const projectOwners: ProjectOwnersDictionary = getAllProjectOwners();
 
-    const projectsWithOwners = projects.map((p) => ({
-        ...p,
-        owners: projectOwners[p.id] || [],
-    }));
+    // const projectsWithOwners = projects.map((p) => ({
+    //     ...p,
+    //     owners: projectOwners[p.id] || [],
+    // }));
 
     return [];
 };

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -1,7 +1,8 @@
 import type { Db } from '../../db/db';
 import type { IProjectWithCount } from '../../types';
 
-export type ProjectOwner =
+export type SystemOwner = { ownerType: 'system' };
+export type NonSystemProjectOwner =
     | {
           ownerType: 'user';
           name: string;
@@ -13,10 +14,12 @@ export type ProjectOwner =
           name: string;
       };
 
-export type ProjectOwnersDictionary = Record<string, ProjectOwner[]>;
+type ProjectOwners = [SystemOwner] | NonSystemProjectOwner[];
+
+export type ProjectOwnersDictionary = Record<string, ProjectOwners>;
 
 type IProjectWithCountAndOwners = IProjectWithCount & {
-    owners: ProjectOwner[];
+    owners: ProjectOwners;
 };
 
 export class ProjectOwnersReadModel {


### PR DESCRIPTION
## About the changes
Implementation of the logic for fetching project owners.

Based on pattern documented in https://docs.getunleash.io/contributing/ADRs/back-end/write-model-vs-read-models

### Next up
- Create and test function combining projects list result with project owners read model results.
- Create Schema update
- Add project owners to the response when the feature flag is enabled

Internal ticket https://linear.app/unleash/issue/1-2318/get-project-owner-users-and-groups-from-db
