### PR TITLE
fix: validate project names on blur

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -275,6 +275,7 @@ export const CreateProjectDialog = ({
                     errors={errors}
                     icon={StyledProjectIcon}
                     onClose={onClose}
+                    validateName={validateName}
                     configButtons={
                         <>
                             <MultiSelectConfigButton

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -128,7 +128,6 @@ export const CreateProjectDialog = ({
     const navigate = useNavigate();
     const { trackEvent } = usePlausibleTracker();
     const {
-        projectId,
         projectName,
         projectDesc,
         projectMode,

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -86,14 +86,12 @@ function resolveCreateButtonData(
     }
 }
 
-const ProjectCreationButton: FC<{ projectCount: number }> = ({
-    projectCount,
-}) => {
+const ProjectCreationButton: FC = () => {
     const [searchParams] = useSearchParams();
     const showCreateDialog = Boolean(searchParams.get('create'));
     const [openCreateDialog, setOpenCreateDialog] = useState(showCreateDialog);
     const { hasAccess } = useContext(AccessContext);
-    const { isOss, uiConfig, loading } = useUiConfig();
+    const { isOss, loading } = useUiConfig();
 
     const createButtonData = resolveCreateButtonData(
         isOss(),


### PR DESCRIPTION
This fix validates the project name when you blur the field in the new project form. The only instances where it'll be wrong is if you have just whitespace or an empty string, but you'll be notified immediately.

Also removes some unused variables and parameters that I found.