### PR TITLE
fix: Avoid weird spacing between title and collab mode icon

### DIFF
--- a/frontend/src/component/project/Project/Project.styles.ts
+++ b/frontend/src/component/project/Project/Project.styles.ts
@@ -58,7 +58,6 @@ export const StyledProjectTitle = styled('span')(({ theme }) => ({
     fontSize: theme.fontSizes.mainHeader,
     fontWeight: 'bold',
     display: 'flex',
-    justifyContent: 'space-between',
     alignItems: 'center',
     gap: theme.spacing(2),
     overflow: 'hidden',


### PR DESCRIPTION
This change fixes an issue where the title of the project would be
pushed all the way to the right when the project was set to "private".

The cause was that the container with the project mode and the title
was a flex box with `justifyContent` set to `space-between`.

Removing that line fixes the issue, and the contents align to the
start of the box. There are no other elements in that container, so it
does not affect anything else.

Before:
![image](https://github.com/user-attachments/assets/e8024e3f-8c68-4ed8-b135-ae49f24664b4)


After:
![image](https://github.com/user-attachments/assets/c5039e59-4ea4-49bb-b391-89864e7520d0)
