### PR TITLE
fix: Update OpenAPI error converter to handle query param errors too

### DIFF
--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -44,7 +44,7 @@ const missingRequiredPropertyMessage = (
     missingPropertyName: string,
 ) => {
     const path = constructPath(pathToParentObject, missingPropertyName);
-    const message = `The \`${path}\` property is required. It was not present on the data you sent.`;
+    const message = `The \`${path}\` value is required. It was not present on the data you sent.`;
     return {
         path,
         message,
@@ -74,7 +74,7 @@ const genericErrorMessage = (
     const input = getProp(requestBody, propertyName.split('/'));
 
     const youSent = JSON.stringify(input);
-    const message = `The \`${propertyName}\` property ${errorMessage}. You sent ${youSent}.`;
+    const message = `The \`${propertyName}\` value ${errorMessage}. You sent ${youSent}.`;
     return {
         message,
         path: propertyName,
@@ -86,7 +86,7 @@ const oneOfMessage = (
     errorMessage: string = 'is invalid',
 ) => {
     const errorPosition =
-        propertyName === '' ? 'root object' : `"${propertyName}" property`;
+        propertyName === '' ? 'root object' : `"${propertyName}" value`;
 
     const message = `The ${errorPosition} ${errorMessage}. The data you provided matches more than one option in the schema. These options are mutually exclusive. Please refer back to the schema and remove any excess properties.`;
 
@@ -102,13 +102,13 @@ const enumMessage = (
     allowedValues: string[],
     suppliedValue: string | null | undefined,
 ) => {
-    const fullMessage = `The \`${propertyName}\` property ${
+    const fullMessage = `The \`${propertyName}\` value ${
         message ?? 'must match one of the allowed values'
     }: ${allowedValues
         .map((value) => `"${value}"`)
         .join(
             ', ',
-        )}. You provided "${suppliedValue}", which is not valid. Please use one of the allowed values instead..`;
+        )}. You provided "${suppliedValue}", which is not valid. Please use one of the allowed values instead.`;
 
     return {
         message: fullMessage,
@@ -164,7 +164,7 @@ export const fromOpenApiValidationErrors = (
     );
 
     return new BadDataError(
-        "Request validation failed: the payload you provided doesn't conform to the schema. Check the `details` property for a list of errors that we found.",
+        "Request validation failed: your request doesn't conform to the schema. Check the `details` property for a list of errors that we found.",
         [firstDetail, ...remainingDetails],
     );
 };

--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -120,11 +120,11 @@ export const fromOpenApiValidationError =
     (request: { body: object; query: object }) =>
     (validationError: ErrorObject): ValidationErrorDescription => {
         const { instancePath, params, message } = validationError;
-        const [errorSource, startTrimLength] = instancePath.startsWith('/body')
+        const [errorSource, substringOffset] = instancePath.startsWith('/body')
             ? [request.body, '/body/'.length]
             : [request.query, '/query/'.length];
 
-        const propertyName = instancePath.substring(startTrimLength);
+        const propertyName = instancePath.substring(substringOffset);
 
         switch (validationError.keyword) {
             case 'required':
@@ -144,7 +144,7 @@ export const fromOpenApiValidationError =
                     params.allowedValues,
                     getProp(
                         errorSource,
-                        instancePath.substring(startTrimLength).split('/'),
+                        instancePath.substring(substringOffset).split('/'),
                     ),
                 );
 

--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -44,7 +44,7 @@ const missingRequiredPropertyMessage = (
     missingPropertyName: string,
 ) => {
     const path = constructPath(pathToParentObject, missingPropertyName);
-    const message = `The \`${path}\` value is required. It was not present on the data you sent.`;
+    const message = `The \`${path}\` property is required. It was not present on the data you sent.`;
     return {
         path,
         message,
@@ -74,7 +74,7 @@ const genericErrorMessage = (
     const input = getProp(requestBody, propertyName.split('/'));
 
     const youSent = JSON.stringify(input);
-    const message = `The \`${propertyName}\` value ${errorMessage}. You sent ${youSent}.`;
+    const message = `The \`${propertyName}\` property ${errorMessage}. You sent ${youSent}.`;
     return {
         message,
         path: propertyName,
@@ -86,7 +86,7 @@ const oneOfMessage = (
     errorMessage: string = 'is invalid',
 ) => {
     const errorPosition =
-        propertyName === '' ? 'root object' : `"${propertyName}" value`;
+        propertyName === '' ? 'root object' : `"${propertyName}" property`;
 
     const message = `The ${errorPosition} ${errorMessage}. The data you provided matches more than one option in the schema. These options are mutually exclusive. Please refer back to the schema and remove any excess properties.`;
 
@@ -102,13 +102,13 @@ const enumMessage = (
     allowedValues: string[],
     suppliedValue: string | null | undefined,
 ) => {
-    const fullMessage = `The \`${propertyName}\` value ${
+    const fullMessage = `The \`${propertyName}\` property ${
         message ?? 'must match one of the allowed values'
     }: ${allowedValues
         .map((value) => `"${value}"`)
         .join(
             ', ',
-        )}. You provided "${suppliedValue}", which is not valid. Please use one of the allowed values instead.`;
+        )}. You provided "${suppliedValue}", which is not valid. Please use one of the allowed values instead..`;
 
     return {
         message: fullMessage,

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -137,7 +137,7 @@ describe('OpenAPI error conversion', () => {
             expect(result.message).toContain(
                 instancePath === '/body'
                     ? 'root object'
-                    : `"${instancePath.substring('/body/'.length)}" value`,
+                    : `"${instancePath.substring('/body/'.length)}" property`,
             );
         },
     );

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -448,8 +448,6 @@ describe('OpenAPI error conversion', () => {
         expect(result.message).toContain('from');
         // it tells the user what they provided
         expect(result.message).toContain(query.from);
-        // it tells the user that the value is in the query parameter
-        expect(result.message).toContain('query');
     });
 });
 

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -137,7 +137,7 @@ describe('OpenAPI error conversion', () => {
             expect(result.message).toContain(
                 instancePath === '/body'
                     ? 'root object'
-                    : `"${instancePath.substring('/body/'.length)}" property`,
+                    : `"${instancePath.substring('/body/'.length)}" value`,
             );
         },
     );

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -64,7 +64,7 @@ export class OpenApiService {
         app.use((err, req, res, next) => {
             if (err?.status && err.validationErrors) {
                 const apiError = fromOpenApiValidationErrors(
-                    req.body,
+                    req,
                     err.validationErrors,
                 );
 


### PR DESCRIPTION
This PR updates the OpenAPI error converter to also work for errors with query parameters. 
We previously only sent the body of the request along with the error, which meant that query parameter errors would show up incorrectly.

For instance given a query param with the date format and the invalid value `01-2020-01`, you'd previously get the message:
> The `from` value must match format "date". You sent undefined

With this change, you'll get this instead:
> The `from` value must match format "date". You sent "01-2020-01". 

The important changes here are two things:
- passing both request body and query params
- the 3 lines in `fromOpenApiValidationError` that check where we should get the value you sent from.

The rest of it is primarily updating tests to send the right arguments and some slight rewording to more accurately reflect that this can be either request body or query params.