### PR TITLE
feat: stage count by project metric

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -47,6 +47,7 @@ import { ProjectOwnersReadModel } from '../features/project/project-owners-read-
 import { FeatureLifecycleStore } from '../features/feature-lifecycle/feature-lifecycle-store';
 import { ProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model';
 import { FeatureStrategiesReadModel } from '../features/feature-toggle/feature-strategies-read-model';
+import { FeatureLifecycleReadModel } from '../features/feature-lifecycle/feature-lifecycle-read-model';
 
 export const createStores = (
     config: IUnleashConfig,
@@ -161,6 +162,10 @@ export const createStores = (
         projectFlagCreatorsReadModel: new ProjectFlagCreatorsReadModel(db),
         featureLifecycleStore: new FeatureLifecycleStore(db),
         featureStrategiesReadModel: new FeatureStrategiesReadModel(db),
+        featureLifecycleReadModel: new FeatureLifecycleReadModel(
+            db,
+            config.flagResolver,
+        ),
     };
 };
 

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-read-model.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-read-model.test.ts
@@ -4,15 +4,25 @@ import { FeatureLifecycleReadModel } from './feature-lifecycle-read-model';
 import type { IFeatureLifecycleStore } from './feature-lifecycle-store-type';
 import type { IFeatureLifecycleReadModel } from './feature-lifecycle-read-model-type';
 import type { IFeatureToggleStore } from '../feature-toggle/types/feature-toggle-store-type';
+import type { IFlagResolver } from '../../types';
 
 let db: ITestDb;
 let featureLifeycycleReadModel: IFeatureLifecycleReadModel;
 let featureLifecycleStore: IFeatureLifecycleStore;
 let featureToggleStore: IFeatureToggleStore;
 
+const alwaysOnFlagResolver = {
+    isEnabled() {
+        return true;
+    },
+} as unknown as IFlagResolver;
+
 beforeAll(async () => {
     db = await dbInit('feature_lifecycle_read_model', getLogger);
-    featureLifeycycleReadModel = new FeatureLifecycleReadModel(db.rawDatabase);
+    featureLifeycycleReadModel = new FeatureLifecycleReadModel(
+        db.rawDatabase,
+        alwaysOnFlagResolver,
+    );
     featureLifecycleStore = db.stores.featureLifecycleStore;
     featureToggleStore = db.stores.featureToggleStore;
 });

--- a/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
@@ -46,7 +46,10 @@ beforeAll(async () => {
     eventStore = db.stores.eventStore;
     eventBus = app.config.eventBus;
     featureLifecycleService = app.services.featureLifecycleService;
-    featureLifecycleReadModel = new FeatureLifecycleReadModel(db.rawDatabase);
+    featureLifecycleReadModel = new FeatureLifecycleReadModel(
+        db.rawDatabase,
+        app.config.flagResolver,
+    );
     featureLifecycleStore = db.stores.featureLifecycleStore;
 
     await app.request

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -124,7 +124,10 @@ export const createFeatureToggleService = (
 
     const dependentFeaturesReadModel = new DependentFeaturesReadModel(db);
 
-    const featureLifecycleReadModel = new FeatureLifecycleReadModel(db);
+    const featureLifecycleReadModel = new FeatureLifecycleReadModel(
+        db,
+        config.flagResolver,
+    );
 
     const dependentFeaturesService = createDependentFeaturesService(config)(db);
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -160,7 +160,7 @@ export const createServices = (
         ? new DependentFeaturesReadModel(db)
         : new FakeDependentFeaturesReadModel();
     const featureLifecycleReadModel = db
-        ? new FeatureLifecycleReadModel(db)
+        ? new FeatureLifecycleReadModel(db, config.flagResolver)
         : new FakeFeatureLifecycleReadModel();
     const segmentReadModel = db
         ? new SegmentReadModel(db)

--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -44,6 +44,7 @@ import { IProjectOwnersReadModel } from '../features/project/project-owners-read
 import { IFeatureLifecycleStore } from '../features/feature-lifecycle/feature-lifecycle-store-type';
 import { IProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model.type';
 import { IFeatureStrategiesReadModel } from '../features/feature-toggle/types/feature-strategies-read-model-type';
+import { IFeatureLifecycleReadModel } from '../features/feature-lifecycle/feature-lifecycle-read-model-type';
 
 export interface IUnleashStores {
     accessStore: IAccessStore;
@@ -92,6 +93,7 @@ export interface IUnleashStores {
     projectFlagCreatorsReadModel: IProjectFlagCreatorsReadModel;
     featureLifecycleStore: IFeatureLifecycleStore;
     featureStrategiesReadModel: IFeatureStrategiesReadModel;
+    featureLifecycleReadModel: IFeatureLifecycleReadModel;
 }
 
 export {
@@ -139,4 +141,5 @@ export {
     IFeatureLifecycleStore,
     IProjectFlagCreatorsReadModel,
     IFeatureStrategiesReadModel,
+    IFeatureLifecycleReadModel,
 };

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -47,6 +47,7 @@ import { FakeProjectOwnersReadModel } from '../../lib/features/project/fake-proj
 import { FakeFeatureLifecycleStore } from '../../lib/features/feature-lifecycle/fake-feature-lifecycle-store';
 import { FakeProjectFlagCreatorsReadModel } from '../../lib/features/project/fake-project-flag-creators-read-model';
 import { FakeFeatureStrategiesReadModel } from '../../lib/features/feature-toggle/fake-feature-strategies-read-model';
+import { FakeFeatureLifecycleReadModel } from '../../lib/features/feature-lifecycle/fake-feature-lifecycle-read-model';
 
 const db = {
     select: () => ({
@@ -103,6 +104,7 @@ const createStores: () => IUnleashStores = () => {
         projectFlagCreatorsReadModel: new FakeProjectFlagCreatorsReadModel(),
         featureLifecycleStore: new FakeFeatureLifecycleStore(),
         featureStrategiesReadModel: new FakeFeatureStrategiesReadModel(),
+        featureLifecycleReadModel: new FakeFeatureLifecycleReadModel(),
     };
 };
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Expose prometheus metric for counting how many features are in each of the stages grouped by project.

Details:
* this metric is a gauge
* query behind this metric is feature flagged just in case we find perf problems
* reading data in the metrics.ts from the injected read model. This code is not added to instance stats since they don't need it

Next PRs:
* move lifecycle median duration metrics from instance stats to metrics.ts so that generating instance stats doesn't run unnecessary lifecycle queries
* change duration metric type to gauge since we don't do sampling in median duration metrics

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
