### PR TITLE
fix: allow for empty groupId in form

### DIFF
--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Box, styled } from '@mui/material';
 import type { IFeatureStrategyParameters } from 'interfaces/strategy';
 import RolloutSlider from '../RolloutSlider/RolloutSlider';
@@ -82,7 +82,7 @@ const FlexibleStrategy = ({
         return parseParameterString(parameters.stickiness);
     }, [loading, defaultStickiness, parameters.stickiness]);
 
-    const groupId = useMemo(() => {
+    useEffect(() => {
         if (!parameters.groupId && !loading) {
             if (isDefaultStrategyEdit || !featureId) {
                 updateParameter('groupId', '');
@@ -90,9 +90,9 @@ const FlexibleStrategy = ({
                 updateParameter('groupId', featureId);
             }
         }
+    }, [isDefaultStrategyEdit, featureId, loading]);
 
-        return parseParameterString(parameters.groupId);
-    }, [parameters.groupId, isDefaultStrategyEdit, featureId, loading]);
+    const groupId = parseParameterString(parameters.groupId);
 
     if (loading) {
         return <Loader />;

--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
@@ -126,7 +126,10 @@ const FlexibleStrategy = ({
                         value={groupId}
                         disabled={!editable}
                         onChange={(e) =>
-                            updateParameter('groupId', e.target.value)
+                            updateParameter(
+                                'groupId',
+                                parseParameterString(e.target.value),
+                            )
                         }
                         data-testid={FLEXIBLE_STRATEGY_GROUP_ID}
                         error={Boolean(errors?.getFormError('groupId'))}


### PR DESCRIPTION
`groupId` parameter because of the change in validation wasn't parsed correctly.

Intent was to fill it when it is empty, when the form is loaded.
By mistake the same logic applies when you manually remove all characters from the text field.