### PR TITLE
chore: allow CR selection when no envs are enabled

### DIFF
--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -1,39 +1,54 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useProjectForm from './useProjectForm';
 
-test('setting project environments removes any change request envs that are not in the new project env list', () => {
-    const { result } = renderHook(() => useProjectForm());
+describe('configuring change requests', () => {
+    test('setting project environments removes any change request envs that are not in the new project env list', () => {
+        const { result } = renderHook(() => useProjectForm());
 
-    result.current.setProjectEnvironments(new Set(['dev', 'prod']));
-    result.current.updateProjectChangeRequestConfig.enableChangeRequests(
-        'prod',
-        5,
-    );
+        result.current.setProjectEnvironments(new Set(['dev', 'prod']));
+        result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+            'prod',
+            5,
+        );
 
-    expect(result.current.projectChangeRequestConfiguration).toMatchObject({
-        prod: { requiredApprovals: 5 },
+        expect(result.current.projectChangeRequestConfiguration).toMatchObject({
+            prod: { requiredApprovals: 5 },
+        });
+
+        result.current.setProjectEnvironments(new Set(['dev']));
+
+        expect(
+            'prod' in result.current.projectChangeRequestConfiguration,
+        ).toBeFalsy();
     });
 
-    result.current.setProjectEnvironments(new Set(['dev']));
+    test(`if specific project envs are selected, adding a change request config for an env not in the project envs doesn't work and the change request envs is not changed`, () => {
+        const { result } = renderHook(() => useProjectForm());
 
-    expect(
-        'prod' in result.current.projectChangeRequestConfiguration,
-    ).toBeFalsy();
-});
+        result.current.setProjectEnvironments(new Set(['prod']));
 
-test(`adding a change request config for an env not in the project envs doesn't work and the change request envs is not changed`, () => {
-    const { result } = renderHook(() => useProjectForm());
+        result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+            'dev',
+            5,
+        );
 
-    result.current.setProjectEnvironments(new Set(['prod']));
+        expect(
+            'dev' in result.current.projectChangeRequestConfiguration,
+        ).toBeFalsy();
+    });
 
-    result.current.updateProjectChangeRequestConfig.enableChangeRequests(
-        'dev',
-        5,
-    );
+    test(`if no project envs are selected, you can add a change request for any env you want`, () => {
+        const { result } = renderHook(() => useProjectForm());
 
-    expect(
-        'dev' in result.current.projectChangeRequestConfiguration,
-    ).toBeFalsy();
+        result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+            'dev',
+            5,
+        );
+
+        expect(
+            'dev' in result.current.projectChangeRequestConfiguration,
+        ).toBeTruthy();
+    });
 });
 
 describe('payload generation', () => {

--- a/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.test.ts
@@ -22,6 +22,22 @@ describe('configuring change requests', () => {
         ).toBeFalsy();
     });
 
+    test('setting project environments to an empty set preserves change request configuration', () => {
+        const { result } = renderHook(() => useProjectForm());
+
+        result.current.setProjectEnvironments(new Set(['dev', 'prod']));
+        result.current.updateProjectChangeRequestConfig.enableChangeRequests(
+            'prod',
+            5,
+        );
+
+        result.current.setProjectEnvironments(new Set([]));
+
+        expect(result.current.projectChangeRequestConfiguration).toMatchObject({
+            prod: { requiredApprovals: 5 },
+        });
+    });
+
     test(`if specific project envs are selected, adding a change request config for an env not in the project envs doesn't work and the change request envs is not changed`, () => {
         const { result } = renderHook(() => useProjectForm());
 

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -57,7 +57,10 @@ const useProjectForm = (
         },
 
         enableChangeRequests: (env: string, approvals: number) => {
-            if (projectEnvironments.has(env)) {
+            if (
+                projectEnvironments.has(env) ||
+                projectEnvironments.size === 0
+            ) {
                 setProjectChangeRequestConfiguration((previousState) => ({
                     ...previousState,
                     [env]: { requiredApprovals: approvals },

--- a/frontend/src/component/project/Project/hooks/useProjectForm.ts
+++ b/frontend/src/component/project/Project/hooks/useProjectForm.ts
@@ -38,13 +38,16 @@ const useProjectForm = (
     ] = useState(initialProjectChangeRequestConfiguration);
 
     const updateProjectEnvironments = (newState: Set<string>) => {
-        const filteredChangeRequestEnvs = Object.fromEntries(
-            Object.entries(projectChangeRequestConfiguration).filter(([env]) =>
-                newState.has(env),
-            ),
-        );
+        if (newState.size !== 0) {
+            const filteredChangeRequestEnvs = Object.fromEntries(
+                Object.entries(projectChangeRequestConfiguration).filter(
+                    ([env]) => newState.has(env),
+                ),
+            );
 
-        setProjectChangeRequestConfiguration(filteredChangeRequestEnvs);
+            setProjectChangeRequestConfiguration(filteredChangeRequestEnvs);
+        }
+
         setProjectEnvironments(newState);
     };
 


### PR DESCRIPTION
This PR allows you to configure change requests for all environments when no environments are enabled explicitly. This is the default state of the form and makes it so that you can configure CRs even if you want all envs enabled.

Additionally, it preserves the case where you configure CRs for an environment and then disable all envs.

This is logic only. It's not available in the UI yet.