### PR TITLE
fix: resolve tar to 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "ssh2": "^1.4.0",
     "json-schema": "^0.4.0",
     "ip": "^2.0.1",
+    "tar": "6.2.1",
     "minimatch": "^5.0.0",
     "semver": "^7.5.3",
     "tough-cookie": "4.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,7 +7008,7 @@ swagger2openapi@^7.0.6:
     yaml "^1.10.0"
     yargs "^17.0.1"
 
-tar@^6.1.11:
+tar@6.2.1, tar@^6.1.11:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==


### PR DESCRIPTION
https://github.com/isaacs/node-tar/compare/v6.1.11...v6.2.1

This solves an issue:

> ### Denial of service while parsing a tar file due to lack of folders count validation
> 
> During some analysis today on npm's node-tar package I came across the folder creation process, Basicly if you provide node-tar with a path like this ./a/b/c/foo.txt it would create every folder and sub-folder here a, b and c until it reaches the last folder to create foo.txt, In-this case I noticed that there's no validation at all on the amount of folders being created, that said we're actually able to CPU and memory consume the system running node-tar and even crash the nodejs client within few seconds of running it using a path with too many sub-folders inside