### PR TITLE
feat: show info on healthy flags in health tooltip

### DIFF
--- a/frontend/src/component/insights/InsightsCharts.tsx
+++ b/frontend/src/component/insights/InsightsCharts.tsx
@@ -1,4 +1,4 @@
-import type { VFC } from 'react';
+import type { FC } from 'react';
 import { Box, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Widget } from './components/Widget/Widget';
@@ -71,7 +71,7 @@ const ChartWidget = styled(Widget)(({ theme }) => ({
     },
 }));
 
-export const InsightsCharts: VFC<IChartsProps> = ({
+export const InsightsCharts: FC<IChartsProps> = ({
     projects,
     flags,
     users,

--- a/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo, useState, type VFC } from 'react';
+import { type ReactNode, useMemo, useState, type FC } from 'react';
 import {
     CategoryScale,
     LinearScale,
@@ -81,14 +81,14 @@ const customHighlightPlugin = {
     },
 };
 
-const LineChartComponent: VFC<{
+const LineChartComponent: FC<{
     data: ChartData<'line', unknown>;
     aspectRatio?: number;
     cover?: ReactNode;
     overrideOptions?: ChartOptions<'line'>;
     TooltipComponent?: ({
         tooltip,
-    }: { tooltip: TooltipState | null }) => ReturnType<VFC>;
+    }: { tooltip: TooltipState | null }) => ReturnType<FC>;
 }> = ({
     data,
     aspectRatio = 2.5,

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
@@ -4,7 +4,6 @@ import { Box, Divider, Paper, Typography, styled } from '@mui/material';
 import { Badge } from 'component/common/Badge/Badge';
 import type { TooltipState } from 'component/insights/components/LineChart/ChartTooltip/ChartTooltip';
 import { HorizontalDistributionChart } from 'component/insights/components/HorizontalDistributionChart/HorizontalDistributionChart';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledTooltipItemContainer = styled(Paper)(({ theme }) => ({
     padding: theme.spacing(2),
@@ -34,69 +33,80 @@ const getHealthBadgeColor = (health?: number | null) => {
 };
 
 const Distribution = ({ stale = 0, potentiallyStale = 0, total = 0 }) => {
-    const healthyFlagCount = total - stale - potentiallyStale;
-    return (
-        <>
+    if (stale + potentiallyStale === 0) {
+        return (
             <HorizontalDistributionChart
                 sections={[{ type: 'default', value: 100 }]}
                 size='small'
             />
-            <HorizontalDistributionChart
-                sections={[
-                    {
-                        type: 'error',
-                        value: (stale / total) * 100,
-                    },
-                    {
-                        type: 'warning',
-                        value: (potentiallyStale / total) * 100,
-                    },
-                    {
-                        type: 'success',
-                        value: (healthyFlagCount / total) * 100,
-                    },
-                ]}
-                size='small'
-            />
-            <Typography
-                variant='body2'
-                component='p'
-                sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
-            >
+        );
+    } else {
+        const healthyFlagCount = total - stale - potentiallyStale;
+
+        return (
+            <>
+                <HorizontalDistributionChart
+                    sections={[{ type: 'default', value: 100 }]}
+                    size='small'
+                />
+
+                <HorizontalDistributionChart
+                    sections={[
+                        {
+                            type: 'error',
+                            value: (stale / total) * 100,
+                        },
+                        {
+                            type: 'warning',
+                            value: (potentiallyStale / total) * 100,
+                        },
+                        {
+                            type: 'success',
+                            value: (healthyFlagCount / total) * 100,
+                        },
+                    ]}
+                    size='small'
+                />
                 <Typography
-                    component='span'
-                    sx={(theme) => ({
-                        color: theme.palette.error.border,
-                    })}
+                    variant='body2'
+                    component='p'
+                    sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
                 >
-                    {'● '}
+                    <Typography
+                        component='span'
+                        sx={(theme) => ({
+                            color: theme.palette.error.border,
+                        })}
+                    >
+                        {'● '}
+                    </Typography>
+                    Stale flags: {stale}
                 </Typography>
-                Stale flags: {stale}
-            </Typography>
-            <Typography variant='body2' component='p'>
-                <Typography
-                    component='span'
-                    sx={(theme) => ({
-                        color: theme.palette.warning.border,
-                    })}
-                >
-                    {'● '}
+                <Typography variant='body2' component='p'>
+                    <Typography
+                        component='span'
+                        sx={(theme) => ({
+                            color: theme.palette.warning.border,
+                        })}
+                    >
+                        {'● '}
+                    </Typography>
+                    Potentially stale flags: {potentiallyStale}
                 </Typography>
-                Potentially stale flags: {potentiallyStale}
-            </Typography>
-            <Typography variant='body2' component='p'>
-                <Typography
-                    component='span'
-                    sx={(theme) => ({
-                        color: theme.palette.success.border,
-                    })}
-                >
-                    {'● '}
+                <Typography variant='body2' component='p'>
+                    <Typography
+                        component='span'
+                        sx={(theme) => ({
+                            color: theme.palette.success.border,
+                        })}
+                    >
+                        {'● '}
+                    </Typography>
+                    Healthy flags: {healthyFlagCount}
                 </Typography>
-                Healthy flags: {healthyFlagCount}
-            </Typography>
-        </>
-    );
+            </>
+        );
+    }
 };
 
 export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({
@@ -169,12 +179,7 @@ export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({
                     >
                         Total flags: {point.value.total}
                     </Typography>
-                    <ConditionallyRender
-                        condition={Boolean(
-                            point.value.stale || point.value.potentiallyStale,
-                        )}
-                        show={<Distribution {...point.value} />}
-                    />
+                    <Distribution {...point.value} />{' '}
                 </StyledTooltipItemContainer>
             )) || null}
         </Box>

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
@@ -1,4 +1,4 @@
-import type { VFC } from 'react';
+import type { FC } from 'react';
 import type { InstanceInsightsSchemaProjectFlagTrendsItem } from 'openapi';
 import { Box, Divider, Paper, Typography, styled } from '@mui/material';
 import { Badge } from 'component/common/Badge/Badge';
@@ -81,7 +81,7 @@ const Distribution = ({ stale = 0, potentiallyStale = 0, total = 0 }) => (
     </>
 );
 
-export const HealthTooltip: VFC<{ tooltip: TooltipState | null }> = ({
+export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({
     tooltip,
 }) => {
     const data = tooltip?.dataPoints.map((point) => {

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
@@ -4,6 +4,7 @@ import { Box, Divider, Paper, Typography, styled } from '@mui/material';
 import { Badge } from 'component/common/Badge/Badge';
 import type { TooltipState } from 'component/insights/components/LineChart/ChartTooltip/ChartTooltip';
 import { HorizontalDistributionChart } from 'component/insights/components/HorizontalDistributionChart/HorizontalDistributionChart';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
 const StyledTooltipItemContainer = styled(Paper)(({ theme }) => ({
     padding: theme.spacing(2),
@@ -165,7 +166,12 @@ export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({
                     >
                         Total flags: {point.value.total}
                     </Typography>
-                    <Distribution {...point.value} />{' '}
+                    <ConditionallyRender
+                        condition={Boolean(
+                            point.value.stale || point.value.potentiallyStale,
+                        )}
+                        show={<Distribution {...point.value} />}
+                    />
                 </StyledTooltipItemContainer>
             )) || null}
         </Box>

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
@@ -33,53 +33,71 @@ const getHealthBadgeColor = (health?: number | null) => {
     return 'error';
 };
 
-const Distribution = ({ stale = 0, potentiallyStale = 0, total = 0 }) => (
-    <>
-        <HorizontalDistributionChart
-            sections={[{ type: 'default', value: 100 }]}
-            size='small'
-        />
-        <HorizontalDistributionChart
-            sections={[
-                {
-                    type: 'error',
-                    value: (stale / total) * 100,
-                },
-                {
-                    type: 'warning',
-                    value: (potentiallyStale / total) * 100,
-                },
-            ]}
-            size='small'
-        />
-        <Typography
-            variant='body2'
-            component='p'
-            sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
-        >
+const Distribution = ({ stale = 0, potentiallyStale = 0, total = 0 }) => {
+    const healthyFlagCount = total - stale - potentiallyStale;
+    return (
+        <>
+            <HorizontalDistributionChart
+                sections={[{ type: 'default', value: 100 }]}
+                size='small'
+            />
+            <HorizontalDistributionChart
+                sections={[
+                    {
+                        type: 'error',
+                        value: (stale / total) * 100,
+                    },
+                    {
+                        type: 'warning',
+                        value: (potentiallyStale / total) * 100,
+                    },
+                    {
+                        type: 'success',
+                        value: (healthyFlagCount / total) * 100,
+                    },
+                ]}
+                size='small'
+            />
             <Typography
-                component='span'
-                sx={(theme) => ({
-                    color: theme.palette.error.border,
-                })}
+                variant='body2'
+                component='p'
+                sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
             >
-                {'● '}
+                <Typography
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.error.border,
+                    })}
+                >
+                    {'● '}
+                </Typography>
+                Stale flags: {stale}
             </Typography>
-            Stale flags: {stale}
-        </Typography>
-        <Typography variant='body2' component='p'>
-            <Typography
-                component='span'
-                sx={(theme) => ({
-                    color: theme.palette.warning.border,
-                })}
-            >
-                {'● '}
+            <Typography variant='body2' component='p'>
+                <Typography
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.warning.border,
+                    })}
+                >
+                    {'● '}
+                </Typography>
+                Potentially stale flags: {potentiallyStale}
             </Typography>
-            Potentially stale flags: {potentiallyStale}
-        </Typography>
-    </>
-);
+            <Typography variant='body2' component='p'>
+                <Typography
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.success.border,
+                    })}
+                >
+                    {'● '}
+                </Typography>
+                Healthy flags: {healthyFlagCount}
+            </Typography>
+        </>
+    );
+};
 
 export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({
     tooltip,

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/HealthChartTooltip/HealthChartTooltip.tsx
@@ -33,80 +33,66 @@ const getHealthBadgeColor = (health?: number | null) => {
 };
 
 const Distribution = ({ stale = 0, potentiallyStale = 0, total = 0 }) => {
-    if (stale + potentiallyStale === 0) {
-        return (
+    const healthyFlagCount = total - stale - potentiallyStale;
+
+    return (
+        <>
             <HorizontalDistributionChart
-                sections={[{ type: 'default', value: 100 }]}
+                sections={[
+                    {
+                        type: 'error',
+                        value: (stale / total) * 100,
+                    },
+                    {
+                        type: 'warning',
+                        value: (potentiallyStale / total) * 100,
+                    },
+                    {
+                        type: 'success',
+                        value: (healthyFlagCount / total) * 100,
+                    },
+                ]}
                 size='small'
             />
-        );
-    } else {
-        const healthyFlagCount = total - stale - potentiallyStale;
-
-        return (
-            <>
-                <HorizontalDistributionChart
-                    sections={[{ type: 'default', value: 100 }]}
-                    size='small'
-                />
-
-                <HorizontalDistributionChart
-                    sections={[
-                        {
-                            type: 'error',
-                            value: (stale / total) * 100,
-                        },
-                        {
-                            type: 'warning',
-                            value: (potentiallyStale / total) * 100,
-                        },
-                        {
-                            type: 'success',
-                            value: (healthyFlagCount / total) * 100,
-                        },
-                    ]}
-                    size='small'
-                />
+            <Typography
+                variant='body2'
+                component='p'
+                sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
+            >
                 <Typography
-                    variant='body2'
-                    component='p'
-                    sx={(theme) => ({ marginTop: theme.spacing(0.5) })}
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.error.border,
+                    })}
                 >
-                    <Typography
-                        component='span'
-                        sx={(theme) => ({
-                            color: theme.palette.error.border,
-                        })}
-                    >
-                        {'● '}
-                    </Typography>
-                    Stale flags: {stale}
+                    {'● '}
                 </Typography>
-                <Typography variant='body2' component='p'>
-                    <Typography
-                        component='span'
-                        sx={(theme) => ({
-                            color: theme.palette.warning.border,
-                        })}
-                    >
-                        {'● '}
-                    </Typography>
-                    Potentially stale flags: {potentiallyStale}
+                Stale flags: {stale}
+            </Typography>
+            <Typography variant='body2' component='p'>
+                <Typography
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.warning.border,
+                    })}
+                >
+                    {'● '}
                 </Typography>
-                <Typography variant='body2' component='p'>
-                    <Typography
-                        component='span'
-                        sx={(theme) => ({
-                            color: theme.palette.success.border,
-                        })}
-                    >
-                        {'● '}
-                    </Typography>
-                    Healthy flags: {healthyFlagCount}
+                Potentially stale flags: {potentiallyStale}
+            </Typography>
+            <Typography variant='body2' component='p'>
+                <Typography
+                    component='span'
+                    sx={(theme) => ({
+                        color: theme.palette.success.border,
+                    })}
+                >
+                    {'● '}
                 </Typography>
-            </>
-        );
-    }
+                Healthy flags: {healthyFlagCount}
+            </Typography>
+        </>
+    );
 };
 
 export const HealthTooltip: FC<{ tooltip: TooltipState | null }> = ({

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -1,5 +1,5 @@
 import 'chartjs-adapter-date-fns';
-import { useMemo, type VFC } from 'react';
+import { type FC, useMemo } from 'react';
 import type { InstanceInsightsSchema } from 'openapi';
 import { HealthTooltip } from './HealthChartTooltip/HealthChartTooltip';
 import { useProjectChartData } from 'component/insights/hooks/useProjectChartData';
@@ -20,7 +20,7 @@ interface IProjectHealthChartProps {
     isLoading?: boolean;
 }
 
-export const ProjectHealthChart: VFC<IProjectHealthChartProps> = ({
+export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
     projectFlagTrends,
     isAggregate,
     isLoading,

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -46,7 +46,8 @@ export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
                         (acc, item) => {
                             if (item) {
                                 acc.total += item.total;
-                                acc.stale += item.stale + item.potentiallyStale;
+                                acc.stale += item.stale;
+                                acc.potentiallyStale += item.potentiallyStale;
                             }
                             if (!acc.date) {
                                 acc.date = item?.date;
@@ -56,10 +57,12 @@ export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
                         {
                             total: 0,
                             stale: 0,
+                            potentiallyStale: 0,
                             week: label,
                         } as {
                             total: number;
                             stale: number;
+                            potentiallyStale: number;
                             week: string;
                             date?: string;
                         },
@@ -73,12 +76,17 @@ export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
                     data: weeks.map((item) => ({
                         health: item.total
                             ? (
-                                  ((item.total - item.stale) / item.total) *
+                                  ((item.total -
+                                      item.stale -
+                                      item.potentiallyStale) /
+                                      item.total) *
                                   100
                               ).toFixed(2)
                             : undefined,
                         date: item.date,
                         total: item.total,
+                        stale: item.stale,
+                        potentiallyStale: item.potentiallyStale,
                     })),
                     borderColor: theme.palette.primary.light,
                     backgroundColor: fillGradientPrimary,

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -20,11 +20,15 @@ interface IProjectHealthChartProps {
     isLoading?: boolean;
 }
 
-const calculateHealth = (item: {
+type WeekData = {
     total: number;
     stale: number;
     potentiallyStale: number;
-}) =>
+    week: string;
+    date?: string;
+};
+
+const calculateHealth = (item: WeekData) =>
     (
         ((item.total - item.stale - item.potentiallyStale) / item.total) *
         100
@@ -69,13 +73,7 @@ export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
                             stale: 0,
                             potentiallyStale: 0,
                             week: label,
-                        } as {
-                            total: number;
-                            stale: number;
-                            potentiallyStale: number;
-                            week: string;
-                            date?: string;
-                        },
+                        } as WeekData,
                     );
             })
             .sort((a, b) => (a.week > b.week ? 1 : -1));

--- a/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
+++ b/frontend/src/component/insights/componentsChart/ProjectHealthChart/ProjectHealthChart.tsx
@@ -20,6 +20,16 @@ interface IProjectHealthChartProps {
     isLoading?: boolean;
 }
 
+const calculateHealth = (item: {
+    total: number;
+    stale: number;
+    potentiallyStale: number;
+}) =>
+    (
+        ((item.total - item.stale - item.potentiallyStale) / item.total) *
+        100
+    ).toFixed(2);
+
 export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
     projectFlagTrends,
     isAggregate,
@@ -74,15 +84,7 @@ export const ProjectHealthChart: FC<IProjectHealthChartProps> = ({
                 {
                     label: 'Health',
                     data: weeks.map((item) => ({
-                        health: item.total
-                            ? (
-                                  ((item.total -
-                                      item.stale -
-                                      item.potentiallyStale) /
-                                      item.total) *
-                                  100
-                              ).toFixed(2)
-                            : undefined,
+                        health: item.total ? calculateHealth(item) : undefined,
                         date: item.date,
                         total: item.total,
                         stale: item.stale,

--- a/frontend/src/component/insights/componentsStat/HealthStats/HealthStats.tsx
+++ b/frontend/src/component/insights/componentsStat/HealthStats/HealthStats.tsx
@@ -1,4 +1,4 @@
-import type { VFC } from 'react';
+import type { FC } from 'react';
 import { useThemeMode } from 'hooks/useThemeMode';
 import { useTheme } from '@mui/material';
 
@@ -9,7 +9,7 @@ interface IHealthStatsProps {
     potentiallyStale: number;
 }
 
-export const HealthStats: VFC<IHealthStatsProps> = ({
+export const HealthStats: FC<IHealthStatsProps> = ({
     value,
     healthy,
     stale,


### PR DESCRIPTION
This PR updates the tooltips for the health chart to also include information on how healthy  flags there are. The user could make this calculation themselves before, but it'd require them to subtract the sum of stale and potentially stale flags from the total. This makes it so that they don't have to do the calculation.

I've also included a bar for the healthy flags in the overview, so that it's easier to see how large a portion it is compared to the others.

Also: clean up some uses of the now-deprecated VFC.

![image](https://github.com/user-attachments/assets/fa33b5ec-b5aa-472d-8ee3-329c5ed0d0c6)