### PR TITLE
chore: use HTML (custom) tooltip for permission switches

### DIFF
--- a/frontend/src/component/common/PermissionSwitch/PermissionSwitch.tsx
+++ b/frontend/src/component/common/PermissionSwitch/PermissionSwitch.tsx
@@ -64,7 +64,11 @@ const BasePermissionSwitch = React.forwardRef<
     } = props;
 
     return (
-        <TooltipResolver title={formatAccessText(access, tooltip)} arrow>
+        <TooltipResolver
+            title={formatAccessText(access, tooltip)}
+            arrow
+            variant='custom'
+        >
             <span data-loading>
                 <Switch
                     data-testid='toggle-switch'


### PR DESCRIPTION
This PR changes the environment permission switch to use the HTML tooltip instead of the default MUI tooltip. This aligns with how we've been doing tooltips recently.

The main driver behind this change was that the project flag table used two different tooltips. This makes it so that they all look the same, but it also impacts other places that use the same switch.

In feature flag table:
![image](https://github.com/Unleash/unleash/assets/17786332/4d411285-c00e-41ec-95f9-9e6855d46661)

On flag page:
![image](https://github.com/Unleash/unleash/assets/17786332/11de1daf-7d0f-4214-8dc7-10b11631ce58)

In project env table:

![image](https://github.com/Unleash/unleash/assets/17786332/cc7a3a99-e48c-4989-9a14-2d5d4035a3cb)
