### PR TITLE
feat: expose postgres version

### DIFF
--- a/src/lib/db/setting-store.ts
+++ b/src/lib/db/setting-store.ts
@@ -14,6 +14,11 @@ export default class SettingStore implements ISettingStore {
         this.logger = getLogger('settings-store.ts');
     }
 
+    async postgresVersion(): Promise<string> {
+        const showResult = await this.db.raw('SHOW server_version');
+        return showResult?.rows[0]?.server_version || '';
+    }
+
     async updateRow(name: string, content: any): Promise<void> {
         return this.db(TABLE)
             .where('name', name)

--- a/src/lib/db/setting-store.ts
+++ b/src/lib/db/setting-store.ts
@@ -15,8 +15,13 @@ export default class SettingStore implements ISettingStore {
     }
 
     async postgresVersion(): Promise<string> {
-        const showResult = await this.db.raw('SHOW server_version');
-        return showResult?.rows[0]?.server_version || '';
+        try {
+            const showResult = await this.db.raw('SHOW server_version');
+            return showResult?.rows[0]?.server_version || '';
+        } catch (e) {
+            this.logger.warn('Failed to fetch postgres version', e);
+            return '';
+        }
     }
 
     async updateRow(name: string, content: any): Promise<void> {

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -34,6 +34,11 @@ import {
 } from './util/metrics';
 import type { SchedulerService } from './services';
 
+async function getPostgresVersion(db: Knex) {
+    const rows = await db.raw('SHOW server_version');
+    return rows.rows[0].server_version || '';
+}
+
 export default class MetricsMonitor {
     constructor() {}
 
@@ -674,6 +679,13 @@ export default class MetricsMonitor {
                 'registerPoolMetrics',
                 0, // no jitter
             );
+            const postgresVersion = await getPostgresVersion(db);
+            const database_version = createGauge({
+                name: 'postgres_version',
+                help: 'Which version of postgres is running (SHOW server_version)',
+                labelNames: ['version'],
+            });
+            database_version.labels({ version: postgresVersion }).set(1);
         }
     }
 

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -65,6 +65,7 @@ export interface IFeatureUsageInfo {
     productionChanges30: number;
     productionChanges60: number;
     productionChanges90: number;
+    postgresVersion: string;
 }
 
 export default class VersionService {
@@ -260,6 +261,7 @@ export default class VersionService {
             featureImports,
             userActive,
             productionChanges,
+            postgresVersion,
         ] = await Promise.all([
             this.featureToggleStore.count({
                 archived: false,
@@ -282,6 +284,7 @@ export default class VersionService {
             this.eventStore.filteredCount({ type: FEATURES_IMPORTED }),
             this.userStats(),
             this.productionChanges(),
+            this.postgresVersion(),
         ]);
         const versionInfo = await this.getVersionInfo();
         const customStrategies =
@@ -315,6 +318,7 @@ export default class VersionService {
             productionChanges30: productionChanges.last30,
             productionChanges60: productionChanges.last60,
             productionChanges90: productionChanges.last90,
+            postgresVersion,
         };
         return featureInfo;
     }
@@ -334,6 +338,10 @@ export default class VersionService {
         last90: number;
     }> {
         return this.getProductionChanges();
+    }
+
+    async postgresVersion(): Promise<string> {
+        return this.settingStore.postgresVersion();
     }
 
     async hasOIDC(): Promise<boolean> {

--- a/src/lib/types/stores/settings-store.ts
+++ b/src/lib/types/stores/settings-store.ts
@@ -8,5 +8,6 @@ export interface ISettingInsert {
 export interface ISettingStore extends Store<any, string> {
     insert<T>(name: string, content: T): Promise<void>;
     updateRow(name: string, content: any): Promise<void>;
+    postgresVersion(): Promise<string>;
     get<T>(name: string): Promise<T | undefined>;
 }

--- a/src/test/fixtures/fake-setting-store.ts
+++ b/src/test/fixtures/fake-setting-store.ts
@@ -38,4 +38,8 @@ export default class FakeSettingStore implements ISettingStore {
     async updateRow(name: string, content: any): Promise<void> {
         this.settings.set(name, content);
     }
+
+    async postgresVersion(): Promise<string> {
+        return Promise.resolve('fake-postgres-version');
+    }
 }


### PR DESCRIPTION
Adds a postgres_version gauge to allow us to see postgres_version in prometheus and to post it upstream when version checking. Depends on https://github.com/bricks-software/version-function/pull/20 to be merged first to ensure our version-function doesn't crash when given the postgres-version data.