### PR TITLE
fix: don't chain more commands after clear

### DIFF
--- a/frontend/cypress/support/UI.ts
+++ b/frontend/cypress/support/UI.ts
@@ -181,9 +181,10 @@ export const updateFlexibleRolloutStrategy_UI = (
         .click();
 
     cy.wait(500);
+    cy.get('[data-testid=FLEXIBLE_STRATEGY_GROUP_ID]').first().clear();
+
     cy.get('[data-testid=FLEXIBLE_STRATEGY_GROUP_ID]')
         .first()
-        .clear()
         .type('new-group-id');
 
     cy.intercept(


### PR DESCRIPTION
The [docs for `cy.clear()`](https://docs.cypress.io/api/commands/clear) say that:
> It is unsafe to chain further commands that rely on the subject after .clear().

So let's not do that.