### PR TITLE
chore: don't ask OSS users to reach out to CS

### DIFF
--- a/frontend/src/component/common/Limit/Limit.tsx
+++ b/frontend/src/component/common/Limit/Limit.tsx
@@ -6,6 +6,7 @@ import ErrorIcon from '@mui/icons-material/Cancel';
 import CloseIcon from '@mui/icons-material/Close';
 import type { FC } from 'react';
 import { ConditionallyRender } from '../ConditionallyRender/ConditionallyRender';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -70,6 +71,7 @@ export const Limit: FC<{
     onClose?: () => void;
     className?: string;
 }> = ({ name, shortName, limit, currentValue, onClose, className }) => {
+    const { isOss } = useUiConfig();
     const percentageLimit = Math.floor((currentValue / limit) * 100);
     const belowLimit = currentValue < limit;
     const threshold = 80;
@@ -77,6 +79,21 @@ export const Limit: FC<{
     if (percentageLimit < threshold) {
         return null;
     }
+
+    const footerContent = isOss() ? (
+        <>
+            Need help with resource limits? Try the the{' '}
+            <a href='https://slack.unleash.run'>Unleash community Slack</a>.
+        </>
+    ) : (
+        <>
+            If you need more than <strong>{limit}</strong> {shortName ?? name},
+            please reach out to us at{' '}
+            <a href='mailto:cs@getunleash.io?subject=Increase limit'>
+                cs@getunleash.io
+            </a>
+        </>
+    );
 
     return (
         <StyledBox className={className}>
@@ -135,13 +152,7 @@ export const Limit: FC<{
                     <Typography fontWeight='bold'>Limit: {limit}</Typography>
                 </LimitExplanation>
             </Main>
-            <Footer>
-                If you need more than <strong>{limit}</strong>{' '}
-                {shortName ?? name}, please reach out to us at{' '}
-                <a href='mailto:cs@getunleash.io?subject=Increase limit'>
-                    cs@getunleash.io
-                </a>
-            </Footer>
+            <Footer>{footerContent}</Footer>
         </StyledBox>
     );
 };


### PR DESCRIPTION
The limit card says to contact cs@getunleash if you're at the limits,
but we probably don't want to show that to OSS customers (it's not
terrible, just not very helpful), so let's hide it for OSS.

Instead, we'll ask them to try the community slack.

Screenie:

![image](https://github.com/user-attachments/assets/5a5dc292-3878-4181-98ac-f1ce4583d8a3)
