### PR TITLE
fix: lifecycle button permissions

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.test.tsx
@@ -8,6 +8,7 @@ import {
     DELETE_FEATURE,
     UPDATE_FEATURE,
 } from 'component/providers/AccessProvider/permissions';
+import { Route, Routes } from 'react-router-dom';
 
 const currentTime = '2024-04-25T08:05:00.000Z';
 const twoMinutesAgo = '2024-04-25T08:03:00.000Z';
@@ -22,16 +23,24 @@ const renderOpenTooltip = (
     loading = false,
 ) => {
     render(
-        <FeatureLifecycleTooltip
-            stage={stage}
-            onArchive={onArchive}
-            onComplete={onComplete}
-            onUncomplete={onUncomplete}
-            loading={loading}
-        >
-            <span>child</span>
-        </FeatureLifecycleTooltip>,
+        <Routes>
+            <Route
+                path={'/projects/:projectId'}
+                element={
+                    <FeatureLifecycleTooltip
+                        stage={stage}
+                        onArchive={onArchive}
+                        onComplete={onComplete}
+                        onUncomplete={onUncomplete}
+                        loading={loading}
+                    >
+                        <span>child</span>
+                    </FeatureLifecycleTooltip>
+                }
+            />
+        </Routes>,
         {
+            route: '/projects/default',
             permissions: [
                 { permission: DELETE_FEATURE },
                 { permission: UPDATE_FEATURE },

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
@@ -25,6 +25,7 @@ import { isSafeToArchive } from './isSafeToArchive';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { formatDateYMDHMS } from 'utils/formatDate';
 import { formatDistanceToNow, parseISO } from 'date-fns';
+import { useRequiredPathParam } from '../../../../../hooks/useRequiredPathParam';
 
 const TimeLabel = styled('span')(({ theme }) => ({
     color: theme.palette.text.secondary,
@@ -267,6 +268,8 @@ const LiveStageDescription: FC<{
     loading: boolean;
     children?: React.ReactNode;
 }> = ({ children, onComplete, loading }) => {
+    const projectId = useRequiredPathParam('projectId');
+
     return (
         <>
             <BoldTitle>Is this feature complete?</BoldTitle>
@@ -285,6 +288,7 @@ const LiveStageDescription: FC<{
                 size='small'
                 onClick={onComplete}
                 disabled={loading}
+                projectId={projectId}
             >
                 Mark completed
             </PermissionButton>
@@ -303,6 +307,8 @@ const SafeToArchive: FC<{
     onUncomplete: () => void;
     loading: boolean;
 }> = ({ onArchive, onUncomplete, loading }) => {
+    const projectId = useRequiredPathParam('projectId');
+
     return (
         <>
             <BoldTitle>Safe to archive</BoldTitle>
@@ -319,6 +325,7 @@ const SafeToArchive: FC<{
                 sx={{
                     display: 'flex',
                     flexDirection: 'row',
+                    flexWrap: 'wrap',
                     gap: 2,
                 }}
             >
@@ -329,6 +336,7 @@ const SafeToArchive: FC<{
                     size='small'
                     onClick={onUncomplete}
                     disabled={loading}
+                    projectId={projectId}
                 >
                     Revert to live
                 </PermissionButton>
@@ -339,6 +347,7 @@ const SafeToArchive: FC<{
                     size='small'
                     sx={{ mb: 2 }}
                     onClick={onArchive}
+                    projectId={projectId}
                 >
                     Archive feature
                 </PermissionButton>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
@@ -25,7 +25,7 @@ import { isSafeToArchive } from './isSafeToArchive';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { formatDateYMDHMS } from 'utils/formatDate';
 import { formatDistanceToNow, parseISO } from 'date-fns';
-import { useRequiredPathParam } from '../../../../../hooks/useRequiredPathParam';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 
 const TimeLabel = styled('span')(({ theme }) => ({
     color: theme.palette.text.secondary,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We were missing projectId on 3 lifecycle buttons: mark completed, revert and archive. 
<img width="263" alt="Screenshot 2024-06-14 at 09 44 30" src="https://github.com/Unleash/unleash/assets/1394682/6f5bed75-2eb1-4cdb-b741-f2870766f6f3">

Also fixed styling for locked buttons. Previously they were growing and moving text in another line. Now we move the second button to the next line.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
