### PR TITLE
feat: add tooltips to new project creation form config buttons

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
@@ -10,7 +10,7 @@ import {
 
 type ChangeRequestTableConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
 > & {
     search: {
         label: string;

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
@@ -10,7 +10,7 @@ import {
 
 type ChangeRequestTableConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipHeader'
 > & {
     search: {
         label: string;

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ConfigButton.tsx
@@ -17,7 +17,7 @@ export type ConfigButtonProps = {
     preventOpen?: boolean;
     anchorEl: HTMLDivElement | null | undefined;
     setAnchorEl: (el: HTMLDivElement | null | undefined) => void;
-    tooltipText: string;
+    tooltipHeader: string;
 };
 
 export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
@@ -29,7 +29,7 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
     preventOpen,
     anchorEl,
     setAnchorEl,
-    tooltipText,
+    tooltipHeader,
 }) => {
     const ref = useRef<HTMLDivElement>(null);
     const descriptionId = uuidv4();
@@ -50,7 +50,7 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
                 <TooltipResolver
                     titleComponent={
                         <article>
-                            <h3>{tooltipText}</h3>
+                            <h3>{tooltipHeader}</h3>
                             <p>{description}</p>
                         </article>
                     }

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ConfigButton.tsx
@@ -7,6 +7,7 @@ import {
     HiddenDescription,
     ButtonLabel,
 } from './ConfigButton.styles';
+import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
 
 export type ConfigButtonProps = {
     button: { label: string; icon: ReactNode; labelWidth?: string };
@@ -16,6 +17,7 @@ export type ConfigButtonProps = {
     preventOpen?: boolean;
     anchorEl: HTMLDivElement | null | undefined;
     setAnchorEl: (el: HTMLDivElement | null | undefined) => void;
+    tooltipText: string;
 };
 
 export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
@@ -27,6 +29,7 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
     preventOpen,
     anchorEl,
     setAnchorEl,
+    tooltipText,
 }) => {
     const ref = useRef<HTMLDivElement>(null);
     const descriptionId = uuidv4();
@@ -44,20 +47,30 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
     return (
         <>
             <Box ref={ref}>
-                <Button
-                    variant='outlined'
-                    color='primary'
-                    startIcon={button.icon}
-                    onClick={() => {
-                        if (!preventOpen) {
-                            open();
-                        }
-                    }}
+                <TooltipResolver
+                    titleComponent={
+                        <article>
+                            <h3>{tooltipText}</h3>
+                            <p>{description}</p>
+                        </article>
+                    }
+                    variant='custom'
                 >
-                    <ButtonLabel labelWidth={button.labelWidth}>
-                        {button.label}
-                    </ButtonLabel>
-                </Button>
+                    <Button
+                        variant='outlined'
+                        color='primary'
+                        startIcon={button.icon}
+                        onClick={() => {
+                            if (!preventOpen) {
+                                open();
+                            }
+                        }}
+                    >
+                        <ButtonLabel labelWidth={button.labelWidth}>
+                            {button.label}
+                        </ButtonLabel>
+                    </Button>
+                </TooltipResolver>
             </Box>
             <StyledPopover
                 open={Boolean(anchorEl)}

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/MultiSelectConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/MultiSelectConfigButton.tsx
@@ -4,7 +4,7 @@ import { DropdownList, type DropdownListProps } from './DropdownList';
 
 type MultiSelectConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipHeader'
 > &
     Pick<DropdownListProps, 'search' | 'options'> & {
         selectedOptions: Set<string>;

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/MultiSelectConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/MultiSelectConfigButton.tsx
@@ -4,7 +4,7 @@ import { DropdownList, type DropdownListProps } from './DropdownList';
 
 type MultiSelectConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
 > &
     Pick<DropdownListProps, 'search' | 'options'> & {
         selectedOptions: Set<string>;

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/SingleSelectConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/SingleSelectConfigButton.tsx
@@ -4,7 +4,7 @@ import { DropdownList, type DropdownListProps } from './DropdownList';
 
 type SingleSelectConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
 > &
     Pick<DropdownListProps, 'search' | 'onChange' | 'options'>;
 

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/SingleSelectConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/SingleSelectConfigButton.tsx
@@ -4,7 +4,7 @@ import { DropdownList, type DropdownListProps } from './DropdownList';
 
 type SingleSelectConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipText'
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltipHeader'
 > &
     Pick<DropdownListProps, 'search' | 'onChange' | 'options'>;
 

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/NewProjectForm.tsx
@@ -180,7 +180,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
 
             <OptionButtons>
                 <MultiSelectConfigButton
-                    tooltipText='Select project environments'
+                    tooltipHeader='Select project environments'
                     description={configButtonData.environments.text}
                     selectedOptions={projectEnvironments}
                     options={activeEnvironments.map((env) => ({
@@ -207,7 +207,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                 />
 
                 <SingleSelectConfigButton
-                    tooltipText='Set default project stickiness'
+                    tooltipHeader='Set default project stickiness'
                     description={configButtonData.stickiness.text}
                     options={stickinessOptions.map(({ key, ...rest }) => ({
                         value: key,
@@ -235,7 +235,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <SingleSelectConfigButton
-                            tooltipText='Set project mode'
+                            tooltipHeader='Set project mode'
                             description={configButtonData.mode.text}
                             options={projectModeOptions}
                             onChange={(value: any) => {
@@ -261,7 +261,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <ChangeRequestTableConfigButton
-                            tooltipText='Configure change requests'
+                            tooltipHeader='Configure change requests'
                             description={configButtonData.changeRequests.text}
                             activeEnvironments={
                                 availableChangeRequestEnvironments

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/NewProjectForm.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/NewProjectForm.tsx
@@ -180,6 +180,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
 
             <OptionButtons>
                 <MultiSelectConfigButton
+                    tooltipText='Select project environments'
                     description={configButtonData.environments.text}
                     selectedOptions={projectEnvironments}
                     options={activeEnvironments.map((env) => ({
@@ -206,6 +207,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                 />
 
                 <SingleSelectConfigButton
+                    tooltipText='Set default project stickiness'
                     description={configButtonData.stickiness.text}
                     options={stickinessOptions.map(({ key, ...rest }) => ({
                         value: key,
@@ -233,6 +235,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <SingleSelectConfigButton
+                            tooltipText='Set project mode'
                             description={configButtonData.mode.text}
                             options={projectModeOptions}
                             onChange={(value: any) => {
@@ -258,6 +261,7 @@ export const NewProjectForm: React.FC<FormProps> = ({
                     condition={isEnterprise()}
                     show={
                         <ChangeRequestTableConfigButton
+                            tooltipText='Configure change requests'
                             description={configButtonData.changeRequests.text}
                             activeEnvironments={
                                 availableChangeRequestEnvironments


### PR DESCRIPTION
This PR adds tooltips to the new project creation form buttons to make it clearer what they do. The tooltips tell you what the buttons do and contains the same description that we use for docs.

![image](https://github.com/Unleash/unleash/assets/17786332/74667ff8-25b7-4daa-bb93-8938fe4e3dd2)

The tooltips will cover other buttons on narrow windows, but I think that's an acceptable tradeoff

![image](https://github.com/Unleash/unleash/assets/17786332/9886f717-9db9-40bd-bd0b-0e6150896889)
