### PR TITLE
feat: command bar up down navigation

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -207,20 +207,25 @@ export const CommandBar = () => {
     const placeholder = `Command bar (${hotkey})`;
 
     useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
-        const all = searchContainerRef.current?.querySelectorAll('ul > a');
-        if (all && all.length > selectedIndex) {
+        const allCommandBarLinks =
+            searchContainerRef.current?.querySelectorAll('ul > a');
+        if (allCommandBarLinks && allCommandBarLinks.length > selectedIndex) {
             const newIndex = selectedIndex + 1;
             setSelectedIndex(newIndex);
-            (all[newIndex] as HTMLElement).focus();
+            (allCommandBarLinks[newIndex] as HTMLElement).focus();
         }
     });
     useKeyboardShortcut({ key: 'ArrowUp', preventDefault: true }, () => {
         if (selectedIndex > 0) {
-            const all = searchContainerRef.current?.querySelectorAll('ul > a');
-            if (all && all.length >= selectedIndex) {
+            const allCommandBarLinks =
+                searchContainerRef.current?.querySelectorAll('ul > a');
+            if (
+                allCommandBarLinks &&
+                allCommandBarLinks.length >= selectedIndex
+            ) {
                 const newIndex = selectedIndex - 1;
                 setSelectedIndex(newIndex);
-                (all[newIndex] as HTMLElement).focus();
+                (allCommandBarLinks[newIndex] as HTMLElement).focus();
             }
         } else {
             setSelectedIndex(-1);

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -239,12 +239,10 @@ export const CommandBar = () => {
             const element = searchInputRef.current;
             if (element) {
                 element.focus();
-                setTimeout(() => {
-                    element.setSelectionRange(
-                        element.value.length,
-                        element.value.length,
-                    );
-                }, 5);
+                element.setSelectionRange(
+                    element.value.length,
+                    element.value.length,
+                );
             }
         }
     });

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -204,7 +204,7 @@ export const CommandBar = () => {
     useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
         const allCommandBarLinks =
             searchContainerRef.current?.querySelectorAll('ul > a');
-        if (!allCommandBarLinks) return;
+        if (!allCommandBarLinks || allCommandBarLinks.length === 0) return;
 
         let selectedIndex = -1;
 
@@ -221,7 +221,7 @@ export const CommandBar = () => {
     useKeyboardShortcut({ key: 'ArrowUp', preventDefault: true }, () => {
         const allCommandBarLinks =
             searchContainerRef.current?.querySelectorAll('ul > a');
-        if (!allCommandBarLinks) return;
+        if (!allCommandBarLinks || allCommandBarLinks.length === 0) return;
 
         let selectedIndex = -1;
         allCommandBarLinks.forEach((link, index) => {

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -209,7 +209,10 @@ export const CommandBar = () => {
     useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
         const allCommandBarLinks =
             searchContainerRef.current?.querySelectorAll('ul > a');
-        if (allCommandBarLinks && allCommandBarLinks.length > selectedIndex) {
+        if (
+            allCommandBarLinks &&
+            allCommandBarLinks.length > selectedIndex + 1
+        ) {
             const newIndex = selectedIndex + 1;
             setSelectedIndex(newIndex);
             (allCommandBarLinks[newIndex] as HTMLElement).focus();

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -106,6 +106,7 @@ export const CommandBar = () => {
     const [searchedFlagCount, setSearchedFlagCount] = useState(0);
     const [hasNoResults, setHasNoResults] = useState(false);
     const [value, setValue] = useState<string>('');
+    const [selectedIndex, setSelectedIndex] = useState(-1);
     const { routes } = useRoutes();
     const allRoutes: Record<string, IPageRouteInfo> = {};
     for (const route of [
@@ -169,6 +170,10 @@ export const CommandBar = () => {
         debouncedSetSearchState(value);
     }, [searchedFlagCount]);
 
+    useEffect(() => {
+        setSelectedIndex(-1);
+    }, [value, showSuggestions]);
+
     const onSearchChange = (value: string) => {
         debouncedSetSearchState(value);
         setValue(value);
@@ -200,6 +205,37 @@ export const CommandBar = () => {
         }
     });
     const placeholder = `Command bar (${hotkey})`;
+
+    useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
+        const all = searchContainerRef.current?.querySelectorAll('ul > a');
+        if (all && all.length > selectedIndex) {
+            const newIndex = selectedIndex + 1;
+            setSelectedIndex(newIndex);
+            (all[newIndex] as HTMLElement).focus();
+        }
+    });
+    useKeyboardShortcut({ key: 'ArrowUp', preventDefault: true }, () => {
+        if (selectedIndex > 0) {
+            const all = searchContainerRef.current?.querySelectorAll('ul > a');
+            if (all && all.length >= selectedIndex) {
+                const newIndex = selectedIndex - 1;
+                setSelectedIndex(newIndex);
+                (all[newIndex] as HTMLElement).focus();
+            }
+        } else {
+            setSelectedIndex(-1);
+            const element = searchInputRef.current;
+            if (element) {
+                element.focus();
+                setTimeout(() => {
+                    element.setSelectionRange(
+                        element.value.length,
+                        element.value.length,
+                    );
+                }, 5);
+            }
+        }
+    });
 
     useOnClickOutside([searchContainerRef], hideSuggestions);
     const onKeyDown = (event: React.KeyboardEvent) => {

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -201,7 +201,7 @@ export const CommandBar = () => {
     });
     const placeholder = `Command bar (${hotkey})`;
 
-    useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
+    const findCommandBarLinksAndSelectedIndex = () => {
         const allCommandBarLinks =
             searchContainerRef.current?.querySelectorAll('ul > a');
         if (!allCommandBarLinks || allCommandBarLinks.length === 0) return;
@@ -213,6 +213,14 @@ export const CommandBar = () => {
                 selectedIndex = index;
             }
         });
+
+        return { allCommandBarLinks, selectedIndex };
+    };
+
+    useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
+        const itemsAndIndex = findCommandBarLinksAndSelectedIndex();
+        if (!itemsAndIndex) return;
+        const { allCommandBarLinks, selectedIndex } = itemsAndIndex;
 
         const newIndex = selectedIndex + 1;
         if (newIndex >= allCommandBarLinks.length) return;
@@ -220,16 +228,9 @@ export const CommandBar = () => {
         (allCommandBarLinks[newIndex] as HTMLElement).focus();
     });
     useKeyboardShortcut({ key: 'ArrowUp', preventDefault: true }, () => {
-        const allCommandBarLinks =
-            searchContainerRef.current?.querySelectorAll('ul > a');
-        if (!allCommandBarLinks || allCommandBarLinks.length === 0) return;
-
-        let selectedIndex = -1;
-        allCommandBarLinks.forEach((link, index) => {
-            if (link === document.activeElement) {
-                selectedIndex = index;
-            }
-        });
+        const itemsAndIndex = findCommandBarLinksAndSelectedIndex();
+        if (!itemsAndIndex) return;
+        const { allCommandBarLinks, selectedIndex } = itemsAndIndex;
 
         const newIndex = selectedIndex - 1;
 

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -215,6 +215,7 @@ export const CommandBar = () => {
         });
 
         const newIndex = selectedIndex + 1;
+        if (newIndex >= allCommandBarLinks.length) return;
 
         (allCommandBarLinks[newIndex] as HTMLElement).focus();
     });

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -106,7 +106,6 @@ export const CommandBar = () => {
     const [searchedFlagCount, setSearchedFlagCount] = useState(0);
     const [hasNoResults, setHasNoResults] = useState(false);
     const [value, setValue] = useState<string>('');
-    const [selectedIndex, setSelectedIndex] = useState(-1);
     const { routes } = useRoutes();
     const allRoutes: Record<string, IPageRouteInfo> = {};
     for (const route of [
@@ -170,10 +169,6 @@ export const CommandBar = () => {
         debouncedSetSearchState(value);
     }, [searchedFlagCount]);
 
-    useEffect(() => {
-        setSelectedIndex(-1);
-    }, [value, showSuggestions]);
-
     const onSearchChange = (value: string) => {
         debouncedSetSearchState(value);
         setValue(value);
@@ -209,29 +204,37 @@ export const CommandBar = () => {
     useKeyboardShortcut({ key: 'ArrowDown', preventDefault: true }, () => {
         const allCommandBarLinks =
             searchContainerRef.current?.querySelectorAll('ul > a');
-        if (
-            allCommandBarLinks &&
-            allCommandBarLinks.length > selectedIndex + 1
-        ) {
-            const newIndex = selectedIndex + 1;
-            setSelectedIndex(newIndex);
-            (allCommandBarLinks[newIndex] as HTMLElement).focus();
-        }
+        if (!allCommandBarLinks) return;
+
+        let selectedIndex = -1;
+
+        allCommandBarLinks.forEach((link, index) => {
+            if (link === document.activeElement) {
+                selectedIndex = index;
+            }
+        });
+
+        const newIndex = selectedIndex + 1;
+
+        (allCommandBarLinks[newIndex] as HTMLElement).focus();
     });
     useKeyboardShortcut({ key: 'ArrowUp', preventDefault: true }, () => {
-        if (selectedIndex > 0) {
-            const allCommandBarLinks =
-                searchContainerRef.current?.querySelectorAll('ul > a');
-            if (
-                allCommandBarLinks &&
-                allCommandBarLinks.length >= selectedIndex
-            ) {
-                const newIndex = selectedIndex - 1;
-                setSelectedIndex(newIndex);
-                (allCommandBarLinks[newIndex] as HTMLElement).focus();
+        const allCommandBarLinks =
+            searchContainerRef.current?.querySelectorAll('ul > a');
+        if (!allCommandBarLinks) return;
+
+        let selectedIndex = -1;
+        allCommandBarLinks.forEach((link, index) => {
+            if (link === document.activeElement) {
+                selectedIndex = index;
             }
+        });
+
+        const newIndex = selectedIndex - 1;
+
+        if (newIndex >= 0) {
+            (allCommandBarLinks[newIndex] as HTMLElement).focus();
         } else {
-            setSelectedIndex(-1);
             const element = searchInputRef.current;
             if (element) {
                 element.focus();


### PR DESCRIPTION
Adds arrow up / down navigation to command bar using the DOM

When we move up/down check to see if any of the items in the list has focus, and sets the index to focus to be the one before or after the current focus. this lets us use both tabs (react built in) and arrows to navigate the list