### PR TITLE
feat: playground try configuration mode

### DIFF
--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -1,6 +1,6 @@
-import { type FormEventHandler, useEffect, useState, type FC } from 'react';
+import { type FC, type FormEventHandler, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Box, Paper, useTheme, styled, Alert } from '@mui/material';
+import { Alert, Box, Paper, styled, useTheme } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import useToast from 'hooks/useToast';
@@ -246,14 +246,28 @@ export const AdvancedPlayground: FC<{
         }
     };
 
+    const trackTryConfiguration = () => {
+        let mode: 'default' | 'api_token' | 'change_request' = 'default';
+        if (token && token !== '') {
+            mode = 'api_token';
+        } else if (changeRequest) {
+            mode = 'change_request';
+        }
+        console.log('mode', mode);
+        trackEvent('playground', {
+            props: {
+                eventType: 'try-configuration',
+                mode,
+            },
+        });
+    };
+
     const onSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
         event.preventDefault();
 
         setHasFormBeenSubmitted(true);
 
-        if (token && token !== '') {
-            trackEvent('playground_token_input_used');
-        }
+        trackTryConfiguration();
 
         await evaluatePlaygroundContext(environments, projects, context, () => {
             setURLParameters();

--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -253,7 +253,6 @@ export const AdvancedPlayground: FC<{
         } else if (changeRequest) {
             mode = 'change_request';
         }
-        console.log('mode', mode);
         trackEvent('playground', {
             props: {
                 eventType: 'try-configuration',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* removing old event `playground_token_input_used` - it was never registered in plausible
* re-using more generic event `playground` with type of `try-configuration` and `mode`
* we have 3 modes: default, api token and change request

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
