### PR TITLE
fix: use a fullscreen loader for the initial redirect load

### DIFF
--- a/frontend/src/component/InitialRedirect.tsx
+++ b/frontend/src/component/InitialRedirect.tsx
@@ -34,7 +34,7 @@ export const InitialRedirect = () => {
     }, [getRedirect]);
 
     if (loading) {
-        return <Loader />;
+        return <Loader type='fullscreen' />;
     }
 
     return null;


### PR DESCRIPTION
This PR fixes a minor visual glitch where the initial Unleash load might display a jumping loading icon. The reason was that the initial redirect's loader wasn't marked as a fullscreen loader.