### PR TITLE
fix: remove focus on ESC

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -195,6 +195,9 @@ export const CommandBar = () => {
     );
     useKeyboardShortcut({ key: 'Escape' }, () => {
         setShowSuggestions(false);
+        if (searchContainerRef.current?.contains(document.activeElement)) {
+            searchInputRef.current?.blur();
+        }
     });
     const placeholder = `Command bar (${hotkey})`;
 


### PR DESCRIPTION
Now when pressing ESC, command bar will lose focus.

![image](https://github.com/Unleash/unleash/assets/964450/9aea3b2b-bf06-4910-96be-0a67472945af)
