### PR TITLE
feat: manage filter state in front end

### DIFF
--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -133,7 +133,7 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
     );
 };
 
-export const EventLog = ({ title, project, feature }: IEventLogProps) => {
+export const LegacyEventLog = ({ title, project, feature }: IEventLogProps) => {
     const [query, setQuery] = useState('');
     const { events, totalEvents, fetchNextPage } = useLegacyEventSearch(
         project,
@@ -143,8 +143,6 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const fetchNextPageRef = useOnVisible<HTMLDivElement>(fetchNextPage);
     const { eventSettings, setEventSettings } = useEventSettings();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-    const { isEnterprise } = useUiConfig();
-    const showFilters = useUiFlag('newEventSearch') && isEnterprise();
 
     // Cache the previous search results so that we can show those while
     // fetching new results for a new search query in the background.
@@ -173,12 +171,6 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const count = events?.length || 0;
     const totalCount = totalEvents || 0;
     const countText = `${count} of ${totalCount}`;
-
-    if (showFilters) {
-        return (
-            <NewEventLog title={title} project={project} feature={feature} />
-        );
-    }
 
     return (
         <PageContent
@@ -218,4 +210,14 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
             <div ref={fetchNextPageRef} />
         </PageContent>
     );
+};
+
+export const EventLog = (props: IEventLogProps) => {
+    const { isEnterprise } = useUiConfig();
+    const showFilters = useUiFlag('newEventSearch') && isEnterprise();
+    if (showFilters) {
+        return <NewEventLog {...props} />;
+    } else {
+        return <LegacyEventLog {...props} />;
+    }
 };

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -83,6 +83,27 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
         />
     );
 
+    const resultComponent = () => {
+        if (loading) {
+            return <p>Loading...</p>;
+        } else if (events.length === 0) {
+            return <p>No events found.</p>;
+        } else {
+            return (
+                <StyledEventsList>
+                    {events.map((entry) => (
+                        <ConditionallyRender
+                            key={entry.id}
+                            condition={eventSettings.showData}
+                            show={() => <EventJson entry={entry} />}
+                            elseShow={() => <EventCard entry={entry} />}
+                        />
+                    ))}
+                </StyledEventsList>
+            );
+        }
+    };
+
     return (
         <PageContent
             bodyClass={'no-padding'}
@@ -106,39 +127,7 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                     state={filterState}
                     onChange={setTableState}
                 />
-                <ConditionallyRender
-                    condition={loading}
-                    show={<p>Loading...</p>}
-                    elseShow={
-                        <>
-                            <ConditionallyRender
-                                condition={events.length === 0}
-                                show={<p>No events found.</p>}
-                            />
-                            <ConditionallyRender
-                                condition={events.length > 0}
-                                show={
-                                    <StyledEventsList>
-                                        {events.map((entry) => (
-                                            <ConditionallyRender
-                                                key={entry.id}
-                                                condition={
-                                                    eventSettings.showData
-                                                }
-                                                show={() => (
-                                                    <EventJson entry={entry} />
-                                                )}
-                                                elseShow={() => (
-                                                    <EventCard entry={entry} />
-                                                )}
-                                            />
-                                        ))}
-                                    </StyledEventsList>
-                                }
-                            />
-                        </>
-                    }
-                />
+                {resultComponent()}
             </EventResultWrapper>
         </PageContent>
     );

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -43,22 +43,14 @@ const EventResultWrapper = styled('div')(({ theme }) => ({
 }));
 
 const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
-    const {
-        events,
-        total,
-        refetch: refetchEvents,
-        loading,
-        initialLoad,
-        tableState,
-        setTableState,
-        filterState,
-    } = useEventLogSearch(
-        project
-            ? { type: 'project', projectId: project }
-            : feature
-              ? { type: 'flag', flagName: feature }
-              : { type: 'global' },
-    );
+    const { events, total, loading, tableState, setTableState, filterState } =
+        useEventLogSearch(
+            project
+                ? { type: 'project', projectId: project }
+                : feature
+                  ? { type: 'flag', flagName: feature }
+                  : { type: 'global' },
+        );
 
     const setSearchValue = (query = '') => {
         setTableState({ query });

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -115,22 +115,36 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                     onChange={setTableState}
                 />
                 <ConditionallyRender
-                    condition={events.length === 0}
-                    show={<p>No events found.</p>}
-                />
-                <ConditionallyRender
-                    condition={events.length > 0}
-                    show={
-                        <StyledEventsList>
-                            {events.map((entry) => (
-                                <ConditionallyRender
-                                    key={entry.id}
-                                    condition={eventSettings.showData}
-                                    show={() => <EventJson entry={entry} />}
-                                    elseShow={() => <EventCard entry={entry} />}
-                                />
-                            ))}
-                        </StyledEventsList>
+                    condition={loading}
+                    show={<p>Loading...</p>}
+                    elseShow={
+                        <>
+                            <ConditionallyRender
+                                condition={events.length === 0}
+                                show={<p>No events found.</p>}
+                            />
+                            <ConditionallyRender
+                                condition={events.length > 0}
+                                show={
+                                    <StyledEventsList>
+                                        {events.map((entry) => (
+                                            <ConditionallyRender
+                                                key={entry.id}
+                                                condition={
+                                                    eventSettings.showData
+                                                }
+                                                show={() => (
+                                                    <EventJson entry={entry} />
+                                                )}
+                                                elseShow={() => (
+                                                    <EventCard entry={entry} />
+                                                )}
+                                            />
+                                        ))}
+                                    </StyledEventsList>
+                                }
+                            />
+                        </>
                     }
                 />
             </EventResultWrapper>

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -65,8 +65,6 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
     };
     const { eventSettings, setEventSettings } = useEventSettings();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-    const { isEnterprise } = useUiConfig();
-    const showFilters = useUiFlag('newEventSearch') && isEnterprise();
 
     const onShowData = () => {
         setEventSettings((prev) => ({ showData: !prev.showData }));
@@ -113,6 +111,8 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
             <EventResultWrapper>
                 <StyledFilters
                     logType={project ? 'project' : feature ? 'flag' : 'global'}
+                    state={filterState}
+                    onChange={setTableState}
                 />
                 <ConditionallyRender
                     condition={events.length === 0}
@@ -179,7 +179,11 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const totalCount = totalEvents || 0;
     const countText = `${count} of ${totalCount}`;
 
-    // return <NewEventLog title={title} project={project} feature={feature} />;
+    if (showFilters) {
+        return (
+            <NewEventLog title={title} project={project} feature={feature} />
+        );
+    }
 
     return (
         <PageContent

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -179,8 +179,24 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
     const totalCount = totalEvents || 0;
     const countText = `${count} of ${totalCount}`;
 
-    const EventResults = (
-        <>
+    // return <NewEventLog title={title} project={project} feature={feature} />;
+
+    return (
+        <PageContent
+            header={
+                <PageHeader
+                    title={`${title} (${countText})`}
+                    actions={
+                        <>
+                            {showDataSwitch}
+                            {!isSmallScreen && searchInputField}
+                        </>
+                    }
+                >
+                    {isSmallScreen && searchInputField}
+                </PageHeader>
+            }
+        >
             <ConditionallyRender
                 condition={Boolean(cache && cache.length === 0)}
                 show={<p>No events found.</p>}
@@ -200,45 +216,6 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
                     </StyledEventsList>
                 }
             />
-        </>
-    );
-
-    return (
-        <PageContent
-            bodyClass={showFilters ? 'no-padding' : ''}
-            header={
-                <PageHeader
-                    title={`${title} (${countText})`}
-                    actions={
-                        <>
-                            {showDataSwitch}
-                            {!isSmallScreen && searchInputField}
-                        </>
-                    }
-                >
-                    {isSmallScreen && searchInputField}
-                </PageHeader>
-            }
-        >
-            <ConditionallyRender
-                condition={showFilters}
-                show={
-                    <EventResultWrapper>
-                        <StyledFilters
-                            logType={
-                                project
-                                    ? 'project'
-                                    : feature
-                                      ? 'flag'
-                                      : 'global'
-                            }
-                        />
-                        {EventResults}
-                    </EventResultWrapper>
-                }
-                elseShow={EventResults}
-            />
-
             <div ref={fetchNextPageRef} />
         </PageContent>
     );

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -60,29 +60,25 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
               : { type: 'global' },
     );
 
-    console.log(events, total);
-    // const [query, setQuery] = useState('');
-    // const { events, totalEvents, fetchNextPage } = useLegacyEventSearch(
-    //     project,
-    //     feature,
-    //     query,
-    // );
-    // const fetchNextPageRef = useOnVisible<HTMLDivElement>(fetchNextPage);
+    const setSearchValue = (query = '') => {
+        setTableState({ query });
+    };
     const { eventSettings, setEventSettings } = useEventSettings();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
     const { isEnterprise } = useUiConfig();
     const showFilters = useUiFlag('newEventSearch') && isEnterprise();
 
-    // Cache the previous search results so that we can show those while
-    // fetching new results for a new search query in the background.
-    const [cache, setCache] = useState<EventSchema[]>();
-    useEffect(() => events && setCache(events), [events]);
-
     const onShowData = () => {
         setEventSettings((prev) => ({ showData: !prev.showData }));
     };
 
-    const searchInputField = <Search onChange={() => {}} debounceTime={500} />;
+    const searchInputField = (
+        <Search
+            onChange={setSearchValue}
+            initialValue={tableState.query || ''}
+            debounceTime={500}
+        />
+    );
 
     const showDataSwitch = (
         <FormControlLabel
@@ -97,33 +93,9 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
         />
     );
 
-    const EventResults = (
-        <>
-            <ConditionallyRender
-                condition={Boolean(cache && cache.length === 0)}
-                show={<p>No events found.</p>}
-            />
-            <ConditionallyRender
-                condition={Boolean(cache && cache.length > 0)}
-                show={
-                    <StyledEventsList>
-                        {cache?.map((entry) => (
-                            <ConditionallyRender
-                                key={entry.id}
-                                condition={eventSettings.showData}
-                                show={() => <EventJson entry={entry} />}
-                                elseShow={() => <EventCard entry={entry} />}
-                            />
-                        ))}
-                    </StyledEventsList>
-                }
-            />
-        </>
-    );
-
     return (
         <PageContent
-            bodyClass={showFilters ? 'no-padding' : ''}
+            bodyClass={'no-padding'}
             header={
                 <PageHeader
                     title={`${title} (${total})`}
@@ -138,24 +110,30 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                 </PageHeader>
             }
         >
-            <ConditionallyRender
-                condition={showFilters}
-                show={
-                    <EventResultWrapper>
-                        <StyledFilters
-                            logType={
-                                project
-                                    ? 'project'
-                                    : feature
-                                      ? 'flag'
-                                      : 'global'
-                            }
-                        />
-                        {EventResults}
-                    </EventResultWrapper>
-                }
-                elseShow={EventResults}
-            />
+            <EventResultWrapper>
+                <StyledFilters
+                    logType={project ? 'project' : feature ? 'flag' : 'global'}
+                />
+                <ConditionallyRender
+                    condition={events.length === 0}
+                    show={<p>No events found.</p>}
+                />
+                <ConditionallyRender
+                    condition={events.length > 0}
+                    show={
+                        <StyledEventsList>
+                            {events.map((entry) => (
+                                <ConditionallyRender
+                                    key={entry.id}
+                                    condition={eventSettings.showData}
+                                    show={() => <EventJson entry={entry} />}
+                                    elseShow={() => <EventCard entry={entry} />}
+                                />
+                            ))}
+                        </StyledEventsList>
+                    }
+                />
+            </EventResultWrapper>
         </PageContent>
     );
 };
@@ -203,7 +181,6 @@ export const EventLog = ({ title, project, feature }: IEventLogProps) => {
 
     const EventResults = (
         <>
-            <NewEventLog />
             <ConditionallyRender
                 condition={Boolean(cache && cache.length === 0)}
                 show={<p>No events found.</p>}

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -108,7 +108,6 @@ export const EventLogFilters: FC<EventLogFiltersProps> = ({
         setAvailableFilters(availableFilters);
     }, [JSON.stringify(features), JSON.stringify(projects)]);
 
-    console.log('state', state);
     return (
         <Filters
             className={className}

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, type FC } from 'react';
-import { Filters, type IFilterItem } from 'component/filter/Filters/Filters';
+import {
+    type FilterItemParamHolder,
+    Filters,
+    type IFilterItem,
+} from 'component/filter/Filters/Filters';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import { EventSchemaType } from 'openapi';
@@ -37,7 +41,7 @@ const sharedFilters: IFilterItem[] = [
             label: key,
             value: value,
         })),
-        filterKey: 'eventType',
+        filterKey: 'type',
         singularOperators: ['IS'],
         pluralOperators: ['IS_ANY_OF'],
     },
@@ -46,11 +50,15 @@ const sharedFilters: IFilterItem[] = [
 type EventLogFiltersProps = {
     logType: 'flag' | 'project' | 'global';
     className?: string;
+    state: FilterItemParamHolder;
+    onChange: (value: FilterItemParamHolder) => void;
 };
-export const EventLogFilters: FC<EventLogFiltersProps> = (
-    { logType, className },
-    // {state, onChange,} // these are to fill in later to make the filters work
-) => {
+export const EventLogFilters: FC<EventLogFiltersProps> = ({
+    logType,
+    className,
+    state,
+    onChange,
+}) => {
     const { projects } = useProjects();
     const { features } = useFeatureSearch({});
 
@@ -90,7 +98,7 @@ export const EventLogFilters: FC<EventLogFiltersProps> = (
                           label: 'Feature Flag',
                           icon: 'flag',
                           options: flagOptions,
-                          filterKey: 'flag',
+                          filterKey: 'feature',
                           singularOperators: ['IS'],
                           pluralOperators: ['IS_ANY_OF'],
                       },
@@ -101,12 +109,13 @@ export const EventLogFilters: FC<EventLogFiltersProps> = (
         setAvailableFilters(availableFilters);
     }, [JSON.stringify(features), JSON.stringify(projects)]);
 
+    console.log('state', state);
     return (
         <Filters
             className={className}
             availableFilters={availableFilters}
-            state={{}}
-            onChange={(v) => console.log(v)}
+            state={state}
+            onChange={onChange}
         />
     );
 };

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -34,7 +34,6 @@ const sharedFilters: IFilterItem[] = [
         pluralOperators: ['IS_ANY_OF'],
     },
     {
-        // todo fill this in with actual values
         label: 'Event type',
         icon: 'announcement',
         options: Object.entries(EventSchemaType).map(([key, value]) => ({

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -1,0 +1,102 @@
+import {
+    encodeQueryParams,
+    NumberParam,
+    type QueryParamConfig,
+    StringParam,
+    withDefault,
+} from 'use-query-params';
+import { DEFAULT_PAGE_LIMIT } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { FilterItemParam } from 'utils/serializeQueryParams';
+import { usePersistentTableState } from 'hooks/usePersistentTableState';
+import mapValues from 'lodash.mapvalues';
+import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
+import omit from 'lodash.omit';
+
+type Log =
+    | { type: 'global' }
+    | { type: 'project'; projectId: string }
+    | { type: 'flag'; flagName: string };
+
+const extraParameters = (
+    logType: Log,
+): {
+    [key in 'project' | 'feature']:
+        | typeof FilterItemParam
+        | QueryParamConfig<string | null | undefined, string>;
+} => {
+    switch (logType.type) {
+        case 'global':
+            return { project: FilterItemParam, feature: FilterItemParam };
+        case 'project':
+            return {
+                feature: FilterItemParam,
+                project: withDefault(StringParam, logType.projectId),
+            };
+        case 'flag':
+            return {
+                project: FilterItemParam,
+                feature: withDefault(StringParam, logType.flagName),
+            };
+    }
+};
+
+export const useEventLogSearch = (
+    logType: Log,
+    storageKey = 'event-log',
+    refreshInterval = 15 * 1000,
+) => {
+    const stateConfig = {
+        offset: withDefault(NumberParam, 0),
+        limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
+        query: StringParam,
+        tag: FilterItemParam,
+        state: FilterItemParam,
+        createdAfter: FilterItemParam,
+        createdBefore: FilterItemParam,
+        createdBy: FilterItemParam,
+        ...extraParameters(logType),
+    };
+
+    const fullStorageKey = (() => {
+        switch (logType.type) {
+            case 'global':
+                return `${storageKey}-global`;
+            case 'project':
+                return `${storageKey}-project:${logType.projectId}`;
+            case 'flag':
+                return `${storageKey}-flag:${logType.flagName}`;
+        }
+    })();
+
+    const [tableState, setTableState] = usePersistentTableState(
+        fullStorageKey,
+        stateConfig,
+    );
+
+    const apiTableState = omit(tableState, 'columns');
+
+    const { offset, limit, query, ...filterState } = tableState;
+
+    const { events, total, refetch, loading, initialLoad } = useEventSearch(
+        mapValues(
+            {
+                ...encodeQueryParams(stateConfig, apiTableState),
+            },
+            (value) => (value ? `${value}` : undefined),
+        ),
+        {
+            refreshInterval,
+        },
+    );
+
+    return {
+        events,
+        total,
+        refetch,
+        loading,
+        initialLoad,
+        tableState,
+        setTableState,
+        filterState,
+    };
+};

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -74,7 +74,11 @@ export const useEventLogSearch = (
             case 'project':
                 return { ...fs, project: undefined } as FilterItemParamHolder;
             case 'flag':
-                return { ...fs, feature: undefined } as FilterItemParamHolder;
+                return {
+                    ...fs,
+                    feature: undefined,
+                    project: undefined,
+                } as FilterItemParamHolder;
         }
     })();
 

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -30,12 +30,12 @@ const extraParameters = (
         case 'project':
             return {
                 feature: FilterItemParam,
-                project: withDefault(StringParam, logType.projectId),
+                project: withDefault(StringParam, `IS:${logType.projectId}`),
             };
         case 'flag':
             return {
                 project: FilterItemParam,
-                feature: withDefault(StringParam, logType.flagName),
+                feature: withDefault(StringParam, `IS:${logType.flagName}`),
             };
     }
 };

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -1,7 +1,6 @@
 import {
     encodeQueryParams,
     NumberParam,
-    type QueryParamConfig,
     StringParam,
     withDefault,
 } from 'use-query-params';
@@ -10,20 +9,14 @@ import { FilterItemParam } from 'utils/serializeQueryParams';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
-import omit from 'lodash.omit';
+import type { SearchEventsParams } from 'openapi';
 
 type Log =
     | { type: 'global' }
     | { type: 'project'; projectId: string }
     | { type: 'flag'; flagName: string };
 
-const extraParameters = (
-    logType: Log,
-): {
-    [key in 'project' | 'feature']:
-        | typeof FilterItemParam
-        | QueryParamConfig<string | null | undefined, string>;
-} => {
+const extraParameters = (logType: Log) => {
     switch (logType.type) {
         case 'global':
             return { project: FilterItemParam, feature: FilterItemParam };
@@ -72,17 +65,12 @@ export const useEventLogSearch = (
         stateConfig,
     );
 
-    const apiTableState = omit(tableState, 'columns');
-
     const { offset, limit, query, ...filterState } = tableState;
 
     const { events, total, refetch, loading, initialLoad } = useEventSearch(
-        mapValues(
-            {
-                ...encodeQueryParams(stateConfig, apiTableState),
-            },
-            (value) => (value ? `${value}` : undefined),
-        ),
+        mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
+            value ? `${value}` : undefined,
+        ) as SearchEventsParams,
         {
             refreshInterval,
         },

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -49,11 +49,10 @@ export const useEventLogSearch = (
         offset: withDefault(NumberParam, 0),
         limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
         query: StringParam,
-        tag: FilterItemParam,
-        state: FilterItemParam,
-        createdAfter: FilterItemParam,
-        createdBefore: FilterItemParam,
+        from: FilterItemParam,
+        to: FilterItemParam,
         createdBy: FilterItemParam,
+        type: FilterItemParam,
         ...extraParameters(logType),
     };
 

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -9,18 +9,14 @@ import { FilterItemParam } from 'utils/serializeQueryParams';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
-import type { SearchEventsParams } from 'openapi';
 
 type Log =
     | { type: 'global' }
     | { type: 'project'; projectId: string }
     | { type: 'flag'; flagName: string };
-export const useEventLogSearch = (
-    logType: Log,
-    storageKey = 'event-log',
-    refreshInterval = 15 * 1000,
-) => {
-    const { fullStorageKey, filterState, otherState } = (() => {
+
+const getTypeSpecificData = (logType: Log, storageKey: string) => {
+    return () => {
         const sharedFilters = {
             from: FilterItemParam,
             to: FilterItemParam,
@@ -71,7 +67,18 @@ export const useEventLogSearch = (
                     },
                 };
         }
-    })();
+    };
+};
+export const useEventLogSearch = (
+    logType: Log,
+    storageKey = 'event-log',
+    refreshInterval = 15 * 1000,
+) => {
+    const { fullStorageKey, filterState, otherState } = getTypeSpecificData(
+        logType,
+        storageKey,
+    )();
+
     const stateConfig = {
         ...filterState,
         ...otherState,
@@ -85,7 +92,7 @@ export const useEventLogSearch = (
     const { events, total, refetch, loading, initialLoad } = useEventSearch(
         mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
             value ? `${value}` : undefined,
-        ) as SearchEventsParams,
+        ),
         {
             refreshInterval,
         },

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -16,58 +16,53 @@ type Log =
     | { type: 'flag'; flagName: string };
 
 const getTypeSpecificData = (logType: Log, storageKey: string) => {
-    return () => {
-        const sharedFilters = {
-            from: FilterItemParam,
-            to: FilterItemParam,
-            createdBy: FilterItemParam,
-            type: FilterItemParam,
-        };
-
-        const sharedOtherState = {
-            offset: withDefault(NumberParam, 0),
-            limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
-            query: StringParam,
-        };
-
-        switch (logType.type) {
-            case 'global':
-                return {
-                    fullStorageKey: `${storageKey}-global`,
-                    filterState: {
-                        ...sharedFilters,
-                        project: FilterItemParam,
-                        feature: FilterItemParam,
-                    },
-                    otherState: sharedOtherState,
-                };
-
-            case 'project':
-                return {
-                    fullStorageKey: `${storageKey}-project:${logType.projectId}`,
-                    filterState: { ...sharedFilters, feature: FilterItemParam },
-                    otherState: {
-                        ...sharedOtherState,
-                        project: withDefault(
-                            StringParam,
-                            `IS:${logType.projectId}`,
-                        ),
-                    },
-                };
-            case 'flag':
-                return {
-                    fullStorageKey: `${storageKey}-flag:${logType.flagName}`,
-                    filterState: { ...sharedFilters, feature: FilterItemParam },
-                    otherState: {
-                        ...sharedOtherState,
-                        feature: withDefault(
-                            StringParam,
-                            `IS:${logType.flagName}`,
-                        ),
-                    },
-                };
-        }
+    const sharedFilters = {
+        from: FilterItemParam,
+        to: FilterItemParam,
+        createdBy: FilterItemParam,
+        type: FilterItemParam,
     };
+
+    const sharedOtherState = {
+        offset: withDefault(NumberParam, 0),
+        limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
+        query: StringParam,
+    };
+
+    switch (logType.type) {
+        case 'global':
+            return {
+                fullStorageKey: `${storageKey}-global`,
+                filterState: {
+                    ...sharedFilters,
+                    project: FilterItemParam,
+                    feature: FilterItemParam,
+                },
+                otherState: sharedOtherState,
+            };
+
+        case 'project':
+            return {
+                fullStorageKey: `${storageKey}-project:${logType.projectId}`,
+                filterState: { ...sharedFilters, feature: FilterItemParam },
+                otherState: {
+                    ...sharedOtherState,
+                    project: withDefault(
+                        StringParam,
+                        `IS:${logType.projectId}`,
+                    ),
+                },
+            };
+        case 'flag':
+            return {
+                fullStorageKey: `${storageKey}-flag:${logType.flagName}`,
+                filterState: { ...sharedFilters, feature: FilterItemParam },
+                otherState: {
+                    ...sharedOtherState,
+                    feature: withDefault(StringParam, `IS:${logType.flagName}`),
+                },
+            };
+    }
 };
 export const useEventLogSearch = (
     logType: Log,
@@ -77,7 +72,7 @@ export const useEventLogSearch = (
     const { fullStorageKey, filterState, otherState } = getTypeSpecificData(
         logType,
         storageKey,
-    )();
+    );
 
     const stateConfig = {
         ...filterState,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -10,6 +10,7 @@ import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
 import type { SearchEventsParams } from 'openapi';
+import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
 
 type Log =
     | { type: 'global' }
@@ -65,7 +66,23 @@ export const useEventLogSearch = (
         stateConfig,
     );
 
-    const { offset, limit, query, ...filterState } = tableState;
+    const filterState = (() => {
+        switch (logType.type) {
+            case 'global': {
+                const { offset, limit, query, ...fs } = tableState;
+                return fs as FilterItemParamHolder;
+            }
+            case 'project': {
+                const { offset, limit, query, project, ...fs } = tableState;
+                return fs as FilterItemParamHolder;
+            }
+            case 'flag': {
+                const { offset, limit, query, feature, ...fs } = tableState;
+                return fs as FilterItemParamHolder;
+            }
+        }
+    })();
+    // const { offset, limit, query, ...filterState } = tableState;
 
     const { events, total, refetch, loading, initialLoad } = useEventSearch(
         mapValues(encodeQueryParams(stateConfig, tableState), (value) =>

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -57,7 +57,7 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
-        name: 'from',
+        name: 'createdAtFrom',
         schema: {
             type: 'string',
             example: 'IS:2024-01-01',
@@ -68,7 +68,7 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
-        name: 'to',
+        name: 'createdAtTo',
         schema: {
             type: 'string',
             example: 'IS:2024-01-31',

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -57,7 +57,7 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
-        name: 'createdAtFrom',
+        name: 'from',
         schema: {
             type: 'string',
             example: 'IS:2024-01-01',
@@ -68,7 +68,7 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
-        name: 'createdAtTo',
+        name: 'to',
         schema: {
             type: 'string',
             example: 'IS:2024-01-31',


### PR DESCRIPTION
Add a `useEventLogSearch` hook and hook it up to the existing `EventLog` component.

All the filters work except for the date filters. They don't work because the query parameters in the API don't match what's here, but an update to the API is coming in a follow-up.

This is a little messy because the three different event logs should have slightly different filters, which makes making the type checker happy a bit of a pain. However, I'd like to get back to that in a different follow-up PR later. At the same time, suggestions are welcome.