### PR TITLE
chore: test that the tags API still returns tags that you can't create anymore

### DIFF
--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -209,3 +209,10 @@ test('Can bulk remove tags', async () => {
         })
         .expect(200);
 });
+
+describe('backward compatibility', () => {
+    test('should return invalid tag names if they exist', async () => {
+        await db.stores.tagStore.createTag({ value: '  ', type: 'simple' });
+        await app.request.get('/api/admin/tags').expect(200);
+    });
+});

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -214,5 +214,5 @@ test('backward compatibility: the API should return invalid tag names if they ex
     const tag = { value: '  ', type: 'simple' };
     await db.stores.tagStore.createTag(tag);
     const { body } = await app.request.get('/api/admin/tags').expect(200);
-    expect(body.tags).toMatchObject([tag]);
+    expect(body.tags).toContainEqual(tag);
 });

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -212,7 +212,9 @@ test('Can bulk remove tags', async () => {
 
 describe('backward compatibility', () => {
     test('should return invalid tag names if they exist', async () => {
-        await db.stores.tagStore.createTag({ value: '  ', type: 'simple' });
-        await app.request.get('/api/admin/tags').expect(200);
+        const tag = { value: '  ', type: 'simple' };
+        await db.stores.tagStore.createTag(tag);
+        const { body } = await app.request.get('/api/admin/tags').expect(200);
+        expect(body.tags).toMatchObject([tag]);
     });
 });

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -210,11 +210,9 @@ test('Can bulk remove tags', async () => {
         .expect(200);
 });
 
-describe('backward compatibility', () => {
-    test('should return invalid tag names if they exist', async () => {
-        const tag = { value: '  ', type: 'simple' };
-        await db.stores.tagStore.createTag(tag);
-        const { body } = await app.request.get('/api/admin/tags').expect(200);
-        expect(body.tags).toMatchObject([tag]);
-    });
+test('backward compatibility: the API should return invalid tag names if they exist', async () => {
+    const tag = { value: '  ', type: 'simple' };
+    await db.stores.tagStore.createTag(tag);
+    const { body } = await app.request.get('/api/admin/tags').expect(200);
+    expect(body.tags).toMatchObject([tag]);
 });


### PR DESCRIPTION
This change adds a test to the tags API to ensure that even if you
can't create tags that are pure whitespace anymore, you'll still
receive pre-existing tags from the API that fit this description.

The test is here to ensure that we don't break this in future versions
of Unleash.