### PR TITLE
chore: mark deprecations with version

### DIFF
--- a/src/lib/openapi/spec/client-application-schema.ts
+++ b/src/lib/openapi/spec/client-application-schema.ts
@@ -25,7 +25,7 @@ export const clientApplicationSchema = {
             example: 'unleash-client-java:7.0.0',
         },
         environment: {
-            description: `The SDK's configured 'environment' property. Deprecated. This property  does **not** control which Unleash environment the SDK gets toggles for. To control Unleash environments, use the SDKs API key.`,
+            description: `The SDK's configured 'environment' property. This property was deprecated in v5. This property  does **not** control which Unleash environment the SDK gets toggles for. To control Unleash environments, use the SDKs API key.`,
             deprecated: true,
             type: 'string',
             example: 'development',

--- a/src/lib/openapi/spec/client-features-query-schema.ts
+++ b/src/lib/openapi/spec/client-features-query-schema.ts
@@ -23,7 +23,7 @@ export const clientFeaturesQuerySchema = {
                 type: 'string',
             },
             description:
-                'Features that are part of these projects are included in this response. (DEPRECATED) - Handled by API tokens',
+                'Features that are part of these projects are included in this response. This is now handled by API tokens and was marked as deprecated in v5',
             example: ['new.payment.flow'],
             deprecated: true,
         },
@@ -36,7 +36,7 @@ export const clientFeaturesQuerySchema = {
         environment: {
             type: 'string',
             description:
-                'Strategies for the feature flag configured for this environment are included. (DEPRECATED) - Handled by API tokens',
+                'Strategies for the feature flag configured for this environment are included. This is now handled by API tokens and was marked as deprecated in v5',
             deprecated: true,
         },
         inlineSegmentConstraints: {

--- a/src/lib/openapi/spec/create-api-token-schema.ts
+++ b/src/lib/openapi/spec/create-api-token-schema.ts
@@ -33,7 +33,7 @@ const usernameSchema = {
             deprecated: true,
             type: 'string',
             description:
-                'The name of the token. This property is deprecated. Use `tokenName` instead.',
+                'The name of the token. This property was deprecated in v5. Use `tokenName` instead.',
             example: 'token-64523',
         },
     },

--- a/src/lib/openapi/spec/feature-schema.ts
+++ b/src/lib/openapi/spec/feature-schema.ts
@@ -87,7 +87,7 @@ export const featureSchema = {
             deprecated: true,
             example: '2023-01-28T16:21:39.975Z',
             description:
-                'The date when metrics where last collected for the feature. This field is deprecated, use the one in featureEnvironmentSchema',
+                'The date when metrics where last collected for the feature. This field was deprecated in v5, use the one in featureEnvironmentSchema',
         },
         environments: {
             type: 'array',
@@ -110,7 +110,8 @@ export const featureSchema = {
             items: {
                 type: 'object',
             },
-            description: 'This is a legacy field that will be deprecated',
+            description:
+                'This was deprecated in v5 and will be removed in a future major version',
             deprecated: true,
         },
         tags: {

--- a/src/lib/openapi/spec/feature-search-response-schema.ts
+++ b/src/lib/openapi/spec/feature-search-response-schema.ts
@@ -101,7 +101,7 @@ export const featureSearchResponseSchema = {
             deprecated: true,
             example: '2023-01-28T16:21:39.975Z',
             description:
-                'The date when metrics where last collected for the feature. This field is deprecated, use the one in featureEnvironmentSchema',
+                'The date when metrics where last collected for the feature. This field was deprecated in v5 and will be removed in a future release, use the one in featureEnvironmentSchema',
         },
         environments: {
             type: 'array',
@@ -124,7 +124,8 @@ export const featureSearchResponseSchema = {
             items: {
                 $ref: '#/components/schemas/variantSchema',
             },
-            description: 'The list of feature variants',
+            description:
+                'The list of feature variants. This field was deprecated in v5',
             deprecated: true,
         },
         strategies: {
@@ -132,7 +133,7 @@ export const featureSearchResponseSchema = {
             items: {
                 type: 'object',
             },
-            description: 'This is a legacy field that will be deprecated',
+            description: 'This is a legacy field that was deprecated in v5',
             deprecated: true,
         },
         tags: {

--- a/src/lib/openapi/spec/user-schema.ts
+++ b/src/lib/openapi/spec/user-schema.ts
@@ -15,7 +15,7 @@ export const userSchema = {
         },
         isAPI: {
             description:
-                '(Deprecated): Used internally to know which operations the user should be allowed to perform',
+                'Deprecated in v5. Used internally to know which operations the user should be allowed to perform',
             type: 'boolean',
             example: true,
             deprecated: true,


### PR DESCRIPTION
Makes some deprecation messages in open API clearer around which version they were deprecated in so that they can be removed in v7