### PR TITLE
fix: sidebar update active when navigated via command menu.

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -1,5 +1,5 @@
 import { Box, styled } from '@mui/material';
-import { type FC, useState } from 'react';
+import { type FC, useState, useEffect } from 'react';
 import { useNavigationMode } from './useNavigationMode';
 import { ShowAdmin, ShowHide } from './ShowHide';
 import { useRoutes } from './useRoutes';
@@ -66,6 +66,10 @@ export const NavigationSidebar = () => {
 
     const { lastViewed: lastViewedFlags } = useLastViewedFlags();
     const showRecentFlags = mode === 'full' && lastViewedFlags.length > 0;
+
+    useEffect(() => {
+        setActiveItem(initialPathname);
+    }, [initialPathname]);
 
     return (
         <StretchContainer>


### PR DESCRIPTION
Currently, if the location changes, it does not update the active item. I added useEffect to update the active item.

This is required when the user navigates via the command menu.