### PR TITLE
chore: add flag for the new project creation form layout

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -84,6 +84,7 @@ export type UiFlags = {
     projectListFilterMyProjects?: boolean;
     createProjectWithEnvironmentConfig?: boolean;
     projectsListNewCards?: boolean;
+    newCreateProjectUI?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -131,6 +131,7 @@ exports[`should create default config 1`] = `
         },
       },
       "migrationLock": true,
+      "newCreateProjectUI": false,
       "outdatedSdksBanner": false,
       "parseProjectFromSession": false,
       "personalAccessTokensKillSwitch": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -58,7 +58,8 @@ export type IFlagKey =
     | 'projectListFilterMyProjects'
     | 'projectsListNewCards'
     | 'parseProjectFromSession'
-    | 'createProjectWithEnvironmentConfig';
+    | 'createProjectWithEnvironmentConfig'
+    | 'newCreateProjectUI';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -281,6 +282,10 @@ const flags: IFlags = {
     ),
     projectsListNewCards: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PROJECTS_LIST_NEW_CARDS,
+        false,
+    ),
+    newCreateProjectUI: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_CREATE_PROJECT_UI,
         false,
     ),
 };


### PR DESCRIPTION
Add a flag to enable/disable the new UI for project creation.
This flag is separate from the impl on the back end so that we can enable one without the other (but uses flag dependencies in Unleash, so that we can never enable the new UI without the new back end).

I have not set the flag to `true` in server startup because the form doesn't work yet, so it's a manual step for now.