### PR TITLE
fix: add descriptions to selection button dropdowns

### DIFF
--- a/frontend/src/assets/icons/projectIconSmall.svg
+++ b/frontend/src/assets/icons/projectIconSmall.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="37" height="35" viewBox="0 0 37 35" fill="none">
-    <rect x="8.9864" y="9.93245" width="3.78378" height="13.2432" rx="1.41892" fill="#6C65E5" stroke="#6C65E5" stroke-width="0.945947" />
-    <rect x="16.5542" y="13.7161" width="3.78378" height="9.45946" rx="1.41892" fill="#6C65E5" stroke="#6C65E5" stroke-width="0.945947" />
-    <rect x="24.1217" y="18.4456" width="3.78378" height="4.72973" rx="1.41892" fill="#6C65E5" stroke="#6C65E5" stroke-width="0.945947" />
+    <rect x="8.9864" y="9.93245" width="3.78378" height="13.2432" rx="1.41892" stroke-width="0.945947" />
+    <rect x="16.5542" y="13.7161" width="3.78378" height="9.45946" rx="1.41892" stroke-width="0.945947" />
+    <rect x="24.1217" y="18.4456" width="3.78378" height="4.72973" rx="1.41892" stroke-width="0.945947" />
 </svg>

--- a/frontend/src/assets/icons/projectIconSmall.svg
+++ b/frontend/src/assets/icons/projectIconSmall.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="37" height="35" viewBox="0 0 37 35" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" focusable='false' aria-hidden='true' width="37" height="35" viewBox="0 0 37 35" fill="none">
     <rect x="8.9864" y="9.93245" width="3.78378" height="13.2432" rx="1.41892" stroke-width="0.945947" />
     <rect x="16.5542" y="13.7161" width="3.78378" height="9.45946" rx="1.41892" stroke-width="0.945947" />
     <rect x="24.1217" y="18.4456" width="3.78378" height="4.72973" rx="1.41892" stroke-width="0.945947" />

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -174,7 +174,7 @@ const StyledDescriptionCard = styled('article')(({ theme }) => ({
     zIndex: 1,
     color: theme.palette.common.white,
     position: 'relative',
-    margin: theme.spacing(3, 0),
+    marginBlockEnd: theme.spacing(3),
 }));
 
 const StyledDescription = styled('p')(({ theme }) => ({

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -24,7 +24,8 @@ interface ICreateProps {
     title?: ReactNode;
     description: string;
     documentationLink: string;
-    documentationLinkLabel: string;
+    documentationIcon?: ReactNode;
+    documentationLinkLabel?: string;
     loading?: boolean;
     modal?: boolean;
     disablePadding?: boolean;
@@ -165,10 +166,18 @@ const StyledSidebar = styled('aside')(({ theme }) => ({
     },
 }));
 
-const StyledDescription = styled('p')(({ theme }) => ({
-    color: theme.palette.common.white,
+const StyledDescriptionCard = styled('article')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    gap: theme.spacing(2),
+    alignItems: 'center',
     zIndex: 1,
+    color: theme.palette.common.white,
     position: 'relative',
+}));
+
+const StyledDescription = styled('p')(({ theme }) => ({
+    width: '100%',
 }));
 
 const StyledLinkContainer = styled('div')(({ theme }) => ({
@@ -195,6 +204,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
     description,
     children,
     documentationLink,
+    documentationIcon,
     documentationLinkLabel,
     loading,
     modal,
@@ -261,6 +271,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
                     <StyledRelativeDiv>
                         <MobileGuidance
                             description={description}
+                            documentationIcon={documentationIcon}
                             documentationLink={documentationLink}
                             documentationLinkLabel={documentationLinkLabel}
                         />
@@ -300,6 +311,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
                 condition={showGuidance && !smallScreen}
                 show={
                     <Guidance
+                        documentationIcon={documentationIcon}
                         description={description}
                         documentationLink={documentationLink}
                         documentationLinkLabel={documentationLinkLabel}
@@ -318,8 +330,9 @@ const FormTemplate: React.FC<ICreateProps> = ({
 };
 
 interface IMobileGuidance {
-    description: string;
+    description: ReactNode;
     documentationLink: string;
+    documentationIcon?: ReactNode;
     documentationLinkLabel?: string;
 }
 
@@ -327,6 +340,7 @@ const MobileGuidance = ({
     description,
     documentationLink,
     documentationLinkLabel,
+    documentationIcon,
 }: IMobileGuidance) => {
     const [open, setOpen] = useState(false);
 
@@ -345,6 +359,7 @@ const MobileGuidance = ({
             </Tooltip>
             <Collapse in={open} timeout={500}>
                 <Guidance
+                    documentationIcon={documentationIcon}
                     description={description}
                     documentationLink={documentationLink}
                     documentationLinkLabel={documentationLinkLabel}
@@ -356,6 +371,7 @@ const MobileGuidance = ({
 
 interface IGuidanceProps {
     description: string;
+    documentationIcon?: ReactNode;
     documentationLink: string;
     documentationLinkLabel?: string;
     showDescription?: boolean;
@@ -366,6 +382,7 @@ const Guidance: React.FC<IGuidanceProps> = ({
     description,
     children,
     documentationLink,
+    documentationIcon,
     documentationLinkLabel = 'Learn more',
     showDescription = true,
     showLink = true,
@@ -374,7 +391,15 @@ const Guidance: React.FC<IGuidanceProps> = ({
         <StyledSidebar>
             <ConditionallyRender
                 condition={showDescription}
-                show={<StyledDescription>{description}</StyledDescription>}
+                show={
+                    <StyledDescriptionCard>
+                        <ConditionallyRender
+                            condition={!!documentationIcon}
+                            show={documentationIcon}
+                        />
+                        <StyledDescription>{description}</StyledDescription>
+                    </StyledDescriptionCard>
+                }
             />
 
             <ConditionallyRender

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -174,8 +174,7 @@ const StyledDescriptionCard = styled('article')(({ theme }) => ({
     zIndex: 1,
     color: theme.palette.common.white,
     position: 'relative',
-    paddingBlock: theme.spacing(4),
-    minHeight: '13rem',
+    margin: theme.spacing(3, 0),
 }));
 
 const StyledDescription = styled('p')(({ theme }) => ({
@@ -183,7 +182,7 @@ const StyledDescription = styled('p')(({ theme }) => ({
 }));
 
 const StyledLinkContainer = styled('div')(({ theme }) => ({
-    // margin: theme.spacing(3, 0),
+    margin: theme.spacing(3, 0),
     display: 'flex',
     alignItems: 'center',
     width: '100%',
@@ -363,7 +362,6 @@ const MobileGuidance = ({
             <Collapse in={open} timeout={500}>
                 <Guidance
                     documentationIcon={documentationIcon}
-                    showLink={!!documentationLink}
                     description={description}
                     documentationLink={documentationLink}
                     documentationLinkLabel={documentationLinkLabel}
@@ -402,26 +400,25 @@ const Guidance: React.FC<IGuidanceProps> = ({
                             show={documentationIcon}
                         />
                         <StyledDescription>{description}</StyledDescription>
-
-                        <ConditionallyRender
-                            condition={showLink && !!documentationLink}
-                            show={
-                                <StyledLinkContainer>
-                                    <StyledLinkIcon />
-                                    <StyledDocumentationLink
-                                        href={documentationLink}
-                                        rel='noopener noreferrer'
-                                        target='_blank'
-                                    >
-                                        {documentationLinkLabel}
-                                    </StyledDocumentationLink>
-                                </StyledLinkContainer>
-                            }
-                        />
                     </StyledDescriptionCard>
                 }
             />
 
+            <ConditionallyRender
+                condition={showLink && !!documentationLink}
+                show={
+                    <StyledLinkContainer>
+                        <StyledLinkIcon />
+                        <StyledDocumentationLink
+                            href={documentationLink}
+                            rel='noopener noreferrer'
+                            target='_blank'
+                        >
+                            {documentationLinkLabel}
+                        </StyledDocumentationLink>
+                    </StyledLinkContainer>
+                }
+            />
             {children}
         </StyledSidebar>
     );

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -23,7 +23,7 @@ import { relative } from 'themes/themeStyles';
 interface ICreateProps {
     title?: ReactNode;
     description: string;
-    documentationLink: string;
+    documentationLink?: string;
     documentationIcon?: ReactNode;
     documentationLinkLabel?: string;
     loading?: boolean;
@@ -174,6 +174,8 @@ const StyledDescriptionCard = styled('article')(({ theme }) => ({
     zIndex: 1,
     color: theme.palette.common.white,
     position: 'relative',
+    paddingBlock: theme.spacing(4),
+    minHeight: '13rem',
 }));
 
 const StyledDescription = styled('p')(({ theme }) => ({
@@ -181,9 +183,10 @@ const StyledDescription = styled('p')(({ theme }) => ({
 }));
 
 const StyledLinkContainer = styled('div')(({ theme }) => ({
-    margin: theme.spacing(3, 0),
+    // margin: theme.spacing(3, 0),
     display: 'flex',
     alignItems: 'center',
+    width: '100%',
 }));
 
 const StyledLinkIcon = styled(MenuBookIcon)(({ theme }) => ({
@@ -330,8 +333,8 @@ const FormTemplate: React.FC<ICreateProps> = ({
 };
 
 interface IMobileGuidance {
-    description: ReactNode;
-    documentationLink: string;
+    description: string;
+    documentationLink?: string;
     documentationIcon?: ReactNode;
     documentationLinkLabel?: string;
 }
@@ -360,6 +363,7 @@ const MobileGuidance = ({
             <Collapse in={open} timeout={500}>
                 <Guidance
                     documentationIcon={documentationIcon}
+                    showLink={!!documentationLink}
                     description={description}
                     documentationLink={documentationLink}
                     documentationLinkLabel={documentationLinkLabel}
@@ -372,7 +376,7 @@ const MobileGuidance = ({
 interface IGuidanceProps {
     description: string;
     documentationIcon?: ReactNode;
-    documentationLink: string;
+    documentationLink?: string;
     documentationLinkLabel?: string;
     showDescription?: boolean;
     showLink?: boolean;
@@ -398,23 +402,23 @@ const Guidance: React.FC<IGuidanceProps> = ({
                             show={documentationIcon}
                         />
                         <StyledDescription>{description}</StyledDescription>
-                    </StyledDescriptionCard>
-                }
-            />
 
-            <ConditionallyRender
-                condition={showLink}
-                show={
-                    <StyledLinkContainer>
-                        <StyledLinkIcon />
-                        <StyledDocumentationLink
-                            href={documentationLink}
-                            rel='noopener noreferrer'
-                            target='_blank'
-                        >
-                            {documentationLinkLabel}
-                        </StyledDocumentationLink>
-                    </StyledLinkContainer>
+                        <ConditionallyRender
+                            condition={showLink && !!documentationLink}
+                            show={
+                                <StyledLinkContainer>
+                                    <StyledLinkIcon />
+                                    <StyledDocumentationLink
+                                        href={documentationLink}
+                                        rel='noopener noreferrer'
+                                        target='_blank'
+                                    >
+                                        {documentationLinkLabel}
+                                    </StyledDocumentationLink>
+                                </StyledLinkContainer>
+                            }
+                        />
+                    </StyledDescriptionCard>
                 }
             />
 

--- a/frontend/src/component/project/NewProjectCard/NewProjectCard.styles.ts
+++ b/frontend/src/component/project/NewProjectCard/NewProjectCard.styles.ts
@@ -76,7 +76,8 @@ export const StyledParagraphInfo = styled('p')(({ theme }) => ({
 }));
 
 export const StyledProjectIcon = styled(ProjectIcon)(({ theme }) => ({
-    color: theme.palette.primary.main,
+    fill: theme.palette.primary.main,
+    stroke: theme.palette.primary.main,
 }));
 
 export const StyledIconBox = styled(Box)(({ theme }) => ({

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -1,5 +1,4 @@
 import { formatUnknownError } from 'utils/formatUnknownError';
-import StickinessIcon from '@mui/icons-material/FormatPaint';
 import useProjectApi from 'hooks/api/actions/useProjectApi/useProjectApi';
 import useToast from 'hooks/useToast';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
@@ -15,6 +14,7 @@ import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useNavigate } from 'react-router-dom';
 import { Button, Dialog, styled } from '@mui/material';
+import { ReactComponent as ProjectIcon } from 'assets/icons/projectIconSmall.svg';
 
 interface ICreateProjectDialogueProps {
     open: boolean;
@@ -35,6 +35,11 @@ const CREATE_PROJECT_BTN = 'CREATE_PROJECT_BTN';
 
 const StyledButton = styled(Button)(({ theme }) => ({
     marginLeft: theme.spacing(3),
+}));
+
+const StyledProjectIcon = styled(ProjectIcon)(({ theme }) => ({
+    fill: theme.palette.common.white,
+    stroke: theme.palette.common.white,
 }));
 
 export const CreateProjectDialogue = ({
@@ -69,8 +74,10 @@ export const CreateProjectDialogue = ({
         errors,
     } = useProjectForm();
 
-    const generalDocumentation =
-        'Projects allows you to group feature flags together in the management UI.';
+    const generalDocumentation = {
+        icon: <StyledProjectIcon />,
+        text: 'Projects allows you to group feature flags together in the management UI.',
+    };
 
     const [documentation, setDocumentation] = useState(generalDocumentation);
 
@@ -122,10 +129,10 @@ export const CreateProjectDialogue = ({
         <StyledDialog open={open} onClose={onClose}>
             <FormTemplate
                 disablePadding
-                description={documentation}
+                description={documentation.text}
+                documentationIcon={documentation.icon}
                 documentationLink='https://docs.getunleash.io/reference/projects'
                 documentationLinkLabel='Projects documentation'
-                documentationIcon={<StickinessIcon />}
                 formatApiCode={formatApiCode}
             >
                 <NewProjectForm

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -24,6 +24,7 @@ const StyledDialog = styled(Dialog)(({ theme, maxWidth }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
         maxWidth: theme.spacing(170),
+        width: '100%',
         backgroundColor: 'transparent',
     },
     padding: 0,

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -9,7 +9,7 @@ import useProjectForm, {
     DEFAULT_PROJECT_STICKINESS,
 } from '../../hooks/useProjectForm';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useNavigate } from 'react-router-dom';
@@ -74,9 +74,17 @@ export const CreateProjectDialogue = ({
         errors,
     } = useProjectForm();
 
-    const generalDocumentation = {
+    const generalDocumentation: {
+        icon: ReactNode;
+        text: string;
+        link?: { url: string; label: string };
+    } = {
         icon: <StyledProjectIcon />,
         text: 'Projects allows you to group feature flags together in the management UI.',
+        link: {
+            url: 'https://docs.getunleash.io/reference/projects',
+            label: 'Projects documentation',
+        },
     };
 
     const [documentation, setDocumentation] = useState(generalDocumentation);
@@ -131,8 +139,8 @@ export const CreateProjectDialogue = ({
                 disablePadding
                 description={documentation.text}
                 documentationIcon={documentation.icon}
-                documentationLink='https://docs.getunleash.io/reference/projects'
-                documentationLinkLabel='Projects documentation'
+                documentationLink={documentation.link?.url}
+                documentationLinkLabel={documentation.link?.label}
                 formatApiCode={formatApiCode}
             >
                 <NewProjectForm

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -1,4 +1,5 @@
 import { formatUnknownError } from 'utils/formatUnknownError';
+import StickinessIcon from '@mui/icons-material/FormatPaint';
 import useProjectApi from 'hooks/api/actions/useProjectApi/useProjectApi';
 import useToast from 'hooks/useToast';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
@@ -116,6 +117,7 @@ export const CreateProjectDialogue = ({
             }
         }
     };
+
     return (
         <StyledDialog open={open} onClose={onClose}>
             <FormTemplate
@@ -123,6 +125,7 @@ export const CreateProjectDialogue = ({
                 description={documentation}
                 documentationLink='https://docs.getunleash.io/reference/projects'
                 documentationLinkLabel='Projects documentation'
+                documentationIcon={<StickinessIcon />}
                 formatApiCode={formatApiCode}
             >
                 <NewProjectForm

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -15,6 +15,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import EnvironmentsIcon from '@mui/icons-material/CloudCircle';
 import { useStickinessOptions } from 'hooks/useStickinessOptions';
 import { ReactComponent as ChangeRequestIcon } from 'assets/icons/merge.svg';
+import type { ReactNode } from 'react';
 
 const StyledForm = styled('form')(({ theme }) => ({
     background: theme.palette.background.default,
@@ -37,7 +38,8 @@ const TopGrid = styled(StyledFormSection)(({ theme }) => ({
 }));
 
 const StyledIcon = styled(ProjectIcon)(({ theme }) => ({
-    color: theme.palette.primary.main,
+    fill: theme.palette.primary.main,
+    stroke: theme.palette.primary.main,
 }));
 
 const StyledHeader = styled(Typography)(({ theme }) => ({
@@ -108,7 +110,7 @@ type FormProps = {
     mode: 'Create' | 'Edit';
     clearErrors: () => void;
     validateProjectId: () => void;
-    overrideDocumentation: (description: string) => void;
+    overrideDocumentation: (args: { text: string; icon: ReactNode }) => void;
     clearDocumentationOverride: () => void;
 };
 
@@ -216,9 +218,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         placeholder: 'Select project environments',
                     }}
                     onOpen={() =>
-                        overrideDocumentation(
-                            `Each feature flag can have a separate configuration per environment. This setting configures which environments your project should start with.`,
-                        )
+                        overrideDocumentation({
+                            icon: <EnvironmentsIcon />,
+                            text: `Each feature flag can have a separate configuration per environment. This setting configures which environments your project should start with.`,
+                        })
                     }
                     onClose={clearDocumentationOverride}
                 />
@@ -240,9 +243,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         placeholder: 'Select default stickiness',
                     }}
                     onOpen={() =>
-                        overrideDocumentation(
-                            'Stickiness is used to guarantee that your users see the same result when using a gradual rollout. Default stickiness allows you to choose which field is used by default in this project.',
-                        )
+                        overrideDocumentation({
+                            icon: <StickinessIcon />,
+                            text: 'Stickiness is used to guarantee that your users see the same result when using a gradual rollout. Default stickiness allows you to choose which field is used by default in this project.',
+                        })
                     }
                     onClose={clearDocumentationOverride}
                 />
@@ -264,9 +268,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                 placeholder: 'Select project mode',
                             }}
                             onOpen={() =>
-                                overrideDocumentation(
-                                    'Mode defines who should be allowed to interact and see your project. Private mode hides the project from anyone except the project owner and members.',
-                                )
+                                overrideDocumentation({
+                                    icon: <ProjectModeIcon />,
+                                    text: 'Mode defines who should be allowed to interact and see your project. Private mode hides the project from anyone except the project owner and members.',
+                                })
                             }
                             onClose={clearDocumentationOverride}
                         />
@@ -309,9 +314,10 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                 projectChangeRequestConfiguration
                             }
                             onOpen={() =>
-                                overrideDocumentation(
-                                    'Change requests can be configured per environment and require changes to go through an approval process before being applied.',
-                                )
+                                overrideDocumentation({
+                                    icon: <ChangeRequestIcon />,
+                                    text: 'Change requests can be configured per environment and require changes to go through an approval process before being applied.',
+                                })
                             }
                             onClose={clearDocumentationOverride}
                         />

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -161,6 +161,25 @@ export const NewProjectForm: React.FC<FormProps> = ({
 
     const stickinessOptions = useStickinessOptions(projectStickiness);
 
+    const selectionButtonData = {
+        environments: {
+            icon: <EnvironmentsIcon />,
+            text: `Each feature flag can have a separate configuration per environment. This setting configures which environments your project should start with.`,
+        },
+        stickiness: {
+            icon: <StickinessIcon />,
+            text: 'Stickiness is used to guarantee that your users see the same result when using a gradual rollout. Default stickiness allows you to choose which field is used by default in this project.',
+        },
+        mode: {
+            icon: <ProjectModeIcon />,
+            text: 'Mode defines who should be allowed to interact and see your project. Private mode hides the project from anyone except the project owner and members.',
+        },
+        changeRequests: {
+            icon: <ChangeRequestIcon />,
+            text: 'Change requests can be configured per environment and require changes to go through an approval process before being applied.',
+        },
+    };
+
     return (
         <StyledForm
             onSubmit={(submitEvent) => {
@@ -200,6 +219,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
 
             <OptionButtons>
                 <MultiselectList
+                    description={selectionButtonData.environments.text}
                     selectedOptions={projectEnvironments}
                     options={activeEnvironments.map((env) => ({
                         label: env.name,
@@ -218,15 +238,13 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         placeholder: 'Select project environments',
                     }}
                     onOpen={() =>
-                        overrideDocumentation({
-                            icon: <EnvironmentsIcon />,
-                            text: `Each feature flag can have a separate configuration per environment. This setting configures which environments your project should start with.`,
-                        })
+                        overrideDocumentation(selectionButtonData.environments)
                     }
                     onClose={clearDocumentationOverride}
                 />
 
                 <SingleSelectList
+                    description={selectionButtonData.stickiness.text}
                     options={stickinessOptions.map(({ key, ...rest }) => ({
                         value: key,
                         ...rest,
@@ -243,10 +261,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         placeholder: 'Select default stickiness',
                     }}
                     onOpen={() =>
-                        overrideDocumentation({
-                            icon: <StickinessIcon />,
-                            text: 'Stickiness is used to guarantee that your users see the same result when using a gradual rollout. Default stickiness allows you to choose which field is used by default in this project.',
-                        })
+                        overrideDocumentation(selectionButtonData.stickiness)
                     }
                     onClose={clearDocumentationOverride}
                 />
@@ -255,6 +270,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <SingleSelectList
+                            description={selectionButtonData.mode.text}
                             options={projectModeOptions}
                             onChange={(value: any) => {
                                 setProjectMode(value);
@@ -268,10 +284,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                 placeholder: 'Select project mode',
                             }}
                             onOpen={() =>
-                                overrideDocumentation({
-                                    icon: <ProjectModeIcon />,
-                                    text: 'Mode defines who should be allowed to interact and see your project. Private mode hides the project from anyone except the project owner and members.',
-                                })
+                                overrideDocumentation(selectionButtonData.mode)
                             }
                             onClose={clearDocumentationOverride}
                         />
@@ -281,6 +294,9 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <TableSelect
+                            description={
+                                selectionButtonData.changeRequests.text
+                            }
                             disabled={projectEnvironments.size === 0}
                             activeEnvironments={activeEnvironments
                                 .filter((env) =>
@@ -314,10 +330,9 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                 projectChangeRequestConfiguration
                             }
                             onOpen={() =>
-                                overrideDocumentation({
-                                    icon: <ChangeRequestIcon />,
-                                    text: 'Change requests can be configured per environment and require changes to go through an approval process before being applied.',
-                                })
+                                overrideDocumentation(
+                                    selectionButtonData.changeRequests,
+                                )
                             }
                             onClose={clearDocumentationOverride}
                         />

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.styles.tsx
@@ -39,6 +39,11 @@ const visuallyHiddenStyles = {
     whiteSpace: 'nowrap',
 };
 
+export const HiddenDescription = styled('p')(() => ({
+    ...visuallyHiddenStyles,
+    position: 'absolute',
+}));
+
 export const StyledDropdownSearch = styled(TextField, {
     shouldForwardProp: (prop) => prop !== 'hideLabel',
 })<{ hideLabel?: boolean }>(({ theme, hideLabel }) => ({

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -1,4 +1,5 @@
 import Search from '@mui/icons-material/Search';
+import { v4 as uuidv4 } from 'uuid';
 import { Box, Button, InputAdornment, List, ListItemText } from '@mui/material';
 import { type FC, type ReactNode, useRef, useState, useMemo } from 'react';
 import {
@@ -8,6 +9,7 @@ import {
     StyledPopover,
     StyledDropdownSearch,
     TableSearchInput,
+    HiddenDescription,
 } from './SelectionButton.styles';
 import { ChangeRequestTable } from './ChangeRequestTable';
 
@@ -81,6 +83,7 @@ type CombinedSelectProps = {
     multiselect?: { selectedOptions: Set<string> };
     onOpen?: () => void;
     onClose?: () => void;
+    description: string; // visually hidden, for assistive tech
 };
 
 const CombinedSelect: FC<CombinedSelectProps> = ({
@@ -91,10 +94,12 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
     multiselect,
     onOpen = () => {},
     onClose = () => {},
+    description,
 }) => {
     const ref = useRef<HTMLDivElement>(null);
     const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>();
     const [searchText, setSearchText] = useState('');
+    const descriptionId = uuidv4();
 
     const open = () => {
         setSearchText('');
@@ -151,7 +156,10 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
                     horizontal: 'left',
                 }}
             >
-                <StyledDropdown>
+                <HiddenDescription id={descriptionId}>
+                    {description}
+                </HiddenDescription>
+                <StyledDropdown aria-describedby={descriptionId}>
                     <StyledDropdownSearch
                         variant='outlined'
                         size='small'
@@ -181,6 +189,7 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
 
                             return (
                                 <StyledListItem
+                                    aria-describedby={labelId}
                                     key={option.value}
                                     dense
                                     disablePadding
@@ -229,7 +238,7 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
 
 type MultiselectListProps = Pick<
     CombinedSelectProps,
-    'options' | 'button' | 'search' | 'onOpen' | 'onClose'
+    'options' | 'button' | 'search' | 'onOpen' | 'onClose' | 'description'
 > & {
     selectedOptions: Set<string>;
     onChange: (values: Set<string>) => void;
@@ -265,7 +274,13 @@ export const MultiselectList: FC<MultiselectListProps> = ({
 
 type SingleSelectListProps = Pick<
     CombinedSelectProps,
-    'options' | 'button' | 'search' | 'onChange' | 'onOpen' | 'onClose'
+    | 'options'
+    | 'button'
+    | 'search'
+    | 'onChange'
+    | 'onOpen'
+    | 'onClose'
+    | 'description'
 >;
 
 export const SingleSelectList: FC<SingleSelectListProps> = (props) => {
@@ -274,7 +289,7 @@ export const SingleSelectList: FC<SingleSelectListProps> = (props) => {
 
 type TableSelectProps = Pick<
     CombinedSelectProps,
-    'button' | 'search' | 'onOpen' | 'onClose'
+    'button' | 'search' | 'onOpen' | 'onClose' | 'description'
 > & {
     updateProjectChangeRequestConfiguration: {
         disableChangeRequests: (env: string) => void;


### PR DESCRIPTION
This PR adds accessible descriptions to the dropdown widgets in the new project creation form. The description is the same as we show in the background