### PR TITLE
feat: configure CRs when creating projects

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -27,7 +27,8 @@ const StyledBox = styled(Box)(({ theme }) => ({
 
 const StyledTable = styled(Table)(({ theme }) => ({
     th: { whiteSpace: 'nowrap' },
-    width: 'min(90vw, 50rem)',
+    width: '50rem',
+    maxWidth: '90vw',
 }));
 
 type TableProps = {

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -29,6 +29,9 @@ const StyledTable = styled(Table)(({ theme }) => ({
     th: { whiteSpace: 'nowrap' },
     width: '50rem',
     maxWidth: '90vw',
+    'tr:last-of-type > td': {
+        borderBottom: 'none',
+    },
 }));
 
 type TableProps = {

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -46,15 +46,8 @@ export const ChangeRequestTable = (props: TableProps) => {
             requiredApprovals: number,
         ) =>
         () => {
-            console.log(
-                'onRowChange',
-                environmentName,
-                previousState,
-                requiredApprovals,
-            );
             const newState = !previousState;
             if (newState) {
-                console.log('Calling enable env from table');
                 props.enableEnvironment(environmentName, requiredApprovals);
             } else {
                 props.disableEnvironment(environmentName);
@@ -128,8 +121,6 @@ export const ChangeRequestTable = (props: TableProps) => {
                 align: 'center',
 
                 Cell: ({ value, row: { original } }: any) => {
-                    console.log('Rendering a cell', value, original);
-
                     return (
                         <StyledBox data-loading>
                             <Switch
@@ -164,7 +155,6 @@ export const ChangeRequestTable = (props: TableProps) => {
                 // @ts-ignore
                 columns,
                 data: props.environments.map((env) => {
-                    console.log('Mapping env', env);
                     return {
                         environment: env.name,
                         type: env.type,

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react';
+import { type HeaderGroup, useGlobalFilter, useTable } from 'react-table';
+import { Box, styled } from '@mui/material';
+import {
+    SortableTableHeader,
+    Table,
+    TableBody,
+    TableCell,
+    TableRow,
+} from 'component/common/Table';
+import { sortTypes } from 'utils/sortTypes';
+import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
+import PermissionSwitch from 'component/common/PermissionSwitch/PermissionSwitch';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import type { IChangeRequestConfig } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
+import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
+import { useTheme } from '@mui/material/styles';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+// import { PROJECT_CHANGE_REQUEST_WRITE } from '../../../../providers/AccessProvider/permissions';
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(1),
+    display: 'flex',
+    justifyContent: 'center',
+    '& .MuiInputBase-input': {
+        fontSize: theme.fontSizes.smallBody,
+    },
+}));
+
+type TableProps = {
+    environments: (
+        | {
+              name: string;
+              type: string;
+              changeRequestEnabled: false;
+          }
+        | {
+              name: string;
+              type: string;
+              requiredApprovals: number;
+              changeRequestEnabled: boolean;
+          }
+    )[];
+    enableEnvironment: (args: {
+        name: string;
+        requiredApprovals: number;
+    }) => void;
+    disableEnvironment: (name: string) => void;
+};
+
+export const ChangeRequestTable = (props: TableProps) => {
+    const { trackEvent } = usePlausibleTracker();
+    const [dialogState, setDialogState] = useState<{
+        isOpen: boolean;
+        enableEnvironment: string;
+        isEnabled: boolean;
+        requiredApprovals: number;
+    }>({
+        isOpen: false,
+        enableEnvironment: '',
+        isEnabled: false,
+        requiredApprovals: 1,
+    });
+
+    const theme = useTheme();
+
+    const onRowChange =
+        (
+            enableEnvironment: string,
+            isEnabled: boolean,
+            requiredApprovals: number,
+        ) =>
+        () => {
+            setDialogState({
+                isOpen: true,
+                enableEnvironment,
+                isEnabled,
+                requiredApprovals,
+            });
+        };
+
+    const onConfirm = async () => {
+        if (dialogState.enableEnvironment) {
+            await updateConfiguration();
+        }
+        setDialogState((state) => ({ ...state, isOpen: false }));
+    };
+
+    async function updateConfiguration(config?: IChangeRequestConfig) {
+        try {
+            // update state here
+        } catch (error) {
+            // probably not gonna happen because it's not an api call
+        }
+    }
+
+    const approvalOptions = Array.from(Array(10).keys())
+        .map((key) => String(key + 1))
+        .map((key) => {
+            const labelText = key === '1' ? 'approval' : 'approvals';
+            return {
+                key,
+                label: `${key} ${labelText}`,
+                sx: { fontSize: theme.fontSizes.smallBody },
+            };
+        });
+
+    function onRequiredApprovalsChange(original: any, approvals: string) {
+        updateConfiguration({
+            project: projectId,
+            environment: original.environment,
+            enabled: original.changeRequestEnabled,
+            requiredApprovals: Number(approvals),
+        });
+    }
+
+    const columns = useMemo(
+        () => [
+            {
+                Header: 'Environment',
+                accessor: 'environment',
+                disableSortBy: true,
+            },
+            {
+                Header: 'Type',
+                accessor: 'type',
+                disableGlobalFilter: true,
+                disableSortBy: true,
+            },
+            {
+                Header: 'Required approvals',
+                Cell: ({ row: { original } }: any) => {
+                    return (
+                        <ConditionallyRender
+                            condition={original.changeRequestEnabled}
+                            show={
+                                <StyledBox data-loading>
+                                    <GeneralSelect
+                                        sx={{ width: '140px', marginLeft: 1 }}
+                                        options={approvalOptions}
+                                        value={original.requiredApprovals || 1}
+                                        onChange={(approvals) => {
+                                            onRequiredApprovalsChange(
+                                                original,
+                                                approvals,
+                                            );
+                                        }}
+                                        IconComponent={
+                                            KeyboardArrowDownOutlined
+                                        }
+                                        fullWidth
+                                    />
+                                </StyledBox>
+                            }
+                        />
+                    );
+                },
+                width: 100,
+                disableGlobalFilter: true,
+                disableSortBy: true,
+            },
+            {
+                Header: 'Status',
+                accessor: 'changeRequestEnabled',
+                id: 'changeRequestEnabled',
+                align: 'center',
+
+                Cell: ({ value, row: { original } }: any) => (
+                    <StyledBox data-loading>
+                        <PermissionSwitch
+                            checked={value}
+                            permission={[]}
+                            inputProps={{ 'aria-label': original.environment }}
+                            onClick={onRowChange(
+                                original.environment,
+                                original.changeRequestEnabled,
+                                original.requiredApprovals,
+                            )}
+                        />
+                    </StyledBox>
+                ),
+                width: 100,
+                disableGlobalFilter: true,
+                disableSortBy: true,
+            },
+        ],
+        [],
+    );
+
+    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+        useTable(
+            {
+                // @ts-ignore
+                columns,
+                data: props.environments.map((env) => ({
+                    environment: env.name,
+                    type: env.type,
+                    changeRequestEnabled: env.changeRequestEnabled,
+                    // @ts-ignore
+                    requiredApprovals: env.requiredApprovals ?? 1,
+                })),
+
+                sortTypes,
+                autoResetGlobalFilter: false,
+                disableSortRemove: true,
+                defaultColumn: {
+                    Cell: TextCell,
+                },
+            },
+            useGlobalFilter,
+        );
+    return (
+        <Table {...getTableProps()}>
+            <SortableTableHeader
+                headerGroups={headerGroups as HeaderGroup<object>[]}
+            />
+            <TableBody {...getTableBodyProps()}>
+                {rows.map((row) => {
+                    prepareRow(row);
+                    return (
+                        <TableRow hover {...row.getRowProps()}>
+                            {row.cells.map((cell) => (
+                                <TableCell {...cell.getCellProps()}>
+                                    {cell.render('Cell')}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+};

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -11,7 +11,6 @@ import {
 import { sortTypes } from 'utils/sortTypes';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import type { IChangeRequestConfig } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import { useTheme } from '@mui/material/styles';
@@ -62,14 +61,6 @@ export const ChangeRequestTable = (props: TableProps) => {
             }
         };
 
-    async function updateConfiguration(config?: IChangeRequestConfig) {
-        try {
-            // update state here
-        } catch (error) {
-            // probably not gonna happen because it's not an api call
-        }
-    }
-
     const approvalOptions = Array.from(Array(10).keys())
         .map((key) => String(key + 1))
         .map((key) => {
@@ -83,14 +74,6 @@ export const ChangeRequestTable = (props: TableProps) => {
 
     function onRequiredApprovalsChange(original: any, approvals: string) {
         props.enableEnvironment(original.environment, Number(approvals));
-        console.log('onRequiredApprovalsChange', original, approvals);
-        // onEnableEnvironment(original.environment, Number(approvals));
-        // updateConfiguration({
-        //     project: projectId,
-        //     environment: original.environment,
-        //     enabled: original.changeRequestEnabled,
-        //     requiredApprovals: Number(approvals),
-        // });
     }
 
     const columns = useMemo(
@@ -186,7 +169,6 @@ export const ChangeRequestTable = (props: TableProps) => {
                         environment: env.name,
                         type: env.type,
                         changeRequestEnabled: env.changeRequestEnabled,
-                        // @ts-ignore
                         requiredApprovals: env.requiredApprovals ?? 1,
                     };
                 }),

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -97,7 +97,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                                     <GeneralSelect
                                         label={`Set required approvals for ${original.environment}`}
                                         id={`cr-approvals-${original.environment}`}
-                                        sx={{ width: '140px', marginLeft: 1 }}
+                                        sx={{ width: '140px' }}
                                         options={approvalOptions}
                                         value={original.requiredApprovals || 1}
                                         onChange={(approvals) => {
@@ -179,7 +179,7 @@ export const ChangeRequestTable = (props: TableProps) => {
             useGlobalFilter,
         );
     return (
-        <Table {...getTableProps()}>
+        <StyledTable {...getTableProps()}>
             <SortableTableHeader
                 headerGroups={headerGroups as HeaderGroup<object>[]}
             />
@@ -197,6 +197,6 @@ export const ChangeRequestTable = (props: TableProps) => {
                     );
                 })}
             </TableBody>
-        </Table>
+        </StyledTable>
     );
 };

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { type HeaderGroup, useGlobalFilter, useTable } from 'react-table';
 import { Box, styled } from '@mui/material';
 import {
@@ -16,7 +16,6 @@ import type { IChangeRequestConfig } from 'hooks/api/actions/useChangeRequestApi
 import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import { useTheme } from '@mui/material/styles';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 // import { PROJECT_CHANGE_REQUEST_WRITE } from '../../../../providers/AccessProvider/permissions';
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -29,40 +28,17 @@ const StyledBox = styled(Box)(({ theme }) => ({
 }));
 
 type TableProps = {
-    environments: (
-        | {
-              name: string;
-              type: string;
-              changeRequestEnabled: false;
-          }
-        | {
-              name: string;
-              type: string;
-              requiredApprovals: number;
-              changeRequestEnabled: boolean;
-          }
-    )[];
-    enableEnvironment: (args: {
+    environments: {
         name: string;
+        type: string;
         requiredApprovals: number;
-    }) => void;
+        changeRequestEnabled: boolean;
+    }[];
+    enableEnvironment: (name: string, requiredApprovals: number) => void;
     disableEnvironment: (name: string) => void;
 };
 
 export const ChangeRequestTable = (props: TableProps) => {
-    const { trackEvent } = usePlausibleTracker();
-    const [dialogState, setDialogState] = useState<{
-        isOpen: boolean;
-        enableEnvironment: string;
-        isEnabled: boolean;
-        requiredApprovals: number;
-    }>({
-        isOpen: false,
-        enableEnvironment: '',
-        isEnabled: false,
-        requiredApprovals: 1,
-    });
-
     const theme = useTheme();
 
     const onRowChange =
@@ -72,20 +48,13 @@ export const ChangeRequestTable = (props: TableProps) => {
             requiredApprovals: number,
         ) =>
         () => {
-            setDialogState({
-                isOpen: true,
+            console.log(
+                'onRowChange',
                 enableEnvironment,
                 isEnabled,
                 requiredApprovals,
-            });
+            );
         };
-
-    const onConfirm = async () => {
-        if (dialogState.enableEnvironment) {
-            await updateConfiguration();
-        }
-        setDialogState((state) => ({ ...state, isOpen: false }));
-    };
 
     async function updateConfiguration(config?: IChangeRequestConfig) {
         try {
@@ -107,12 +76,14 @@ export const ChangeRequestTable = (props: TableProps) => {
         });
 
     function onRequiredApprovalsChange(original: any, approvals: string) {
-        updateConfiguration({
-            project: projectId,
-            environment: original.environment,
-            enabled: original.changeRequestEnabled,
-            requiredApprovals: Number(approvals),
-        });
+        console.log('onRequiredApprovalsChange', original, approvals);
+        // onEnableEnvironment(original.environment, Number(approvals));
+        // updateConfiguration({
+        //     project: projectId,
+        //     environment: original.environment,
+        //     enabled: original.changeRequestEnabled,
+        //     requiredApprovals: Number(approvals),
+        // });
     }
 
     const columns = useMemo(

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -27,6 +27,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
 
 const StyledTable = styled(Table)(({ theme }) => ({
     th: { whiteSpace: 'nowrap' },
+    width: 'min(90vw, 50rem)',
 }));
 
 type TableProps = {

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -25,6 +25,10 @@ const StyledBox = styled(Box)(({ theme }) => ({
     },
 }));
 
+const StyledTable = styled(Table)(({ theme }) => ({
+    th: { whiteSpace: 'nowrap' },
+}));
+
 type TableProps = {
     environments: {
         name: string;

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -91,6 +91,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                             show={
                                 <StyledBox data-loading>
                                     <GeneralSelect
+                                        label={`Set required approvals for ${original.environment}`}
                                         sx={{ width: '140px', marginLeft: 1 }}
                                         options={approvalOptions}
                                         value={original.requiredApprovals || 1}

--- a/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/ChangeRequestTable.tsx
@@ -92,6 +92,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                                 <StyledBox data-loading>
                                     <GeneralSelect
                                         label={`Set required approvals for ${original.environment}`}
+                                        id={`cr-approvals-${original.environment}`}
                                         sx={{ width: '140px', marginLeft: 1 }}
                                         options={approvalOptions}
                                         value={original.requiredApprovals || 1}

--- a/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
@@ -35,11 +35,13 @@ const CreateProject = () => {
         projectDesc,
         projectMode,
         projectEnvironments,
+        projectChangeRequestConfiguration,
         setProjectMode,
         setProjectId,
         setProjectName,
         setProjectDesc,
         setProjectEnvironments,
+        setProjectChangeRequestConfiguration,
         getCreateProjectPayload,
         clearErrors,
         validateProjectId,
@@ -114,6 +116,12 @@ const CreateProject = () => {
                     setProjectId={setProjectId}
                     projectName={projectName}
                     projectStickiness={projectStickiness}
+                    projectChangeRequestConfiguration={
+                        projectChangeRequestConfiguration
+                    }
+                    setProjectChangeRequestConfiguration={
+                        setProjectChangeRequestConfiguration
+                    }
                     projectMode={projectMode}
                     setProjectMode={setProjectMode}
                     setProjectStickiness={setProjectStickiness}

--- a/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
@@ -41,7 +41,7 @@ const CreateProject = () => {
         setProjectName,
         setProjectDesc,
         setProjectEnvironments,
-        setProjectChangeRequestConfiguration,
+        updateProjectChangeRequestConfig,
         getCreateProjectPayload,
         clearErrors,
         validateProjectId,
@@ -119,8 +119,8 @@ const CreateProject = () => {
                     projectChangeRequestConfiguration={
                         projectChangeRequestConfiguration
                     }
-                    setProjectChangeRequestConfiguration={
-                        setProjectChangeRequestConfiguration
+                    updateProjectChangeRequestConfig={
+                        updateProjectChangeRequestConfig
                     }
                     projectMode={projectMode}
                     setProjectMode={setProjectMode}

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -84,6 +84,10 @@ type FormProps = {
     featureCount?: number;
     projectMode: string;
     projectEnvironments: Set<string>;
+    projectChangeRequestConfiguration: Record<
+        string,
+        { requiredApprovals: number }
+    >;
     setProjectStickiness: React.Dispatch<React.SetStateAction<string>>;
     setProjectEnvironments: React.Dispatch<React.SetStateAction<Set<string>>>;
     setProjectId: React.Dispatch<React.SetStateAction<string>>;
@@ -91,6 +95,9 @@ type FormProps = {
     setProjectDesc: React.Dispatch<React.SetStateAction<string>>;
     setFeatureLimit?: React.Dispatch<React.SetStateAction<string>>;
     setProjectMode: React.Dispatch<React.SetStateAction<ProjectMode>>;
+    setProjectChangeRequestConfiguration: React.Dispatch<
+        React.SetStateAction<Record<string, { requiredApprovals: number }>>
+    >;
     handleSubmit: (e: any) => void;
     errors: { [key: string]: string };
     mode: 'Create' | 'Edit';

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -264,13 +264,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                     projectEnvironments.has(env.name),
                                 )
                                 .map((env) => ({
-                                    // label: env.name,
-                                    // value: env.name,
                                     name: env.name,
                                     type: env.type,
                                 }))}
                             onChange={(args) => {
-                                console.log('calling on change', args);
                                 setProjectChangeRequestConfiguration(args);
                             }}
                             button={{

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography, styled } from '@mui/material';
+import { Typography, styled } from '@mui/material';
 import { v4 as uuidv4 } from 'uuid';
 import Input from 'component/common/Input/Input';
 import type { ProjectMode } from '../hooks/useProjectEnterpriseSettingsForm';
@@ -11,6 +11,7 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import EnvironmentsIcon from '@mui/icons-material/CloudCircle';
 import { useStickinessOptions } from 'hooks/useStickinessOptions';
+import { ReactComponent as ChangeRequestIcon } from 'assets/icons/merge.svg';
 
 const StyledForm = styled('form')(({ theme }) => ({
     background: theme.palette.background.default,
@@ -245,7 +246,25 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         />
                     }
                 />
-                <Button variant='outlined'>1 environment configured</Button>
+                <MultiselectList
+                    selectedOptions={projectEnvironments}
+                    options={activeEnvironments.map((env) => ({
+                        label: env.name,
+                        value: env.name,
+                    }))}
+                    onChange={handleFilterChange}
+                    button={{
+                        label:
+                            projectEnvironments.size > 0
+                                ? `${projectEnvironments.size} selected`
+                                : 'Select environments',
+                        icon: <ChangeRequestIcon />,
+                    }}
+                    search={{
+                        label: 'Filter environments',
+                        placeholder: 'Filter environments',
+                    }}
+                />
             </OptionButtons>
             <FormActions>{children}</FormActions>
         </StyledForm>

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -255,37 +255,45 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         />
                     }
                 />
-                <TableSelect
-                    activeEnvironments={activeEnvironments
-                        .filter((env) => projectEnvironments.has(env.name))
-                        .map((env) => ({
-                            // label: env.name,
-                            // value: env.name,
-                            name: env.name,
-                            type: env.type,
-                        }))}
-                    onChange={(args) => {
-                        console.log('calling on change', args);
-                        setProjectChangeRequestConfiguration(args);
-                    }}
-                    button={{
-                        label:
-                            Object.keys(projectChangeRequestConfiguration)
-                                .length > 0
-                                ? `${
-                                      Object.keys(
-                                          projectChangeRequestConfiguration,
-                                      ).length
-                                  } selected`
-                                : 'Configure change requests',
-                        icon: <ChangeRequestIcon />,
-                    }}
-                    search={{
-                        label: 'Filter environments',
-                        placeholder: 'Filter environments',
-                    }}
-                    projectChangeRequestConfiguration={
-                        projectChangeRequestConfiguration
+                <ConditionallyRender
+                    condition={isEnterprise()}
+                    show={
+                        <TableSelect
+                            activeEnvironments={activeEnvironments
+                                .filter((env) =>
+                                    projectEnvironments.has(env.name),
+                                )
+                                .map((env) => ({
+                                    // label: env.name,
+                                    // value: env.name,
+                                    name: env.name,
+                                    type: env.type,
+                                }))}
+                            onChange={(args) => {
+                                console.log('calling on change', args);
+                                setProjectChangeRequestConfiguration(args);
+                            }}
+                            button={{
+                                label:
+                                    Object.keys(
+                                        projectChangeRequestConfiguration,
+                                    ).length > 0
+                                        ? `${
+                                              Object.keys(
+                                                  projectChangeRequestConfiguration,
+                                              ).length
+                                          } selected`
+                                        : 'Configure change requests',
+                                icon: <ChangeRequestIcon />,
+                            }}
+                            search={{
+                                label: 'Filter environments',
+                                placeholder: 'Filter environments',
+                            }}
+                            projectChangeRequestConfiguration={
+                                projectChangeRequestConfiguration
+                            }
+                        />
                     }
                 />
             </OptionButtons>

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -264,7 +264,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                             name: env.name,
                             type: env.type,
                         }))}
-                    onChange={setProjectChangeRequestConfiguration}
+                    onChange={(args) => {
+                        console.log('calling on change', args);
+                        setProjectChangeRequestConfiguration(args);
+                    }}
                     button={{
                         label:
                             Object.keys(projectChangeRequestConfiguration)

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -148,10 +148,6 @@ export const NewProjectForm: React.FC<FormProps> = ({
         setProjectId(maybeProjectId);
     };
 
-    const handleFilterChange = (envs: Set<string>) => {
-        setProjectEnvironments(envs);
-    };
-
     const projectModeOptions = [
         { value: 'open', label: 'open' },
         { value: 'protected', label: 'protected' },
@@ -204,7 +200,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         label: env.name,
                         value: env.name,
                     }))}
-                    onChange={handleFilterChange}
+                    onChange={setProjectEnvironments}
                     button={{
                         label:
                             projectEnvironments.size > 0

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -115,6 +115,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
     projectDesc,
     projectStickiness,
     projectEnvironments,
+    projectChangeRequestConfiguration,
     featureLimit,
     featureCount,
     projectMode,
@@ -124,6 +125,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
     setProjectName,
     setProjectDesc,
     setProjectStickiness,
+    setProjectChangeRequestConfiguration,
     setFeatureLimit,
     errors,
     mode,
@@ -255,16 +257,23 @@ export const NewProjectForm: React.FC<FormProps> = ({
                 />
                 <MultiselectList
                     selectedOptions={projectEnvironments}
-                    options={activeEnvironments.map((env) => ({
-                        label: env.name,
-                        value: env.name,
-                    }))}
+                    options={activeEnvironments
+                        .filter((env) => projectEnvironments.has(env.name))
+                        .map((env) => ({
+                            label: env.name,
+                            value: env.name,
+                        }))}
                     onChange={handleFilterChange}
                     button={{
                         label:
-                            projectEnvironments.size > 0
-                                ? `${projectEnvironments.size} selected`
-                                : 'Select environments',
+                            Object.keys(projectChangeRequestConfiguration)
+                                .length > 0
+                                ? `${
+                                      Object.keys(
+                                          projectChangeRequestConfiguration,
+                                      ).length
+                                  } selected`
+                                : 'Configure change requests',
                         icon: <ChangeRequestIcon />,
                     }}
                     search={{

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -93,15 +93,16 @@ type FormProps = {
         { requiredApprovals: number }
     >;
     setProjectStickiness: React.Dispatch<React.SetStateAction<string>>;
-    setProjectEnvironments: React.Dispatch<React.SetStateAction<Set<string>>>;
+    setProjectEnvironments: (envs: Set<string>) => void;
     setProjectId: React.Dispatch<React.SetStateAction<string>>;
     setProjectName: React.Dispatch<React.SetStateAction<string>>;
     setProjectDesc: React.Dispatch<React.SetStateAction<string>>;
     setFeatureLimit?: React.Dispatch<React.SetStateAction<string>>;
     setProjectMode: React.Dispatch<React.SetStateAction<ProjectMode>>;
-    setProjectChangeRequestConfiguration: React.Dispatch<
-        React.SetStateAction<Record<string, { requiredApprovals: number }>>
-    >;
+    updateProjectChangeRequestConfig: {
+        disableChangeRequests: (env: string) => void;
+        enableChangeRequests: (env: string, requiredApprovals: number) => void;
+    };
     handleSubmit: (e: any) => void;
     errors: { [key: string]: string };
     mode: 'Create' | 'Edit';
@@ -129,7 +130,8 @@ export const NewProjectForm: React.FC<FormProps> = ({
     setProjectName,
     setProjectDesc,
     setProjectStickiness,
-    setProjectChangeRequestConfiguration,
+    // setProjectChangeRequestConfiguration,
+    updateProjectChangeRequestConfig,
     setFeatureLimit,
     errors,
     mode,
@@ -267,9 +269,9 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                     name: env.name,
                                     type: env.type,
                                 }))}
-                            onChange={(args) => {
-                                setProjectChangeRequestConfiguration(args);
-                            }}
+                            updateProjectChangeRequestConfiguration={
+                                updateProjectChangeRequestConfig
+                            }
                             button={{
                                 label:
                                     Object.keys(

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -261,6 +261,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <TableSelect
+                            disabled={projectEnvironments.size === 0}
                             activeEnvironments={activeEnvironments
                                 .filter((env) =>
                                     projectEnvironments.has(env.name),

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from 'uuid';
 import Input from 'component/common/Input/Input';
 import type { ProjectMode } from '../hooks/useProjectEnterpriseSettingsForm';
 import { ReactComponent as ProjectIcon } from 'assets/icons/projectIconSmall.svg';
-import { MultiselectList, SingleSelectList } from './SelectionButton';
+import {
+    MultiselectList,
+    SingleSelectList,
+    TableSelect,
+} from './SelectionButton';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import StickinessIcon from '@mui/icons-material/FormatPaint';
 import ProjectModeIcon from '@mui/icons-material/Adjust';
@@ -251,15 +255,16 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         />
                     }
                 />
-                <MultiselectList
-                    selectedOptions={projectEnvironments}
+                <TableSelect
                     options={activeEnvironments
                         .filter((env) => projectEnvironments.has(env.name))
                         .map((env) => ({
                             label: env.name,
                             value: env.name,
+                            // name: env.name,
+                            // type: env.type,
                         }))}
-                    onChange={handleFilterChange}
+                    onChange={setProjectChangeRequestConfiguration}
                     button={{
                         label:
                             Object.keys(projectChangeRequestConfiguration)

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -70,6 +70,7 @@ const StyledProjectDescription = styled(StyledInput)(({ theme }) => ({
 
 const OptionButtons = styled(StyledFormSection)(({ theme }) => ({
     display: 'flex',
+    flexFlow: 'row wrap',
     gap: theme.spacing(2),
 }));
 

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -256,13 +256,13 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     }
                 />
                 <TableSelect
-                    options={activeEnvironments
+                    activeEnvironments={activeEnvironments
                         .filter((env) => projectEnvironments.has(env.name))
                         .map((env) => ({
-                            label: env.name,
-                            value: env.name,
-                            // name: env.name,
-                            // type: env.type,
+                            // label: env.name,
+                            // value: env.name,
+                            name: env.name,
+                            type: env.type,
                         }))}
                     onChange={setProjectChangeRequestConfiguration}
                     button={{
@@ -281,6 +281,9 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         label: 'Filter environments',
                         placeholder: 'Filter environments',
                     }}
+                    projectChangeRequestConfiguration={
+                        projectChangeRequestConfiguration
+                    }
                 />
             </OptionButtons>
             <FormActions>{children}</FormActions>

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
@@ -37,3 +37,7 @@ export const StyledTextField = styled(TextField)(({ theme }) => ({
         fontSize: theme.typography.body2.fontSize,
     },
 }));
+
+export const TableSearchInput = styled(StyledTextField)(({ theme }) => ({
+    maxWidth: '30ch',
+}));

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, ListItem, Popover, TextField, styled } from '@mui/material';
 
 export const StyledDropdown = styled('div')(({ theme }) => ({
-    padding: theme.spacing(1.5),
+    padding: theme.spacing(2),
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
@@ -36,16 +36,4 @@ export const StyledTextField = styled(TextField)(({ theme }) => ({
         padding: theme.spacing(0.75, 0),
         fontSize: theme.typography.body2.fontSize,
     },
-
-    '& label': {
-        border: 0,
-        clip: 'rect(0 0 0 0)',
-        height: 'auto',
-        margin: 0,
-        overflow: 'hidden',
-        padding: 0,
-        position: 'absolute',
-        width: '1px',
-        whiteSpace: 'nowrap',
-    },
 }));

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -288,14 +288,17 @@ export const TableSelect: FC<TableSelectProps> = ({
         Record<
             string,
             {
-                enabled: boolean;
+                changeRequestEnabled: boolean;
                 requiredApprovals: number;
             }
         >
     >(
         Object.fromEntries(
             Object.entries(projectChangeRequestConfiguration).map(
-                ([name, config]) => [name, { ...config, enabled: true }],
+                ([name, config]) => [
+                    name,
+                    { ...config, changeRequestEnabled: true },
+                ],
             ),
         ),
     );
@@ -307,9 +310,18 @@ export const TableSelect: FC<TableSelectProps> = ({
         ...(configured[name] ?? {}),
     }));
 
-    const propagateChanges = () => {
+    const propagateChanges = (
+        newState: Record<
+            string,
+            {
+                changeRequestEnabled: boolean;
+                requiredApprovals: number;
+            }
+        >,
+    ) => {
+        setConfigured(newState);
         const configuredEnvs = Object.fromEntries(
-            Object.entries(configured).map(([name, { requiredApprovals }]) => [
+            Object.entries(newState).map(([name, { requiredApprovals }]) => [
                 name,
                 { requiredApprovals },
             ]),
@@ -317,16 +329,21 @@ export const TableSelect: FC<TableSelectProps> = ({
         onChange(configuredEnvs);
     };
 
+    console.log('Configured is', configured);
+
     const onEnable = (name: string, requiredApprovals: number) => {
-        setConfigured({
+        console.log('Got called!', name, requiredApprovals);
+
+        propagateChanges({
             ...configured,
-            name: { enabled: true, requiredApprovals },
+            [name]: { changeRequestEnabled: true, requiredApprovals },
         });
     };
 
     const onDisable = (name: string) => {
         const { [name]: _, ...rest } = configured;
-        setConfigured(rest);
+
+        propagateChanges(rest);
     };
 
     const ref = useRef<HTMLDivElement>(null);

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -265,9 +265,6 @@ export const SingleSelectList: FC<SingleSelectListProps> = (props) => {
 };
 
 type TableSelectProps = Pick<CombinedSelectProps, 'button' | 'search'> & {
-    onChange: (
-        changeRequestConfig: Record<string, { requiredApprovals: number }>,
-    ) => void;
     updateProjectChangeRequestConfiguration: {
         disableChangeRequests: (env: string) => void;
         enableChangeRequests: (env: string, requiredApprovals: number) => void;
@@ -286,7 +283,6 @@ export const TableSelect: FC<TableSelectProps> = ({
     button,
     disabled,
     search,
-    onChange,
     projectChangeRequestConfiguration,
     updateProjectChangeRequestConfiguration,
     activeEnvironments,

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -336,7 +336,7 @@ export const TableSelect: FC<TableSelectProps> = ({
         env.name.toLowerCase().includes(searchText.toLowerCase()),
     );
 
-    const handleSelection = (event: React.KeyboardEvent) => {
+    const toggleTopItem = (event: React.KeyboardEvent) => {
         if (
             event.key === 'Enter' &&
             searchText.trim().length > 0 &&
@@ -395,7 +395,7 @@ export const TableSelect: FC<TableSelectProps> = ({
                                 </InputAdornment>
                             ),
                         }}
-                        onKeyDown={handleSelection}
+                        onKeyDown={toggleTopItem}
                     />
                     <ChangeRequestTable
                         environments={filteredEnvs}

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -340,9 +340,9 @@ export const TableSelect: FC<TableSelectProps> = ({
         handleToggle: (selected: string) => () => onSelection(selected),
     });
 
-    // const filteredOptions = options?.filter((option) =>
-    //     option.label.toLowerCase().includes(searchText.toLowerCase()),
-    // );
+    const filteredEnvs = tableEnvs.filter((env) =>
+        env.name.toLowerCase().includes(searchText.toLowerCase()),
+    );
 
     // const filteredOptions = [];
     return (
@@ -398,7 +398,7 @@ export const TableSelect: FC<TableSelectProps> = ({
                         onKeyDown={(event) => handleSelection(event, 0, [])}
                     />
                     <ChangeRequestTable
-                        environments={tableEnvs}
+                        environments={filteredEnvs}
                         enableEnvironment={onEnable}
                         disableEnvironment={onDisable}
                     />

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -8,6 +8,7 @@ import {
     StyledPopover,
     StyledTextField,
 } from './SelectionButton.styles';
+import { ChangeRequestTable } from './ChangeRequestTable';
 
 export interface IFilterItemProps {
     label: ReactNode;
@@ -261,4 +262,94 @@ type SingleSelectListProps = Pick<
 
 export const SingleSelectList: FC<SingleSelectListProps> = (props) => {
     return <CombinedSelect {...props} />;
+};
+
+type TableSelectProps = Pick<CombinedSelectProps, 'button' | 'search'>;
+export const TableSelect: FC<TableSelectProps> = ({ button, search }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>();
+    const [searchText, setSearchText] = useState('');
+
+    const open = () => {
+        setSearchText('');
+        setAnchorEl(ref.current);
+    };
+
+    const onClose = () => {
+        setAnchorEl(null);
+    };
+
+    const onSelection = (selected: string) => {
+        // onChange(selected);
+    };
+
+    const { listRefs, handleSelection } = useSelectionManagement({
+        handleToggle: (selected: string) => () => onSelection(selected),
+    });
+
+    // const filteredOptions = options?.filter((option) =>
+    //     option.label.toLowerCase().includes(searchText.toLowerCase()),
+    // );
+
+    // const filteredOptions = [];
+    return (
+        <>
+            <Box ref={ref}>
+                <Button
+                    variant='outlined'
+                    color='primary'
+                    startIcon={button.icon}
+                    onClick={() => {
+                        // todo: find out why this is clicked when you
+                        // press enter in the search bar (only in
+                        // single-select mode)
+                        open();
+                    }}
+                >
+                    {button.label}
+                </Button>
+            </Box>
+            <StyledPopover
+                open={Boolean(anchorEl)}
+                anchorEl={anchorEl}
+                onClose={onClose}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+            >
+                <StyledDropdown>
+                    <StyledTextField
+                        variant='outlined'
+                        size='small'
+                        value={searchText}
+                        onChange={(event) => setSearchText(event.target.value)}
+                        label={search.label}
+                        placeholder={search.placeholder}
+                        autoFocus
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position='start'>
+                                    <Search fontSize='small' />
+                                </InputAdornment>
+                            ),
+                        }}
+                        inputRef={(el) => {
+                            listRefs.current[0] = el;
+                        }}
+                        onKeyDown={(event) => handleSelection(event, 0, [])}
+                    />
+                    <ChangeRequestTable
+                        environments={[]}
+                        enableEnvironment={(args) => {}}
+                        disableEnvironment={(s) => {}}
+                    />
+                </StyledDropdown>
+            </StyledPopover>
+        </>
+    );
 };

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -329,11 +329,7 @@ export const TableSelect: FC<TableSelectProps> = ({
         onChange(configuredEnvs);
     };
 
-    console.log('Configured is', configured);
-
     const onEnable = (name: string, requiredApprovals: number) => {
-        console.log('Got called!', name, requiredApprovals);
-
         propagateChanges({
             ...configured,
             [name]: { changeRequestEnabled: true, requiredApprovals },

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -7,6 +7,7 @@ import {
     StyledListItem,
     StyledPopover,
     StyledTextField,
+    TableSearchInput,
 } from './SelectionButton.styles';
 import { ChangeRequestTable } from './ChangeRequestTable';
 
@@ -380,7 +381,7 @@ export const TableSelect: FC<TableSelectProps> = ({
                 }}
             >
                 <StyledDropdown>
-                    <StyledTextField
+                    <TableSearchInput
                         variant='outlined'
                         size='small'
                         value={searchText}

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -290,19 +290,6 @@ export const TableSelect: FC<TableSelectProps> = ({
     activeEnvironments,
 }) => {
     const configured = useMemo(() => {
-        console.log(
-            'updating configured from',
-            projectChangeRequestConfiguration,
-            Object.fromEntries(
-                Object.entries(projectChangeRequestConfiguration).map(
-                    ([name, config]) => [
-                        name,
-                        { ...config, changeRequestEnabled: true },
-                    ],
-                ),
-            ),
-        );
-
         return Object.fromEntries(
             Object.entries(projectChangeRequestConfiguration).map(
                 ([name, config]) => [
@@ -324,69 +311,16 @@ export const TableSelect: FC<TableSelectProps> = ({
         [configured, activeEnvironments],
     );
 
-    console.log(
-        'Configured is',
-        configured,
-        'project is',
-        projectChangeRequestConfiguration,
-        'table envs are',
-        tableEnvs,
-    );
-
-    const propagateChanges = (
-        newState: Record<
-            string,
-            {
-                changeRequestEnabled: boolean;
-                requiredApprovals: number;
-            }
-        >,
-    ) => {
-        console.log('Setting new state', newState);
-
-        // setConfigured(newState);
-        const configuredEnvs = Object.fromEntries(
-            Object.entries(newState).map(([name, { requiredApprovals }]) => [
-                name,
-                { requiredApprovals },
-            ]),
-        );
-        onChange(configuredEnvs);
-    };
-
-    // bug behavior: when the table renders, it has the correct envs selected.
-    // if you enable one env, that works as you'd expect.
-    // if you try to enable a second env, it enables the second one, but disables the first one
-    // if you disable one of the originally selected envs after enabling another env, both the originally selected and the recently enabled env are disabled
-    // updating number of approvers works the same. if you update the number of approvers or an orig toggle, it resets any other changes you've made since opening
-
     const onEnable = (name: string, requiredApprovals: number) => {
-        console.log(
-            'On enable. Configured is',
-            configured,
-            'project cr config',
-            projectChangeRequestConfiguration,
-            'tableState',
-            tableEnvs,
-        );
-
-        // propagateChanges({
-        //     ...configured,
-        //     [name]: { changeRequestEnabled: true, requiredApprovals },
-        // });
         updateProjectChangeRequestConfiguration.enableChangeRequests(
             name,
             requiredApprovals,
         );
-        // onChange.enableCrs(name, requiredApprovals);
     };
-
-    console.log('cr config update', updateProjectChangeRequestConfiguration);
 
     const onDisable = (name: string) => {
         const { [name]: _, ...rest } = configured;
 
-        // propagateChanges(rest);
         updateProjectChangeRequestConfiguration.disableChangeRequests(name);
     };
 

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -316,8 +316,6 @@ export const TableSelect: FC<TableSelectProps> = ({
     };
 
     const onDisable = (name: string) => {
-        const { [name]: _, ...rest } = configured;
-
         updateProjectChangeRequestConfiguration.disableChangeRequests(name);
     };
 

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -336,13 +336,31 @@ export const TableSelect: FC<TableSelectProps> = ({
         // onChange(selected);
     };
 
-    const { listRefs, handleSelection } = useSelectionManagement({
-        handleToggle: (selected: string) => () => onSelection(selected),
-    });
+    // const { listRefs, handleSelection } = useSelectionManagement({
+    //     handleToggle: (selected: string) => () =>
+    //         selected in configured
+    //             ? onDisable(selected)
+    //             : onEnable(selected, 1),
+    // });
 
     const filteredEnvs = tableEnvs.filter((env) =>
         env.name.toLowerCase().includes(searchText.toLowerCase()),
     );
+
+    const handleSelection = (event: React.KeyboardEvent) => {
+        if (
+            event.key === 'Enter' &&
+            searchText.trim().length > 0 &&
+            filteredEnvs.length > 0
+        ) {
+            const firstEnv = filteredEnvs[0];
+            if (firstEnv.name in configured) {
+                onDisable(firstEnv.name);
+            } else {
+                onEnable(firstEnv.name, 1);
+            }
+        }
+    };
 
     // const filteredOptions = [];
     return (
@@ -392,10 +410,10 @@ export const TableSelect: FC<TableSelectProps> = ({
                                 </InputAdornment>
                             ),
                         }}
-                        inputRef={(el) => {
-                            listRefs.current[0] = el;
-                        }}
-                        onKeyDown={(event) => handleSelection(event, 0, [])}
+                        // inputRef={(el) => {
+                        //     listRefs.current[0] = el;
+                        // }}
+                        onKeyDown={handleSelection}
                     />
                     <ChangeRequestTable
                         environments={filteredEnvs}

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -280,9 +280,11 @@ type TableSelectProps = Pick<CombinedSelectProps, 'button' | 'search'> & {
         string,
         { requiredApprovals: number }
     >;
+    disabled: boolean;
 };
 export const TableSelect: FC<TableSelectProps> = ({
     button,
+    disabled,
     search,
     onChange,
     projectChangeRequestConfiguration,
@@ -363,6 +365,7 @@ export const TableSelect: FC<TableSelectProps> = ({
                         // single-select mode)
                         open();
                     }}
+                    disabled={disabled}
                 >
                     {button.label}
                 </Button>

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -304,12 +304,20 @@ export const TableSelect: FC<TableSelectProps> = ({
 
     const tableEnvs = useMemo(
         () =>
-            activeEnvironments.map(({ name, type }) => ({
-                name,
-                type,
-                changeRequestEnabled: false,
-                ...(configured[name] ?? {}),
-            })),
+            activeEnvironments.map(({ name, type }) => {
+                if (name in configured) {
+                    return {
+                        name,
+                        type,
+                        ...configured[name],
+                    };
+                } else
+                    return {
+                        name,
+                        type,
+                        changeRequestEnabled: false,
+                    };
+            }),
         [configured, activeEnvironments],
     );
 

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -332,17 +332,6 @@ export const TableSelect: FC<TableSelectProps> = ({
         setAnchorEl(null);
     };
 
-    const onSelection = (selected: string) => {
-        // onChange(selected);
-    };
-
-    // const { listRefs, handleSelection } = useSelectionManagement({
-    //     handleToggle: (selected: string) => () =>
-    //         selected in configured
-    //             ? onDisable(selected)
-    //             : onEnable(selected, 1),
-    // });
-
     const filteredEnvs = tableEnvs.filter((env) =>
         env.name.toLowerCase().includes(searchText.toLowerCase()),
     );
@@ -362,7 +351,6 @@ export const TableSelect: FC<TableSelectProps> = ({
         }
     };
 
-    // const filteredOptions = [];
     return (
         <>
             <Box ref={ref}>
@@ -371,9 +359,6 @@ export const TableSelect: FC<TableSelectProps> = ({
                     color='primary'
                     startIcon={button.icon}
                     onClick={() => {
-                        // todo: find out why this is clicked when you
-                        // press enter in the search bar (only in
-                        // single-select mode)
                         open();
                     }}
                     disabled={disabled}
@@ -410,9 +395,6 @@ export const TableSelect: FC<TableSelectProps> = ({
                                 </InputAdornment>
                             ),
                         }}
-                        // inputRef={(el) => {
-                        //     listRefs.current[0] = el;
-                        // }}
                         onKeyDown={handleSelection}
                     />
                     <ChangeRequestTable

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -304,20 +304,11 @@ export const TableSelect: FC<TableSelectProps> = ({
 
     const tableEnvs = useMemo(
         () =>
-            activeEnvironments.map(({ name, type }) => {
-                if (name in configured) {
-                    return {
-                        name,
-                        type,
-                        ...configured[name],
-                    };
-                } else
-                    return {
-                        name,
-                        type,
-                        changeRequestEnabled: false,
-                    };
-            }),
+            activeEnvironments.map(({ name, type }) => ({
+                name,
+                type,
+                ...(configured[name] ?? { changeRequestEnabled: false }),
+            })),
         [configured, activeEnvironments],
     );
 

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -59,6 +59,8 @@ export const ChangeRequestTable: VFC = () => {
     const projectId = useRequiredPathParam('projectId');
     const { data, loading, refetchChangeRequestConfig } =
         useChangeRequestConfig(projectId);
+    console.log('cr table data is', data);
+
     const { updateChangeRequestEnvironmentConfig } = useChangeRequestApi();
     const { setToastData, setToastApiError } = useToast();
 

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -59,8 +59,6 @@ export const ChangeRequestTable: VFC = () => {
     const projectId = useRequiredPathParam('projectId');
     const { data, loading, refetchChangeRequestConfig } =
         useChangeRequestConfig(projectId);
-    console.log('cr table data is', data);
-
     const { updateChangeRequestEnvironmentConfig } = useChangeRequestApi();
     const { setToastData, setToastApiError } = useToast();
 

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -37,6 +37,8 @@ const useProjectForm = (
         setProjectChangeRequestConfiguration,
     ] = useState(initialProjectChangeRequestConfiguration);
 
+    // todo: write tests for this
+    // also: disallow adding a project to cr config that isn't in envs
     const updateProjectEnvironments = (newState: Set<string>) => {
         const filteredChangeRequestEnvs = Object.fromEntries(
             Object.entries(projectChangeRequestConfiguration).filter(([env]) =>

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -96,8 +96,8 @@ const useProjectForm = (
                   description: projectDesc,
                   defaultStickiness: projectStickiness,
                   mode: projectMode,
-                  changeRequestEnvironments,
                   ...environmentsPayload,
+                  changeRequestEnvironments,
               }
             : {
                   id: projectId,

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -37,6 +37,17 @@ const useProjectForm = (
         setProjectChangeRequestConfiguration,
     ] = useState(initialProjectChangeRequestConfiguration);
 
+    const updateProjectEnvironments = (newState: Set<string>) => {
+        const filteredChangeRequestEnvs = Object.fromEntries(
+            Object.entries(projectChangeRequestConfiguration).filter(([env]) =>
+                newState.has(env),
+            ),
+        );
+
+        setProjectChangeRequestConfiguration(filteredChangeRequestEnvs);
+        setProjectEnvironments(newState);
+    };
+
     const [errors, setErrors] = useState({});
 
     const { validateId } = useProjectApi();
@@ -156,7 +167,7 @@ const useProjectForm = (
         setProjectStickiness,
         setFeatureLimit,
         setProjectMode,
-        setProjectEnvironments,
+        setProjectEnvironments: updateProjectEnvironments,
         setProjectChangeRequestConfiguration,
         getCreateProjectPayload,
         getEditProjectPayload,

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -50,6 +50,22 @@ const useProjectForm = (
         setProjectEnvironments(newState);
     };
 
+    const crConfig = {
+        disableChangeRequests: (env: string) => {
+            setProjectChangeRequestConfiguration((previousState) => {
+                const { [env]: _, ...rest } = previousState;
+                return rest;
+            });
+        },
+
+        enableChangeRequests: (env: string, approvals: number) => {
+            setProjectChangeRequestConfiguration((previousState) => ({
+                ...previousState,
+                [env]: { requiredApprovals: approvals },
+            }));
+        },
+    };
+
     const [errors, setErrors] = useState({});
 
     const { validateId } = useProjectApi();
@@ -170,7 +186,7 @@ const useProjectForm = (
         setFeatureLimit,
         setProjectMode,
         setProjectEnvironments: updateProjectEnvironments,
-        setProjectChangeRequestConfiguration,
+        updateProjectChangeRequestConfig: crConfig,
         getCreateProjectPayload,
         getEditProjectPayload,
         validateName,

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -13,6 +13,10 @@ const useProjectForm = (
     initialFeatureLimit = '',
     initialProjectMode: ProjectMode = 'open',
     initialProjectEnvironments: Set<string> = new Set(),
+    initialProjectChangeRequestConfiguration: Record<
+        string,
+        { requiredApprovals: number }
+    > = {},
 ) => {
     const { isEnterprise } = useUiConfig();
     const [projectId, setProjectId] = useState(initialProjectId);
@@ -28,6 +32,10 @@ const useProjectForm = (
     const [projectEnvironments, setProjectEnvironments] = useState<Set<string>>(
         initialProjectEnvironments,
     );
+    const [
+        projectChangeRequestConfiguration,
+        setProjectChangeRequestConfiguration,
+    ] = useState(initialProjectChangeRequestConfiguration);
 
     const [errors, setErrors] = useState({});
 
@@ -63,6 +71,13 @@ const useProjectForm = (
                 ? { environments: [...projectEnvironments] }
                 : {};
 
+        const changeRequestEnvironments = Object.entries(
+            projectChangeRequestConfiguration,
+        ).map(([env, { requiredApprovals }]) => ({
+            name: env,
+            requiredApprovals,
+        }));
+
         return isEnterprise()
             ? {
                   id: projectId,
@@ -70,6 +85,7 @@ const useProjectForm = (
                   description: projectDesc,
                   defaultStickiness: projectStickiness,
                   mode: projectMode,
+                  changeRequestEnvironments,
                   ...environmentsPayload,
               }
             : {
@@ -133,6 +149,7 @@ const useProjectForm = (
         projectStickiness,
         featureLimit,
         projectEnvironments,
+        projectChangeRequestConfiguration,
         setProjectId,
         setProjectName,
         setProjectDesc,
@@ -140,6 +157,7 @@ const useProjectForm = (
         setFeatureLimit,
         setProjectMode,
         setProjectEnvironments,
+        setProjectChangeRequestConfiguration,
         getCreateProjectPayload,
         getEditProjectPayload,
         validateName,


### PR DESCRIPTION
This PR adds the ability to configure CRs when creating a project.

The design is unfinished, and the code certainly needs cleanup, but I'd like to get this into sandbox so we can look at it.

Things that still need to be done:

1. What do we do about this button when the user has no environments selected? As a rough draft, I've disabled it. However, we should make it possible to navigate to and give you an explanation why it was disabled, e.g. "You have no project environments selected. Please select at least one project environment.".
2. The form design is not done: the width should be constant and not jumpy the way it is now. Also, the search field is too wide.
3. I've made the desicion that if you deselect a project env, we also remove that env from your CR config it it's in there.
4. Potential improvement: if you enable and then disable CRs for an env, we *could* probably store the data in between, so that if you set required approvers 5 and then disabled it, it'd still be 5 when you re-enabled it. That sounds like a good user experience. We should also be able to extend that to adding/removing environments from project envs.