### PR TITLE
fix: shorten max project name width in feature toggles creation form

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -258,7 +258,7 @@ export const CreateFeatureDialog = ({
                                             label:
                                                 currentProjectName ?? project,
                                             icon: configButtonData.project.icon,
-                                            labelWidth: '30ch',
+                                            labelWidth: '20ch',
                                         }}
                                         search={{
                                             label: 'Filter projects',


### PR DESCRIPTION
This change sets the max project name label width to 20ch instead of 30ch.

At 30ch, the button is wide enough that it causes the buttons always
to overflow. At 20, it's about as wide as the impression data button,
and it renders on one line.


Before:
![image](https://github.com/user-attachments/assets/8d28a948-dfa1-4f75-bc8d-473ceb322631)

After:
![image](https://github.com/user-attachments/assets/c73ccc58-13ab-4b33-a82e-275130494c3d)
