### PR TITLE
chore: allow you to lower constraint values even when they're above limit

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -408,10 +408,23 @@ class FeatureToggleService {
         }
 
         const constraintValuesLimit = this.resourceLimits.constraintValues;
+        const coompareWithExistingValues =
+            constraints.existing.length === constraints.updated.length;
         const constraintOverLimit = constraints.updated.find(
-            (constraint) =>
-                Array.isArray(constraint.values) &&
-                constraint.values?.length > constraintValuesLimit,
+            (constraint, i) => {
+                const updatedConstraintValueCount =
+                    constraint.values?.length ?? 0;
+                const overLimit =
+                    Array.isArray(constraint.values) &&
+                    updatedConstraintValueCount > constraintValuesLimit;
+                if (!overLimit) return false;
+                const allowAnyway = coompareWithExistingValues
+                    ? (constraints.existing[i].values?.length ?? 0) >=
+                      updatedConstraintValueCount
+                    : false;
+
+                return !allowAnyway;
+            },
         );
         if (constraintOverLimit) {
             throwExceedsLimitError(this.eventBus, {


### PR DESCRIPTION
This PR allows you to gradually lower constraint values, even if they're above the limits.

It does, however, come with a few caveats because of how Unleash deals with constraints:
Constraints are just json blobs. They have no IDs or other distinguishing features. Because of this, we can't compare the current and previous state of a specific constraint.

What we can do instead, is to allow you to lower the amount of constraint values if and only if the number of constraints hasn't changed. In this case, we assume that you also haven't reordered the constraints (not possible from the UI today). That way, we can compare constraint values between updated and existing constraints based on their index in the constraint list.

It's not foolproof, but it's a workaround that you can use. There's a few edge cases that pop up, but that I don't think it's worth trying to cover:

Case: If you **both** have too many constraints **and** too many constraint values
Result: You won't be allowed to lower the amount of constraints as long as the amount of strategy values is still above the limit.
Workaround: First, lower the amount of constraint values until you're under the limit and then lower constraints. OR, set the constraint you want to delete to a constraint that is trivially true (e.g. `currentTime > yesterday` ). That will essentially take that constraint out of the equation, achieving the same end result.

Case: You re-order constraints and at least one of them has too many values
Result: You won't be allowed to (except for in the edge case where the one with too many values doesn't move or switches places with another one with the exact same amount of values).
Workaround: We don't need one. The order of constraints has no effect on the evaluation.