### PR TITLE
chore: add gitignores to frontend and website subdirectories

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -53,3 +53,12 @@ cypress/videos/*
 cypress/downloads/*
 cypress/screenshots/*
 .env.local
+
+# Yarn (https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -23,3 +23,12 @@ yarn-error.log*
 docs/reference/api/**/sidebar.js
 *.api.mdx
 *.tag.mdx
+
+# Yarn (https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
This PR is a follow up to #7333. It appears that the `.gitignore` file in the root of the repository is not ignoring the yarn files in the `/frontend` and `/website` directories.

This PR adds those.

Because the patterns contain slashes, they're interpreted as being relative to the root directory, as mentioned the description of the [gitignore format](https://git-scm.com/docs/gitignore#_description) in the official git docs:

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.