### PR TITLE
fix: Capitalize input labels

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
@@ -46,6 +46,9 @@ export const ProjectDescriptionContainer = styled('div')({
 export const StyledInput = styled(Input)({
     width: '100%',
     fieldset: { border: 'none' },
+    'label::first-letter': {
+        textTransform: 'uppercase',
+    },
 });
 
 export const ConfigButtons = styled(StyledFormSection)(({ theme }) => ({

--- a/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
+++ b/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
@@ -134,8 +134,8 @@ const CreateFeature = () => {
                     replace: true,
                 });
                 setToastData({
-                    title: 'Toggle created successfully',
-                    text: 'Now you can start using your toggle.',
+                    title: 'Flag created successfully',
+                    text: 'Now you can start using your flag.',
                     confetti: true,
                     type: 'success',
                 });


### PR DESCRIPTION
This change makes it so that all form input labels start with a
capital letter, regardless of the data we use to generate them.

Also fixes a leftover toggle -> flag renaming.