### PR TITLE
chore: register integration events in webhooks

### DIFF
--- a/src/lib/addons/datadog.test.ts
+++ b/src/lib/addons/datadog.test.ts
@@ -9,8 +9,18 @@ import type { Logger } from '../logger';
 import DatadogAddon from './datadog';
 
 import noLogger from '../../test/fixtures/no-logger';
+import type { IAddonConfig, IFlagResolver } from '../types';
+import type { IntegrationEventsService } from '../services';
 
 let fetchRetryCalls: any[] = [];
+
+const INTEGRATION_ID = 1337;
+const ARGS: IAddonConfig = {
+    getLogger: noLogger,
+    unleashUrl: 'http://some-unleash-url',
+    integrationEventsService: {} as IntegrationEventsService,
+    flagResolver: {} as IFlagResolver,
+};
 
 jest.mock(
     './addon',
@@ -32,14 +42,15 @@ jest.mock(
                 });
                 return Promise.resolve({ status: 200 });
             }
+
+            async registerEvent(_) {
+                return Promise.resolve();
+            }
         },
 );
 
 test('Should call datadog webhook', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 1,
         createdAt: new Date(),
@@ -59,17 +70,14 @@ test('Should call datadog webhook', async () => {
         apiKey: 'fakeKey',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls.length).toBe(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatchSnapshot();
 });
 
 test('Should call datadog webhook  for archived toggle', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 2,
         createdAt: new Date(),
@@ -87,17 +95,14 @@ test('Should call datadog webhook  for archived toggle', async () => {
         apiKey: 'fakeKey',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls.length).toBe(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatchSnapshot();
 });
 
 test('Should call datadog webhook  for archived toggle with project info', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 2,
         createdAt: new Date(),
@@ -116,17 +121,14 @@ test('Should call datadog webhook  for archived toggle with project info', async
         apiKey: 'fakeKey',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls.length).toBe(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatchSnapshot();
 });
 
 test('Should call datadog webhook for toggled environment', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 2,
         createdAt: new Date(),
@@ -146,7 +148,7 @@ test('Should call datadog webhook for toggled environment', async () => {
         apiKey: 'fakeKey',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls).toHaveLength(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatch(/disabled/);
@@ -154,10 +156,7 @@ test('Should call datadog webhook for toggled environment', async () => {
 });
 
 test('Should include customHeaders in headers when calling service', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 2,
         createdAt: new Date(),
@@ -177,7 +176,7 @@ test('Should include customHeaders in headers when calling service', async () =>
         apiKey: 'fakeKey',
         customHeaders: `{ "MY_CUSTOM_HEADER": "MY_CUSTOM_VALUE" }`,
     };
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls).toHaveLength(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatch(/disabled/);
@@ -186,10 +185,7 @@ test('Should include customHeaders in headers when calling service', async () =>
 });
 
 test('Should not include source_type_name when included in the config', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 2,
         createdAt: new Date(),
@@ -210,7 +206,7 @@ test('Should not include source_type_name when included in the config', async ()
         sourceTypeName: 'my-custom-source-type',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls).toHaveLength(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatch(
@@ -221,10 +217,7 @@ test('Should not include source_type_name when included in the config', async ()
 });
 
 test('Should call datadog webhook with JSON when template set', async () => {
-    const addon = new DatadogAddon({
-        getLogger: noLogger,
-        unleashUrl: 'http://some-url.com',
-    });
+    const addon = new DatadogAddon(ARGS);
     const event: IEvent = {
         id: 1,
         createdAt: new Date(),
@@ -246,7 +239,7 @@ test('Should call datadog webhook with JSON when template set', async () => {
             '{\n  "event": "{{event.type}}",\n  "createdBy": "{{event.createdBy}}"\n}',
     };
 
-    await addon.handleEvent(event, parameters);
+    await addon.handleEvent(event, parameters, INTEGRATION_ID);
     expect(fetchRetryCalls.length).toBe(1);
     expect(fetchRetryCalls[0].url).toBe(parameters.url);
     expect(fetchRetryCalls[0].options.body).toMatchSnapshot();

--- a/src/lib/addons/datadog.test.ts
+++ b/src/lib/addons/datadog.test.ts
@@ -17,7 +17,7 @@ let fetchRetryCalls: any[] = [];
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger: noLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/datadog.ts
+++ b/src/lib/addons/datadog.ts
@@ -39,6 +39,7 @@ export default class DatadogAddon extends Addon {
     async handleEvent(
         event: IEvent,
         parameters: IDatadogParameters,
+        integrationId: number,
     ): Promise<void> {
         const {
             url = 'https://api.datadoghq.com/api/v1/events',

--- a/src/lib/addons/index.ts
+++ b/src/lib/addons/index.ts
@@ -4,26 +4,21 @@ import TeamsAddon from './teams';
 import DatadogAddon from './datadog';
 import NewRelicAddon from './new-relic';
 import type Addon from './addon';
-import type { LogProvider } from '../logger';
 import SlackAppAddon from './slack-app';
-import type { IFlagResolver } from '../types';
+import type { IAddonConfig } from '../types';
 
 export interface IAddonProviders {
     [key: string]: Addon;
 }
 
-export const getAddons: (args: {
-    getLogger: LogProvider;
-    unleashUrl: string;
-    flagResolver: IFlagResolver;
-}) => IAddonProviders = ({ getLogger, unleashUrl, flagResolver }) => {
+export const getAddons: (args: IAddonConfig) => IAddonProviders = (args) => {
     const addons: Addon[] = [
-        new Webhook({ getLogger }),
-        new SlackAddon({ getLogger, unleashUrl }),
-        new SlackAppAddon({ getLogger, unleashUrl }),
-        new TeamsAddon({ getLogger, unleashUrl }),
-        new DatadogAddon({ getLogger, unleashUrl }),
-        new NewRelicAddon({ getLogger, unleashUrl }),
+        new Webhook(args),
+        new SlackAddon(args),
+        new SlackAppAddon(args),
+        new TeamsAddon(args),
+        new DatadogAddon(args),
+        new NewRelicAddon(args),
     ];
 
     return addons.reduce((map, addon) => {

--- a/src/lib/addons/new-relic.test.ts
+++ b/src/lib/addons/new-relic.test.ts
@@ -22,7 +22,7 @@ let fetchRetryCalls: any[] = [];
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger: noLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/new-relic.ts
+++ b/src/lib/addons/new-relic.ts
@@ -44,6 +44,7 @@ export default class NewRelicAddon extends Addon {
     async handleEvent(
         event: IEvent,
         parameters: INewRelicParameters,
+        integrationId: number,
     ): Promise<void> {
         const { url, licenseKey, customHeaders, bodyTemplate } = parameters;
         const context = {

--- a/src/lib/addons/slack-app.test.ts
+++ b/src/lib/addons/slack-app.test.ts
@@ -22,7 +22,7 @@ const getLogger = jest.fn(() => loggerMock);
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -44,6 +44,7 @@ export default class SlackAppAddon extends Addon {
     async handleEvent(
         event: IEvent,
         parameters: ISlackAppAddonParameters,
+        integrationId: number,
     ): Promise<void> {
         try {
             const { accessToken, defaultChannels } = parameters;

--- a/src/lib/addons/slack.test.ts
+++ b/src/lib/addons/slack.test.ts
@@ -21,7 +21,7 @@ let fetchRetryCalls: any[] = [];
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger: noLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/slack.ts
+++ b/src/lib/addons/slack.ts
@@ -32,6 +32,7 @@ export default class SlackAddon extends Addon {
     async handleEvent(
         event: IEvent,
         parameters: ISlackAddonParameters,
+        integrationId: number,
     ): Promise<void> {
         const {
             url,

--- a/src/lib/addons/teams.test.ts
+++ b/src/lib/addons/teams.test.ts
@@ -22,7 +22,7 @@ let fetchRetryCalls: any[];
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger: noLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/teams.ts
+++ b/src/lib/addons/teams.ts
@@ -24,6 +24,7 @@ export default class TeamsAddon extends Addon {
     async handleEvent(
         event: IEvent,
         parameters: ITeamsParameters,
+        integrationId: number,
     ): Promise<void> {
         const { url, customHeaders } = parameters;
         const { createdBy } = event;

--- a/src/lib/addons/webhook.test.ts
+++ b/src/lib/addons/webhook.test.ts
@@ -19,7 +19,7 @@ const registerEventMock = jest.fn();
 const INTEGRATION_ID = 1337;
 const ARGS: IAddonConfig = {
     getLogger: noLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/addons/webhook.test.ts
+++ b/src/lib/addons/webhook.test.ts
@@ -5,9 +5,24 @@ import { FEATURE_CREATED, type IEvent } from '../types/events';
 import WebhookAddon from './webhook';
 
 import noLogger from '../../test/fixtures/no-logger';
-import { SYSTEM_USER_ID } from '../types';
+import {
+    type IAddonConfig,
+    type IFlagResolver,
+    serializeDates,
+    SYSTEM_USER_ID,
+} from '../types';
+import type { IntegrationEventsService } from '../services';
 
 let fetchRetryCalls: any[] = [];
+const registerEventMock = jest.fn();
+
+const INTEGRATION_ID = 1337;
+const ARGS: IAddonConfig = {
+    getLogger: noLogger,
+    unleashUrl: 'http://some-unleash-url',
+    integrationEventsService: {} as IntegrationEventsService,
+    flagResolver: {} as IFlagResolver,
+};
 
 jest.mock(
     './addon',
@@ -27,127 +42,182 @@ jest.mock(
                     retries,
                     backoff,
                 });
-                return Promise.resolve({ status: 200 });
+                return Promise.resolve({ ok: true, status: 200 });
+            }
+
+            async registerEvent(event) {
+                return registerEventMock(event);
             }
         },
 );
 
-test('Should handle event without "bodyTemplate"', () => {
-    const addon = new WebhookAddon({ getLogger: noLogger });
-    const event: IEvent = {
-        id: 1,
-        createdAt: new Date(),
-        createdByUserId: SYSTEM_USER_ID,
-        type: FEATURE_CREATED,
-        createdBy: 'some@user.com',
-        featureName: 'some-toggle',
-        data: {
-            name: 'some-toggle',
-            enabled: false,
-            strategies: [{ name: 'default' }],
-        },
-    };
+describe('Webhook integration', () => {
+    beforeEach(() => {
+        registerEventMock.mockClear();
+    });
 
-    const parameters = {
-        url: 'http://test.webhook.com',
-    };
+    test('Should handle event without "bodyTemplate"', () => {
+        const addon = new WebhookAddon(ARGS);
+        const event: IEvent = {
+            id: 1,
+            createdAt: new Date(),
+            createdByUserId: SYSTEM_USER_ID,
+            type: FEATURE_CREATED,
+            createdBy: 'some@user.com',
+            featureName: 'some-toggle',
+            data: {
+                name: 'some-toggle',
+                enabled: false,
+                strategies: [{ name: 'default' }],
+            },
+        };
 
-    addon.handleEvent(event, parameters);
-    expect(fetchRetryCalls.length).toBe(1);
-    expect(fetchRetryCalls[0].url).toBe(parameters.url);
-    expect(fetchRetryCalls[0].options.body).toBe(JSON.stringify(event));
-});
+        const parameters = {
+            url: 'http://test.webhook.com',
+        };
 
-test('Should format event with "bodyTemplate"', () => {
-    const addon = new WebhookAddon({ getLogger: noLogger });
-    const event: IEvent = {
-        id: 1,
-        createdAt: new Date(),
-        createdByUserId: SYSTEM_USER_ID,
-        type: FEATURE_CREATED,
-        createdBy: 'some@user.com',
-        featureName: 'some-toggle',
-        data: {
-            name: 'some-toggle',
-            enabled: false,
-            strategies: [{ name: 'default' }],
-        },
-    };
+        addon.handleEvent(event, parameters, INTEGRATION_ID);
+        expect(fetchRetryCalls.length).toBe(1);
+        expect(fetchRetryCalls[0].url).toBe(parameters.url);
+        expect(fetchRetryCalls[0].options.body).toBe(JSON.stringify(event));
+    });
 
-    const parameters = {
-        url: 'http://test.webhook.com/plain',
-        bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
-        contentType: 'text/plain',
-    };
+    test('Should format event with "bodyTemplate"', () => {
+        const addon = new WebhookAddon(ARGS);
+        const event: IEvent = {
+            id: 1,
+            createdAt: new Date(),
+            createdByUserId: SYSTEM_USER_ID,
+            type: FEATURE_CREATED,
+            createdBy: 'some@user.com',
+            featureName: 'some-toggle',
+            data: {
+                name: 'some-toggle',
+                enabled: false,
+                strategies: [{ name: 'default' }],
+            },
+        };
 
-    addon.handleEvent(event, parameters);
-    const call = fetchRetryCalls[0];
-    expect(fetchRetryCalls.length).toBe(1);
-    expect(call.url).toBe(parameters.url);
-    expect(call.options.headers['Content-Type']).toBe('text/plain');
-    expect(call.options.body).toBe('feature-created on toggle some-toggle');
-});
+        const parameters = {
+            url: 'http://test.webhook.com/plain',
+            bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
+            contentType: 'text/plain',
+        };
 
-test('Should format event with "authorization"', () => {
-    const addon = new WebhookAddon({ getLogger: noLogger });
-    const event: IEvent = {
-        id: 1,
-        createdAt: new Date(),
-        createdByUserId: SYSTEM_USER_ID,
-        type: FEATURE_CREATED,
-        createdBy: 'some@user.com',
-        featureName: 'some-toggle',
-        data: {
-            name: 'some-toggle',
-            enabled: false,
-            strategies: [{ name: 'default' }],
-        },
-    };
+        addon.handleEvent(event, parameters, INTEGRATION_ID);
+        const call = fetchRetryCalls[0];
+        expect(fetchRetryCalls.length).toBe(1);
+        expect(call.url).toBe(parameters.url);
+        expect(call.options.headers['Content-Type']).toBe('text/plain');
+        expect(call.options.body).toBe('feature-created on toggle some-toggle');
+    });
 
-    const parameters = {
-        url: 'http://test.webhook.com/plain',
-        bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
-        contentType: 'text/plain',
-        authorization: 'API KEY 123abc',
-    };
+    test('Should format event with "authorization"', () => {
+        const addon = new WebhookAddon(ARGS);
+        const event: IEvent = {
+            id: 1,
+            createdAt: new Date(),
+            createdByUserId: SYSTEM_USER_ID,
+            type: FEATURE_CREATED,
+            createdBy: 'some@user.com',
+            featureName: 'some-toggle',
+            data: {
+                name: 'some-toggle',
+                enabled: false,
+                strategies: [{ name: 'default' }],
+            },
+        };
 
-    addon.handleEvent(event, parameters);
-    const call = fetchRetryCalls[0];
-    expect(fetchRetryCalls.length).toBe(1);
-    expect(call.url).toBe(parameters.url);
-    expect(call.options.headers.Authorization).toBe(parameters.authorization);
-    expect(call.options.body).toBe('feature-created on toggle some-toggle');
-});
+        const parameters = {
+            url: 'http://test.webhook.com/plain',
+            bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
+            contentType: 'text/plain',
+            authorization: 'API KEY 123abc',
+        };
 
-test('Should handle custom headers', async () => {
-    const addon = new WebhookAddon({ getLogger: noLogger });
-    const event: IEvent = {
-        id: 1,
-        createdAt: new Date(),
-        createdByUserId: SYSTEM_USER_ID,
-        type: FEATURE_CREATED,
-        createdBy: 'some@user.com',
-        featureName: 'some-toggle',
-        data: {
-            name: 'some-toggle',
-            enabled: false,
-            strategies: [{ name: 'default' }],
-        },
-    };
+        addon.handleEvent(event, parameters, INTEGRATION_ID);
+        const call = fetchRetryCalls[0];
+        expect(fetchRetryCalls.length).toBe(1);
+        expect(call.url).toBe(parameters.url);
+        expect(call.options.headers.Authorization).toBe(
+            parameters.authorization,
+        );
+        expect(call.options.body).toBe('feature-created on toggle some-toggle');
+    });
 
-    const parameters = {
-        url: 'http://test.webhook.com/plain',
-        bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
-        contentType: 'text/plain',
-        authorization: 'API KEY 123abc',
-        customHeaders: `{ "MY_CUSTOM_HEADER": "MY_CUSTOM_VALUE" }`,
-    };
+    test('Should handle custom headers', async () => {
+        const addon = new WebhookAddon(ARGS);
+        const event: IEvent = {
+            id: 1,
+            createdAt: new Date(),
+            createdByUserId: SYSTEM_USER_ID,
+            type: FEATURE_CREATED,
+            createdBy: 'some@user.com',
+            featureName: 'some-toggle',
+            data: {
+                name: 'some-toggle',
+                enabled: false,
+                strategies: [{ name: 'default' }],
+            },
+        };
 
-    addon.handleEvent(event, parameters);
-    const call = fetchRetryCalls[0];
-    expect(fetchRetryCalls.length).toBe(1);
-    expect(call.url).toBe(parameters.url);
-    expect(call.options.headers.Authorization).toBe(parameters.authorization);
-    expect(call.options.headers.MY_CUSTOM_HEADER).toBe('MY_CUSTOM_VALUE');
-    expect(call.options.body).toBe('feature-created on toggle some-toggle');
+        const parameters = {
+            url: 'http://test.webhook.com/plain',
+            bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
+            contentType: 'text/plain',
+            authorization: 'API KEY 123abc',
+            customHeaders: `{ "MY_CUSTOM_HEADER": "MY_CUSTOM_VALUE" }`,
+        };
+
+        addon.handleEvent(event, parameters, INTEGRATION_ID);
+        const call = fetchRetryCalls[0];
+        expect(fetchRetryCalls.length).toBe(1);
+        expect(call.url).toBe(parameters.url);
+        expect(call.options.headers.Authorization).toBe(
+            parameters.authorization,
+        );
+        expect(call.options.headers.MY_CUSTOM_HEADER).toBe('MY_CUSTOM_VALUE');
+        expect(call.options.body).toBe('feature-created on toggle some-toggle');
+    });
+
+    test('Should call registerEvent', async () => {
+        const addon = new WebhookAddon(ARGS);
+        const event: IEvent = {
+            id: 1,
+            createdAt: new Date(),
+            createdByUserId: SYSTEM_USER_ID,
+            type: FEATURE_CREATED,
+            createdBy: 'some@user.com',
+            featureName: 'some-toggle',
+            data: {
+                name: 'some-toggle',
+                enabled: false,
+                strategies: [{ name: 'default' }],
+            },
+        };
+
+        const parameters = {
+            url: 'http://test.webhook.com/plain',
+            bodyTemplate: '{{event.type}} on toggle {{event.data.name}}',
+            contentType: 'text/plain',
+            authorization: 'API KEY 123abc',
+            customHeaders: `{ "MY_CUSTOM_HEADER": "MY_CUSTOM_VALUE" }`,
+        };
+
+        await addon.handleEvent(event, parameters, INTEGRATION_ID);
+
+        expect(registerEventMock).toHaveBeenCalledTimes(1);
+        expect(registerEventMock).toHaveBeenCalledWith({
+            integrationId: INTEGRATION_ID,
+            state: 'success',
+            stateDetails:
+                'Webhook request was successful with status code: 200',
+            event: serializeDates(event),
+            details: {
+                url: parameters.url,
+                contentType: parameters.contentType,
+                body: 'feature-created on toggle some-toggle',
+            },
+        });
+    });
 });

--- a/src/lib/addons/webhook.ts
+++ b/src/lib/addons/webhook.ts
@@ -1,8 +1,9 @@
 import Mustache from 'mustache';
 import Addon from './addon';
 import definition from './webhook-definition';
-import type { LogProvider } from '../logger';
 import type { IEvent } from '../types/events';
+import { type IAddonConfig, serializeDates } from '../types';
+import type { IntegrationEventState } from '../features/integration-events/integration-events-store';
 
 interface IParameters {
     url: string;
@@ -13,11 +14,18 @@ interface IParameters {
 }
 
 export default class Webhook extends Addon {
-    constructor(args: { getLogger: LogProvider }) {
+    constructor(args: IAddonConfig) {
         super(definition, args);
     }
 
-    async handleEvent(event: IEvent, parameters: IParameters): Promise<void> {
+    async handleEvent(
+        event: IEvent,
+        parameters: IParameters,
+        integrationId: number,
+    ): Promise<void> {
+        let state: IntegrationEventState = 'success';
+        let stateDetails = '';
+
         const { url, bodyTemplate, contentType, authorization, customHeaders } =
             parameters;
         const context = {
@@ -39,9 +47,9 @@ export default class Webhook extends Addon {
             try {
                 extraHeaders = JSON.parse(customHeaders);
             } catch (e) {
-                this.logger.warn(
-                    `Could not parse the json in the customHeaders parameter. [${customHeaders}]`,
-                );
+                state = 'successWithErrors';
+                stateDetails =
+                    'Could not parse the JSON in the customHeaders parameter.';
             }
         }
         const requestOpts = {
@@ -58,5 +66,24 @@ export default class Webhook extends Addon {
         this.logger.info(
             `Handled event "${event.type}". Status code: ${res.status}`,
         );
+
+        if (res.ok) {
+            stateDetails = `Webhook request was successful with status code: ${res.status}`;
+        } else {
+            state = 'failed';
+            stateDetails = `Webhook request failed with status code: ${res.status}`;
+        }
+
+        this.registerEvent({
+            integrationId,
+            state,
+            stateDetails,
+            event: serializeDates(event),
+            details: {
+                url,
+                contentType,
+                body,
+            },
+        });
     }
 }

--- a/src/lib/addons/webhook.ts
+++ b/src/lib/addons/webhook.ts
@@ -50,6 +50,7 @@ export default class Webhook extends Addon {
                 state = 'successWithErrors';
                 stateDetails =
                     'Could not parse the JSON in the customHeaders parameter.';
+                this.logger.warn(stateDetails);
             }
         }
         const requestOpts = {

--- a/src/lib/features/integration-events/integration-events-store.ts
+++ b/src/lib/features/integration-events/integration-events-store.ts
@@ -7,6 +7,8 @@ export type IntegrationEventWriteModel = Omit<
     'id' | 'createdAt'
 >;
 
+export type IntegrationEventState = IntegrationEventWriteModel['state'];
+
 export class IntegrationEventsStore extends CRUDStore<
     IntegrationEventSchema,
     IntegrationEventWriteModel

--- a/src/lib/services/addon-service-test-simple-addon.ts
+++ b/src/lib/services/addon-service-test-simple-addon.ts
@@ -12,7 +12,7 @@ import type { IFlagResolver, IntegrationEventsService } from '../internals';
 
 const ARGS: IAddonConfig = {
     getLogger,
-    unleashUrl: 'http://some-unleash-url',
+    unleashUrl: 'http://some-url.com',
     integrationEventsService: {} as IntegrationEventsService,
     flagResolver: {} as IFlagResolver,
 };

--- a/src/lib/services/addon-service-test-simple-addon.ts
+++ b/src/lib/services/addon-service-test-simple-addon.ts
@@ -1,6 +1,6 @@
 import Addon from '../addons/addon';
 import getLogger from '../../test/fixtures/no-logger';
-import type { IAddonDefinition } from '../types/model';
+import type { IAddonConfig, IAddonDefinition } from '../types/model';
 import {
     FEATURE_ARCHIVED,
     FEATURE_CREATED,
@@ -8,6 +8,14 @@ import {
     FEATURE_UPDATED,
     type IEvent,
 } from '../types/events';
+import type { IFlagResolver, IntegrationEventsService } from '../internals';
+
+const ARGS: IAddonConfig = {
+    getLogger,
+    unleashUrl: 'http://some-unleash-url',
+    integrationEventsService: {} as IntegrationEventsService,
+    flagResolver: {} as IFlagResolver,
+};
 
 const definition: IAddonDefinition = {
     name: 'simple',
@@ -57,7 +65,7 @@ export default class SimpleAddon extends Addon {
     events: any[];
 
     constructor() {
-        super(definition, { getLogger });
+        super(definition, ARGS);
         this.events = [];
     }
 

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -15,8 +15,9 @@ import type { IAddonDto } from '../types/stores/addon-store';
 import SimpleAddon from './addon-service-test-simple-addon';
 import type { IAddonProviders } from '../addons';
 import EventService from '../features/events/event-service';
-import { SYSTEM_USER, TEST_AUDIT_USER } from '../types';
+import { type IFlagResolver, SYSTEM_USER, TEST_AUDIT_USER } from '../types';
 import EventEmitter from 'node:events';
+import { IntegrationEventsService } from '../internals';
 
 const MASKED_VALUE = '*****';
 
@@ -35,6 +36,10 @@ function getSetup() {
         { getLogger },
         eventService,
     );
+    const integrationEventsService = new IntegrationEventsService(stores, {
+        getLogger,
+        flagResolver: {} as IFlagResolver,
+    });
 
     addonProvider = { simple: new SimpleAddon() };
     return {
@@ -47,6 +52,7 @@ function getSetup() {
             },
             tagTypeService,
             eventService,
+            integrationEventsService,
             addonProvider,
         ),
         eventService,

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -67,6 +67,7 @@ export default class AddonService {
         }: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>,
         tagTypeService: TagTypeService,
         eventService: EventService,
+        integrationEventsService,
         addons?: IAddonProviders,
     ) {
         this.addonStore = addonStore;
@@ -80,6 +81,7 @@ export default class AddonService {
             getAddons({
                 getLogger,
                 unleashUrl: server.unleashUrl,
+                integrationEventsService,
                 flagResolver,
             });
         this.sensitiveParams = this.loadSensitiveParams(this.addonProviders);
@@ -145,6 +147,7 @@ export default class AddonService {
                         addonProviders[addon.provider].handleEvent(
                             event,
                             addon.parameters,
+                            addon.id,
                         ),
                     );
             });

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -201,6 +201,7 @@ export const createServices = (
         config,
         tagTypeService,
         eventService,
+        integrationEventsService,
     );
     const sessionService = new SessionService(stores, config);
     const settingService = new SettingService(stores, config, eventService);

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -7,6 +7,8 @@ import type { IProjectStats } from '../features/project/project-service';
 import type { CreateFeatureStrategySchema } from '../openapi';
 import type { ProjectEnvironment } from '../features/project/project-store-type';
 import type { FeatureSearchEnvironmentSchema } from '../openapi/spec/feature-search-environment-schema';
+import type { IntegrationEventsService } from '../features/integration-events/integration-events-service';
+import type { IFlagResolver } from './experimental';
 
 export type Operator = (typeof ALL_OPERATORS)[number];
 
@@ -376,6 +378,8 @@ export interface IAddonAlert {
 export interface IAddonConfig {
     getLogger: LogProvider;
     unleashUrl: string;
+    integrationEventsService: IntegrationEventsService;
+    flagResolver: IFlagResolver;
 }
 
 export interface IUserWithRole {

--- a/src/test/e2e/services/addon-service.e2e.test.ts
+++ b/src/test/e2e/services/addon-service.e2e.test.ts
@@ -7,7 +7,7 @@ import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import SimpleAddon from '../../../lib/services/addon-service-test-simple-addon';
 import TagTypeService from '../../../lib/features/tag-type/tag-type-service';
 import { FEATURE_CREATED } from '../../../lib/types/events';
-import { EventService } from '../../../lib/services';
+import { EventService, IntegrationEventsService } from '../../../lib/services';
 
 const addonProvider = { simple: new SimpleAddon() };
 
@@ -24,11 +24,16 @@ beforeAll(async () => {
     stores = db.stores;
     const eventService = new EventService(stores, config);
     const tagTypeService = new TagTypeService(stores, config, eventService);
+    const integrationEventsService = new IntegrationEventsService(
+        stores,
+        config,
+    );
     addonService = new AddonService(
         stores,
         config,
         tagTypeService,
         eventService,
+        integrationEventsService,
         addonProvider,
     );
 });


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2450/register-integration-events-webhook

Registers integration events in the **Webhook** integration.

Even though this touches a lot of files, most of it is preparation for the next steps. The only actual implementation of registering integration events is in the **Webhook** integration. The rest will follow on separate PRs.

Here's an example of how this looks like in the database table:

```json
{
  "id": 7,
  "integration_id": 2,
  "created_at": "2024-07-18T18:11:11.376348+01:00",
  "state": "failed",
  "state_details": "Webhook request failed with status code: ECONNREFUSED",
  "event": {
    "id": 130,
    "data": null,
    "tags": [],
    "type": "feature-environment-enabled",
    "preData": null,
    "project": "default",
    "createdAt": "2024-07-18T17:11:10.821Z",
    "createdBy": "admin",
    "environment": "development",
    "featureName": "test",
    "createdByUserId": 1
  },
  "details": {
    "url": "http://localhost:1337",
    "body": "{ \"id\": 130, \"type\": \"feature-environment-enabled\", \"createdBy\": \"admin\", \"createdAt\": \"2024-07-18T17: 11: 10.821Z\", \"createdByUserId\": 1, \"data\": null, \"preData\": null, \"tags\": [], \"featureName\": \"test\", \"project\": \"default\", \"environment\": \"development\" }"
  }
}
```