### PR TITLE
fix: break long project/flag names in the event log to prevent overflow

### DIFF
--- a/frontend/src/component/events/EventCard/EventCard.tsx
+++ b/frontend/src/component/events/EventCard/EventCard.tsx
@@ -39,6 +39,10 @@ const StyledContainerListItem = styled('li')(({ theme }) => ({
         },
     },
 
+    '& dd': {
+        overflowWrap: 'anywhere',
+    },
+
     a: {
         color: theme.palette.links,
     },


### PR DESCRIPTION
This change sets the `overflow-wrap` property for the definition list
values in the event log. This is to prevent long project/flag names
from making the left-hand side of the card suuuper wide, causing
overflow of the whole container.