### PR TITLE
chore: fix create project form environment selector button width

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewProjectForm.tsx
@@ -239,6 +239,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                             projectEnvironments.size > 0
                                 ? `${projectEnvironments.size} selected`
                                 : 'All environments',
+                        labelWidth: `${'all environments'.length}ch`,
                         icon: <EnvironmentsIcon />,
                     }}
                     search={{


### PR DESCRIPTION
This commit sets the width of the environment selector button to a
fixed width (wide enough to display "all environments").