### PR TITLE
fix: flex layout used the wrong axes for layout.

### DIFF
--- a/frontend/src/component/feature/FeatureView/Collaborators.tsx
+++ b/frontend/src/component/feature/FeatureView/Collaborators.tsx
@@ -13,7 +13,7 @@ const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
 
 const SectionContainer = styled('div')(({ theme }) => ({
     display: 'flex',
-    flexFlow: 'row',
+    flexFlow: 'column',
     gap: theme.spacing(0.5),
     alignItems: 'flex-start',
     height: 'min-content',
@@ -21,7 +21,7 @@ const SectionContainer = styled('div')(({ theme }) => ({
 
 const LastModifiedByAvatarAndLink = styled('div')(({ theme }) => ({
     display: 'flex',
-    flexFlow: 'column',
+    flexFlow: 'row',
     gap: theme.spacing(1),
 }));
 


### PR DESCRIPTION
This change fixes an issue where the flex layouts for collaborator
info used the wrong axes for layout (row instead of column and vice
versa), causing the component to look wonky.

Before:
![image](https://github.com/user-attachments/assets/695a9f67-ef07-4b3c-936f-69b2f2d62a28)

After:
![image](https://github.com/user-attachments/assets/a0a2c73a-2787-4985-807b-012bb4db94a4)
