### PR TITLE
feat: insights filters

### DIFF
--- a/frontend/src/component/insights/InsightsFilters.tsx
+++ b/frontend/src/component/insights/InsightsFilters.tsx
@@ -1,0 +1,69 @@
+import { type FC, useEffect, useState } from 'react';
+import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import {
+    type FilterItemParamHolder,
+    Filters,
+    type IFilterItem,
+} from 'component/filter/Filters/Filters';
+
+interface IFeatureToggleFiltersProps {
+    state: FilterItemParamHolder;
+    onChange: (value: FilterItemParamHolder) => void;
+}
+
+export const InsightsFilters: FC<IFeatureToggleFiltersProps> = ({
+    state,
+    onChange,
+}) => {
+    const { projects } = useProjects();
+
+    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
+
+    useEffect(() => {
+        const projectsOptions = (projects || []).map((project) => ({
+            label: project.name,
+            value: project.id,
+        }));
+
+        const hasMultipleProjects = projectsOptions.length > 1;
+
+        const availableFilters: IFilterItem[] = [
+            {
+                label: 'Date From',
+                icon: 'today',
+                options: [],
+                filterKey: 'from',
+                dateOperators: ['IS'],
+            },
+            {
+                label: 'Date To',
+                icon: 'today',
+                options: [],
+                filterKey: 'to',
+                dateOperators: ['IS'],
+            },
+            ...(hasMultipleProjects
+                ? ([
+                      {
+                          label: 'Project',
+                          icon: 'topic',
+                          options: projectsOptions,
+                          filterKey: 'projects',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      },
+                  ] as IFilterItem[])
+                : []),
+        ];
+
+        setAvailableFilters(availableFilters);
+    }, [JSON.stringify(projects)]);
+
+    return (
+        <Filters
+            availableFilters={availableFilters}
+            state={state}
+            onChange={onChange}
+        />
+    );
+};

--- a/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
+++ b/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
@@ -18,6 +18,7 @@ type DashboardHeaderProps = {
 
 const StyledActionsContainer = styled('div')(({ theme }) => ({
     display: 'flex',
+    alignItems: 'center',
     gap: theme.spacing(1),
     [theme.breakpoints.down('md')]: {
         flexDirection: 'column',

--- a/frontend/src/hooks/api/getters/useInsights/useInsights.ts
+++ b/frontend/src/hooks/api/getters/useInsights/useInsights.ts
@@ -12,9 +12,11 @@ interface IUseInsightsDataOutput {
 }
 
 export const useInsights = (
+    from = '',
+    to = '',
     options?: SWRConfiguration,
 ): IUseInsightsDataOutput => {
-    const path = formatApiPath('api/admin/insights');
+    const path = formatApiPath(`api/admin/insights?from=${from}&to=${to}`);
 
     const { data, error } = useSWR<InstanceInsightsSchema>(
         path,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding date and project filters to the insights view.

Initial state
<img width="1546" alt="Screenshot 2024-07-17 at 11 05 01" src="https://github.com/user-attachments/assets/4db421c7-c801-479e-b758-43c7c6bd7304">

All filters added
<img width="1551" alt="Screenshot 2024-07-17 at 11 04 51" src="https://github.com/user-attachments/assets/c876cc18-dc6e-46bd-a5df-c36ad62cd426">

Design decisions:
* split the insights page into two variants (legacy and new) so that we can evolve them independently. Previously only charts were split but we also need to split on the header
* re-using existing filters component. It saves a lot of effort and gives us project filtering for free. I tried other approaches and this one is by far the cheapest to implement and brings consistency across the pages

Next PR:
* I will add tests for the insights filtering since I couldn't find any

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
