### PR TITLE
fix: added a check to avoid double counting

### DIFF
--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -70,7 +70,9 @@ export function responseTimeMetrics(
             time,
             appName,
         };
-
-        eventBus.emit(REQUEST_TIME, timingInfo);
+        if (!res.locals.responseTimeEmitted) {
+            res.locals.responseTimeEmitted = true;
+            eventBus.emit(REQUEST_TIME, timingInfo);
+        }
     });
 }


### PR DESCRIPTION
Due to how we handle redirects of embedded proxy, we ended up counting the same request twice. This PR adds a boolean to res.locals which we then check if set to avoid double counting.