### PR TITLE
feat: exclude archived features in max reporting

### DIFF
--- a/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-strategies-store.e2e.test.ts
@@ -305,7 +305,7 @@ describe('max metrics collection', () => {
         } as const;
     };
 
-    const strategyWithConstrains = (
+    const strategyWithConstraints = (
         feature: string,
         constraint: IConstraint,
     ) => {
@@ -343,18 +343,18 @@ describe('max metrics collection', () => {
 
         const maxValueCount = 100;
         await featureStrategiesStore.createStrategyFeatureEnv(
-            strategyWithConstrains(flagA.name, bigConstraint(maxValueCount)),
+            strategyWithConstraints(flagA.name, bigConstraint(maxValueCount)),
         );
         await featureStrategiesStore.createStrategyFeatureEnv(
-            strategyWithConstrains(flagB.name, {
+            strategyWithConstraints(flagB.name, {
                 operator: 'IN',
                 contextName: 'appName',
             }),
         );
         await featureStrategiesStore.createStrategyFeatureEnv(
-            strategyWithConstrains(
+            strategyWithConstraints(
                 flagC.name,
-                bigConstraint(maxValueCount + 10),
+                bigConstraint(maxValueCount + 1),
             ),
         );
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When reporting max values in prometheus metrics we want to exclude strategies that belong to archived features. It means we need to join with the features table in the queries.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
