### PR TITLE
fix: attempt a react friendly fix of summing

### DIFF
--- a/.github/workflows/build_frontend_prs.yml
+++ b/.github/workflows/build_frontend_prs.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: build
     defaults:
       run:
         working-directory: frontend

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingPlan.tsx
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingPlan.tsx
@@ -131,8 +131,6 @@ export const BillingPlan: FC<IBillingPlanProps> = ({ instanceStatus }) => {
             );
             setOverageCost(overageCostCalc);
             setTotalCost(finalPrice + overageCostCalc);
-        } else {
-            setTotalCost(finalPrice);
         }
     }, [traffic]);
 
@@ -313,7 +311,18 @@ export const BillingPlan: FC<IBillingPlanProps> = ({ instanceStatus }) => {
                                                 fontSize: '2rem',
                                             })}
                                         >
-                                            ${totalCost.toFixed(2)}
+                                            <ConditionallyRender
+                                                condition={
+                                                    flagEnabled &&
+                                                    includedTraffic > 0
+                                                }
+                                                show={`$${totalCost.toFixed(
+                                                    2,
+                                                )}`}
+                                                elseShow={`$${finalPrice.toFixed(
+                                                    2,
+                                                )}`}
+                                            />
                                         </Typography>
                                     </GridCol>
                                 </GridRow>


### PR DESCRIPTION
## About the changes

Summing on Billing page got a little wonky after changing how the summing worked when the estimation flag is off. This attempts to return it to previous way of showing numbers when flag is off

If you go directly to the billing page it will not add user calculations to the total. If you however interact with the UI, like change tabs back and forth, it will suddenly show the correct sum:

![image](https://github.com/Unleash/unleash/assets/707867/af6eeddf-be3f-42ae-a588-f57c30d739ca)

![image](https://github.com/Unleash/unleash/assets/707867/b4a0b832-a550-4e87-aa69-7b27f96d3beb)
