### PR TITLE
chore: change to fs/promises and add an import from file e2e test

### DIFF
--- a/src/lib/features/export-import-toggles/export-import-service.ts
+++ b/src/lib/features/export-import-toggles/export-import-service.ts
@@ -57,7 +57,7 @@ import type { IDependentFeaturesReadModel } from '../dependent-features/dependen
 import groupBy from 'lodash.groupby';
 import { allSettledWithRejection } from '../../util/allSettledWithRejection';
 import type { ISegmentReadModel } from '../segment/segment-read-model-type';
-import { readFile } from './import-file-reader';
+import { readFile } from '../../util/read-file';
 
 export type IImportService = {
     validate(

--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -1280,3 +1280,31 @@ test(`should give errors with flag names if the flags don't match the project pa
     expect(body.message).toContain(pattern);
     expect(body.message).toContain(flagName);
 });
+
+test('should import features from file', async () => {
+    await db.stores.environmentStore.create({
+        name: DEFAULT_ENV,
+        type: 'production',
+    });
+
+    await db.stores.projectStore.create({
+        name: DEFAULT_PROJECT,
+        description: '',
+        id: DEFAULT_PROJECT,
+        mode: 'open' as const,
+    });
+    await app.linkProjectToEnvironment(DEFAULT_PROJECT, DEFAULT_ENV);
+
+    await app.services.importService.importFromFile(
+        'src/lib/features/export-import-toggles/import-data.json',
+        DEFAULT_PROJECT,
+        DEFAULT_ENV,
+    );
+    const { body: importedFeature } = await getFeature(defaultFeatureName);
+    expect(importedFeature).toMatchObject({
+        name: defaultFeatureName,
+        project: DEFAULT_PROJECT,
+        type: 'release',
+        variants,
+    });
+});

--- a/src/lib/features/export-import-toggles/import-data.json
+++ b/src/lib/features/export-import-toggles/import-data.json
@@ -1,0 +1,64 @@
+{
+  "features": [
+    { "project": "old_project", "name": "first_feature", "type": "release" }
+  ],
+  "featureStrategies": [
+    {
+      "featureName": "first_feature",
+      "id": "798cb25a-2abd-47bd-8a95-40ec13472309",
+      "name": "default",
+      "parameters": {},
+      "constraints": [
+        {
+          "values": ["conduit"],
+          "inverted": false,
+          "operator": "IN",
+          "contextName": "appName",
+          "caseInsensitive": false
+        }
+      ]
+    }
+  ],
+  "featureEnvironments": [
+    {
+      "enabled": true,
+      "environment": "irrelevant",
+      "featureName": "first_feature",
+      "name": "first_feature",
+      "variants": [
+        {
+          "name": "variantA",
+          "weight": 500,
+          "payload": { "type": "string", "value": "payloadA" },
+          "overrides": [],
+          "stickiness": "default",
+          "weightType": "variable"
+        },
+        {
+          "name": "variantB",
+          "weight": 500,
+          "payload": { "type": "string", "value": "payloadB" },
+          "overrides": [],
+          "stickiness": "default",
+          "weightType": "variable"
+        }
+      ]
+    }
+  ],
+  "featureTags": [
+    { "featureName": "first_feature", "tagType": "simple", "tagValue": "tag1" },
+    { "featureName": "first_feature", "tagType": "simple", "tagValue": "tag2" },
+    {
+      "featureName": "first_feature",
+      "tagType": "special_tag",
+      "tagValue": "feature_tagged"
+    }
+  ],
+  "tagTypes": [
+    { "name": "bestt", "description": "test" },
+    { "name": "special_tag", "description": "this is my special tag" },
+    { "name": "special_tag", "description": "this is my special tag" }
+  ],
+  "contextFields": [],
+  "segments": []
+}

--- a/src/lib/features/export-import-toggles/import-file-reader.ts
+++ b/src/lib/features/export-import-toggles/import-file-reader.ts
@@ -1,8 +1,0 @@
-import * as fs from 'fs';
-
-export const readFile: (file: string) => Promise<string> = async (file) =>
-    new Promise((resolve, reject) =>
-        fs.readFile(file, (err, v) =>
-            err ? reject(err) : resolve(v.toString('utf-8')),
-        ),
-    );

--- a/src/lib/util/read-file.ts
+++ b/src/lib/util/read-file.ts
@@ -1,0 +1,4 @@
+import { promises as fs } from 'fs';
+
+export const readFile: (file: string) => Promise<string> = async (file) =>
+    await fs.readFile(file, 'utf-8');


### PR DESCRIPTION
## About the changes

- Makes readFile a generic utility
- Uses fs/promises in readFile
- Adds a e2e file import test
