### PR TITLE
fix: make default for gradual rollout work on the correct strategy name

### DIFF
--- a/src/lib/features/client-feature-toggles/tests/client-feature-toggles.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/tests/client-feature-toggles.e2e.test.ts
@@ -25,7 +25,11 @@ const apiClientResponse = [
             {
                 name: 'flexibleRollout',
                 constraints: [],
-                parameters: { rollout: '100' },
+                parameters: {
+                    rollout: '100',
+                    stickiness: 'default',
+                    groupId: 'test1',
+                },
                 variants: [],
             },
         ],
@@ -169,7 +173,11 @@ test('should return correct data structure from /api/client/features', async () 
         {
             name: 'flexibleRollout',
             constraints: [],
-            parameters: { rollout: '100' },
+            parameters: {
+                rollout: '100',
+                stickiness: 'default',
+                groupId: 'test1',
+            },
         },
         DEFAULT_ENV,
         'test1',

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -159,7 +159,7 @@ const defaultParameters = (
     params: PartialSome<IFeatureStrategy, 'id' | 'createdAt'>,
     stickiness: string,
 ) => {
-    if (params.strategyName === 'gradualRollout') {
+    if (params.strategyName === 'flexibleRollout') {
         return {
             rollout: '100',
             stickiness,

--- a/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
@@ -164,7 +164,7 @@ describe('strategy parameters default to sane defaults', () => {
             createdByUserId: 9999,
         });
         const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
-            strategyName: 'gradualRollout',
+            strategyName: 'flexibleRollout',
             projectId: 'default',
             environment: 'default',
             featureName: toggle.name,
@@ -184,7 +184,7 @@ describe('strategy parameters default to sane defaults', () => {
             createdByUserId: 9999,
         });
         const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
-            strategyName: 'gradualRollout',
+            strategyName: 'flexibleRollout',
             projectId: 'default',
             environment: 'default',
             featureName: toggle.name,
@@ -236,7 +236,7 @@ describe('strategy parameters default to sane defaults', () => {
             createdByUserId: 9999,
         });
         const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
-            strategyName: 'gradualRollout',
+            strategyName: 'flexibleRollout',
             projectId: project.id,
             environment: 'default',
             featureName: toggle.name,


### PR DESCRIPTION
This moves the defaults parameters check for adding strategies to target the correct name for gradual rollout strategies. Previously we checked for `gradualRollout` but actually on the backend/SDKs the strategy name is `flexibleRollout`.

Tests have been updated but tested by checking against the API call the UI suggests and cURLs.