### PR TITLE
fix: project settings table overflow

### DIFF
--- a/frontend/src/component/common/VerticalTabs/VerticalTabs.tsx
+++ b/frontend/src/component/common/VerticalTabs/VerticalTabs.tsx
@@ -4,7 +4,7 @@ import { VerticalTab } from './VerticalTab/VerticalTab';
 const StyledTabPage = styled('div')(({ theme }) => ({
     display: 'flex',
     gap: theme.spacing(3),
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('xl')]: {
         flexDirection: 'column',
     },
 }));
@@ -21,7 +21,7 @@ const StyledTabs = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
     width: theme.spacing(30),
     flexShrink: 0,
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('xl')]: {
         width: '100%',
     },
 }));


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Stop project settings tables from overflowing. Some tables (e.g. API tokens) in the project settings had px based min width that is overflowing after we added a sidebar. I'm adjusting the breakpoint for mobile view a bit earlier. We could also consider not using px based min width and use % based width instead.

Before (on 1500px, type, created and other columns push the content out of the parent container):
<img width="1128" alt="Screenshot 2024-06-05 at 13 47 25" src="https://github.com/Unleash/unleash/assets/1394682/a56fb817-87c7-4fa1-ab8c-e4222aab9b96">

After (on 1500px):
<img width="1103" alt="Screenshot 2024-06-05 at 13 48 08" src="https://github.com/Unleash/unleash/assets/1394682/e1c98b15-8cdc-4903-9fd7-9692052bf374">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
