### PR TITLE
fix: show "System" for system users, instead of "User ID n" where n is the project's number in the order.

### DIFF
--- a/frontend/src/component/common/AvatarGroup/AvatarGroup.tsx
+++ b/frontend/src/component/common/AvatarGroup/AvatarGroup.tsx
@@ -74,10 +74,7 @@ const GroupCardAvatarsInner = ({
     return (
         <StyledAvatars>
             {shownUsers.map((user) => (
-                <AvatarComponent
-                    key={objectId(user)}
-                    user={{ ...user, id: objectId(user) }}
-                />
+                <AvatarComponent key={objectId(user)} user={{ ...user }} />
             ))}
             <ConditionallyRender
                 condition={users.length > avatarLimit}

--- a/frontend/src/component/common/AvatarGroup/AvatarGroup.tsx
+++ b/frontend/src/component/common/AvatarGroup/AvatarGroup.tsx
@@ -74,7 +74,7 @@ const GroupCardAvatarsInner = ({
     return (
         <StyledAvatars>
             {shownUsers.map((user) => (
-                <AvatarComponent key={objectId(user)} user={{ ...user }} />
+                <AvatarComponent key={objectId(user)} user={user} />
             ))}
             <ConditionallyRender
                 condition={users.length > avatarLimit}

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -73,7 +73,7 @@ export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
             </StyledContainer>
             <ConditionallyRender
                 condition={owners.length === 1}
-                show={<StyledUserName>{users[0]?.name}</StyledUserName>}
+                show={<StyledUserName>{users[0].name}</StyledUserName>}
                 elseShow={<div />}
             />
         </>

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -18,7 +18,6 @@ const useOwnersMap = () => {
         name: string;
         imageUrl?: string;
         email?: string;
-        description?: string;
     } => {
         if (owner.ownerType === 'user') {
             return {
@@ -30,7 +29,6 @@ const useOwnersMap = () => {
         if (owner.ownerType === 'group') {
             return {
                 name: owner.name,
-                description: 'group',
             };
         }
         return {

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -73,11 +73,7 @@ export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
             </StyledContainer>
             <ConditionallyRender
                 condition={owners.length === 1}
-                show={
-                    <StyledUserName>
-                        {users[0]?.name || users[0]?.description}
-                    </StyledUserName>
-                }
+                show={<StyledUserName>{users[0]?.name}</StyledUserName>}
                 elseShow={<div />}
             />
         </>

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -34,8 +34,7 @@ const useOwnersMap = () => {
             };
         }
         return {
-            name: '',
-            description: 'System',
+            name: 'System',
             imageUrl: `${uiConfig.unleashUrl}/logo-unleash.png`,
         };
     };

--- a/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectOwners/ProjectOwners.tsx
@@ -73,7 +73,7 @@ export const ProjectOwners: FC<IProjectOwnersProps> = ({ owners = [] }) => {
             </StyledContainer>
             <ConditionallyRender
                 condition={owners.length === 1}
-                show={<StyledUserName>{users[0].name}</StyledUserName>}
+                show={<StyledUserName>{users[0]?.name}</StyledUserName>}
                 elseShow={<div />}
             />
         </>


### PR DESCRIPTION
Fixes a bug introduced with the new tooltips where the system user was shown as "User ID n" instead of "System". The "n" in this case is actually the user's index number in the list of project owners (including duplicates).

There's a few things happening: 
1. Change the object for system owners: use `name` instead of `description`. At the same time, remove the `description` property completely because it's not used at the moment. 
2. Remove the assignnment of `id: objectId(user)` to the user sent to the User Avatar component. This was a leftover from when we split out the AvatarGroup component, and is not something we use anymore.

Before:
![image](https://github.com/user-attachments/assets/bd348daf-c81e-4ea9-b8a9-f10af71a0da7)

After:
![image](https://github.com/user-attachments/assets/d147f7c7-d683-43ac-9ee2-6116f155dad6)
