### PR TITLE
chore: bump node 20 version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20.13.1-alpine
+ARG NODE_VERSION=20.14.0-alpine
 
 FROM node:$NODE_VERSION as builder
 


### PR DESCRIPTION
As the title says, bumps from 20.13.1 to 20.14.0 to ensure v6 gets the latest and greatest next week