### PR TITLE
chore: rename component to match file name and american spelling

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectDialog/CreateProjectDialog.tsx
@@ -16,7 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Dialog, styled } from '@mui/material';
 import { ReactComponent as ProjectIcon } from 'assets/icons/projectIconSmall.svg';
 
-interface ICreateProjectDialogueProps {
+interface ICreateProjectDialogProps {
     open: boolean;
     onClose: () => void;
 }
@@ -42,10 +42,10 @@ const StyledProjectIcon = styled(ProjectIcon)(({ theme }) => ({
     stroke: theme.palette.common.white,
 }));
 
-export const CreateProjectDialogue = ({
+export const CreateProjectDialog = ({
     open,
     onClose,
-}: ICreateProjectDialogueProps) => {
+}: ICreateProjectDialogProps) => {
     const { createProject, loading } = useProjectApi();
     const { refetchUser } = useAuthUser();
     const { uiConfig } = useUiConfig();

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -24,7 +24,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import { useProfile } from 'hooks/api/getters/useProfile/useProfile';
 import { groupProjects } from './group-projects';
 import { ProjectGroup } from './ProjectGroup';
-import { CreateProjectDialogue } from '../Project/CreateProject/CreateProjectDialog/CreateProjectDialog';
+import { CreateProjectDialog } from '../Project/CreateProject/CreateProjectDialog/CreateProjectDialog';
 
 const StyledApiError = styled(ApiError)(({ theme }) => ({
     maxWidth: '500px',
@@ -251,7 +251,7 @@ export const ProjectListNew = () => {
             <ConditionallyRender
                 condition={useNewProjectForm}
                 show={
-                    <CreateProjectDialogue
+                    <CreateProjectDialog
                         open={openCreateDialog}
                         onClose={() => setOpenCreateDialog(false)}
                     />


### PR DESCRIPTION
Renames the create project dialog component to match the name of the file (both using the same spelling of dialog)