### PR TITLE
fix: yarn v4 requires prepack instead of prepare script when building…

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",
     "preversion": "./scripts/check-release.sh",
-    "heroku-postbuild": "cd frontend && yarn && yarn build"
+    "heroku-postbuild": "cd frontend && yarn && yarn build",
+    "prepack": "./scripts/prepack.sh"
   },
   "jest-junit": {
     "suiteName": "Unleash Unit Tests",

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+yarn --cwd ./frontend install && if [ ! -d ./dist ]; then yarn build; fi


### PR DESCRIPTION
What the title says. After the migration to yarn v4, needed a prepack script/action instead of a prepare step.