### PR TITLE
chore: change generated project id format to use incrementing numbers instead of hashes

### DIFF
--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -2650,10 +2650,10 @@ describe('automatic ID generation for create project', () => {
             auditUser,
         );
 
-        expect(project.id).toMatch(/^new-name-/);
+        expect(project.id).toBe('new-name');
     });
 
-    test('two projects with the same name get different ids', async () => {
+    test('projects with the same name get ids with incrementing counters', async () => {
         const createProject = async () =>
             projectService.createProject(
                 { name: 'some name' },
@@ -2663,10 +2663,11 @@ describe('automatic ID generation for create project', () => {
 
         const project1 = await createProject();
         const project2 = await createProject();
+        const project3 = await createProject();
 
-        expect(project1.id).toMatch(/^some-name-/);
-        expect(project2.id).toMatch(/^some-name-/);
-        expect(project1.id).not.toBe(project2.id);
+        expect(project1.id).toBe('some-name');
+        expect(project2.id).toBe('some-name-1');
+        expect(project3.id).toBe('some-name-2');
     });
 
     test.each(['', undefined, '     '])(
@@ -2679,7 +2680,7 @@ describe('automatic ID generation for create project', () => {
                 auditUser,
             );
 
-            expect(project.id).toMatch(new RegExp(`^${name}-`));
+            expect(project.id).toBe(name);
         },
     );
 

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -1,4 +1,3 @@
-import fc from 'fast-check';
 import { createTestConfig } from '../../../test/config/test-config';
 import { BadDataError } from '../../error';
 import { type IBaseEvent, RoleName, TEST_AUDIT_USER } from '../../types';
@@ -300,31 +299,5 @@ describe('enterprise extension: enable change requests', () => {
                 TEST_AUDIT_USER,
             ),
         ).resolves.toBeTruthy();
-    });
-});
-
-describe('project ID generation', () => {
-    const createService = () => {
-        const config = createTestConfig();
-        const service = createFakeProjectService(config);
-
-        return service;
-    };
-
-    test('the name that comes out is always url friendly', () => {
-        const service = createService();
-        fc.assert(
-            fc.property(fc.string(), (name) => {
-                const projectId = service.generateProjectSlug(name);
-                expect(projectId).toMatch(encodeURIComponent(projectId));
-            }),
-        );
-    });
-
-    test('it does not add anything to the name unless it has to', () => {
-        const service = createService();
-
-        const projectId = service.generateProjectSlug('one');
-        expect(projectId).toBe('one');
     });
 });

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -315,16 +315,16 @@ describe('project ID generation', () => {
         const service = createService();
         fc.assert(
             fc.property(fc.string(), (name) => {
-                const projectId = service.generateProjectId(name);
+                const projectId = service.generateProjectSlug(name);
                 expect(projectId).toMatch(encodeURIComponent(projectId));
             }),
         );
     });
 
-    test('it adds a 12 character hex to the end of the id', () => {
+    test('it does not add anything to the name unless it has to', () => {
         const service = createService();
 
-        const projectId = service.generateProjectId('one');
-        expect(projectId).toMatch(/^one-[a-f0-9]{12}$/);
+        const projectId = service.generateProjectSlug('one');
+        expect(projectId).toBe('one');
     });
 });

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -62,7 +62,7 @@ import type {
 import type FeatureToggleService from '../feature-toggle/feature-toggle-service';
 import IncompatibleProjectError from '../../error/incompatible-project-error';
 import ProjectWithoutOwnerError from '../../error/project-without-owner-error';
-import { arraysHaveSameItems, randomId } from '../../util';
+import { arraysHaveSameItems } from '../../util';
 import type { GroupService } from '../../services/group-service';
 import type { IGroupRole } from '../../types/group';
 import type { FavoritesService } from '../../services/favorites-service';
@@ -305,20 +305,19 @@ export default class ProjectService {
         }
     }
 
-    generateProjectId(name: string): string {
-        const urlFriendly = slug(name);
-        const tail = randomId().slice(-12);
-        const id = `${urlFriendly}-${tail}`;
-        return id;
-    }
+    generateProjectSlug = (name: string): string => slug(name);
 
     async generateUniqueProjectId(name: string): Promise<string> {
-        const id = this.generateProjectId(name);
-        if (await this.projectStore.hasProject(id)) {
-            return await this.generateUniqueProjectId(name);
-        } else {
-            return id;
-        }
+        const generate = async (name: string, suffix?: number) => {
+            const slug = this.generateProjectSlug(name);
+            const id = suffix ? `${slug}-${suffix}` : slug;
+            if (await this.projectStore.hasProject(id)) {
+                return await generate(name, (suffix ?? 0) + 1);
+            } else {
+                return id;
+            }
+        };
+        return generate(name);
     }
 
     async createProject(

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -1,6 +1,6 @@
 import { subDays } from 'date-fns';
 import { ValidationError } from 'joi';
-import slug from 'slug';
+import createSlug from 'slug';
 import type { IAuditUser, IUser } from '../../types/user';
 import type {
     AccessService,
@@ -304,12 +304,9 @@ export default class ProjectService {
             await this.validateEnvironmentsExist(environments);
         }
     }
-
-    generateProjectSlug = (name: string): string => slug(name);
-
     async generateProjectId(name: string): Promise<string> {
         const generateUniqueId = async (name: string, suffix?: number) => {
-            const slug = this.generateProjectSlug(name);
+            const slug = createSlug(name);
             const id = suffix ? `${slug}-${suffix}` : slug;
             if (await this.projectStore.hasProject(id)) {
                 return await generateUniqueId(name, (suffix ?? 0) + 1);

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -307,17 +307,17 @@ export default class ProjectService {
 
     generateProjectSlug = (name: string): string => slug(name);
 
-    async generateUniqueProjectId(name: string): Promise<string> {
-        const generate = async (name: string, suffix?: number) => {
+    async generateProjectId(name: string): Promise<string> {
+        const generateUniqueId = async (name: string, suffix?: number) => {
             const slug = this.generateProjectSlug(name);
             const id = suffix ? `${slug}-${suffix}` : slug;
             if (await this.projectStore.hasProject(id)) {
-                return await generate(name, (suffix ?? 0) + 1);
+                return await generateUniqueId(name, (suffix ?? 0) + 1);
             } else {
                 return id;
             }
         };
-        return generate(name);
+        return generateUniqueId(name);
     }
 
     async createProject(
@@ -336,9 +336,7 @@ export default class ProjectService {
             await this.validateProjectEnvironments(newProject.environments);
 
             if (!newProject.id?.trim()) {
-                newProject.id = await this.generateUniqueProjectId(
-                    newProject.name,
-                );
+                newProject.id = await this.generateProjectId(newProject.name);
                 return await projectSchema.validateAsync(newProject);
             } else {
                 const validatedData =


### PR DESCRIPTION
This change changes how we generate project IDs. Instead of adding a
12-character hash, we now use an incrementing number when necessary.
We first slugify the project name (as we already do). If no project
with that ID exists, that's what you get. If that ID already exists,
then we add a number to the end of the slugified name, starting at 1.

So if you create a project called "My Project" three times over,
first one will have the ID "my-project", the second one will have the
ID "my-project-1", and the third one will have the ID "my-project-2".

In a list:
- my-project
- my-project-1
- my-project-2

This does not impact any existing projects.

The only potential drawback I can see this having, is that it makes
race conditions more likely. If two people create a project with the
same name at the same time (so that the service gives them the same
ID), the db will error out at one of them. With the random hashes,
that's much less of a concern.

At the same time, though: is that really a problem? If two people
create a project with the same name at the same time, isn't it likely
that they'd prefer it if that was the same project instead of two
different ones?