### PR TITLE
fix: toast error doesn't tell you what the error is

### DIFF
--- a/frontend/src/hooks/api/actions/useAuthSettingsApi/useAuthSettingsApi.ts
+++ b/frontend/src/hooks/api/actions/useAuthSettingsApi/useAuthSettingsApi.ts
@@ -12,8 +12,9 @@ export const handleBadRequest = async (
     if (!setErrors) return;
     if (res) {
         const data = await res.json();
-        setErrors({ message: data.message });
-        throw new Error(data.message);
+        const message = data.details?.[0]?.message ?? data.message;
+        setErrors({ message });
+        throw new Error(message);
     }
 
     throw new Error();


### PR DESCRIPTION
This change improves the toast error message for auth settings by
preferring the message from the error's details list if it exists. If
it doesn't it'll still fall back to the original error message.

Before:
![image](https://github.com/user-attachments/assets/6ecb425c-7d6d-4cb9-844e-c7c2ff7088b2)

After:
![image](https://github.com/user-attachments/assets/87d827a8-7f52-40c1-a2c6-ca2d1d3abfb4)
