### PR TITLE
feat: scim assume control UI - move scim into sso configs

### DIFF
--- a/frontend/src/component/admin/auth/AuthSettings.tsx
+++ b/frontend/src/component/admin/auth/AuthSettings.tsx
@@ -11,14 +11,10 @@ import { ADMIN } from '@server/types/permissions';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { useState } from 'react';
 import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
-import { useUiFlag } from 'hooks/useUiFlag';
-import { ScimSettings } from './ScimSettings/ScimSettings';
 
 export const AuthSettings = () => {
     const { authenticationType } = useUiConfig().uiConfig;
     const { uiConfig } = useUiConfig();
-
-    const scimEnabled = useUiFlag('scimApi');
 
     const tabs = [
         {
@@ -40,13 +36,6 @@ export const AuthSettings = () => {
     ].filter(
         (item) => uiConfig.flags?.googleAuthEnabled || item.label !== 'Google',
     );
-
-    if (scimEnabled) {
-        tabs.push({
-            label: 'Provisioning (SCIM)',
-            component: <ScimSettings />,
-        });
-    }
 
     const [activeTab, setActiveTab] = useState(0);
 

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -23,7 +23,8 @@ import { SsoGroupSettings } from '../SsoGroupSettings';
 import type { IRole } from 'interfaces/role';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { ScimSettings } from '../ScimSettings/ScimSettings';
+import { useScim } from 'hooks/useScim';
+import { ScimConfigSettings } from '../ScimSettings/ScimSettings';
 
 const initialState = {
     enabled: false,
@@ -51,10 +52,6 @@ export const OidcAuth = () => {
     const [data, setData] = useState<State>(initialState);
     const { config } = useAuthSettings('oidc');
     const { updateSettings, errors, loading } = useAuthSettingsApi('oidc');
-    let saveHook: (() => Promise<void>) | undefined;
-    const registerSaveHook = (callback: () => Promise<void>) => {
-        saveHook = callback;
-    };
 
     useEffect(() => {
         if (config.discoverUrl) {
@@ -92,6 +89,22 @@ export const OidcAuth = () => {
         });
     };
 
+    const {
+        settings,
+        enabled,
+        setEnabled,
+        assumeControlOfExisting,
+        setAssumeControlOfExisting,
+        newToken,
+        tokenGenerationDialog,
+        setTokenGenerationDialog,
+        tokenDialog,
+        setTokenDialog,
+        loading: scimLoading,
+        saveScimSettings,
+        onGenerateNewTokenConfirm,
+    } = useScim();
+
     const onSubmit = async (event: React.SyntheticEvent) => {
         event.preventDefault();
 
@@ -101,9 +114,7 @@ export const OidcAuth = () => {
                 title: 'Settings stored',
                 type: 'success',
             });
-            if (saveHook) {
-                await saveHook();
-            }
+            saveScimSettings();
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
         }
@@ -271,9 +282,24 @@ export const OidcAuth = () => {
                 <ConditionallyRender
                     condition={scimEnabled}
                     show={
-                        <ScimSettings
+                        <ScimConfigSettings
                             disabled={!data.enabled}
-                            registerSaveHook={registerSaveHook}
+                            settings={settings}
+                            enabled={enabled}
+                            setEnabled={setEnabled}
+                            assumeControlOfExisting={assumeControlOfExisting}
+                            setAssumeControlOfExisting={
+                                setAssumeControlOfExisting
+                            }
+                            newToken={newToken}
+                            tokenGenerationDialog={tokenGenerationDialog}
+                            setTokenGenerationDialog={setTokenGenerationDialog}
+                            tokenDialog={tokenDialog}
+                            setTokenDialog={setTokenDialog}
+                            loading={scimLoading}
+                            onGenerateNewTokenConfirm={
+                                onGenerateNewTokenConfirm
+                            }
                         />
                     }
                 />

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -19,7 +19,8 @@ import { SsoGroupSettings } from '../SsoGroupSettings';
 import type { IRole } from 'interfaces/role';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { ScimSettings } from '../ScimSettings/ScimSettings';
+import { useScim } from 'hooks/useScim';
+import { ScimConfigSettings } from '../ScimSettings/ScimSettings';
 
 const initialState = {
     enabled: false,
@@ -46,10 +47,6 @@ export const SamlAuth = () => {
     const [data, setData] = useState<State>(initialState);
     const { config } = useAuthSettings('saml');
     const { updateSettings, errors, loading } = useAuthSettingsApi('saml');
-    let saveHook: (() => Promise<void>) | undefined;
-    const registerSaveHook = (callback: () => Promise<void>) => {
-        saveHook = callback;
-    };
 
     useEffect(() => {
         if (config.entityId) {
@@ -83,6 +80,22 @@ export const SamlAuth = () => {
         });
     };
 
+    const {
+        settings,
+        enabled,
+        setEnabled,
+        assumeControlOfExisting,
+        setAssumeControlOfExisting,
+        newToken,
+        tokenGenerationDialog,
+        setTokenGenerationDialog,
+        tokenDialog,
+        setTokenDialog,
+        loading: scimLoading,
+        saveScimSettings,
+        onGenerateNewTokenConfirm,
+    } = useScim();
+
     const onSubmit = async (event: React.SyntheticEvent) => {
         event.preventDefault();
 
@@ -92,9 +105,7 @@ export const SamlAuth = () => {
                 title: 'Settings stored',
                 type: 'success',
             });
-            if (saveHook) {
-                await saveHook();
-            }
+            saveScimSettings();
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
         }
@@ -278,9 +289,24 @@ export const SamlAuth = () => {
                 <ConditionallyRender
                     condition={scimEnabled}
                     show={
-                        <ScimSettings
+                        <ScimConfigSettings
                             disabled={!data.enabled}
-                            registerSaveHook={registerSaveHook}
+                            settings={settings}
+                            enabled={enabled}
+                            setEnabled={setEnabled}
+                            assumeControlOfExisting={assumeControlOfExisting}
+                            setAssumeControlOfExisting={
+                                setAssumeControlOfExisting
+                            }
+                            newToken={newToken}
+                            tokenGenerationDialog={tokenGenerationDialog}
+                            setTokenGenerationDialog={setTokenGenerationDialog}
+                            tokenDialog={tokenDialog}
+                            setTokenDialog={setTokenDialog}
+                            loading={scimLoading}
+                            onGenerateNewTokenConfirm={
+                                onGenerateNewTokenConfirm
+                            }
                         />
                     }
                 />

--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -19,6 +19,8 @@ export const ScimSettings = () => {
         useScimSettingsApi();
 
     const [enabled, setEnabled] = useState(false);
+    const [assumeControlOfExisting, setAssumeControlOfExisting] =
+        useState(false);
 
     const [tokenGenerationDialog, setTokenGenerationDialog] = useState(false);
     const [tokenDialog, setTokenDialog] = useState(false);
@@ -26,13 +28,14 @@ export const ScimSettings = () => {
 
     useEffect(() => {
         setEnabled(settings.enabled ?? false);
+        setAssumeControlOfExisting(settings.assumeControlOfExisting ?? false);
     }, [settings]);
 
     const onSubmit = async (event: React.SyntheticEvent) => {
         event.preventDefault();
 
         try {
-            await saveSettings({ enabled });
+            await saveSettings({ enabled, assumeControlOfExisting });
             if (enabled && !settings.hasToken) {
                 const token = await generateNewToken();
                 setNewToken(token);
@@ -98,6 +101,30 @@ export const ScimSettings = () => {
                                 />
                             }
                             label={enabled ? 'Enabled' : 'Disabled'}
+                        />
+                    </Grid>
+                </Grid>
+
+                <Grid container spacing={3}>
+                    <Grid item md={5} mb={2}>
+                        <strong>Assume control</strong>
+                        <p>Assumes control of users and groups</p>
+                    </Grid>
+                    <Grid item md={6}>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    onChange={(_, enabled) =>
+                                        setAssumeControlOfExisting(enabled)
+                                    }
+                                    value={assumeControlOfExisting}
+                                    name='assumeControlOfExisting'
+                                    checked={assumeControlOfExisting}
+                                />
+                            }
+                            label={
+                                assumeControlOfExisting ? 'Enabled' : 'Disabled'
+                            }
                         />
                     </Grid>
                 </Grid>

--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -1,71 +1,46 @@
-import { useEffect, useState } from 'react';
 import { Button, FormControlLabel, Grid, Switch } from '@mui/material';
 import { Alert } from '@mui/material';
-import useToast from 'hooks/useToast';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { useScimSettings } from 'hooks/api/getters/useScimSettings/useScimSettings';
-import { useScimSettingsApi } from 'hooks/api/actions/useScimSettingsApi/useScimSettingsApi';
-import { formatUnknownError } from 'utils/formatUnknownError';
 import { ScimTokenGenerationDialog } from './ScimTokenGenerationDialog';
 import { ScimTokenDialog } from './ScimTokenDialog';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import type { ScimSettings } from 'hooks/api/getters/useScimSettings/useScimSettings';
 
 export interface IScimSettingsParameters {
     disabled: boolean;
-    registerSaveHook: (callback: () => Promise<void>) => void;
+    loading: boolean;
+    enabled: boolean;
+    setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+    assumeControlOfExisting: boolean;
+    setAssumeControlOfExisting: React.Dispatch<React.SetStateAction<boolean>>;
+    newToken: string;
+    settings: ScimSettings;
+    tokenGenerationDialog: boolean;
+    setTokenGenerationDialog: React.Dispatch<React.SetStateAction<boolean>>;
+    onGenerateNewTokenConfirm: () => void;
+    tokenDialog: boolean;
+    setTokenDialog: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const ScimSettings = ({
+export const ScimConfigSettings = ({
     disabled,
-    registerSaveHook,
+    loading,
+    enabled,
+    setEnabled,
+    assumeControlOfExisting,
+    setAssumeControlOfExisting,
+    newToken,
+    settings,
+    tokenGenerationDialog,
+    setTokenGenerationDialog,
+    onGenerateNewTokenConfirm,
+    tokenDialog,
+    setTokenDialog,
 }: IScimSettingsParameters) => {
-    const { setToastData, setToastApiError } = useToast();
     const { uiConfig } = useUiConfig();
-    const { settings, refetch } = useScimSettings();
-    const { saveSettings, generateNewToken, errors, loading } =
-        useScimSettingsApi();
-
-    const [enabled, setEnabled] = useState(false);
-    const [assumeControlOfExisting, setAssumeControlOfExisting] =
-        useState(false);
-
-    const [tokenGenerationDialog, setTokenGenerationDialog] = useState(false);
-    const [tokenDialog, setTokenDialog] = useState(false);
-    const [newToken, setNewToken] = useState('');
-
-    useEffect(() => {
-        setEnabled(settings.enabled ?? false);
-        setAssumeControlOfExisting(settings.assumeControlOfExisting ?? false);
-    }, [settings]);
-
-    registerSaveHook(async () => {
-        try {
-            await saveSettings({ enabled, assumeControlOfExisting });
-            if (enabled && !settings.hasToken) {
-                const token = await generateNewToken();
-                setNewToken(token);
-                setTokenDialog(true);
-            }
-
-            setToastData({
-                title: 'Settings stored',
-                type: 'success',
-            });
-            refetch();
-        } catch (error: unknown) {
-            setToastApiError(formatUnknownError(error));
-        }
-    });
 
     const onGenerateNewToken = async () => {
         setTokenGenerationDialog(true);
-    };
-
-    const onGenerateNewTokenConfirm = async () => {
-        setTokenGenerationDialog(false);
-        const token = await generateNewToken();
-        setNewToken(token);
-        setTokenDialog(true);
     };
 
     return (
@@ -118,8 +93,8 @@ export const ScimSettings = ({
                     <FormControlLabel
                         control={
                             <Switch
-                                onChange={(_, enabled) =>
-                                    setAssumeControlOfExisting(enabled)
+                                onChange={(_, set_enabled) =>
+                                    setAssumeControlOfExisting(set_enabled)
                                 }
                                 value={assumeControlOfExisting}
                                 name='assumeControlOfExisting'

--- a/frontend/src/hooks/api/getters/useScimSettings/useScimSettings.ts
+++ b/frontend/src/hooks/api/getters/useScimSettings/useScimSettings.ts
@@ -10,11 +10,13 @@ const ENDPOINT = 'api/admin/scim-settings';
 export type ScimSettings = {
     enabled: boolean;
     hasToken: boolean;
+    assumeControlOfExisting: boolean;
 };
 
 const DEFAULT_DATA: ScimSettings = {
     enabled: false,
     hasToken: false,
+    assumeControlOfExisting: false,
 };
 
 export const useScimSettings = () => {

--- a/frontend/src/hooks/useScim.ts
+++ b/frontend/src/hooks/useScim.ts
@@ -1,0 +1,66 @@
+import { useScimSettingsApi } from 'hooks/api/actions/useScimSettingsApi/useScimSettingsApi';
+import { useEffect, useState } from 'react';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import useToast from 'hooks/useToast';
+import { useScimSettings } from './api/getters/useScimSettings/useScimSettings';
+
+export const useScim = () => {
+    const [newToken, setNewToken] = useState('');
+    const [enabled, setEnabled] = useState(false);
+    const [tokenGenerationDialog, setTokenGenerationDialog] = useState(false);
+    const [tokenDialog, setTokenDialog] = useState(false);
+    const [assumeControlOfExisting, setAssumeControlOfExisting] =
+        useState(false);
+
+    const { saveSettings, generateNewToken, errors, loading } =
+        useScimSettingsApi();
+
+    const { settings, refetch } = useScimSettings();
+    const { setToastData, setToastApiError } = useToast();
+    const saveScimSettings = async () => {
+        try {
+            await saveSettings({ enabled, assumeControlOfExisting });
+            if (enabled && !settings.hasToken) {
+                const token = await generateNewToken();
+                setNewToken(token);
+                setTokenDialog(true);
+            }
+
+            setToastData({
+                title: 'Settings stored',
+                type: 'success',
+            });
+            refetch();
+        } catch (error: unknown) {
+            setToastApiError(formatUnknownError(error));
+        }
+    };
+
+    const onGenerateNewTokenConfirm = async () => {
+        setTokenGenerationDialog(false);
+        const token = await generateNewToken();
+        setNewToken(token);
+        setTokenDialog(true);
+    };
+
+    useEffect(() => {
+        setEnabled(settings.enabled ?? false);
+        setAssumeControlOfExisting(settings.assumeControlOfExisting ?? false);
+    }, [settings]);
+
+    return {
+        settings,
+        enabled,
+        setEnabled,
+        assumeControlOfExisting,
+        setAssumeControlOfExisting,
+        newToken,
+        tokenGenerationDialog,
+        setTokenGenerationDialog,
+        tokenDialog,
+        setTokenDialog,
+        loading,
+        saveScimSettings,
+        onGenerateNewTokenConfirm,
+    };
+};


### PR DESCRIPTION
## About the changes

- Adds support for the configuration option for SCIM taking over control of users and groups
- Moves SCIM settings into SSO config pages (OIDC and SAML). SCIM registers a callback to be invoked when saving in a parent SSO config page

![image](https://github.com/Unleash/unleash/assets/707867/e50dafaf-1681-4b02-885e-b57af2ada027)
