### PR TITLE
fix: import export pointing to new docs

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -73,7 +73,7 @@ const OPENAPI_TAGS = [
     {
         name: 'Import/Export',
         description:
-            '[Import and export](https://docs.getunleash.io/deploy/import_export) the state of your Unleash instance.',
+            '[Import and export](https://docs.getunleash.io/how-to/how-to-environment-import-export) the state of your Unleash instance.',
     },
     {
         name: 'Instance Admin',


### PR DESCRIPTION
I believe this link is pointing to old docs and should be updated