### PR TITLE
feat: add popover to users in flags list

### DIFF
--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -4,10 +4,9 @@ import {
     styled,
     type SxProps,
     type Theme,
-    Popover,
 } from '@mui/material';
 import type { IUser } from 'interfaces/user';
-import { useState, type FC } from 'react';
+import type { FC } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledAvatar = styled(Avatar, {
@@ -78,7 +77,7 @@ export const UserAvatar: FC<IUserAvatarProps> = ({
             sx={sx}
             {...props}
             data-loading
-            alt='Gravatar'
+            alt={user?.name || user?.email || user?.username || 'Gravatar'}
             src={src}
             title={title}
             onMouseEnter={onMouseEnter}
@@ -90,138 +89,5 @@ export const UserAvatar: FC<IUserAvatarProps> = ({
                 elseShow={children}
             />
         </StyledAvatar>
-    );
-};
-
-type PopoverProps = {
-    mainText: string;
-    supplementaryText?: string;
-    open: boolean;
-    anchorEl: HTMLElement | null;
-    onPopoverClose(event: React.MouseEvent<HTMLElement>): void;
-};
-
-const StyledPopover = styled(Popover)(({ theme }) => ({
-    pointerEvents: 'none',
-    '.MuiPaper-root': {
-        padding: theme.spacing(1),
-    },
-}));
-
-const StyledSupplementaryText = styled('p')(({ theme }) => ({
-    color: theme.palette.text.secondary,
-    fontSize: theme.fontSizes.smallBody,
-}));
-
-const AvatarPopover = ({
-    mainText,
-    supplementaryText,
-    open,
-    anchorEl,
-    onPopoverClose,
-}: PopoverProps) => {
-    return (
-        <StyledPopover
-            open={open}
-            anchorEl={anchorEl}
-            onClose={onPopoverClose}
-            disableScrollLock={true}
-            disableRestoreFocus={true}
-            anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'left',
-            }}
-            transformOrigin={{
-                vertical: 'top',
-                horizontal: 'left',
-            }}
-        >
-            <ConditionallyRender
-                condition={Boolean(supplementaryText)}
-                show={
-                    <StyledSupplementaryText>
-                        {supplementaryText}
-                    </StyledSupplementaryText>
-                }
-            />
-
-            <p>{mainText}</p>
-        </StyledPopover>
-    );
-};
-
-export const UserAvatarWithPopover: FC<IUserAvatarProps> = ({
-    user,
-    src,
-    title,
-    onMouseEnter,
-    onMouseLeave,
-    className,
-    sx,
-    children,
-    ...props
-}) => {
-    if (!title && !onMouseEnter && user) {
-        title = `${user?.name || user?.email || user?.username} (id: ${
-            user?.id
-        })`;
-    }
-
-    if (!src && user) {
-        src = user?.imageUrl;
-    }
-
-    let fallback: string | undefined;
-    if (!children && user) {
-        fallback = user?.name || user?.email || user?.username;
-        if (fallback?.includes(' ')) {
-            fallback = `${fallback.split(' ')[0][0]}${
-                fallback.split(' ')[1][0]
-            }`.toUpperCase();
-        } else if (fallback) {
-            fallback = fallback[0].toUpperCase();
-        }
-    }
-
-    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-    const onPopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const onPopoverClose = () => {
-        setAnchorEl(null);
-    };
-
-    const avatarOpen = Boolean(anchorEl);
-
-    return (
-        <>
-            <StyledAvatar
-                className={className}
-                sx={sx}
-                {...props}
-                data-loading
-                alt='Gravatar'
-                src={src}
-                title={title}
-                onMouseEnter={(event) => {
-                    onPopoverOpen(event);
-                }}
-                onMouseLeave={onPopoverClose}
-            >
-                <ConditionallyRender
-                    condition={Boolean(fallback)}
-                    show={fallback}
-                    elseShow={children}
-                />
-            </StyledAvatar>
-            <AvatarPopover
-                mainText={user?.name || 'nothing'}
-                supplementaryText={user?.id ? `id: ${user.id}` : undefined}
-                open={avatarOpen}
-                anchorEl={anchorEl}
-                onPopoverClose={onPopoverClose}
-            />
-        </>
     );
 };

--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -4,9 +4,10 @@ import {
     styled,
     type SxProps,
     type Theme,
+    Popover,
 } from '@mui/material';
 import type { IUser } from 'interfaces/user';
-import type { FC } from 'react';
+import { useState, type FC } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledAvatar = styled(Avatar, {
@@ -25,7 +26,7 @@ const StyledAvatar = styled(Avatar, {
     };
 });
 
-interface IUserAvatarProps extends AvatarProps {
+export interface IUserAvatarProps extends AvatarProps {
     user?: Partial<
         Pick<IUser, 'id' | 'name' | 'email' | 'username' | 'imageUrl'>
     >;
@@ -89,5 +90,138 @@ export const UserAvatar: FC<IUserAvatarProps> = ({
                 elseShow={children}
             />
         </StyledAvatar>
+    );
+};
+
+type PopoverProps = {
+    mainText: string;
+    supplementaryText?: string;
+    open: boolean;
+    anchorEl: HTMLElement | null;
+    onPopoverClose(event: React.MouseEvent<HTMLElement>): void;
+};
+
+const StyledPopover = styled(Popover)(({ theme }) => ({
+    pointerEvents: 'none',
+    '.MuiPaper-root': {
+        padding: theme.spacing(1),
+    },
+}));
+
+const StyledSupplementaryText = styled('p')(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallBody,
+}));
+
+const AvatarPopover = ({
+    mainText,
+    supplementaryText,
+    open,
+    anchorEl,
+    onPopoverClose,
+}: PopoverProps) => {
+    return (
+        <StyledPopover
+            open={open}
+            anchorEl={anchorEl}
+            onClose={onPopoverClose}
+            disableScrollLock={true}
+            disableRestoreFocus={true}
+            anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+            }}
+            transformOrigin={{
+                vertical: 'top',
+                horizontal: 'left',
+            }}
+        >
+            <ConditionallyRender
+                condition={Boolean(supplementaryText)}
+                show={
+                    <StyledSupplementaryText>
+                        {supplementaryText}
+                    </StyledSupplementaryText>
+                }
+            />
+
+            <p>{mainText}</p>
+        </StyledPopover>
+    );
+};
+
+export const UserAvatarWithPopover: FC<IUserAvatarProps> = ({
+    user,
+    src,
+    title,
+    onMouseEnter,
+    onMouseLeave,
+    className,
+    sx,
+    children,
+    ...props
+}) => {
+    if (!title && !onMouseEnter && user) {
+        title = `${user?.name || user?.email || user?.username} (id: ${
+            user?.id
+        })`;
+    }
+
+    if (!src && user) {
+        src = user?.imageUrl;
+    }
+
+    let fallback: string | undefined;
+    if (!children && user) {
+        fallback = user?.name || user?.email || user?.username;
+        if (fallback?.includes(' ')) {
+            fallback = `${fallback.split(' ')[0][0]}${
+                fallback.split(' ')[1][0]
+            }`.toUpperCase();
+        } else if (fallback) {
+            fallback = fallback[0].toUpperCase();
+        }
+    }
+
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const onPopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const onPopoverClose = () => {
+        setAnchorEl(null);
+    };
+
+    const avatarOpen = Boolean(anchorEl);
+
+    return (
+        <>
+            <StyledAvatar
+                className={className}
+                sx={sx}
+                {...props}
+                data-loading
+                alt='Gravatar'
+                src={src}
+                title={title}
+                onMouseEnter={(event) => {
+                    onPopoverOpen(event);
+                }}
+                onMouseLeave={onPopoverClose}
+            >
+                <ConditionallyRender
+                    condition={Boolean(fallback)}
+                    show={fallback}
+                    elseShow={children}
+                />
+            </StyledAvatar>
+            <AvatarPopover
+                mainText={user?.name || 'nothing'}
+                supplementaryText={user?.id ? `id: ${user.id}` : undefined}
+                open={avatarOpen}
+                anchorEl={anchorEl}
+                onPopoverClose={onPopoverClose}
+            />
+        </>
     );
 };

--- a/frontend/src/component/common/UserAvatar/UserAvatarWithPopover.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatarWithPopover.tsx
@@ -1,0 +1,91 @@
+import { styled, Popover } from '@mui/material';
+import { useState, type FC } from 'react';
+import type React from 'react';
+import { type IUserAvatarProps, UserAvatar } from './UserAvatar';
+
+type PopoverProps = {
+    mainText: string;
+    open: boolean;
+    anchorEl: HTMLElement | null;
+    onPopoverClose(event: React.MouseEvent<HTMLElement>): void;
+};
+
+const StyledPopover = styled(Popover)(({ theme }) => ({
+    pointerEvents: 'none',
+    '.MuiPaper-root': {
+        padding: theme.spacing(1),
+    },
+}));
+
+const AvatarPopover = ({
+    mainText,
+    open,
+    anchorEl,
+    onPopoverClose,
+}: PopoverProps) => {
+    return (
+        <StyledPopover
+            open={open}
+            anchorEl={anchorEl}
+            onClose={onPopoverClose}
+            disableScrollLock={true}
+            disableRestoreFocus={true}
+            anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'center',
+            }}
+            transformOrigin={{
+                vertical: 'top',
+                horizontal: 'center',
+            }}
+        >
+            <p>{mainText}</p>
+        </StyledPopover>
+    );
+};
+
+type UserAvatarWithPopoverProps = Omit<
+    IUserAvatarProps,
+    'user' | 'onMouseEnter' | 'onMouseLeave'
+> & {
+    user: {
+        name: string;
+        imageUrl: string;
+    };
+};
+
+export const UserAvatarWithPopover: FC<UserAvatarWithPopoverProps> = ({
+    user,
+    ...userAvatarProps
+}) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const onPopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const onPopoverClose = () => {
+        setAnchorEl(null);
+    };
+
+    const avatarOpen = Boolean(anchorEl);
+
+    return (
+        <>
+            <UserAvatar
+                {...userAvatarProps}
+                user={user}
+                data-loading
+                onMouseEnter={(event) => {
+                    onPopoverOpen(event);
+                }}
+                onMouseLeave={onPopoverClose}
+            />
+            <AvatarPopover
+                mainText={user.name}
+                open={avatarOpen}
+                anchorEl={anchorEl}
+                onPopoverClose={onPopoverClose}
+            />
+        </>
+    );
+};

--- a/frontend/src/component/common/UserAvatar/UserAvatarWithPopover.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatarWithPopover.tsx
@@ -50,7 +50,8 @@ type UserAvatarWithPopoverProps = Omit<
 > & {
     user: {
         name: string;
-        imageUrl: string;
+        id?: number;
+        imageUrl?: string;
     };
 };
 

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -40,6 +40,7 @@ import {
     useProjectFeatureSearchActions,
 } from './useProjectFeatureSearch';
 import { UserAvatarWithPopover } from '../../../common/UserAvatar/UserAvatar';
+import type { Theme } from '@mui/material';
 
 interface IPaginatedProjectFeatureTogglesProps {
     environments: string[];
@@ -182,7 +183,9 @@ export const ProjectFeatureToggles = ({
                                           name: original.createdBy.name,
                                           imageUrl: original.createdBy.imageUrl,
                                       }}
-                                      avatarWidth={(theme) => theme.spacing(3)}
+                                      avatarWidth={(theme: Theme) =>
+                                          theme.spacing(3)
+                                      }
                                   />
                               );
                           },

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -39,7 +39,7 @@ import {
     useProjectFeatureSearch,
     useProjectFeatureSearchActions,
 } from './useProjectFeatureSearch';
-import { UserAvatar } from '../../../common/UserAvatar/UserAvatar';
+import { UserAvatarWithPopover } from '../../../common/UserAvatar/UserAvatar';
 
 interface IPaginatedProjectFeatureTogglesProps {
     environments: string[];
@@ -176,7 +176,7 @@ export const ProjectFeatureToggles = ({
                           header: 'By',
                           cell: ({ row: { original } }) => {
                               return (
-                                  <UserAvatar
+                                  <UserAvatarWithPopover
                                       user={{
                                           id: original.createdBy.id,
                                           name: original.createdBy.name,

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -39,7 +39,7 @@ import {
     useProjectFeatureSearch,
     useProjectFeatureSearchActions,
 } from './useProjectFeatureSearch';
-import { UserAvatarWithPopover } from '../../../common/UserAvatar/UserAvatar';
+import { UserAvatarWithPopover } from '../../../common/UserAvatar/UserAvatarWithPopover';
 import type { Theme } from '@mui/material';
 
 interface IPaginatedProjectFeatureTogglesProps {


### PR DESCRIPTION
This PR adds a popover to the user avatars in the flag list.

The popover is similar to the one used for projects and groups, but it differs in a few ways:
- There's less padding. There's quite a lot of padding in the other popovers, and it felt like too much for this table.
- It only shows one bit of text (the user's name/username/email). The other popovers show email and name/username, but we don't have all that information, so this is a stripped down version.

Flag list popover:
![image](https://github.com/Unleash/unleash/assets/17786332/6a86f638-ba6d-48e0-87e2-078b582697cf)

Group popover:
![image](https://github.com/Unleash/unleash/assets/17786332/d5fc7172-8fcb-4fac-87c4-05f211c0938c)

or if no email
![image](https://github.com/Unleash/unleash/assets/17786332/51955ead-849f-4bfc-81aa-e1852677647c)
