### PR TITLE
feat: deprecate feature toggle variants at environment level

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -48,6 +48,8 @@ import { ReactComponent as ParentLinkIcon } from 'assets/icons/link-parent.svg';
 import { ChildrenTooltip } from './FeatureOverview/FeatureOverviewMetaData/ChildrenTooltip';
 import copy from 'copy-to-clipboard';
 import useToast from 'hooks/useToast';
+import { useUiFlag } from 'hooks/useUiFlag';
+import type { IFeatureToggle } from 'interfaces/featureToggle';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -133,6 +135,14 @@ export const StyledLink = styled(Link)(({ theme }) => ({
     },
 }));
 
+const useLegacyVariants = (environments: IFeatureToggle['environments']) => {
+    const enableLegacyVariants = useUiFlag('enableLegacyVariants');
+    const existingLegacyVariantsExist = environments.some(
+        (environment) => environment.variants?.length,
+    );
+    return enableLegacyVariants || existingLegacyVariantsExist;
+};
+
 export const FeatureView = () => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -157,6 +167,8 @@ export const FeatureView = () => {
 
     const basePath = `/projects/${projectId}/features/${featureId}`;
 
+    const showLegacyVariants = useLegacyVariants(feature.environments);
+
     const tabData = [
         {
             title: 'Overview',
@@ -168,7 +180,15 @@ export const FeatureView = () => {
             path: `${basePath}/metrics`,
             name: 'Metrics',
         },
-        { title: 'Variants', path: `${basePath}/variants`, name: 'Variants' },
+        ...(showLegacyVariants
+            ? [
+                  {
+                      title: 'Variants',
+                      path: `${basePath}/variants`,
+                      name: 'Variants',
+                  },
+              ]
+            : []),
         { title: 'Settings', path: `${basePath}/settings`, name: 'Settings' },
         {
             title: 'Event log',

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -85,6 +85,7 @@ export type UiFlags = {
     projectsListNewCards?: boolean;
     newCreateProjectUI?: boolean;
     manyStrategiesPagination?: boolean;
+    enableLegacyVariants?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -93,6 +93,7 @@ exports[`should create default config 1`] = `
       "edgeBulkMetrics": false,
       "embedProxy": true,
       "embedProxyFrontend": true,
+      "enableLegacyVariants": false,
       "enableLicense": false,
       "enableLicenseChecker": false,
       "encryptEmails": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -60,7 +60,8 @@ export type IFlagKey =
     | 'parseProjectFromSession'
     | 'createProjectWithEnvironmentConfig'
     | 'manyStrategiesPagination'
-    | 'newCreateProjectUI';
+    | 'newCreateProjectUI'
+    | 'enableLegacyVariants';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -287,6 +288,10 @@ const flags: IFlags = {
     ),
     manyStrategiesPagination: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_MANY_STRATEGIES_PAGINATION,
+        false,
+    ),
+    enableLegacyVariants: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ENABLE_LEGACY_VARIANTS,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -55,6 +55,7 @@ process.nextTick(async () => {
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,
                         manyStrategiesPagination: true,
+                        enableLegacyVariants: false,
                     },
                 },
                 authentication: {

--- a/website/docs/reference/feature-toggle-variants.md
+++ b/website/docs/reference/feature-toggle-variants.md
@@ -1,6 +1,14 @@
 ---
-title: Feature Toggle Variants
+title: Feature Toggle Variants (deprecated)
 ---
+:::warning
+
+Feature Toggle Variants at the environment level are deprecated in favor of the [strategy variants](./strategy-variants.md). 
+Only features that have existing feature environment variants will keep them. 
+If you'd like to keep the old variants in your hosted instance [contact us](https://slack.unleash.run) for further assistance.
+
+:::
+
 :::info Availability
 
 **Feature toggle variants** were first introduced in Unleash 3.2.


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Variants tab will be hidden for new features and feature that don't use environment variants. 
We'd like to encourage the usage of the strategy variants. Env variants are still kept for the features that already use them for backwards compatibility.

Variants in this tab will be gone for new features and existing features without env variants
<img width="870" alt="Screenshot 2024-05-14 at 15 29 26" src="https://github.com/Unleash/unleash/assets/1394682/01c99420-0a55-44cc-b94f-f1d54bae8660">

We also have a sunset flag called "enableLegacyVariants" that can be used to enable environment variants even for the new features.

This PR also updates docs with a deprecation notice.

Next PR will be created to block environment variants in the backend API.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Original PR https://github.com/Unleash/unleash/pull/7054 was working at the instance level but we found that feature level deprecation is more versatile and simpler.