### PR TITLE
fix: omit yes no from stale data comparison

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
+++ b/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
@@ -6,5 +6,5 @@ export const comparisonModerator = (
 ): DeepOmit<IFeatureToggle, keyof IFeatureToggle> => {
     const tempData = { ...data };
 
-    return deepOmit(tempData, 'lastSeenAt');
+    return deepOmit(tempData, 'lastSeenAt', 'yes', 'no');
 };

--- a/frontend/src/utils/deepOmit.test.ts
+++ b/frontend/src/utils/deepOmit.test.ts
@@ -47,3 +47,33 @@ test('should omit all instances of a given field', () => {
         },
     });
 });
+
+test('should omit all instances of multiple fields', () => {
+    const input = {
+        name: 'some-name',
+        color: 'blue',
+        children: {
+            name: 'some-name',
+            color: 'blue',
+            children: {
+                name: 'some-name',
+                color: 'blue',
+                children: {
+                    name: 'some-name',
+                    color: 'blue',
+                    children: {},
+                },
+            },
+        },
+    };
+
+    expect(deepOmit(input, 'name', 'color')).toEqual({
+        children: {
+            children: {
+                children: {
+                    children: {},
+                },
+            },
+        },
+    });
+});

--- a/frontend/src/utils/deepOmit.ts
+++ b/frontend/src/utils/deepOmit.ts
@@ -4,17 +4,22 @@ export type DeepOmit<T, K extends keyof any> = T extends Record<string, any>
 
 export function deepOmit<T, K extends keyof any>(
     obj: T,
-    keyToOmit: K,
+    ...keysToOmit: K[]
 ): DeepOmit<T, K> {
+    const omitSet = new Set(keysToOmit);
+
     if (Array.isArray(obj)) {
         return obj.map((item) =>
-            deepOmit(item, keyToOmit),
+            deepOmit(item, ...keysToOmit),
         ) as unknown as DeepOmit<T, K>;
     } else if (typeof obj === 'object' && obj !== null) {
         const result: Partial<DeepOmit<T, K>> = {};
         for (const [key, value] of Object.entries(obj)) {
-            if (key !== keyToOmit) {
-                result[key as Exclude<keyof T, K>] = deepOmit(value, keyToOmit);
+            if (!omitSet.has(key as K)) {
+                result[key as Exclude<keyof T, K>] = deepOmit(
+                    value,
+                    ...keysToOmit,
+                );
             }
         }
         return result as DeepOmit<T, K>;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When computing stale data e.g. on strategy edit we need to omit yes/no counts same way we do it for lastSeenAt.

Expanded deepOmit function to support multiple keys.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
