### PR TITLE
chore: command bar remove strategy types as page suggestion

### DIFF
--- a/frontend/src/component/commandBar/CommandPageSuggestions.tsx
+++ b/frontend/src/component/commandBar/CommandPageSuggestions.tsx
@@ -38,7 +38,6 @@ const pages = [
     '/segments',
     '/tag-types',
     '/applications',
-    '/strategies',
 ];
 
 export const CommandPageSuggestions = ({


### PR DESCRIPTION
Removes strategy types as command bar page suggestion