### PR TITLE
fix: get rid of horizontal scrollbar on narrow screens in CreateProjectDialog

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -21,7 +21,7 @@ interface ICreateProjectDialogProps {
     onClose: () => void;
 }
 
-const StyledDialog = styled(Dialog)(({ theme, maxWidth }) => ({
+const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
         maxWidth: theme.spacing(170),
@@ -29,6 +29,9 @@ const StyledDialog = styled(Dialog)(({ theme, maxWidth }) => ({
         backgroundColor: 'transparent',
     },
     padding: 0,
+    '& .MuiPaper-root > section': {
+        overflowX: 'hidden',
+    },
 }));
 
 const CREATE_PROJECT_BTN = 'CREATE_PROJECT_BTN';


### PR DESCRIPTION
This PR hides horizontal overflow in the dialog.

The pop-up docs that we have on small windows was causing a tiny bit of overflow, giving us an annoying (and pretty useless) horizontal scrollbar. We can hide that scrollbar by hiding horizontal overflow.