### PR TITLE
fix: cap project ids to 90 characters (without suffix)

### DIFF
--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -2684,23 +2684,38 @@ describe('automatic ID generation for create project', () => {
         },
     );
 
-    test('Projects with long names get ids capped at <= 90 characters', async () => {
+    test('Projects with long names get ids capped at 90 characters and then suffixed', async () => {
         const name = Array.from({ length: 200 })
             .map(() => 'a')
-            .join('');
-        const createProject = async () =>
-            projectService.createProject(
-                {
-                    name,
-                },
-                user,
-                auditUser,
-            );
+            .join();
 
-        const project = await createProject();
+        const project = await projectService.createProject(
+            {
+                name,
+            },
+            user,
+            auditUser,
+        );
 
         expect(project.name).toBe(name);
         expect(project.id.length).toBeLessThanOrEqual(90);
+
+        const secondName =
+            name +
+            Array.from({ length: 100 })
+                .map(() => 'b')
+                .join();
+
+        const secondProject = await projectService.createProject(
+            {
+                name: secondName,
+            },
+            user,
+            auditUser,
+        );
+
+        expect(secondProject.name).toBe(secondName);
+        expect(secondProject.id).toBe(`${project.id}-1`);
     });
 
     describe('backwards compatibility', () => {

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -2684,6 +2684,25 @@ describe('automatic ID generation for create project', () => {
         },
     );
 
+    test('Projects with long names get ids capped at <= 90 characters', async () => {
+        const name = Array.from({ length: 200 })
+            .map(() => 'a')
+            .join('');
+        const createProject = async () =>
+            projectService.createProject(
+                {
+                    name,
+                },
+                user,
+                auditUser,
+            );
+
+        const project = await createProject();
+
+        expect(project.name).toBe(name);
+        expect(project.id.length).toBeLessThanOrEqual(90);
+    });
+
     describe('backwards compatibility', () => {
         const featureFlag = 'createProjectWithEnvironmentConfig';
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -305,16 +305,16 @@ export default class ProjectService {
         }
     }
     async generateProjectId(name: string): Promise<string> {
-        const generateUniqueId = async (name: string, suffix?: number) => {
-            const slug = createSlug(name);
+        const slug = createSlug(name).slice(0, 90);
+        const generateUniqueId = async (suffix?: number) => {
             const id = suffix ? `${slug}-${suffix}` : slug;
             if (await this.projectStore.hasProject(id)) {
-                return await generateUniqueId(name, (suffix ?? 0) + 1);
+                return await generateUniqueId((suffix ?? 0) + 1);
             } else {
                 return id;
             }
         };
-        return generateUniqueId(name);
+        return generateUniqueId();
     }
 
     async createProject(


### PR DESCRIPTION
This fixes the issue where project names that are 100 characters long
or longer would cause the project creation to fail. This is because
the resulting ID would be longer than the 100 character limit imposed
by the back end.

We solve this by capping the project ID to 90 characters, which leaves
us with 10 characters for the suffix, meaning you can have 1 billion
projects (999,999,999 + 1) that start with the same 90
characters (after slugification) before anything breaks.

It's a little shorter than what it strictly has to be (we could
probably get around with 95 characters), but at this point, you're
reaching into edge case territory anyway, and I'd rather have a little
too much wiggle room here.