### PR TITLE
feat: add global isAdmin method for access service

### DIFF
--- a/src/lib/features/access/createAccessService.ts
+++ b/src/lib/features/access/createAccessService.ts
@@ -12,7 +12,7 @@ import FakeRoleStore from '../../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../project-environments/fake-environment-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
-import type { IEventStore } from '../../types';
+import type { IAccessStore, IEventStore, IRoleStore } from '../../types';
 import { createEventsService } from '../events/createEventsService';
 
 export const createAccessService = (
@@ -42,7 +42,12 @@ export const createAccessService = (
 
 export const createFakeAccessService = (
     config: IUnleashConfig,
-): { accessService: AccessService; eventStore: IEventStore } => {
+): {
+    accessService: AccessService;
+    eventStore: IEventStore;
+    accessStore: IAccessStore;
+    roleStore: IRoleStore;
+} => {
     const { getLogger, flagResolver } = config;
     const eventStore = new FakeEventStore();
     const groupStore = new FakeGroupStore();
@@ -71,5 +76,7 @@ export const createFakeAccessService = (
     return {
         accessService,
         eventStore,
+        accessStore,
+        roleStore,
     };
 };

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -294,7 +294,7 @@ test('should return true if user has admin role', async () => {
         .fn()
         .mockResolvedValue([{ id: 1, name: 'ADMIN', type: 'custom' }]);
 
-    const result = await accessService.isAdmin(userId);
+    const result = await accessService.isRootAdmin(userId);
 
     expect(result).toBe(true);
     expect(accessStore.getRolesForUserId).toHaveBeenCalledWith(userId);
@@ -308,7 +308,7 @@ test('should return false if user does not have admin role', async () => {
         .fn()
         .mockResolvedValue([{ id: 2, name: 'user', type: 'custom' }]);
 
-    const result = await accessService.isAdmin(userId);
+    const result = await accessService.isRootAdmin(userId);
 
     expect(result).toBe(false);
     expect(accessStore.getRolesForUserId).toHaveBeenCalledWith(userId);

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -285,3 +285,31 @@ describe('addAccessToProject', () => {
         ).rejects.toThrow(BadDataError);
     });
 });
+
+test('should return true if user has admin role', async () => {
+    const { accessService, accessStore } = getSetup();
+
+    const userId = 1;
+    accessStore.getRolesForUserId = jest
+        .fn()
+        .mockResolvedValue([{ id: 1, name: 'ADMIN', type: 'custom' }]);
+
+    const result = await accessService.isAdmin(userId);
+
+    expect(result).toBe(true);
+    expect(accessStore.getRolesForUserId).toHaveBeenCalledWith(userId);
+});
+
+test('should return false if user does not have admin role', async () => {
+    const { accessService, accessStore } = getSetup();
+
+    const userId = 2;
+    accessStore.getRolesForUserId = jest
+        .fn()
+        .mockResolvedValue([{ id: 2, name: 'user', type: 'custom' }]);
+
+    const result = await accessService.isAdmin(userId);
+
+    expect(result).toBe(false);
+    expect(accessStore.getRolesForUserId).toHaveBeenCalledWith(userId);
+});

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -887,4 +887,11 @@ export class AccessService {
     async getUserAccessOverview(): Promise<IUserAccessOverview[]> {
         return this.store.getUserAccessOverview();
     }
+
+    async isAdmin(userId: number): Promise<boolean> {
+        const roles = await this.store.getRolesForUserId(userId);
+        return roles.some(
+            (role) => role.name.toLowerCase() === ADMIN.toLowerCase(),
+        );
+    }
 }

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -888,7 +888,7 @@ export class AccessService {
         return this.store.getUserAccessOverview();
     }
 
-    async isAdmin(userId: number): Promise<boolean> {
+    async isRootAdmin(userId: number): Promise<boolean> {
         const roles = await this.store.getRolesForUserId(userId);
         return roles.some(
             (role) => role.name.toLowerCase() === ADMIN.toLowerCase(),


### PR DESCRIPTION
This is preparation, so we do not need to define an `isAdmin` method in the change request context.