### PR TITLE
feat: search only features when there is search string

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -124,7 +124,6 @@ export const CommandBar = () => {
         setShowSuggestions(false);
     };
 
-    const [value, setValue] = useState<string>('');
     const { projects } = useProjects();
 
     const debouncedSetSearchState = useAsyncDebounce((query) => {
@@ -153,7 +152,6 @@ export const CommandBar = () => {
 
     const onSearchChange = (value: string) => {
         debouncedSetSearchState(value);
-        setValue(value);
     };
 
     const hotkey = useKeyboardShortcut(
@@ -196,7 +194,7 @@ export const CommandBar = () => {
                         'aria-label': placeholder,
                         'data-testid': SEARCH_INPUT,
                     }}
-                    value={value}
+                    value={searchString}
                     onChange={(e) => onSearchChange(e.target.value)}
                     onFocus={() => {
                         setShowSuggestions(true);
@@ -205,7 +203,7 @@ export const CommandBar = () => {
 
                 <Box sx={{ width: (theme) => theme.spacing(4) }}>
                     <ConditionallyRender
-                        condition={Boolean(value)}
+                        condition={Boolean(searchString)}
                         show={
                             <Tooltip title='Clear search query' arrow>
                                 <IconButton
@@ -228,7 +226,7 @@ export const CommandBar = () => {
             </StyledSearch>
 
             <ConditionallyRender
-                condition={Boolean(value) && showSuggestions}
+                condition={Boolean(searchString) && showSuggestions}
                 show={
                     <CommandResultsPaper>
                         {searchString !== undefined && (

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -24,7 +24,7 @@ import { PageSuggestions } from './PageSuggestions';
 import { useRoutes } from 'component/layout/MainLayout/NavigationSidebar/useRoutes';
 import { useAsyncDebounce } from 'react-table';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
-import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { CommandFeatures } from './CommandFeatures';
 
 export const CommandResultsPaper = styled(Paper)(({ theme }) => ({
     position: 'absolute',
@@ -125,16 +125,6 @@ export const CommandBar = () => {
     };
 
     const [value, setValue] = useState<string>('');
-
-    const { features = [] } = useFeatureSearch(
-        {
-            query: searchString,
-            limit: '3',
-        },
-        {
-            revalidateOnFocus: false,
-        },
-    );
     const { projects } = useProjects();
 
     const debouncedSetSearchState = useAsyncDebounce((query) => {
@@ -190,11 +180,6 @@ export const CommandBar = () => {
     useOnClickOutside([searchContainerRef], hideSuggestions);
     useOnBlur(searchContainerRef, hideSuggestions);
 
-    const flags: CommandResultGroupItem[] = features.map((feature) => ({
-        name: feature.name,
-        link: `/projects/${feature.project}/features/${feature.name}`,
-    }));
-
     return (
         <StyledContainer ref={searchContainerRef} active={showSuggestions}>
             <StyledSearch>
@@ -246,11 +231,9 @@ export const CommandBar = () => {
                 condition={Boolean(value) && showSuggestions}
                 show={
                     <CommandResultsPaper>
-                        <CommandResultGroup
-                            groupName={'Flags'}
-                            icon={'flag'}
-                            items={flags}
-                        />
+                        {searchString !== undefined && (
+                            <CommandFeatures searchString={searchString} />
+                        )}
                         <CommandResultGroup
                             groupName={'Projects'}
                             icon={'flag'}

--- a/frontend/src/component/commandBar/CommandFeatures.tsx
+++ b/frontend/src/component/commandBar/CommandFeatures.tsx
@@ -1,0 +1,29 @@
+import {
+    CommandResultGroup,
+    type CommandResultGroupItem,
+} from './RecentlyVisited/CommandResultGroup';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+
+interface ICommandBar {
+    searchString: string;
+}
+export const CommandFeatures = ({ searchString }: ICommandBar) => {
+    const { features = [] } = useFeatureSearch(
+        {
+            query: searchString,
+            limit: '3',
+        },
+        {
+            revalidateOnFocus: false,
+        },
+    );
+
+    const flags: CommandResultGroupItem[] = features.map((feature) => ({
+        name: feature.name,
+        link: `/projects/${feature.project}/features/${feature.name}`,
+    }));
+
+    return (
+        <CommandResultGroup groupName={'Flags'} icon={'flag'} items={flags} />
+    );
+};


### PR DESCRIPTION
Now the search hook is inside another component, so we do not get searches without search query.
Also we had 2 state variable handing the search query. Removed one of them.