### PR TITLE
feat: allow searching for unknown users

### DIFF
--- a/src/lib/features/feature-search/feature-search-service.ts
+++ b/src/lib/features/feature-search/feature-search-service.ts
@@ -80,7 +80,15 @@ export class FeatureSearchService {
                 'users.id',
                 params.createdBy,
             );
-            if (parsed) queryParams.push(parsed);
+            if (parsed) {
+                parsed.values = parsed.values.map((value) => {
+                    if (value === '0') {
+                        return null;
+                    }
+                    return value;
+                });
+                queryParams.push(parsed);
+            }
         }
 
         if (params.type) {

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1097,3 +1097,30 @@ test('should return dependencyType', async () => {
         ],
     });
 });
+
+test('returns flags with unknown creators if you set createdBy to 0', async () => {
+    const flagName = 'feature_without_creator';
+    await app.createFeature(flagName);
+    await db.rawDatabase.table('features').update({ createdBy: null }).where({
+        name: flagName,
+    });
+
+    const { body: checkBody } = await searchFeatures({});
+
+    console.log(checkBody);
+
+    const { body } = await filterFeaturesByCreatedBy('IS:0');
+
+    expect(body).toMatchObject({
+        features: [
+            {
+                name: flagName,
+                createdBy: {
+                    id: 0,
+                    name: 'unknown',
+                    imageUrl: null,
+                },
+            },
+        ],
+    });
+});

--- a/src/lib/features/feature-search/search-utils.ts
+++ b/src/lib/features/feature-search/search-utils.ts
@@ -38,6 +38,9 @@ export const applyGenericQueryParams = (
             case 'IS':
             case 'IS_ANY_OF':
                 query.whereIn(param.field, param.values);
+                if (param.values.includes(null)) {
+                    query.or.whereNull(param.field);
+                }
                 break;
             case 'IS_NOT':
             case 'IS_NONE_OF':

--- a/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
@@ -55,7 +55,7 @@ export type IQueryOperator =
 export interface IQueryParam {
     field: string;
     operator: IQueryOperator;
-    values: string[];
+    values: (string | null)[];
 }
 
 export interface IFeatureStrategiesStore

--- a/src/lib/features/project/project-flag-creators-read-model.ts
+++ b/src/lib/features/project/project-flag-creators-read-model.ts
@@ -24,6 +24,17 @@ export class ProjectFlagCreatorsReadModel
                 'users.username',
                 'users.email',
             ]);
+
+        const hasUnknownCreators = await this.db('features')
+            .where('features.project', project)
+            .where('features.archived_at', null)
+            .whereNull('features.created_by_user_id')
+            .first();
+
+        if (hasUnknownCreators) {
+            result.push({ id: 0, name: 'unknown' });
+        }
+
         return result
             .filter((row) => row.name || row.username || row.email)
             .map((row) => ({


### PR DESCRIPTION
This PR allows you to search for flags with unknown creators.

But I'm not sure this is the right approach.