### PR TITLE
feat: add filter dropdowns to event log pages

### DIFF
--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -14,8 +14,7 @@ import type { IEvent } from 'interfaces/event';
 import { styled } from '@mui/system';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
-import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import { EventLogFilters } from './EventLogFilters';
 
 interface IEventLogProps {
     title: string;
@@ -30,70 +29,6 @@ const StyledEventsList = styled('ul')(({ theme }) => ({
     display: 'grid',
     gap: theme.spacing(2),
 }));
-
-const EventLogFilters = (
-    // {state, onChange,}
-) => {
-    const { projects } = useProjects();
-
-    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
-
-    useEffect(() => {
-        const projectsOptions = (projects || []).map((project) => ({
-            label: project.name,
-            value: project.id,
-        }));
-
-        const hasMultipleProjects = projectsOptions.length > 1;
-
-        const availableFilters: IFilterItem[] = [
-            {
-                label: 'Date From',
-                icon: 'today',
-                options: [],
-                filterKey: 'from',
-                dateOperators: ['IS'],
-            },
-            {
-                label: 'Date To',
-                icon: 'today',
-                options: [],
-                filterKey: 'to',
-                dateOperators: ['IS'],
-            },
-            {
-                label: 'Feature Flag',
-                icon: 'flag',
-                options: [],
-                filterKey: 'flag',
-                singularOperators: ['IS'],
-                pluralOperators: ['IS_ANY_OF'],
-            },
-            ...(hasMultipleProjects
-                ? ([
-                      {
-                          label: 'Project',
-                          icon: 'topic',
-                          options: projectsOptions,
-                          filterKey: 'project',
-                          singularOperators: ['IS'],
-                          pluralOperators: ['IS_ANY_OF'],
-                      },
-                  ] as IFilterItem[])
-                : []),
-        ];
-
-        setAvailableFilters(availableFilters);
-    }, [JSON.stringify(projects)]);
-
-    return (
-        <Filters
-            availableFilters={availableFilters}
-            state={{}}
-            onChange={(v) => console.log(v)}
-        />
-    );
-};
 
 export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const [query, setQuery] = useState('');

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -14,11 +14,7 @@ import type { IEvent } from 'interfaces/event';
 import { styled } from '@mui/system';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
-import {
-    FlagLogFilters,
-    GlobalLogFilters,
-    ProjectLogFilters,
-} from './EventLogFilters';
+import { EventLogFilters } from './EventLogFilters';
 
 interface IEventLogProps {
     title: string;
@@ -71,6 +67,7 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
         />
     );
 
+    const logType = project ? 'project' : feature ? 'flag' : 'global';
     const count = events?.length || 0;
     const totalCount = totalEvents || 0;
     const countText = `${count} of ${totalCount}`;
@@ -93,11 +90,8 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
         >
             <ConditionallyRender
                 condition={isEnterprise() && showFilters}
-                show={<FlagLogFilters />}
+                show={<EventLogFilters logType={logType} />}
             />
-            <FlagLogFilters />
-            <ProjectLogFilters />
-            <GlobalLogFilters />
             <ConditionallyRender
                 condition={Boolean(cache && cache.length === 0)}
                 show={<p>No events found.</p>}

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -14,7 +14,11 @@ import type { IEvent } from 'interfaces/event';
 import { styled } from '@mui/system';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { EventLogFilters } from './EventLogFilters';
+import {
+    FlagLogFilters,
+    GlobalLogFilters,
+    ProjectLogFilters,
+} from './EventLogFilters';
 
 interface IEventLogProps {
     title: string;
@@ -89,8 +93,11 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
         >
             <ConditionallyRender
                 condition={isEnterprise() && showFilters}
-                show={<EventLogFilters />}
+                show={<FlagLogFilters />}
             />
+            <FlagLogFilters />
+            <ProjectLogFilters />
+            <GlobalLogFilters />
             <ConditionallyRender
                 condition={Boolean(cache && cache.length === 0)}
                 show={<p>No events found.</p>}

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -39,36 +39,30 @@ export const FlagLogFilters = () => {
 };
 
 const useProjectLogFilters = () => {
-    const { projects } = useProjects();
-
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
 
-    useEffect(() => {
-        const projectsOptions = (projects || []).map((project) => ({
-            label: project.name,
-            value: project.id,
-        }));
+    const { features } = useFeatureSearch({ project: 'default' });
 
-        const hasMultipleProjects = projectsOptions.length > 1;
+    useEffect(() => {
+        const flagOptions = (features || []).map((flag) => ({
+            label: flag.name,
+            value: flag.name,
+        }));
 
         const availableFilters: IFilterItem[] = [
             ...flagLogFilters,
-            ...(hasMultipleProjects
-                ? ([
-                      {
-                          label: 'Project',
-                          icon: 'topic',
-                          options: projectsOptions,
-                          filterKey: 'project',
-                          singularOperators: ['IS'],
-                          pluralOperators: ['IS_ANY_OF'],
-                      },
-                  ] as IFilterItem[])
-                : []),
+            {
+                label: 'Feature Flag',
+                icon: 'flag',
+                options: flagOptions,
+                filterKey: 'flag',
+                singularOperators: ['IS'],
+                pluralOperators: ['IS_ANY_OF'],
+            },
         ];
 
         setAvailableFilters(availableFilters);
-    }, [JSON.stringify(projects)]);
+    }, [JSON.stringify(features)]);
 
     return availableFilters;
 };
@@ -87,26 +81,26 @@ export const ProjectLogFilters = () => {
 
 export const GlobalLogFilters = () => {
     const projectFilters = useProjectLogFilters();
-    const { features } = useFeatureSearch({});
+    const { projects } = useProjects();
 
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
     useEffect(() => {
-        const flagOptions = (features || []).map((flag) => ({
-            label: flag.name,
-            value: flag.name,
+        const projectOptions = (projects || []).map((project) => ({
+            label: project.name,
+            value: project.id,
         }));
 
-        const hasMultipleFlags = flagOptions.length > 1;
+        const hasMultipleProjects = projectOptions.length > 1;
 
         const availableFilters: IFilterItem[] = [
             ...projectFilters,
-            ...(hasMultipleFlags
+            ...(hasMultipleProjects
                 ? ([
                       {
-                          label: 'Feature Flag',
-                          icon: 'flag',
-                          options: flagOptions,
-                          filterKey: 'flag',
+                          label: 'Project',
+                          icon: 'topic',
+                          options: projectOptions,
+                          filterKey: 'project',
                           singularOperators: ['IS'],
                           pluralOperators: ['IS_ANY_OF'],
                       },
@@ -115,7 +109,7 @@ export const GlobalLogFilters = () => {
         ];
 
         setAvailableFilters(availableFilters);
-    }, [JSON.stringify(projectFilters), JSON.stringify(features)]);
+    }, [JSON.stringify(projectFilters), JSON.stringify(projects)]);
     return (
         <Filters
             availableFilters={availableFilters}

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type FC } from 'react';
 import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
@@ -110,6 +110,7 @@ export const GlobalLogFilters = () => {
 
         setAvailableFilters(availableFilters);
     }, [JSON.stringify(projectFilters), JSON.stringify(projects)]);
+
     return (
         <Filters
             availableFilters={availableFilters}
@@ -119,74 +120,19 @@ export const GlobalLogFilters = () => {
     );
 };
 
-export const EventLogFilters = (
-    // {state, onChange,}
+type EventLogFiltersProps = {
+    logType: 'flag' | 'project' | 'global';
+};
+export const EventLogFilters: FC<EventLogFiltersProps> = (
+    { logType },
+    // {state, onChange,} // these are to fill in later to make the filters work
 ) => {
-    const { projects } = useProjects();
-
-    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
-
-    useEffect(() => {
-        const projectsOptions = (projects || []).map((project) => ({
-            label: project.name,
-            value: project.id,
-        }));
-
-        const hasMultipleProjects = projectsOptions.length > 1;
-
-        const availableFilters: IFilterItem[] = [
-            {
-                label: 'Date From',
-                icon: 'today',
-                options: [],
-                filterKey: 'from',
-                dateOperators: ['IS'],
-            },
-            {
-                label: 'Date To',
-                icon: 'today',
-                options: [],
-                filterKey: 'to',
-                dateOperators: ['IS'],
-            },
-            {
-                label: 'Feature Flag',
-                icon: 'flag',
-                options: [],
-                filterKey: 'flag',
-                singularOperators: ['IS'],
-                pluralOperators: ['IS_ANY_OF'],
-            },
-            ...(hasMultipleProjects
-                ? ([
-                      {
-                          label: 'Project',
-                          icon: 'topic',
-                          options: projectsOptions,
-                          filterKey: 'project',
-                          singularOperators: ['IS'],
-                          pluralOperators: ['IS_ANY_OF'],
-                      },
-                  ] as IFilterItem[])
-                : []),
-            {
-                label: 'Created by',
-                icon: 'person',
-                options: [],
-                filterKey: 'createdBy',
-                singularOperators: ['IS'],
-                pluralOperators: ['IS_ANY_OF'],
-            },
-        ];
-
-        setAvailableFilters(availableFilters);
-    }, [JSON.stringify(projects)]);
-
-    return (
-        <Filters
-            availableFilters={availableFilters}
-            state={{}}
-            onChange={(v) => console.log(v)}
-        />
-    );
+    switch (logType) {
+        case 'flag':
+            return <FlagLogFilters />;
+        case 'project':
+            return <ProjectLogFilters />;
+        case 'global':
+            return <GlobalLogFilters />;
+    }
 };

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
+import useProjects from 'hooks/api/getters/useProjects/useProjects';
+
+export const EventLogFilters = (
+    // {state, onChange,}
+) => {
+    const { projects } = useProjects();
+
+    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
+
+    useEffect(() => {
+        const projectsOptions = (projects || []).map((project) => ({
+            label: project.name,
+            value: project.id,
+        }));
+
+        const hasMultipleProjects = projectsOptions.length > 1;
+
+        const availableFilters: IFilterItem[] = [
+            {
+                label: 'Date From',
+                icon: 'today',
+                options: [],
+                filterKey: 'from',
+                dateOperators: ['IS'],
+            },
+            {
+                label: 'Date To',
+                icon: 'today',
+                options: [],
+                filterKey: 'to',
+                dateOperators: ['IS'],
+            },
+            {
+                label: 'Feature Flag',
+                icon: 'flag',
+                options: [],
+                filterKey: 'flag',
+                singularOperators: ['IS'],
+                pluralOperators: ['IS_ANY_OF'],
+            },
+            ...(hasMultipleProjects
+                ? ([
+                      {
+                          label: 'Project',
+                          icon: 'topic',
+                          options: projectsOptions,
+                          filterKey: 'project',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      },
+                  ] as IFilterItem[])
+                : []),
+            {
+                label: 'Created by',
+                icon: 'person',
+                options: [],
+                filterKey: 'createdBy',
+                singularOperators: ['IS'],
+                pluralOperators: ['IS_ANY_OF'],
+            },
+        ];
+
+        setAvailableFilters(availableFilters);
+    }, [JSON.stringify(projects)]);
+
+    return (
+        <Filters
+            availableFilters={availableFilters}
+            state={{}}
+            onChange={(v) => console.log(v)}
+        />
+    );
+};

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -19,10 +19,20 @@ const flagLogFilters: IFilterItem[] = [
         dateOperators: ['IS'],
     },
     {
+        // todo fill this in with actual values
         label: 'Created by',
         icon: 'person',
         options: [],
         filterKey: 'createdBy',
+        singularOperators: ['IS'],
+        pluralOperators: ['IS_ANY_OF'],
+    },
+    {
+        // todo fill this in with actual values
+        label: 'Event type',
+        icon: 'announcement',
+        options: [],
+        filterKey: 'eventType',
         singularOperators: ['IS'],
         pluralOperators: ['IS_ANY_OF'],
     },

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -1,6 +1,129 @@
 import { useState, useEffect } from 'react';
 import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+
+const flagLogFilters: IFilterItem[] = [
+    {
+        label: 'Date From',
+        icon: 'today',
+        options: [],
+        filterKey: 'from',
+        dateOperators: ['IS'],
+    },
+    {
+        label: 'Date To',
+        icon: 'today',
+        options: [],
+        filterKey: 'to',
+        dateOperators: ['IS'],
+    },
+    {
+        label: 'Created by',
+        icon: 'person',
+        options: [],
+        filterKey: 'createdBy',
+        singularOperators: ['IS'],
+        pluralOperators: ['IS_ANY_OF'],
+    },
+];
+
+export const FlagLogFilters = () => {
+    return (
+        <Filters
+            availableFilters={flagLogFilters}
+            state={{}}
+            onChange={(v) => console.log(v)}
+        />
+    );
+};
+
+const useProjectLogFilters = () => {
+    const { projects } = useProjects();
+
+    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
+
+    useEffect(() => {
+        const projectsOptions = (projects || []).map((project) => ({
+            label: project.name,
+            value: project.id,
+        }));
+
+        const hasMultipleProjects = projectsOptions.length > 1;
+
+        const availableFilters: IFilterItem[] = [
+            ...flagLogFilters,
+            ...(hasMultipleProjects
+                ? ([
+                      {
+                          label: 'Project',
+                          icon: 'topic',
+                          options: projectsOptions,
+                          filterKey: 'project',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      },
+                  ] as IFilterItem[])
+                : []),
+        ];
+
+        setAvailableFilters(availableFilters);
+    }, [JSON.stringify(projects)]);
+
+    return availableFilters;
+};
+
+export const ProjectLogFilters = () => {
+    const availableFilters = useProjectLogFilters();
+
+    return (
+        <Filters
+            availableFilters={availableFilters}
+            state={{}}
+            onChange={(v) => console.log(v)}
+        />
+    );
+};
+
+export const GlobalLogFilters = () => {
+    const projectFilters = useProjectLogFilters();
+    const { features } = useFeatureSearch({});
+
+    const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
+    useEffect(() => {
+        const flagOptions = (features || []).map((flag) => ({
+            label: flag.name,
+            value: flag.name,
+        }));
+
+        const hasMultipleFlags = flagOptions.length > 1;
+
+        const availableFilters: IFilterItem[] = [
+            ...projectFilters,
+            ...(hasMultipleFlags
+                ? ([
+                      {
+                          label: 'Feature Flag',
+                          icon: 'flag',
+                          options: flagOptions,
+                          filterKey: 'flag',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      },
+                  ] as IFilterItem[])
+                : []),
+        ];
+
+        setAvailableFilters(availableFilters);
+    }, [JSON.stringify(projectFilters), JSON.stringify(features)]);
+    return (
+        <Filters
+            availableFilters={availableFilters}
+            state={{}}
+            onChange={(v) => console.log(v)}
+        />
+    );
+};
 
 export const EventLogFilters = (
     // {state, onChange,}

--- a/frontend/src/component/filter/Filters/Filters.tsx
+++ b/frontend/src/component/filter/Filters/Filters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type VFC } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import { Box, Icon, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { AddFilterButton } from '../AddFilterButton';
@@ -57,7 +57,7 @@ const StyledIcon = styled(Icon)(({ theme }) => ({
     },
 }));
 
-export const Filters: VFC<IFilterProps> = ({
+export const Filters: FC<IFilterProps> = ({
     state,
     onChange,
     availableFilters,


### PR DESCRIPTION
Adds placeholder filter buttons (that don't work at all) yet to the three event logs.

Flag logs get to choose to and from dates, created by, and event type.

Project logs get all that flag logs get + a filter for flag.

The global log gets all project log filters + a project filter.

There's still work to be done to add data to createdBy, eventType, to hook it up to the API, and to finalize the layout, but I wanted to get a rough outline in to iterate on later. The eventType icon will also need to be decided on.

![image](https://github.com/user-attachments/assets/06a65301-9cc5-45ed-b753-2b9235d64ea6)
