### PR TITLE
fix: improve menu styling

### DIFF
--- a/frontend/src/component/commandBar/CommandPageSuggestions.tsx
+++ b/frontend/src/component/commandBar/CommandPageSuggestions.tsx
@@ -75,15 +75,7 @@ export const CommandPageSuggestions = ({
                     }}
                     sx={listItemButtonStyle}
                 >
-                    <StyledListItemIcon
-                        sx={(theme) => ({
-                            fontSize: theme.fontSizes.smallBody,
-                            minWidth: theme.spacing(0.5),
-                            margin: theme.spacing(0, 1, 0, 0),
-                        })}
-                    >
-                        {item.icon}
-                    </StyledListItemIcon>
+                    <StyledListItemIcon>{item.icon}</StyledListItemIcon>
                     <StyledListItemText>
                         <StyledButtonTypography color='textPrimary'>
                             {item.name}

--- a/frontend/src/component/commandBar/CommandPages.tsx
+++ b/frontend/src/component/commandBar/CommandPages.tsx
@@ -49,13 +49,7 @@ export const CommandPages = ({
                     }}
                     sx={listItemButtonStyle}
                 >
-                    <StyledListItemIcon
-                        sx={(theme) => ({
-                            fontSize: theme.fontSizes.smallBody,
-                            minWidth: theme.spacing(0.5),
-                            margin: theme.spacing(0, 1, 0, 0),
-                        })}
-                    >
+                    <StyledListItemIcon>
                         <IconRenderer path={item.link} />
                     </StyledListItemIcon>
                     <StyledListItemText>

--- a/frontend/src/component/commandBar/CommandRecent.tsx
+++ b/frontend/src/component/commandBar/CommandRecent.tsx
@@ -4,7 +4,6 @@ import {
     RecentlyVisitedPathButton,
     RecentlyVisitedProjectButton,
 } from './RecentlyVisited/CommandResultGroup';
-import { List } from '@mui/material';
 import {
     useRecentlyVisited,
     type LastViewedPage,
@@ -57,7 +56,7 @@ export const CommandRecent = ({
             groupName='Quick suggestions'
             onClick={onClick}
         >
-            <List>{buttons}</List>
+            {buttons}
         </CommandResultGroup>
     );
 };


### PR DESCRIPTION
Now quick suggestions padding is not bigger than for pages. 

![image](https://github.com/Unleash/unleash/assets/964450/9708faab-67d4-4159-8af4-b203f7778f6b)
