### PR TITLE
Update app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "13"
+        "version": "14"
       }
     }
   ]


### PR DESCRIPTION
Getting this error when deploying to Heroku: 

```
We tried to create heroku-postgresql:essential-0, but received an error from the add-on provider. Try the request again, or log a support ticket and include this message: Unsupported version: 13. We support the following versions: 14, 15, 16
```

This PR upgrades the postgres version to 14