### PR TITLE
fix: don't send change request info unless using the new form

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -75,11 +75,16 @@ export const CreateProjectDialogue = ({
     const clearDocumentationOverride = () =>
         setDocumentation(generalDocumentation);
 
+    const projectPayload = getCreateProjectPayload({
+        omitId: true,
+        includeChangeRequestConfig: true,
+    });
+
     const formatApiCode = () => {
         return `curl --location --request POST '${uiConfig.unleashUrl}/api/admin/projects' \\
 --header 'Authorization: INSERT_API_KEY' \\
 --header 'Content-Type: application/json' \\
---data-raw '${JSON.stringify(getCreateProjectPayload(), undefined, 2)}'`;
+--data-raw '${JSON.stringify(projectPayload, undefined, 2)}'`;
     };
 
     const handleSubmit = async (e: Event) => {
@@ -88,11 +93,8 @@ export const CreateProjectDialogue = ({
         const validName = validateName();
 
         if (validName) {
-            const payload = getCreateProjectPayload({
-                omitId: true,
-            });
             try {
-                const createdProject = await createProject(payload);
+                const createdProject = await createProject(projectPayload);
                 refetchUser();
                 navigate(`/projects/${createdProject.id}`, { replace: true });
                 setToastData({

--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useProjectForm from './useProjectForm';
+import { vi } from 'vitest';
 
 test('setting project environments removes any change request envs that are not in the new project env list', () => {
     const { result } = renderHook(() => useProjectForm());
@@ -34,4 +35,56 @@ test(`adding a change request config for an env not in the project envs doesn't 
     expect(
         'dev' in result.current.projectChangeRequestConfiguration,
     ).toBeFalsy();
+});
+
+describe('payload generation', () => {
+    test(`change request env info is not included unless asked for specifically`, () => {
+        vi.mock(
+            'hooks/api/getters/useUiConfig/useUiConfig',
+            async (importOriginal) => {
+                const actual = await importOriginal();
+                return {
+                    //@ts-ignore
+                    ...actual,
+                    useUiConfig: () => ({
+                        isEnterprise: () => true,
+                    }),
+                };
+            },
+        );
+
+        const { result } = renderHook(() => useProjectForm());
+
+        const payloadWithoutCrs = result.current.getCreateProjectPayload();
+        expect('changeRequestEnvironments' in payloadWithoutCrs).toBeFalsy();
+
+        const payloadWithCrs = result.current.getCreateProjectPayload({
+            includeChangeRequestConfig: true,
+        });
+        expect('changeRequestEnvironments' in payloadWithCrs).toBeTruthy();
+    });
+
+    test(`id is omitted only when explicitly asked to be`, () => {
+        const { result } = renderHook(() => useProjectForm());
+
+        const payloadWithId = result.current.getCreateProjectPayload();
+        expect('id' in payloadWithId).toBeTruthy();
+
+        const payloadWithoutId = result.current.getCreateProjectPayload({
+            omitId: true,
+        });
+        expect('id' in payloadWithoutId).toBeFalsy();
+    });
+});
+
+describe('name validation', () => {
+    test.each([
+        ['An empty string', ''],
+        ['Just whitespace', '     '],
+    ])(`%s is not valid`, (_, value) => {
+        const { result } = renderHook(() => useProjectForm());
+
+        result.current.setProjectName(value);
+        expect(result.current.validateName()).toBeFalsy();
+    });
 });

--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useProjectForm from './useProjectForm';
-import { vi } from 'vitest';
 
 test('setting project environments removes any change request envs that are not in the new project env list', () => {
     const { result } = renderHook(() => useProjectForm());
@@ -38,32 +37,6 @@ test(`adding a change request config for an env not in the project envs doesn't 
 });
 
 describe('payload generation', () => {
-    test(`change request env info is not included unless asked for specifically`, () => {
-        vi.mock(
-            'hooks/api/getters/useUiConfig/useUiConfig',
-            async (importOriginal) => {
-                const actual = await importOriginal();
-                return {
-                    //@ts-ignore
-                    ...actual,
-                    useUiConfig: () => ({
-                        isEnterprise: () => true,
-                    }),
-                };
-            },
-        );
-
-        const { result } = renderHook(() => useProjectForm());
-
-        const payloadWithoutCrs = result.current.getCreateProjectPayload();
-        expect('changeRequestEnvironments' in payloadWithoutCrs).toBeFalsy();
-
-        const payloadWithCrs = result.current.getCreateProjectPayload({
-            includeChangeRequestConfig: true,
-        });
-        expect('changeRequestEnvironments' in payloadWithCrs).toBeTruthy();
-    });
-
     test(`id is omitted only when explicitly asked to be`, () => {
         const { result } = renderHook(() => useProjectForm());
 

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -18,7 +18,7 @@ const useProjectForm = (
         { requiredApprovals: number }
     > = {},
 ) => {
-    const { isEnterprise } = useUiConfig();
+    const { isEnterprise, ...rest } = useUiConfig();
     const [projectId, setProjectId] = useState(initialProjectId);
     const [projectMode, setProjectMode] =
         useState<ProjectMode>(initialProjectMode);
@@ -66,6 +66,8 @@ const useProjectForm = (
         },
     };
 
+    console.log('is enterprise?', isEnterprise(), rest);
+
     const [errors, setErrors] = useState({});
 
     const { validateId } = useProjectApi();
@@ -94,7 +96,10 @@ const useProjectForm = (
         setProjectMode(initialProjectMode);
     }, [initialProjectMode]);
 
-    const getCreateProjectPayload = (options?: { omitId?: boolean }) => {
+    const getCreateProjectPayload = (options?: {
+        omitId?: boolean;
+        includeChangeRequestConfig?: boolean;
+    }) => {
         const environmentsPayload =
             projectEnvironments.size > 0
                 ? { environments: [...projectEnvironments] }
@@ -119,7 +124,9 @@ const useProjectForm = (
             ? {
                   ...ossPayload,
                   mode: projectMode,
-                  changeRequestEnvironments,
+                  ...(options?.includeChangeRequestConfig
+                      ? { changeRequestEnvironments }
+                      : {}),
               }
             : ossPayload;
     };

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -18,7 +18,7 @@ const useProjectForm = (
         { requiredApprovals: number }
     > = {},
 ) => {
-    const { isEnterprise, ...rest } = useUiConfig();
+    const { isEnterprise } = useUiConfig();
     const [projectId, setProjectId] = useState(initialProjectId);
     const [projectMode, setProjectMode] =
         useState<ProjectMode>(initialProjectMode);
@@ -65,8 +65,6 @@ const useProjectForm = (
             }
         },
     };
-
-    console.log('is enterprise?', isEnterprise(), rest);
 
     const [errors, setErrors] = useState({});
 


### PR DESCRIPTION
I realized that, in an oversight, the form now shows and sends project CR config, even if the new form isn't active. The API just ignores it if it doesn't understand it, so it's not very harmful, but it's better if we don't send it at all. This PR does that.

It does not actually test that change request info isn't included (but it does test ID inclusion). This is because:
- change request info is only included if we're enterprise. The rendered version of the hook isn't by default.
- Setting up module mocking and making it work seems like a lot of work for a small gain, considering we're probably going to be removing the old form anyway.
- I've tested it locally.

Also adds some testing for the hook related to name validation and payload creation