### PR TITLE
chore: db migration for integration events

### DIFF
--- a/src/migrations/20240716135038-integration-events.js
+++ b/src/migrations/20240716135038-integration-events.js
@@ -3,7 +3,7 @@ exports.up = function (db, cb) {
         `
         CREATE TABLE IF NOT EXISTS integration_events
         (
-            id SERIAL PRIMARY KEY NOT NULL,
+            id BIGSERIAL PRIMARY KEY NOT NULL,
             integration_id INTEGER NOT NULL REFERENCES addons(id) ON DELETE CASCADE,
             created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
             state TEXT NOT NULL,

--- a/src/migrations/20240716135038-integration-events.js
+++ b/src/migrations/20240716135038-integration-events.js
@@ -1,0 +1,29 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        CREATE TABLE IF NOT EXISTS integration_events
+        (
+            id SERIAL PRIMARY KEY NOT NULL,
+            integration_id INTEGER NOT NULL REFERENCES addons(id) ON DELETE CASCADE,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            state TEXT NOT NULL,
+            state_details TEXT NOT NULL,
+            event JSONB NOT NULL,
+            details JSONB NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_integration_events_integration_id ON integration_events(integration_id);
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DROP INDEX IF EXISTS idx_integration_events_integration_id;
+        DROP TABLE IF EXISTS integration_events;
+        `,
+        cb,
+    );
+};

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -174,8 +174,8 @@ module.exports = {
                         {
                             type: 'doc',
                             label: 'Examples',
-                            id: 'feature-flag-tutorials/rust/examples'
-                        }
+                            id: 'feature-flag-tutorials/rust/examples',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2435/create-migration-for-a-new-integration-events-table

Adds a DB migration that creates the `integration_events` table:
 - `id`: Auto-incrementing primary key;
 - `integration_id`: The id of the respective integration (i.e. integration configuration);
 - `created_at`: Date of insertion;
 - `state`: Integration event state, as text. Can be anything we'd like, but I'm thinking this will be something like:
   - Success ✅
   - Failed ❌
   - SuccessWithErrors ⚠️
 - `state_details`: Expands on the previous column with more details, as text. Examples:
   - OK. Status code: 200
   - Status code: 429 - Rate limit reached
   - No access token provided
 - `event`: The whole event object, stored as a JSON blob;
 - `details`: JSON blob with details about the integration execution. Will depend on the integration itself, but for example:
   - Webhook: Request body
   - Slack App: Message text and an array with all the channels we're posting to

I think this gives us enough flexibility to cover all present and (possibly) future integrations, but I'd like to hear your thoughts.

I'm also really torn on what to call this table:
 - `integration_events`: Consistent with the feature name. Addons are now called integrations, so this would be consistent with the new thing;
 - `addon_events`: Consistent with the existing `addons` table.