### PR TITLE
test: test how the project form deals with project envs and cr env interaction

### DIFF
--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useProjectForm from './useProjectForm';
+
+// refer to : https://www.npmjs.com/package/@testing-library/react-hooks
+
+test('setting project environments removes any change request envs that are not in the new project env list', () => {
+    const { result } = renderHook(() => useProjectForm());
+
+    result.current.setProjectEnvironments(new Set(['dev', 'prod']));
+    result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+        'prod',
+        5,
+    );
+
+    expect(result.current.projectChangeRequestConfiguration).toMatchObject({
+        prod: { requiredApprovals: 5 },
+    });
+
+    result.current.setProjectEnvironments(new Set(['dev']));
+
+    expect(
+        'prod' in result.current.projectChangeRequestConfiguration,
+    ).toBeFalsy();
+});
+
+test(`adding a change request config for an env not in the project envs doesn't work and the change request envs is not changed`, () => {
+    const { result } = renderHook(() => useProjectForm());
+
+    result.current.setProjectEnvironments(new Set(['prod']));
+
+    result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+        'dev',
+        5,
+    );
+
+    expect(
+        'dev' in result.current.projectChangeRequestConfiguration,
+    ).toBeFalsy();
+});

--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -1,8 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useProjectForm from './useProjectForm';
 
-// refer to : https://www.npmjs.com/package/@testing-library/react-hooks
-
 test('setting project environments removes any change request envs that are not in the new project env list', () => {
     const { result } = renderHook(() => useProjectForm());
 

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -57,10 +57,12 @@ const useProjectForm = (
         },
 
         enableChangeRequests: (env: string, approvals: number) => {
-            setProjectChangeRequestConfiguration((previousState) => ({
-                ...previousState,
-                [env]: { requiredApprovals: approvals },
-            }));
+            if (projectEnvironments.has(env)) {
+                setProjectChangeRequestConfiguration((previousState) => ({
+                    ...previousState,
+                    [env]: { requiredApprovals: approvals },
+                }));
+            }
         },
     };
 

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -37,8 +37,6 @@ const useProjectForm = (
         setProjectChangeRequestConfiguration,
     ] = useState(initialProjectChangeRequestConfiguration);
 
-    // todo: write tests for this
-    // also: disallow adding a project to cr config that isn't in envs
     const updateProjectEnvironments = (newState: Set<string>) => {
         const filteredChangeRequestEnvs = Object.fromEntries(
             Object.entries(projectChangeRequestConfiguration).filter(([env]) =>


### PR DESCRIPTION
This PR adds some tests around how project envs and change request envs interact in the new project form. It tests that:
1. If you remove an env from the project setup, that env is also removed from the change request list.
2. If you try to enable CRs for an env that isn't enabled, nothing happens.