### PR TITLE
feat: allow you to gradually scale back constraint usage

### DIFF
--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -219,5 +219,10 @@ export const createFakeFeatureToggleService = (config: IUnleashConfig) => {
         dependentFeaturesService,
         featureLifecycleReadModel,
     );
-    return { featureToggleService, featureToggleStore, projectStore };
+    return {
+        featureToggleService,
+        featureToggleStore,
+        projectStore,
+        featureStrategiesStore,
+    };
 };

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -391,16 +391,15 @@ class FeatureToggleService {
     }
 
     validateConstraintsLimit(constraints: {
-        updatedConstraints: IConstraint[];
-        existingConstraints: IConstraint[];
+        updated: IConstraint[];
+        existing: IConstraint[];
     }) {
         if (!this.flagResolver.isEnabled('resourceLimits')) return;
 
         const constraintsLimit = this.resourceLimits.constraints;
         if (
-            constraints.updatedConstraints.length > constraintsLimit &&
-            constraints.updatedConstraints.length >
-                constraints.existingConstraints.length
+            constraints.updated.length > constraintsLimit &&
+            constraints.updated.length > constraints.existing.length
         ) {
             throwExceedsLimitError(this.eventBus, {
                 resource: `constraints`,
@@ -409,7 +408,7 @@ class FeatureToggleService {
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
-        const constraintOverLimit = constraints.updatedConstraints.find(
+        const constraintOverLimit = constraints.updated.find(
             (constraint) =>
                 Array.isArray(constraint.values) &&
                 constraint.values?.length > constraintValuesLimit,
@@ -669,8 +668,8 @@ class FeatureToggleService {
             strategyConfig.constraints.length > 0
         ) {
             this.validateConstraintsLimit({
-                updatedConstraints: strategyConfig.constraints,
-                existingConstraints: [],
+                updated: strategyConfig.constraints,
+                existing: [],
             });
             strategyConfig.constraints = await this.validateConstraints(
                 strategyConfig.constraints,
@@ -831,8 +830,8 @@ class FeatureToggleService {
         if (existingStrategy.id === id) {
             if (updates.constraints && updates.constraints.length > 0) {
                 this.validateConstraintsLimit({
-                    updatedConstraints: updates.constraints,
-                    existingConstraints: existingStrategy.constraints,
+                    updated: updates.constraints,
+                    existing: existingStrategy.constraints,
                 });
                 updates.constraints = await this.validateConstraints(
                     updates.constraints,

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -390,11 +390,17 @@ class FeatureToggleService {
         }
     }
 
-    validateConstraintsLimit(updatedConstraints: IConstraint[]) {
+    validateConstraintsLimit(
+        updatedConstraints: IConstraint[],
+        existingConstraints: IConstraint[],
+    ) {
         if (!this.flagResolver.isEnabled('resourceLimits')) return;
 
         const constraintsLimit = this.resourceLimits.constraints;
-        if (updatedConstraints.length > constraintsLimit) {
+        if (
+            updatedConstraints.length > constraintsLimit &&
+            updatedConstraints.length > existingConstraints.length
+        ) {
             throwExceedsLimitError(this.eventBus, {
                 resource: `constraints`,
                 limit: constraintsLimit,
@@ -661,7 +667,7 @@ class FeatureToggleService {
             strategyConfig.constraints &&
             strategyConfig.constraints.length > 0
         ) {
-            this.validateConstraintsLimit(strategyConfig.constraints);
+            this.validateConstraintsLimit(strategyConfig.constraints, []);
             strategyConfig.constraints = await this.validateConstraints(
                 strategyConfig.constraints,
             );
@@ -820,7 +826,10 @@ class FeatureToggleService {
 
         if (existingStrategy.id === id) {
             if (updates.constraints && updates.constraints.length > 0) {
-                this.validateConstraintsLimit(updates.constraints);
+                this.validateConstraintsLimit(
+                    updates.constraints,
+                    existingStrategy.constraints,
+                );
                 updates.constraints = await this.validateConstraints(
                     updates.constraints,
                 );

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -390,16 +390,17 @@ class FeatureToggleService {
         }
     }
 
-    validateConstraintsLimit(
-        updatedConstraints: IConstraint[],
-        existingConstraints: IConstraint[],
-    ) {
+    validateConstraintsLimit(constraints: {
+        updatedConstraints: IConstraint[];
+        existingConstraints: IConstraint[];
+    }) {
         if (!this.flagResolver.isEnabled('resourceLimits')) return;
 
         const constraintsLimit = this.resourceLimits.constraints;
         if (
-            updatedConstraints.length > constraintsLimit &&
-            updatedConstraints.length > existingConstraints.length
+            constraints.updatedConstraints.length > constraintsLimit &&
+            constraints.updatedConstraints.length >
+                constraints.existingConstraints.length
         ) {
             throwExceedsLimitError(this.eventBus, {
                 resource: `constraints`,
@@ -408,7 +409,7 @@ class FeatureToggleService {
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
-        const constraintOverLimit = updatedConstraints.find(
+        const constraintOverLimit = constraints.updatedConstraints.find(
             (constraint) =>
                 Array.isArray(constraint.values) &&
                 constraint.values?.length > constraintValuesLimit,
@@ -667,7 +668,10 @@ class FeatureToggleService {
             strategyConfig.constraints &&
             strategyConfig.constraints.length > 0
         ) {
-            this.validateConstraintsLimit(strategyConfig.constraints, []);
+            this.validateConstraintsLimit({
+                updatedConstraints: strategyConfig.constraints,
+                existingConstraints: [],
+            });
             strategyConfig.constraints = await this.validateConstraints(
                 strategyConfig.constraints,
             );
@@ -826,10 +830,10 @@ class FeatureToggleService {
 
         if (existingStrategy.id === id) {
             if (updates.constraints && updates.constraints.length > 0) {
-                this.validateConstraintsLimit(
-                    updates.constraints,
-                    existingStrategy.constraints,
-                );
+                this.validateConstraintsLimit({
+                    updatedConstraints: updates.constraints,
+                    existingConstraints: existingStrategy.constraints,
+                });
                 updates.constraints = await this.validateConstraints(
                     updates.constraints,
                 );

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -390,7 +390,7 @@ class FeatureToggleService {
         }
     }
 
-    validateConstraintsLimit(constraints: {
+    private validateConstraintsLimit(constraints: {
         updated: IConstraint[];
         existing: IConstraint[];
     }) {

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -390,11 +390,11 @@ class FeatureToggleService {
         }
     }
 
-    validateConstraintsLimit(updatedConstrains: IConstraint[]) {
+    validateConstraintsLimit(updatedConstraints: IConstraint[]) {
         if (!this.flagResolver.isEnabled('resourceLimits')) return;
 
         const constraintsLimit = this.resourceLimits.constraints;
-        if (updatedConstrains.length > constraintsLimit) {
+        if (updatedConstraints.length > constraintsLimit) {
             throwExceedsLimitError(this.eventBus, {
                 resource: `constraints`,
                 limit: constraintsLimit,
@@ -402,7 +402,7 @@ class FeatureToggleService {
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
-        const constraintOverLimit = updatedConstrains.find(
+        const constraintOverLimit = updatedConstraints.find(
             (constraint) =>
                 Array.isArray(constraint.values) &&
                 constraint.values?.length > constraintValuesLimit,

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -94,17 +94,14 @@ describe('Strategy limits', () => {
 
     test('Should not throw limit exceeded errors if the new number of constraints is less than or equal to the previous number', async () => {
         const LIMIT = 1;
-        const {
-            featureToggleService,
-            featureToggleStore,
-            featureStrategiesStore,
-        } = createFakeFeatureToggleService({
-            getLogger,
-            flagResolver: alwaysOnFlagResolver,
-            resourceLimits: {
-                constraints: LIMIT,
-            },
-        } as unknown as IUnleashConfig);
+        const { featureToggleService, featureStrategiesStore } =
+            createFakeFeatureToggleService({
+                getLogger,
+                flagResolver: alwaysOnFlagResolver,
+                resourceLimits: {
+                    constraints: LIMIT,
+                },
+            } as unknown as IUnleashConfig);
 
         const constraints: IConstraint[] = [
             {
@@ -124,29 +121,25 @@ describe('Strategy limits', () => {
             },
         ];
 
-        await featureToggleStore.create('default', {
-            name: 'feature',
-            createdByUserId: 1,
-        });
+        const flagName = 'feature';
+
         await featureStrategiesStore.createFeature({
-            name: 'feature',
+            name: flagName,
             createdByUserId: 1,
         });
 
-        const strat = await featureStrategiesStore.createStrategyFeatureEnv({
+        const strategy = await featureStrategiesStore.createStrategyFeatureEnv({
             parameters: {},
             strategyName: 'default',
-            featureName: 'feature',
+            featureName: flagName,
             constraints: constraints,
             projectId: 'default',
             environment: 'default',
         });
 
-        console.log('created strat', strat);
-
         const updateStrategy = (newConstraints) =>
             featureToggleService.unprotectedUpdateStrategy(
-                strat.id,
+                strategy.id,
                 {
                     constraints: newConstraints,
                 },

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -91,7 +91,7 @@ describe('Strategy limits', () => {
         );
     });
 
-    test("Should allow you to save a value that's above the limit, as long as it is no more than the previous value", () => {
+    test('Should not throw limit exceeded errors if the new number of constraints is less than or equal to the previous number', () => {
         const LIMIT = 1;
         const { featureToggleService } = createFakeFeatureToggleService({
             getLogger,

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -93,8 +93,6 @@ describe('Strategy limits', () => {
     });
 
     test('Should not throw limit exceeded errors if the new number of constraints is less than or equal to the previous number', async () => {
-        let activateResourceLimits = false;
-
         const LIMIT = 1;
         const {
             featureToggleService,
@@ -102,11 +100,7 @@ describe('Strategy limits', () => {
             featureStrategiesStore,
         } = createFakeFeatureToggleService({
             getLogger,
-            flagResolver: {
-                isEnabled() {
-                    return activateResourceLimits;
-                },
-            },
+            flagResolver: alwaysOnFlagResolver,
             resourceLimits: {
                 constraints: LIMIT,
             },
@@ -139,17 +133,16 @@ describe('Strategy limits', () => {
             createdByUserId: 1,
         });
 
-        const strat = await featureToggleService.unprotectedCreateStrategy(
-            {
-                name: 'default',
-                featureName: 'feature',
-                constraints: constraints,
-            } as IStrategyConfig,
-            { projectId: 'default', featureName: 'feature' } as any,
-            {} as IAuditUser,
-        );
+        const strat = await featureStrategiesStore.createStrategyFeatureEnv({
+            parameters: {},
+            strategyName: 'default',
+            featureName: 'feature',
+            constraints: constraints,
+            projectId: 'default',
+            environment: 'default',
+        });
 
-        activateResourceLimits = true;
+        console.log('created strat', strat);
 
         const updateStrategy = (newConstraints) =>
             featureToggleService.unprotectedUpdateStrategy(

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -119,11 +119,14 @@ describe('Strategy limits', () => {
             },
         ];
 
-        featureToggleService.validateConstraintsLimit(constraints, constraints);
-        featureToggleService.validateConstraintsLimit(
-            constraints.slice(0, 2),
-            constraints,
-        );
+        featureToggleService.validateConstraintsLimit({
+            updatedConstraints: constraints,
+            existingConstraints: constraints,
+        });
+        featureToggleService.validateConstraintsLimit({
+            updatedConstraints: constraints.slice(0, 2),
+            existingConstraints: constraints,
+        });
     });
 
     test('Should not allow to exceed constraint values limit', async () => {

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.limit.test.ts
@@ -120,12 +120,12 @@ describe('Strategy limits', () => {
         ];
 
         featureToggleService.validateConstraintsLimit({
-            updatedConstraints: constraints,
-            existingConstraints: constraints,
+            updated: constraints,
+            existing: constraints,
         });
         featureToggleService.validateConstraintsLimit({
-            updatedConstraints: constraints.slice(0, 2),
-            existingConstraints: constraints,
+            updated: constraints.slice(0, 2),
+            existing: constraints,
         });
     });
 


### PR DESCRIPTION
This PR updates the limit validation for constraint numbers on a single strategy. In cases where you're already above the limit, it allows you to still update the strategy as long as you don't add any **new** constraints (that is: the number of constraints doesn't increase).

A discussion point: I've only tested this with unit tests of the method directly. I haven't tested that the right parameters are passed in from calling functions. The main reason being that that would involve updating the fake strategy and feature stores to sync their flag lists (or just checking that the thrown error isn't a limit exceeded error), because right now the fake strategy store throws an error when it doesn't find the flag I want to update.