### PR TITLE
fix: validate patched data with schema

### DIFF
--- a/src/lib/error/bad-data-error.ts
+++ b/src/lib/error/bad-data-error.ts
@@ -126,7 +126,7 @@ export const fromOpenApiValidationError =
             : instancePath.startsWith('/query')
               ? [(data as { query: object }).query, '/query/'.length]
               : // This is not validating body or query, so we can assume this is manually validating plain data
-                [data!, 1];
+                [data, 1];
 
         const propertyName = instancePath.substring(substringOffset);
 

--- a/src/lib/error/unleash-error.test.ts
+++ b/src/lib/error/unleash-error.test.ts
@@ -317,6 +317,49 @@ describe('OpenAPI error conversion', () => {
         });
     });
 
+    it('Handles any data, not only requests', () => {
+        const errors: [ErrorObject, ...ErrorObject[]] = [
+            {
+                keyword: 'maximum',
+                instancePath: '/newprop',
+                schemaPath:
+                    '#/components/schemas/addonCreateUpdateSchema/properties/newprop/maximum',
+                params: {
+                    comparison: '<=',
+                    limit: 5,
+                    exclusive: false,
+                },
+                message: 'should be <= 5',
+            },
+            {
+                keyword: 'required',
+                instancePath: '/',
+                schemaPath:
+                    '#/components/schemas/addonCreateUpdateSchema/required',
+                params: {
+                    missingProperty: 'enabled',
+                },
+                message: "should have required property 'enabled'",
+            },
+        ];
+
+        const serializedUnleashError: ApiErrorSchema =
+            fromOpenApiValidationErrors({ newprop: 7 }, errors).toJSON();
+
+        expect(serializedUnleashError).toMatchObject({
+            name: 'BadDataError',
+            message: expect.stringContaining('`details`'),
+            details: [
+                {
+                    message: expect.stringContaining('newprop'),
+                },
+                {
+                    message: expect.stringContaining('enabled'),
+                },
+            ],
+        });
+    });
+
     describe('Disallowed additional properties', () => {
         it('gives useful messages for base-level properties', () => {
             const openApiError = {

--- a/src/lib/features/feature-toggle/feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-controller.ts
@@ -32,6 +32,7 @@ import {
     type FeatureSchema,
     featuresSchema,
     type FeaturesSchema,
+    featureStrategySchema,
     type FeatureStrategySchema,
     getStandardResponses,
     type ParametersSchema,
@@ -54,6 +55,7 @@ import type {
 } from '../../db/transaction';
 import { BadDataError } from '../../error';
 import { anonymise } from '../../util';
+import { throwOnInvalidSchema } from '../../openapi/validate';
 
 interface FeatureStrategyParams {
     projectId: string;
@@ -1060,6 +1062,9 @@ export default class ProjectFeaturesController extends Controller {
         const strategy = await this.featureService.getStrategy(strategyId);
 
         const { newDocument } = applyPatch(strategy, patch);
+
+        throwOnInvalidSchema(newDocument, featureStrategySchema.$id);
+
         const updatedStrategy = await this.startTransaction(async (tx) =>
             this.transactionalFeatureToggleService(tx).updateStrategy(
                 strategyId,

--- a/src/lib/features/feature-toggle/feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-controller.ts
@@ -1063,7 +1063,7 @@ export default class ProjectFeaturesController extends Controller {
 
         const { newDocument } = applyPatch(strategy, patch);
 
-        throwOnInvalidSchema(newDocument, featureStrategySchema.$id);
+        throwOnInvalidSchema(featureStrategySchema.$id, newDocument);
 
         const updatedStrategy = await this.startTransaction(async (tx) =>
             this.transactionalFeatureToggleService(tx).updateStrategy(

--- a/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
@@ -1500,7 +1500,7 @@ test('Can patch a strategy based on id', async () => {
                 strategy!.id
             }`,
         )
-        .send([{ op: 'replace', path: '/parameters/rollout', value: 42 }])
+        .send([{ op: 'replace', path: '/parameters/rollout', value: '42' }])
         .expect(200);
     await app.request
         .get(

--- a/src/lib/openapi/validate.test.ts
+++ b/src/lib/openapi/validate.test.ts
@@ -1,7 +1,30 @@
-import { validateSchema } from './validate';
+import { constraintSchema } from './spec';
+import { throwOnInvalidSchema, validateSchema } from './validate';
 
 test('validateSchema', () => {
     expect(() => validateSchema('unknownSchemaId' as any, {})).toThrow(
         'no schema with key or ref "unknownSchemaId"',
+    );
+});
+
+test('throwOnInvalidSchema', () => {
+    expect(() =>
+        throwOnInvalidSchema(constraintSchema.$id, {
+            contextName: 'a',
+            operator: 'NUM_LTE',
+            value: '1',
+        }),
+    ).not.toThrow();
+});
+
+test('throwOnInvalidSchema', () => {
+    expect(() =>
+        throwOnInvalidSchema(constraintSchema.$id, {
+            contextName: 'a',
+            operator: 'invalid-operator',
+            value: '1',
+        }),
+    ).toThrow(
+        'Request validation failed: your request body or params contain invalid data. Refer to the `details` list for more information.',
     );
 });

--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -41,14 +41,15 @@ export const validateSchema = <S = SchemaId>(
 };
 
 export const throwOnInvalidSchema = <S = SchemaId>(
-    data: object,
     schema: S,
+    data: object,
 ): void => {
     const validationErrors = validateSchema(schema, data);
     if (validationErrors) {
-        throw fromOpenApiValidationErrors(
-            data,
-            validationErrors.errors as [ErrorObject, ...ErrorObject[]],
-        );
+        const [firstError, ...remainingErrors] = validationErrors.errors;
+        throw fromOpenApiValidationErrors(data, [
+            firstError,
+            ...remainingErrors,
+        ]);
     }
 };

--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -1,6 +1,7 @@
 import Ajv, { type ErrorObject } from 'ajv';
 import { type SchemaId, schemas } from './index';
 import { omitKeys } from '../util/omit-keys';
+import { fromOpenApiValidationErrors } from '../error/bad-data-error';
 
 export interface ISchemaValidationErrors<S = SchemaId> {
     schema: S;
@@ -36,5 +37,18 @@ export const validateSchema = <S = SchemaId>(
             schema,
             errors: ajv.errors ?? [],
         };
+    }
+};
+
+export const throwOnInvalidSchema = <S = SchemaId>(
+    data: object,
+    schema: S,
+): void => {
+    const validationErrors = validateSchema(schema, data);
+    if (validationErrors) {
+        throw fromOpenApiValidationErrors(
+            data,
+            validationErrors.errors as [ErrorObject, ...ErrorObject[]],
+        );
     }
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2453/validate-patched-data-against-schema

This adds schema validation to patched data, fixing potential issues of patching data to an invalid state.

This can be easily reproduced by patching a strategy constraints to be an object (invalid), instead of an array (valid):

```sh
curl -X 'PATCH' \
  'http://localhost:4242/api/admin/projects/default/features/test/environments/development/strategies/8cb3fec6-c40a-45f7-8be0-138c5aaa5263' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "path": "/constraints",
    "op": "replace",
    "from": "/constraints",
    "value": {}
  }
]'
```

Unleash will accept this because there's no validation that the patched data actually looks like a proper strategy, and we'll start seeing Unleash errors due to the invalid state.

This PR adapts some of our existing logic in the way we handle validation errors to support any dynamic object. This way we can perform schema validation with any object and still get the benefits of our existing validation error handling.

This PR also takes the liberty to expose the full instancePath as propertyName, instead of only the path's last section. We believe this has more upsides than downsides, especially now that we support the validation of any type of object.

![image](https://github.com/user-attachments/assets/f6503261-f6b5-4e1d-9ec3-66547d0d061f)
