### PR TITLE
feat: add paging to event log

### DIFF
--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -55,7 +55,6 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
         tableState,
         setTableState,
         filterState,
-        limit,
         pagination,
     } = useEventLogSearch(
         project
@@ -148,11 +147,11 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                 {resultComponent()}
             </EventResultWrapper>
             <ConditionallyRender
-                condition={total > (limit ?? 0)}
+                condition={total > pagination.pageSize}
                 show={
                     <StickyPaginationBar
                         totalItems={total}
-                        pageSize={limit ?? 0}
+                        pageSize={pagination.pageSize}
                         pageIndex={pagination.currentPage}
                         fetchPrevPage={pagination.prevPage}
                         fetchNextPage={pagination.nextPage}

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -43,10 +43,6 @@ const EventResultWrapper = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
-const LoadingWrapper = styled('div')({
-    minHeight: '100vh',
-});
-
 const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
     const {
         events,
@@ -97,11 +93,7 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
 
     const resultComponent = () => {
         if (loading) {
-            return (
-                <LoadingWrapper>
-                    <p>Loading...</p>
-                </LoadingWrapper>
-            );
+            return <p>Loading...</p>;
         } else if (events.length === 0) {
             return <p>No events found.</p>;
         } else {

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -52,13 +52,13 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
         setTableState,
         filterState,
         pagination,
-    } = useEventLogSearch({
-        logType: project
+    } = useEventLogSearch(
+        project
             ? { type: 'project', projectId: project }
             : feature
               ? { type: 'flag', flagName: feature }
               : { type: 'global' },
-    });
+    );
 
     const setSearchValue = (query = '') => {
         setTableState({ query });

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -56,13 +56,13 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
         setTableState,
         filterState,
         pagination,
-    } = useEventLogSearch(
-        project
+    } = useEventLogSearch({
+        logType: project
             ? { type: 'project', projectId: project }
             : feature
               ? { type: 'flag', flagName: feature }
               : { type: 'global' },
-    );
+    });
 
     console.log(tableState);
     const setSearchValue = (query = '') => {

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -43,6 +43,10 @@ const EventResultWrapper = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
+const LoadingWrapper = styled('div')({
+    minHeight: '70vh',
+});
+
 const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
     const {
         events,
@@ -95,7 +99,11 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
 
     const resultComponent = () => {
         if (loading) {
-            return <p>Loading...</p>;
+            return (
+                <LoadingWrapper>
+                    <p>Loading...</p>
+                </LoadingWrapper>
+            );
         } else if (events.length === 0) {
             return <p>No events found.</p>;
         } else {

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -44,7 +44,7 @@ const EventResultWrapper = styled('div')(({ theme }) => ({
 }));
 
 const LoadingWrapper = styled('div')({
-    minHeight: '70vh',
+    minHeight: '100vh',
 });
 
 const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
@@ -147,15 +147,18 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                 />
                 {resultComponent()}
             </EventResultWrapper>
-            <StickyPaginationBar
-                totalItems={total}
-                pageSize={25}
-                pageIndex={pagination.currentPage}
-                fetchPrevPage={pagination.prevPage}
-                fetchNextPage={pagination.nextPage}
-                setPageLimit={(limit: number): void => {
-                    throw new Error('Function not implemented.');
-                }}
+            <ConditionallyRender
+                condition={total > (limit ?? 0)}
+                show={
+                    <StickyPaginationBar
+                        totalItems={total}
+                        pageSize={limit ?? 0}
+                        pageIndex={pagination.currentPage}
+                        fetchPrevPage={pagination.prevPage}
+                        fetchNextPage={pagination.nextPage}
+                        setPageLimit={pagination.setPageLimit}
+                    />
+                }
             />
         </PageContent>
     );

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -64,7 +64,6 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
               : { type: 'global' },
     });
 
-    console.log(tableState);
     const setSearchValue = (query = '') => {
         setTableState({ query });
     };

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -16,6 +16,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import { EventLogFilters } from './EventLogFilters';
 import type { EventSchema } from 'openapi';
 import { useEventLogSearch } from './useEventLogSearch';
+import { StickyPaginationBar } from 'component/common/Table/StickyPaginationBar/StickyPaginationBar';
 
 interface IEventLogProps {
     title: string;
@@ -43,15 +44,24 @@ const EventResultWrapper = styled('div')(({ theme }) => ({
 }));
 
 const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
-    const { events, total, loading, tableState, setTableState, filterState } =
-        useEventLogSearch(
-            project
-                ? { type: 'project', projectId: project }
-                : feature
-                  ? { type: 'flag', flagName: feature }
-                  : { type: 'global' },
-        );
+    const {
+        events,
+        total,
+        loading,
+        tableState,
+        setTableState,
+        filterState,
+        limit,
+        pagination,
+    } = useEventLogSearch(
+        project
+            ? { type: 'project', projectId: project }
+            : feature
+              ? { type: 'flag', flagName: feature }
+              : { type: 'global' },
+    );
 
+    console.log(tableState);
     const setSearchValue = (query = '') => {
         setTableState({ query });
     };
@@ -129,6 +139,16 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                 />
                 {resultComponent()}
             </EventResultWrapper>
+            <StickyPaginationBar
+                totalItems={total}
+                pageSize={25}
+                pageIndex={pagination.currentPage}
+                fetchPrevPage={pagination.prevPage}
+                fetchNextPage={pagination.nextPage}
+                setPageLimit={(limit: number): void => {
+                    throw new Error('Function not implemented.');
+                }}
+            />
         </PageContent>
     );
 };

--- a/frontend/src/component/events/EventLog/EventLog.tsx
+++ b/frontend/src/component/events/EventLog/EventLog.tsx
@@ -138,7 +138,7 @@ const NewEventLog = ({ title, project, feature }: IEventLogProps) => {
                 {resultComponent()}
             </EventResultWrapper>
             <ConditionallyRender
-                condition={total > pagination.pageSize}
+                condition={total > 25}
                 show={
                     <StickyPaginationBar
                         totalItems={total}

--- a/frontend/src/component/events/EventLog/useEventLogSearch.test.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.test.ts
@@ -1,0 +1,35 @@
+import { calculatePaginationInfo } from './useEventLogSearch';
+
+test.each([
+    [{ offset: 5, pageSize: 2 }, { currentPage: 2 }],
+    [{ offset: 6, pageSize: 2 }, { currentPage: 3 }],
+])('it calculates currentPage correctly', (input, output) => {
+    const result = calculatePaginationInfo(input);
+    expect(result).toMatchObject(output);
+});
+
+test("it doesn't try to divide by zero", () => {
+    const result = calculatePaginationInfo({ offset: 0, pageSize: 0 });
+
+    expect(result.currentPage).not.toBeNaN();
+});
+
+test('it calculates the correct offsets', () => {
+    const result = calculatePaginationInfo({ offset: 50, pageSize: 25 });
+
+    expect(result).toMatchObject({
+        currentPage: 2,
+        nextPageOffset: 75,
+        previousPageOffset: 25,
+    });
+});
+
+test(`it "fixes" offsets if you've set a weird offset`, () => {
+    const result = calculatePaginationInfo({ offset: 35, pageSize: 25 });
+
+    expect(result).toMatchObject({
+        currentPage: 1,
+        nextPageOffset: 50,
+        previousPageOffset: 0,
+    });
+});

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -115,8 +115,8 @@ export const useEventLogSearch = (
         tableState,
         setTableState,
         filterState,
-        limit: tableState.limit,
         pagination: {
+            pageSize: tableState.limit ?? 0,
             currentPage,
             nextPage: () => {
                 const nextPage = currentPage + 1;

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -33,7 +33,7 @@ const extraParameters = (logType: Log) => {
     }
 };
 
-export const DEFAULT_PAGE_SIZE = 25;
+const DEFAULT_PAGE_SIZE = 25;
 
 export const calculatePaginationInfo = ({
     offset,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -36,12 +36,6 @@ const extraParameters = (logType: Log) => {
 
 export const DEFAULT_PAGE_SIZE = 25;
 
-type Pagination = {
-    currentPage: number;
-    nextPage: () => void;
-    prevPage: () => void;
-};
-
 export const useEventLogSearch = (
     logType: Log,
     storageKey = 'event-log',
@@ -137,6 +131,13 @@ export const useEventLogSearch = (
                 setCurrentPage((prev) => prev - 1);
                 setTableState({
                     offset: pageSize * Math.max(currentPage - 1, 0),
+                });
+            },
+            setPageLimit: (limit: number) => {
+                setCurrentPage(0);
+                setTableState({
+                    limit,
+                    offset: 0,
                 });
             },
         },

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -45,7 +45,7 @@ export const calculatePaginationInfo = ({
     const currentPage = Math.floor(offset / Math.max(pageSize, 1));
 
     const nextPageOffset = pageSize * (currentPage + 1);
-    const previousPageOffset = Math.max(pageSize * (currentPage - 1), 0);
+    const previousPageOffset = pageSize * Math.max(currentPage - 1, 0);
 
     return {
         currentPage,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -44,13 +44,10 @@ export const calculatePaginationInfo = ({
 }) => {
     const currentPage = Math.floor(offset / Math.max(pageSize, 1));
 
-    const nextPageOffset = pageSize * (currentPage + 1);
-    const previousPageOffset = pageSize * Math.max(currentPage - 1, 0);
-
     return {
         currentPage,
-        nextPageOffset,
-        previousPageOffset,
+        nextPageOffset: pageSize * (currentPage + 1),
+        previousPageOffset: pageSize * Math.max(currentPage - 1, 0),
     };
 };
 

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -10,7 +10,6 @@ import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
 import type { SearchEventsParams } from 'openapi';
 import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
-import { useState } from 'react';
 
 type Log =
     | { type: 'global' }
@@ -41,12 +40,7 @@ export const useEventLogSearch = (
     storageKey = 'event-log',
     refreshInterval = 15 * 1000,
     pageSize = DEFAULT_PAGE_SIZE,
-    initialPage = 0,
 ) => {
-    const [currentPage, setCurrentPage] = useState(Math.max(initialPage, 0));
-
-    console.log('current page', currentPage, pageSize * (currentPage - 1));
-
     const stateConfig = {
         offset: NumberParam,
         limit: NumberParam,
@@ -108,6 +102,10 @@ export const useEventLogSearch = (
         },
     );
 
+    const currentPage = Math.floor(
+        (tableState.offset ?? 0) / (tableState.limit ?? 1),
+    );
+
     return {
         events,
         total,
@@ -121,20 +119,19 @@ export const useEventLogSearch = (
         pagination: {
             currentPage,
             nextPage: () => {
-                setCurrentPage((prev) => prev + 1);
+                const nextPage = currentPage + 1;
                 setTableState({
-                    offset: pageSize * currentPage,
+                    offset: (tableState.limit ?? 0) * nextPage,
                 });
             },
 
             prevPage: () => {
-                setCurrentPage((prev) => prev - 1);
+                const prevPage = currentPage - 1;
                 setTableState({
-                    offset: pageSize * Math.max(currentPage - 1, 0),
+                    offset: (tableState.limit ?? 0) * prevPage,
                 });
             },
             setPageLimit: (limit: number) => {
-                setCurrentPage(0);
                 setTableState({
                     limit,
                     offset: 0,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -55,17 +55,15 @@ type UseEventLogSearchProps = {
     logType: Log;
     storageKey?: string;
     refreshInterval?: number;
-    pageSize?: number;
 };
 export const useEventLogSearch = ({
     logType,
     storageKey = 'event-log',
     refreshInterval = 15 * 1000,
-    pageSize = DEFAULT_PAGE_SIZE,
 }: UseEventLogSearchProps) => {
     const stateConfig = {
         offset: withDefault(NumberParam, 0),
-        limit: withDefault(NumberParam, pageSize),
+        limit: withDefault(NumberParam, DEFAULT_PAGE_SIZE),
         query: StringParam,
         from: FilterItemParam,
         to: FilterItemParam,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -35,12 +35,18 @@ const extraParameters = (logType: Log) => {
 
 export const DEFAULT_PAGE_SIZE = 25;
 
-export const useEventLogSearch = (
-    logType: Log,
+type UseEventLogSearchProps = {
+    logType: Log;
+    storageKey?: string;
+    refreshInterval?: number;
+    pageSize?: number;
+};
+export const useEventLogSearch = ({
+    logType,
     storageKey = 'event-log',
     refreshInterval = 15 * 1000,
     pageSize = DEFAULT_PAGE_SIZE,
-) => {
+}: UseEventLogSearchProps) => {
     const stateConfig = {
         offset: withDefault(NumberParam, 0),
         limit: withDefault(NumberParam, pageSize),

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -58,8 +58,6 @@ export const useEventLogSearch = ({
         ...extraParameters(logType),
     };
 
-    console.log('stateConfig', stateConfig.offset);
-
     const fullStorageKey = (() => {
         switch (logType.type) {
             case 'global':
@@ -92,13 +90,6 @@ export const useEventLogSearch = ({
         }
     })();
 
-    console.log(
-        tableState,
-        stateConfig,
-        mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
-            value ? `${value}` : undefined,
-        ),
-    );
     const { events, total, refetch, loading, initialLoad } = useEventSearch(
         mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
             value ? `${value}` : undefined,

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -35,6 +35,25 @@ const extraParameters = (logType: Log) => {
 
 export const DEFAULT_PAGE_SIZE = 25;
 
+export const calculatePaginationInfo = ({
+    offset,
+    pageSize,
+}: {
+    offset: number;
+    pageSize: number;
+}) => {
+    const currentPage = Math.floor(offset / Math.max(pageSize, 1));
+
+    const nextPageOffset = pageSize * (currentPage + 1);
+    const previousPageOffset = Math.max(pageSize * (currentPage - 1), 0);
+
+    return {
+        currentPage,
+        nextPageOffset,
+        previousPageOffset,
+    };
+};
+
 type UseEventLogSearchProps = {
     logType: Log;
     storageKey?: string;
@@ -99,9 +118,11 @@ export const useEventLogSearch = ({
         },
     );
 
-    const currentPage = Math.floor(
-        (tableState.offset ?? 0) / (tableState.limit ?? 1),
-    );
+    const { currentPage, nextPageOffset, previousPageOffset } =
+        calculatePaginationInfo({
+            offset: tableState.offset ?? 0,
+            pageSize: tableState.limit ?? 1,
+        });
 
     return {
         events,
@@ -116,23 +137,13 @@ export const useEventLogSearch = ({
             pageSize: tableState.limit ?? 0,
             currentPage,
             nextPage: () => {
-                const nextPage = currentPage + 1;
-                setTableState({
-                    offset: (tableState.limit ?? 0) * nextPage,
-                });
+                setTableState({ offset: nextPageOffset });
             },
-
             prevPage: () => {
-                const prevPage = currentPage - 1;
-                setTableState({
-                    offset: (tableState.limit ?? 0) * prevPage,
-                });
+                setTableState({ offset: previousPageOffset });
             },
             setPageLimit: (limit: number) => {
-                setTableState({
-                    limit,
-                    offset: 0,
-                });
+                setTableState({ limit, offset: 0 });
             },
         },
     };

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -51,16 +51,11 @@ export const calculatePaginationInfo = ({
     };
 };
 
-type UseEventLogSearchProps = {
-    logType: Log;
-    storageKey?: string;
-    refreshInterval?: number;
-};
-export const useEventLogSearch = ({
-    logType,
+export const useEventLogSearch = (
+    logType: Log,
     storageKey = 'event-log',
     refreshInterval = 15 * 1000,
-}: UseEventLogSearchProps) => {
+) => {
     const stateConfig = {
         offset: withDefault(NumberParam, 0),
         limit: withDefault(NumberParam, DEFAULT_PAGE_SIZE),

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -42,8 +42,8 @@ export const useEventLogSearch = (
     pageSize = DEFAULT_PAGE_SIZE,
 ) => {
     const stateConfig = {
-        offset: NumberParam,
-        limit: NumberParam,
+        offset: withDefault(NumberParam, 0),
+        limit: withDefault(NumberParam, pageSize),
         query: StringParam,
         from: FilterItemParam,
         to: FilterItemParam,

--- a/frontend/src/hooks/api/getters/useEventSearch/useEventSearch.ts
+++ b/frontend/src/hooks/api/getters/useEventSearch/useEventSearch.ts
@@ -57,7 +57,6 @@ const createEventSearch = () => {
         options: SWRConfiguration = {},
         cachePrefix: string = '',
     ): UseEventSearchOutput => {
-        console.log('useEventSearch. params', params);
         const { KEY, fetcher } = getEventSearchFetcher(params);
         const swrKey = `${cachePrefix}${KEY}`;
         const cacheId = params.project || '';

--- a/frontend/src/hooks/api/getters/useEventSearch/useEventSearch.ts
+++ b/frontend/src/hooks/api/getters/useEventSearch/useEventSearch.ts
@@ -57,6 +57,7 @@ const createEventSearch = () => {
         options: SWRConfiguration = {},
         cachePrefix: string = '',
     ): UseEventSearchOutput => {
+        console.log('useEventSearch. params', params);
         const { KEY, fetcher } = getEventSearchFetcher(params);
         const swrKey = `${cachePrefix}${KEY}`;
         const cacheId = params.project || '';


### PR DESCRIPTION
Adds sticky pagination to the event log:

![image](https://github.com/user-attachments/assets/c426f30d-bb64-44a5-b3b4-8c295207b249)

This PR uses the sticky pagination bar that we use on other tables to navigate the event search results.

## Decisions / discussion points

The trickiest issue here is how we calculate the next and previous page offsets. This is tricky because we don't expose the page number to the API, but the raw offset itself. This abstraction makes it possible to set an offset that isn't a multiple of the page size.

Say the page size is 25. If you manually set an offset of 30 (through changing the URL), what do you expect should happen when you:
- load the page? Should you see results 31 to 55? 26 to 50?
- go to the next page? Should your next offset be 55 or 50?
- previous page: should your previous page offset be 5? 25? 0?

The current implementation has taken what I thought would be the easiest way out: If your offset is between two multiples of the page size, we'll consider it to be the lower of the two.
- The next page's offset is the next multiple of the page size that is higher than the current offset (50 in the example above).
- The previous page's offset will be not the nearest lower page size, but the one below. So if you set offset 35 and page size 25, your next page will take you back to 0 (as if the offset was 25).

We could instead update the API to accept `page` instead of offset, but that wouldn't align with how other tables do it.

Comparing to the global flags table, if you set an offset that isn't a multiple of the page size, we force the offset to 0. We can look at handling it like that in a follow-up, though I'd argue that forcing it to be the next lower multiple of the page size would make more sense.

One issue that appears when you can set custom offsets is that the little "showing x-y items out of z" gets out of whack (because it only operates on multiples of the page size (seemingly))
![image](https://github.com/user-attachments/assets/ec9df89c-2717-45d9-97dd-5c4e8ebc24cc)

## The Event Log as a table

While we haven't used the HTML `table` element to render the event log, I would argue that it _is_ actually a table. It displays tabular data. Each card (row) has an id, a project, etc. 

The current implementation forces the event log search to act as a table state manager, but we could transform the event list into an events table to better align the pagination handling. The best part? We can keep the exact same design too. A table doesn't have to _look_ like a table to be a table.