### PR TITLE
docs: move provisioning reference to scim reference

### DIFF
--- a/website/docs/reference/scim.md
+++ b/website/docs/reference/scim.md
@@ -1,5 +1,5 @@
 ---
-id: provisioning
+id: scim
 title: Provisioning
 ---
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -243,7 +243,7 @@ module.exports = {
                         'reference/public-signup',
                         'reference/projects',
                         'reference/project-collaboration-mode',
-                        'reference/provisioning',
+                        'reference/scim',
                         'reference/rbac',
                         'reference/search-operators',
                         'reference/segments',


### PR DESCRIPTION
Moves the docs at refence/provisioning to reference/scim because there's already a reference to /scim in our source code.