### PR TITLE
fix: new strategy using default strategy

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -119,6 +119,7 @@ export const FeatureStrategyCreate = () => {
     }, [
         featureId,
         JSON.stringify(strategyDefinition),
+        JSON.stringify(defaultStrategy),
         shouldUseDefaultStrategy,
     ]);
 

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.test.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.test.tsx
@@ -21,7 +21,7 @@ const RenderFallbackStrategy = () => {
 };
 
 test('should render default strategy from project', async () => {
-    testServerRoute(server, '/api/admin/projects/default', {
+    testServerRoute(server, '/api/admin/projects/default/overview', {
         environments: [
             {
                 environment: 'development',
@@ -35,7 +35,7 @@ test('should render default strategy from project', async () => {
 });
 
 test('should render fallback default strategy with project default stickiness', async () => {
-    testServerRoute(server, '/api/admin/projects/default', {
+    testServerRoute(server, '/api/admin/projects/default/overview', {
         defaultStickiness: 'clientId',
         environments: [],
     });
@@ -45,7 +45,7 @@ test('should render fallback default strategy with project default stickiness', 
 });
 
 test('should render fallback default strategy with no project default stickiness', async () => {
-    testServerRoute(server, '/api/admin/projects/default', {
+    testServerRoute(server, '/api/admin/projects/default/overview', {
         environments: [],
     });
     render(<RenderFallbackStrategy />);

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -18,14 +18,13 @@ import useProjectApi from 'hooks/api/actions/useProjectApi/useProjectApi';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { ProjectDefaultStrategyForm } from './ProjectDefaultStrategyForm';
 import type { CreateFeatureStrategySchema } from 'openapi';
-import useProject from 'hooks/api/getters/useProject/useProject';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const useDefaultStrategy = (
     projectId: string,
     environmentId: string,
 ) => {
-    const { project, refetch } = useProject(projectId);
+    const { project, refetch } = useProjectOverview(projectId);
 
     const defaultStrategyFallback = {
         name: 'flexibleRollout',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

First click on add strategy didn't respect the default strategy. Subsequent ones did. The reason for that is useEffect didn't observe the default strategy being updated from no strategy to actual strategy from the API. 

Also, updated useProject to useProjectOverview which is part of the useProject deprecation. They are almost the same. The only difference is project overview doesn't read all project features which we don't need here to read env default strategy. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Since we're observing all changes to the default strategy it means that if I'm editing a strategy and the default project environment strategy changes my edits are erased and I have to start from scratch. I'm assuming that default strategy changes are so rare it shouldn't be a problem and more complex logic is not justified.