### PR TITLE
fix: only send cr flag config when the flag is turned on

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProject.tsx
@@ -61,6 +61,10 @@ const CreateProject = () => {
         setDocumentation(generalDocumentation);
 
     const useNewProjectForm = useUiFlag('newCreateProjectUI');
+    const projectPayload = getCreateProjectPayload({
+        omitId: useNewProjectForm,
+        includeChangeRequestConfig: useNewProjectForm,
+    });
 
     const { createProject, loading } = useProjectApi();
 
@@ -71,11 +75,8 @@ const CreateProject = () => {
         const validId = useNewProjectForm || (await validateProjectId());
 
         if (validName && validId) {
-            const payload = getCreateProjectPayload({
-                omitId: useNewProjectForm,
-            });
             try {
-                const createdProject = await createProject(payload);
+                const createdProject = await createProject(projectPayload);
                 refetchUser();
                 navigate(`/projects/${createdProject.id}`, { replace: true });
                 setToastData({
@@ -101,11 +102,7 @@ const CreateProject = () => {
         return `curl --location --request POST '${uiConfig.unleashUrl}/api/admin/projects' \\
 --header 'Authorization: INSERT_API_KEY' \\
 --header 'Content-Type: application/json' \\
---data-raw '${JSON.stringify(
-            getCreateProjectPayload({ omitId: useNewProjectForm }),
-            undefined,
-            2,
-        )}'`;
+--data-raw '${JSON.stringify(projectPayload, undefined, 2)}'`;
     };
 
     const handleCancel = () => {

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -94,7 +94,10 @@ const useProjectForm = (
         setProjectMode(initialProjectMode);
     }, [initialProjectMode]);
 
-    const getCreateProjectPayload = (options?: { omitId?: boolean }) => {
+    const getCreateProjectPayload = (options?: {
+        omitId?: boolean;
+        includeChangeRequestConfig?: boolean;
+    }) => {
         const environmentsPayload =
             projectEnvironments.size > 0
                 ? { environments: [...projectEnvironments] }
@@ -119,7 +122,9 @@ const useProjectForm = (
             ? {
                   ...ossPayload,
                   mode: projectMode,
-                  changeRequestEnvironments,
+                  ...(options?.includeChangeRequestConfig
+                      ? { changeRequestEnvironments }
+                      : {}),
               }
             : ossPayload;
     };


### PR DESCRIPTION
I realized that, in an oversight, the form now includes CR config, even if the new form isn't active. The API should just ignore it if it doesn't understand it, so it's not very harmful, but it's better if we don't send it at all. This PR does that.