### PR TITLE
fix: lifecycle metrics on metrics insert

### DIFF
--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.test.ts
@@ -1,5 +1,5 @@
 import {
-    CLIENT_METRICS,
+    CLIENT_METRICS_ADDED,
     FEATURE_ARCHIVED,
     FEATURE_COMPLETED,
     FEATURE_CREATED,
@@ -33,7 +33,7 @@ test('can insert and read lifecycle stages', async () => {
     );
 
     function emitMetricsEvent(environment: string) {
-        eventBus.emit(CLIENT_METRICS, [
+        eventBus.emit(CLIENT_METRICS_ADDED, [
             {
                 featureName,
                 environment,
@@ -120,7 +120,7 @@ test('ignores lifecycle state updates when flag disabled', async () => {
 
     await eventStore.emit(FEATURE_CREATED, { featureName });
     await eventStore.emit(FEATURE_COMPLETED, { featureName });
-    await eventBus.emit(CLIENT_METRICS, {
+    await eventBus.emit(CLIENT_METRICS_ADDED, {
         bucket: { toggles: { [featureName]: 'irrelevant' } },
         environment: 'development',
     });

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
@@ -1,5 +1,5 @@
 import {
-    CLIENT_METRICS,
+    CLIENT_METRICS_ADDED,
     FEATURE_ARCHIVED,
     FEATURE_CREATED,
     FEATURE_REVIVED,
@@ -9,8 +9,8 @@ import {
     type IEnvironmentStore,
     type IEventStore,
     type IFeatureEnvironmentStore,
-    type IProjectLifecycleStageDuration,
     type IFlagResolver,
+    type IProjectLifecycleStageDuration,
     type IUnleashConfig,
 } from '../../types';
 import type {
@@ -95,7 +95,7 @@ export class FeatureLifecycleService extends EventEmitter {
             );
         });
         this.eventBus.on(
-            CLIENT_METRICS,
+            CLIENT_METRICS_ADDED,
             async (events: IClientMetricsEnv[]) => {
                 if (events.length > 0) {
                     const groupedByEnvironment = groupBy(events, 'environment');

--- a/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../test/e2e/helpers/test-helper';
 import getLogger from '../../../test/fixtures/no-logger';
 import {
-    CLIENT_METRICS,
+    CLIENT_METRICS_ADDED,
     FEATURE_ARCHIVED,
     FEATURE_CREATED,
     FEATURE_REVIVED,
@@ -121,7 +121,7 @@ test('should return lifecycle stages', async () => {
     eventStore.emit(FEATURE_CREATED, { featureName: 'my_feature_a' });
     await reachedStage('my_feature_a', 'initial');
     await expectFeatureStage('my_feature_a', 'initial');
-    eventBus.emit(CLIENT_METRICS, [
+    eventBus.emit(CLIENT_METRICS_ADDED, [
         {
             featureName: 'my_feature_a',
             environment: 'default',
@@ -133,7 +133,7 @@ test('should return lifecycle stages', async () => {
     ]);
 
     // missing feature
-    eventBus.emit(CLIENT_METRICS, [
+    eventBus.emit(CLIENT_METRICS_ADDED, [
         {
             environment: 'default',
             yes: 0,
@@ -141,7 +141,7 @@ test('should return lifecycle stages', async () => {
         },
     ]);
     // non existent env
-    eventBus.emit(CLIENT_METRICS, [
+    eventBus.emit(CLIENT_METRICS_ADDED, [
         {
             featureName: 'my_feature_a',
             environment: 'non-existent',

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -1,5 +1,9 @@
 import type { Logger } from '../../../logger';
-import type { IFlagResolver, IUnleashConfig } from '../../../types';
+import {
+    CLIENT_METRICS_ADDED,
+    type IFlagResolver,
+    type IUnleashConfig,
+} from '../../../types';
 import type { IUnleashStores } from '../../../types';
 import type { ToggleMetricsSummary } from '../../../types/models/metrics';
 import type {
@@ -182,6 +186,7 @@ export default class ClientMetricsServiceV2 {
             const copy = [...this.unsavedMetrics];
             this.unsavedMetrics = [];
             await this.clientMetricsStoreV2.batchInsertMetrics(copy);
+            this.config.eventBus.emit(CLIENT_METRICS_ADDED, copy);
         }
     }
 

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -129,6 +129,7 @@ export const PROJECT_ENVIRONMENT_REMOVED =
 export const DEFAULT_STRATEGY_UPDATED = 'default-strategy-updated' as const;
 
 export const CLIENT_METRICS = 'client-metrics' as const;
+export const CLIENT_METRICS_ADDED = 'client-metrics-added' as const;
 export const CLIENT_REGISTER = 'client-register' as const;
 
 export const PAT_CREATED = 'pat-created' as const;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

CLIENT_METRICS is emitted too often to update lifecycle as a result. Piggybacking on the bulk insert of metrics into a DB with a new event CLIENT_METRICS_ADDED

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
