### PR TITLE
fix: command menu hover

### DIFF
--- a/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
+++ b/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
@@ -22,10 +22,6 @@ import { Children } from 'react';
 export const listItemButtonStyle = (theme: Theme) => ({
     border: `1px solid transparent`,
     borderLeft: `${theme.spacing(0.5)} solid transparent`,
-    '&:hover, &:focus': {
-        border: `1px solid ${theme.palette.primary.main}`,
-        borderLeft: `${theme.spacing(0.5)} solid ${theme.palette.primary.main}`,
-    },
 });
 export const StyledTypography = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.bodySize,


### PR DESCRIPTION
Now command menu hover has same styling as sidebar

![image](https://github.com/Unleash/unleash/assets/964450/22dd869f-0256-4922-b56a-826f1f37ff45)
