### PR TITLE
feat: copy strategy to current environment

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -120,7 +120,7 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                 }
             />
             <Tooltip
-                title={`Copy to another environment${
+                title={`Copy to environment${
                     enabled ? '' : ' (Access denied)'
                 }`}
             >
@@ -150,7 +150,7 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                     'aria-labelledby': `copy-strategy-icon-menu-${strategy.id}`,
                 }}
             >
-                {environments.map((environment) => {
+                {[...environments, environmentId].map((environment) => {
                     const access = checkAccess(
                         CREATE_FEATURE_STRATEGY,
                         environment,
@@ -179,7 +179,10 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                                         }
                                     />
                                     <ListItemText>
-                                        Copy to {environment}
+                                        Copy to{' '}
+                                        {environment === environmentId
+                                            ? 'current'
+                                            : environment}
                                     </ListItemText>
                                 </MenuItem>
                             </div>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -179,10 +179,9 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                                         }
                                     />
                                     <ListItemText>
-                                        Copy to{' '}
                                         {environment === environmentId
-                                            ? 'current'
-                                            : environment}
+                                            ? 'Duplicate in current'
+                                            : `Copy to ${environment}`}
                                     </ListItemText>
                                 </MenuItem>
                             </div>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

You can copy strategy not only to other environments but also to the current one
<img width="1212" alt="Screenshot 2024-08-02 at 08 57 31" src="https://github.com/user-attachments/assets/e890d92b-f89d-45d0-8cde-514d4f501eb9">

Use case: you configure variants once and want to have a few strategies with the same variants without having to type them manually
<img width="1114" alt="Screenshot 2024-08-02 at 08 58 46" src="https://github.com/user-attachments/assets/4ebe0cb6-a81e-45d2-b807-68bf43c616bc">

Details:
* it's a UI change only, we're adding current environment to the list of envs you can copy to
* current env is the last one on the list and has a text: "Copy to current"
* I checked and it also supports change requests out of the box
* tooltip changes from "copy to another environment" to "copy to environment"

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
