### PR TITLE
chore: scheduled change request cache kill switch

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -120,7 +120,7 @@ exports[`should create default config 1`] = `
       },
       "filterInvalidClientMetrics": false,
       "googleAuthEnabled": false,
-      "inMemoryScheduledChangeRequests": false,
+      "killScheduledChangeRequestCache": false,
       "maintenanceMode": false,
       "messageBanner": {
         "enabled": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -38,7 +38,7 @@ export type IFlagKey =
     | 'executiveDashboardUI'
     | 'feedbackComments'
     | 'showInactiveUsers'
-    | 'inMemoryScheduledChangeRequests'
+    | 'killScheduledChangeRequestCache'
     | 'collectTrafficDataUsage'
     | 'displayTrafficDataUsage'
     | 'useMemoizedActiveTokens'
@@ -210,8 +210,8 @@ const flags: IFlags = {
         process.env.UNLEASH_EXPERIMENTAL_MEMOIZED_ACTIVE_TOKENS,
         false,
     ),
-    inMemoryScheduledChangeRequests: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_IN_MEMORY_SCHEDULED_CHANGE_REQUESTS,
+    killScheduledChangeRequestCache: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_KILL_SCHEDULED_CHANGE_REQUEST_CACHE,
         false,
     ),
     collectTrafficDataUsage: parseEnvVarBoolean(


### PR DESCRIPTION
Removes the `inMemoryScheduledChangeRequests` flag and adds `killScheduledChangeRequestCache`
