### PR TITLE
chore: send prometheus metrics when someone tries to exceed resource limits

### DIFF
--- a/src/lib/error/exceeds-limit-error.test.ts
+++ b/src/lib/error/exceeds-limit-error.test.ts
@@ -1,0 +1,23 @@
+import type EventEmitter from 'events';
+import { EXCEEDS_LIMIT } from '../metric-events';
+import {
+    ExceedsLimitError,
+    throwExceedsLimitError,
+} from './exceeds-limit-error';
+
+it('emits events event when created through the external function', () => {
+    const emitEvent = jest.fn();
+    const resource = 'some-resource';
+    const limit = 10;
+
+    expect(() =>
+        throwExceedsLimitError(resource, limit, {
+            emit: emitEvent,
+        } as unknown as EventEmitter),
+    ).toThrow(ExceedsLimitError);
+
+    expect(emitEvent).toHaveBeenCalledWith(EXCEEDS_LIMIT, {
+        resource,
+        limit,
+    });
+});

--- a/src/lib/error/exceeds-limit-error.test.ts
+++ b/src/lib/error/exceeds-limit-error.test.ts
@@ -11,9 +11,13 @@ it('emits events event when created through the external function', () => {
     const limit = 10;
 
     expect(() =>
-        throwExceedsLimitError(resource, limit, {
-            emit: emitEvent,
-        } as unknown as EventEmitter),
+        throwExceedsLimitError(
+            {
+                emit: emitEvent,
+            } as unknown as EventEmitter,
+            resource,
+            limit,
+        ),
     ).toThrow(ExceedsLimitError);
 
     expect(emitEvent).toHaveBeenCalledWith(EXCEEDS_LIMIT, {

--- a/src/lib/error/exceeds-limit-error.test.ts
+++ b/src/lib/error/exceeds-limit-error.test.ts
@@ -15,13 +15,40 @@ it('emits events event when created through the external function', () => {
             {
                 emit: emitEvent,
             } as unknown as EventEmitter,
-            resource,
-            limit,
+            {
+                resource,
+                limit,
+            },
         ),
     ).toThrow(ExceedsLimitError);
 
     expect(emitEvent).toHaveBeenCalledWith(EXCEEDS_LIMIT, {
         resource,
+        limit,
+    });
+});
+
+it('emits uses the resourceNameOverride for the event when provided, but uses the resource for the error', () => {
+    const emitEvent = jest.fn();
+    const resource = 'not this';
+    const resourceNameOverride = 'but this!';
+    const limit = 10;
+
+    expect(() =>
+        throwExceedsLimitError(
+            {
+                emit: emitEvent,
+            } as unknown as EventEmitter,
+            {
+                resource,
+                resourceNameOverride,
+                limit,
+            },
+        ),
+    ).toThrow(new ExceedsLimitError(resource, limit));
+
+    expect(emitEvent).toHaveBeenCalledWith(EXCEEDS_LIMIT, {
+        resource: resourceNameOverride,
         limit,
     });
 });

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -3,13 +3,13 @@ import { GenericUnleashError } from './unleash-error';
 import { EXCEEDS_LIMIT } from '../metric-events';
 
 export class ExceedsLimitError extends GenericUnleashError {
-    constructor(resource: string, limit: number, eventBus: EventEmitter) {
+    constructor(resource: string, limit: number, eventBus?: EventEmitter) {
         super({
             name: 'ExceedsLimitError',
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
             statusCode: 400,
         });
 
-        eventBus.emit(EXCEEDS_LIMIT, { resource, limit });
+        eventBus?.emit(EXCEEDS_LIMIT, { resource, limit });
     }
 }

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -1,11 +1,15 @@
+import type EventEmitter from 'events';
 import { GenericUnleashError } from './unleash-error';
+import { EXCEEDS_LIMIT } from '../metric-events';
 
 export class ExceedsLimitError extends GenericUnleashError {
-    constructor(resource: string, limit: number) {
+    constructor(resource: string, limit: number, eventBus: EventEmitter) {
         super({
             name: 'ExceedsLimitError',
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
             statusCode: 400,
         });
+
+        eventBus.emit(EXCEEDS_LIMIT, { resource, limit });
     }
 }

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -12,11 +12,15 @@ export class ExceedsLimitError extends GenericUnleashError {
     }
 }
 
+type ExceedsLimitErrorData = {
+    resource: string;
+    limit: number;
+    resourceNameOverride?: string;
+};
+
 export const throwExceedsLimitError = (
     eventBus: EventEmitter,
-    resource: string,
-    limit: number,
-    resourceNameOverride?: string,
+    { resource, limit, resourceNameOverride }: ExceedsLimitErrorData,
 ) => {
     eventBus.emit(EXCEEDS_LIMIT, {
         resource: resourceNameOverride ?? resource,

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -3,7 +3,11 @@ import { GenericUnleashError } from './unleash-error';
 import { EXCEEDS_LIMIT } from '../metric-events';
 
 export class ExceedsLimitError extends GenericUnleashError {
-    constructor(resource: string, limit: number, eventBus?: EventEmitter) {
+    private constructor(
+        resource: string,
+        limit: number,
+        eventBus?: EventEmitter,
+    ) {
         super({
             name: 'ExceedsLimitError',
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -1,19 +1,22 @@
-import type EventEmitter from 'events';
 import { GenericUnleashError } from './unleash-error';
 import { EXCEEDS_LIMIT } from '../metric-events';
+import type EventEmitter from 'events';
 
 export class ExceedsLimitError extends GenericUnleashError {
-    private constructor(
-        resource: string,
-        limit: number,
-        eventBus?: EventEmitter,
-    ) {
+    constructor(resource: string, limit: number) {
         super({
             name: 'ExceedsLimitError',
             message: `Failed to create ${resource}. You can't create more than the established limit of ${limit}.`,
             statusCode: 400,
         });
-
-        eventBus?.emit(EXCEEDS_LIMIT, { resource, limit });
     }
 }
+
+export const throwExceedsLimitError = (
+    resource: string,
+    limit: number,
+    eventBus: EventEmitter,
+) => {
+    eventBus.emit(EXCEEDS_LIMIT, { resource, limit });
+    throw new ExceedsLimitError(resource, limit);
+};

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -13,10 +13,14 @@ export class ExceedsLimitError extends GenericUnleashError {
 }
 
 export const throwExceedsLimitError = (
+    eventBus: EventEmitter,
     resource: string,
     limit: number,
-    eventBus: EventEmitter,
+    resourceGroupName?: string,
 ) => {
-    eventBus.emit(EXCEEDS_LIMIT, { resource, limit });
+    eventBus.emit(EXCEEDS_LIMIT, {
+        resource: resourceGroupName ?? resource,
+        limit,
+    });
     throw new ExceedsLimitError(resource, limit);
 };

--- a/src/lib/error/exceeds-limit-error.ts
+++ b/src/lib/error/exceeds-limit-error.ts
@@ -16,10 +16,10 @@ export const throwExceedsLimitError = (
     eventBus: EventEmitter,
     resource: string,
     limit: number,
-    resourceGroupName?: string,
+    resourceNameOverride?: string,
 ) => {
     eventBus.emit(EXCEEDS_LIMIT, {
-        resource: resourceGroupName ?? resource,
+        resource: resourceNameOverride ?? resource,
         limit,
     });
     throw new ExceedsLimitError(resource, limit);

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -383,7 +383,7 @@ class FeatureToggleService {
             )
         ).length;
         if (existingCount >= limit) {
-            throw new ExceedsLimitError('strategy', limit);
+            throw new ExceedsLimitError('strategy', limit, this.eventBus);
         }
     }
 
@@ -392,7 +392,11 @@ class FeatureToggleService {
 
         const constraintsLimit = this.resourceLimits.constraints;
         if (updatedConstrains.length > constraintsLimit) {
-            throw new ExceedsLimitError(`constraints`, constraintsLimit);
+            throw new ExceedsLimitError(
+                `constraints`,
+                constraintsLimit,
+                this.eventBus,
+            );
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
@@ -405,6 +409,7 @@ class FeatureToggleService {
             throw new ExceedsLimitError(
                 `constraint values for ${constraintOverLimit.contextName}`,
                 constraintValuesLimit,
+                this.eventBus,
             );
         }
     }
@@ -1181,7 +1186,11 @@ class FeatureToggleService {
             const currentFlagCount = await this.featureToggleStore.count();
             const limit = this.resourceLimits.featureFlags;
             if (currentFlagCount >= limit) {
-                throw new ExceedsLimitError('feature flag', limit);
+                throw new ExceedsLimitError(
+                    'feature flag',
+                    limit,
+                    this.eventBus,
+                );
             }
         }
     }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -383,7 +383,10 @@ class FeatureToggleService {
             )
         ).length;
         if (existingCount >= limit) {
-            throwExceedsLimitError(this.eventBus, 'strategy', limit);
+            throwExceedsLimitError(this.eventBus, {
+                resource: 'strategy',
+                limit,
+            });
         }
     }
 
@@ -392,11 +395,10 @@ class FeatureToggleService {
 
         const constraintsLimit = this.resourceLimits.constraints;
         if (updatedConstrains.length > constraintsLimit) {
-            throwExceedsLimitError(
-                this.eventBus,
-                `constraints`,
-                constraintsLimit,
-            );
+            throwExceedsLimitError(this.eventBus, {
+                resource: `constraints`,
+                limit: constraintsLimit,
+            });
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
@@ -406,12 +408,11 @@ class FeatureToggleService {
                 constraint.values?.length > constraintValuesLimit,
         );
         if (constraintOverLimit) {
-            throwExceedsLimitError(
-                this.eventBus,
-                `constraint values for ${constraintOverLimit.contextName}`,
-                constraintValuesLimit,
-                'constraint values',
-            );
+            throwExceedsLimitError(this.eventBus, {
+                resource: `constraint values for ${constraintOverLimit.contextName}`,
+                limit: constraintValuesLimit,
+                resourceNameOverride: 'constraint values',
+            });
         }
     }
 
@@ -1187,7 +1188,10 @@ class FeatureToggleService {
             const currentFlagCount = await this.featureToggleStore.count();
             const limit = this.resourceLimits.featureFlags;
             if (currentFlagCount >= limit) {
-                throwExceedsLimitError(this.eventBus, 'feature flag', limit);
+                throwExceedsLimitError(this.eventBus, {
+                    resource: 'feature flag',
+                    limit,
+                });
             }
         }
     }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -109,7 +109,7 @@ import { allSettledWithRejection } from '../../util/allSettledWithRejection';
 import type EventEmitter from 'node:events';
 import type { IFeatureLifecycleReadModel } from '../feature-lifecycle/feature-lifecycle-read-model-type';
 import type { ResourceLimitsSchema } from '../../openapi';
-import { ExceedsLimitError } from '../../error/exceeds-limit-error';
+import { throwExceedsLimitError } from '../../error/exceeds-limit-error';
 
 interface IFeatureContext {
     featureName: string;
@@ -383,7 +383,7 @@ class FeatureToggleService {
             )
         ).length;
         if (existingCount >= limit) {
-            throw new ExceedsLimitError('strategy', limit, this.eventBus);
+            throwExceedsLimitError('strategy', limit, this.eventBus);
         }
     }
 
@@ -392,7 +392,7 @@ class FeatureToggleService {
 
         const constraintsLimit = this.resourceLimits.constraints;
         if (updatedConstrains.length > constraintsLimit) {
-            throw new ExceedsLimitError(
+            throwExceedsLimitError(
                 `constraints`,
                 constraintsLimit,
                 this.eventBus,
@@ -406,7 +406,7 @@ class FeatureToggleService {
                 constraint.values?.length > constraintValuesLimit,
         );
         if (constraintOverLimit) {
-            throw new ExceedsLimitError(
+            throwExceedsLimitError(
                 `constraint values for ${constraintOverLimit.contextName}`,
                 constraintValuesLimit,
                 this.eventBus,
@@ -1186,11 +1186,7 @@ class FeatureToggleService {
             const currentFlagCount = await this.featureToggleStore.count();
             const limit = this.resourceLimits.featureFlags;
             if (currentFlagCount >= limit) {
-                throw new ExceedsLimitError(
-                    'feature flag',
-                    limit,
-                    this.eventBus,
-                );
+                throwExceedsLimitError('feature flag', limit, this.eventBus);
             }
         }
     }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -410,6 +410,7 @@ class FeatureToggleService {
                 this.eventBus,
                 `constraint values for ${constraintOverLimit.contextName}`,
                 constraintValuesLimit,
+                'constraint values',
             );
         }
     }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -403,7 +403,7 @@ class FeatureToggleService {
         );
         if (constraintOverLimit) {
             throw new ExceedsLimitError(
-                `content values for ${constraintOverLimit.contextName}`,
+                `constraint values for ${constraintOverLimit.contextName}`,
                 constraintValuesLimit,
             );
         }

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -383,7 +383,7 @@ class FeatureToggleService {
             )
         ).length;
         if (existingCount >= limit) {
-            throwExceedsLimitError('strategy', limit, this.eventBus);
+            throwExceedsLimitError(this.eventBus, 'strategy', limit);
         }
     }
 
@@ -393,9 +393,9 @@ class FeatureToggleService {
         const constraintsLimit = this.resourceLimits.constraints;
         if (updatedConstrains.length > constraintsLimit) {
             throwExceedsLimitError(
+                this.eventBus,
                 `constraints`,
                 constraintsLimit,
-                this.eventBus,
             );
         }
 
@@ -407,9 +407,9 @@ class FeatureToggleService {
         );
         if (constraintOverLimit) {
             throwExceedsLimitError(
+                this.eventBus,
                 `constraint values for ${constraintOverLimit.contextName}`,
                 constraintValuesLimit,
-                this.eventBus,
             );
         }
     }
@@ -1186,7 +1186,7 @@ class FeatureToggleService {
             const currentFlagCount = await this.featureToggleStore.count();
             const limit = this.resourceLimits.featureFlags;
             if (currentFlagCount >= limit) {
-                throwExceedsLimitError('feature flag', limit, this.eventBus);
+                throwExceedsLimitError(this.eventBus, 'feature flag', limit);
             }
         }
     }

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -125,7 +125,7 @@ describe('Strategy limits', () => {
                 },
             ]),
         ).rejects.toThrow(
-            "Failed to create content values for userId. You can't create more than the established limit of 3",
+            "Failed to create constraint values for userId. You can't create more than the established limit of 3",
         );
     });
 });

--- a/src/lib/features/project/project-service.limit.test.ts
+++ b/src/lib/features/project/project-service.limit.test.ts
@@ -17,6 +17,9 @@ test('Should not allow to exceed project limit', async () => {
         resourceLimits: {
             projects: LIMIT,
         },
+        eventBus: {
+            emit: () => {},
+        },
     } as unknown as IUnleashConfig);
 
     const createProject = (name: string) =>

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -84,7 +84,7 @@ import type {
     IProjectQuery,
 } from './project-store-type';
 import type { IProjectFlagCreatorsReadModel } from './project-flag-creators-read-model.type';
-import { ExceedsLimitError } from '../../error/exceeds-limit-error';
+import { throwExceedsLimitError } from '../../error/exceeds-limit-error';
 import type EventEmitter from 'events';
 
 type Days = number;
@@ -329,7 +329,7 @@ export default class ProjectService {
         const projectCount = await this.projectStore.count();
 
         if (projectCount >= limit) {
-            throw new ExceedsLimitError('project', limit, this.eventBus);
+            throwExceedsLimitError('project', limit, this.eventBus);
         }
     }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -329,7 +329,7 @@ export default class ProjectService {
         const projectCount = await this.projectStore.count();
 
         if (projectCount >= limit) {
-            throwExceedsLimitError('project', limit, this.eventBus);
+            throwExceedsLimitError(this.eventBus, 'project', limit);
         }
     }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -329,7 +329,10 @@ export default class ProjectService {
         const projectCount = await this.projectStore.count();
 
         if (projectCount >= limit) {
-            throwExceedsLimitError(this.eventBus, 'project', limit);
+            throwExceedsLimitError(this.eventBus, {
+                resource: 'project',
+                limit,
+            });
         }
     }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -85,6 +85,7 @@ import type {
 } from './project-store-type';
 import type { IProjectFlagCreatorsReadModel } from './project-flag-creators-read-model.type';
 import { ExceedsLimitError } from '../../error/exceeds-limit-error';
+import type EventEmitter from 'events';
 
 type Days = number;
 type Count = number;
@@ -159,6 +160,8 @@ export default class ProjectService {
 
     private resourceLimits: ResourceLimitsSchema;
 
+    private eventBus: EventEmitter;
+
     constructor(
         {
             projectStore,
@@ -215,6 +218,7 @@ export default class ProjectService {
         this.flagResolver = config.flagResolver;
         this.isEnterprise = config.isEnterprise;
         this.resourceLimits = config.resourceLimits;
+        this.eventBus = config.eventBus;
     }
 
     async getProjects(
@@ -325,7 +329,7 @@ export default class ProjectService {
         const projectCount = await this.projectStore.count();
 
         if (projectCount >= limit) {
-            throw new ExceedsLimitError('project', limit);
+            throw new ExceedsLimitError('project', limit, this.eventBus);
         }
     }
 

--- a/src/lib/features/segment/segment-service.limit.test.ts
+++ b/src/lib/features/segment/segment-service.limit.test.ts
@@ -16,6 +16,9 @@ test('Should not allow to exceed segment limit', async () => {
         resourceLimits: {
             segments: LIMIT,
         },
+        eventBus: {
+            emit: () => {},
+        },
     } as unknown as IUnleashConfig);
 
     const createSegment = (name: string) =>

--- a/src/lib/features/segment/segment-service.ts
+++ b/src/lib/features/segment/segment-service.ts
@@ -136,7 +136,10 @@ export class SegmentService implements ISegmentService {
         const segmentCount = await this.segmentStore.count();
 
         if (segmentCount >= limit) {
-            throwExceedsLimitError(this.config.eventBus, 'segment', limit);
+            throwExceedsLimitError(this.config.eventBus, {
+                resource: 'segment',
+                limit,
+            });
         }
     }
 

--- a/src/lib/features/segment/segment-service.ts
+++ b/src/lib/features/segment/segment-service.ts
@@ -26,7 +26,7 @@ import type { IPrivateProjectChecker } from '../private-project/privateProjectCh
 import type EventService from '../events/event-service';
 import type { IChangeRequestSegmentUsageReadModel } from '../change-request-segment-usage-service/change-request-segment-usage-read-model';
 import type { ResourceLimitsSchema } from '../../openapi';
-import { ExceedsLimitError } from '../../error/exceeds-limit-error';
+import { throwExceedsLimitError } from '../../error/exceeds-limit-error';
 
 export class SegmentService implements ISegmentService {
     private logger: Logger;
@@ -136,7 +136,7 @@ export class SegmentService implements ISegmentService {
         const segmentCount = await this.segmentStore.count();
 
         if (segmentCount >= limit) {
-            throw new ExceedsLimitError('segment', limit, this.config.eventBus);
+            throwExceedsLimitError('segment', limit, this.config.eventBus);
         }
     }
 

--- a/src/lib/features/segment/segment-service.ts
+++ b/src/lib/features/segment/segment-service.ts
@@ -136,7 +136,7 @@ export class SegmentService implements ISegmentService {
         const segmentCount = await this.segmentStore.count();
 
         if (segmentCount >= limit) {
-            throw new ExceedsLimitError('segment', limit);
+            throw new ExceedsLimitError('segment', limit, this.config.eventBus);
         }
     }
 

--- a/src/lib/features/segment/segment-service.ts
+++ b/src/lib/features/segment/segment-service.ts
@@ -136,7 +136,7 @@ export class SegmentService implements ISegmentService {
         const segmentCount = await this.segmentStore.count();
 
         if (segmentCount >= limit) {
-            throwExceedsLimitError('segment', limit, this.config.eventBus);
+            throwExceedsLimitError(this.config.eventBus, 'segment', limit);
         }
     }
 

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -8,6 +8,7 @@ const FRONTEND_API_REPOSITORY_CREATED = 'frontend_api_repository_created';
 const PROXY_REPOSITORY_CREATED = 'proxy_repository_created';
 const PROXY_FEATURES_FOR_TOKEN_TIME = 'proxy_features_for_token_time';
 const STAGE_ENTERED = 'stage-entered' as const;
+const EXCEEDS_LIMIT = 'exceeds-limit' as const;
 
 export {
     REQUEST_TIME,
@@ -20,4 +21,5 @@ export {
     PROXY_REPOSITORY_CREATED,
     PROXY_FEATURES_FOR_TOKEN_TIME,
     STAGE_ENTERED,
+    EXCEEDS_LIMIT,
 };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -341,8 +341,8 @@ export default class MetricsMonitor {
             help: 'Number of API tokens with v1 format, last seen within 3 months',
         });
 
-        const exceedsLimitErrorCount = createCounter({
-            name: 'exceeds_limit_error_count',
+        const exceedsLimitErrorCounter = createCounter({
+            name: 'exceeds_limit_error',
             help: 'The number of exceeds limit errors registered by this instance.',
             labelNames: ['resource', 'limit'],
         });
@@ -402,6 +402,18 @@ export default class MetricsMonitor {
                     (entered: { stage: string; feature: string }) => {
                         featureLifecycleStageEnteredCounter
                             .labels({ stage: entered.stage })
+                            .inc();
+                    },
+                );
+
+                eventBus.on(
+                    events.EXCEEDS_LIMIT,
+                    ({
+                        resource,
+                        limit,
+                    }: { resource: string; limit: number }) => {
+                        exceedsLimitErrorCounter
+                            .labels({ resource, limit })
                             .inc();
                     },
                 );

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -341,6 +341,12 @@ export default class MetricsMonitor {
             help: 'Number of API tokens with v1 format, last seen within 3 months',
         });
 
+        const exceedsLimitErrorCount = createCounter({
+            name: 'exceeds_limit_error_count',
+            help: 'The number of exceeds limit errors registered by this instance.',
+            labelNames: ['resource', 'limit'],
+        });
+
         async function collectStaticCounters() {
             try {
                 const stats = await instanceStatsService.getStats();

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -312,7 +312,7 @@ export class ApiTokenService {
             const currentTokenCount = await this.store.count();
             const limit = this.resourceLimits.apiTokens;
             if (currentTokenCount >= limit) {
-                throwExceedsLimitError('api token', limit, this.eventBus);
+                throwExceedsLimitError(this.eventBus, 'api token', limit);
             }
         }
     }

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -34,7 +34,7 @@ import { addMinutes, isPast } from 'date-fns';
 import metricsHelper from '../util/metrics-helper';
 import { FUNCTION_TIME } from '../metric-events';
 import type { ResourceLimitsSchema } from '../openapi';
-import { ExceedsLimitError } from '../error/exceeds-limit-error';
+import { throwExceedsLimitError } from '../error/exceeds-limit-error';
 import type EventEmitter from 'events';
 
 const resolveTokenPermissions = (tokenType: string) => {
@@ -312,7 +312,7 @@ export class ApiTokenService {
             const currentTokenCount = await this.store.count();
             const limit = this.resourceLimits.apiTokens;
             if (currentTokenCount >= limit) {
-                throw new ExceedsLimitError('api token', limit, this.eventBus);
+                throwExceedsLimitError('api token', limit, this.eventBus);
             }
         }
     }

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -312,7 +312,10 @@ export class ApiTokenService {
             const currentTokenCount = await this.store.count();
             const limit = this.resourceLimits.apiTokens;
             if (currentTokenCount >= limit) {
-                throwExceedsLimitError(this.eventBus, 'api token', limit);
+                throwExceedsLimitError(this.eventBus, {
+                    resource: 'api token',
+                    limit,
+                });
             }
         }
     }

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -35,6 +35,7 @@ import metricsHelper from '../util/metrics-helper';
 import { FUNCTION_TIME } from '../metric-events';
 import type { ResourceLimitsSchema } from '../openapi';
 import { ExceedsLimitError } from '../error/exceeds-limit-error';
+import type EventEmitter from 'events';
 
 const resolveTokenPermissions = (tokenType: string) => {
     if (tokenType === ApiTokenType.ADMIN) {
@@ -73,6 +74,8 @@ export class ApiTokenService {
 
     private resourceLimits: ResourceLimitsSchema;
 
+    private eventBus: EventEmitter;
+
     constructor(
         {
             apiTokenStore,
@@ -109,6 +112,8 @@ export class ApiTokenService {
                 className: 'ApiTokenService',
                 functionName,
             });
+
+        this.eventBus = config.eventBus;
     }
 
     /**
@@ -307,7 +312,7 @@ export class ApiTokenService {
             const currentTokenCount = await this.store.count();
             const limit = this.resourceLimits.apiTokens;
             if (currentTokenCount >= limit) {
-                throw new ExceedsLimitError('api token', limit);
+                throw new ExceedsLimitError('api token', limit, this.eventBus);
             }
         }
     }


### PR DESCRIPTION
This PR adds prometheus metrics for when users attempt to exceed the limits for a given resource. 

The implementation sets up a second function exported from the ExceedsLimitError file that records metrics and then throws the error. This could also be a static method on the class, but I'm not sure that'd be better.