### PR TITLE
docs: add subpages of edge documentation

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "test": "NODE_ENV=test node --trace-warnings ../node_modules/.bin/jest remote-content"
   },
   "dependencies": {
     "@docusaurus/core": "2.3.1",

--- a/website/remote-content/edge-proxy.js
+++ b/website/remote-content/edge-proxy.js
@@ -14,16 +14,16 @@ const DOCS = mapObject(enrich)({
     'unleash-edge': {
         sidebarName: 'Unleash Edge',
         slugName: 'unleash-edge',
-    },
-    'unleash-edge-concepts': {
-        sidebarName: 'Concepts',
-        slugName: 'unleash-edge/concepts',
-        remotePath: 'docs/concepts.md',
-    },
-    'unleash-edge-deploying': {
-        sidebarName: 'Deploying',
-        slugName: 'unleash-edge/deploying',
-        remotePath: 'docs/deploying.md',
+        subPages: {
+            'docs/concepts.md': {
+                sidebarName: 'Concepts',
+                slugName: 'concepts',
+            },
+            'docs/deploying.md': {
+                sidebarName: 'Deploying',
+                slugName: 'deploying',
+            },
+        },
     },
 });
 

--- a/website/remote-content/edge-proxy.js
+++ b/website/remote-content/edge-proxy.js
@@ -15,6 +15,16 @@ const DOCS = mapObject(enrich)({
         sidebarName: 'Unleash Edge',
         slugName: 'unleash-edge',
     },
+    'unleash-edge-concepts': {
+        sidebarName: 'Concepts',
+        slugName: 'unleash-edge/concepts',
+        remotePath: 'docs/concepts.md',
+    },
+    'unleash-edge-deploying': {
+        sidebarName: 'Deploying',
+        slugName: 'unleash-edge/deploying',
+        remotePath: 'docs/deploying.md',
+    },
 });
 
 const getAdmonitions = (data) => {

--- a/website/remote-content/sdks.test.js
+++ b/website/remote-content/sdks.test.js
@@ -1,0 +1,36 @@
+const { docs } = require('./edge-proxy');
+
+test('Should get all sub pages', () => {
+    expect(docs.urls).toStrictEqual([
+        'unleash-proxy/main/README.md',
+        'unleash-edge/main/README.md',
+        'unleash-edge/main/docs/concepts.md',
+        'unleash-edge/main/docs/deploying.md',
+    ]);
+});
+
+test('Modifies filenames and content properly', () => {
+    const proxyContent = docs.modifyContent(docs.urls[0], '');
+    const edgeMainContent = docs.modifyContent(docs.urls[1], '');
+    const firstSubpage = docs.modifyContent(docs.urls[2], '');
+    const secondSubpage = docs.modifyContent(docs.urls[3], '');
+
+    expect(proxyContent.filename).toBe('unleash-proxy.md');
+    expect(edgeMainContent.filename).toBe('unleash-edge.md');
+    expect(firstSubpage.filename).toBe('unleash-edge/concepts.md');
+    expect(secondSubpage.filename).toBe('unleash-edge/deploying.md');
+
+    expect(edgeMainContent.content).toContain('title: Unleash Edge');
+    expect(edgeMainContent.content).toContain('slug: /reference/unleash-edge');
+    expect(edgeMainContent.content).toContain(
+        'custom_edit_url: https://github.com/Unleash/unleash-edge/edit/main/README.md',
+    );
+
+    expect(firstSubpage.content).toContain('title: Concepts');
+    expect(firstSubpage.content).toContain(
+        'slug: /reference/unleash-edge/concepts',
+    );
+    expect(firstSubpage.content).toContain(
+        'custom_edit_url: https://github.com/Unleash/unleash-edge/edit/main/docs/concepts.md',
+    );
+});

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -149,5 +149,6 @@ This content was generated on <time dateTime="${generationTime.toISOString()}">$
 
 module.exports.getUrls = (documents) =>
     Object.entries(documents).map(
-        ([repo, { branch }]) => `${repo}/${branch}/README.md`,
+        ([repo, { branch, remotePath }]) =>
+            `${repo}/${branch}/${remotePath ?? 'README.md'}`,
     );

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -132,7 +132,7 @@ custom_edit_url: ${data.repoUrl}/edit/${data.branch}/${subpage ? subpageKey : 'R
 ---
 
 :::info Generated content
-This document was generated from the README in the [${subpage?.sidebarName ?? data.sidebarName} GitHub repository](${data.repoUrl}).
+This document was generated from the ${subpage ? subpageKey : 'README'} in the [${subpage?.sidebarName ?? data.sidebarName} GitHub repository](${data.repoUrl}).
 :::
 
 ${additionalAdmonitions}

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -89,6 +89,8 @@ module.exports.modifyContent =
     }) =>
     (filename, content) => {
         const data = getRepoDataFn(filename);
+        const subpageKey = filename.replace(`${data.name}/${data.branch}/`, '');
+        const subpage = data.subPages?.[subpageKey];
 
         const generationTime = new Date();
 
@@ -96,6 +98,7 @@ module.exports.modifyContent =
             const constructed = `${path.join(
                 filePath(data) ?? '',
                 data.slugName,
+                subpage?.slugName ?? '',
             )}.md`;
 
             // ensure the file path does *not* start with a leading /
@@ -105,7 +108,11 @@ module.exports.modifyContent =
         })();
 
         const processedSlug = (() => {
-            const constructed = path.join(urlPath ?? '', data.slugName);
+            const constructed = path.join(
+                urlPath ?? '',
+                data.slugName,
+                subpage?.slugName ?? '',
+            );
             // ensure the slug *does* start with a leading /
             const prefix = constructed.charAt(0) === '/' ? '' : '/';
 
@@ -119,15 +126,13 @@ module.exports.modifyContent =
         return {
             filename: processedFilename,
             content: `---
-title: ${data.sidebarName}
+title: ${subpage?.sidebarName ?? data.sidebarName}
 slug: ${processedSlug}
-custom_edit_url: ${data.repoUrl}/edit/${data.branch}/README.md
+custom_edit_url: ${data.repoUrl}/edit/${data.branch}/${subpage ? subpageKey : 'README.md'}
 ---
 
 :::info Generated content
-This document was generated from the README in the [${
-                data.sidebarName
-            } GitHub repository](${data.repoUrl}).
+This document was generated from the README in the [${subpage?.sidebarName ?? data.sidebarName} GitHub repository](${data.repoUrl}).
 :::
 
 ${additionalAdmonitions}
@@ -148,7 +153,9 @@ This content was generated on <time dateTime="${generationTime.toISOString()}">$
     };
 
 module.exports.getUrls = (documents) =>
-    Object.entries(documents).map(
-        ([repo, { branch, remotePath }]) =>
-            `${repo}/${branch}/${remotePath ?? 'README.md'}`,
-    );
+    Object.entries(documents).flatMap(([repo, { branch, subPages }]) => [
+        `${repo}/${branch}/README.md`,
+        ...(Object.keys(subPages ?? {}).map(
+            (remotePath) => `${repo}/${branch}/${remotePath}`,
+        ) ?? []),
+    ]);

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -132,7 +132,7 @@ custom_edit_url: ${data.repoUrl}/edit/${data.branch}/${subpage ? subpageKey : 'R
 ---
 
 :::info Generated content
-This document was generated from the ${subpage ? subpageKey : 'README'} in the [${data.sidebarName} GitHub repository](${data.repoUrl}).
+This document was generated from ${subpage ? subpageKey : 'README.md'} in the [${data.sidebarName} GitHub repository](${data.repoUrl}).
 :::
 
 ${additionalAdmonitions}

--- a/website/remote-content/shared.js
+++ b/website/remote-content/shared.js
@@ -132,7 +132,7 @@ custom_edit_url: ${data.repoUrl}/edit/${data.branch}/${subpage ? subpageKey : 'R
 ---
 
 :::info Generated content
-This document was generated from the ${subpage ? subpageKey : 'README'} in the [${subpage?.sidebarName ?? data.sidebarName} GitHub repository](${data.repoUrl}).
+This document was generated from the ${subpage ? subpageKey : 'README'} in the [${data.sidebarName} GitHub repository](${data.repoUrl}).
 :::
 
 ${additionalAdmonitions}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -587,7 +587,19 @@ module.exports = {
                         'using-unleash/troubleshooting/flag-abn-test-unexpected-result',
                     ],
                 },
-                'generated/unleash-edge',
+                {
+                    type: 'category',
+                    label: 'Unleash Edge',
+                    collapsed: true,
+                    link: {
+                        type: 'doc',
+                        id: 'generated/unleash-edge',
+                    },
+                    items: [
+                        'generated/unleash-edge/concepts',
+                        'generated/unleash-edge/deploying',
+                    ],
+                },
                 'generated/unleash-proxy',
             ],
         },


### PR DESCRIPTION
When all edge documentation was in a single page, we had all of it here: https://docs.getunleash.io/reference/unleash-edge but after splitting up https://github.com/Unleash/unleash-edge/pull/475 some of that documentation is not present in our docs and we should probably have them as sub-pages

This change allows us to include subpages for external documentation. Note that the key of the subpage needs to match the remote path

Checkout the preview: https://unleash-docs-git-add-edge-subpages-unleash-team.vercel.app/
![image](https://github.com/user-attachments/assets/4b87fe25-fca6-4995-b296-aa58caab4f62)
