### PR TITLE
feat: menubar is not dependant on query params anymroe

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -22,7 +22,7 @@ import {
 } from './RecentlyVisited/CommandResultGroup';
 import { useAsyncDebounce } from 'react-table';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
-import { useFeatureSearch } from '../../hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 
 export const CommandResultsPaper = styled(Paper)(({ theme }) => ({
     position: 'absolute',

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -16,13 +16,13 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside';
 import { useOnBlur } from 'hooks/useOnBlur';
 import { RecentlyVisited } from './RecentlyVisited/RecentlyVisited';
 import { useRecentlyVisited } from 'hooks/useRecentlyVisited';
-import { useGlobalFeatureSearch } from '../feature/FeatureToggleList/useGlobalFeatureSearch';
 import {
     CommandResultGroup,
     type CommandResultGroupItem,
 } from './RecentlyVisited/CommandResultGroup';
 import { useAsyncDebounce } from 'react-table';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import { useFeatureSearch } from '../../hooks/api/getters/useFeatureSearch/useFeatureSearch';
 
 export const CommandResultsPaper = styled(Paper)(({ theme }) => ({
     position: 'absolute',
@@ -85,6 +85,7 @@ export const CommandBar = () => {
     const searchInputRef = useRef<HTMLInputElement>(null);
     const searchContainerRef = useRef<HTMLInputElement>(null);
     const [showSuggestions, setShowSuggestions] = useState(false);
+    const [searchString, setSearchString] = useState(undefined);
     const [searchedProjects, setSearchedProjects] = useState<
         CommandResultGroupItem[]
     >([]);
@@ -95,11 +96,14 @@ export const CommandBar = () => {
 
     const [value, setValue] = useState<string>('');
 
-    const { features, setTableState } = useGlobalFeatureSearch(3);
+    const { features = [] } = useFeatureSearch({
+        query: searchString,
+        limit: '3',
+    });
     const { projects } = useProjects();
 
     const debouncedSetSearchState = useAsyncDebounce((query) => {
-        setTableState({ query });
+        setSearchString(query);
 
         const filteredProjects = projects.filter((project) =>
             project.name.toLowerCase().includes(query.toLowerCase()),


### PR DESCRIPTION
Previously since query params were changing by global search, and menubar was also altering them, they were conflicting. Menubar does not need query params as state. So using search hook directly.