### PR TITLE
chore: change log level to info in origin middleware

### DIFF
--- a/src/lib/middleware/origin-middleware.test.ts
+++ b/src/lib/middleware/origin-middleware.test.ts
@@ -45,7 +45,7 @@ describe('originMiddleware', () => {
 
         middleware(req, res, next);
 
-        expect(loggerMock.debug).toHaveBeenCalledWith('UI request', {
+        expect(loggerMock.info).toHaveBeenCalledWith('UI request', {
             method: req.method,
         });
     });
@@ -58,7 +58,7 @@ describe('originMiddleware', () => {
 
         middleware(req, res, next);
 
-        expect(loggerMock.debug).toHaveBeenCalledWith('API request', {
+        expect(loggerMock.info).toHaveBeenCalledWith('API request', {
             method: req.method,
             userAgent: TEST_USER_AGENT,
         });

--- a/src/lib/middleware/origin-middleware.ts
+++ b/src/lib/middleware/origin-middleware.ts
@@ -16,9 +16,9 @@ export const originMiddleware = ({
         const isUI = !req.headers.authorization;
 
         if (isUI) {
-            logger.debug('UI request', { method: req.method });
+            logger.info('UI request', { method: req.method });
         } else {
-            logger.debug('API request', {
+            logger.info('API request', {
                 method: req.method,
                 userAgent: req.headers['user-agent'],
             });


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2492/change-origin-middleware-log-level-to-info

Changes origin middleware log level to `info` instead of `debug`.