### PR TITLE
fix: check for permission in group access assignment

### DIFF
--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -38,6 +38,7 @@ import { caseInsensitiveSearch } from 'utils/search';
 import type { IServiceAccount } from 'interfaces/service-account';
 import { MultipleRoleSelect } from 'component/common/MultipleRoleSelect/MultipleRoleSelect';
 import type { IUserProjectRole } from '../../../../interfaces/userProjectRoles';
+import { useCheckProjectPermissions } from 'hooks/useHasAccess';
 
 const StyledForm = styled('form')(() => ({
     display: 'flex',
@@ -118,6 +119,8 @@ export const ProjectAccessAssign = ({
     const { addAccessToProject, setUserRoles, setGroupRoles, loading } =
         useProjectApi();
     const edit = Boolean(selected);
+
+    const checkPermissions = useCheckProjectPermissions(projectId);
 
     const { setToastData, setToastApiError } = useToast();
     const navigate = useNavigate();
@@ -323,6 +326,7 @@ export const ProjectAccessAssign = ({
 
     const isValid = selectedOptions.length > 0 && selectedRoles.length > 0;
     const displayAllRoles =
+        checkPermissions('ADMIN') ||
         userRoles.length === 0 ||
         userRoles.some(
             (userRole) =>

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -39,6 +39,7 @@ import type { IServiceAccount } from 'interfaces/service-account';
 import { MultipleRoleSelect } from 'component/common/MultipleRoleSelect/MultipleRoleSelect';
 import type { IUserProjectRole } from '../../../../interfaces/userProjectRoles';
 import { useCheckProjectPermissions } from 'hooks/useHasAccess';
+import { ADMIN } from 'component/providers/AccessProvider/permissions';
 
 const StyledForm = styled('form')(() => ({
     display: 'flex',
@@ -326,12 +327,10 @@ export const ProjectAccessAssign = ({
 
     const isValid = selectedOptions.length > 0 && selectedRoles.length > 0;
     const displayAllRoles =
-        checkPermissions('ADMIN') ||
+        checkPermissions(ADMIN) ||
         userRoles.length === 0 ||
-        userRoles.some(
-            (userRole) =>
-                userRole.name === 'Admin' || userRole.name === 'Owner',
-        );
+        userRoles.some((userRole) => userRole.name === 'Owner');
+
     let filteredRoles: IRole[];
     if (displayAllRoles) {
         filteredRoles = roles;

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -440,6 +440,51 @@ describe('Managing Project access', () => {
             ),
         ).resolves.not.toThrow();
     });
+
+    test('Admin group members should be allowed to add any project role', async () => {
+        const viewerUser = await stores.userStore.insert({
+            name: 'Some project admin',
+            email: 'admin@example.com',
+        });
+        await accessService.setUserRootRole(viewerUser.id, RoleName.VIEWER);
+
+        const adminRole = await stores.roleStore.getRoleByName(RoleName.ADMIN);
+        const adminGroup = await stores.groupStore.create({
+            name: 'admin_group',
+            rootRole: adminRole.id,
+        });
+        await stores.groupStore.addUsersToGroup(
+            adminGroup.id,
+            [{ user: { id: viewerUser.id } }],
+            opsUser.username!,
+        );
+
+        const project = {
+            id: 'some-project',
+            name: 'sp',
+            description: '',
+            mode: 'open' as const,
+            defaultStickiness: 'clientId',
+        };
+        await projectService.createProject(project, user, auditUser);
+        const customRole = await stores.roleStore.create({
+            name: 'my_custom_role_admin_user',
+            roleType: 'custom',
+            description:
+                'Used to prove that you can assign a role when you are admin',
+        });
+
+        await expect(
+            projectService.addAccess(
+                project.id,
+                [customRole.id], // roles
+                [], // groups
+                [opsUser.id], // users
+                extractAuditInfoFromUser(viewerUser),
+            ),
+        ).resolves.not.toThrow();
+    });
+
     test('Users with project owner should be allowed to add any project role', async () => {
         const project = {
             id: 'project-owner',

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -444,7 +444,7 @@ describe('Managing Project access', () => {
     test('Admin group members should be allowed to add any project role', async () => {
         const viewerUser = await stores.userStore.insert({
             name: 'Some project admin',
-            email: 'admin@example.com',
+            email: 'some_project_admin@example.com',
         });
         await accessService.setUserRootRole(viewerUser.id, RoleName.VIEWER);
 
@@ -468,7 +468,7 @@ describe('Managing Project access', () => {
         };
         await projectService.createProject(project, user, auditUser);
         const customRole = await stores.roleStore.create({
-            name: 'my_custom_role_admin_user',
+            name: 'my_custom_project_role_admin_user',
             roleType: 'custom',
             description:
                 'Used to prove that you can assign a role when you are admin',
@@ -496,11 +496,11 @@ describe('Managing Project access', () => {
         await projectService.createProject(project, user, auditUser);
         const projectAdmin = await stores.userStore.insert({
             name: 'Some project admin',
-            email: 'admin@example.com',
+            email: 'some_other_project_admin@example.com',
         });
         const projectCustomer = await stores.userStore.insert({
             name: 'Some project customer',
-            email: 'customer@example.com',
+            email: 'some_project_customer@example.com',
         });
         const ownerRole = await stores.roleStore.getRoleByName(RoleName.OWNER);
         await accessService.addUserToRole(
@@ -509,7 +509,7 @@ describe('Managing Project access', () => {
             project.id,
         );
         const customRole = await stores.roleStore.create({
-            name: 'my_custom_role',
+            name: 'my_custom_project_role',
             roleType: 'custom',
             description:
                 'Used to prove that you can assign a role the project owner does not have',
@@ -522,7 +522,7 @@ describe('Managing Project access', () => {
                 [projectCustomer.id],
                 auditUser,
             ),
-        ).resolves;
+        ).resolves.not.toThrow();
     });
     test('Users with project role should only be allowed to grant same role to others', async () => {
         const project = {


### PR DESCRIPTION
Fix project role assignment for users with `ADMIN` permission, even if they don't have the Admin root role. This happens when e.g. users inherit the `ADMIN` permission from a group root role, but are not Admins themselves.