### PR TITLE
feat: segments limit ui

### DIFF
--- a/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
+++ b/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
@@ -15,7 +15,6 @@ export const CreateSegmentButton: FC<{
     const projectId = useOptionalPathParam('projectId');
     const navigate = useNavigate();
 
-    console.log('***', disabled);
 
     return (
         <PermissionButton

--- a/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
+++ b/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
@@ -15,7 +15,6 @@ export const CreateSegmentButton: FC<{
     const projectId = useOptionalPathParam('projectId');
     const navigate = useNavigate();
 
-
     return (
         <PermissionButton
             onClick={() => {

--- a/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
+++ b/frontend/src/component/segments/CreateSegmentButton/CreateSegmentButton.tsx
@@ -6,10 +6,16 @@ import PermissionButton from 'component/common/PermissionButton/PermissionButton
 import { NAVIGATE_TO_CREATE_SEGMENT } from 'utils/testIds';
 import { useNavigate } from 'react-router-dom';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
+import type { FC } from 'react';
 
-export const CreateSegmentButton = () => {
+export const CreateSegmentButton: FC<{
+    disabled: boolean;
+    tooltip?: string;
+}> = ({ disabled, tooltip }) => {
     const projectId = useOptionalPathParam('projectId');
     const navigate = useNavigate();
+
+    console.log('***', disabled);
 
     return (
         <PermissionButton
@@ -22,6 +28,10 @@ export const CreateSegmentButton = () => {
             }}
             permission={[CREATE_SEGMENT, UPDATE_PROJECT_SEGMENT]}
             projectId={projectId}
+            disabled={disabled}
+            tooltipProps={{
+                title: tooltip,
+            }}
             data-testid={NAVIGATE_TO_CREATE_SEGMENT}
         >
             New segment

--- a/frontend/src/component/segments/SegmentTable/SegmentTable.test.tsx
+++ b/frontend/src/component/segments/SegmentTable/SegmentTable.test.tsx
@@ -2,6 +2,7 @@ import { render } from 'utils/testRenderer';
 import { screen } from '@testing-library/react';
 import { SegmentTable } from './SegmentTable';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { CREATE_SEGMENT } from '../../providers/AccessProvider/permissions';
 
 const server = testServerSetup();
 
@@ -23,6 +24,10 @@ const setupRoutes = () => {
     testServerRoute(server, '/api/admin/ui-config', {
         flags: {
             SE: true,
+            resourceLimits: true,
+        },
+        resourceLimits: {
+            segments: 2,
         },
     });
 };
@@ -30,8 +35,14 @@ const setupRoutes = () => {
 test('should show the count of projects and features used in', async () => {
     setupRoutes();
 
-    render(<SegmentTable />);
+    render(<SegmentTable />, { permissions: [{ permission: CREATE_SEGMENT }] });
+
+    const loadingSegment = await screen.findByText('New segment');
+    expect(loadingSegment).toBeDisabled();
 
     await screen.findByText('2 feature flags');
     await screen.findByText('3 projects');
+
+    const segment = await screen.findByText('New segment');
+    expect(segment).not.toBeDisabled();
 });

--- a/frontend/src/hooks/api/getters/useUiConfig/defaultValue.tsx
+++ b/frontend/src/hooks/api/getters/useUiConfig/defaultValue.tsx
@@ -41,5 +41,6 @@ export const defaultValue: IUiConfig = {
         environments: 50,
         constraintValues: 250,
         projects: 500,
+        segments: 300,
     },
 };

--- a/frontend/src/openapi/models/resourceLimitsSchema.ts
+++ b/frontend/src/openapi/models/resourceLimitsSchema.ts
@@ -32,4 +32,6 @@ export interface ResourceLimitsSchema {
     constraintValues: number;
     /** The maximum number of projects allowed. */
     projects: number;
+    /** The maximum number of segment allowed. */
+    segments: number;
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Disable 'New segment' button when limit of 300 reached. Screenshot has manually adjusted limit of 6
<img width="296" alt="Screenshot 2024-07-03 at 11 19 26" src="https://github.com/Unleash/unleash/assets/1394682/bc959132-3355-4362-ad9b-a4da1ebb1efb">

Additionally, I decided to make the create segment button disabled when segments are being loaded or config is being loaded.

Modified existing test to avoid adding too many UI tests since they are quite slow.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
