### PR TITLE
feat: adjust change request banner for new layout

### DIFF
--- a/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
+++ b/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
@@ -6,7 +6,7 @@ import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequ
 import type { ChangeRequestType } from 'component/changeRequest/changeRequest.types';
 import { changesCount } from 'component/changeRequest/changesCount';
 import { Sticky } from 'component/common/Sticky/Sticky';
-import { useUiFlag } from '../../../../hooks/useUiFlag';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IDraftBannerProps {
     project: string;

--- a/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
+++ b/frontend/src/component/layout/MainLayout/DraftBanner/DraftBanner.tsx
@@ -6,6 +6,7 @@ import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequ
 import type { ChangeRequestType } from 'component/changeRequest/changeRequest.types';
 import { changesCount } from 'component/changeRequest/changesCount';
 import { Sticky } from 'component/common/Sticky/Sticky';
+import { useUiFlag } from '../../../../hooks/useUiFlag';
 
 interface IDraftBannerProps {
     project: string;
@@ -17,7 +18,7 @@ const StyledDraftBannerContentWrapper = styled(Box)(({ theme }) => ({
     padding: theme.spacing(1, 0),
 }));
 
-const StyledDraftBanner = styled(Box)(({ theme }) => ({
+const OldStyledDraftBanner = styled(Box)(({ theme }) => ({
     maxWidth: '1512px',
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
@@ -33,10 +34,26 @@ const StyledDraftBanner = styled(Box)(({ theme }) => ({
     },
 }));
 
+const StyledDraftBanner = styled(Box)(({ theme }) => ({
+    width: '100%',
+    paddingLeft: theme.spacing(3),
+    paddingRight: theme.spacing(9),
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    [theme.breakpoints.down(1024)]: {
+        marginLeft: 0,
+        marginRight: 0,
+    },
+    [theme.breakpoints.down('sm')]: {
+        minWidth: '100%',
+    },
+}));
+
 const DraftBannerContent: FC<{
     changeRequests: ChangeRequestType[];
     onClick: () => void;
 }> = ({ changeRequests, onClick }) => {
+    const sidebarNavigationEnabled = useUiFlag('navigationSidebar');
     const environments = changeRequests.map(({ environment }) => environment);
     const allChangesCount = changeRequests.reduce(
         (acc, curr) => acc + changesCount(curr),
@@ -54,8 +71,12 @@ const DraftBannerContent: FC<{
           }[changeRequests[0].state as 'Draft' | 'In review' | 'Approved']
         : '';
 
+    const Banner = sidebarNavigationEnabled
+        ? StyledDraftBanner
+        : OldStyledDraftBanner;
+
     return (
-        <StyledDraftBanner>
+        <Banner>
             <StyledDraftBannerContentWrapper>
                 <Typography variant='body2' sx={{ mr: 4 }}>
                     <strong>Change request mode</strong> – You have changes{' '}
@@ -91,7 +112,7 @@ const DraftBannerContent: FC<{
                     View changes ({allChangesCount})
                 </Button>
             </StyledDraftBannerContentWrapper>
-        </StyledDraftBanner>
+        </Banner>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

New layout requires CR banner stretch with the wider top nav
<img width="1906" alt="Screenshot 2024-05-27 at 10 44 40" src="https://github.com/Unleash/unleash/assets/1394682/c6ce2356-0a20-4102-98be-148e9823a0a3">

Previous layout had CR banners in the middle
<img width="1908" alt="Screenshot 2024-05-27 at 10 47 04" src="https://github.com/Unleash/unleash/assets/1394682/6755f9b0-8bb6-4eff-9f09-08605201b5d1">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
