### PR TITLE
poc: many strategies pagination

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyNonDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyNonDraggableItem.tsx
@@ -1,0 +1,128 @@
+import { useRef } from 'react';
+import { Box, useMediaQuery, useTheme } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
+import type { IFeatureEnvironment } from 'interfaces/featureToggle';
+import type { IFeatureStrategy } from 'interfaces/strategy';
+import { StrategyItem } from './StrategyItem/StrategyItem';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import {
+    useStrategyChangesFromRequest,
+    type UseStrategyChangeFromRequestResult,
+} from './StrategyItem/useStrategyChangesFromRequest';
+import { ChangesScheduledBadge } from 'component/changeRequest/ModifiedInChangeRequestStatusBadge/ChangesScheduledBadge';
+import type { IFeatureChange } from 'component/changeRequest/changeRequest.types';
+import { Badge } from 'component/common/Badge/Badge';
+import {
+    type ScheduledChangeRequestViewModel,
+    useScheduledChangeRequestsWithStrategy,
+} from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
+
+interface IStrategyItemProps {
+    strategy: IFeatureStrategy;
+    environmentName: string;
+    index: number;
+    otherEnvironments?: IFeatureEnvironment['name'][];
+}
+
+export const StrategyNonDraggableItem = ({
+    strategy,
+    index,
+    environmentName,
+    otherEnvironments,
+}: IStrategyItemProps) => {
+    const projectId = useRequiredPathParam('projectId');
+    const featureId = useRequiredPathParam('featureId');
+    const ref = useRef<HTMLDivElement>(null);
+    const strategyChangesFromRequest = useStrategyChangesFromRequest(
+        projectId,
+        featureId,
+        environmentName,
+        strategy.id,
+    );
+
+    const { changeRequests: scheduledChangesUsingStrategy } =
+        useScheduledChangeRequestsWithStrategy(projectId, strategy.id);
+
+    return (
+        <Box key={strategy.id} ref={ref} sx={{ opacity: '1' }}>
+            <ConditionallyRender
+                condition={index > 0}
+                show={<StrategySeparator text='OR' />}
+            />
+
+            <StrategyItem
+                strategy={strategy}
+                environmentId={environmentName}
+                otherEnvironments={otherEnvironments}
+                orderNumber={index + 1}
+                headerChildren={renderHeaderChildren(
+                    strategyChangesFromRequest,
+                    scheduledChangesUsingStrategy,
+                )}
+            />
+        </Box>
+    );
+};
+
+const ChangeRequestStatusBadge = ({
+    change,
+}: {
+    change: IFeatureChange | undefined;
+}) => {
+    const theme = useTheme();
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+    if (isSmallScreen) {
+        return null;
+    }
+
+    return (
+        <Box sx={{ mr: 1.5 }}>
+            <ConditionallyRender
+                condition={change?.action === 'updateStrategy'}
+                show={<Badge color='warning'>Modified in draft</Badge>}
+            />
+            <ConditionallyRender
+                condition={change?.action === 'deleteStrategy'}
+                show={<Badge color='error'>Deleted in draft</Badge>}
+            />
+        </Box>
+    );
+};
+
+const renderHeaderChildren = (
+    changes?: UseStrategyChangeFromRequestResult,
+    scheduledChanges?: ScheduledChangeRequestViewModel[],
+): JSX.Element[] => {
+    const badges: JSX.Element[] = [];
+    if (changes?.length === 0 && scheduledChanges?.length === 0) {
+        return [];
+    }
+
+    const draftChange = changes?.find(
+        ({ isScheduledChange }) => !isScheduledChange,
+    );
+
+    if (draftChange) {
+        badges.push(
+            <ChangeRequestStatusBadge
+                key={`draft-change#${draftChange.change.id}`}
+                change={draftChange.change}
+            />,
+        );
+    }
+
+    if (scheduledChanges && scheduledChanges.length > 0) {
+        badges.push(
+            <ChangesScheduledBadge
+                key='scheduled-changes'
+                scheduledChangeRequestIds={scheduledChanges.map(
+                    (scheduledChange) => scheduledChange.id,
+                )}
+            />,
+        );
+    }
+
+    return badges;
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyNonDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyNonDraggableItem.tsx
@@ -25,6 +25,9 @@ interface IStrategyItemProps {
     otherEnvironments?: IFeatureEnvironment['name'][];
 }
 
+/**
+ * @deprecated
+ */
 export const StrategyNonDraggableItem = ({
     strategy,
     index,

--- a/frontend/src/hooks/usePagination.ts
+++ b/frontend/src/hooks/usePagination.ts
@@ -20,7 +20,7 @@ const usePagination = <T>(
         }
 
         const result = paginate(dataToPaginate, limit);
-        setPageIndex(0);
+        // setPageIndex(0);
         setPaginatedData(result);
         /* eslint-disable-next-line */
     }, [JSON.stringify(data), limit]);

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -59,6 +59,7 @@ export type CustomEvents =
     | 'search-bar'
     | 'sdk-reporting'
     | 'insights-share'
+    | 'many-strategies'
     | 'sdk-banner';
 
 export const usePlausibleTracker = () => {

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -84,6 +84,7 @@ export type UiFlags = {
     createProjectWithEnvironmentConfig?: boolean;
     projectsListNewCards?: boolean;
     newCreateProjectUI?: boolean;
+    manyStrategiesPagination?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -122,6 +122,7 @@ exports[`should create default config 1`] = `
       "googleAuthEnabled": false,
       "killScheduledChangeRequestCache": false,
       "maintenanceMode": false,
+      "manyStrategiesPagination": false,
       "messageBanner": {
         "enabled": false,
         "name": "message-banner",

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -58,6 +58,7 @@ export type IFlagKey =
     | 'projectsListNewCards'
     | 'parseProjectFromSession'
     | 'createProjectWithEnvironmentConfig'
+    | 'manyStrategiesPagination'
     | 'newCreateProjectUI';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -281,6 +282,10 @@ const flags: IFlags = {
     ),
     newCreateProjectUI: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_CREATE_PROJECT_UI,
+        false,
+    ),
+    manyStrategiesPagination: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_MANY_STRATEGIES_PAGINATION,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -54,6 +54,7 @@ process.nextTick(async () => {
                         projectsListNewCards: true,
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,
+                        manyStrategiesPagination: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
This fixes the case when a customer have thousands of strategies causing the react UI to crash. We still consider it incorrect to use that amount of strategies and this is more a workaround to help the customer out of a crashing state.

We put it behind a flag called `manyStrategiesPagination` and plan to only enable it for the customer in trouble. 