### PR TITLE
docs: add new android sdk readme

### DIFF
--- a/website/remote-content/sdks.js
+++ b/website/remote-content/sdks.js
@@ -55,6 +55,10 @@ const serverSideSdks = {
 
 const clientSideSdks = {
     'unleash-android-proxy-sdk': {
+        sidebarName: 'Android (legacy)',
+        slugName: 'legacy-android-proxy',
+    },
+    'unleash-android': {
         sidebarName: 'Android',
         slugName: 'android-proxy',
     },

--- a/website/remote-content/sdks.js
+++ b/website/remote-content/sdks.js
@@ -56,7 +56,7 @@ const serverSideSdks = {
 const clientSideSdks = {
     'unleash-android-proxy-sdk': {
         sidebarName: 'Android (legacy)',
-        slugName: 'legacy-android-proxy',
+        slugName: 'android-proxy-legacy',
     },
     'unleash-android': {
         sidebarName: 'Android',


### PR DESCRIPTION
This will download the README of the new SDK from the remote location based on this:
https://github.com/Unleash/unleash/blob/1e3c6901850e1719f870dae08350ef806564e038/website/docusaurus.config.js#L883-L892

And we can here see the preview: https://unleash-docs-git-update-internal-docs-to-ne-9ba815-unleash-team.vercel.app/reference/sdks/android-proxy