### PR TITLE
fix: sort segments before comparing in cr diff calculations

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.test.ts
@@ -99,6 +99,24 @@ describe('Strategy change conflict detection', () => {
         expect(resultMissing).toBeNull();
     });
 
+    test('It sorts segments before comparing (because their order is irrelevant)', () => {
+        const result = getStrategyChangesThatWouldBeOverwritten(
+            {
+                ...existingStrategy,
+                segments: [25, 26, 1],
+            },
+            {
+                ...change,
+                payload: {
+                    ...change.payload,
+                    segments: [26, 1, 25],
+                },
+            },
+        );
+
+        expect(result).toBeNull();
+    });
+
     test('It treats `undefined` or missing strategy variants in old config and change as equal to `[]`', () => {
         const undefinedVariantsExistingStrategy = {
             ...existingStrategy,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -149,7 +149,7 @@ export function getStrategyChangesThatWouldBeOverwritten(
                 ...change,
                 payload: {
                     ...change.payload,
-                    segments: [...(change.payload.segments ?? [])].sort(),
+                    segments: [...change.payload.segments].sort(),
                 },
             };
 

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -142,6 +142,11 @@ export function getStrategyChangesThatWouldBeOverwritten(
     change: IChangeRequestUpdateStrategy,
 ): ChangesThatWouldBeOverwritten | null {
     const fallbacks = { segments: [], variants: [], title: '' };
+    if (change.payload.segments && currentStrategyConfig?.segments) {
+        change.payload.segments.sort();
+        currentStrategyConfig.segments.sort();
+    }
+
     return getChangesThatWouldBeOverwritten(
         omit(currentStrategyConfig, 'strategyName'),
         change,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -142,14 +142,25 @@ export function getStrategyChangesThatWouldBeOverwritten(
     change: IChangeRequestUpdateStrategy,
 ): ChangesThatWouldBeOverwritten | null {
     const fallbacks = { segments: [], variants: [], title: '' };
-    if (change.payload.segments && currentStrategyConfig?.segments) {
-        change.payload.segments.sort();
-        currentStrategyConfig.segments.sort();
-    }
+
+    const withSortedSegments = (() => {
+        if (change.payload.segments && currentStrategyConfig?.segments) {
+            const changeCopy = { ...change };
+            changeCopy.payload.segments =
+                changeCopy.payload.segments?.toSorted();
+
+            const currentCopy = { ...currentStrategyConfig };
+            currentCopy.segments = currentCopy.segments?.toSorted();
+
+            return { current: currentCopy, change: changeCopy };
+        } else {
+            return { current: currentStrategyConfig, change: change };
+        }
+    })();
 
     return getChangesThatWouldBeOverwritten(
-        omit(currentStrategyConfig, 'strategyName'),
-        change,
+        omit(withSortedSegments.current, 'strategyName'),
+        withSortedSegments.change,
         fallbacks,
     );
 }

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -144,24 +144,24 @@ export function getStrategyChangesThatWouldBeOverwritten(
     const fallbacks = { segments: [], variants: [], title: '' };
 
     const withSortedSegments = (() => {
-        if (change.payload.segments && currentStrategyConfig?.segments) {
-            const changeCopy = {
-                ...change,
-                payload: {
-                    ...change.payload,
-                    segments: [...change.payload.segments].sort(),
-                },
-            };
-
-            const currentCopy = {
-                ...currentStrategyConfig,
-                segments: [...currentStrategyConfig.segments].sort(),
-            };
-
-            return { current: currentCopy, change: changeCopy };
-        } else {
+        if (!(change.payload.segments && currentStrategyConfig?.segments)) {
             return { current: currentStrategyConfig, change: change };
         }
+
+        const changeCopy = {
+            ...change,
+            payload: {
+                ...change.payload,
+                segments: [...change.payload.segments].sort(),
+            },
+        };
+
+        const currentCopy = {
+            ...currentStrategyConfig,
+            segments: [...currentStrategyConfig.segments].sort(),
+        };
+
+        return { current: currentCopy, change: changeCopy };
     })();
 
     return getChangesThatWouldBeOverwritten(

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -145,12 +145,18 @@ export function getStrategyChangesThatWouldBeOverwritten(
 
     const withSortedSegments = (() => {
         if (change.payload.segments && currentStrategyConfig?.segments) {
-            const changeCopy = { ...change };
-            changeCopy.payload.segments =
-                changeCopy.payload.segments?.toSorted();
+            const changeCopy = {
+                ...change,
+                payload: {
+                    ...change.payload,
+                    segments: [...(change.payload.segments ?? [])].sort(),
+                },
+            };
 
-            const currentCopy = { ...currentStrategyConfig };
-            currentCopy.segments = currentCopy.segments?.toSorted();
+            const currentCopy = {
+                ...currentStrategyConfig,
+                segments: [...currentStrategyConfig.segments].sort(),
+            };
 
             return { current: currentCopy, change: changeCopy };
         } else {


### PR DESCRIPTION
This change fixes a bug where we would show the list of segments as
changed (causing a conflict) if their order wasn't the same in the
change as in the original.

By sorting the segments before comparing them, we can avoid this issue.

To avoid modifying the objects that are passed in (in case that has knock-on effects anywhere), we copy the objects. And because `toSorted` "only" has about 89% coverage now, I chose to use `sort` and spread the arrays instead.