### PR TITLE
fix: prevent project cell overflow on api keys table

### DIFF
--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
@@ -44,4 +44,34 @@ describe('ProjectsList', () => {
 
         expect(container.textContent).toEqual('*');
     });
+
+    it('should show up to 4 projects', async () => {
+        const { container } = render(
+            <ProjectsList
+                projects={['project1', 'project2', 'project3', 'project4']}
+            />,
+        );
+
+        expect(container.textContent).toContain(
+            'project1, project2, project3, project4',
+        );
+    });
+
+    it('should abbreviate for 5 projects', async () => {
+        const { container } = render(
+            <ProjectsList
+                projects={[
+                    'project1',
+                    'project2',
+                    'project3',
+                    'project4',
+                    'project5',
+                ]}
+            />,
+        );
+
+        expect(container.textContent).toContain(
+            'project1, project2, project3, +2 more',
+        );
+    });
 });

--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
@@ -4,19 +4,14 @@ import { ProjectsList } from 'component/admin/apiToken/ProjectsList/ProjectsList
 
 describe('ProjectsList', () => {
     it('should prioritize new "projects" array over deprecated "project"', async () => {
-        render(
+        const { container } = render(
             <ProjectsList
                 project='project'
                 projects={['project1', 'project2']}
             />,
         );
 
-        const links = await screen.findAllByRole('link');
-        expect(links).toHaveLength(2);
-        expect(links[0]).toHaveTextContent('project1');
-        expect(links[1]).toHaveTextContent('project2');
-        expect(links[0]).toHaveAttribute('href', '/projects/project1');
-        expect(links[1]).toHaveAttribute('href', '/projects/project2');
+        expect(container.textContent).toContain('2 projects');
     });
 
     it('should render correctly with single "project"', async () => {
@@ -25,12 +20,6 @@ describe('ProjectsList', () => {
         const links = await screen.findAllByRole('link');
         expect(links).toHaveLength(1);
         expect(links[0]).toHaveTextContent('project');
-    });
-
-    it('should have comma between project links', async () => {
-        const { container } = render(<ProjectsList projects={['a', 'b']} />);
-
-        expect(container.textContent).toContain(', ');
     });
 
     it('should render asterisk if no projects are passed', async () => {
@@ -45,33 +34,13 @@ describe('ProjectsList', () => {
         expect(container.textContent).toEqual('*');
     });
 
-    it('should show up to 4 projects', async () => {
+    it('should show number of projects', async () => {
         const { container } = render(
             <ProjectsList
                 projects={['project1', 'project2', 'project3', 'project4']}
             />,
         );
 
-        expect(container.textContent).toContain(
-            'project1, project2, project3, project4',
-        );
-    });
-
-    it('should abbreviate for 5 projects', async () => {
-        const { container } = render(
-            <ProjectsList
-                projects={[
-                    'project1',
-                    'project2',
-                    'project3',
-                    'project4',
-                    'project5',
-                ]}
-            />,
-        );
-
-        expect(container.textContent).toContain(
-            'project1, project2, project3, +2 more',
-        );
+        expect(container.textContent).toContain('4 projects');
     });
 });

--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.test.tsx
@@ -34,7 +34,7 @@ describe('ProjectsList', () => {
         expect(container.textContent).toEqual('*');
     });
 
-    it('should show number of projects', async () => {
+    it('should show the number of projects', async () => {
         const { container } = render(
             <ProjectsList
                 projects={['project1', 'project2', 'project3', 'project4']}

--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
@@ -1,5 +1,7 @@
 import { styled } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Fragment, type VFC } from 'react';
@@ -38,9 +40,12 @@ export const ProjectsList: VFC<IProjectsListProps> = ({
         );
     }
 
+    const fieldsHead = fields.length < 5 ? fields : fields.slice(0, 3);
+    const fieldsTail = fields.length < 5 ? [] : fields.slice(3);
+
     return (
         <TextCell>
-            {fields.map((item, index) => (
+            {fieldsHead.map((item, index) => (
                 <Fragment key={item}>
                     {index > 0 && ', '}
                     {!item || item === '*' ? (
@@ -54,6 +59,36 @@ export const ProjectsList: VFC<IProjectsListProps> = ({
                     )}
                 </Fragment>
             ))}
+            <ConditionallyRender
+                condition={fieldsTail.length > 0}
+                show={
+                    <>
+                        {', '}
+                        <HtmlTooltip
+                            title={fieldsTail.map((item, index) => (
+                                <Fragment key={item}>
+                                    {index > 0 && ', '}
+                                    {!item || item === '*' ? (
+                                        <Highlighter search={searchQuery}>
+                                            *
+                                        </Highlighter>
+                                    ) : (
+                                        <StyledLink to={`/projects/${item}`}>
+                                            <Highlighter search={searchQuery}>
+                                                {item}
+                                            </Highlighter>
+                                        </StyledLink>
+                                    )}
+                                </Fragment>
+                            ))}
+                            placement='bottom-start'
+                            arrow
+                        >
+                            <span>+{`${fieldsTail.length}`} more</span>
+                        </HtmlTooltip>
+                    </>
+                }
+            />
         </TextCell>
     );
 };

--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
@@ -50,6 +50,7 @@ export const ProjectsList: FC<IProjectsListProps> = ({ projects, project }) => {
                     ))}
                     placement='bottom-start'
                     arrow
+                    tabIndex={0}
                 >
                     <span>{`${projectsList.length}`} projects</span>
                 </HtmlTooltip>

--- a/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
+++ b/frontend/src/component/admin/apiToken/ProjectsList/ProjectsList.tsx
@@ -1,10 +1,10 @@
 import { styled } from '@mui/material';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
+import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { Fragment, type VFC } from 'react';
+import { Fragment, type FC } from 'react';
 import { Link } from 'react-router-dom';
 
 const StyledLink = styled(Link)(({ theme }) => ({
@@ -20,75 +20,68 @@ interface IProjectsListProps {
     projects?: string | string[];
 }
 
-export const ProjectsList: VFC<IProjectsListProps> = ({
-    projects,
-    project,
-}) => {
+export const ProjectsList: FC<IProjectsListProps> = ({ projects, project }) => {
     const { searchQuery } = useSearchHighlightContext();
-    const fields: string[] =
-        projects && Array.isArray(projects)
-            ? projects
-            : project
-              ? [project]
-              : [];
 
-    if (fields.length === 0) {
+    const projectsList =
+        projects && Array.isArray(projects) && projects.length > 1
+            ? projects
+            : [];
+
+    if (projectsList.length > 0) {
         return (
             <TextCell>
-                <Highlighter search={searchQuery}>*</Highlighter>
+                <HtmlTooltip
+                    title={projectsList.map((item, index) => (
+                        <Fragment key={item}>
+                            {index > 0 && ', '}
+                            {!item || item === '*' ? (
+                                <Highlighter search={searchQuery}>
+                                    *
+                                </Highlighter>
+                            ) : (
+                                <StyledLink to={`/projects/${item}`}>
+                                    <Highlighter search={searchQuery}>
+                                        {item}
+                                    </Highlighter>
+                                </StyledLink>
+                            )}
+                        </Fragment>
+                    ))}
+                    placement='bottom-start'
+                    arrow
+                >
+                    <span>{`${projectsList.length}`} projects</span>
+                </HtmlTooltip>
             </TextCell>
         );
     }
 
-    const fieldsHead = fields.length < 5 ? fields : fields.slice(0, 3);
-    const fieldsTail = fields.length < 5 ? [] : fields.slice(3);
-
-    return (
-        <TextCell>
-            {fieldsHead.map((item, index) => (
-                <Fragment key={item}>
-                    {index > 0 && ', '}
-                    {!item || item === '*' ? (
+    if (
+        (projectsList.length === 1 && projectsList[0] === '*') ||
+        project === '*' ||
+        (!project && (!projectsList || projectsList.length === 0))
+    ) {
+        return (
+            <TextCell>
+                <HtmlTooltip
+                    title='ALL current and future projects'
+                    placement='bottom'
+                    arrow
+                >
+                    <span>
                         <Highlighter search={searchQuery}>*</Highlighter>
-                    ) : (
-                        <StyledLink to={`/projects/${item}`}>
-                            <Highlighter search={searchQuery}>
-                                {item}
-                            </Highlighter>
-                        </StyledLink>
-                    )}
-                </Fragment>
-            ))}
-            <ConditionallyRender
-                condition={fieldsTail.length > 0}
-                show={
-                    <>
-                        {', '}
-                        <HtmlTooltip
-                            title={fieldsTail.map((item, index) => (
-                                <Fragment key={item}>
-                                    {index > 0 && ', '}
-                                    {!item || item === '*' ? (
-                                        <Highlighter search={searchQuery}>
-                                            *
-                                        </Highlighter>
-                                    ) : (
-                                        <StyledLink to={`/projects/${item}`}>
-                                            <Highlighter search={searchQuery}>
-                                                {item}
-                                            </Highlighter>
-                                        </StyledLink>
-                                    )}
-                                </Fragment>
-                            ))}
-                            placement='bottom-start'
-                            arrow
-                        >
-                            <span>+{`${fieldsTail.length}`} more</span>
-                        </HtmlTooltip>
-                    </>
-                }
-            />
-        </TextCell>
-    );
+                    </span>
+                </HtmlTooltip>
+            </TextCell>
+        );
+    }
+
+    if (projectsList.length === 1 || project) {
+        const item = project || projectsList[0];
+
+        return <LinkCell to={`/projects/${item}`} title={item} />;
+    }
+
+    return null;
 };

--- a/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
+++ b/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
@@ -68,6 +68,7 @@ export interface IHtmlTooltipProps extends TooltipProps {
     maxWidth?: SpacingArgument;
     maxHeight?: SpacingArgument;
     fontSize?: string;
+    tabIndex?: number;
 }
 
 export const HtmlTooltip = (props: IHtmlTooltipProps) => {


### PR DESCRIPTION
![image](https://github.com/Unleash/unleash/assets/2625371/3e7f966d-930d-4065-bd12-7a198cca258b)

Instead of listing all projects, that currently stretch the row height, I added a tooltip. This is similar to segments. It will enable virtualization of the table