### PR TITLE
fix: use FeatureSchema instead of deprecated IFeatureToggle in `useFeature`

### DIFF
--- a/frontend/src/hooks/api/getters/useFeature/emptyFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/emptyFeature.ts
@@ -1,6 +1,6 @@
-import type { IFeatureToggle } from 'interfaces/featureToggle';
+import type { FeatureSchema } from 'openapi';
 
-export const emptyFeature: IFeatureToggle = {
+export const emptyFeature: FeatureSchema = {
     environments: [],
     name: '',
     type: '',

--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -3,10 +3,10 @@ import { useCallback } from 'react';
 import { emptyFeature } from './emptyFeature';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { formatApiPath } from 'utils/formatPath';
-import type { IFeatureToggle } from 'interfaces/featureToggle';
+import type { FeatureSchema } from 'openapi';
 
 export interface IUseFeatureOutput {
-    feature: IFeatureToggle;
+    feature: FeatureSchema;
     refetchFeature: () => void;
     loading: boolean;
     status?: number;
@@ -15,7 +15,7 @@ export interface IUseFeatureOutput {
 
 export interface IFeatureResponse {
     status: number;
-    body?: IFeatureToggle;
+    body?: FeatureSchema;
 }
 
 export const useFeature = (


### PR DESCRIPTION
`IFeatureToggle` has been deprecated for a hot minute, so let's stop using it in the `useFeature` hook.