### PR TITLE
fix: use a fixed-width button label for CR selector in new project creation form

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/SelectionButton.tsx
@@ -399,6 +399,10 @@ export const TableSelect: FC<TableSelectProps> = ({
         }
     };
 
+    const ButtonLabel = styled('span')(() => ({
+        width: button.labelWidth || 'unset',
+    }));
+
     return (
         <>
             <Box ref={ref}>
@@ -411,7 +415,7 @@ export const TableSelect: FC<TableSelectProps> = ({
                     }}
                     disabled={disabled}
                 >
-                    {button.label}
+                    <ButtonLabel>{button.label}</ButtonLabel>
                 </Button>
             </Box>
             <StyledPopover


### PR DESCRIPTION
This change makes the button label for the CR selector in the new
project creation form have a fixed width. It adds a missing wrapper
element.