### PR TITLE
chore: change "toggle updated" to "flag updated" in toast message

### DIFF
--- a/frontend/src/component/feature/EditFeature/EditFeature.tsx
+++ b/frontend/src/component/feature/EditFeature/EditFeature.tsx
@@ -57,7 +57,7 @@ const EditFeature = () => {
             await patchFeatureFlag(project, featureId, patch);
             navigate(`/projects/${project}/features/${name}`);
             setToastData({
-                title: 'Toggle updated successfully',
+                title: 'Flag updated successfully',
                 type: 'success',
             });
         } catch (error: unknown) {


### PR DESCRIPTION
This message appears to have been missed when we did the previous
migration from "toggle" to "flag".