### PR TITLE
fix: don't apply bearer token middleware to root

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -61,7 +61,7 @@ export default async function getApp(
 
     app.use(requestLogger(config));
 
-    app.use(bearerTokenMiddleware(config));
+    app.use('/api', bearerTokenMiddleware(config)); // We only need bearer token compatibility on /api paths.
 
     if (typeof config.preHook === 'function') {
         config.preHook(app, config, services, db);


### PR DESCRIPTION
Conflicts with scim which assumes Bearer <token>, and is located under /scim, with no /api prefix