### PR TITLE
fix: always hide horizontal overflow

### DIFF
--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -47,7 +47,8 @@ const StyledContainer = styled('section', {
     width: '100%',
     display: 'flex',
     margin: '0 auto',
-    overflow: modal || compact ? 'unset' : 'hidden',
+    overflowX: 'hidden',
+    overflowY: modal || compact ? 'auto' : 'hidden',
     [theme.breakpoints.down(1100)]: {
         flexDirection: 'column',
         minHeight: 0,


### PR DESCRIPTION
Set Y scroll to auto in compact and modal modes.

None of our modals should ever be wider than the viewport, so we can always hide horizontal overflow.