### PR TITLE
fix: insights sticky header

### DIFF
--- a/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
@@ -48,9 +48,14 @@ const BreadcrumbNav = () => {
                 item !== 'features2' &&
                 item !== 'create-toggle' &&
                 item !== 'settings' &&
-                item !== 'profile',
+                item !== 'profile' &&
+                item !== 'insights',
         )
         .map(decodeURI);
+
+    if (paths.length === 0) {
+        return null;
+    }
 
     return (
         <StyledBreadcrumbContainer>

--- a/frontend/src/component/insights/Insights.tsx
+++ b/frontend/src/component/insights/Insights.tsx
@@ -1,5 +1,5 @@
 import { useState, type FC } from 'react';
-import { styled } from '@mui/material';
+import { Box, styled } from '@mui/material';
 import { ArrayParam, withDefault } from 'use-query-params';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import {
@@ -29,6 +29,20 @@ const StickyContainer = styled(Sticky)(({ theme }) => ({
     transition: 'padding 0.3s ease',
 }));
 
+/**
+ * @deprecated remove with insightsV2 flag
+ */
+const StickyWrapper = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'scrolled',
+})<{ scrolled?: boolean }>(({ theme, scrolled }) => ({
+    position: 'sticky',
+    top: 0,
+    zIndex: theme.zIndex.sticky,
+    padding: scrolled ? theme.spacing(2, 0) : theme.spacing(0, 0, 2),
+    background: theme.palette.background.application,
+    transition: 'padding 0.3s ease',
+}));
+
 const StyledProjectSelect = styled(ProjectSelect)(({ theme }) => ({
     flex: 1,
     width: '300px',
@@ -37,6 +51,9 @@ const StyledProjectSelect = styled(ProjectSelect)(({ theme }) => ({
     },
 }));
 
+/**
+ * @deprecated remove with insightsV2 flag
+ */
 const LegacyInsights: FC = () => {
     const [scrolled, setScrolled] = useState(false);
     const { insights, loading, error } = useInsights();
@@ -84,7 +101,7 @@ const LegacyInsights: FC = () => {
                 projects={projects}
                 {...insightsData}
             />
-        </>
+        </StyledWrapper>
     );
 };
 
@@ -119,8 +136,8 @@ const NewInsights = () => {
     }
 
     return (
-        <>
-            <StickyWrapper scrolled={scrolled}>
+        <StyledWrapper>
+            <StickyWrapper>
                 <InsightsHeader
                     actions={
                         <InsightsFilters state={state} onChange={setState} />
@@ -136,8 +153,10 @@ const NewInsights = () => {
     );
 };
 
-export const Insights: VFC = () => {
+export const Insights: FC = () => {
     const isInsightsV2Enabled = useUiFlag('insightsV2');
+
     if (isInsightsV2Enabled) return <NewInsights />;
+
     return <LegacyInsights />;
 };

--- a/frontend/src/component/insights/Insights.tsx
+++ b/frontend/src/component/insights/Insights.tsx
@@ -1,5 +1,5 @@
-import { useState, type VFC } from 'react';
-import { Box, styled } from '@mui/material';
+import { useState, type FC } from 'react';
+import { styled } from '@mui/material';
 import { ArrayParam, withDefault } from 'use-query-params';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import {
@@ -13,19 +13,22 @@ import { InsightsCharts } from './InsightsCharts';
 import { LegacyInsightsCharts } from './LegacyInsightsCharts';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { Sticky } from 'component/common/Sticky/Sticky';
 
-const StickyWrapper = styled(Box, {
-    shouldForwardProp: (prop) => prop !== 'scrolled',
-})<{ scrolled?: boolean }>(({ theme, scrolled }) => ({
+const StyledWrapper = styled('div')(({ theme }) => ({
+    paddingTop: theme.spacing(1),
+}));
+
+const StickyContainer = styled(Sticky)(({ theme }) => ({
     position: 'sticky',
     top: 0,
     zIndex: theme.zIndex.sticky,
-    padding: scrolled ? theme.spacing(2, 0) : theme.spacing(0, 0, 2),
+    padding: theme.spacing(2, 0),
     background: theme.palette.background.application,
     transition: 'padding 0.3s ease',
 }));
 
-export const Insights: VFC = () => {
+export const Insights: FC = () => {
     const [scrolled, setScrolled] = useState(false);
     const { insights, loading, error } = useInsights();
     const stateConfig = {
@@ -56,8 +59,8 @@ export const Insights: VFC = () => {
     const isInsightsV2Enabled = useUiFlag('insightsV2');
 
     return (
-        <>
-            <StickyWrapper scrolled={scrolled}>
+        <StyledWrapper>
+            <StickyContainer>
                 <InsightsHeader
                     actions={
                         <ProjectSelect
@@ -73,7 +76,7 @@ export const Insights: VFC = () => {
                         />
                     }
                 />
-            </StickyWrapper>
+            </StickyContainer>
             <ConditionallyRender
                 condition={isInsightsV2Enabled}
                 show={
@@ -91,6 +94,6 @@ export const Insights: VFC = () => {
                     />
                 }
             />
-        </>
+        </StyledWrapper>
     );
 };

--- a/frontend/src/component/insights/InsightsCharts.tsx
+++ b/frontend/src/component/insights/InsightsCharts.tsx
@@ -1,4 +1,4 @@
-import type { VFC } from 'react';
+import type { FC } from 'react';
 import { Box, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Widget } from './components/Widget/Widget';
@@ -71,7 +71,7 @@ const ChartWidget = styled(Widget)(({ theme }) => ({
     },
 }));
 
-export const InsightsCharts: VFC<IChartsProps> = ({
+export const InsightsCharts: FC<IChartsProps> = ({
     projects,
     flags,
     users,


### PR DESCRIPTION
## About the changes
Insights header should show below banners.

![image](https://github.com/user-attachments/assets/6634af71-71b0-4818-b474-d9b96124c979)


### Before:
![image](https://github.com/user-attachments/assets/05576f87-6648-425b-93ae-9acdbdde7f53)

## Discussion
- We should revisit "breadcrubms", because current implementation is inconsistent - try project tabs navigation. Added task: https://linear.app/unleash/issue/1-2568/fix-inconsistent-breadcrumbs
