### PR TITLE
fix: don't delete projects screen from history

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -180,7 +180,7 @@ export const CreateProjectDialog = ({
             try {
                 const createdProject = await createProject(projectPayload);
                 refetchUser();
-                navigate(`/projects/${createdProject.id}`, { replace: true });
+                navigate(`/projects/${createdProject.id}`);
                 setToastData({
                     title: 'Project created',
                     text: 'Now you can add flags to this project',


### PR DESCRIPTION
Fixes a bug in the navigation when you create a project. It used to be
that we'd replace the current entry in the browser history when we
took you to a separate form for it. However, now that we instead
use a dialog, we don't want to replace the history.

Before: if you created a project and navigated back, you'd be taken to
the page you were at BEFORE you went to the projects page, whether
that was in Unleash or otherwise.

Now you'll be taken back to the projects page.