### PR TITLE
chore[demo]: update handling of strategy deletion for demo walkthrough

### DIFF
--- a/frontend/src/component/demo/demo-setup.ts
+++ b/frontend/src/component/demo/demo-setup.ts
@@ -83,24 +83,10 @@ const deleteOldStrategies = async (featureId: string) => {
         ),
     ).then((res) => res.json());
 
-    const tooGenericStrategies = results.filter(
-        (strategy: { constraints: Array<unknown>; segments: Array<unknown> }) =>
-            strategy.constraints.length === 0 && strategy.segments.length === 0,
-    );
-    const constrainedStrategies = results.filter(
-        (strategy: { constraints: Array<unknown>; segments: Array<unknown> }) =>
-            strategy.constraints.length > 0 || strategy.segments.length > 0,
-    );
-    await Promise.all(
-        tooGenericStrategies.map((result: { id: string }) =>
-            deleteStrategy(featureId, result.id),
-        ),
-    );
-
     const strategyLimit = 30;
-    if (constrainedStrategies.length > strategyLimit) {
+    if (results.length >= strategyLimit) {
         await Promise.all(
-            constrainedStrategies
+            results
                 .slice(0, strategyLimit - 1)
                 .map((result: { id: string }) =>
                     deleteStrategy(featureId, result.id),

--- a/frontend/src/component/demo/demo-setup.ts
+++ b/frontend/src/component/demo/demo-setup.ts
@@ -84,10 +84,24 @@ const deleteOldStrategies = async (featureId: string) => {
         ),
     ).then((res) => res.json());
 
+    const tooGenericStrategies = results.filter(
+        (strategy: { constraints: Array<unknown>; segments: Array<unknown> }) =>
+            strategy.constraints.length === 0 && strategy.segments.length === 0,
+    );
+    const constrainedStrategies = results.filter(
+        (strategy: { constraints: Array<unknown>; segments: Array<unknown> }) =>
+            strategy.constraints.length > 0 || strategy.segments.length > 0,
+    );
+    await Promise.all(
+        tooGenericStrategies.map((result: { id: string }) =>
+            deleteStrategy(featureId, result.id),
+        ),
+    );
+
     const strategyLimit = 25;
-    if (results.length >= strategyLimit) {
+    if (constrainedStrategies.length >= strategyLimit) {
         await Promise.all(
-            results
+            constrainedStrategies
                 .slice(0, strategyLimit - 1)
                 .map((result: { id: string }) =>
                     deleteStrategy(featureId, result.id),

--- a/frontend/src/component/demo/demo-setup.ts
+++ b/frontend/src/component/demo/demo-setup.ts
@@ -84,7 +84,7 @@ const deleteOldStrategies = async (featureId: string) => {
         ),
     ).then((res) => res.json());
 
-    const strategyLimit = 30;
+    const strategyLimit = 25;
     if (results.length >= strategyLimit) {
         await Promise.all(
             results

--- a/frontend/src/component/demo/demo-setup.ts
+++ b/frontend/src/component/demo/demo-setup.ts
@@ -33,6 +33,7 @@ export const specificUser = async () => {
 };
 
 export const gradualRollout = async () => {
+    await deleteOldStrategies('demoApp.step3');
     const featureId = 'demoApp.step3';
 
     const { environments }: IFeatureToggle = await fetch(


### PR DESCRIPTION
This PR makes some small changes to how we handle strategy deletion in the demo environment, which has become extra important with the recent soft limits.

The changes are:
- lower the strategy limit from 30 to 25. The standard limit is 30, so we want to make sure we're below that.
- when checking whether we should delete a strategy, check whether we're **at or above** the limit. It used to only check if we were above, but if soft limits would prevent you from adding more, then you'd never be able to go above the limit.
- Also delete strategies for step3.

