### PR TITLE
Ignore files in `.yarn` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,15 @@ typings
 # We use yarn.lock
 package-lock.json
 
+## Yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # Website stuff
 /website/build
 /website/backers.json


### PR DESCRIPTION
As per [the official docs](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored), this adds files in the the `.yarn` folder to gitignore.