### PR TITLE
feat: do not insert into database stages that already exist

### DIFF
--- a/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
@@ -43,7 +43,6 @@ export class FeatureLifecycleStore implements IFeatureLifecycleStore {
             .into('feature_lifecycles')
             .onConflict(['feature', 'stage'])
             .ignore();
-        console.log(query.toQuery());
         await query;
     }
 

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
@@ -22,16 +22,16 @@ export class FeatureLifecycleStore implements IFeatureLifecycleStore {
     async insert(
         featureLifecycleStages: FeatureLifecycleStage[],
     ): Promise<void> {
+        const joinedLifecycleStages = featureLifecycleStages
+            .map((stage) => `('${stage.feature}', '${stage.stage}')`)
+            .join(', ');
+
         const query = this.db
             .with(
                 'new_stages',
                 this.db.raw(`
                     SELECT v.feature, v.stage
-                    FROM (VALUES ${featureLifecycleStages
-                        .map(
-                            (stage) => `('${stage.feature}', '${stage.stage}')`,
-                        )
-                        .join(', ')}) AS v(feature, stage)
+                    FROM (VALUES ${joinedLifecycleStages}) AS v(feature, stage)
                     JOIN features ON features.name = v.feature
                     LEFT JOIN feature_lifecycles ON feature_lifecycles.feature = v.feature AND feature_lifecycles.stage = v.stage
                     WHERE feature_lifecycles.feature IS NULL AND feature_lifecycles.stage IS NULL

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-store.ts
@@ -22,29 +22,29 @@ export class FeatureLifecycleStore implements IFeatureLifecycleStore {
     async insert(
         featureLifecycleStages: FeatureLifecycleStage[],
     ): Promise<void> {
-        const existingFeatures = await this.db('features')
-            .select('name')
-            .whereIn(
-                'name',
-                featureLifecycleStages.map((stage) => stage.feature),
-            );
-        const existingFeaturesSet = new Set(
-            existingFeatures.map((item) => item.name),
-        );
-        const validStages = featureLifecycleStages.filter((stage) =>
-            existingFeaturesSet.has(stage.feature),
-        );
-
-        await this.db('feature_lifecycles')
-            .insert(
-                validStages.map((stage) => ({
-                    feature: stage.feature,
-                    stage: stage.stage,
-                })),
+        const query = this.db
+            .with(
+                'new_stages',
+                this.db.raw(`
+                    SELECT v.feature, v.stage
+                    FROM (VALUES ${featureLifecycleStages
+                        .map(
+                            (stage) => `('${stage.feature}', '${stage.stage}')`,
+                        )
+                        .join(', ')}) AS v(feature, stage)
+                    JOIN features ON features.name = v.feature
+                    LEFT JOIN feature_lifecycles ON feature_lifecycles.feature = v.feature AND feature_lifecycles.stage = v.stage
+                    WHERE feature_lifecycles.feature IS NULL AND feature_lifecycles.stage IS NULL
+                `),
             )
-            .returning('*')
+            .insert((query) => {
+                query.select('feature', 'stage').from('new_stages');
+            })
+            .into('feature_lifecycles')
             .onConflict(['feature', 'stage'])
             .ignore();
+        console.log(query.toQuery());
+        await query;
     }
 
     async get(feature: string): Promise<FeatureLifecycleView> {


### PR DESCRIPTION
Previously when we had thousands of metrics coming in, we were trying to write them all to database and running into on conflict 