### PR TITLE
feat: add project id to prometheus and feature flag

### DIFF
--- a/src/lib/features/feature-lifecycle/fake-feature-lifecycle-store.ts
+++ b/src/lib/features/feature-lifecycle/fake-feature-lifecycle-store.ts
@@ -2,7 +2,7 @@ import type {
     FeatureLifecycleStage,
     IFeatureLifecycleStore,
     FeatureLifecycleView,
-    FeatureLifecycleFullItem,
+    FeatureLifecycleProjectItem,
 } from './feature-lifecycle-store-type';
 
 export class FakeFeatureLifecycleStore implements IFeatureLifecycleStore {
@@ -36,12 +36,13 @@ export class FakeFeatureLifecycleStore implements IFeatureLifecycleStore {
         return this.lifecycles[feature] || [];
     }
 
-    async getAll(): Promise<FeatureLifecycleFullItem[]> {
+    async getAll(): Promise<FeatureLifecycleProjectItem[]> {
         const result = Object.entries(this.lifecycles).flatMap(
-            ([key, items]): FeatureLifecycleFullItem[] =>
+            ([key, items]): FeatureLifecycleProjectItem[] =>
                 items.map((item) => ({
                     ...item,
                     feature: key,
+                    project: 'fake-project',
                 })),
         );
         return result;

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.test.ts
@@ -144,26 +144,31 @@ test('can find feature lifecycle stage timings', async () => {
         {
             feature: 'a',
             stage: 'initial',
+            project: 'default',
             enteredStageAt: minusTenMinutes,
         },
         {
             feature: 'b',
             stage: 'initial',
+            project: 'default',
             enteredStageAt: minusTenMinutes,
         },
         {
             feature: 'a',
             stage: 'pre-live',
+            project: 'default',
             enteredStageAt: minusOneMinute,
         },
         {
             feature: 'b',
             stage: 'live',
+            project: 'default',
             enteredStageAt: minusOneMinute,
         },
         {
             feature: 'c',
             stage: 'initial',
+            project: 'default',
             enteredStageAt: minusTenMinutes,
         },
     ]);

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
@@ -247,6 +247,7 @@ export class FeatureLifecycleService extends EventEmitter {
                 times.push({
                     feature: stage.feature,
                     stage: stage.stage,
+                    project: stage.project,
                     duration,
                 });
             });

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
@@ -14,7 +14,7 @@ import {
     type IUnleashConfig,
 } from '../../types';
 import type {
-    FeatureLifecycleFullItem,
+    FeatureLifecycleProjectItem,
     FeatureLifecycleView,
     IFeatureLifecycleStore,
 } from './feature-lifecycle-store-type';
@@ -215,10 +215,10 @@ export class FeatureLifecycleService extends EventEmitter {
     }
 
     public calculateStageDurations(
-        featureLifeCycles: FeatureLifecycleFullItem[],
+        featureLifeCycles: FeatureLifecycleProjectItem[],
     ) {
         const groupedByFeature = featureLifeCycles.reduce<{
-            [feature: string]: FeatureLifecycleFullItem[];
+            [feature: string]: FeatureLifecycleProjectItem[];
         }>((acc, curr) => {
             if (!acc[curr.feature]) {
                 acc[curr.feature] = [];

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-store-type.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-store-type.ts
@@ -7,14 +7,15 @@ export type FeatureLifecycleStage = {
 
 export type FeatureLifecycleView = IFeatureLifecycleStage[];
 
-export type FeatureLifecycleFullItem = FeatureLifecycleStage & {
+export type FeatureLifecycleProjectItem = FeatureLifecycleStage & {
     enteredStageAt: Date;
+    project: string;
 };
 
 export interface IFeatureLifecycleStore {
     insert(featureLifecycleStages: FeatureLifecycleStage[]): Promise<void>;
     get(feature: string): Promise<FeatureLifecycleView>;
-    getAll(): Promise<FeatureLifecycleFullItem[]>;
+    getAll(): Promise<FeatureLifecycleProjectItem[]>;
     stageExists(stage: FeatureLifecycleStage): Promise<boolean>;
     delete(feature: string): Promise<void>;
     deleteStage(stage: FeatureLifecycleStage): Promise<void>;

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -30,10 +30,16 @@ let environmentStore: IEnvironmentStore;
 let statsService: InstanceStatsService;
 let stores: IUnleashStores;
 let schedulerService: SchedulerService;
+
 beforeAll(async () => {
     const config = createTestConfig({
         server: {
             serverMetrics: true,
+        },
+        experimental: {
+            flags: {
+                featureLifecycleMetrics: true,
+            },
         },
     });
     stores = createStores();

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -294,7 +294,7 @@ export default class MetricsMonitor {
                         .labels({
                             feature_id: stage.feature,
                             stage: stage.stage,
-                            project: stage.project,
+                            project_id: stage.project,
                         })
                         .observe(stage.duration);
                 });

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -294,6 +294,7 @@ export default class MetricsMonitor {
                         .labels({
                             feature_id: stage.feature,
                             stage: stage.stage,
+                            project: stage.project,
                         })
                         .observe(stage.duration);
                 });

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -261,7 +261,7 @@ export default class MetricsMonitor {
 
         const featureLifecycleStageDuration = createHistogram({
             name: 'feature_lifecycle_stage_duration',
-            labelNames: ['feature_id', 'stage'],
+            labelNames: ['feature_id', 'stage', 'project_id'],
             help: 'Duration of feature lifecycle stages',
         });
 

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -128,6 +128,7 @@ class InstanceAdminController extends Controller {
             featureLifeCycles: [
                 {
                     feature: 'feature1',
+                    project: 'default',
                     stage: 'archived',
                     duration: 2000,
                 },

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -54,6 +54,7 @@ export type IFlagKey =
     | 'disableShowContextFieldSelectionValues'
     | 'projectOverviewRefactorFeedback'
     | 'featureLifecycle'
+    | 'featureLifecycleMetrics'
     | 'projectListFilterMyProjects'
     | 'projectsListNewCards'
     | 'parseProjectFromSession'

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -168,6 +168,7 @@ export interface IFeatureLifecycleStage {
 
 export type IFeatureLifecycleStageDuration = FeatureLifecycleStage & {
     duration: number;
+    project: string;
 };
 
 export interface IFeatureDependency {


### PR DESCRIPTION
Now we are also sending project id to prometheus, also querying from database. This sets us up for grafana dashboard.
Also put the metrics behind flag, just incase it causes cpu/memory issues.