### PR TITLE
feat: largest projects and features metric

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -48,6 +48,7 @@ import { FeatureLifecycleStore } from '../features/feature-lifecycle/feature-lif
 import { ProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model';
 import { FeatureStrategiesReadModel } from '../features/feature-toggle/feature-strategies-read-model';
 import { FeatureLifecycleReadModel } from '../features/feature-lifecycle/feature-lifecycle-read-model';
+import { LargestResourcesReadModel } from '../features/metrics/sizes/largest-resources-read-model';
 
 export const createStores = (
     config: IUnleashConfig,
@@ -166,6 +167,7 @@ export const createStores = (
             db,
             config.flagResolver,
         ),
+        largestResourcesReadModel: new LargestResourcesReadModel(db),
     };
 };
 

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-read-model.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-read-model.test.ts
@@ -7,7 +7,7 @@ import type { IFeatureToggleStore } from '../feature-toggle/types/feature-toggle
 import type { IFlagResolver } from '../../types';
 
 let db: ITestDb;
-let featureLifeycycleReadModel: IFeatureLifecycleReadModel;
+let featureLifecycleReadModel: IFeatureLifecycleReadModel;
 let featureLifecycleStore: IFeatureLifecycleStore;
 let featureToggleStore: IFeatureToggleStore;
 
@@ -19,7 +19,7 @@ const alwaysOnFlagResolver = {
 
 beforeAll(async () => {
     db = await dbInit('feature_lifecycle_read_model', getLogger);
-    featureLifeycycleReadModel = new FeatureLifecycleReadModel(
+    featureLifecycleReadModel = new FeatureLifecycleReadModel(
         db.rawDatabase,
         alwaysOnFlagResolver,
     );
@@ -59,14 +59,14 @@ test('can return stage count', async () => {
         { feature: 'featureA', stage: 'pre-live' },
     ]);
 
-    const stageCount = await featureLifeycycleReadModel.getStageCount();
+    const stageCount = await featureLifecycleReadModel.getStageCount();
     expect(stageCount).toMatchObject([
         { stage: 'pre-live', count: 1 },
         { stage: 'initial', count: 2 },
     ]);
 
     const stageCountByProject =
-        await featureLifeycycleReadModel.getStageCountByProject();
+        await featureLifecycleReadModel.getStageCountByProject();
     expect(stageCountByProject).toMatchObject([
         { project: 'default', stage: 'pre-live', count: 1 },
         { project: 'default', stage: 'initial', count: 2 },

--- a/src/lib/features/metrics/sizes/fake-largest-resources-read-model.ts
+++ b/src/lib/features/metrics/sizes/fake-largest-resources-read-model.ts
@@ -1,0 +1,16 @@
+import type { ILargestResourcesReadModel } from './largest-resources-read-model-type';
+
+export class FakeLargestResourcesReadModel
+    implements ILargestResourcesReadModel
+{
+    async getLargestProjectEnvironments(
+        limit: number,
+    ): Promise<{ project: string; environment: string; size: number }[]> {
+        return [];
+    }
+    async getLargestFeatureEnvironments(
+        limit: number,
+    ): Promise<{ feature: string; environment: string; size: number }[]> {
+        return [];
+    }
+}

--- a/src/lib/features/metrics/sizes/largest-resources-read-model-type.ts
+++ b/src/lib/features/metrics/sizes/largest-resources-read-model-type.ts
@@ -1,0 +1,8 @@
+export interface ILargestResourcesReadModel {
+    getLargestProjectEnvironments(
+        limit: number,
+    ): Promise<Array<{ project: string; environment: string; size: number }>>;
+    getLargestFeatureEnvironments(
+        limit: number,
+    ): Promise<Array<{ feature: string; environment: string; size: number }>>;
+}

--- a/src/lib/features/metrics/sizes/largest-resources-read-model.test.ts
+++ b/src/lib/features/metrics/sizes/largest-resources-read-model.test.ts
@@ -1,0 +1,94 @@
+import type { ILargestResourcesReadModel } from './largest-resources-read-model-type';
+import dbInit, {
+    type ITestDb,
+} from '../../../../test/e2e/helpers/database-init';
+import type { IFeatureToggleStore } from '../../feature-toggle/types/feature-toggle-store-type';
+import getLogger from '../../../../test/fixtures/no-logger';
+import type { IFeatureStrategiesStore } from '../../feature-toggle/types/feature-toggle-strategies-store-type';
+import type { IFeatureStrategy } from '../../../types';
+
+let db: ITestDb;
+let largestResourcesReadModel: ILargestResourcesReadModel;
+let featureToggleStore: IFeatureToggleStore;
+let featureStrategiesStore: IFeatureStrategiesStore;
+
+beforeAll(async () => {
+    db = await dbInit('largest_resources_read_model', getLogger);
+    featureToggleStore = db.stores.featureToggleStore;
+    featureStrategiesStore = db.stores.featureStrategiesStore;
+    largestResourcesReadModel = db.stores.largestResourcesReadModel;
+});
+
+afterAll(async () => {
+    if (db) {
+        await db.destroy();
+    }
+});
+
+beforeEach(async () => {
+    await featureToggleStore.deleteAll();
+});
+
+type FeatureConfig = Pick<
+    IFeatureStrategy,
+    'featureName' | 'constraints' | 'parameters' | 'variants'
+>;
+const createFeature = async (config: FeatureConfig) => {
+    await featureToggleStore.create('default', {
+        name: config.featureName,
+        createdByUserId: 9999,
+    });
+    await featureStrategiesStore.createStrategyFeatureEnv({
+        strategyName: 'flexibleRollout',
+        projectId: 'default',
+        environment: 'default',
+        featureName: config.featureName,
+        constraints: config.constraints,
+        parameters: config.parameters,
+        variants: config.variants,
+    });
+};
+
+test('can calculate resource size', async () => {
+    await createFeature({
+        featureName: 'featureA',
+        parameters: {
+            groupId: 'flag_init_test_1',
+            rollout: '25',
+            stickiness: 'default',
+        },
+        constraints: [
+            {
+                contextName: 'clientId',
+                operator: 'IN',
+                values: ['1', '2', '3', '4', '5', '6'],
+                caseInsensitive: false,
+                inverted: false,
+            },
+        ],
+        variants: [
+            {
+                name: 'a',
+                weight: 1000,
+                weightType: 'fix',
+                stickiness: 'default',
+            },
+        ],
+    });
+
+    await createFeature({
+        featureName: 'featureB',
+        parameters: {},
+        constraints: [],
+        variants: [],
+    });
+
+    const [project] =
+        await largestResourcesReadModel.getLargestProjectEnvironments(1);
+    const [feature1, feature2] =
+        await largestResourcesReadModel.getLargestFeatureEnvironments(2);
+
+    expect(project.size).toBeGreaterThan(400);
+    expect(project.size).toBe(feature1.size + feature2.size);
+    expect(feature1.size).toBeGreaterThan(feature2.size);
+});

--- a/src/lib/features/metrics/sizes/largest-resources-read-model.ts
+++ b/src/lib/features/metrics/sizes/largest-resources-read-model.ts
@@ -1,0 +1,76 @@
+import type { Db } from '../../../db/db';
+import type { ILargestResourcesReadModel } from './largest-resources-read-model-type';
+
+export class LargestResourcesReadModel implements ILargestResourcesReadModel {
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    async getLargestProjectEnvironments(
+        limit: number,
+    ): Promise<Array<{ project: string; environment: string; size: number }>> {
+        const { rows } = await this.db.raw(`
+            WITH ProjectSizes AS (
+                SELECT
+                    project_name,
+                    environment,
+                    SUM(pg_column_size(constraints) + pg_column_size(variants) + pg_column_size(parameters)) AS total_size
+                FROM
+                    feature_strategies
+                GROUP BY
+                    project_name,
+                    environment
+            )
+            SELECT
+                project_name,
+                environment,
+                total_size
+            FROM
+                ProjectSizes
+            ORDER BY
+                total_size DESC
+            LIMIT ${limit}
+        `);
+
+        return rows.map((row) => ({
+            project: row.project_name,
+            environment: row.environment,
+            size: Number(row.total_size),
+        }));
+    }
+
+    async getLargestFeatureEnvironments(
+        limit: number,
+    ): Promise<Array<{ feature: string; environment: string; size: number }>> {
+        const { rows } = await this.db.raw(`
+            WITH FeatureSizes AS (
+                SELECT
+                    feature_name,
+                    environment,
+                    SUM(pg_column_size(constraints) + pg_column_size(variants) + pg_column_size(parameters)) AS total_size
+                FROM
+                    feature_strategies
+                GROUP BY
+                    feature_name,
+                    environment
+            )
+            SELECT
+                feature_name,
+                environment,
+                total_size
+            FROM
+                FeatureSizes
+            ORDER BY
+                total_size DESC
+            LIMIT ${limit}
+        `);
+
+        return rows.map((row) => ({
+            feature: row.feature_name,
+            environment: row.environment,
+            size: Number(row.total_size),
+        }));
+    }
+}

--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -45,6 +45,7 @@ import { IFeatureLifecycleStore } from '../features/feature-lifecycle/feature-li
 import { IProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model.type';
 import { IFeatureStrategiesReadModel } from '../features/feature-toggle/types/feature-strategies-read-model-type';
 import { IFeatureLifecycleReadModel } from '../features/feature-lifecycle/feature-lifecycle-read-model-type';
+import { ILargestResourcesReadModel } from '../features/metrics/sizes/largest-resources-read-model-type';
 
 export interface IUnleashStores {
     accessStore: IAccessStore;
@@ -94,6 +95,7 @@ export interface IUnleashStores {
     featureLifecycleStore: IFeatureLifecycleStore;
     featureStrategiesReadModel: IFeatureStrategiesReadModel;
     featureLifecycleReadModel: IFeatureLifecycleReadModel;
+    largestResourcesReadModel: ILargestResourcesReadModel;
 }
 
 export {
@@ -142,4 +144,5 @@ export {
     IProjectFlagCreatorsReadModel,
     IFeatureStrategiesReadModel,
     IFeatureLifecycleReadModel,
+    ILargestResourcesReadModel,
 };

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -48,6 +48,7 @@ import { FakeFeatureLifecycleStore } from '../../lib/features/feature-lifecycle/
 import { FakeProjectFlagCreatorsReadModel } from '../../lib/features/project/fake-project-flag-creators-read-model';
 import { FakeFeatureStrategiesReadModel } from '../../lib/features/feature-toggle/fake-feature-strategies-read-model';
 import { FakeFeatureLifecycleReadModel } from '../../lib/features/feature-lifecycle/fake-feature-lifecycle-read-model';
+import { FakeLargestResourcesReadModel } from '../../lib/features/metrics/sizes/fake-largest-resources-read-model';
 
 const db = {
     select: () => ({
@@ -105,6 +106,7 @@ const createStores: () => IUnleashStores = () => {
         featureLifecycleStore: new FakeFeatureLifecycleStore(),
         featureStrategiesReadModel: new FakeFeatureStrategiesReadModel(),
         featureLifecycleReadModel: new FakeFeatureLifecycleReadModel(),
+        largestResourcesReadModel: new FakeLargestResourcesReadModel(),
     };
 };
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Proactive **project env and feature env weight metrics** allowing us to asses which feature environments and which project environments are the largest in the Unleash instance. 

### Background
* Unleash should always protect SDKs from fetching unnecessary data causing memory problems or CPU problems due to excessive config data

### Constraints
* We want to get feedback on the excessive configuration at the feature environment level and at the project level way before the first client feature request is being made (being proactive)

### Solution

<img width="1188" alt="Screenshot 2024-06-26 at 15 48 34" src="https://github.com/Unleash/unleash/assets/1394682/1200e97c-dde8-42ff-b594-9aea69a94514">

We can use feature_strategies table to calculate size heuristic for large feature environments and project environments.
Both are affected by two dimensions of the feature_strategies table. The vertical axis is the numbers of strategies and the horizontal axis is the sum of sizes of constraints/parameters/variants that are main contributors to the size.
We can multiply those dimensions for a single feature environment or project environment to get estimated size.

### Possible ideas

Currently we only expose largest project env and feature env to prometheus but we can use this query in other places:
* when creating a project token we can give you the estimated data fetch size for the project

<img width="796" alt="Screenshot 2024-06-26 at 16 00 58" src="https://github.com/Unleash/unleash/assets/1394682/34920b7a-fb2c-44bc-8f1c-b64297eacf1e">


* when opening project insights we can tell you the weight of the project
<img width="266" alt="Screenshot 2024-06-26 at 16 02 34" src="https://github.com/Unleash/unleash/assets/1394682/fbece526-2371-4637-9713-b1fdd0feed17">



* when showing multiple features we can indicate which features are the heaviest

<img width="637" alt="Screenshot 2024-06-26 at 16 03 23" src="https://github.com/Unleash/unleash/assets/1394682/919f89b9-8e81-4730-9d4d-5af3de796dfc">



## Discussion points
The most important takeaway is that we're introducing a concept of a *weight*: project weight (= project API key weight) and feature environment weight

As a results we can reason which projects/project keys are heavy and which individual feature envs are heavy. Since Unleash relies on the config transfer from the API to the SDK this concept can be made more explicit for educational purposes.