### PR TITLE
feat: human readable project names in insight charts

### DIFF
--- a/frontend/src/component/insights/hooks/useProjectChartData.ts
+++ b/frontend/src/component/insights/hooks/useProjectChartData.ts
@@ -3,6 +3,7 @@ import type { InstanceInsightsSchema } from 'openapi';
 import { useProjectColor } from './useProjectColor';
 import { useTheme } from '@mui/material';
 import type { GroupedDataByProject } from './useGroupedProjectTrends';
+import useProjects from 'hooks/api/getters/useProjects/useProjects';
 
 type ProjectFlagTrends = InstanceInsightsSchema['projectFlagTrends'];
 
@@ -11,13 +12,17 @@ export const useProjectChartData = (
 ) => {
     const theme = useTheme();
     const getProjectColor = useProjectColor();
+    const { projects } = useProjects();
+    const projectNames = new Map(
+        projects.map((project) => [project.id, project.name]),
+    );
 
     const data = useMemo(() => {
         const datasets = Object.entries(projectFlagTrends).map(
             ([project, trends]) => {
                 const color = getProjectColor(project);
                 return {
-                    label: project,
+                    label: projectNames.get(project) || project,
                     data: trends,
                     borderColor: color,
                     backgroundColor: color,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adds human readable project names in all the charts so that we match the selectors from the project filter
<img width="1591" alt="Screenshot 2024-07-29 at 11 38 56" src="https://github.com/user-attachments/assets/da87b948-63bd-446c-973c-29d3c2ae2c48">

Details:
* decided to query the projects hook and create a map for quick lookup of names by project id
* fallback to project id if the name cannot be found

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
