### PR TITLE
chore: improve release process

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -21,7 +21,13 @@ jobs:
       matrix:
         version: [18.18.2-alpine]
     steps:
+      - name: Checkout tag v${{ inputs.version }}
+        if: ${{ inputs.version != '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }} # tag that should be created by the caller workflow
       - name: Checkout
+        if: ${{ inputs.version == '' }}
         uses: actions/checkout@v4
       - name: Setup QEmu so we can build multiplatform
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }} # tag that should be created by the caller workflow
       - name: Setup to npm
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release_changelog.yml
+++ b/.github/workflows/release_changelog.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }} # tag that should be created by the caller workflow
       - name: Build changelog
         id: github_release
         uses: metcalfc/changelog-generator@v4.3.1

--- a/package.json
+++ b/package.json
@@ -82,9 +82,7 @@
     "testTimeout": 10000,
     "globalSetup": "./scripts/jest-setup.js",
     "transform": {
-      "^.+\\.tsx?$": [
-        "@swc/jest"
-      ]
+      "^.+\\.tsx?$": ["@swc/jest"]
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "testPathIgnorePatterns": [
@@ -93,13 +91,7 @@
       "/frontend/",
       "/website/"
     ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/dist/",
@@ -237,14 +229,8 @@
     "tough-cookie": "4.1.3"
   },
   "lint-staged": {
-    "*.{js,ts}": [
-      "biome check --apply --no-errors-on-unmatched"
-    ],
-    "*.{jsx,tsx}": [
-      "biome check --apply --no-errors-on-unmatched"
-    ],
-    "*.json": [
-      "biome format --write --no-errors-on-unmatched"
-    ]
+    "*.{js,ts}": ["biome check --apply --no-errors-on-unmatched"],
+    "*.{jsx,tsx}": ["biome check --apply --no-errors-on-unmatched"],
+    "*.json": ["biome format --write --no-errors-on-unmatched"]
   }
 }


### PR DESCRIPTION
Use the tag created by the build action when running npm version, otherwise the checkout actions gets the HEAD of the commit that triggered the original workflow resulting in the usage of the previous version.

Potentially in the future, instead of triggering the build manually we could consider using the tag as a trigger for the build process and then all the dependent workflows should work fine. It's good we have this manual for validation, and we workaround some of the limitations before we invest more into more automation