### PR TITLE
fix: prevent long project names from blowing out the form

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -20,6 +20,7 @@ export const ButtonLabel = styled('span', {
     width: labelWidth || 'unset',
     overflowX: 'hidden',
     textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
     [theme.breakpoints.down('sm')]: {
         width: 'max-content',
     },

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -175,15 +175,6 @@ export const CreateFeatureDialog = ({
         0,
     );
 
-    const projectButtonLabelWidth = useMemo(() => {
-        const longestProjectName = projects.reduce(
-            (prev: number, type: { name: string }) =>
-                prev >= type.name.length ? prev : type.name.length,
-            0,
-        );
-        return `${Math.min(longestProjectName, 30)}ch`;
-    }, [projects]);
-
     const currentProjectName = useMemo(() => {
         const projectObject = projects.find((p) => p.id === project);
         return projectObject?.name;
@@ -256,7 +247,7 @@ export const CreateFeatureDialog = ({
                                             label:
                                                 currentProjectName ?? project,
                                             icon: configButtonData.project.icon,
-                                            labelWidth: projectButtonLabelWidth,
+                                            labelWidth: '30ch',
                                         }}
                                         search={{
                                             label: 'Filter projects',

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -247,7 +247,7 @@ export const CreateFeatureDialog = ({
                                             label:
                                                 currentProjectName ?? project,
                                             icon: configButtonData.project.icon,
-                                            labelWidth: '12ch',
+                                            labelWidth: '30ch',
                                         }}
                                         search={{
                                             label: 'Filter projects',

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -175,6 +175,15 @@ export const CreateFeatureDialog = ({
         0,
     );
 
+    const projectButtonLabelWidth = useMemo(() => {
+        const longestProjectName = projects.reduce(
+            (prev: number, type: { name: string }) =>
+                prev >= type.name.length ? prev : type.name.length,
+            0,
+        );
+        return `${Math.min(longestProjectName, 30)}ch`;
+    }, [projects]);
+
     const currentProjectName = useMemo(() => {
         const projectObject = projects.find((p) => p.id === project);
         return projectObject?.name;
@@ -247,7 +256,7 @@ export const CreateFeatureDialog = ({
                                             label:
                                                 currentProjectName ?? project,
                                             icon: configButtonData.project.icon,
-                                            labelWidth: '30ch',
+                                            labelWidth: projectButtonLabelWidth,
                                         }}
                                         search={{
                                             label: 'Filter projects',


### PR DESCRIPTION
This change prevents long project names from blowing the form out of proportion.

To do so, it:
1. sets `whitespace: no-wrap` on the button labels. Judging by the other
styles, this was the intention all along, but it didn't really come up
until now.

2. It also sets the label width for projects to 30ch,so that you'll get
to see quite a bit of the project name before it gets cut off.

It would be possible to set a dynamic width for this button based on the longest project name, but I'm not sure it adds much value, so I'm leaning towards keeping it simple.

Here's what the dynamic width would look like:

``` tsx
    const projectButtonLabelWidth = useMemo(() => {
        const longestProjectName = projects.reduce(
            (prev: number, type: { name: string }) =>
                prev >= type.name.length ? prev : type.name.length,
            0,
        );
        return `${Math.min(longestProjectName, 30)}ch`;
    }, [projects]);
```

What it looks like:
![image](https://github.com/user-attachments/assets/51bca3f6-aeb3-4a41-b57e-5ebd9baa3ef6)
