### PR TITLE
fix: allow editors to create flags again

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -60,6 +60,7 @@ const FlagCreationButton: FC = () => {
                         onClick={() => setOpenCreateDialog(true)}
                         maxWidth='960px'
                         Icon={Add}
+                        projectId={projectId}
                         disabled={loading}
                         permission={CREATE_FEATURE}
                         data-testid='NAVIGATE_TO_CREATE_FEATURE'


### PR DESCRIPTION
This change fixes a bug where editors were suddenly unable to create
flags. The issue is that the new project creation dialog used a
permission button, but didn't supply the project ID.