### PR TITLE
fix: badge should render children 0 value

### DIFF
--- a/frontend/src/component/common/Badge/Badge.test.tsx
+++ b/frontend/src/component/common/Badge/Badge.test.tsx
@@ -1,0 +1,17 @@
+import { screen } from '@testing-library/react';
+import { Badge } from './Badge';
+import { render } from '../../../utils/testRenderer';
+
+test('Badge should render text', async () => {
+    render(<Badge color='success'>Predefined</Badge>);
+
+    const result = await screen.findByText('Predefined');
+    expect(result).toBeInTheDocument();
+});
+
+test('Badge should children number 0', async () => {
+    render(<Badge color='success'>{0}</Badge>);
+
+    const result = await screen.findByText('0');
+    expect(result).toBeInTheDocument();
+});

--- a/frontend/src/component/common/Badge/Badge.tsx
+++ b/frontend/src/component/common/Badge/Badge.tsx
@@ -28,7 +28,6 @@ interface IBadgeProps {
     sx?: SxProps<Theme>;
     children?: ReactNode;
     title?: string;
-    showZero?: boolean;
     onClick?: (event: React.SyntheticEvent) => void;
 }
 

--- a/frontend/src/component/common/Badge/Badge.tsx
+++ b/frontend/src/component/common/Badge/Badge.tsx
@@ -28,6 +28,7 @@ interface IBadgeProps {
     sx?: SxProps<Theme>;
     children?: ReactNode;
     title?: string;
+    showZero?: boolean;
     onClick?: (event: React.SyntheticEvent) => void;
 }
 
@@ -113,7 +114,11 @@ export const Badge: FC<IBadgeProps> = forwardRef(
                 show={BadgeIcon(color, icon!)}
             />
             <ConditionallyRender
-                condition={Boolean(children)}
+                condition={
+                    children !== null &&
+                    children !== undefined &&
+                    children !== ''
+                }
                 show={<div>{children}</div>}
             />
             <ConditionallyRender


### PR DESCRIPTION
When passing 0 in as child, the 0 was not rendred. Fixed the badge component and added tests.

![image](https://github.com/Unleash/unleash/assets/964450/d681b70c-5d55-4818-86ea-7d05fa86c7b3)
