### PR TITLE
chore: use a command bar shadow thats visible in darkmode as well

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -39,7 +39,7 @@ export const CommandResultsPaper = styled(Paper)(({ theme }) => ({
     borderRadius: 0,
     borderBottomLeftRadius: theme.spacing(1),
     borderBottomRightRadius: theme.spacing(1),
-    boxShadow: '0px 8px 20px rgba(33, 33, 33, 0.15)',
+    boxShadow: theme.shadows[2],
     fontSize: theme.fontSizes.smallBody,
     color: theme.palette.text.secondary,
     wordBreak: 'break-word',


### PR DESCRIPTION
Adds a drop shadow to command bar that is visible also in dark mode

![Skjermbilde 2024-07-05 kl  13 00 58](https://github.com/Unleash/unleash/assets/707867/054c4b68-2d4a-4bfe-a669-04843a9558cd)
![Skjermbilde 2024-07-05 kl  13 00 52](https://github.com/Unleash/unleash/assets/707867/50e988fe-ead5-449e-a9a6-03ce6ed2f05c)
