### PR TITLE
fix: trim sso URL fields

### DIFF
--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -59,6 +59,10 @@ export const OidcAuth = () => {
         setValue(event.target.name, event.target.value);
     };
 
+    const trimAndUpdateField = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.name, event.target.value.trim());
+    };
+
     const updateEnabled = () => {
         setData({ ...data, enabled: !data.enabled });
     };
@@ -146,7 +150,7 @@ export const OidcAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Discover URL'
                             name='discoverUrl'
                             value={data.discoverUrl}
@@ -164,7 +168,7 @@ export const OidcAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Client ID'
                             name='clientId'
                             value={data.clientId}
@@ -185,7 +189,7 @@ export const OidcAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Client Secret'
                             name='secret'
                             value={data.secret}

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -54,6 +54,10 @@ export const SamlAuth = () => {
         setValue(event.target.name, event.target.value);
     };
 
+    const trimAndUpdateField = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.name, event.target.value.trim());
+    };
+
     const updateEnabled = () => {
         setData({ ...data, enabled: !data.enabled });
     };
@@ -137,7 +141,7 @@ export const SamlAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Entity ID'
                             name='entityId'
                             value={data.entityId}
@@ -159,7 +163,7 @@ export const SamlAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Single Sign-On URL'
                             name='signOnUrl'
                             value={data.signOnUrl}
@@ -213,7 +217,7 @@ export const SamlAuth = () => {
                     </Grid>
                     <Grid item md={6}>
                         <TextField
-                            onChange={updateField}
+                            onChange={trimAndUpdateField}
                             label='Single Sign-out URL'
                             name='signOutUrl'
                             value={data.signOutUrl}


### PR DESCRIPTION
What the title says. There are input values that are whitespace sensitive, so this will trim clientId and entity field, preventing the form from sending leading or trailing whitespace. Will make a PR on enterprise as well to trim on the backend as well.