### PR TITLE
feat: add resource limits for API tokens

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -196,6 +196,7 @@ exports[`should create default config 1`] = `
     "actionSetFilterValues": 25,
     "actionSetFilters": 5,
     "actionSetsPerProject": 5,
+    "apiTokens": 2000,
     "constraintValues": 250,
     "environments": 50,
     "featureEnvironmentStrategies": 30,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -661,6 +661,10 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             process.env.UNLEASH_ENVIRONMENTS_LIMIT,
             50,
         ),
+        apiTokens: parseEnvVarNumber(
+            process.env.UNLEASH_API_TOKENS_LIMIT,
+            2000,
+        ),
     };
 
     return {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -663,7 +663,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ),
         apiTokens: parseEnvVarNumber(
             process.env.UNLEASH_API_TOKENS_LIMIT,
-            options?.resourceLimits?.apiTokens || 2000,
+            2000,
         ),
     };
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -663,7 +663,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ),
         apiTokens: parseEnvVarNumber(
             process.env.UNLEASH_API_TOKENS_LIMIT,
-            2000,
+            options?.resourceLimits?.apiTokens || 2000,
         ),
     };
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -661,9 +661,9 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             process.env.UNLEASH_ENVIRONMENTS_LIMIT,
             50,
         ),
-        apiTokens: parseEnvVarNumber(
-            process.env.UNLEASH_API_TOKENS_LIMIT,
-            2000,
+        apiTokens: Math.max(
+            0,
+            parseEnvVarNumber(process.env.UNLEASH_API_TOKENS_LIMIT, 2000),
         ),
     };
 

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -82,13 +82,12 @@ export const resourceLimitsSchema = {
             example: 50,
             description: 'The maximum number of environments allowed.',
         },
-        // should it be sdkApiTokens?
         apiTokens: {
             type: 'integer',
             minimum: 1,
             example: 2000,
             description:
-                'The maximum number of SDK API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens. Personal access tokens and admin tokens are not subject to this limit.',
+                'The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.',
         },
     },
     components: {},

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -89,6 +89,7 @@ export const resourceLimitsSchema = {
             example: 2000,
             description:
                 'The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.',
+        },
         projects: {
             type: 'integer',
             minimum: 1,

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -84,7 +84,7 @@ export const resourceLimitsSchema = {
         },
         apiTokens: {
             type: 'integer',
-            minimum: 1,
+            minimum: 0,
             example: 2000,
             description:
                 'The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.',

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -82,6 +82,14 @@ export const resourceLimitsSchema = {
             example: 50,
             description: 'The maximum number of environments allowed.',
         },
+        // should it be sdkApiTokens?
+        apiTokens: {
+            type: 'integer',
+            minimum: 1,
+            example: 2000,
+            description:
+                'The maximum number of SDK API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens. Personal access tokens and admin tokens are not subject to this limit.',
+        },
     },
     components: {},
 } as const;

--- a/src/lib/services/api-token-service.limit.test.ts
+++ b/src/lib/services/api-token-service.limit.test.ts
@@ -14,9 +14,6 @@ const createServiceWithLimit = (limit: number) => {
                 resourceLimits: true,
             },
         },
-        resourceLimits: {
-            apiTokens: limit,
-        },
     });
 
     const apiTokenStore = new FakeApiTokenStore();
@@ -33,7 +30,12 @@ const createServiceWithLimit = (limit: number) => {
 
     const service = new ApiTokenService(
         { apiTokenStore, environmentStore },
-        config,
+        {
+            ...config,
+            resourceLimits: {
+                apiTokens: limit,
+            },
+        },
         eventService,
     );
 

--- a/src/lib/services/api-token-service.limit.test.ts
+++ b/src/lib/services/api-token-service.limit.test.ts
@@ -28,15 +28,11 @@ const createServiceWithLimit = (limit: number) => {
 
     const eventService = createFakeEventsService(config);
 
+    config.resourceLimits.apiTokens = limit;
+
     const service = new ApiTokenService(
         { apiTokenStore, environmentStore },
-        {
-            ...config,
-            resourceLimits: {
-                ...config.resourceLimits,
-                apiTokens: limit,
-            },
-        },
+        config,
         eventService,
     );
 

--- a/src/lib/services/api-token-service.limit.test.ts
+++ b/src/lib/services/api-token-service.limit.test.ts
@@ -33,6 +33,7 @@ const createServiceWithLimit = (limit: number) => {
         {
             ...config,
             resourceLimits: {
+                ...config.resourceLimits,
                 apiTokens: limit,
             },
         },

--- a/src/lib/services/api-token-service.limit.test.ts
+++ b/src/lib/services/api-token-service.limit.test.ts
@@ -1,0 +1,100 @@
+import { ApiTokenService } from './api-token-service';
+import { createTestConfig } from '../../test/config/test-config';
+import type { IUnleashConfig } from '../server-impl';
+import { ApiTokenType } from '../types/models/api-token';
+import FakeApiTokenStore from '../../test/fixtures/fake-api-token-store';
+import FakeEnvironmentStore from '../features/project-environments/fake-environment-store';
+import { createFakeEventsService } from '../../lib/features';
+import { ExceedsLimitError } from '../error/exceeds-limit-error';
+
+const createServiceWithLimit = (limit: number) => {
+    const config: IUnleashConfig = createTestConfig({
+        experimental: {
+            flags: {
+                resourceLimits: true,
+            },
+        },
+        resourceLimits: {
+            apiTokens: limit,
+        },
+    });
+
+    const apiTokenStore = new FakeApiTokenStore();
+    const environmentStore = new FakeEnvironmentStore();
+    environmentStore.create({
+        name: 'production',
+        type: 'production',
+        enabled: true,
+        protected: true,
+        sortOrder: 1,
+    });
+
+    const eventService = createFakeEventsService(config);
+
+    const service = new ApiTokenService(
+        { apiTokenStore, environmentStore },
+        config,
+        eventService,
+    );
+
+    return service;
+};
+
+test('Should allow you to create tokens up to and including the limit', async () => {
+    const limit = 3;
+    const service = createServiceWithLimit(limit);
+
+    for (let i = 0; i < limit; i++) {
+        await service.createApiTokenWithProjects(
+            {
+                tokenName: `token-${i}`,
+                type: ApiTokenType.CLIENT,
+                environment: 'production',
+                projects: ['*'],
+            },
+            {
+                id: 1,
+                username: 'audit user',
+                ip: '127.0.0.1',
+            },
+        );
+    }
+});
+
+test.each([ApiTokenType.ADMIN, ApiTokenType.CLIENT, ApiTokenType.FRONTEND])(
+    "Should prevent you from creating %s tokens when you're already at the limit",
+    async (tokenType) => {
+        const limit = 1;
+        const service = createServiceWithLimit(limit);
+        const auditUser = {
+            id: 1,
+            username: 'audit user',
+            ip: '127.0.0.1',
+        };
+
+        await service.createApiTokenWithProjects(
+            {
+                tokenName: 'token-1',
+                type: ApiTokenType.CLIENT,
+                environment: 'production',
+                projects: ['*'],
+            },
+            auditUser,
+        );
+
+        const environment =
+            tokenType === ApiTokenType.ADMIN ? '*' : 'production';
+
+        await expect(
+            service.createApiTokenWithProjects(
+                {
+                    tokenName: 'exceeds-limit',
+                    type: tokenType,
+                    environment,
+                    projects: ['*'],
+                },
+                auditUser,
+            ),
+        ).rejects.toThrow(ExceedsLimitError);
+    },
+);

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -33,6 +33,8 @@ import type EventService from '../features/events/event-service';
 import { addMinutes, isPast } from 'date-fns';
 import metricsHelper from '../util/metrics-helper';
 import { FUNCTION_TIME } from '../metric-events';
+import type { ResourceLimitsSchema } from '../openapi';
+import { ExceedsLimitError } from '../error/exceeds-limit-error';
 
 const resolveTokenPermissions = (tokenType: string) => {
     if (tokenType === ApiTokenType.ADMIN) {
@@ -69,6 +71,8 @@ export class ApiTokenService {
 
     private timer: Function;
 
+    private resourceLimits: ResourceLimitsSchema;
+
     constructor(
         {
             apiTokenStore,
@@ -76,7 +80,11 @@ export class ApiTokenService {
         }: Pick<IUnleashStores, 'apiTokenStore' | 'environmentStore'>,
         config: Pick<
             IUnleashConfig,
-            'getLogger' | 'authentication' | 'flagResolver' | 'eventBus'
+            | 'getLogger'
+            | 'authentication'
+            | 'flagResolver'
+            | 'eventBus'
+            | 'resourceLimits'
         >,
         eventService: EventService,
     ) {
@@ -85,6 +93,7 @@ export class ApiTokenService {
         this.environmentStore = environmentStore;
         this.flagResolver = config.flagResolver;
         this.logger = config.getLogger('/services/api-token-service.ts');
+        this.resourceLimits = config.resourceLimits;
         if (!this.flagResolver.isEnabled('useMemoizedActiveTokens')) {
             // This is probably not needed because the scheduler will run it
             this.fetchActiveTokens();
@@ -285,6 +294,14 @@ export class ApiTokenService {
         validateApiToken(newToken);
         const environments = await this.environmentStore.getAll();
         validateApiTokenEnvironment(newToken, environments);
+
+        if (this.flagResolver.isEnabled('resourceLimits')) {
+            const currentTokenCount = await this.store.count();
+            const limit = this.resourceLimits.apiTokens;
+            if (currentTokenCount >= limit) {
+                throw new ExceedsLimitError('api token', limit);
+            }
+        }
 
         const secret = this.generateSecretKey(newToken);
         const createNewToken = { ...newToken, secret };

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -141,7 +141,9 @@ export interface IUnleashOptions {
     metricsRateLimiting?: Partial<IMetricsRateLimiting>;
     dailyMetricsStorageDays?: number;
     rateLimiting?: Partial<IRateLimiting>;
-    resourceLimits?: Partial<Pick<ResourceLimitsSchema, 'constraintValues'>>;
+    resourceLimits?: Partial<
+        Pick<ResourceLimitsSchema, 'constraintValues' | 'apiTokens'>
+    >;
 }
 
 export interface IEmailOption {

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -141,9 +141,7 @@ export interface IUnleashOptions {
     metricsRateLimiting?: Partial<IMetricsRateLimiting>;
     dailyMetricsStorageDays?: number;
     rateLimiting?: Partial<IRateLimiting>;
-    resourceLimits?: Partial<
-        Pick<ResourceLimitsSchema, 'constraintValues' | 'apiTokens'>
-    >;
+    resourceLimits?: Partial<Pick<ResourceLimitsSchema, 'constraintValues'>>;
 }
 
 export interface IEmailOption {


### PR DESCRIPTION
This PR adds the back end for API token resource limits. 

It adds the limit to the schema and checks the limit in the service.

## Discussion points

The PAT service uses a different service and different store entirely, so I have not included testing any edge cases where PATs are included. However, that could be seen as "knowing too much". We could add tests that check both of the stores in tandem, but I think it's overkill for now.