### PR TITLE
fix: flag trends should support bigint for yes and no evaluations

### DIFF
--- a/src/migrations/20240425132155-flag-trends-bigint.js
+++ b/src/migrations/20240425132155-flag-trends-bigint.js
@@ -6,5 +6,9 @@ exports.up = function (db, cb) {
 };
 
 exports.down = function (db, cb) {
-
+    db.runSql(
+        `
+        `,
+        cb,
+    );
 };

--- a/src/migrations/20240425132155-flag-trends-bigint.js
+++ b/src/migrations/20240425132155-flag-trends-bigint.js
@@ -1,0 +1,10 @@
+exports.up = function (db, cb) {
+    db.runSql(`
+        ALTER TABLE flag_trends ALTER COLUMN total_yes TYPE bigint;
+        ALTER TABLE flag_trends ALTER COLUMN total_no TYPE bigint;
+    `, cb);
+};
+
+exports.down = function (db, cb) {
+
+};


### PR DESCRIPTION
Recently we see some pods failing with inserting yes, no values that were over int. Increasing type to bigint.