### PR TITLE
chore: new create project dialog UI fixes

### DIFF
--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -403,39 +403,6 @@ const MobileGuidance = ({
     );
 };
 
-const FixedMobileGuidance = ({
-    description,
-    documentationLink,
-    documentationLinkLabel,
-    documentationIcon,
-}: IMobileGuidance) => {
-    const [open, setOpen] = useState(false);
-
-    return (
-        <>
-            <StyledMobileGuidanceContainer>
-                <StyledMobileGuidanceBackground />
-            </StyledMobileGuidanceContainer>
-            <Tooltip title='Toggle help' arrow>
-                <StyledMobileGuidanceButton
-                    onClick={() => setOpen((prev) => !prev)}
-                    size='large'
-                >
-                    <StyledInfoIcon />
-                </StyledMobileGuidanceButton>
-            </Tooltip>
-            <Collapse in={open} timeout={500}>
-                <Guidance
-                    documentationIcon={documentationIcon}
-                    description={description}
-                    documentationLink={documentationLink}
-                    documentationLinkLabel={documentationLinkLabel}
-                />
-            </Collapse>
-        </>
-    );
-};
-
 interface IGuidanceProps {
     description: string;
     documentationIcon?: ReactNode;

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -37,6 +37,7 @@ interface ICreateProps {
     compact?: boolean;
     showGuidance?: boolean;
     sidebarWidth?: string;
+    useFixedSidebar?: boolean;
 }
 
 const StyledContainer = styled('section', {
@@ -55,7 +56,15 @@ const StyledContainer = styled('section', {
     },
 }));
 
-const StyledRelativeDiv = styled('div')(({ theme }) => relative);
+const StyledMobileGuidanceWrapper = styled('div')(({ theme }) => ({
+    ...relative,
+    // todo: review this. We're reaching down into a nested
+    // component, but due to the component structure, it'd be a
+    // lot of work to pass this down as a prop.
+    aside: {
+        height: '240px',
+    },
+}));
 
 const StyledMain = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -274,14 +283,14 @@ const FormTemplate: React.FC<ICreateProps> = ({
             <ConditionallyRender
                 condition={showGuidance && smallScreen}
                 show={
-                    <StyledRelativeDiv>
+                    <StyledMobileGuidanceWrapper>
                         <MobileGuidance
                             description={description}
                             documentationIcon={documentationIcon}
                             documentationLink={documentationLink}
                             documentationLinkLabel={documentationLinkLabel}
                         />
-                    </StyledRelativeDiv>
+                    </StyledMobileGuidanceWrapper>
                 }
             />
             <StyledMain>
@@ -376,6 +385,39 @@ const MobileGuidance = ({
     );
 };
 
+const FixedMobileGuidance = ({
+    description,
+    documentationLink,
+    documentationLinkLabel,
+    documentationIcon,
+}: IMobileGuidance) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <StyledMobileGuidanceContainer>
+                <StyledMobileGuidanceBackground />
+            </StyledMobileGuidanceContainer>
+            <Tooltip title='Toggle help' arrow>
+                <StyledMobileGuidanceButton
+                    onClick={() => setOpen((prev) => !prev)}
+                    size='large'
+                >
+                    <StyledInfoIcon />
+                </StyledMobileGuidanceButton>
+            </Tooltip>
+            <Collapse in={open} timeout={500}>
+                <Guidance
+                    documentationIcon={documentationIcon}
+                    description={description}
+                    documentationLink={documentationLink}
+                    documentationLinkLabel={documentationLinkLabel}
+                />
+            </Collapse>
+        </>
+    );
+};
+
 interface IGuidanceProps {
     description: string;
     documentationIcon?: ReactNode;
@@ -396,36 +438,121 @@ const Guidance: React.FC<IGuidanceProps> = ({
     showLink = true,
     sidebarWidth = undefined,
 }) => {
+    const StyledDocumentationWrapper = styled('div')(({ theme }) => ({
+        height: '170px',
+        overflowY: 'auto',
+    }));
+
+    const StyledDocumentationIconWrapper = styled('div')(({ theme }) => ({
+        height: '2rem',
+        // aspectRatio: '1',
+        display: 'grid',
+        placeItems: 'center',
+        svg: {
+            width: '100%',
+        },
+    }));
+
     return (
         <StyledSidebar sidebarWidth={sidebarWidth}>
-            <ConditionallyRender
-                condition={showDescription}
-                show={
-                    <StyledDescriptionCard>
-                        <ConditionallyRender
-                            condition={!!documentationIcon}
-                            show={documentationIcon}
-                        />
-                        <StyledDescription>{description}</StyledDescription>
-                    </StyledDescriptionCard>
-                }
-            />
+            <StyledDocumentationWrapper>
+                <ConditionallyRender
+                    condition={showDescription}
+                    show={
+                        <StyledDescriptionCard>
+                            <ConditionallyRender
+                                condition={!!documentationIcon}
+                                show={
+                                    <StyledDocumentationIconWrapper>
+                                        {documentationIcon}
+                                    </StyledDocumentationIconWrapper>
+                                }
+                            />
+                            <StyledDescription>{description}</StyledDescription>
+                        </StyledDescriptionCard>
+                    }
+                />
 
-            <ConditionallyRender
-                condition={showLink && !!documentationLink}
-                show={
-                    <StyledLinkContainer>
-                        <StyledLinkIcon />
-                        <StyledDocumentationLink
-                            href={documentationLink}
-                            rel='noopener noreferrer'
-                            target='_blank'
-                        >
-                            {documentationLinkLabel}
-                        </StyledDocumentationLink>
-                    </StyledLinkContainer>
-                }
-            />
+                <ConditionallyRender
+                    condition={showLink && !!documentationLink}
+                    show={
+                        <StyledLinkContainer>
+                            <StyledLinkIcon />
+                            <StyledDocumentationLink
+                                href={documentationLink}
+                                rel='noopener noreferrer'
+                                target='_blank'
+                            >
+                                {documentationLinkLabel}
+                            </StyledDocumentationLink>
+                        </StyledLinkContainer>
+                    }
+                />
+            </StyledDocumentationWrapper>
+            {children}
+        </StyledSidebar>
+    );
+};
+
+const FixedGuidance: React.FC<IGuidanceProps> = ({
+    description,
+    children,
+    documentationLink,
+    documentationIcon,
+    documentationLinkLabel = 'Learn more',
+    showDescription = true,
+    showLink = true,
+}) => {
+    const StyledDocumentationWrapper = styled('div')(({ theme }) => ({
+        height: '170px',
+        overflowY: 'auto',
+    }));
+
+    const StyledDocumentationIconWrapper = styled('div')(({ theme }) => ({
+        height: '2rem',
+        display: 'grid',
+        placeItems: 'center',
+        svg: {
+            width: '100%',
+        },
+    }));
+
+    return (
+        <StyledSidebar sidebarWidth={'420px'}>
+            <StyledDocumentationWrapper>
+                <ConditionallyRender
+                    condition={showDescription}
+                    show={
+                        <StyledDescriptionCard>
+                            <ConditionallyRender
+                                condition={!!documentationIcon}
+                                show={
+                                    <StyledDocumentationIconWrapper>
+                                        {documentationIcon}
+                                    </StyledDocumentationIconWrapper>
+                                }
+                            />
+                            <StyledDescription>{description}</StyledDescription>
+                        </StyledDescriptionCard>
+                    }
+                />
+
+                <ConditionallyRender
+                    condition={showLink && !!documentationLink}
+                    show={
+                        <StyledLinkContainer>
+                            <StyledLinkIcon />
+                            <StyledDocumentationLink
+                                href={documentationLink}
+                                rel='noopener noreferrer'
+                                target='_blank'
+                            >
+                                {documentationLinkLabel}
+                            </StyledDocumentationLink>
+                        </StyledLinkContainer>
+                    }
+                />
+            </StyledDocumentationWrapper>
             {children}
         </StyledSidebar>
     );

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -36,7 +36,6 @@ interface ICreateProps {
     footer?: ReactNode;
     compact?: boolean;
     showGuidance?: boolean;
-    sidebarWidth?: string;
     useFixedSidebar?: boolean;
 }
 
@@ -162,21 +161,31 @@ const StyledInfoIcon = styled(Info)(({ theme }) => ({
 }));
 
 const StyledSidebar = styled('aside', {
-    shouldForwardProp: (prop) => prop !== 'sidebarWidth',
-})<{ sidebarWidth?: string }>(({ theme, sidebarWidth }) => ({
-    backgroundColor: theme.palette.background.sidebar,
-    padding: theme.spacing(4),
-    flexGrow: 0,
-    flexShrink: 0,
-    width: sidebarWidth || formTemplateSidebarWidth,
-    [theme.breakpoints.down(1100)]: {
-        width: '100%',
-        color: 'red',
-    },
-    [theme.breakpoints.down(500)]: {
-        padding: theme.spacing(4, 2),
-    },
-}));
+    shouldForwardProp: (prop) =>
+        !['sidebarWidth', 'fixedCodeHeight'].includes(prop.toString()),
+})<{ sidebarWidth?: string; fixedCodeHeight?: string }>(
+    ({ theme, sidebarWidth, fixedCodeHeight }) => ({
+        backgroundColor: theme.palette.background.sidebar,
+        padding: theme.spacing(4),
+        flexGrow: 0,
+        flexShrink: 0,
+        width: sidebarWidth || formTemplateSidebarWidth,
+        [theme.breakpoints.down(1100)]: {
+            width: '100%',
+            color: 'red',
+        },
+        [theme.breakpoints.down(500)]: {
+            padding: theme.spacing(4, 2),
+        },
+        ...(fixedCodeHeight
+            ? {
+                  pre: {
+                      height: fixedCodeHeight,
+                  },
+              }
+            : {}),
+    }),
+);
 
 const StyledDescriptionCard = styled('article')(({ theme }) => ({
     display: 'flex',
@@ -230,7 +239,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
     footer,
     compact,
     showGuidance = true,
-    sidebarWidth,
+    useFixedSidebar,
 }) => {
     const { setToastData } = useToast();
     const smallScreen = useMediaQuery(`(max-width:${1099}px)`);
@@ -332,7 +341,6 @@ const FormTemplate: React.FC<ICreateProps> = ({
                         documentationLinkLabel={documentationLinkLabel}
                         showDescription={showDescription}
                         showLink={showLink}
-                        sidebarWidth={sidebarWidth}
                     >
                         {renderApiInfo(
                             formatApiCode === undefined,
@@ -425,7 +433,6 @@ interface IGuidanceProps {
     documentationLinkLabel?: string;
     showDescription?: boolean;
     showLink?: boolean;
-    sidebarWidth?: string;
 }
 
 const Guidance: React.FC<IGuidanceProps> = ({
@@ -436,13 +443,7 @@ const Guidance: React.FC<IGuidanceProps> = ({
     documentationLinkLabel = 'Learn more',
     showDescription = true,
     showLink = true,
-    sidebarWidth = undefined,
 }) => {
-    const StyledDocumentationWrapper = styled('div')(({ theme }) => ({
-        height: '170px',
-        overflowY: 'auto',
-    }));
-
     const StyledDocumentationIconWrapper = styled('div')(({ theme }) => ({
         height: '2rem',
         // aspectRatio: '1',
@@ -454,41 +455,39 @@ const Guidance: React.FC<IGuidanceProps> = ({
     }));
 
     return (
-        <StyledSidebar sidebarWidth={sidebarWidth}>
-            <StyledDocumentationWrapper>
-                <ConditionallyRender
-                    condition={showDescription}
-                    show={
-                        <StyledDescriptionCard>
-                            <ConditionallyRender
-                                condition={!!documentationIcon}
-                                show={
-                                    <StyledDocumentationIconWrapper>
-                                        {documentationIcon}
-                                    </StyledDocumentationIconWrapper>
-                                }
-                            />
-                            <StyledDescription>{description}</StyledDescription>
-                        </StyledDescriptionCard>
-                    }
-                />
+        <StyledSidebar>
+            <ConditionallyRender
+                condition={showDescription}
+                show={
+                    <StyledDescriptionCard>
+                        <ConditionallyRender
+                            condition={!!documentationIcon}
+                            show={
+                                <StyledDocumentationIconWrapper>
+                                    {documentationIcon}
+                                </StyledDocumentationIconWrapper>
+                            }
+                        />
+                        <StyledDescription>{description}</StyledDescription>
+                    </StyledDescriptionCard>
+                }
+            />
 
-                <ConditionallyRender
-                    condition={showLink && !!documentationLink}
-                    show={
-                        <StyledLinkContainer>
-                            <StyledLinkIcon />
-                            <StyledDocumentationLink
-                                href={documentationLink}
-                                rel='noopener noreferrer'
-                                target='_blank'
-                            >
-                                {documentationLinkLabel}
-                            </StyledDocumentationLink>
-                        </StyledLinkContainer>
-                    }
-                />
-            </StyledDocumentationWrapper>
+            <ConditionallyRender
+                condition={showLink && !!documentationLink}
+                show={
+                    <StyledLinkContainer>
+                        <StyledLinkIcon />
+                        <StyledDocumentationLink
+                            href={documentationLink}
+                            rel='noopener noreferrer'
+                            target='_blank'
+                        >
+                            {documentationLinkLabel}
+                        </StyledDocumentationLink>
+                    </StyledLinkContainer>
+                }
+            />
             {children}
         </StyledSidebar>
     );
@@ -518,7 +517,7 @@ const FixedGuidance: React.FC<IGuidanceProps> = ({
     }));
 
     return (
-        <StyledSidebar sidebarWidth={'420px'}>
+        <StyledSidebar sidebarWidth='420px' fixedCodeHeight='300px'>
             <StyledDocumentationWrapper>
                 <ConditionallyRender
                     condition={showDescription}

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -36,6 +36,7 @@ interface ICreateProps {
     footer?: ReactNode;
     compact?: boolean;
     showGuidance?: boolean;
+    sidebarWidth?: string;
 }
 
 const StyledContainer = styled('section', {
@@ -151,12 +152,14 @@ const StyledInfoIcon = styled(Info)(({ theme }) => ({
     fill: theme.palette.primary.contrastText,
 }));
 
-const StyledSidebar = styled('aside')(({ theme }) => ({
+const StyledSidebar = styled('aside', {
+    shouldForwardProp: (prop) => prop !== 'sidebarWidth',
+})<{ sidebarWidth?: string }>(({ theme, sidebarWidth }) => ({
     backgroundColor: theme.palette.background.sidebar,
     padding: theme.spacing(4),
     flexGrow: 0,
     flexShrink: 0,
-    width: formTemplateSidebarWidth,
+    width: sidebarWidth || formTemplateSidebarWidth,
     [theme.breakpoints.down(1100)]: {
         width: '100%',
         color: 'red',
@@ -218,6 +221,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
     footer,
     compact,
     showGuidance = true,
+    sidebarWidth,
 }) => {
     const { setToastData } = useToast();
     const smallScreen = useMediaQuery(`(max-width:${1099}px)`);
@@ -319,6 +323,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
                         documentationLinkLabel={documentationLinkLabel}
                         showDescription={showDescription}
                         showLink={showLink}
+                        sidebarWidth={sidebarWidth}
                     >
                         {renderApiInfo(
                             formatApiCode === undefined,
@@ -378,6 +383,7 @@ interface IGuidanceProps {
     documentationLinkLabel?: string;
     showDescription?: boolean;
     showLink?: boolean;
+    sidebarWidth?: string;
 }
 
 const Guidance: React.FC<IGuidanceProps> = ({
@@ -388,9 +394,10 @@ const Guidance: React.FC<IGuidanceProps> = ({
     documentationLinkLabel = 'Learn more',
     showDescription = true,
     showLink = true,
+    sidebarWidth = undefined,
 }) => {
     return (
-        <StyledSidebar>
+        <StyledSidebar sidebarWidth={sidebarWidth}>
             <ConditionallyRender
                 condition={showDescription}
                 show={

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -65,7 +65,7 @@ const StyledMobileGuidanceWrapper = styled('div', {
     ...(guidanceHeight
         ? {
               aside: {
-                  height: '240px',
+                  height: guidanceHeight,
               },
           }
         : {}),

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -143,6 +143,7 @@ export const CreateProjectDialogue = ({
                 documentationLink={documentation.link?.url}
                 documentationLinkLabel={documentation.link?.label}
                 formatApiCode={formatApiCode}
+                sidebarWidth={'420px'}
             >
                 <NewProjectForm
                     errors={errors}

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -29,12 +29,6 @@ const StyledDialog = styled(Dialog)(({ theme, maxWidth }) => ({
         backgroundColor: 'transparent',
     },
     padding: 0,
-    pre: {
-        // todo: review this. We're reaching deep down into a nested
-        // component, but due to the component structure, it'd be a
-        // lot of work to pass this down as a prop.
-        height: '300px',
-    },
 }));
 
 const CREATE_PROJECT_BTN = 'CREATE_PROJECT_BTN';
@@ -149,7 +143,7 @@ export const CreateProjectDialogue = ({
                 documentationLink={documentation.link?.url}
                 documentationLinkLabel={documentation.link?.label}
                 formatApiCode={formatApiCode}
-                sidebarWidth={'420px'}
+                useFixedSidebar
             >
                 <NewProjectForm
                     errors={errors}

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -29,6 +29,12 @@ const StyledDialog = styled(Dialog)(({ theme, maxWidth }) => ({
         backgroundColor: 'transparent',
     },
     padding: 0,
+    pre: {
+        // todo: review this. We're reaching deep down into a nested
+        // component, but due to the component structure, it'd be a
+        // lot of work to pass this down as a prop.
+        height: '300px',
+    },
 }));
 
 const CREATE_PROJECT_BTN = 'CREATE_PROJECT_BTN';

--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -210,7 +210,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                         className='description'
                         label='Description (optional)'
                         multiline
-                        maxRows={20}
+                        maxRows={3}
                         value={projectDesc}
                         onChange={(e) => setProjectDesc(e.target.value)}
                         data-testid={PROJECT_DESCRIPTION_INPUT}
@@ -285,6 +285,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                             button={{
                                 label: projectMode,
                                 icon: <ProjectModeIcon />,
+                                labelWidth: `${`protected`.length}ch`,
                             }}
                             search={{
                                 label: 'Filter project mode options',

--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -1,6 +1,13 @@
 import Search from '@mui/icons-material/Search';
 import { v4 as uuidv4 } from 'uuid';
-import { Box, Button, InputAdornment, List, ListItemText } from '@mui/material';
+import {
+    Box,
+    Button,
+    InputAdornment,
+    List,
+    ListItemText,
+    styled,
+} from '@mui/material';
 import { type FC, type ReactNode, useRef, useState, useMemo } from 'react';
 import {
     StyledCheckbox,
@@ -75,7 +82,7 @@ const useSelectionManagement = ({
 type CombinedSelectProps = {
     options: Array<{ label: string; value: string }>;
     onChange: (value: string) => void;
-    button: { label: string; icon: ReactNode };
+    button: { label: string; icon: ReactNode; labelWidth?: string };
     search: {
         label: string;
         placeholder: string;
@@ -132,6 +139,11 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
     const filteredOptions = options?.filter((option) =>
         option.label.toLowerCase().includes(searchText.toLowerCase()),
     );
+
+    const ButtonLabel = styled('span')(() => ({
+        width: button.labelWidth || 'unset',
+    }));
+
     return (
         <>
             <Box ref={ref}>
@@ -145,7 +157,7 @@ const CombinedSelect: FC<CombinedSelectProps> = ({
                         }
                     }}
                 >
-                    {button.label}
+                    <ButtonLabel>{button.label}</ButtonLabel>
                 </Button>
             </Box>
             <StyledPopover


### PR DESCRIPTION
This PR addresses several related fixes to the new project creation dialog to prevent unnecessary growing and shifting:

- use a fixed width for the guidance sidebar
- use a fixed height for the guidance code snippet
- use a fixed height for the mobile guidance
- use a fixed width for the mode selector button
- cap description height

This is a little tricky because we don't want the changes for the dialog to affect other forms. As such, I've added some new options you can use when you create the guidance components / sidebar.