### PR TITLE
fix: playground parent disabled with strategy

### DIFF
--- a/src/lib/features/playground/feature-evaluator/client.ts
+++ b/src/lib/features/playground/feature-evaluator/client.ts
@@ -225,7 +225,7 @@ export default class UnleashClient {
 
         const [result, variants, variant] = overallStrategyResult();
         const evalResults: FeatureStrategiesEvaluationResult = {
-            result,
+            result: feature.enabled ? result : false,
             variant,
             variants,
             strategies,

--- a/src/lib/features/playground/feature-evaluator/client.ts
+++ b/src/lib/features/playground/feature-evaluator/client.ts
@@ -75,6 +75,9 @@ export default class UnleashClient {
             if (parentToggle.dependencies?.length) {
                 return false;
             }
+            if (parentToggle.enabled === false) {
+                return false;
+            }
 
             if (parent.enabled !== false) {
                 if (parent.variants?.length) {
@@ -225,7 +228,7 @@ export default class UnleashClient {
 
         const [result, variants, variant] = overallStrategyResult();
         const evalResults: FeatureStrategiesEvaluationResult = {
-            result: feature.enabled ? result : false,
+            result,
             variant,
             variants,
             strategies,

--- a/src/lib/features/playground/feature-evaluator/client.ts
+++ b/src/lib/features/playground/feature-evaluator/client.ts
@@ -75,7 +75,7 @@ export default class UnleashClient {
             if (parentToggle.dependencies?.length) {
                 return false;
             }
-            if (parentToggle.enabled === false) {
+            if (Boolean(parent.enabled) !== Boolean(parentToggle.enabled)) {
                 return false;
             }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

This bug manifests when you evaluate parent/child relationship where parent is disabled but has some strategies.
I added extra check in the parent deps checking code. It's different from the node SDK but should pass the tests and keep it backwards compatible with the execution plans requirement of the playground.

This solution diverges from the node SDK because of the playground behavior described as a test "considers disabled features with a default strategy to be enabled". I had to add an extra check in parent deps checking function to overcome for the differences in the behavior.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
