### PR TITLE
fix: check for admin in signal endpoints hook

### DIFF
--- a/frontend/src/hooks/api/getters/useSignalEndpoints/useSignalEndpoints.ts
+++ b/frontend/src/hooks/api/getters/useSignalEndpoints/useSignalEndpoints.ts
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 import useUiConfig from '../useUiConfig/useUiConfig';
 import type { ISignalEndpoint } from 'interfaces/signal';
 import { useUiFlag } from 'hooks/useUiFlag';
+import AccessContext from 'contexts/AccessContext';
 
 const ENDPOINT = 'api/admin/signal-endpoints';
 
@@ -13,13 +14,14 @@ const DEFAULT_DATA = {
 };
 
 export const useSignalEndpoints = () => {
+    const { isAdmin } = useContext(AccessContext);
     const { isEnterprise } = useUiConfig();
     const signalsEnabled = useUiFlag('signals');
 
     const { data, error, mutate } = useConditionalSWR<{
         signalEndpoints: ISignalEndpoint[];
     }>(
-        isEnterprise() && signalsEnabled,
+        isEnterprise() && isAdmin && signalsEnabled,
         DEFAULT_DATA,
         formatApiPath(ENDPOINT),
         fetcher,


### PR DESCRIPTION
This avoids a 403 on `api/admin/signal-endpoints` for non-admins when browsing the integrations page.