### PR TITLE
feat: segments limit

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -202,6 +202,7 @@ exports[`should create default config 1`] = `
     "featureEnvironmentStrategies": 30,
     "projects": 500,
     "segmentValues": 1000,
+    "segments": 300,
     "signalEndpoints": 5,
     "signalTokensPerEndpoint": 5,
     "strategySegments": 5,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -675,6 +675,10 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             0,
             parseEnvVarNumber(process.env.UNLEASH_API_TOKENS_LIMIT, 2000),
         ),
+        segments: Math.max(
+            1,
+            parseEnvVarNumber(process.env.UNLEASH_SEGMENTS_LIMIT, 300),
+        ),
     };
 
     return {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -676,7 +676,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             parseEnvVarNumber(process.env.UNLEASH_API_TOKENS_LIMIT, 2000),
         ),
         segments: Math.max(
-            1,
+            0,
             parseEnvVarNumber(process.env.UNLEASH_SEGMENTS_LIMIT, 300),
         ),
     };

--- a/src/lib/features/segment/segment-service.limit.test.ts
+++ b/src/lib/features/segment/segment-service.limit.test.ts
@@ -1,0 +1,29 @@
+import type { IAuditUser, IFlagResolver, IUnleashConfig } from '../../types';
+import getLogger from '../../../test/fixtures/no-logger';
+import { createFakeSegmentService } from './createSegmentService';
+
+const alwaysOnFlagResolver = {
+    isEnabled() {
+        return true;
+    },
+} as unknown as IFlagResolver;
+
+test('Should not allow to exceed segment limit', async () => {
+    const LIMIT = 1;
+    const segmentService = createFakeSegmentService({
+        getLogger,
+        flagResolver: alwaysOnFlagResolver,
+        resourceLimits: {
+            segments: LIMIT,
+        },
+    } as unknown as IUnleashConfig);
+
+    const createSegment = (name: string) =>
+        segmentService.create({ name, constraints: [] }, {} as IAuditUser);
+
+    await createSegment('segmentA');
+
+    await expect(() => createSegment('segmentB')).rejects.toThrow(
+        "Failed to create segment. You can't create more than the established limit of 1.",
+    );
+});

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -17,6 +17,8 @@ export const resourceLimitsSchema = {
         'constraintValues',
         'environments',
         'projects',
+        'apiTokens',
+        'segments',
     ],
     additionalProperties: false,
     properties: {
@@ -95,6 +97,11 @@ export const resourceLimitsSchema = {
             minimum: 1,
             example: 500,
             description: 'The maximum number of projects allowed.',
+        },
+        segments: {
+            type: 'integer',
+            example: 300,
+            description: 'The maximum number of segments allowed.',
         },
     },
     components: {},

--- a/src/test/fixtures/fake-segment-store.ts
+++ b/src/test/fixtures/fake-segment-store.ts
@@ -2,12 +2,18 @@ import type { ISegmentStore } from '../../lib/features/segment/segment-store-typ
 import type { IFeatureStrategySegment, ISegment } from '../../lib/types/model';
 
 export default class FakeSegmentStore implements ISegmentStore {
-    count(): Promise<number> {
-        return Promise.resolve(0);
+    segments: ISegment[] = [];
+    currentId: number = 0;
+
+    async count(): Promise<number> {
+        return this.segments.length;
     }
 
-    create(): Promise<ISegment> {
-        throw new Error('Method not implemented.');
+    async create(segment: Omit<ISegment, 'id'>): Promise<ISegment> {
+        const newSegment = { ...segment, id: this.currentId++ };
+        this.segments.push(newSegment);
+
+        return newSegment;
     }
 
     async delete(): Promise<void> {
@@ -50,8 +56,8 @@ export default class FakeSegmentStore implements ISegmentStore {
         return [];
     }
 
-    async existsByName(): Promise<boolean> {
-        throw new Error('Method not implemented.');
+    async existsByName(name: string): Promise<boolean> {
+        return this.segments.some((segment) => segment.name === name);
     }
 
     destroy(): void {}

--- a/src/test/fixtures/fake-segment-store.ts
+++ b/src/test/fixtures/fake-segment-store.ts
@@ -10,7 +10,8 @@ export default class FakeSegmentStore implements ISegmentStore {
     }
 
     async create(segment: Omit<ISegment, 'id'>): Promise<ISegment> {
-        const newSegment = { ...segment, id: this.currentId++ };
+        const newSegment = { ...segment, id: this.currentId };
+        this.currentId = this.currentId + 1;
         this.segments.push(newSegment);
 
         return newSegment;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Limit how many segments we can create in our backend (by default it's 300). 

Details:
* I had to add method to our fake store to get the unit test for limits running
* if we set limit to 0 then we can effectively disable segment creation

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
