### PR TITLE
fix: make collaborator component smaller.

### DIFF
--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -55,12 +55,19 @@ export const GroupCardAvatars = ({
     return <GroupCardAvatarsInner AvatarComponent={Avatar} {...props} />;
 };
 
+type GroupCardAvatarsInnerProps = Omit<
+    IGroupCardAvatarsProps,
+    'AvatarComponent'
+> & {
+    AvatarComponent: typeof UserAvatar;
+};
+
 const GroupCardAvatarsInner = ({
     users = [],
     header = null,
     avatarLimit = 9,
     AvatarComponent,
-}: IGroupCardAvatarsProps) => {
+}: GroupCardAvatarsInnerProps) => {
     const shownUsers = useMemo(
         () =>
             users

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -1,4 +1,4 @@
-import { type Theme, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { IGroupUser } from 'interfaces/group';
 import type React from 'react';
@@ -19,23 +19,14 @@ const StyledAvatars = styled('div')(({ theme }) => ({
     marginLeft: theme.spacing(1),
 }));
 
-const StyledAvatar = styled(UserAvatar, {
-    shouldForwardProp: (prop) => prop !== 'avatarDiameter',
-})<{ avatarDiameter?: (theme: Theme) => string }>(
-    ({ theme, avatarDiameter }) => ({
+const StyledAvatar = (component: typeof UserAvatar) =>
+    styled(component)(({ theme }) => ({
         outline: `${theme.spacing(0.25)} solid ${theme.palette.background.paper}`,
         marginLeft: theme.spacing(-1),
         '&:hover': {
             outlineColor: theme.palette.primary.main,
         },
-        ...(avatarDiameter
-            ? {
-                  width: avatarDiameter(theme),
-                  height: avatarDiameter(theme),
-              }
-            : {}),
-    }),
-);
+    }));
 
 const StyledHeader = styled('h3')(({ theme }) => ({
     margin: theme.spacing(0, 0, 1),
@@ -52,14 +43,14 @@ interface IGroupCardAvatarsProps {
     }[];
     header?: ReactNode;
     avatarLimit?: number;
-    avatarDiameter?: (theme: Theme) => string;
+    avatarComponent?: typeof UserAvatar;
 }
 
 export const GroupCardAvatars = ({
     users = [],
     header = null,
     avatarLimit = 9,
-    avatarDiameter,
+    avatarComponent,
 }: IGroupCardAvatarsProps) => {
     const shownUsers = useMemo(
         () =>
@@ -97,6 +88,8 @@ export const GroupCardAvatars = ({
 
     const avatarOpen = Boolean(anchorEl);
 
+    const Avatar = StyledAvatar(avatarComponent ?? UserAvatar);
+
     return (
         <StyledContainer>
             <ConditionallyRender
@@ -106,8 +99,7 @@ export const GroupCardAvatars = ({
             />
             <StyledAvatars>
                 {shownUsers.map((user) => (
-                    <StyledAvatar
-                        avatarDiameter={avatarDiameter}
+                    <Avatar
                         key={objectId(user)}
                         user={{ ...user, id: objectId(user) }}
                         onMouseEnter={(event) => {
@@ -119,11 +111,7 @@ export const GroupCardAvatars = ({
                 ))}
                 <ConditionallyRender
                     condition={users.length > avatarLimit}
-                    show={
-                        <StyledAvatar avatarDiameter={avatarDiameter}>
-                            +{users.length - shownUsers.length}
-                        </StyledAvatar>
-                    }
+                    show={<Avatar>+{users.length - shownUsers.length}</Avatar>}
                 />
                 <GroupPopover
                     open={avatarOpen}

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -28,6 +28,14 @@ const StyledAvatar = (component: typeof UserAvatar) =>
         },
     }));
 
+const StyledAvatarRaw = styled(UserAvatar)(({ theme }) => ({
+    outline: `${theme.spacing(0.25)} solid ${theme.palette.background.paper}`,
+    marginLeft: theme.spacing(-1),
+    '&:hover': {
+        outlineColor: theme.palette.primary.main,
+    },
+}));
+
 const StyledHeader = styled('h3')(({ theme }) => ({
     margin: theme.spacing(0, 0, 1),
     fontSize: theme.typography.caption.fontSize,
@@ -43,14 +51,20 @@ interface IGroupCardAvatarsProps {
     }[];
     header?: ReactNode;
     avatarLimit?: number;
-    avatarComponent?: typeof UserAvatar;
+    AvatarComponent?: typeof UserAvatar;
 }
+
+export const GCA = ({ AvatarComponent, ...props }: IGroupCardAvatarsProps) => {
+    const Avatar = StyledAvatar(AvatarComponent ?? UserAvatar);
+
+    return <GroupCardAvatars AvatarComponent={Avatar} {...props} />;
+};
 
 export const GroupCardAvatars = ({
     users = [],
     header = null,
     avatarLimit = 9,
-    avatarComponent,
+    AvatarComponent,
 }: IGroupCardAvatarsProps) => {
     const shownUsers = useMemo(
         () =>
@@ -79,6 +93,9 @@ export const GroupCardAvatars = ({
     }>();
 
     const onPopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+        if (event.currentTarget) {
+            console.log('event.currentTarget', event.currentTarget);
+        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -86,9 +103,8 @@ export const GroupCardAvatars = ({
         setAnchorEl(null);
     };
 
+    // console.log('anchorEl', anchorEl);
     const avatarOpen = Boolean(anchorEl);
-
-    const Avatar = StyledAvatar(avatarComponent ?? UserAvatar);
 
     return (
         <StyledContainer>
@@ -99,10 +115,11 @@ export const GroupCardAvatars = ({
             />
             <StyledAvatars>
                 {shownUsers.map((user) => (
-                    <Avatar
+                    <AvatarComponent
                         key={objectId(user)}
                         user={{ ...user, id: objectId(user) }}
-                        onMouseEnter={(event) => {
+                        onMouseEnter={(event: any) => {
+                            // console.log('mouse enter event', event);
                             onPopoverOpen(event);
                             setPopupUser(user);
                         }}
@@ -111,7 +128,11 @@ export const GroupCardAvatars = ({
                 ))}
                 <ConditionallyRender
                     condition={users.length > avatarLimit}
-                    show={<Avatar>+{users.length - shownUsers.length}</Avatar>}
+                    show={
+                        <AvatarComponent>
+                            +{users.length - shownUsers.length}
+                        </AvatarComponent>
+                    }
                 />
                 <GroupPopover
                     open={avatarOpen}

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -88,9 +88,6 @@ const GroupCardAvatarsInner = ({
     }>();
 
     const onPopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
-        if (event.currentTarget) {
-            console.log('event.currentTarget', event.currentTarget);
-        }
         setAnchorEl(event.currentTarget);
     };
 
@@ -98,7 +95,6 @@ const GroupCardAvatarsInner = ({
         setAnchorEl(null);
     };
 
-    // console.log('anchorEl', anchorEl);
     const avatarOpen = Boolean(anchorEl);
 
     return (
@@ -114,7 +110,6 @@ const GroupCardAvatarsInner = ({
                         key={objectId(user)}
                         user={{ ...user, id: objectId(user) }}
                         onMouseEnter={(event: any) => {
-                            // console.log('mouse enter event', event);
                             onPopoverOpen(event);
                             setPopupUser(user);
                         }}

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -28,14 +28,6 @@ const StyledAvatar = (component: typeof UserAvatar) =>
         },
     }));
 
-const StyledAvatarRaw = styled(UserAvatar)(({ theme }) => ({
-    outline: `${theme.spacing(0.25)} solid ${theme.palette.background.paper}`,
-    marginLeft: theme.spacing(-1),
-    '&:hover': {
-        outlineColor: theme.palette.primary.main,
-    },
-}));
-
 const StyledHeader = styled('h3')(({ theme }) => ({
     margin: theme.spacing(0, 0, 1),
     fontSize: theme.typography.caption.fontSize,
@@ -54,13 +46,16 @@ interface IGroupCardAvatarsProps {
     AvatarComponent?: typeof UserAvatar;
 }
 
-export const GCA = ({ AvatarComponent, ...props }: IGroupCardAvatarsProps) => {
+export const GroupCardAvatars = ({
+    AvatarComponent,
+    ...props
+}: IGroupCardAvatarsProps) => {
     const Avatar = StyledAvatar(AvatarComponent ?? UserAvatar);
 
-    return <GroupCardAvatars AvatarComponent={Avatar} {...props} />;
+    return <GroupCardAvatarsInner AvatarComponent={Avatar} {...props} />;
 };
 
-export const GroupCardAvatars = ({
+const GroupCardAvatarsInner = ({
     users = [],
     header = null,
     avatarLimit = 9,

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { type Theme, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { IGroupUser } from 'interfaces/group';
 import type React from 'react';
@@ -19,13 +19,23 @@ const StyledAvatars = styled('div')(({ theme }) => ({
     marginLeft: theme.spacing(1),
 }));
 
-const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
-    outline: `${theme.spacing(0.25)} solid ${theme.palette.background.paper}`,
-    marginLeft: theme.spacing(-1),
-    '&:hover': {
-        outlineColor: theme.palette.primary.main,
-    },
-}));
+const StyledAvatar = styled(UserAvatar, {
+    shouldForwardProp: (prop) => prop !== 'avatarDiameter',
+})<{ avatarDiameter?: (theme: Theme) => string }>(
+    ({ theme, avatarDiameter }) => ({
+        outline: `${theme.spacing(0.25)} solid ${theme.palette.background.paper}`,
+        marginLeft: theme.spacing(-1),
+        '&:hover': {
+            outlineColor: theme.palette.primary.main,
+        },
+        ...(avatarDiameter
+            ? {
+                  width: avatarDiameter(theme),
+                  height: avatarDiameter(theme),
+              }
+            : {}),
+    }),
+);
 
 const StyledHeader = styled('h3')(({ theme }) => ({
     margin: theme.spacing(0, 0, 1),
@@ -42,12 +52,14 @@ interface IGroupCardAvatarsProps {
     }[];
     header?: ReactNode;
     avatarLimit?: number;
+    avatarDiameter?: (theme: Theme) => string;
 }
 
 export const GroupCardAvatars = ({
     users = [],
     header = null,
     avatarLimit = 9,
+    avatarDiameter,
 }: IGroupCardAvatarsProps) => {
     const shownUsers = useMemo(
         () =>
@@ -95,6 +107,7 @@ export const GroupCardAvatars = ({
             <StyledAvatars>
                 {shownUsers.map((user) => (
                     <StyledAvatar
+                        avatarDiameter={avatarDiameter}
                         key={objectId(user)}
                         user={{ ...user, id: objectId(user) }}
                         onMouseEnter={(event) => {
@@ -107,7 +120,7 @@ export const GroupCardAvatars = ({
                 <ConditionallyRender
                     condition={users.length > avatarLimit}
                     show={
-                        <StyledAvatar>
+                        <StyledAvatar avatarDiameter={avatarDiameter}>
                             +{users.length - shownUsers.length}
                         </StyledAvatar>
                     }

--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -9,21 +9,15 @@ import type { IUser } from 'interfaces/user';
 import type { FC } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
-const StyledAvatar = styled(Avatar, {
-    shouldForwardProp: (prop) => prop !== 'avatarWidth',
-})<{ avatarWidth?: (theme: Theme) => string }>(({ theme, avatarWidth }) => {
-    const width = avatarWidth ? avatarWidth(theme) : theme.spacing(3.5);
-
-    return {
-        width,
-        height: width,
-        margin: 'auto',
-        backgroundColor: theme.palette.secondary.light,
-        color: theme.palette.text.primary,
-        fontSize: theme.fontSizes.smallerBody,
-        fontWeight: theme.fontWeight.bold,
-    };
-});
+const StyledAvatar = styled(Avatar)(({ theme }) => ({
+    width: theme.spacing(3.5),
+    height: theme.spacing(3.5),
+    margin: 'auto',
+    backgroundColor: theme.palette.secondary.light,
+    color: theme.palette.text.primary,
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.fontWeight.bold,
+}));
 
 export interface IUserAvatarProps extends AvatarProps {
     user?: Partial<
@@ -35,7 +29,6 @@ export interface IUserAvatarProps extends AvatarProps {
     onMouseLeave?: () => void;
     className?: string;
     sx?: SxProps<Theme>;
-    avatarWidth?: (theme: Theme) => string;
     hideTitle?: boolean;
 }
 

--- a/frontend/src/component/feature/FeatureView/Collaborators.tsx
+++ b/frontend/src/component/feature/FeatureView/Collaborators.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material';
-import { GroupCardAvatars } from 'component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars';
+import { GCA } from 'component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
 import type { FC } from 'react';
@@ -42,7 +43,10 @@ const LastModifiedBy: FC<LastModifiedByProps> = ({ id, name, imageUrl }) => {
     return (
         <LastModifiedByContainer>
             <span className='description'>Last modified by</span>
-            <StyledAvatar className='avatar' user={{ id, name, imageUrl }} />
+            <HtmlTooltip arrow describeChild className='avatar' title={name}>
+                <StyledAvatar user={{ id, name, imageUrl }} hideTitle />
+            </HtmlTooltip>
+
             <Link className='link' to='logs'>
                 view change
             </Link>
@@ -66,11 +70,7 @@ const CollaboratorList: FC<CollaboratorListProps> = ({ users }) => {
     return (
         <CollaboratorListContainer>
             <span className='description'>Collaborators</span>
-            <GroupCardAvatars
-                users={users}
-                avatarLimit={8}
-                avatarComponent={StyledAvatar}
-            />
+            <GCA users={users} avatarLimit={8} AvatarComponent={StyledAvatar} />
         </CollaboratorListContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureView/Collaborators.tsx
+++ b/frontend/src/component/feature/FeatureView/Collaborators.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material';
-import { GCA } from 'component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars';
+import { GroupCardAvatars } from 'component/admin/groups/GroupsList/GroupCard/GroupCardAvatars/NewGroupCardAvatars';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
@@ -70,7 +70,11 @@ const CollaboratorList: FC<CollaboratorListProps> = ({ users }) => {
     return (
         <CollaboratorListContainer>
             <span className='description'>Collaborators</span>
-            <GCA users={users} avatarLimit={8} AvatarComponent={StyledAvatar} />
+            <GroupCardAvatars
+                users={users}
+                avatarLimit={8}
+                AvatarComponent={StyledAvatar}
+            />
         </CollaboratorListContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureView/Collaborators.tsx
+++ b/frontend/src/component/feature/FeatureView/Collaborators.tsx
@@ -85,7 +85,6 @@ const Container = styled('article')(({ theme }) => ({
     gap: theme.spacing(10),
     alignItems: 'center',
     justifyContent: 'space-between',
-    fontSize: `calc(0.9 * ${theme.typography.body2.fontSize})`,
     [theme.breakpoints.down('xl')]: {
         display: 'none',
     },

--- a/frontend/src/component/feature/FeatureView/Collaborators.tsx
+++ b/frontend/src/component/feature/FeatureView/Collaborators.tsx
@@ -11,16 +11,21 @@ type LastModifiedByProps = {
     imageUrl: string;
 };
 
+const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+}));
+
 const LastModifiedByContainer = styled('div')(({ theme }) => ({
     display: 'grid',
     gridTemplateAreas: `
     'description description'
     'avatar link'
     `,
-    gap: theme.spacing(1),
+    rowGap: theme.spacing(0.5),
+    columnGap: theme.spacing(1),
     alignItems: 'center',
     height: 'min-content',
-    fontSize: theme.typography.body2.fontSize,
 
     '.description': {
         gridArea: 'description',
@@ -37,9 +42,9 @@ const LastModifiedBy: FC<LastModifiedByProps> = ({ id, name, imageUrl }) => {
     return (
         <LastModifiedByContainer>
             <span className='description'>Last modified by</span>
-            <UserAvatar className='avatar' user={{ id, name, imageUrl }} />
+            <StyledAvatar className='avatar' user={{ id, name, imageUrl }} />
             <Link className='link' to='logs'>
-                View change
+                view change
             </Link>
         </LastModifiedByContainer>
     );
@@ -52,17 +57,20 @@ type CollaboratorListProps = {
 const CollaboratorListContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'column',
-    gap: theme.spacing(1),
+    gap: theme.spacing(0.5),
     alignItems: 'flex-start',
     height: 'min-content',
-    fontSize: theme.typography.body2.fontSize,
 }));
 
 const CollaboratorList: FC<CollaboratorListProps> = ({ users }) => {
     return (
         <CollaboratorListContainer>
             <span className='description'>Collaborators</span>
-            <GroupCardAvatars users={users} avatarLimit={8} />
+            <GroupCardAvatars
+                users={users}
+                avatarLimit={8}
+                avatarComponent={StyledAvatar}
+            />
         </CollaboratorListContainer>
     );
 };
@@ -73,6 +81,7 @@ const Container = styled('article')(({ theme }) => ({
     gap: theme.spacing(10),
     alignItems: 'center',
     justifyContent: 'space-between',
+    fontSize: `calc(0.9 * ${theme.typography.body2.fontSize})`,
     [theme.breakpoints.down('xl')]: {
         display: 'none',
     },

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/AvatarCell.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/AvatarCell.tsx
@@ -1,4 +1,4 @@
-import { type Theme, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import type { FC } from 'react';
 import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
@@ -35,6 +35,11 @@ const StyledSecondaryText = styled('p')(({ theme }) => ({
     color: theme.palette.text.secondary,
 }));
 
+const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+}));
+
 export const AvatarCell =
     (onAvatarClick: (userId: number) => void): FC<AvatarCellProps> =>
     ({ row: { original } }) => {
@@ -67,14 +72,13 @@ export const AvatarCell =
                             </span>
                         </ScreenReaderOnly>
 
-                        <UserAvatar
+                        <StyledAvatar
                             hideTitle
                             user={{
                                 id: original.createdBy.id,
                                 name: original.createdBy.name,
                                 imageUrl: original.createdBy.imageUrl,
                             }}
-                            avatarWidth={(theme: Theme) => theme.spacing(3)}
                         />
                     </StyledAvatarButton>
                 </HtmlTooltip>


### PR DESCRIPTION
This PR makes the collaborator component smaller, bringing it more into line with what the sketches show.

To achieve this, we need to modify the group card avatars component a bit to allow you to somehow decide the size of the avatars. I opted to do this by allowing you to override the avatar component that gets passed in. We could also allow you to pass in `avatarDiameter` or something of the sort, but that felt clunkier and like more code.

It's worth noting, though, that you can't affect the avatar overlap from outside at the moment. This works fine when the avatars are the current size, but it might be trouble if you make them tiny. However, there's no reason why we would do that, so I think it's fine for now. We could do something like use CSS custom properties that you have to set, but that feels like it'd break easily, or we could pass in extra react props, but nah.

Updated component in context:
![image](https://github.com/user-attachments/assets/f392cca9-7fdb-456b-8dd4-437352fde6e7)

Previous iteration:
![image](https://github.com/user-attachments/assets/7141d480-7f9c-47c6-a1f8-be654523e2c2)

Sketches:
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/f2483c39-730e-4565-bd05-ac558771dcd5">
