### PR TITLE
feat: clickable tags in project overview

### DIFF
--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.test.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.test.tsx
@@ -1,8 +1,10 @@
 import { screen } from '@testing-library/react';
 import { render } from 'utils/testRenderer';
-import { FeatureOverviewCell } from './FeatureOverviewCell';
+import { FeatureOverviewCell as makeFeatureOverviewCell } from './FeatureOverviewCell';
 
 test('Display full overview information', () => {
+    const FeatureOverviewCell = makeFeatureOverviewCell(() => {});
+
     render(
         <FeatureOverviewCell
             row={{
@@ -38,6 +40,8 @@ test('Display full overview information', () => {
 });
 
 test('Display minimal overview information', () => {
+    const FeatureOverviewCell = makeFeatureOverviewCell(() => {});
+
     render(
         <FeatureOverviewCell
             row={{

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -42,7 +42,6 @@ test('selects project features', async () => {
     await screen.findByText('featureA');
     await screen.findByText('featureB');
     await screen.findByText('Feature flags (2)');
-    await screen.findByText('backend:sdk');
 
     const [selectAll, selectFeatureA, selectFeatureB] =
         screen.queryAllByRole('checkbox');

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -93,6 +93,24 @@ export const ProjectFeatureToggles = ({
 
     const featureLifecycleEnabled = useUiFlag('featureLifecycle');
 
+    const onTagClick = (tag: string) => {
+        if (
+            tableState.tag &&
+            tableState.tag.values.length > 0 &&
+            !tableState.tag.values.includes(tag)
+        ) {
+            setTableState({
+                tag: {
+                    operator: tableState.tag.operator,
+                    values: [...tableState.tag.values, tag],
+                },
+            });
+        }
+        if (!tableState.tag) {
+            setTableState({ tag: { operator: 'INCLUDE', values: [tag] } });
+        }
+    };
+
     const columns = useMemo(
         () => [
             columnHelper.display({
@@ -144,7 +162,7 @@ export const ProjectFeatureToggles = ({
             columnHelper.accessor('name', {
                 id: 'name',
                 header: 'Name',
-                cell: FeatureOverviewCell,
+                cell: FeatureOverviewCell(onTagClick),
                 enableHiding: false,
                 meta: {
                     width: '50%',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Making tags in project overview clickable to add tag filters with one click:

<img width="743" alt="Screenshot 2024-06-04 at 10 07 43" src="https://github.com/Unleash/unleash/assets/1394682/a95eb818-04d0-4540-bff6-b48f42bf1585">

Details:
* tags are modelled as buttons so that keyboard navigation works
* tags within "more tags" section are also clickable
* clicking same tag is idempotent
* clicking for the first time adds include tag operator
* clicking for the second time keeps the existing operator
* styling button similarly to the previous div

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
