### PR TITLE
feat: link to release notes from orphaned tokens

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenIcon/ApiTokenIcon.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenIcon/ApiTokenIcon.tsx
@@ -3,6 +3,7 @@ import KeyIcon from '@mui/icons-material/Key';
 import WarningIcon from '@mui/icons-material/WarningAmber';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
+import { Link } from '@mui/material';
 
 interface IApiTokenIconProps {
     project?: string;
@@ -25,7 +26,16 @@ export const ApiTokenIcon: FC<IApiTokenIconProps> = ({ secret }) => {
                                 This is an orphaned token. All of its original
                                 projects have been deleted and it now has access
                                 to all current and future projects. You should
-                                stop using this token and delete it.
+                                stop using this token and delete it. Read more
+                                in{' '}
+                                <Link
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    href='https://github.com/Unleash/unleash/releases/tag/v6.1.0'
+                                >
+                                    release notes
+                                </Link>
+                                .
                             </p>
                         }
                         placement='bottom-start'


### PR DESCRIPTION
Adding a link "Read more in [release notes](https://github.com/Unleash/unleash/releases/tag/v6.1.0)" to orphaned tokens.

This needs to be added on v6.1, with the following changelog entry:


> **SDK tokens for deleted projects**
> 
> In previous versions of Unleash, when a project was deleted, the associated SDK tokens were not removed. This issue has been addressed in the current version of Unleash.
> 
> Unfortunately, if you deleted a project in the past without manually removing the associated tokens, these "orphaned" tokens were automatically converted to “wildcard” tokens, granting access to all feature flags across all projects.
> 
> Our assessment indicates this poses a minor security concern due to the following reasons:
> 
> This issue only affects tokens whose entire project scope has been deleted. 
> 
> Access requires knowledge of the token.
> 
> SDK tokens have limited read access and must be assigned to a single environment.
> 
> In the SDK tokens overview, orphaned tokens are flagged with a warning. We recommend discontinuing the use of these tokens and creating new, dedicated tokens instead.
> 
> With the latest version, when a project is deleted, all API tokens scoped to that project will be removed as well. If you need further assistance, please contact customer support.