### PR TITLE
fix: footer overflow

### DIFF
--- a/frontend/src/component/menu/Footer/Footer.tsx
+++ b/frontend/src/component/menu/Footer/Footer.tsx
@@ -13,6 +13,7 @@ const StyledFooter = styled('footer')(({ theme }) => ({
     flexGrow: 1,
     zIndex: 100,
     backgroundColor: theme.palette.background.paper,
+    overflowY: 'hidden',
 }));
 
 const StyledList = styled(List)({

--- a/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should render DrawerMenu 1`] = `
 [
   <footer
-    className="css-10ce49z"
+    className="css-u2qlp3"
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-10 css-16chest-MuiGrid-root"
@@ -547,7 +547,7 @@ exports[`should render DrawerMenu 1`] = `
 exports[`should render DrawerMenu with "features" selected 1`] = `
 [
   <footer
-    className="css-10ce49z"
+    className="css-u2qlp3"
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-10 css-16chest-MuiGrid-root"


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Footer component overflows the main content making some elements e.g. hide/expand not clickable. Instead of zIndex escalation I prefer to prevent the overflow. 
<img width="1564" alt="Screenshot 2024-05-29 at 10 51 48" src="https://github.com/Unleash/unleash/assets/1394682/174a356d-61a9-4fe7-99f0-4665ad7653ab">

Root cause:
Footer uses mui grid. The grid has a negative margin. The negative margin comes from the spacing property on the grid. It has this behavior: https://github.com/mui/material-ui/issues/10223. We could also remove the spacing and set it to 0 but the spacing is needed for keeping footer elements apart vertically and we can live with the horizontal impact of the negative margin once we hide it behind overflow hidden. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
