### PR TITLE
fix: also check includedTraffic before calculating overage and showing warning

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -257,20 +257,23 @@ export const NetworkTrafficUsage: VFC = () => {
     useEffect(() => {
         if (data) {
             const usage = toTrafficUsageSum(data.datasets);
-            const calculatedOverageCost = calculateOverageCost(
-                usage,
-                includedTraffic,
-            );
             setUsageTotal(usage);
-            setOverageCost(calculatedOverageCost);
-            setEstimatedMonthlyCost(
-                calculateEstimatedMonthlyCost(
-                    period,
-                    data.datasets,
+            if (includedTraffic > 0) {
+                const calculatedOverageCost = calculateOverageCost(
+                    usage,
                     includedTraffic,
-                    new Date(),
-                ),
-            );
+                );
+                setOverageCost(calculatedOverageCost);
+
+                setEstimatedMonthlyCost(
+                    calculateEstimatedMonthlyCost(
+                        period,
+                        data.datasets,
+                        includedTraffic,
+                        new Date(),
+                    ),
+                );
+            }
         }
     }, [data]);
 
@@ -281,7 +284,7 @@ export const NetworkTrafficUsage: VFC = () => {
             elseShow={
                 <>
                     <ConditionallyRender
-                        condition={overageCost > 0}
+                        condition={includedTraffic > 0 && overageCost > 0}
                         show={
                             <Alert severity='warning' sx={{ mb: 4 }}>
                                 <b>Heads up!</b> You are currently consuming


### PR DESCRIPTION
## About the changes

Fixes a bug that would display the overage warning on network/traffic-usage when included traffic was 0. (it assumed all traffic was overage)

![image](https://github.com/Unleash/unleash/assets/707867/793f8cb2-7c1d-4f67-b0e9-45c32fcb78e6)
