### PR TITLE
fix: remove stale stats widget

### DIFF
--- a/frontend/src/component/project/Project/ProjectInsights/ProjectInsightsStats/ProjectInsightsStats.tsx
+++ b/frontend/src/component/project/Project/ProjectInsights/ProjectInsightsStats/ProjectInsightsStats.tsx
@@ -9,7 +9,7 @@ import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 const StyledBox = styled(Box)(({ theme }) => ({
     display: 'grid',
     gap: theme.spacing(2),
-    gridTemplateColumns: 'repeat(5, 1fr)',
+    gridTemplateColumns: 'repeat(4, 1fr)',
     flexWrap: 'wrap',
     [theme.breakpoints.down('lg')]: {
         gridTemplateColumns: 'repeat(2, 1fr)',
@@ -101,18 +101,6 @@ export const ProjectInsightsStats = ({ stats }: IProjectStatsProps) => {
                 change={createdCurrentWindow - createdPastWindow}
             >
                 <NavigationBar to={`/projects/${projectId}`}>
-                    <KeyboardArrowRight />
-                </NavigationBar>
-            </StatusBox>
-
-            <StatusBox
-                title='Stale flags'
-                boxText={String(projectActivityCurrentWindow)}
-                change={
-                    projectActivityCurrentWindow - projectActivityPastWindow
-                }
-            >
-                <NavigationBar to={`/projects/${projectId}/health`}>
                     <KeyboardArrowRight />
                 </NavigationBar>
             </StatusBox>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Removed stale stats widget that had incorrect data
<img width="1550" alt="Screenshot 2024-06-11 at 12 32 39" src="https://github.com/Unleash/unleash/assets/1394682/24e03f7b-eca1-4175-a1c0-bf062a80aa4b">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
