### PR TITLE
feat: event search on new endpoint, first test

### DIFF
--- a/src/lib/features/events/event-search-controller.ts
+++ b/src/lib/features/events/event-search-controller.ts
@@ -1,0 +1,184 @@
+import type { Request, Response } from 'express';
+import type { IUnleashConfig } from '../../types/option';
+import type { IUnleashServices } from '../../types/services';
+import type EventService from '../../features/events/event-service';
+import { NONE } from '../../types/permissions';
+import type { IEvent, IEventList } from '../../types/events';
+import { anonymiseKeys } from '../../util/anonymise';
+import type { OpenApiService } from '../../services/openapi-service';
+import { createResponseSchema } from '../../openapi/util/create-response-schema';
+import {
+    eventsSchema,
+    type EventsSchema,
+} from '../../../lib/openapi/spec/events-schema';
+import { serializeDates } from '../../../lib/types/serialize-dates';
+import {
+    featureEventsSchema,
+    type FeatureEventsSchema,
+} from '../../../lib/openapi/spec/feature-events-schema';
+import type { DeprecatedSearchEventsSchema } from '../../openapi/spec/deprecated-search-events-schema';
+import type { IFlagResolver } from '../../types/experimental';
+import {
+    type EventSearchQueryParameters,
+    eventSearchQueryParameters,
+} from '../../openapi/spec/event-search-query-parameters';
+import {
+    type EventSearchResponseSchema,
+    eventSearchResponseSchema,
+} from '../../openapi';
+import { normalizeQueryParams } from '../../features/feature-search/search-utils';
+import Controller from '../../routes/controller';
+import type { IAuthRequest } from '../../server-impl';
+
+const ANON_KEYS = ['email', 'username', 'createdBy'];
+const version = 1 as const;
+export default class EventSearchController extends Controller {
+    private eventService: EventService;
+
+    private flagResolver: IFlagResolver;
+
+    private openApiService: OpenApiService;
+
+    constructor(
+        config: IUnleashConfig,
+        {
+            eventService,
+            openApiService,
+        }: Pick<IUnleashServices, 'eventService' | 'openApiService'>,
+    ) {
+        super(config);
+        this.eventService = eventService;
+        this.flagResolver = config.flagResolver;
+        this.openApiService = openApiService;
+
+        this.route({
+            method: 'get',
+            path: '',
+            handler: this.searchEvents,
+            permission: NONE,
+            middleware: [
+                openApiService.validPath({
+                    operationId: 'searchEvents',
+                    tags: ['Events'],
+                    summary: 'Search for events',
+                    description:
+                        'Allows searching for events matching the search criteria in the request body. This operation is deprecated. You should perform a GET request to the same endpoint with your query encoded as query parameters instead.',
+                    parameters: [...eventSearchQueryParameters],
+                    responses: {
+                        200: createResponseSchema('eventSearchResponseSchema'),
+                    },
+                }),
+            ],
+        });
+    }
+
+    maybeAnonymiseEvents(events: IEvent[]): IEvent[] {
+        if (this.flagResolver.isEnabled('anonymiseEventLog')) {
+            return anonymiseKeys(events, ANON_KEYS);
+        }
+        return events;
+    }
+
+    async getEvents(
+        req: Request<any, any, any, { project?: string }>,
+        res: Response<EventsSchema>,
+    ): Promise<void> {
+        const { project } = req.query;
+        let eventList: IEventList;
+        if (project) {
+            eventList = await this.eventService.deprecatedSearchEvents({
+                project,
+            });
+        } else {
+            eventList = await this.eventService.getEvents();
+        }
+
+        const response: EventsSchema = {
+            version,
+            events: serializeDates(this.maybeAnonymiseEvents(eventList.events)),
+            totalEvents: eventList.totalEvents,
+        };
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            eventsSchema.$id,
+            response,
+        );
+    }
+
+    async getEventsForToggle(
+        req: Request<{ featureName: string }>,
+        res: Response<FeatureEventsSchema>,
+    ): Promise<void> {
+        const feature = req.params.featureName;
+        const eventList = await this.eventService.deprecatedSearchEvents({
+            feature,
+        });
+
+        const response = {
+            version,
+            toggleName: feature,
+            events: serializeDates(this.maybeAnonymiseEvents(eventList.events)),
+            totalEvents: eventList.totalEvents,
+        };
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            featureEventsSchema.$id,
+            response,
+        );
+    }
+
+    async deprecatedSearchEvents(
+        req: Request<unknown, unknown, DeprecatedSearchEventsSchema>,
+        res: Response<EventsSchema>,
+    ): Promise<void> {
+        const eventList = await this.eventService.deprecatedSearchEvents(
+            req.body,
+        );
+
+        const response = {
+            version,
+            events: serializeDates(this.maybeAnonymiseEvents(eventList.events)),
+            totalEvents: eventList.totalEvents,
+        };
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            featureEventsSchema.$id,
+            response,
+        );
+    }
+
+    async searchEvents(
+        req: IAuthRequest<any, any, any, EventSearchQueryParameters>,
+        res: Response<EventSearchResponseSchema>,
+    ): Promise<void> {
+        const { normalizedLimit, normalizedOffset } = normalizeQueryParams(
+            req.query,
+            {
+                limitDefault: 50,
+                maxLimit: 1000,
+            },
+        );
+
+        const { events, totalEvents } = await this.eventService.searchEvents({
+            ...req.query,
+            offset: normalizedOffset,
+            limit: normalizedLimit,
+        });
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            eventSearchResponseSchema.$id,
+            serializeDates({
+                events: serializeDates(this.maybeAnonymiseEvents(events)),
+                total: totalEvents,
+            }),
+        );
+    }
+}

--- a/src/lib/features/events/event-search-controller.ts
+++ b/src/lib/features/events/event-search-controller.ts
@@ -18,6 +18,8 @@ import {
 import { normalizeQueryParams } from '../../features/feature-search/search-utils';
 import Controller from '../../routes/controller';
 import type { IAuthRequest } from '../../server-impl';
+import type { IEvent } from '../../types';
+import { anonymiseKeys } from '../../util';
 
 const ANON_KEYS = ['email', 'username', 'createdBy'];
 const version = 1 as const;
@@ -88,5 +90,12 @@ export default class EventSearchController extends Controller {
                 total: totalEvents,
             }),
         );
+    }
+
+    maybeAnonymiseEvents(events: IEvent[]): IEvent[] {
+        if (this.flagResolver.isEnabled('anonymiseEventLog')) {
+            return anonymiseKeys(events, ANON_KEYS);
+        }
+        return events;
     }
 }

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -20,7 +20,6 @@ export interface IEventSearchParams {
     type?: string;
     offset: number;
     limit: number;
-    // sortBy?: string;
 }
 
 export default class EventService {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -8,9 +8,20 @@ import type EventEmitter from 'events';
 import type { IApiUser, ITag, IUser } from '../../types';
 import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
-import type { EventSearchQueryParameters } from '../../openapi/spec/event-search-query-parameters';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
+
+export interface IEventSearchParams {
+    project?: string;
+    query?: string;
+    createdAtFrom?: string;
+    createdAtTo?: string;
+    createdBy?: string;
+    type?: string;
+    offset: number;
+    limit: number;
+    // sortBy?: string;
+}
 
 export default class EventService {
     private logger: Logger;
@@ -55,9 +66,7 @@ export default class EventService {
         };
     }
 
-    async searchEvents(
-        search: EventSearchQueryParameters,
-    ): Promise<IEventList> {
+    async searchEvents(search: IEventSearchParams): Promise<IEventList> {
         const queryParams = this.convertToDbParams(search);
         const totalEvents = await this.eventStore.searchEventsCount(
             {
@@ -143,7 +152,7 @@ export default class EventService {
         }
     }
 
-    convertToDbParams = (params: EventSearchQueryParameters): IQueryParam[] => {
+    convertToDbParams = (params: IEventSearchParams): IQueryParam[] => {
         const queryParams: IQueryParam[] = [];
 
         if (params.createdAtFrom) {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -1,7 +1,10 @@
 import type { IUnleashConfig } from '../../types/option';
 import type { IFeatureTagStore, IUnleashStores } from '../../types/stores';
 import type { Logger } from '../../logger';
-import type { IEventStore } from '../../types/stores/event-store';
+import type {
+    IEventSearchParams,
+    IEventStore,
+} from '../../types/stores/event-store';
 import type { IBaseEvent, IEventList } from '../../types/events';
 import type { DeprecatedSearchEventsSchema } from '../../openapi/spec/deprecated-search-events-schema';
 import type EventEmitter from 'events';
@@ -10,17 +13,6 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
-
-export interface IEventSearchParams {
-    project?: string;
-    query?: string;
-    createdAtFrom?: string;
-    createdAtTo?: string;
-    createdBy?: string;
-    type?: string;
-    offset: number;
-    limit: number;
-}
 
 export default class EventService {
     private logger: Logger;

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -17,6 +17,7 @@ import { ADMIN_TOKEN_USER, SYSTEM_USER_ID } from '../../types';
 import type { DeprecatedSearchEventsSchema } from '../../openapi';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { applyGenericQueryParams } from '../feature-search/search-utils';
+import type { IEventSearchParams } from './event-service';
 
 const EVENT_COLUMNS = [
     'id',
@@ -85,12 +86,6 @@ export interface IEventTable {
     project?: string;
     environment?: string;
     tags: ITag[];
-}
-
-export interface IEventSearchParams {
-    query: string | undefined;
-    offset: number | undefined;
-    limit: number | undefined;
 }
 
 const TABLE = 'events';

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -89,8 +89,8 @@ export interface IEventTable {
 
 export interface IEventSearchParams {
     query: string | undefined;
-    offset: string | undefined;
-    limit: string | undefined;
+    offset: number | undefined;
+    limit: number | undefined;
 }
 
 const TABLE = 'events';

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -7,7 +7,10 @@ import {
     SEGMENT_UPDATED,
 } from '../../types/events';
 import type { Logger, LogProvider } from '../../logger';
-import type { IEventStore } from '../../types/stores/event-store';
+import type {
+    IEventSearchParams,
+    IEventStore,
+} from '../../types/stores/event-store';
 import type { ITag } from '../../types/model';
 import { sharedEventEmitter } from '../../util/anyEventEmitter';
 import type { Db } from '../../db/db';
@@ -17,7 +20,6 @@ import { ADMIN_TOKEN_USER, SYSTEM_USER_ID } from '../../types';
 import type { DeprecatedSearchEventsSchema } from '../../openapi';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { applyGenericQueryParams } from '../feature-search/search-utils';
-import type { IEventSearchParams } from './event-service';
 
 const EVENT_COLUMNS = [
     'id',

--- a/src/lib/features/feature-search/feature-search-controller.ts
+++ b/src/lib/features/feature-search/feature-search-controller.ts
@@ -24,8 +24,6 @@ import {
 import { normalizeQueryParams } from './search-utils';
 import { anonymise } from '../../util';
 
-const PATH = '/features';
-
 type FeatureSearchServices = Pick<
     IUnleashServices,
     'openApiService' | 'featureSearchService'
@@ -54,7 +52,7 @@ export default class FeatureSearchController extends Controller {
 
         this.route({
             method: 'get',
-            path: PATH,
+            path: '',
             handler: this.searchFeatures,
             permission: NONE,
             middleware: [

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1,3 +1,4 @@
+import expressListEndpoints from 'express-list-endpoints';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import {
     insertLastSeenAt,
@@ -178,6 +179,8 @@ test('should search matching features by name', async () => {
     await app.createFeature('my_feature_a');
     await app.createFeature('my_feature_b');
     await app.createFeature('my_feat_c');
+
+    const endpoints = expressListEndpoints(app);
 
     const { body } = await searchFeatures({ query: 'feature' });
 

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1,4 +1,3 @@
-import expressListEndpoints from 'express-list-endpoints';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import {
     insertLastSeenAt,
@@ -179,8 +178,6 @@ test('should search matching features by name', async () => {
     await app.createFeature('my_feature_a');
     await app.createFeature('my_feature_b');
     await app.createFeature('my_feat_c');
-
-    const endpoints = expressListEndpoints(app);
 
     const { body } = await searchFeatures({ query: 'feature' });
 

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -8,7 +8,7 @@ export const eventSearchQueryParameters = [
             example: 'admin@example.com',
         },
         description:
-            'Find events by a free-text search query. The query will be matched against the event type and the event data payload (if any).',
+            'Find events by a free-text search query. The query will be matched against the event data payload (if any).',
         in: 'query',
     },
     {
@@ -53,7 +53,7 @@ export const eventSearchQueryParameters = [
             pattern: '^(IS|IS_ANY_OF):(.*?)(,([a-zA-Z0-9_]+))*$',
         },
         description:
-            'The ID of event creator to filter by. The creators can be specified with an operator. The supported operators are IS, IS_ANY_OF.',
+            'Filter by the ID of the event creator, using supported operators: IS, IS_ANY_OF.',
         in: 'query',
     },
     {
@@ -83,6 +83,7 @@ export const eventSearchQueryParameters = [
         schema: {
             type: 'string',
             example: '50',
+            default: '0',
         },
         description:
             'The number of features to skip when returning a page. By default it is set to 0.',
@@ -93,9 +94,10 @@ export const eventSearchQueryParameters = [
         schema: {
             type: 'string',
             example: '50',
+            default: '50',
         },
         description:
-            'The number of feature environments to return in a page. By default it is set to 50.',
+            'The number of feature environments to return in a page. By default it is set to 50. The maximum is 1000.',
         in: 'query',
     },
 ] as const;

--- a/src/lib/routes/admin-api/index.ts
+++ b/src/lib/routes/admin-api/index.ts
@@ -32,9 +32,9 @@ import { createKnexTransactionStarter } from '../../db/transaction';
 import type { Db } from '../../db/db';
 import ExportImportController from '../../features/export-import-toggles/export-import-controller';
 import { SegmentsController } from '../../features/segment/segment-controller';
-import FeatureSearchController from '../../features/feature-search/feature-search-controller';
 import { InactiveUsersController } from '../../users/inactive/inactive-users-controller';
 import { UiObservabilityController } from '../../features/ui-observability-controller/ui-observability-controller';
+import { SearchApi } from './search';
 
 export class AdminApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices, db: Db) {
@@ -158,10 +158,7 @@ export class AdminApi extends Controller {
             new TelemetryController(config, services).router,
         );
 
-        this.app.use(
-            '/search',
-            new FeatureSearchController(config, services).router,
-        );
+        this.app.use('/search', new SearchApi(config, services, db).router);
 
         this.app.use(
             '/record-ui-error',

--- a/src/lib/routes/admin-api/search/index.ts
+++ b/src/lib/routes/admin-api/search/index.ts
@@ -1,0 +1,24 @@
+import EventSearchController from '../../../features/events/event-search-controller';
+import FeatureSearchController from '../../../features/feature-search/feature-search-controller';
+import type {
+    Db,
+    IUnleashConfig,
+    IUnleashServices,
+} from '../../../server-impl';
+import Controller from '../../controller';
+
+export class SearchApi extends Controller {
+    constructor(config: IUnleashConfig, services: IUnleashServices, db: Db) {
+        super(config);
+
+        this.app.use(
+            '/features',
+            new FeatureSearchController(config, services).router,
+        );
+
+        this.app.use(
+            '/events',
+            new EventSearchController(config, services).router,
+        );
+    }
+}

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -2,11 +2,19 @@ import type { IBaseEvent, IEvent } from '../events';
 import type { Store } from './store';
 import type { DeprecatedSearchEventsSchema } from '../../openapi';
 import type EventEmitter from 'events';
-import type {
-    IEventSearchParams,
-    IQueryOperations,
-} from '../../features/events/event-store';
+import type { IQueryOperations } from '../../features/events/event-store';
 import type { IQueryParam } from '../../features/feature-toggle/types/feature-toggle-strategies-store-type';
+
+export interface IEventSearchParams {
+    project?: string;
+    query?: string;
+    createdAtFrom?: string;
+    createdAtTo?: string;
+    createdBy?: string;
+    type?: string;
+    offset: number;
+    limit: number;
+}
 
 export interface IEventStore
     extends Store<IEvent, number>,

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -1,0 +1,89 @@
+import type { EventSearchQueryParameters } from '../../../../lib/openapi/spec/event-search-query-parameters';
+import dbInit, { type ITestDb } from '../../helpers/database-init';
+
+import { FEATURE_CREATED } from '../../../../lib/types';
+import { EventService } from '../../../../lib/services';
+import EventEmitter from 'events';
+import getLogger from '../../../fixtures/no-logger';
+import {
+    type IUnleashTest,
+    setupAppWithCustomConfig,
+} from '../../helpers/test-helper';
+
+let app: IUnleashTest;
+let db: ITestDb;
+let eventService: EventService;
+const TEST_USER_ID = -9999;
+
+beforeAll(async () => {
+    db = await dbInit('event_search', getLogger);
+    app = await setupAppWithCustomConfig(db.stores, {
+        experimental: {
+            flags: {
+                strictSchemaValidation: true,
+            },
+        },
+    });
+
+    eventService = new EventService(db.stores, {
+        getLogger,
+        eventBus: new EventEmitter(),
+    });
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+beforeEach(async () => {
+    await db.stores.featureToggleStore.deleteAll();
+    await db.stores.segmentStore.deleteAll();
+    await db.stores.eventStore.deleteAll();
+});
+
+const searchEvents = async (
+    queryParams: EventSearchQueryParameters,
+    expectedCode = 200,
+) => {
+    const query = new URLSearchParams(queryParams as any).toString();
+    return app.request
+        .get(`/api/admin/search/events?${query}`)
+        .expect(expectedCode);
+};
+
+test('should search events by query', async () => {
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'something-else',
+        data: { id: 'some-other-feature' },
+        tags: [],
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'something-else',
+        data: { id: 'my-other-feature' },
+        tags: [],
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    const { body } = await searchEvents({ query: 'some-other-feature' });
+
+    expect(body).toMatchObject({
+        events: [
+            {
+                type: 'feature-created',
+                data: {
+                    id: 'some-other-feature',
+                },
+            },
+        ],
+        total: 1,
+    });
+});


### PR DESCRIPTION
Changed the url of event search to search/events to align with search/features. With that created a search controller to keep all searches under there.
Added first test.