### PR TITLE
fix: deprecate useProjectNameOrId

### DIFF
--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
@@ -1,15 +1,15 @@
 import { usePageTitle } from 'hooks/usePageTitle';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
 import { ChangeRequestsTabs } from './ChangeRequestsTabs/ChangeRequestsTabs';
 import { useProjectChangeRequests } from 'hooks/api/getters/useProjectChangeRequests/useProjectChangeRequests';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const ProjectChangeRequests = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     const { isOss, isPro } = useUiConfig();
 
     usePageTitle(`Change requests – ${projectName}`);

--- a/frontend/src/component/project/Project/ProjectFeaturesArchive/ProjectFeaturesArchive.tsx
+++ b/frontend/src/component/project/Project/ProjectFeaturesArchive/ProjectFeaturesArchive.tsx
@@ -1,11 +1,11 @@
 import { ProjectFeaturesArchiveTable } from 'component/archive/ProjectFeaturesArchiveTable';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const ProjectFeaturesArchive = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     usePageTitle(`Project archive – ${projectName}`);
 
     return <ProjectFeaturesArchiveTable projectId={projectId} />;

--- a/frontend/src/component/project/Project/ProjectHealth/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectHealth/ProjectHealth.tsx
@@ -5,11 +5,11 @@ import { usePageTitle } from 'hooks/usePageTitle';
 import { ReportCard } from './ReportTable/ReportCard/ReportCard';
 import { ReportTable } from './ReportTable/ReportTable';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 const ProjectHealth = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     usePageTitle(`Project health – ${projectName}`);
 
     const { healthReport, refetchHealthReport, error } = useHealthReport(

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestConfiguration.tsx
@@ -10,14 +10,14 @@ import {
 } from 'component/providers/AccessProvider/permissions';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
 import { ChangeRequestTable } from './ChangeRequestTable';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { ChangeRequestProcessHelp } from './ChangeRequestProcessHelp/ChangeRequestProcessHelp';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const ChangeRequestConfiguration = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     const { hasAccess } = useContext(AccessContext);
     const { isOss, isPro } = useUiConfig();
 

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSegments/ProjectSegments.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSegments/ProjectSegments.tsx
@@ -3,7 +3,6 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
 import { SegmentTable } from 'component/segments/SegmentTable/SegmentTable';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { Route, Routes, useNavigate } from 'react-router-dom';
@@ -11,10 +10,11 @@ import { CreateSegment } from 'component/segments/CreateSegment/CreateSegment';
 import { EditSegment } from 'component/segments/EditSegment/EditSegment';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { GO_BACK } from 'constants/navigate';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const ProjectSegments = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     const { isOss } = useUiConfig();
     const navigate = useNavigate();
 

--- a/frontend/src/component/project/ProjectAccess/ProjectAccess.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccess.tsx
@@ -11,12 +11,12 @@ import {
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { ProjectAccessTable } from 'component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable';
-import { useProjectNameOrId } from 'hooks/api/getters/useProject/useProject';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
+import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
 export const ProjectAccess = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     const { hasAccess } = useContext(AccessContext);
     const { isOss } = useUiConfig();
     usePageTitle(`Project access – ${projectName}`);

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -6,9 +6,7 @@ import { UPDATE_PROJECT } from 'component/providers/AccessProvider/permissions';
 import ApiError from 'component/common/ApiError/ApiError';
 import useToast from 'hooks/useToast';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import useProject, {
-    useProjectNameOrId,
-} from 'hooks/api/getters/useProject/useProject';
+import useProject from 'hooks/api/getters/useProject/useProject';
 import { Alert, styled, TableBody, TableRow } from '@mui/material';
 import useProjectApi from 'hooks/api/actions/useProjectApi/useProjectApi';
 import { Link } from 'react-router-dom';
@@ -17,7 +15,7 @@ import type { IProjectEnvironment } from 'interfaces/environments';
 import { getEnabledEnvs } from './helpers';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useTable, useGlobalFilter } from 'react-table';
+import { useGlobalFilter, useTable } from 'react-table';
 import {
     SortableTableHeader,
     Table,
@@ -32,6 +30,7 @@ import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { EnvironmentHideDialog } from './EnvironmentHideDialog/EnvironmentHideDialog';
 import { useProjectEnvironments } from 'hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
+import { useProjectOverviewNameOrId } from '../../../hooks/api/getters/useProjectOverview/useProjectOverview';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(4),
@@ -52,7 +51,7 @@ const StyledApiError = styled(ApiError)(({ theme }) => ({
 
 const ProjectEnvironmentList = () => {
     const projectId = useRequiredPathParam('projectId');
-    const projectName = useProjectNameOrId(projectId);
+    const projectName = useProjectOverviewNameOrId(projectId);
     usePageTitle(`Project environments – ${projectName}`);
 
     // api state

--- a/frontend/src/hooks/api/getters/useProject/useProject.ts
+++ b/frontend/src/hooks/api/getters/useProject/useProject.ts
@@ -51,12 +51,5 @@ const useProject = (id: string, options: SWRConfiguration = {}) => {
         refetch,
     };
 };
-/**
- * @deprecated It is recommended to use useProjectOverviewNameOrId instead, unless you need project features.
- * In that case, we probably should create a project features endpoint and use that instead if features needed.
- */
-export const useProjectNameOrId = (id: string): string => {
-    return useProject(id).project.name || id;
-};
 
 export default useProject;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

`useProjectNameOrId` calls `useProject` under the hood. We use the `useProjectNameOrId` to get page titles so we don't need to fetch all features. Also we gonna remove `useProject` soon so it's a step in this direction. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
