### PR TITLE
chore: remove project list split feature flags

### DIFF
--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -99,7 +99,6 @@ export const ProjectListNew = () => {
         searchParams.get('search') || '',
     );
 
-    const splitProjectList = useUiFlag('projectListFilterMyProjects');
     const myProjects = new Set(useProfile().profile?.projects || []);
 
     const showCreateDialog = Boolean(searchParams.get('create'));
@@ -135,11 +134,8 @@ export const ProjectListNew = () => {
     }, [projects, searchValue]);
 
     const groupedProjects = useMemo(() => {
-        if (!splitProjectList) {
-            return { myProjects: [], otherProjects: filteredProjects };
-        }
         return groupProjects(myProjects, filteredProjects);
-    }, [filteredProjects, myProjects, splitProjectList]);
+    }, [filteredProjects, myProjects]);
 
     const createButtonData = resolveCreateButtonData(
         isOss(),
@@ -228,24 +224,14 @@ export const ProjectListNew = () => {
                         />
                     )}
                 />
-                <ConditionallyRender
-                    condition={splitProjectList}
-                    show={
-                        <>
-                            <ProjectGroupComponent
-                                sectionTitle='My projects'
-                                projects={groupedProjects.myProjects}
-                            />
+                <ProjectGroupComponent
+                    sectionTitle='My projects'
+                    projects={groupedProjects.myProjects}
+                />
 
-                            <ProjectGroupComponent
-                                sectionTitle='Other projects'
-                                projects={groupedProjects.otherProjects}
-                            />
-                        </>
-                    }
-                    elseShow={
-                        <ProjectGroupComponent projects={filteredProjects} />
-                    }
+                <ProjectGroupComponent
+                    sectionTitle='Other projects'
+                    projects={groupedProjects.otherProjects}
                 />
             </StyledContainer>
             <ConditionallyRender

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -81,7 +81,6 @@ export type UiFlags = {
     projectOverviewRefactorFeedback?: boolean;
     featureLifecycle?: boolean;
     scimApi?: boolean;
-    projectListFilterMyProjects?: boolean;
     createProjectWithEnvironmentConfig?: boolean;
     projectsListNewCards?: boolean;
     newCreateProjectUI?: boolean;

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -140,7 +140,6 @@ exports[`should create default config 1`] = `
       "outdatedSdksBanner": false,
       "parseProjectFromSession": false,
       "personalAccessTokensKillSwitch": false,
-      "projectListFilterMyProjects": false,
       "projectOverviewRefactorFeedback": false,
       "projectsListNewCards": false,
       "queryMissingTokens": false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -55,7 +55,6 @@ export type IFlagKey =
     | 'projectOverviewRefactorFeedback'
     | 'featureLifecycle'
     | 'featureLifecycleMetrics'
-    | 'projectListFilterMyProjects'
     | 'projectsListNewCards'
     | 'parseProjectFromSession'
     | 'createProjectWithEnvironmentConfig'
@@ -266,10 +265,6 @@ const flags: IFlags = {
     ),
     featureLifecycle: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FEATURE_LIFECYCLE,
-        false,
-    ),
-    projectListFilterMyProjects: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_PROJECTS_LIST_MY_PROJECTS,
         false,
     ),
     parseProjectFromSession: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -49,7 +49,6 @@ process.nextTick(async () => {
                         disableShowContextFieldSelectionValues: false,
                         projectOverviewRefactorFeedback: true,
                         featureLifecycle: true,
-                        projectListFilterMyProjects: true,
                         projectsListNewCards: true,
                         parseProjectFromSession: true,
                         createProjectWithEnvironmentConfig: true,


### PR DESCRIPTION
This PR removes all the feature flags related to the project list split and updates the snapshot.

Now the project list will always contain "my projects" and "other projects"