### PR TITLE
feat: wait for postgres to boot before running tests

### DIFF
--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -32,6 +32,21 @@ jobs:
       matrix:
         node-version: [ 20.x ]
 
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: "--no-sync"
+        # Set health checks to wait until postgres has started
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Tests were failing on this workflow due to postgres taking longer to boot up, now it will wait for postgres to boot up before continuing.