### PR TITLE
feat: Allow to use CA certificate file path for DB (#6985)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,12 @@
       "^.+\\.tsx?$": ["@swc/jest"]
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "testPathIgnorePatterns": ["/dist/", "/node_modules/", "/frontend/"],
+    "testPathIgnorePatterns": [
+      "/dist/",
+      "/node_modules/",
+      "/frontend/",
+      "/website/"
+    ],
     "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"],
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/package.json
+++ b/package.json
@@ -82,23 +82,11 @@
     "testTimeout": 10000,
     "globalSetup": "./scripts/jest-setup.js",
     "transform": {
-      "^.+\\.tsx?$": [
-        "@swc/jest"
-      ]
+      "^.+\\.tsx?$": ["@swc/jest"]
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "testPathIgnorePatterns": [
-      "/dist/",
-      "/node_modules/",
-      "/frontend/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ],
+    "testPathIgnorePatterns": ["/dist/", "/node_modules/", "/frontend/"],
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/dist/",
@@ -236,14 +224,8 @@
     "tough-cookie": "4.1.3"
   },
   "lint-staged": {
-    "*.{js,ts}": [
-      "biome check --apply --no-errors-on-unmatched"
-    ],
-    "*.{jsx,tsx}": [
-      "biome check --apply --no-errors-on-unmatched"
-    ],
-    "*.json": [
-      "biome format --write --no-errors-on-unmatched"
-    ]
+    "*.{js,ts}": ["biome check --apply --no-errors-on-unmatched"],
+    "*.{jsx,tsx}": ["biome check --apply --no-errors-on-unmatched"],
+    "*.json": ["biome format --write --no-errors-on-unmatched"]
   }
 }


### PR DESCRIPTION
We'd like to get this out so you can get away with only defining a CA certificate, the current iteration requires CA, CERT and KEY in order to work. This PR splits it up and allows you to configure one.