### PR TITLE
chore: extend uiConfig schema with new SSO variables

### DIFF
--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -168,6 +168,18 @@ export const uiConfigSchema = {
         versionInfo: {
             $ref: '#/components/schemas/versionSchema',
         },
+        oidcConfiguredThroughEnv: {
+            type: 'boolean',
+            description:
+                'Whether the OIDC configuration is set through environment variables or not.',
+            example: false,
+        },
+        samlConfiguredThroughEnv: {
+            type: 'boolean',
+            description:
+                'Whether the SAML configuration is set through environment variables or not.',
+            example: false,
+        },
     },
     components: {
         schemas: {


### PR DESCRIPTION
As the title says. Adds two new nullable variables to uiConfig. Used in frontend to decide if SSO config is editable through the GUI