### PR TITLE
feat: make `to` date inclusive

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -13,6 +13,7 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
+import { endOfDay, formatISO } from 'date-fns';
 
 export default class EventService {
     private logger: Logger;
@@ -163,7 +164,9 @@ export default class EventService {
         if (params.createdAtTo) {
             const parsed = parseSearchOperatorValue(
                 'created_at',
-                params.createdAtTo,
+                formatISO(endOfDay(new Date(params.createdAtTo)), {
+                    representation: 'date',
+                }),
             );
             if (parsed) {
                 queryParams.push({

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -246,6 +246,33 @@ test('should filter events by created date range', async () => {
     });
 });
 
+test('should include dates created on the `to` date', async () => {
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        data: { featureName: 'my_feature_b' },
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    const today = new Date();
+
+    const { body } = await searchEvents({
+        createdAtTo: `IS:${today.toISOString().split('T')[0]}`,
+    });
+
+    expect(body).toMatchObject({
+        events: [
+            {
+                type: FEATURE_CREATED,
+                data: { featureName: 'my_feature_b' },
+            },
+        ],
+        total: 1,
+    });
+});
+
 test('should paginate with offset and limit', async () => {
     for (let i = 0; i < 5; i++) {
         await eventService.storeEvent({

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -259,7 +259,7 @@ test('should include dates created on the `to` date', async () => {
     const today = new Date();
 
     const { body } = await searchEvents({
-        createdAtTo: `IS:${today.toISOString().split('T')[0]}`,
+        to: `IS:${today.toISOString().split('T')[0]}`,
     });
 
     expect(body).toMatchObject({


### PR DESCRIPTION
Changes the handling of the `to` query parameter in
the API to be inclusive.