### PR TITLE
feat: add environments to resource limit schema

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -196,6 +196,7 @@ exports[`should create default config 1`] = `
     "actionSetFilterValues": 25,
     "actionSetFilters": 5,
     "actionSetsPerProject": 5,
+    "environments": 50,
     "featureEnvironmentStrategies": 30,
     "segmentValues": 1000,
     "signalEndpoints": 5,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -653,6 +653,10 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
             30,
         ),
+        environments: parseEnvVarNumber(
+            process.env.UNLEASH_ENVIRONMENTS_LIMIT,
+            50,
+        ),
     };
 
     return {

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -14,6 +14,7 @@ export const resourceLimitsSchema = {
         'signalEndpoints',
         'signalTokensPerEndpoint',
         'featureEnvironmentStrategies',
+        'environments',
     ],
     additionalProperties: false,
     properties: {
@@ -67,6 +68,12 @@ export const resourceLimitsSchema = {
             example: 30,
             description:
                 'The maximum number of feature environment strategies allowed.',
+        },
+        environments: {
+            type: 'integer',
+            minimum: 1,
+            example: 50,
+            description: 'The maximum number active environments allowed.',
         },
     },
     components: {},


### PR DESCRIPTION
This PR adds limits for environments to the resource limit schema. The actual limiting will have to be done in Enterprise, however, so this is just laying the groundwork.