### PR TITLE
chore: add metrics/gauges for "max constraint values" and "max constraints"

### DIFF
--- a/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
@@ -26,7 +26,7 @@ export class FakeFeatureStrategiesReadModel
         return null;
     }
 
-    async getMaxConstraintPerStrategy(): Promise<{
+    async getMaxConstraintsPerStrategy(): Promise<{
         feature: string;
         environment: string;
         count: number;

--- a/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
@@ -33,11 +33,4 @@ export class FakeFeatureStrategiesReadModel
     } | null> {
         return null;
     }
-
-    async getMaxProjectFeatures(): Promise<{
-        project: string;
-        count: number;
-    } | null> {
-        return null;
-    }
 }

--- a/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/fake-feature-strategies-read-model.ts
@@ -17,4 +17,27 @@ export class FakeFeatureStrategiesReadModel
     } | null> {
         return null;
     }
+
+    async getMaxConstraintValues(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null> {
+        return null;
+    }
+
+    async getMaxConstraintPerStrategy(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null> {
+        return null;
+    }
+
+    async getMaxProjectFeatures(): Promise<{
+        project: string;
+        count: number;
+    } | null> {
+        return null;
+    }
 }

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -54,7 +54,7 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
     } | null> {
         throw new Error('Method not implemented.');
     }
-    getMaxConstraintPerStrategy(): Promise<{
+    getMaxConstraintsPerStrategy(): Promise<{
         feature: string;
         environment: string;
         count: number;

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -57,10 +57,14 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
                 'feature_name',
                 'environment',
                 this.db.raw(
-                    "MAX(coalesce(jsonb_array_length(value->'values'), 0)) as max_values_count",
+                    "MAX(coalesce(jsonb_array_length(constraint_value->'values'), 0)) as max_values_count",
                 ),
             )
-            .joinRaw('JOIN jsonb_array_elements(constraints) as value ON true')
+            .from(
+                this.db.raw(
+                    'feature_strategies, jsonb_array_elements(constraints) AS constraint_value',
+                ),
+            )
             .groupBy('feature_name', 'environment')
             .orderBy('max_values_count', 'desc')
             .limit(1);

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -63,7 +63,7 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
             .joinRaw('JOIN jsonb_array_elements(constraints) as value ON true')
             .groupBy('feature_name', 'environment')
             .orderBy('max_values_count', 'desc')
-            .limit(2);
+            .limit(1);
 
         return rows.length > 0
             ? {

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -7,7 +7,6 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
     constructor(db: Db) {
         this.db = db;
     }
-
     async getMaxFeatureEnvironmentStrategies(): Promise<{
         feature: string;
         environment: string;
@@ -46,5 +45,26 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
                   count: Number(rows[0].strategy_count),
               }
             : null;
+    }
+
+    getMaxConstraintValues(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null> {
+        throw new Error('Method not implemented.');
+    }
+    getMaxConstraintPerStrategy(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null> {
+        throw new Error('Method not implemented.');
+    }
+    getMaxProjectFeatures(): Promise<{
+        project: string;
+        count: number;
+    } | null> {
+        throw new Error('Method not implemented.');
     }
 }

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -56,16 +56,12 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
             .select(
                 'feature_name',
                 'environment',
-                'constraints',
-                this.db.raw(
-                    'MAX(jsonb_array_length(constraints)) as constraint_count',
-                ),
                 this.db.raw(
                     "MAX(coalesce(jsonb_array_length(value->'values'), 0)) as max_values_count",
                 ),
             )
             .joinRaw('JOIN jsonb_array_elements(constraints) as value ON true')
-            .groupBy('feature_name', 'environment', 'constraints')
+            .groupBy('feature_name', 'environment')
             .orderBy('max_values_count', 'desc')
             .limit(2);
 

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -102,10 +102,4 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
               }
             : null;
     }
-    async getMaxProjectFeatures(): Promise<{
-        project: string;
-        count: number;
-    } | null> {
-        throw new Error('Method not implemented.');
-    }
 }

--- a/src/lib/features/feature-toggle/feature-strategies-read-model.ts
+++ b/src/lib/features/feature-toggle/feature-strategies-read-model.ts
@@ -47,21 +47,61 @@ export class FeatureStrategiesReadModel implements IFeatureStrategiesReadModel {
             : null;
     }
 
-    getMaxConstraintValues(): Promise<{
+    async getMaxConstraintValues(): Promise<{
         feature: string;
         environment: string;
         count: number;
     } | null> {
-        throw new Error('Method not implemented.');
+        const rows = await this.db('feature_strategies')
+            .select(
+                'feature_name',
+                'environment',
+                this.db.raw(
+                    'jsonb_array_length(constraints) as constraint_count',
+                ),
+            )
+
+            .orderBy('constraint_count', 'desc')
+            .limit(1);
+
+        console.log('got rows', rows);
+
+        return rows.length > 0
+            ? {
+                  feature: String(rows[0].feature_name),
+                  environment: String(rows[0].environment),
+                  count: Number(rows[0].constraint_count),
+              }
+            : null;
     }
-    getMaxConstraintsPerStrategy(): Promise<{
+    async getMaxConstraintsPerStrategy(): Promise<{
         feature: string;
         environment: string;
         count: number;
     } | null> {
-        throw new Error('Method not implemented.');
+        const rows = await this.db('feature_strategies')
+            .select(
+                'feature_name',
+                'environment',
+                this.db.raw(
+                    'jsonb_array_length(constraints) as constraint_count',
+                ),
+            )
+
+            .orderBy('constraint_count', 'desc')
+            .limit(1);
+
+        console.log('got rows', rows);
+
+        return rows.length > 0
+            ? {
+                  feature: String(rows[0].feature_name),
+                  environment: String(rows[0].environment),
+                  count: Number(rows[0].constraint_count),
+              }
+            : null;
     }
-    getMaxProjectFeatures(): Promise<{
+    async getMaxProjectFeatures(): Promise<{
         project: string;
         count: number;
     } | null> {

--- a/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
@@ -411,48 +411,4 @@ describe('max metrics collection', () => {
             count: 2,
         });
     });
-
-    // test('Read project with max number of flags', async () => {
-    //     const toggle = await featureToggleStore.create('default', {
-    //         name: 'featureA',
-    //         createdByUserId: 9999,
-    //     });
-
-    //     const maxStrategiesBefore =
-    //         await featureStrategiesReadModel.getMaxFeatureStrategies();
-    //     const maxEnvStrategiesBefore =
-    //         await featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies();
-    //     expect(maxStrategiesBefore).toBe(null);
-    //     expect(maxEnvStrategiesBefore).toBe(null);
-
-    //     await featureStrategiesStore.createStrategyFeatureEnv({
-    //         strategyName: 'gradualRollout',
-    //         projectId: 'default',
-    //         environment: 'default',
-    //         featureName: toggle.name,
-    //         constraints: [],
-    //         sortOrder: 0,
-    //         parameters: {},
-    //     });
-    //     await featureStrategiesStore.createStrategyFeatureEnv({
-    //         strategyName: 'gradualRollout',
-    //         projectId: 'default',
-    //         environment: 'default',
-    //         featureName: toggle.name,
-    //         constraints: [],
-    //         sortOrder: 0,
-    //         parameters: {},
-    //     });
-
-    //     const maxStrategies =
-    //         await featureStrategiesReadModel.getMaxFeatureStrategies();
-    //     const maxEnvStrategies =
-    //         await featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies();
-    //     expect(maxStrategies).toEqual({ feature: 'featureA', count: 2 });
-    //     expect(maxEnvStrategies).toEqual({
-    //         feature: 'featureA',
-    //         environment: 'default',
-    //         count: 2,
-    //     });
-    // });
 });

--- a/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
@@ -317,6 +317,11 @@ describe('max metrics collection', () => {
             featureName: flagA.name,
             constraints: [
                 {
+                    values: ['only one'],
+                    operator: 'IN',
+                    contextName: 'appName',
+                },
+                {
                     values: Array.from({ length: maxValueCount }, (_, i) =>
                         i.toString(),
                     ),
@@ -335,7 +340,6 @@ describe('max metrics collection', () => {
             featureName: flagB.name,
             constraints: [
                 {
-                    values: ['onlyone'],
                     operator: 'IN',
                     contextName: 'appName',
                 },

--- a/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
@@ -13,7 +13,7 @@ export interface IFeatureStrategiesReadModel {
         environment: string;
         count: number;
     } | null>;
-    getMaxConstraintPerStrategy(): Promise<{
+    getMaxConstraintsPerStrategy(): Promise<{
         feature: string;
         environment: string;
         count: number;

--- a/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
@@ -8,4 +8,18 @@ export interface IFeatureStrategiesReadModel {
         feature: string;
         count: number;
     } | null>;
+    getMaxConstraintValues(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null>;
+    getMaxConstraintPerStrategy(): Promise<{
+        feature: string;
+        environment: string;
+        count: number;
+    } | null>;
+    getMaxProjectFeatures(): Promise<{
+        project: string;
+        count: number;
+    } | null>;
 }

--- a/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-strategies-read-model-type.ts
@@ -18,8 +18,4 @@ export interface IFeatureStrategiesReadModel {
         environment: string;
         count: number;
     } | null>;
-    getMaxProjectFeatures(): Promise<{
-        project: string;
-        count: number;
-    } | null>;
 }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -129,11 +129,6 @@ export default class MetricsMonitor {
             help: 'Maximum number of constraints used on a single strategy',
             labelNames: ['feature', 'environment'],
         });
-        const maxProjectFeatures = createGauge({
-            name: 'max_project_features',
-            help: 'Maximum number of flags in one project',
-            labelNames: ['project'],
-        });
 
         const featureTogglesArchivedTotal = createGauge({
             name: 'feature_toggles_archived_total',
@@ -307,11 +302,9 @@ export default class MetricsMonitor {
                 const [
                     maxConstraintValuesResult,
                     maxConstraintsPerStrategyResult,
-                    maxProjectFeaturesResult,
                 ] = await Promise.all([
                     stores.featureStrategiesReadModel.getMaxConstraintValues(),
                     stores.featureStrategiesReadModel.getMaxConstraintsPerStrategy(),
-                    stores.featureStrategiesReadModel.getMaxProjectFeatures(),
                 ]);
 
                 featureFlagsTotal.reset();
@@ -374,12 +367,6 @@ export default class MetricsMonitor {
                             feature: maxConstraintsPerStrategyResult.feature,
                         })
                         .set(maxConstraintsPerStrategyResult.count);
-                }
-                if (maxProjectFeaturesResult) {
-                    maxProjectFeatures.reset();
-                    maxProjectFeatures
-                        .labels({ project: maxProjectFeaturesResult.project })
-                        .set(maxProjectFeaturesResult.count);
                 }
 
                 enabledMetricsBucketsPreviousDay.reset();

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -294,15 +294,14 @@ export default class MetricsMonitor {
         async function collectStaticCounters() {
             try {
                 const stats = await instanceStatsService.getStats();
-                const [maxStrategies, maxEnvironmentStrategies] =
-                    await Promise.all([
-                        stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
-                        stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
-                    ]);
                 const [
+                    maxStrategies,
+                    maxEnvironmentStrategies,
                     maxConstraintValuesResult,
                     maxConstraintsPerStrategyResult,
                 ] = await Promise.all([
+                    stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
+                    stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
                     stores.featureStrategiesReadModel.getMaxConstraintValues(),
                     stores.featureStrategiesReadModel.getMaxConstraintsPerStrategy(),
                 ]);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -124,7 +124,7 @@ export default class MetricsMonitor {
             help: 'Maximum number of constraint values used in a single constraint',
             labelNames: ['feature', 'environment'],
         });
-        const maxStrategyConstraints = createGauge({
+        const maxConstraintsPerStrategy = createGauge({
             name: 'max_strategy_constraints',
             help: 'Maximum number of constraints used on a single strategy',
             labelNames: ['feature', 'environment'],
@@ -304,6 +304,15 @@ export default class MetricsMonitor {
                         stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
                         stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
                     ]);
+                const [
+                    maxConstraintValuesResult,
+                    maxConstraintsPerStrategyResult,
+                    maxProjectFeaturesResult,
+                ] = await Promise.all([
+                    stores.featureStrategiesReadModel.getMaxConstraintValues(),
+                    stores.featureStrategiesReadModel.getMaxConstraintsPerStrategy(),
+                    stores.featureStrategiesReadModel.getMaxProjectFeatures(),
+                ]);
 
                 featureFlagsTotal.reset();
                 featureFlagsTotal.labels({ version }).set(stats.featureToggles);
@@ -346,6 +355,31 @@ export default class MetricsMonitor {
                     maxFeatureStrategies
                         .labels({ feature: maxStrategies.feature })
                         .set(maxStrategies.count);
+                }
+                if (maxConstraintValuesResult) {
+                    maxConstraintValues.reset();
+                    maxConstraintValues
+                        .labels({
+                            environment: maxConstraintValuesResult.environment,
+                            feature: maxConstraintValuesResult.feature,
+                        })
+                        .set(maxConstraintValuesResult.count);
+                }
+                if (maxConstraintsPerStrategyResult) {
+                    maxConstraintsPerStrategy.reset();
+                    maxConstraintsPerStrategy
+                        .labels({
+                            environment:
+                                maxConstraintsPerStrategyResult.environment,
+                            feature: maxConstraintsPerStrategyResult.feature,
+                        })
+                        .set(maxConstraintsPerStrategyResult.count);
+                }
+                if (maxProjectFeaturesResult) {
+                    maxProjectFeatures.reset();
+                    maxProjectFeatures
+                        .labels({ project: maxProjectFeaturesResult.project })
+                        .set(maxProjectFeaturesResult.count);
                 }
 
                 enabledMetricsBucketsPreviousDay.reset();

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -119,6 +119,21 @@ export default class MetricsMonitor {
             help: 'Maximum number of strategies in one feature',
             labelNames: ['feature'],
         });
+        const maxConstraintValues = createGauge({
+            name: 'max_constraint_values',
+            help: 'Maximum number of constraint values used in a single constraint',
+            labelNames: ['feature', 'environment'],
+        });
+        const maxStrategyConstraints = createGauge({
+            name: 'max_strategy_constraints',
+            help: 'Maximum number of constraints used on a single strategy',
+            labelNames: ['feature', 'environment'],
+        });
+        const maxProjectFeatures = createGauge({
+            name: 'max_project_features',
+            help: 'Maximum number of flags in one project',
+            labelNames: ['project'],
+        });
 
         const featureTogglesArchivedTotal = createGauge({
             name: 'feature_toggles_archived_total',


### PR DESCRIPTION
This PR adds metrics tracking for:
- "maxConstraintValues": the highest number of constraint values that are in use
- "maxConstraintsPerStrategy": the highest number of constraints used on a strategy

It updates the existing feature strategy read model that returns max metrics for other strategy-related things.

It also moves one test into a more fitting describe block.