### PR TITLE
fix: avoid react key warnings in tables

### DIFF
--- a/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeader.tsx
+++ b/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeader.tsx
@@ -12,41 +12,47 @@ export const SortableTableHeader = <T extends object>({
     flex?: boolean;
 }) => (
     <TableHead className={className}>
-        {headerGroups.map((headerGroup) => (
-            <TableRow {...headerGroup.getHeaderGroupProps()} data-loading>
-                {headerGroup.headers.map((column: HeaderGroup<T>) => {
-                    const content = column.render('Header');
+        {headerGroups.map((headerGroup) => {
+            const { key, ...props } = headerGroup.getHeaderGroupProps();
+            return (
+                <TableRow key={key} {...props} data-loading>
+                    {headerGroup.headers.map((column: HeaderGroup<T>) => {
+                        const content = column.render('Header');
 
-                    return (
-                        <CellSortable
-                            // @ts-expect-error -- check after `react-table` v8
-                            styles={column.styles || {}}
-                            {...column.getHeaderProps(
-                                column.canSort
-                                    ? column.getSortByToggleProps()
-                                    : undefined,
-                            )}
-                            ariaTitle={
-                                typeof content === 'string'
-                                    ? content
-                                    : undefined
-                            }
-                            isSortable={Boolean(column.canSort)}
-                            isSorted={column.isSorted}
-                            isDescending={column.isSortedDesc}
-                            maxWidth={column.maxWidth}
-                            minWidth={column.minWidth}
-                            width={column.width}
-                            isFlex={flex}
-                            isFlexGrow={Boolean(column.minWidth)}
-                            // @ts-expect-error -- check after `react-table` v8
-                            align={column.align}
-                        >
-                            {content}
-                        </CellSortable>
-                    );
-                })}
-            </TableRow>
-        ))}
+                        const { key, ...props } = column.getHeaderProps(
+                            column.canSort
+                                ? column.getSortByToggleProps()
+                                : undefined,
+                        );
+
+                        return (
+                            <CellSortable
+                                // @ts-expect-error -- check after `react-table` v8
+                                styles={column.styles || {}}
+                                key={key}
+                                {...props}
+                                ariaTitle={
+                                    typeof content === 'string'
+                                        ? content
+                                        : undefined
+                                }
+                                isSortable={Boolean(column.canSort)}
+                                isSorted={column.isSorted}
+                                isDescending={column.isSortedDesc}
+                                maxWidth={column.maxWidth}
+                                minWidth={column.minWidth}
+                                width={column.width}
+                                isFlex={flex}
+                                isFlexGrow={Boolean(column.minWidth)}
+                                // @ts-expect-error -- check after `react-table` v8
+                                align={column.align}
+                            >
+                                {content}
+                            </CellSortable>
+                        );
+                    })}
+                </TableRow>
+            );
+        })}
     </TableHead>
 );

--- a/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTable.tsx
+++ b/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTable.tsx
@@ -89,27 +89,27 @@ export const VirtualizedTable = <T extends object>({
 
                     prepareRow(row);
 
+                    const { key, ...props } = row.getRowProps({
+                        style: { display: 'flex', top },
+                    });
+
                     return (
-                        <TableRow
-                            hover
-                            {...row.getRowProps({
-                                style: { display: 'flex', top },
+                        <TableRow {...props} hover key={key || row.id}>
+                            {row.cells.map((cell) => {
+                                const { key, ...props } = cell.getCellProps({
+                                    style: {
+                                        flex: cell.column.minWidth
+                                            ? '1 0 auto'
+                                            : undefined,
+                                    },
+                                });
+
+                                return (
+                                    <TableCell key={key} {...props}>
+                                        {cell.render('Cell')}
+                                    </TableCell>
+                                );
                             })}
-                            key={row.id}
-                        >
-                            {row.cells.map((cell) => (
-                                <TableCell
-                                    {...cell.getCellProps({
-                                        style: {
-                                            flex: cell.column.minWidth
-                                                ? '1 0 auto'
-                                                : undefined,
-                                        },
-                                    })}
-                                >
-                                    {cell.render('Cell')}
-                                </TableCell>
-                            ))}
                         </TableRow>
                     );
                 })}


### PR DESCRIPTION
Refactoring to get rid of `A props object containing a "key" prop is being spread into JSX` warning. See diff with "hide whitespace" on https://github.com/Unleash/unleash/pull/7694/files?diff=split&w=1

Internal ticket [1-2548](https://linear.app/unleash/issue/1-2548/api-tokens-table-react-warnings-about-keys)