### PR TITLE
fix: handle long owner names for projects

### DIFF
--- a/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
@@ -14,7 +14,7 @@ const StyledFooter = styled(Box)(({ theme }) => ({
     display: 'grid',
     gridTemplateColumns: 'auto 1fr auto',
     alignItems: 'center',
-    padding: theme.spacing(1.5, 3, 2, 3),
+    padding: theme.spacing(1.5, 3, 2.5, 3),
     background: theme.palette.envAccordion.expanded,
     boxShadow: theme.boxShadows.accordionFooter,
 }));

--- a/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
@@ -11,10 +11,10 @@ interface IProjectCardFooterProps {
 }
 
 const StyledFooter = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    justifyContent: 'space-between',
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
     alignItems: 'center',
-    padding: theme.spacing(1.5, 3),
+    padding: theme.spacing(1.5, 3, 2, 3),
     background: theme.palette.envAccordion.expanded,
     boxShadow: theme.boxShadows.accordionFooter,
 }));

--- a/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
@@ -22,6 +22,7 @@ const StyledFooter = styled(Box)(({ theme }) => ({
 const StyledFavoriteIconButton = styled(FavoriteIconButton)(({ theme }) => ({
     marginRight: theme.spacing(-1),
     marginLeft: 'auto',
+    marginBottom: theme.spacing(-1),
 }));
 
 export const ProjectCardFooter: FC<IProjectCardFooterProps> = ({

--- a/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
@@ -21,7 +21,6 @@ const StyledFooter = styled(Box)(({ theme }) => ({
 
 const StyledFavoriteIconButton = styled(FavoriteIconButton)(({ theme }) => ({
     marginRight: theme.spacing(-1),
-    marginLeft: 'auto',
     marginBottom: theme.spacing(-1),
 }));
 

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -41,15 +41,13 @@ const useOwnersMap = () => {
     };
 };
 
-const StyledContainer = styled('div')(({ theme }) => ({
-    marginBottom: theme.spacing(1),
-    display: 'flex',
-    alignItems: 'flex-end',
-}));
-
 const StyledUserName = styled('p')(({ theme }) => ({
     fontSize: theme.typography.body1.fontSize,
     margin: theme.spacing(0, 0, 0.5, 0),
+    overflowX: 'hidden',
+    textOverflow: 'ellipsis',
+    textWrap: 'nowrap',
+    alignSelf: 'end',
 }));
 
 export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
@@ -57,7 +55,7 @@ export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
     const users = owners.map(ownersMap);
 
     return (
-        <StyledContainer>
+        <>
             <GroupCardAvatars
                 header={owners.length === 1 ? 'Owner' : 'Owners'}
                 users={users}
@@ -70,6 +68,6 @@ export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
                     </StyledUserName>
                 }
             />
-        </StyledContainer>
+        </>
     );
 };


### PR DESCRIPTION
This change updates the new project card footer to better handle long
names. Previously, if a name was too long to fit on a single line,
it'd wrap. It didn't cause any layout shift, but it made the card look
off.

So instead of wrapping, we now truncate the name and add an ellipsis.

To achieve this, I changed the layout to grid instead of flexbox and
removed a nested flex container.

Before: 

![image](https://github.com/Unleash/unleash/assets/17786332/2074ac85-ce73-4292-beed-a3da05083a8d)

After:

![image](https://github.com/Unleash/unleash/assets/17786332/8302aae8-959f-4336-acd3-dbc207767d5a)

Other cards remain the same, as shown here (new code on left, old code on right):


<img width="601" alt="image" src="https://github.com/Unleash/unleash/assets/17786332/009c5d5d-3f9d-4640-86a1-3b6afcd04041">
