### PR TITLE
fix: allow editors to submit flag form

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -206,6 +206,7 @@ export const CreateFeatureDialog = ({
             >
                 <DialogFormTemplate
                     createButtonProps={{
+                        projectId: project,
                         disabled:
                             loading ||
                             loadingTotalFlagCount ||


### PR DESCRIPTION
This change is a follow-up to
https://github.com/Unleash/unleash/pull/7685 and fixes another
instance of the same issue.

It wasn't caught previously, because the permissions are passed as
props here, and not used directly.

![image](https://github.com/user-attachments/assets/e8c4cb90-92e3-42ca-9c15-458b5b9d37c2)
