### PR TITLE
docs: add a footnote about how archived flags don't count towards the flag limit

### DIFF
--- a/website/docs/reference/resource-limits.mdx
+++ b/website/docs/reference/resource-limits.mdx
@@ -15,7 +15,7 @@ The resources and their respective limits and environment variables are:
 
 | Resource                                                        | OSS limit | Pro limit | Enterprise limit | Environment variable                           |
 |-----------------------------------------------------------------|----------:|----------:|-----------------:|------------------------------------------------|
-| [Feature flags](feature-toggles.mdx)                            |     5,000 |     5,000 |           50,000 | `UNLEASH_FEATURE_FLAGS_LIMIT`                  |
+| [Feature flags](feature-toggles.mdx)[^1]                        |     5,000 |     5,000 |           50,000 | `UNLEASH_FEATURE_FLAGS_LIMIT`                  |
 | [Strategies](activation-strategies.md) per flag per environment |        30 |        30 |               30 | `UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT` |
 | [Constraints](strategy-constraints.md) per strategy             |        30 |        30 |               30 | `UNLEASH_CONSTRAINTS_LIMIT`                    |
 | Values per [constraint](strategy-constraints.md)                |       250 |       250 |            1,000 | `UNLEASH_CONSTRAINT_VALUES_LIMIT`              |
@@ -43,3 +43,5 @@ If you operate a self-hosted Unleash instance, you can adjust the limit yourself
 The only limits that can't be changed, are
 - the limits for projects and environments for OSS instances
 - the limits for projects and environments for Pro instances
+
+[^1]: Archived feature flags do not count towards your feature flag total. The limit only applies to active (i.e. not archived) feature flags.


### PR DESCRIPTION
This change adds a footnote to the resource limits doc, explaining
that archived flags don't count towards the flag limit.