### PR TITLE
fix: update cache, even when the total is 0

### DIFF
--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
@@ -87,7 +87,7 @@ describe('useFeatureSearch', () => {
         });
 
         // force fetch
-        const button = await screen.findByRole('button');
+        const button = await screen.findByRole('button', { name: 'refetch' });
         button.click();
 
         rerender(<TestComponent params={{ project }} />);

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
@@ -49,7 +49,7 @@ describe('useFeatureSearch', () => {
             total: 1,
         });
         render(<TestComponent params={{ project: 'project1' }} />);
-        await screen.findByText(/Features:/);
+        await screen.findByText(/Features: Feature1/);
         await screen.findByText(
             'Cache: api/admin/search/features?project=project1',
         );
@@ -59,7 +59,7 @@ describe('useFeatureSearch', () => {
             total: 1,
         });
         render(<TestComponent params={{ project: 'project2' }} />);
-        await screen.findByText(/Features:/);
+        await screen.findByText(/Features: Feature2/);
         await screen.findByText(
             'Cache: api/admin/search/features?project=project1api/admin/search/features?project=project2',
         );

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.test.tsx
@@ -64,4 +64,32 @@ describe('useFeatureSearch', () => {
             'Cache: api/admin/search/features?project=project1api/admin/search/features?project=project2',
         );
     });
+
+    test('should overwrite cache total with 0 if the next result has 0 values', async () => {
+        const project = 'project3';
+        testServerRoute(
+            server,
+            `/api/admin/search/features?project=${project}`,
+            {
+                features: [{ name: 'Feature1' }],
+                total: 1,
+            },
+        );
+
+        render(<TestComponent params={{ project }} />);
+
+        await screen.findByText(/Total: 1/);
+
+        testServerRoute(
+            server,
+            `/api/admin/search/features?project=${project}`,
+            {
+                features: [],
+                total: 0,
+            },
+        );
+
+        render(<TestComponent params={{ project }} />);
+        await screen.findByText(/Total: 0/);
+    });
 });

--- a/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
+++ b/frontend/src/hooks/api/getters/useFeatureSearch/useFeatureSearch.ts
@@ -78,7 +78,7 @@ const createFeatureSearch = () => {
 
         const cacheValues = get(cacheId);
 
-        if (data?.total) {
+        if (data?.total !== undefined) {
             set(cacheId, 'total', data.total);
         }
 


### PR DESCRIPTION
This PR fixes a bug where we wouldn't update the `useFeatureSearch` hook's cached `total` value if the new total was `0`. The reason this failed is that we would only update it if `data?.total`. Because `0` is a falsy value, the check would fail.