### PR TITLE
feat: search order by final

### DIFF
--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -288,7 +288,8 @@ class FeatureSearchStore implements IFeatureSearchStore {
                 );
             })
             .joinRaw('CROSS JOIN total_features')
-            .whereBetween('final_rank', [offset + 1, offset + limit]);
+            .whereBetween('final_rank', [offset + 1, offset + limit])
+            .orderBy('final_rank');
         const rows = await finalQuery;
         stopTimer();
         if (rows.length > 0) {


### PR DESCRIPTION
Final rank has always been ordering correctly by default. But after 5.12 I see some issues that sometimes it is not ordered. Just to be extra sure, I am for ordering it.