### PR TITLE
fix: when finding median time to production, ignore 0s

### DIFF
--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
@@ -171,7 +171,7 @@ describe('useFilteredFlagTrends', () => {
             averageUsers: 0,
             averageHealth: undefined,
             flagsPerUser: '0.00',
-            medianTimeToProduction: 0,
+            medianTimeToProduction: undefined,
         });
     });
 

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
@@ -174,4 +174,58 @@ describe('useFilteredFlagTrends', () => {
             medianTimeToProduction: 0,
         });
     });
+
+    it('should not use 0 timeToProduction projects for median calculation', () => {
+        const { result } = renderHook(() =>
+            useFilteredFlagsSummary(
+                [
+                    {
+                        week: '2024-01',
+                        project: 'project1',
+                        total: 0,
+                        active: 0,
+                        stale: 0,
+                        potentiallyStale: 0,
+                        users: 0,
+                        date: '',
+                        timeToProduction: 0,
+                    },
+                    {
+                        week: '2024-01',
+                        project: 'project2',
+                        total: 0,
+                        active: 0,
+                        stale: 0,
+                        potentiallyStale: 0,
+                        users: 0,
+                        date: '',
+                        timeToProduction: 0,
+                    },
+                    {
+                        week: '2024-01',
+                        project: 'project3',
+                        total: 0,
+                        active: 0,
+                        stale: 0,
+                        potentiallyStale: 0,
+                        users: 0,
+                        date: '',
+                        timeToProduction: 5,
+                    },
+                ],
+                { total: 1 } as unknown as InstanceInsightsSchemaUsers,
+            ),
+        );
+
+        expect(result.current).toEqual({
+            total: 0,
+            active: 0,
+            stale: 0,
+            potentiallyStale: 0,
+            averageUsers: 0,
+            averageHealth: undefined,
+            flagsPerUser: '0.00',
+            medianTimeToProduction: 5,
+        });
+    });
 });

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -6,7 +6,10 @@ import type {
 
 const validTimeToProduction = (
     item: InstanceInsightsSchemaProjectFlagTrendsItem,
-) => Boolean(item) && typeof item.timeToProduction === 'number';
+) =>
+    Boolean(item) &&
+    typeof item.timeToProduction === 'number' &&
+    item.timeToProduction !== 0;
 
 // NOTE: should we move project filtering to the backend?
 export const useFilteredFlagsSummary = (

--- a/src/test/e2e/api/admin/playground.e2e.test.ts
+++ b/src/test/e2e/api/admin/playground.e2e.test.ts
@@ -142,7 +142,7 @@ describe('Playground API E2E', () => {
         );
     };
 
-    test('Returned features should be a subset of the provided toggles', async () => {
+    test('Returned features should be a subset of the provided flags', async () => {
         await fc.assert(
             fc
                 .asyncProperty(


### PR DESCRIPTION
We have an issue that if you open up Insights, the Time to Production chart was showing nothing because it was taking the median across all projects. You might have many new or empty projects where the median was 0 (no data).

For example, the median from [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.7, 50.3, 140] was 0.

Now, we will remove the 0 values to have a more reasonable median.
