### PR TITLE
fix: set min-height on dropdown item list

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
@@ -15,6 +15,7 @@ export const StyledListItem = styled(ListItem)(({ theme }) => ({
         backgroundColor: theme.palette.action.hover,
         outline: 'none',
     },
+    minHeight: theme.spacing(4.5),
 }));
 
 export const StyledCheckbox = styled(Checkbox)(({ theme }) => ({


### PR DESCRIPTION
This ensures that the dropdown items without checkbox are the same height as the dropdown items with checkbox.