### PR TITLE
feat: user seats component

### DIFF
--- a/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.test.tsx
+++ b/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.test.tsx
@@ -1,0 +1,40 @@
+import { testServerRoute, testServerSetup } from '../../../../utils/testServer';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { UserSeats } from './UserSeats';
+
+const server = testServerSetup();
+const user1 = {};
+const user2 = {};
+
+const setupApiWithSeats = (seats: number | undefined) => {
+    testServerRoute(server, '/api/admin/user-admin', {
+        users: [user1, user2],
+    });
+    testServerRoute(server, '/api/instance/status', {
+        plan: 'Enterprise',
+        seats,
+    });
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: {
+            UNLEASH_CLOUD: true,
+        },
+    });
+};
+
+test('User seats display when seats are available', async () => {
+    setupApiWithSeats(20);
+
+    render(<UserSeats />);
+
+    await screen.findByText('User seats');
+    await screen.findByText('2/20 seats used');
+});
+
+test('User seats display when seats are available', async () => {
+    setupApiWithSeats(undefined);
+
+    render(<UserSeats />);
+
+    expect(screen.queryByText('User seats')).not.toBeInTheDocument();
+});

--- a/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.test.tsx
+++ b/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.test.tsx
@@ -31,7 +31,7 @@ test('User seats display when seats are available', async () => {
     await screen.findByText('2/20 seats used');
 });
 
-test('User seats display when seats are available', async () => {
+test('User seats does not display when seats are not available', async () => {
     setupApiWithSeats(undefined);
 
     render(<UserSeats />);

--- a/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.tsx
+++ b/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.tsx
@@ -39,7 +39,7 @@ export const UserSeats = () => {
         const percentageSeats = Math.floor((users.length / seats) * 100);
 
         return (
-            <Box sx={{ mt: 4 }}>
+            <Box>
                 <TotalSeatsRow>
                     <LicenseIcon />
                     <Typography sx={{ flex: 1 }}>User seats</Typography>

--- a/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.tsx
+++ b/frontend/src/component/insights/componentsStat/UserSeats/UserSeats.tsx
@@ -1,0 +1,62 @@
+import LicenseIcon from '@mui/icons-material/ReceiptLongOutlined';
+import { Box, styled, Typography } from '@mui/material';
+import LinearProgress from '@mui/material/LinearProgress';
+import { useUsers } from 'hooks/api/getters/useUsers/useUsers';
+import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
+
+const SeatsUsageBar = styled(LinearProgress)(({ theme }) => ({
+    marginTop: theme.spacing(0.5),
+    height: theme.spacing(0.5),
+    borderRadius: theme.shape.borderRadiusMedium,
+}));
+
+const TotalSeatsRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    gap: 1,
+    alignItems: 'center',
+}));
+
+const TotalSeats = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.h1.fontSize,
+    color: theme.palette.primary.main,
+}));
+
+const SeatsUsageRow = styled(Box)(({ theme }) => ({
+    marginTop: theme.spacing(2),
+}));
+
+const SeatsUsageText = styled(Box)(({ theme }) => ({
+    textAlign: 'right',
+}));
+
+export const UserSeats = () => {
+    const { users } = useUsers();
+    const { instanceStatus } = useInstanceStatus();
+    const seats = instanceStatus?.seats;
+
+    if (typeof seats === 'number') {
+        const percentageSeats = Math.floor((users.length / seats) * 100);
+
+        return (
+            <Box sx={{ mt: 4 }}>
+                <TotalSeatsRow>
+                    <LicenseIcon />
+                    <Typography sx={{ flex: 1 }}>User seats</Typography>
+                    <TotalSeats>{seats}</TotalSeats>
+                </TotalSeatsRow>
+                <SeatsUsageRow>
+                    <SeatsUsageText>
+                        {users.length}/{seats} seats used
+                    </SeatsUsageText>
+                    <SeatsUsageBar
+                        variant='determinate'
+                        value={Math.min(100, percentageSeats)}
+                    />
+                </SeatsUsageRow>
+            </Box>
+        );
+    }
+
+    return null;
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Creating self-contained component for user seats.

<img width="267" alt="Screenshot 2024-07-12 at 14 41 13" src="https://github.com/user-attachments/assets/c4983cda-f585-4f89-a009-beecab621fe4">

Decisions:
* this component is hosted on the insights page but since it's not affected by the date range selection I decided to not add this data to the insights endpoint
* instead this components fetches the data it needs from the existing APIs
* I still need to figure out if this is the right way to fetch the user count and the seats count
* I'm calling it user seats not user licenses since I want consistent terms across all pages

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
