### PR TITLE
fix: involuntarily scrolled to the top when mousing off group/project avatars

### DIFF
--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/GroupPopover/GroupPopover.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/GroupPopover/GroupPopover.tsx
@@ -35,6 +35,7 @@ export const GroupPopover = ({
             anchorEl={anchorEl}
             onClose={onPopoverClose}
             disableScrollLock={true}
+            disableRestoreFocus={true}
             anchorOrigin={{
                 vertical: 'bottom',
                 horizontal: 'left',

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/GroupPopover/GroupPopover.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/GroupPopover/GroupPopover.tsx
@@ -34,6 +34,7 @@ export const GroupPopover = ({
             open={open}
             anchorEl={anchorEl}
             onClose={onPopoverClose}
+            disableScrollLock={true}
             anchorOrigin={{
                 vertical: 'bottom',
                 horizontal: 'left',


### PR DESCRIPTION
This PR fixes a bug where if you navigated to the projects page via the menu, scrolled down, and hovered over a project's avatars, you'd be scrolled to the top of the page when you moused off the avatar.

Turns out this issue was also in the group cards. It seems to be that the popover attempts to restore focus back to where you where, which, if you navigated via the menu, is at the top of the page. Because these popovers don't have any focusable content, we can disable that functionality.

Additionally, I've disabled the scroll lock when the popover is open. The scroll lock made it impossible to scroll when one of the popovers is open, which is confusing as a user.