### PR TITLE
fix: make CR button wider always

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -327,7 +327,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                                               Object.keys(
                                                   projectChangeRequestConfiguration,
                                               ).length
-                                          } selected`
+                                          } environment configured`
                                         : 'Configure change requests',
                                 icon: <ChangeRequestIcon />,
                             }}


### PR DESCRIPTION
This change makes the CR button wider when you have environments
selected, reducing the difference between "no environments" and "envs
configured" states, thereby reducing the difference in the layout.