### PR TITLE
fix: change lifecycle stage duration metric type

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -279,7 +279,7 @@ export default class MetricsMonitor {
             help: 'Duration of mapFeaturesForClient function',
         });
 
-        const featureLifecycleStageDuration = createHistogram({
+        const featureLifecycleStageDuration = createGauge({
             name: 'feature_lifecycle_stage_duration',
             labelNames: ['stage', 'project_id'],
             help: 'Duration of feature lifecycle stages',

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -334,7 +334,7 @@ export default class MetricsMonitor {
                             stage: stage.stage,
                             project_id: stage.project,
                         })
-                        .observe(stage.duration);
+                        .set(stage.duration);
                 });
 
                 stageCountByProject.reset();


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Given our approach of calculating the median value in the application code and then reporting this calculated value to Prometheus every 2 hours, the most appropriate Prometheus metric type to use would be a Gauge. This type of metric is best suited for capturing values that can go up or down, like a median calculation, which may change each time it is computed depending on the underlying data.

We'll need to update Grafana queries accordingly. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
