### PR TITLE
chore: remove workaround

### DIFF
--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -50,6 +50,8 @@ describe('enterprise extension: enable change requests', () => {
                 const project = await service.projectStore.get(projectId);
 
                 expect(project).toBeTruthy();
+
+                return [];
             },
         );
     });
@@ -130,9 +132,7 @@ describe('enterprise extension: enable change requests', () => {
                 isAPI: false,
             },
             TEST_AUDIT_USER,
-            async () => {
-                [];
-            },
+            async () => [],
         );
     });
 
@@ -215,9 +215,7 @@ describe('enterprise extension: enable change requests', () => {
                 isAPI: false,
             },
             TEST_AUDIT_USER,
-            async () => {
-                return;
-            },
+            async () => [],
         );
 
         expect(result.changeRequestEnvironments).toStrictEqual([]);
@@ -245,9 +243,7 @@ describe('enterprise extension: enable change requests', () => {
                 isAPI: false,
             },
             TEST_AUDIT_USER,
-            async () => {
-                crEnvs;
-            },
+            async () => crEnvs,
         );
 
         expect('changeRequestEnvironments' in result).toBeFalsy();

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -291,9 +291,9 @@ export default class ProjectService {
         enableChangeRequestsForSpecifiedEnvironments: (
             environments: CreateProject['changeRequestEnvironments'],
         ) => Promise<
-            void | ProjectCreated['changeRequestEnvironments']
+            ProjectCreated['changeRequestEnvironments']
         > = async () => {
-            return;
+            return [];
         },
     ): Promise<ProjectCreated> {
         await this.validateProjectEnvironments(newProject.environments);
@@ -324,17 +324,19 @@ export default class ProjectService {
             this.isEnterprise &&
             this.flagResolver.isEnabled('createProjectWithEnvironmentConfig')
         ) {
-            // todo: this is a workaround for backwards compatibility
-            // (i.e. not breaking enterprise tests) that we can change
-            // once these changes have been merged and enterprise
-            // updated. Instead, we can exit early if there are no cr
-            // envs
-            const crEnvs = newProject.changeRequestEnvironments || [];
-            await this.validateEnvironmentsExist(crEnvs.map((env) => env.name));
-            const changeRequestEnvironments =
-                await enableChangeRequestsForSpecifiedEnvironments(crEnvs);
+            if (newProject.changeRequestEnvironments) {
+                await this.validateEnvironmentsExist(
+                    newProject.changeRequestEnvironments.map((env) => env.name),
+                );
+                const changeRequestEnvironments =
+                    await enableChangeRequestsForSpecifiedEnvironments(
+                        newProject.changeRequestEnvironments,
+                    );
 
-            data.changeRequestEnvironments = changeRequestEnvironments ?? [];
+                data.changeRequestEnvironments = changeRequestEnvironments;
+            } else {
+                data.changeRequestEnvironments = [];
+            }
         }
 
         await this.accessService.createDefaultProjectRoles(user, data.id);


### PR DESCRIPTION
This PR removes the workaround introduced in https://github.com/Unleash/unleash/pull/6931. After https://github.com/ivarconr/unleash-enterprise/pull/1268 has been merged, this should be safe to apply.

Notably, this PR: 
- tightens up the type for the enable change request function, so we can use that to inform the code
- skips trying to do anything with an empty array

The last point is less important than it might seem because both the env validation and the current implementation of the callback is essentially a no-op when there are no envs. However, that's hard to enforce. If we just exit out early, then at least we know nothing happens.

Optionally, we could do something like this instead, but I'm not sure it's better or worse. Happy to take input.
```ts
            const crEnvs = newProject.changeRequestEnvironments ?? []
            await this.validateEnvironmentsExist(crEnvs.map((env) => env.name));
            const changeRequestEnvironments =
                await enableChangeRequestsForSpecifiedEnvironments(crEnvs,);

            data.changeRequestEnvironments = changeRequestEnvironments;
``` 