### PR TITLE
feat: include CR envs enabled on creation in event and update validation

### DIFF
--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -277,4 +277,31 @@ describe('enterprise extension: enable change requests', () => {
             ),
         ).rejects.toThrow(BadDataError);
     });
+
+    test("it does not throw if an error if you provide it with environments that don't exist but aren't on enterprise", async () => {
+        const service = createService();
+        // @ts-expect-error
+        service.isEnterprise = false;
+        // @ts-expect-error
+        service.environmentStore.exists = () => false;
+
+        const projectId = 'fake-project-id';
+        expect(
+            service.createProject(
+                {
+                    id: projectId,
+                    name: 'fake-project-name',
+                    changeRequestEnvironments: [
+                        { name: 'dev', requiredApprovals: 1 },
+                    ],
+                },
+                {
+                    id: 5,
+                    permissions: [],
+                    isAPI: false,
+                },
+                TEST_AUDIT_USER,
+            ),
+        ).resolves.toBeTruthy();
+    });
 });

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -167,9 +167,7 @@ describe('enterprise extension: enable change requests', () => {
                 isAPI: false,
             },
             TEST_AUDIT_USER,
-            async () => {
-                crEnvs;
-            },
+            async () => crEnvs,
         );
     });
 
@@ -196,9 +194,7 @@ describe('enterprise extension: enable change requests', () => {
                 isAPI: false,
             },
             TEST_AUDIT_USER,
-            async () => {
-                crEnvs;
-            },
+            async () => crEnvs,
         );
 
         expect(result.changeRequestEnvironments).toStrictEqual(crEnvs);

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -1,4 +1,5 @@
 import { createTestConfig } from '../../../test/config/test-config';
+import { BadDataError } from '../../error';
 import { type IBaseEvent, RoleName, TEST_AUDIT_USER } from '../../types';
 import { createFakeProjectService } from './createProjectService';
 
@@ -26,7 +27,7 @@ describe('enterprise extension: enable change requests', () => {
         return service;
     };
 
-    test('it calls the change request enablement function on enterprise', async () => {
+    test('it calls the change request enablement function on enterprise after creating the project', async () => {
         expect.assertions(1);
         const service = createService();
 
@@ -35,6 +36,7 @@ describe('enterprise extension: enable change requests', () => {
             {
                 id: projectId,
                 name: 'fake-project-name',
+                changeRequestEnvironments: [],
             },
             {
                 id: 5,
@@ -77,12 +79,12 @@ describe('enterprise extension: enable change requests', () => {
         expect(fn).not.toHaveBeenCalled();
     });
 
-    test('the emitted event contains no changeRequestEnvironments, if the input had none', async () => {
+    test('the emitted event contains an empty list of changeRequestEnvironments if the input had none', async () => {
         expect.assertions(1);
         const service = createService();
 
         const storeEvent = async (e: IBaseEvent) => {
-            expect('changeRequestEnvironments' in e.data).toBeFalsy();
+            expect(e.data.changeRequestEnvironments).toStrictEqual([]);
         };
 
         // @ts-expect-error: for testing purposes
@@ -138,7 +140,11 @@ describe('enterprise extension: enable change requests', () => {
         expect.assertions(1);
         const service = createService();
 
+        // @ts-expect-error: we want this to pass to test the functionality
+        service.environmentStore.exists = () => true;
+
         const crEnvs = [{ name: 'prod', requiredApprovals: 10 }];
+
         const storeEvent = async (e: IBaseEvent) => {
             expect(e.data.changeRequestEnvironments).toMatchObject(crEnvs);
         };
@@ -172,6 +178,9 @@ describe('enterprise extension: enable change requests', () => {
 
         const crEnvs = [{ name: 'prod', requiredApprovals: 10 }];
 
+        // @ts-expect-error: we want this to pass to test the functionality
+        service.environmentStore.exists = () => true;
+
         const projectId = 'fake-project-id';
         const result = await service.createProject(
             {
@@ -193,6 +202,29 @@ describe('enterprise extension: enable change requests', () => {
         );
 
         expect(result.changeRequestEnvironments).toStrictEqual(crEnvs);
+    });
+
+    test('the create project function defaults to returning an empty list if the input had no cr envs', async () => {
+        const service = createService();
+
+        const projectId = 'fake-project-id';
+        const result = await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            async () => {
+                return;
+            },
+        );
+
+        expect(result.changeRequestEnvironments).toStrictEqual([]);
     });
 
     test('the create project function does not return a list of change request envs if we are not on enterprise', async () => {
@@ -223,5 +255,30 @@ describe('enterprise extension: enable change requests', () => {
         );
 
         expect('changeRequestEnvironments' in result).toBeFalsy();
+    });
+
+    test("it throws an error if you provide it with environments that don't exist", async () => {
+        const service = createService();
+        // @ts-expect-error
+        service.environmentStore.exists = () => false;
+
+        const projectId = 'fake-project-id';
+        expect(
+            service.createProject(
+                {
+                    id: projectId,
+                    name: 'fake-project-name',
+                    changeRequestEnvironments: [
+                        { name: 'dev', requiredApprovals: 1 },
+                    ],
+                },
+                {
+                    id: 5,
+                    permissions: [],
+                    isAPI: false,
+                },
+                TEST_AUDIT_USER,
+            ),
+        ).rejects.toThrow(BadDataError);
     });
 });

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -1,15 +1,19 @@
 import { createTestConfig } from '../../../test/config/test-config';
-import { RoleName, TEST_AUDIT_USER } from '../../types';
+import { type IBaseEvent, RoleName, TEST_AUDIT_USER } from '../../types';
 import { createFakeProjectService } from './createProjectService';
 
 describe('enterprise extension: enable change requests', () => {
-    test('it calls the change request enablement function', async () => {
-        expect.assertions(1);
-
+    const createService = () => {
         const config = createTestConfig();
         const service = createFakeProjectService(config);
+        // @ts-expect-error: we're setting this up to test the change request
+        service.flagResolver = {
+            isEnabled: () => true,
+        };
+        // @ts-expect-error: we're setting this up to test the change request
+        service.isEnterprise = true;
 
-        // @ts-expect-error: if we don't set this up, the test will fail due to a missing role.
+        // @ts-expect-error: if we don't set this up, the tests will fail due to a missing role.
         service.accessService.createRole(
             {
                 name: RoleName.OWNER,
@@ -18,6 +22,13 @@ describe('enterprise extension: enable change requests', () => {
             },
             TEST_AUDIT_USER,
         );
+
+        return service;
+    };
+
+    test('it calls the change request enablement function on enterprise', async () => {
+        expect.assertions(1);
+        const service = createService();
 
         const projectId = 'fake-project-id';
         await service.createProject(
@@ -39,5 +50,178 @@ describe('enterprise extension: enable change requests', () => {
                 expect(project).toBeTruthy();
             },
         );
+    });
+
+    test("it does not call the change request enablement function if we're not enterprise", async () => {
+        const service = createService();
+        // @ts-expect-error
+        service.isEnterprise = false;
+
+        const fn = jest.fn();
+
+        const projectId = 'fake-project-id';
+        await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            fn,
+        );
+
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    test('the emitted event contains no changeRequestEnvironments, if the input had none', async () => {
+        expect.assertions(1);
+        const service = createService();
+
+        const storeEvent = async (e: IBaseEvent) => {
+            expect('changeRequestEnvironments' in e.data).toBeFalsy();
+        };
+
+        // @ts-expect-error: for testing purposes
+        service.eventService.storeEvent = storeEvent;
+
+        const projectId = 'fake-project-id';
+        await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+        );
+    });
+
+    test('the emitted event contains no changeRequestEnvironments if we are not on enterprise', async () => {
+        expect.assertions(1);
+        const service = createService();
+        // @ts-expect-error
+        service.isEnterprise = false;
+
+        const storeEvent = async (e: IBaseEvent) => {
+            expect('changeRequestEnvironments' in e.data).toBeFalsy();
+        };
+
+        // @ts-expect-error: for testing purposes
+        service.eventService.storeEvent = storeEvent;
+
+        const projectId = 'fake-project-id';
+        await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            async () => {
+                [];
+            },
+        );
+    });
+
+    test('the emitted event contains the list of change request envs returned from the extension function, *not* what was passed in', async () => {
+        expect.assertions(1);
+        const service = createService();
+
+        const crEnvs = [{ name: 'prod', requiredApprovals: 10 }];
+        const storeEvent = async (e: IBaseEvent) => {
+            expect(e.data.changeRequestEnvironments).toMatchObject(crEnvs);
+        };
+
+        // @ts-expect-error: for testing purposes
+        service.eventService.storeEvent = storeEvent;
+
+        const projectId = 'fake-project-id';
+        await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+                changeRequestEnvironments: [
+                    { name: 'dev', requiredApprovals: 1 },
+                ],
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            async () => {
+                crEnvs;
+            },
+        );
+    });
+
+    test('the create project function returns the list of change request envs returned from the extension function, *not* what was passed in', async () => {
+        const service = createService();
+
+        const crEnvs = [{ name: 'prod', requiredApprovals: 10 }];
+
+        const projectId = 'fake-project-id';
+        const result = await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+                changeRequestEnvironments: [
+                    { name: 'dev', requiredApprovals: 1 },
+                ],
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            async () => {
+                crEnvs;
+            },
+        );
+
+        expect(result.changeRequestEnvironments).toStrictEqual(crEnvs);
+    });
+
+    test('the create project function does not return a list of change request envs if we are not on enterprise', async () => {
+        const service = createService();
+        // @ts-expect-error
+        service.isEnterprise = false;
+
+        const crEnvs = [{ name: 'prod', requiredApprovals: 10 }];
+
+        const projectId = 'fake-project-id';
+        const result = await service.createProject(
+            {
+                id: projectId,
+                name: 'fake-project-name',
+                changeRequestEnvironments: [
+                    { name: 'dev', requiredApprovals: 1 },
+                ],
+            },
+            {
+                id: 5,
+                permissions: [],
+                isAPI: false,
+            },
+            TEST_AUDIT_USER,
+            async () => {
+                crEnvs;
+            },
+        );
+
+        expect('changeRequestEnvironments' in result).toBeFalsy();
     });
 });

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -262,7 +262,7 @@ export default class ProjectService {
 
         if (invalidEnvs.length > 0) {
             throw new BadDataError(
-                `These environments do not exist and can not be selected for the project: ${invalidEnvs
+                `These environments do not exist: ${invalidEnvs
                     .map((env) => `'${env}'`)
                     .join(', ')}.`,
             );
@@ -288,10 +288,9 @@ export default class ProjectService {
         newProject: CreateProject,
         user: IUser,
         auditUser: IAuditUser,
-        enableChangeRequestsForSpecifiedEnvironments: (args: {
-            environments: CreateProject['changeRequestEnvironments'];
-            validateEnvironments: (environments: string[]) => Promise<void>;
-        }) => Promise<
+        enableChangeRequestsForSpecifiedEnvironments: (
+            environments: CreateProject['changeRequestEnvironments'],
+        ) => Promise<
             void | ProjectCreated['changeRequestEnvironments']
         > = async () => {
             return;
@@ -325,14 +324,19 @@ export default class ProjectService {
             this.isEnterprise &&
             this.flagResolver.isEnabled('createProjectWithEnvironmentConfig')
         ) {
-            const changeRequestEnvironments =
-                await enableChangeRequestsForSpecifiedEnvironments({
-                    environments: data.changeRequestEnvironments,
-                    validateEnvironments: this.validateEnvironmentsExist,
-                });
+            if (data.changeRequestEnvironments) {
+                await this.validateEnvironmentsExist(
+                    data.changeRequestEnvironments,
+                );
+                const changeRequestEnvironments =
+                    await enableChangeRequestsForSpecifiedEnvironments(
+                        data.changeRequestEnvironments,
+                    );
 
-            if (changeRequestEnvironments) {
-                data.changeRequestEnvironments = changeRequestEnvironments;
+                data.changeRequestEnvironments =
+                    changeRequestEnvironments ?? [];
+            } else {
+                data.changeRequestEnvironments = [];
             }
         }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -306,8 +306,8 @@ export default class ProjectService {
 
         const envsToEnable =
             this.flagResolver.isEnabled('createProjectWithEnvironmentConfig') &&
-            data.environments?.length
-                ? data.environments
+            newProject.environments?.length
+                ? newProject.environments
                 : (
                       await this.environmentStore.getAll({
                           enabled: true,
@@ -324,13 +324,13 @@ export default class ProjectService {
             this.isEnterprise &&
             this.flagResolver.isEnabled('createProjectWithEnvironmentConfig')
         ) {
-            if (data.changeRequestEnvironments) {
+            if (newProject.changeRequestEnvironments) {
                 await this.validateEnvironmentsExist(
-                    data.changeRequestEnvironments,
+                    newProject.changeRequestEnvironments.map((env) => env.name),
                 );
                 const changeRequestEnvironments =
                     await enableChangeRequestsForSpecifiedEnvironments(
-                        data.changeRequestEnvironments,
+                        newProject.changeRequestEnvironments,
                     );
 
                 data.changeRequestEnvironments =

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -299,7 +299,7 @@ export default class ProjectService {
         await this.validateProjectEnvironments(newProject.environments);
 
         const validatedData = await projectSchema.validateAsync(newProject);
-        const data = this.removeModeForNonEnterprise(validatedData);
+        const data = this.removePropertiesForNonEnterprise(validatedData);
         await this.validateUniqueId(data.id);
 
         await this.projectStore.create(data);
@@ -1385,11 +1385,12 @@ export default class ProjectService {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    removeModeForNonEnterprise(data): any {
+    removePropertiesForNonEnterprise(data): any {
         if (this.isEnterprise) {
             return data;
         }
-        const { mode, ...proData } = data;
+
+        const { mode, changeRequestEnvironments, ...proData } = data;
         return proData;
     }
 }

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -324,20 +324,17 @@ export default class ProjectService {
             this.isEnterprise &&
             this.flagResolver.isEnabled('createProjectWithEnvironmentConfig')
         ) {
-            if (newProject.changeRequestEnvironments) {
-                await this.validateEnvironmentsExist(
-                    newProject.changeRequestEnvironments.map((env) => env.name),
-                );
-                const changeRequestEnvironments =
-                    await enableChangeRequestsForSpecifiedEnvironments(
-                        newProject.changeRequestEnvironments,
-                    );
+            // todo: this is a workaround for backwards compatibility
+            // (i.e. not breaking enterprise tests) that we can change
+            // once these changes have been merged and enterprise
+            // updated. Instead, we can exit early if there are no cr
+            // envs
+            const crEnvs = newProject.changeRequestEnvironments || [];
+            await this.validateEnvironmentsExist(crEnvs.map((env) => env.name));
+            const changeRequestEnvironments =
+                await enableChangeRequestsForSpecifiedEnvironments(crEnvs);
 
-                data.changeRequestEnvironments =
-                    changeRequestEnvironments ?? [];
-            } else {
-                data.changeRequestEnvironments = [];
-            }
+            data.changeRequestEnvironments = changeRequestEnvironments ?? [];
         }
 
         await this.accessService.createDefaultProjectRoles(user, data.id);

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -280,7 +280,7 @@ export default class ProjectService {
                 );
             }
 
-            this.validateEnvironmentsExist(environments);
+            await this.validateEnvironmentsExist(environments);
         }
     }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -1389,7 +1389,6 @@ export default class ProjectService {
         if (this.isEnterprise) {
             return data;
         }
-
         const { mode, changeRequestEnvironments, ...proData } = data;
         return proData;
     }

--- a/src/lib/services/project-schema.ts
+++ b/src/lib/services/project-schema.ts
@@ -18,5 +18,12 @@ export const projectSchema = joi
             example: joi.string().allow(null).allow('').optional(),
             description: joi.string().allow(null).allow('').optional(),
         }),
+        environments: joi.array().items(joi.string()),
+        changeRequestEnvironments: joi.array().items(
+            joi.object({
+                name: joi.string(),
+                requiredApprovals: joi.number(),
+            }),
+        ),
     })
     .options({ allowUnknown: false, stripUnknown: true });

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -483,6 +483,7 @@ export type CreateProject = Pick<IProject, 'id' | 'name'> & {
     mode?: ProjectMode;
     defaultStickiness?: string;
     environments?: string[];
+    changeRequestEnvironments?: { name: string; requiredApprovals?: number }[];
 };
 
 // Create project aligns with #/components/schemas/projectCreatedSchema
@@ -496,6 +497,7 @@ export type ProjectCreated = Pick<
     | 'featureLimit'
 > & {
     environments: string[];
+    changeRequestEnvironments?: { name: string; requiredApprovals: number }[];
 };
 
 export interface IProject {


### PR DESCRIPTION
This PR improves the handling of change request enables on project creation in two ways:

1. We now verify that the envs you try to enable CRs for exist before passing them on to the enterprise functionality.
2. We include data about environments and change request environments in the project created events.