### PR TITLE
feat: hide feature environment variants for new users and those who dont need it

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -48,7 +48,7 @@ import { ReactComponent as ParentLinkIcon } from 'assets/icons/link-parent.svg';
 import { ChildrenTooltip } from './FeatureOverview/FeatureOverviewMetaData/ChildrenTooltip';
 import copy from 'copy-to-clipboard';
 import useToast from 'hooks/useToast';
-import { useUiFlag } from '../../../hooks/useUiFlag';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -48,6 +48,7 @@ import { ReactComponent as ParentLinkIcon } from 'assets/icons/link-parent.svg';
 import { ChildrenTooltip } from './FeatureOverview/FeatureOverviewMetaData/ChildrenTooltip';
 import copy from 'copy-to-clipboard';
 import useToast from 'hooks/useToast';
+import { useUiFlag } from '../../../hooks/useUiFlag';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -145,6 +146,9 @@ export const FeatureView = () => {
     const [openStaleDialog, setOpenStaleDialog] = useState(false);
     const [isFeatureNameCopied, setIsFeatureNameCopied] = useState(false);
     const smallScreen = useMediaQuery(`(max-width:${500}px)`);
+    const hideFeatureEnvironmentVariants = useUiFlag(
+        'hideFeatureEnvironmentVariants',
+    );
 
     const { feature, loading, error, status } = useFeature(
         projectId,
@@ -168,7 +172,15 @@ export const FeatureView = () => {
             path: `${basePath}/metrics`,
             name: 'Metrics',
         },
-        { title: 'Variants', path: `${basePath}/variants`, name: 'Variants' },
+        ...(hideFeatureEnvironmentVariants
+            ? []
+            : [
+                  {
+                      title: 'Variants',
+                      path: `${basePath}/variants`,
+                      name: 'Variants',
+                  },
+              ]),
         { title: 'Settings', path: `${basePath}/settings`, name: 'Settings' },
         {
             title: 'Event log',

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -71,6 +71,7 @@ export type UiFlags = {
     executiveDashboardUI?: boolean;
     feedbackComments?: Variant;
     displayUpgradeEdgeBanner?: boolean;
+    hideFeatureEnvironmentVariants?: boolean;
     showInactiveUsers?: boolean;
     featureSearchFeedbackPosting?: boolean;
     userAccessUIEnabled?: boolean;

--- a/src/lib/db/feature-environment-store.ts
+++ b/src/lib/db/feature-environment-store.ts
@@ -490,4 +490,12 @@ export class FeatureEnvironmentStore implements IFeatureEnvironmentStore {
             );
         }
     }
+
+    async variantExists(): Promise<boolean> {
+        const result = await this.db.raw(
+            `SELECT EXISTS (SELECT 1 FROM ${T.featureEnvs} WHERE variants <> '[]'::jsonb) AS present`,
+        );
+        const { present } = result.rows[0];
+        return present;
+    }
 }

--- a/src/lib/features/metrics/instance/instance-service.test.ts
+++ b/src/lib/features/metrics/instance/instance-service.test.ts
@@ -8,6 +8,7 @@ import FakeClientMetricsStoreV2 from '../client-metrics/fake-client-metrics-stor
 import FakeStrategiesStore from '../../../../test/fixtures/fake-strategies-store';
 import FakeFeatureToggleStore from '../../feature-toggle/fakes/fake-feature-toggle-store';
 import type { IApplicationOverview } from './models';
+import FakeFeatureEnvironmentStore from '../../../../test/fixtures/fake-feature-environment-store';
 
 let config: IUnleashConfig;
 beforeAll(() => {
@@ -29,6 +30,7 @@ test('Multiple registrations of same appname and instanceid within same time per
             featureToggleStore: new FakeFeatureToggleStore(),
             clientApplicationsStore,
             clientInstanceStore,
+            featureEnvironmentStore: new FakeFeatureEnvironmentStore(),
             eventStore: new FakeEventStore(),
         },
         config,
@@ -79,6 +81,7 @@ test('Multiple unique clients causes multiple registrations', async () => {
             featureToggleStore: new FakeFeatureToggleStore(),
             clientApplicationsStore,
             clientInstanceStore,
+            featureEnvironmentStore: new FakeFeatureEnvironmentStore(),
             eventStore: new FakeEventStore(),
         },
         config,
@@ -129,6 +132,7 @@ test('Same client registered outside of dedup interval will be registered twice'
             featureToggleStore: new FakeFeatureToggleStore(),
             clientApplicationsStore,
             clientInstanceStore,
+            featureEnvironmentStore: new FakeFeatureEnvironmentStore(),
             eventStore: new FakeEventStore(),
         },
         config,
@@ -179,6 +183,7 @@ test('No registrations during a time period will not call stores', async () => {
             featureToggleStore: new FakeFeatureToggleStore(),
             clientApplicationsStore,
             clientInstanceStore,
+            featureEnvironmentStore: new FakeFeatureEnvironmentStore(),
             eventStore: new FakeEventStore(),
         },
         config,

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -1,6 +1,9 @@
 import { APPLICATION_CREATED, CLIENT_REGISTER } from '../../../types/events';
 import type { IApplication, IApplicationOverview } from './models';
-import type { IUnleashStores } from '../../../types/stores';
+import type {
+    IFeatureEnvironmentStore,
+    IUnleashStores,
+} from '../../../types/stores';
 import type { IUnleashConfig } from '../../../types/option';
 import type { IEventStore } from '../../../types/stores/event-store';
 import type {
@@ -46,6 +49,8 @@ export default class ClientInstanceService {
 
     private privateProjectChecker: IPrivateProjectChecker;
 
+    private featureEnvironmentStore: IFeatureEnvironmentStore;
+
     private flagResolver: IFlagResolver;
 
     constructor(
@@ -55,6 +60,7 @@ export default class ClientInstanceService {
             featureToggleStore,
             clientInstanceStore,
             clientApplicationsStore,
+            featureEnvironmentStore,
             eventStore,
         }: Pick<
             IUnleashStores,
@@ -63,6 +69,7 @@ export default class ClientInstanceService {
             | 'featureToggleStore'
             | 'clientApplicationsStore'
             | 'clientInstanceStore'
+            | 'featureEnvironmentStore'
             | 'eventStore'
         >,
         {
@@ -78,6 +85,7 @@ export default class ClientInstanceService {
         this.clientInstanceStore = clientInstanceStore;
         this.eventStore = eventStore;
         this.privateProjectChecker = privateProjectChecker;
+        this.featureEnvironmentStore = featureEnvironmentStore;
         this.flagResolver = flagResolver;
         this.logger = getLogger(
             '/services/client-metrics/client-instance-service.ts',
@@ -293,5 +301,9 @@ export default class ClientInstanceService {
                 );
             }
         });
+    }
+
+    async usesFeatureEnvironmentVariants() {
+        return this.featureEnvironmentStore.variantExists();
     }
 }

--- a/src/lib/routes/admin-api/config.test.ts
+++ b/src/lib/routes/admin-api/config.test.ts
@@ -9,7 +9,7 @@ import {
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
 } from '../../util/segments';
 import type TestAgent from 'supertest/lib/agent';
-import type { IUnleashStores } from '../../types';
+import type { IUnleashStores, IVariant } from '../../types';
 
 const uiConfig = {
     headerBackground: 'red',
@@ -109,22 +109,21 @@ describe('hideFeatureEnvironmentVariants', () => {
         expect(body.flags.hideFeatureEnvironmentVariants).toEqual(true);
     });
     test('ui config should have hideFeatureEnvironmentVariants flag disabled if env variants are used', async () => {
+        const someVariant: IVariant = {
+            name: 'a',
+            weight: 1,
+            weightType: 'fix',
+            stickiness: 'default',
+        };
         await stores.featureEnvironmentStore.addEnvironmentToFeature(
-            'test',
-            'default',
+            'feature',
+            'production',
             true,
         );
         await stores.featureEnvironmentStore.addVariantsToFeatureEnvironment(
-            'test',
-            'default',
-            [
-                {
-                    name: 'a',
-                    weight: 1,
-                    weightType: 'fix',
-                    stickiness: 'default',
-                },
-            ],
+            'feature',
+            'production',
+            [someVariant],
         );
         const { body } = await request
             .get(`${base}/api/admin/ui-config`)

--- a/src/lib/routes/admin-api/config.test.ts
+++ b/src/lib/routes/admin-api/config.test.ts
@@ -99,16 +99,16 @@ describe('displayUpgradeEdgeBanner', () => {
     });
 });
 
-describe('displayFeatureEnvironmentVariants', () => {
-    test('ui config should have displayFeatureEnvironmentVariants flag disabled if no env variants are used', async () => {
+describe('hideFeatureEnvironmentVariants', () => {
+    test('ui config should have hideFeatureEnvironmentVariants flag enabled if no env variants are used', async () => {
         const { body } = await request
             .get(`${base}/api/admin/ui-config`)
             .expect('Content-Type', /json/)
             .expect(200);
         expect(body.flags).toBeTruthy();
-        expect(body.flags.displayFeatureEnvironmentVariants).toEqual(false);
+        expect(body.flags.hideFeatureEnvironmentVariants).toEqual(true);
     });
-    test('ui config should have displayFeatureEnvironmentVariants flag enabled if env variants are used', async () => {
+    test('ui config should have hideFeatureEnvironmentVariants flag disabled if env variants are used', async () => {
         await stores.featureEnvironmentStore.addEnvironmentToFeature(
             'test',
             'default',
@@ -131,6 +131,6 @@ describe('displayFeatureEnvironmentVariants', () => {
             .expect('Content-Type', /json/)
             .expect(200);
         expect(body.flags).toBeTruthy();
-        expect(body.flags.displayFeatureEnvironmentVariants).toEqual(true);
+        expect(body.flags.hideFeatureEnvironmentVariants).toEqual(false);
     });
 });

--- a/src/lib/routes/admin-api/config.test.ts
+++ b/src/lib/routes/admin-api/config.test.ts
@@ -98,3 +98,39 @@ describe('displayUpgradeEdgeBanner', () => {
         expect(body.flags.displayUpgradeEdgeBanner).toEqual(false);
     });
 });
+
+describe('displayFeatureEnvironmentVariants', () => {
+    test('ui config should have displayFeatureEnvironmentVariants flag disabled if no env variants are used', async () => {
+        const { body } = await request
+            .get(`${base}/api/admin/ui-config`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(body.flags).toBeTruthy();
+        expect(body.flags.displayFeatureEnvironmentVariants).toEqual(false);
+    });
+    test('ui config should have displayFeatureEnvironmentVariants flag enabled if env variants are used', async () => {
+        await stores.featureEnvironmentStore.addEnvironmentToFeature(
+            'test',
+            'default',
+            true,
+        );
+        await stores.featureEnvironmentStore.addVariantsToFeatureEnvironment(
+            'test',
+            'default',
+            [
+                {
+                    name: 'a',
+                    weight: 1,
+                    weightType: 'fix',
+                    stickiness: 'default',
+                },
+            ],
+        );
+        const { body } = await request
+            .get(`${base}/api/admin/ui-config`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(body.flags).toBeTruthy();
+        expect(body.flags.displayFeatureEnvironmentVariants).toEqual(true);
+    });
+});

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -167,7 +167,7 @@ class ConfigController extends Controller {
             displayUpgradeEdgeBanner:
                 usesOldEdge ||
                 this.config.flagResolver.isEnabled('displayEdgeBanner'),
-            displayFeatureEnvironmentVariants: usesFeatureEnvironmentVariants,
+            hideFeatureEnvironmentVariants: !usesFeatureEnvironmentVariants,
         };
 
         const response: UiConfigSchema = {

--- a/src/lib/types/stores/feature-environment-store.ts
+++ b/src/lib/types/stores/feature-environment-store.ts
@@ -86,4 +86,6 @@ export interface IFeatureEnvironmentStore
     ): Promise<void>;
 
     clonePreviousVariants(environment: string, project: string): Promise<void>;
+
+    variantExists(): Promise<boolean>;
 }

--- a/src/test/e2e/api/admin/config.e2e.test.ts
+++ b/src/test/e2e/api/admin/config.e2e.test.ts
@@ -99,11 +99,11 @@ test('sets ui config with frontendSettings', async () => {
         );
 });
 
-test('ui config should have displayFeatureEnvironmentVariants flag disabled if no env variants are used', async () => {
+test('ui config should have hideFeatureEnvironmentVariants flag enabled if no env variants are used', async () => {
     const { body } = await app.request
         .get('/api/admin/ui-config')
         .expect('Content-Type', /json/)
         .expect(200);
     expect(body.flags).toBeTruthy();
-    expect(body.flags.displayFeatureEnvironmentVariants).toEqual(false);
+    expect(body.flags.hideFeatureEnvironmentVariants).toEqual(true);
 });

--- a/src/test/e2e/api/admin/config.e2e.test.ts
+++ b/src/test/e2e/api/admin/config.e2e.test.ts
@@ -98,3 +98,12 @@ test('sets ui config with frontendSettings', async () => {
             expect(res.body.frontendApiOrigins).toEqual(frontendApiOrigins),
         );
 });
+
+test('ui config should have displayFeatureEnvironmentVariants flag disabled if no env variants are used', async () => {
+    const { body } = await app.request
+        .get('/api/admin/ui-config')
+        .expect('Content-Type', /json/)
+        .expect(200);
+    expect(body.flags).toBeTruthy();
+    expect(body.flags.displayFeatureEnvironmentVariants).toEqual(false);
+});

--- a/src/test/fixtures/fake-feature-environment-store.ts
+++ b/src/test/fixtures/fake-feature-environment-store.ts
@@ -245,4 +245,12 @@ export default class FakeFeatureEnvironmentStore
                 features.includes(featureEnv.featureName),
         );
     }
+
+    async variantExists() {
+        return this.featureEnvironments.some(
+            (featureEnvironment) =>
+                featureEnvironment.variants &&
+                featureEnvironment.variants.length > 0,
+        );
+    }
 }

--- a/website/docs/reference/feature-toggle-variants.md
+++ b/website/docs/reference/feature-toggle-variants.md
@@ -1,12 +1,17 @@
 ---
-title: Feature Toggle Variants
+title: Feature Toggle Variants (deprecated)
 ---
 :::info Availability
 
 **Feature toggle variants** were first introduced in Unleash 3.2.
+
 In Unleash 4.21, variants were updated to be **environment-dependent**, meaning the same feature could have different variant configurations in different environments.
 
+Unleash 6.0 deprecates environment-dependent variants in favor of the [strategy variants](./strategy-variants.md). New Unleash instances and those who never used environment variants will
+not show them in the UI. Instances that used environment variants will keep them.
+
 :::
+
 
 Every toggle in Unleash can have something called _variants_. Where _feature toggles_ allow you to decide which users get access to a feature, _toggle variants_ allow you to further split those users into segments. Say, for instance, that you're testing out a new feature, such as an alternate sign-up form. The feature toggle would expose the form only to a select group of users. The variants could decide whether the user sees a blue or a green submit button on that form.
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Variants tab will be hidden for new instances and those who have never used it before. You can still create feature env variants in the API and UI will respect it and show the UI. This is to encourage the usage of strategy variants.

Variants in this tab will be gone for some users
<img width="870" alt="Screenshot 2024-05-14 at 15 29 26" src="https://github.com/Unleash/unleash/assets/1394682/01c99420-0a55-44cc-b94f-f1d54bae8660">


Backend:
* backend returns `hideFeatureEnvironmentVariants` UI flag based on the DB check if the instance is not using feature environment variants
* feature environment variant check usage is optimized with the `SELECT EXISTS` and extra memoization every 10 minutes (similar solution we already for `displayUpgradeEdgeBanner`)
* `hideFeatureEnvironmentVariants` is added to `config.ts` similar to other instance configs
* I'm injecting `featureEnvironmentStore` to `config.ts` so that we can ask for the existence of the feature environment variants

Frontend:
* In the UI we're only hiding the tab with feature environment variants based on the backend flag. We may consider another flag to control this manually but for now I'd like to minimize the number of flags

Docs:
* I'm adding deprecation notice in the availability section and in the title. Maybe we need to make it even more salient?

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
