### PR TITLE
fix: make rendering of new project form independent of rendering the project list

### DIFF
--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -102,22 +102,12 @@ const ProjectCreationButton = () => {
 
     const useNewProjectForm = useUiFlag('newCreateProjectUI');
 
-    const [dialogMarkup, handleClick] = useNewProjectForm
-        ? [
-              <CreateProjectDialog
-                  open={openCreateDialog}
-                  onClose={() => setOpenCreateDialog(false)}
-              />,
-              () => setOpenCreateDialog(true),
-          ]
-        : [null, () => navigate('/projects/create')];
-
-    return (
-        <>
+    const CreateButton: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+        return (
             <ResponsiveButton
                 Icon={Add}
                 endIcon={createButtonData.endIcon}
-                onClick={handleClick}
+                onClick={onClick}
                 maxWidth='700px'
                 permission={CREATE_PROJECT}
                 disabled={createButtonData.disabled}
@@ -126,9 +116,22 @@ const ProjectCreationButton = () => {
             >
                 New project
             </ResponsiveButton>
-            {dialogMarkup}
-        </>
-    );
+        );
+    };
+
+    if (useNewProjectForm) {
+        return (
+            <>
+                <CreateButton onClick={() => setOpenCreateDialog(true)} />
+                <CreateProjectDialog
+                    open={openCreateDialog}
+                    onClose={() => setOpenCreateDialog(false)}
+                />
+            </>
+        );
+    } else {
+        return <CreateButton onClick={() => navigate('/projects/create')} />;
+    }
 };
 
 export const ProjectListNew = () => {

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -102,20 +102,17 @@ const ProjectCreationButton = () => {
 
     const useNewProjectForm = useUiFlag('newCreateProjectUI');
 
-    const dialogMarkup = useNewProjectForm ? (
-        <CreateProjectDialog
-            open={openCreateDialog}
-            onClose={() => setOpenCreateDialog(false)}
-        />
-    ) : null;
+    const [dialogMarkup, handleClick] = useNewProjectForm
+        ? [
+              <CreateProjectDialog
+                  open={openCreateDialog}
+                  onClose={() => setOpenCreateDialog(false)}
+              />,
+              () => setOpenCreateDialog(true),
+          ]
+        : [null, () => navigate('/projects/create')];
 
-    const handleClick = () => {
-        if (useNewProjectForm) {
-            return setOpenCreateDialog(true);
-        }
-        navigate('/projects/create');
-    };
-    const Dialog = () => (
+    return (
         <>
             <ResponsiveButton
                 Icon={Add}
@@ -132,8 +129,6 @@ const ProjectCreationButton = () => {
             {dialogMarkup}
         </>
     );
-
-    return <Dialog />;
 };
 
 export const ProjectListNew = () => {


### PR DESCRIPTION
This change takes the rendering of the new project form component and
puts in a child component of the project list, thereby
significantly speeding up the time it takes to render the form if you
have lots of projects (about to 10x for 50 projects on my machine).

The reason it was so slow before was that the open state of the form
component was stored in the project list component. This meant that
whenever you wanted to open or close the form, you'd have to rerender
the entire project list.

This change abstracts that process into the new ProjectCreationButton
component. This component takes care of checking the feature flag for
whether to render the dialog or to send the user to the old form, and
takes care of state management for the dialog.

Because this is a child component of the project list, it does not
cause rerenders of the entire project list.