### PR TITLE
Feat/file import

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -333,11 +333,8 @@ const defaultAuthentication: IAuthOption = {
 
 const defaultImport: WithOptional<IImportOption, 'file'> = {
     file: process.env.IMPORT_FILE,
-    dropBeforeImport: parseEnvVarBoolean(
-        process.env.IMPORT_DROP_BEFORE_IMPORT,
-        false,
-    ),
-    keepExisting: parseEnvVarBoolean(process.env.IMPORT_KEEP_EXISTING, false),
+    project: process.env.IMPORT_PROJECT ?? 'default',
+    environment: process.env.IMPORT_ENVIRONMENT ?? 'development',
 };
 
 const defaultEmail: IEmailOption = {

--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -264,6 +264,16 @@ export default class ExportImportService
         ]);
     }
 
+    async fileImportVerify(dto: ImportTogglesSchema): Promise<void> {
+        await allSettledWithRejection([
+            this.verifyStrategies(dto),
+            this.verifyContextFields(dto),
+            this.verifyFeatures(dto),
+            this.verifySegments(dto),
+            this.verifyDependencies(dto),
+        ]);
+    }
+
     async importFeatureData(
         dto: ImportTogglesSchema,
         auditUser: IAuditUser,

--- a/src/lib/features/export-import-toggles/import-file-reader.ts
+++ b/src/lib/features/export-import-toggles/import-file-reader.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+
+export const readFile: (file: string) => Promise<string> = async (file) =>
+    new Promise((resolve, reject) =>
+        fs.readFile(file, (err, v) =>
+            err ? reject(err) : resolve(v.toString('utf-8')),
+        ),
+    );

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -97,7 +97,11 @@ async function createApp(
     };
 
     if (config.import.file) {
-        // TODO: stateservice was here
+        await services.importService.importFromFile(
+            config.import.file,
+            config.import.project,
+            config.import.environment,
+        );
     }
 
     if (

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -81,8 +81,8 @@ export interface IAuthOption {
 
 export interface IImportOption {
     file: string;
-    keepExisting: boolean;
-    dropBeforeImport: boolean;
+    project: string;
+    environment: string;
 }
 
 export interface IServerOption {


### PR DESCRIPTION
## About the changes

Adds a file import option to Unleash

Removes import options:
- dropBeforeImport
- keepExisting

Adds new import options:
- project
- environment

Adds an additional file-import only verify method that skips checking project/flag creation access


## Discussion points

- Should we put this behind a flag? The feature itself IS opt-in, but reuses the IMPORT_FILE env variable (which itself is a very specific variable that you only use when you specifically want to import something and remove before next restart)
- This only addresses OSS. While the interface changes dictates that enterprise will need to implement the interface as well (separate PR), there's currently no mechanism in place to override which import gets used so OSS will currently always be used regardless of hosted option