### PR TITLE
task: added flag to remove unsafe inline style src header

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -145,6 +145,7 @@ exports[`should create default config 1`] = `
       "personalAccessTokensKillSwitch": false,
       "projectOverviewRefactorFeedback": false,
       "queryMissingTokens": false,
+      "removeUnsafeInlineStyleSrc": false,
       "resourceLimits": false,
       "responseTimeMetricsFix": false,
       "responseTimeWithAppNameKillSwitch": false,

--- a/src/lib/middleware/secure-headers.ts
+++ b/src/lib/middleware/secure-headers.ts
@@ -5,6 +5,20 @@ import { hoursToSeconds } from 'date-fns';
 
 const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
     if (config.secureHeaders) {
+        const includeUnsafeInline = !config.flagResolver.isEnabled(
+            'removeUnsafeInlineStyleSrc',
+        );
+        const styleSrc = ["'self'"];
+        if (includeUnsafeInline) {
+            styleSrc.push("'unsafe-inline'");
+        }
+        styleSrc.push(
+            'cdn.getunleash.io',
+            'fonts.googleapis.com',
+            'fonts.gstatic.com',
+            'data:',
+            ...config.additionalCspAllowedDomains.styleSrc,
+        );
         const defaultHelmet = helmet({
             hsts: {
                 maxAge: hoursToSeconds(24 * 365 * 2), // 2 non-leap years
@@ -26,15 +40,7 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
                         'fonts.gstatic.com',
                         ...config.additionalCspAllowedDomains.fontSrc,
                     ],
-                    styleSrc: [
-                        "'self'",
-                        "'unsafe-inline'",
-                        'cdn.getunleash.io',
-                        'fonts.googleapis.com',
-                        'fonts.gstatic.com',
-                        'data:',
-                        ...config.additionalCspAllowedDomains.styleSrc,
-                    ],
+                    styleSrc,
                     scriptSrc: [
                         "'self'",
                         'cdn.getunleash.io',

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -65,7 +65,8 @@ export type IFlagKey =
     | 'resourceLimits'
     | 'extendedMetrics'
     | 'cleanApiTokenWhenOrphaned'
-    | 'allowOrphanedWildcardTokens';
+    | 'allowOrphanedWildcardTokens'
+    | 'removeUnsafeInlineStyleSrc';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -312,6 +313,10 @@ const flags: IFlags = {
     ),
     cleanApiTokenWhenOrphaned: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CLEAN_API_TOKEN_WHEN_ORPHANED,
+        false,
+    ),
+    removeUnsafeInlineStyleSrc: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_REMOVE_UNSAFE_INLINE_STYLE_SRC,
         false,
     ),
 };


### PR DESCRIPTION
Our CSP reports that unsafe-inline is not recommended for styleSrc. This PR adds a flag for making it possible to remove this element of our CSP headers. It should allow us to see what (if anything) breaks hard.