### PR TITLE
feat: Use a toggling button for impression data on/off

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -1,26 +1,36 @@
-import type { ConfigButtonProps } from './ConfigButton';
 import { ButtonLabel, StyledTooltipContent } from './ConfigButton.styles';
 import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
 import { Button } from '@mui/material';
+import type { ReactNode } from 'react';
 
-type ToggleConfigButtonProps = Pick<
-    ConfigButtonProps,
-    'button' | 'description' | 'tooltip'
-> & { onClick: () => void; currentValue: boolean };
+type ToggleConfigButtonProps = {
+    onClick: () => void;
+    currentValue: boolean;
+    label: string;
+    icon: ReactNode;
+    labelWidth?: string;
+    additionalTooltipContent?: ReactNode;
+    tooltip: {
+        header: string;
+        description: string;
+        additionalContent?: ReactNode;
+    };
+};
 
 export function ToggleConfigButton({
     onClick,
     currentValue,
-    button,
+    label,
+    icon,
+    labelWidth,
     tooltip,
-    description,
 }: ToggleConfigButtonProps) {
     return (
         <TooltipResolver
             titleComponent={
                 <StyledTooltipContent>
                     <h3>{tooltip.header}</h3>
-                    <p>{description}</p>
+                    <p>{tooltip.description}</p>
                     {tooltip.additionalContent}
                 </StyledTooltipContent>
             }
@@ -31,13 +41,11 @@ export function ToggleConfigButton({
                 aria-checked={currentValue}
                 variant={currentValue ? 'contained' : 'outlined'}
                 color='primary'
-                startIcon={button.icon}
+                startIcon={icon}
                 onClick={onClick}
                 disableElevation={true}
             >
-                <ButtonLabel labelWidth={button.labelWidth}>
-                    {button.label}
-                </ButtonLabel>
+                <ButtonLabel labelWidth={labelWidth}>{label}</ButtonLabel>
             </Button>
         </TooltipResolver>
     );

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -9,7 +9,6 @@ type ToggleConfigButtonProps = {
     label: string;
     icon: ReactNode;
     labelWidth?: string;
-    additionalTooltipContent?: ReactNode;
     tooltip: {
         header: string;
         description: string;

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -27,6 +27,8 @@ export function ToggleConfigButton({
             variant='custom'
         >
             <Button
+                aria-role='switch'
+                aria-checked={currentValue}
                 variant={currentValue ? 'contained' : 'outlined'}
                 color='primary'
                 startIcon={button.icon}

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -1,0 +1,41 @@
+import type { ConfigButtonProps } from './ConfigButton';
+import { ButtonLabel, StyledTooltipContent } from './ConfigButton.styles';
+import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
+import { Button } from '@mui/material';
+
+type ToggleConfigButtonProps = Pick<
+    ConfigButtonProps,
+    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltip'
+> & { onChange: (value: boolean) => void; currentValue: boolean };
+
+export function ToggleConfigButton({
+    onChange,
+    currentValue,
+    button,
+    tooltip,
+    description,
+}: ToggleConfigButtonProps) {
+    return (
+        <TooltipResolver
+            titleComponent={
+                <StyledTooltipContent>
+                    <h3>{tooltip.header}</h3>
+                    <p>{description}</p>
+                    {tooltip.additionalContent}
+                </StyledTooltipContent>
+            }
+            variant='custom'
+        >
+            <Button
+                variant={currentValue ? 'contained' : 'outlined'}
+                color='primary'
+                startIcon={button.icon}
+                onClick={() => onChange(!currentValue)}
+            >
+                <ButtonLabel labelWidth={button.labelWidth}>
+                    {button.label}
+                </ButtonLabel>
+            </Button>
+        </TooltipResolver>
+    );
+}

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -5,11 +5,11 @@ import { Button } from '@mui/material';
 
 type ToggleConfigButtonProps = Pick<
     ConfigButtonProps,
-    'button' | 'onOpen' | 'onClose' | 'description' | 'tooltip'
-> & { onChange: (value: boolean) => void; currentValue: boolean };
+    'button' | 'description' | 'tooltip'
+> & { onClick: () => void; currentValue: boolean };
 
 export function ToggleConfigButton({
-    onChange,
+    onClick,
     currentValue,
     button,
     tooltip,
@@ -32,7 +32,7 @@ export function ToggleConfigButton({
                 variant={currentValue ? 'contained' : 'outlined'}
                 color='primary'
                 startIcon={button.icon}
-                onClick={() => onChange(!currentValue)}
+                onClick={onClick}
                 disableElevation={true}
             >
                 <ButtonLabel labelWidth={button.labelWidth}>

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton.tsx
@@ -31,6 +31,7 @@ export function ToggleConfigButton({
                 color='primary'
                 startIcon={button.icon}
                 onClick={() => onChange(!currentValue)}
+                disableElevation={true}
             >
                 <ButtonLabel labelWidth={button.labelWidth}>
                     {button.label}

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -344,7 +344,9 @@ export const CreateFeatureDialog = ({
                                 description={
                                     configButtonData.impressionData.text
                                 }
-                                onChange={setImpressionData}
+                                onClick={() =>
+                                    setImpressionData(!impressionData)
+                                }
                                 button={{
                                     label: `Impression data ${impressionData ? 'on' : 'off'}`,
                                     icon: <ImpressionDataIcon />,

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -36,6 +36,7 @@ import Label from '@mui/icons-material/Label';
 import { ProjectIcon } from 'component/common/ProjectIcon/ProjectIcon';
 import { MultiSelectConfigButton } from 'component/common/DialogFormTemplate/ConfigButtons/MultiSelectConfigButton';
 import type { ITag } from 'interfaces/tags';
+import { ToggleConfigButton } from 'component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton';
 
 interface ICreateFeatureDialogProps {
     open: boolean;
@@ -335,35 +336,20 @@ export const CreateFeatureDialog = ({
                                 onClose={clearDocumentationOverride}
                             />
 
-                            <SingleSelectConfigButton<boolean>
+                            <ToggleConfigButton
                                 tooltip={{
                                     header: 'Enable or disable impression data',
                                 }}
+                                currentValue={impressionData}
                                 description={
                                     configButtonData.impressionData.text
                                 }
-                                options={[
-                                    { label: 'On', value: true },
-                                    { label: 'Off', value: false },
-                                ]}
-                                onChange={(value: boolean) => {
-                                    setImpressionData(value);
-                                }}
+                                onChange={setImpressionData}
                                 button={{
                                     label: `Impression data ${impressionData ? 'on' : 'off'}`,
                                     icon: <ImpressionDataIcon />,
                                     labelWidth: `${'impression data off'.length}ch`,
                                 }}
-                                search={{
-                                    label: 'Filter impression data states',
-                                    placeholder: 'Select impression data state',
-                                }}
-                                onOpen={() =>
-                                    setDocumentation(
-                                        configButtonData.impressionData,
-                                    )
-                                }
-                                onClose={clearDocumentationOverride}
                             />
                         </>
                     }

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -339,19 +339,16 @@ export const CreateFeatureDialog = ({
                             <ToggleConfigButton
                                 tooltip={{
                                     header: 'Enable or disable impression data',
+                                    description:
+                                        configButtonData.impressionData.text,
                                 }}
                                 currentValue={impressionData}
-                                description={
-                                    configButtonData.impressionData.text
-                                }
                                 onClick={() =>
                                     setImpressionData(!impressionData)
                                 }
-                                button={{
-                                    label: `Impression data ${impressionData ? 'on' : 'off'}`,
-                                    icon: <ImpressionDataIcon />,
-                                    labelWidth: `${'impression data off'.length}ch`,
-                                }}
+                                label={`Impression data ${impressionData ? 'on' : 'off'}`}
+                                icon={<ImpressionDataIcon />}
+                                labelWidth={`${'impression data off'.length}ch`}
                             />
                         </>
                     }


### PR DESCRIPTION
Instead of using a dropdown list for impression data, this PR introduces a new config button that is a switch type button. It will be filled (contained) when impression data is on and will be outlined when impression data is off.

Off:
![image](https://github.com/user-attachments/assets/4710c8aa-a853-43c3-bf3b-86dbbf1a2779)


On:
![image](https://github.com/user-attachments/assets/08316155-83d1-45a2-941f-1c49c254a02b)
