### PR TITLE
fix: change "features flags" -> "feature flags"

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -63,7 +63,7 @@ const OPENAPI_TAGS = [
     {
         name: 'Features',
         description:
-            'Create, update, and delete [features flags](https://docs.getunleash.io/reference/feature-toggles).',
+            'Create, update, and delete [feature flags](https://docs.getunleash.io/reference/feature-toggles).',
     },
     {
         name: 'Frontend API',


### PR DESCRIPTION
This typo has been around since the tag was introduced. About time we fixed it.