### PR TITLE
chore: keep latest integration events for each integration configuration

### DIFF
--- a/frontend/src/component/integrations/IntegrationEventsModal/IntegrationEventsModal.tsx
+++ b/frontend/src/component/integrations/IntegrationEventsModal/IntegrationEventsModal.tsx
@@ -105,8 +105,10 @@ export const IntegrationEventsModal = ({
                     </StyledHeaderRow>
                     <StyledHeaderRow>
                         <StyledSubtitle>
-                            All events older than the last 100 or older than the
-                            past 2 hours will be automatically deleted.
+                            Except for the most recent event for each
+                            integration, all events older than the last 100 or
+                            older than the past 2 hours will be automatically
+                            deleted.
                         </StyledSubtitle>
                     </StyledHeaderRow>
                 </StyledHeader>

--- a/frontend/src/component/integrations/IntegrationEventsModal/IntegrationEventsModal.tsx
+++ b/frontend/src/component/integrations/IntegrationEventsModal/IntegrationEventsModal.tsx
@@ -105,9 +105,9 @@ export const IntegrationEventsModal = ({
                     </StyledHeaderRow>
                     <StyledHeaderRow>
                         <StyledSubtitle>
-                            Except for the most recent event for each
-                            integration, all events older than the last 100 or
-                            older than the past 2 hours will be automatically
+                            Only the most recent event for each integration and
+                            the last 100 events from the past 2 hours will be
+                            kept. All other events will be automatically
                             deleted.
                         </StyledSubtitle>
                     </StyledHeaderRow>

--- a/src/lib/features/integration-events/integration-events-store.ts
+++ b/src/lib/features/integration-events/integration-events-store.ts
@@ -41,11 +41,21 @@ export class IntegrationEventsStore extends CRUDStore<
                 qb.select('id')
                     .from(this.tableName)
                     .whereRaw(`created_at >= now() - INTERVAL '2 hours'`)
-                    .orderBy('created_at', 'desc')
+                    .orderBy('id', 'desc')
                     .limit(100);
+            })
+            .with('latest_per_integration', (qb) => {
+                qb.select(this.db.raw('DISTINCT ON (integration_id) id'))
+                    .from(this.tableName)
+                    .orderBy('integration_id')
+                    .orderBy('id', 'desc');
             })
             .from(this.tableName)
             .whereNotIn('id', this.db.select('id').from('latest_events'))
+            .whereNotIn(
+                'id',
+                this.db.select('id').from('latest_per_integration'),
+            )
             .delete();
     }
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2469/keep-the-latest-event-for-each-integration-configuration

This makes it so we keep the latest event for each integration configuration, along with the previous logic of keeping the latest 100 events of the last 2 hours. 

This should be a cheap nice-to-have, since now we can always know what the latest integration event looked like. This will tie-in nicely with the next task of making the latest integration event state visible in the integration card.

Also improved the clarity of auto-deletion explanation in the modal.