### PR TITLE
feat: separate command bar and search hotkeys

### DIFF
--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -134,8 +134,8 @@ export const Search = ({
 
     const hotkey = useKeyboardShortcut(
         {
-            modifiers: ['ctrl'],
-            key: 'k',
+            modifiers: ['ctrl', 'shift'],
+            key: 'K',
             preventDefault: true,
         },
         () => {

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -53,14 +53,14 @@ exports[`renders an empty list correctly 1`] = `
                     onClick={[Function]}
                   >
                     <input
-                      aria-label="Search (Ctrl+K)"
+                      aria-label="Search (Ctrl+Shift+K)"
                       className="MuiInputBase-input css-mfsqjb-MuiInputBase-input"
                       data-testid="SEARCH_INPUT"
                       onAnimationStart={[Function]}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
-                      placeholder="Search (Ctrl+K)"
+                      placeholder="Search (Ctrl+Shift+K)"
                       type="text"
                       value=""
                     />

--- a/frontend/src/hooks/useKeyboardShortcut.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.ts
@@ -19,6 +19,7 @@ export const useKeyboardShortcut = (
             if (key !== event.key) {
                 return;
             }
+
             if (modifiers.includes('ctrl')) {
                 if (isAppleDevice) {
                     if (!event.metaKey) {

--- a/frontend/src/hooks/useKeyboardShortcut.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.ts
@@ -19,7 +19,6 @@ export const useKeyboardShortcut = (
             if (key !== event.key) {
                 return;
             }
-
             if (modifiers.includes('ctrl')) {
                 if (isAppleDevice) {
                     if (!event.metaKey) {


### PR DESCRIPTION
Currently, the command bar and search hotkeys are conflicting. I am now separating them and assigning search an extra modifier key: Shift.