### PR TITLE
chore: wait to input the name of the segment when checking for error messages

### DIFF
--- a/frontend/cypress/integration/segments/segments.spec.ts
+++ b/frontend/cypress/integration/segments/segments.spec.ts
@@ -24,6 +24,7 @@ describe('segments', () => {
 
     it('gives an error if a segment exists with the same name', () => {
         cy.get("[data-testid='NAVIGATE_TO_CREATE_SEGMENT']").click();
+        cy.wait(500);
         cy.get("[data-testid='SEGMENT_NAME_ID']").type(segmentName);
         cy.get("[data-testid='SEGMENT_NEXT_BTN_ID']").should('be.disabled');
         cy.get("[data-testid='INPUT_ERROR_TEXT']").contains(


### PR DESCRIPTION
This change adds a wait statement before entering the name of the
segment when checking for error messages that this segment name
already exists.

This is the same workaround that we did in
https://github.com/Unleash/unleash/pull/7289, which seems to have
worked.

Like in that PR, using waits is still an antipattern, but it appears
to be working.