### PR TITLE
chore: make ip mandatory

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -69,7 +69,6 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
-    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -69,6 +69,7 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
+    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -349,9 +349,7 @@ export const IEventTypes = [
 ] as const;
 export type IEventType = (typeof IEventTypes)[number];
 
-/**
- * This type should only be used in the store layer but deprecated elsewhere
- */
+// this rerpresents the write model for events
 export interface IBaseEvent {
     type: IEventType;
     createdBy: string;
@@ -359,7 +357,7 @@ export interface IBaseEvent {
     project?: string;
     environment?: string;
     featureName?: string;
-    ip?: string;
+    ip: string;
     data?: any;
     preData?: any;
     tags?: ITag[];


### PR DESCRIPTION
IP should be mandatory for storing events. Automated events should use 127.0.0.1