### PR TITLE
fix: align event log filter buttons

### DIFF
--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -30,6 +30,10 @@ const StyledEventsList = styled('ul')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
+const EventResultWrapper = styled('div')(({ theme }) => ({
+    padding: theme.spacing(0, 4, 4, 4),
+}));
+
 export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const [query, setQuery] = useState('');
     const { events, totalEvents, fetchNextPage } = useEventSearch(
@@ -67,13 +71,13 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
         />
     );
 
-    const logType = project ? 'project' : feature ? 'flag' : 'global';
     const count = events?.length || 0;
     const totalCount = totalEvents || 0;
     const countText = `${count} of ${totalCount}`;
 
     return (
         <PageContent
+            bodyClass='no-padding'
             header={
                 <PageHeader
                     title={`${title} (${countText})`}
@@ -90,27 +94,36 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
         >
             <ConditionallyRender
                 condition={isEnterprise() && showFilters}
-                show={<EventLogFilters logType={logType} />}
-            />
-            <ConditionallyRender
-                condition={Boolean(cache && cache.length === 0)}
-                show={<p>No events found.</p>}
-            />
-            <ConditionallyRender
-                condition={Boolean(cache && cache.length > 0)}
                 show={
-                    <StyledEventsList>
-                        {cache?.map((entry) => (
-                            <ConditionallyRender
-                                key={entry.id}
-                                condition={eventSettings.showData}
-                                show={() => <EventJson entry={entry} />}
-                                elseShow={() => <EventCard entry={entry} />}
-                            />
-                        ))}
-                    </StyledEventsList>
+                    <EventLogFilters
+                        logType={
+                            project ? 'project' : feature ? 'flag' : 'global'
+                        }
+                    />
                 }
             />
+            <EventResultWrapper>
+                <ConditionallyRender
+                    condition={Boolean(cache && cache.length === 0)}
+                    show={<p>No events found.</p>}
+                />
+                <ConditionallyRender
+                    condition={Boolean(cache && cache.length > 0)}
+                    show={
+                        <StyledEventsList>
+                            {cache?.map((entry) => (
+                                <ConditionallyRender
+                                    key={entry.id}
+                                    condition={eventSettings.showData}
+                                    show={() => <EventJson entry={entry} />}
+                                    elseShow={() => <EventCard entry={entry} />}
+                                />
+                            ))}
+                        </StyledEventsList>
+                    }
+                />
+            </EventResultWrapper>
+
             <div ref={fetchNextPageRef} />
         </PageContent>
     );

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -30,8 +30,16 @@ const StyledEventsList = styled('ul')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
+const StyledFilters = styled(EventLogFilters)(({ theme }) => ({
+    padding: 0,
+}));
+
 const EventResultWrapper = styled('div')(({ theme }) => ({
-    padding: theme.spacing(0, 4, 4, 4),
+    padding: theme.spacing(2, 4, 4, 4),
+    // '& > * + *': { paddingBlockStart: theme.spacing(1) },
+    display: 'flex',
+    flexFlow: 'column',
+    gap: theme.spacing(1),
 }));
 
 export const EventLog = ({ title, project, feature }: IEventLogProps) => {
@@ -92,17 +100,21 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
                 </PageHeader>
             }
         >
-            <ConditionallyRender
-                condition={isEnterprise() && showFilters}
-                show={
-                    <EventLogFilters
-                        logType={
-                            project ? 'project' : feature ? 'flag' : 'global'
-                        }
-                    />
-                }
-            />
             <EventResultWrapper>
+                <ConditionallyRender
+                    condition={isEnterprise() && showFilters}
+                    show={
+                        <StyledFilters
+                            logType={
+                                project
+                                    ? 'project'
+                                    : feature
+                                      ? 'flag'
+                                      : 'global'
+                            }
+                        />
+                    }
+                />
                 <ConditionallyRender
                     condition={Boolean(cache && cache.length === 0)}
                     show={<p>No events found.</p>}

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -3,6 +3,10 @@ import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 
+type FilterProps = {
+    className?: string;
+};
+
 const flagLogFilters: IFilterItem[] = [
     {
         label: 'Date From',
@@ -38,9 +42,10 @@ const flagLogFilters: IFilterItem[] = [
     },
 ];
 
-export const FlagLogFilters = () => {
+export const FlagLogFilters: FC<FilterProps> = ({ className }) => {
     return (
         <Filters
+            className={className}
             availableFilters={flagLogFilters}
             state={{}}
             onChange={(v) => console.log(v)}
@@ -77,11 +82,12 @@ const useProjectLogFilters = () => {
     return availableFilters;
 };
 
-export const ProjectLogFilters = () => {
+export const ProjectLogFilters: FC<FilterProps> = ({ className }) => {
     const availableFilters = useProjectLogFilters();
 
     return (
         <Filters
+            className={className}
             availableFilters={availableFilters}
             state={{}}
             onChange={(v) => console.log(v)}
@@ -89,7 +95,7 @@ export const ProjectLogFilters = () => {
     );
 };
 
-export const GlobalLogFilters = () => {
+export const GlobalLogFilters: FC<FilterProps> = ({ className }) => {
     const projectFilters = useProjectLogFilters();
     const { projects } = useProjects();
 
@@ -123,6 +129,7 @@ export const GlobalLogFilters = () => {
 
     return (
         <Filters
+            className={className}
             availableFilters={availableFilters}
             state={{}}
             onChange={(v) => console.log(v)}
@@ -132,17 +139,17 @@ export const GlobalLogFilters = () => {
 
 type EventLogFiltersProps = {
     logType: 'flag' | 'project' | 'global';
-};
+} & FilterProps;
 export const EventLogFilters: FC<EventLogFiltersProps> = (
-    { logType },
+    { logType, ...props },
     // {state, onChange,} // these are to fill in later to make the filters work
 ) => {
     switch (logType) {
         case 'flag':
-            return <FlagLogFilters />;
+            return <FlagLogFilters {...props} />;
         case 'project':
-            return <ProjectLogFilters />;
+            return <ProjectLogFilters {...props} />;
         case 'global':
-            return <GlobalLogFilters />;
+            return <GlobalLogFilters {...props} />;
     }
 };

--- a/frontend/src/component/filter/Filters/Filters.tsx
+++ b/frontend/src/component/filter/Filters/Filters.tsx
@@ -21,6 +21,7 @@ interface IFilterProps {
     state: FilterItemParamHolder;
     onChange: (value: FilterItemParamHolder) => void;
     availableFilters: IFilterItem[];
+    className?: string;
 }
 
 type IBaseFilterItem = {
@@ -61,6 +62,7 @@ export const Filters: FC<IFilterProps> = ({
     state,
     onChange,
     availableFilters,
+    className,
 }) => {
     const [unselectedFilters, setUnselectedFilters] = useState<string[]>([]);
     const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
@@ -115,7 +117,7 @@ export const Filters: FC<IFilterProps> = ({
 
     const hasAvailableFilters = unselectedFilters.length > 0;
     return (
-        <StyledBox>
+        <StyledBox className={className}>
             {selectedFilters.map((selectedFilter) => {
                 const filter = availableFilters.find(
                     (filter) => filter.label === selectedFilter,


### PR DESCRIPTION
Fixes an issue where the filter buttons were both too far down and too
far to the right.

The issue was that the wrapper body imposed a pretty substantial bit
of padding. However, the filter buttons already came with their own
bit of padding. The result of this was alignment issues.

To fix it I have:
- opened the `Filters` component up to be styled with styled components

And conditionally (when isEnterprise and the flag is on):
- set the page body to have no padding.
- added a wrapper with padding around the event search results for 

This feels a little messy to me, but I also think that because it's still in heavy development, it might change later. I'd be happy to have suggestions forbetter implementations.

What makes this extra tricky is that the top padding differs depending on whether you have the filters there or not, so I couldn't find a way to just remove that component and be done with it. I may very well have missed somehing, though.

Before:
![image](https://github.com/user-attachments/assets/1552d1ec-2c14-450f-9ce8-8e74389f11a1)

After: 
![image](https://github.com/user-attachments/assets/d58b6fe5-437f-4488-bf01-cabfef669e2e)
