### PR TITLE
fix: make numbers in chart to locale string

### DIFF
--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
@@ -112,23 +112,23 @@ export const MetricsSummaryTooltip: VFC<{ tooltip: TooltipState | null }> = ({
                     />
                     <InfoLine
                         iconChar={'▣ '}
-                        title={`Total requests: ${
-                            point.value.totalRequests.toLocaleString() ?? 0
-                        }`}
+                        title={`Total requests: ${(
+                            point.value.totalRequests ?? 0
+                        ).toLocaleString()}`}
                         color={'info'}
                     />
                     <InfoLine
                         iconChar={'▲ '}
-                        title={`Exposed: ${
-                            point.value.totalYes.toLocaleString() ?? 0
-                        }`}
+                        title={`Exposed: ${(
+                            point.value.totalYes ?? 0
+                        ).toLocaleString()}`}
                         color={'success'}
                     />
                     <InfoLine
                         iconChar={'▼ '}
-                        title={`Not exposed: ${
-                            point.value.totalNo.toLocaleString() ?? 0
-                        }`}
+                        title={`Not exposed: ${(
+                            point.value.totalNo ?? 0
+                        ).toLocaleString()}`}
                         color={'error'}
                     />
                     <ConditionallyRender

--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
@@ -113,18 +113,22 @@ export const MetricsSummaryTooltip: VFC<{ tooltip: TooltipState | null }> = ({
                     <InfoLine
                         iconChar={'▣ '}
                         title={`Total requests: ${
-                            point.value.totalRequests ?? 0
+                            point.value.totalRequests.toLocaleString() ?? 0
                         }`}
                         color={'info'}
                     />
                     <InfoLine
                         iconChar={'▲ '}
-                        title={`Exposed: ${point.value.totalYes ?? 0}`}
+                        title={`Exposed: ${
+                            point.value.totalYes.toLocaleString() ?? 0
+                        }`}
                         color={'success'}
                     />
                     <InfoLine
                         iconChar={'▼ '}
-                        title={`Not exposed: ${point.value.totalNo ?? 0}`}
+                        title={`Not exposed: ${
+                            point.value.totalNo.toLocaleString() ?? 0
+                        }`}
                         color={'error'}
                     />
                     <ConditionallyRender


### PR DESCRIPTION
To get correct formatting to number, in our codebase we call toLocaleString(). Added it also to this component.

From

![image (20)](https://github.com/Unleash/unleash/assets/964450/f941a592-4b86-4b64-99c5-4e7e5d4ccaf2)

To 

![Screenshot from 2024-05-20 14-06-19](https://github.com/Unleash/unleash/assets/964450/abac4570-30be-4fa4-a6fd-24b3f70902e0)

