### PR TITLE
fix: allow for empty groupId in form (#7798)

### DIFF
--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Box, styled } from '@mui/material';
 import type { IFeatureStrategyParameters } from 'interfaces/strategy';
 import RolloutSlider from '../RolloutSlider/RolloutSlider';
@@ -82,7 +82,7 @@ const FlexibleStrategy = ({
         return parseParameterString(parameters.stickiness);
     }, [loading, defaultStickiness, parameters.stickiness]);
 
-    const groupId = useMemo(() => {
+    useEffect(() => {
         if (!parameters.groupId && !loading) {
             if (isDefaultStrategyEdit || !featureId) {
                 updateParameter('groupId', '');
@@ -90,9 +90,9 @@ const FlexibleStrategy = ({
                 updateParameter('groupId', featureId);
             }
         }
+    }, [isDefaultStrategyEdit, featureId, loading]);
 
-        return parseParameterString(parameters.groupId);
-    }, [parameters.groupId, isDefaultStrategyEdit, featureId, loading]);
+    const groupId = parseParameterString(parameters.groupId);
 
     if (loading) {
         return <Loader />;
@@ -126,7 +126,10 @@ const FlexibleStrategy = ({
                         value={groupId}
                         disabled={!editable}
                         onChange={(e) =>
-                            updateParameter('groupId', e.target.value)
+                            updateParameter(
+                                'groupId',
+                                parseParameterString(e.target.value),
+                            )
                         }
                         data-testid={FLEXIBLE_STRATEGY_GROUP_ID}
                         error={Boolean(errors?.getFormError('groupId'))}


### PR DESCRIPTION
`groupId` parameter because of the change in validation wasn't parsed correctly. Intent was to fill it when it is empty, when the form is loaded. By mistake the same logic applies when you manually remove all characters from the text field.

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
