### PR TITLE
fix: trying to create a tag that's too short gives errors

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
@@ -108,15 +108,16 @@ export const TagsInput = ({
         options: TagOption[],
         params: FilterOptionsState<TagOption>,
     ) => {
+        const inputValue = params.inputValue.trim();
+
         const filtered = filter(options, {
             ...params,
-            inputValue: params.inputValue.trim(),
+            inputValue,
         });
 
-        const inputValue = params.inputValue.trim();
         // Suggest the creation of a new value
         const isExisting = options.some(
-            (option) => inputValue.trim() === option.title,
+            (option) => inputValue === option.title,
         );
 
         if (inputValue.length >= 2 && !isExisting) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
@@ -110,12 +110,13 @@ export const TagsInput = ({
     ) => {
         const filtered = filter(options, params);
 
-        const { inputValue } = params;
+        const inputValue = params.inputValue.trim();
         // Suggest the creation of a new value
         const isExisting = options.some(
-            (option) => inputValue === option.title,
+            (option) => inputValue.trim() === option.title,
         );
-        if (inputValue !== '' && !isExisting) {
+
+        if (inputValue.length >= 2 && !isExisting) {
             filtered.push({
                 inputValue,
                 title: `Create new value "${inputValue}"`,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
@@ -108,7 +108,10 @@ export const TagsInput = ({
         options: TagOption[],
         params: FilterOptionsState<TagOption>,
     ) => {
-        const filtered = filter(options, params);
+        const filtered = filter(options, {
+            ...params,
+            inputValue: params.inputValue.trim(),
+        });
 
         const inputValue = params.inputValue.trim();
         // Suggest the creation of a new value


### PR DESCRIPTION
1. Only suggest to create a tag value if the input is more than two
characters after trimming.
2. Ignore trailing and leading whitespace when considering which autocomplete options to show