### PR TITLE
fix: make name validation work properly.

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -171,7 +171,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                 <ProjectNameContainer>
                     <StyledProjectName
                         label='Project name'
-                        required
+                        aria-required
                         value={projectName}
                         onChange={handleProjectNameUpdate}
                         error={Boolean(errors.name)}

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -208,7 +208,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         label:
                             projectEnvironments.size > 0
                                 ? `${projectEnvironments.size} selected`
-                                : 'Select environments',
+                                : 'All environments',
                         icon: <EnvironmentsIcon />,
                     }}
                     search={{

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -156,7 +156,7 @@ const useProjectForm = (
     };
 
     const validateName = () => {
-        if (projectName.length === 0) {
+        if (projectName.trim().length === 0) {
             setErrors((prev) => ({ ...prev, name: 'Name can not be empty.' }));
             return false;
         }


### PR DESCRIPTION
Instead of using the `required` attribute, we manually make it
required. This is indicated visually by red error text if the value is
empty (or whitespace only). To indicate to screen readers that it is
required, we add the `aria-required` attribute.

We didn't previously validate if the name
was whitespace only.

Also: if no envs are selected, indicate that all will be included

This prevents this form value from ever being invalid.