### PR TITLE
feat: event creators

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -200,4 +200,8 @@ export default class EventService {
 
         return queryParams;
     };
+
+    async getEventCreators() {
+        return this.eventStore.getEventCreators();
+    }
 }

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -16,7 +16,7 @@ import { sharedEventEmitter } from '../../util/anyEventEmitter';
 import type { Db } from '../../db/db';
 import type { Knex } from 'knex';
 import type EventEmitter from 'events';
-import { ADMIN_TOKEN_USER, SYSTEM_USER_ID } from '../../types';
+import { ADMIN_TOKEN_USER, SYSTEM_USER, SYSTEM_USER_ID } from '../../types';
 import type { DeprecatedSearchEventsSchema } from '../../openapi';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { applyGenericQueryParams } from '../feature-search/search-utils';
@@ -381,12 +381,29 @@ class EventStore implements IEventStore {
     }
 
     async getEventCreators(): Promise<Array<{ id: number; name: string }>> {
-        const query = this.db('events').distinct('created_by');
+        const query = this.db('events')
+            .distinct('events.created_by_user_id')
+            .leftJoin('users', 'users.id', '=', 'events.created_by_user_id')
+            .select([
+                'events.created_by_user_id as id',
+                this.db.raw(`
+            CASE
+                WHEN events.created_by_user_id = -1337 THEN '${SYSTEM_USER.name}'
+                WHEN events.created_by_user_id = -42 THEN '${ADMIN_TOKEN_USER.name}'
+                ELSE COALESCE(users.name, events.created_by)
+            END as name
+        `),
+                'users.username',
+                'users.email',
+            ]);
 
         const result = await query;
         return result
-            .filter((row) => row.created_by)
-            .map((row) => row.created_by);
+            .filter((row) => row.name || row.username || row.email)
+            .map((row) => ({
+                id: Number(row.id),
+                name: String(row.name || row.username || row.email),
+            }));
     }
 
     async deprecatedSearchEvents(

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -380,6 +380,15 @@ class EventStore implements IEventStore {
         return query;
     }
 
+    async getEventCreators(): Promise<Array<{ id: number; name: string }>> {
+        const query = this.db('events').distinct('created_by');
+
+        const result = await query;
+        return result
+            .filter((row) => row.created_by)
+            .map((row) => row.created_by);
+    }
+
     async deprecatedSearchEvents(
         search: DeprecatedSearchEventsSchema = {},
     ): Promise<IEvent[]> {

--- a/src/lib/openapi/spec/event-creators-schema.ts
+++ b/src/lib/openapi/spec/event-creators-schema.ts
@@ -5,10 +5,22 @@ export const eventCreatorsSchema = {
     type: 'array',
     description: 'A list of event creators',
     items: {
-        type: 'string',
-        description:
-            "Name of the user. If the user has no set name, the API falls back to using the user's username (if they have one) or email (if neither name or username is set).",
-        example: 'User',
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'name'],
+        properties: {
+            id: {
+                type: 'integer',
+                example: 50,
+                description: 'The user id.',
+            },
+            name: {
+                description:
+                    "Name of the user. If the user has no set name, the API falls back to using the user's username (if they have one) or email (if neither name or username is set).",
+                type: 'string',
+                example: 'User',
+            },
+        },
     },
 
     components: {

--- a/src/lib/openapi/spec/event-creators-schema.ts
+++ b/src/lib/openapi/spec/event-creators-schema.ts
@@ -1,0 +1,19 @@
+import type { FromSchema } from 'json-schema-to-ts';
+
+export const eventCreatorsSchema = {
+    $id: '#/components/schemas/eventCreatorsSchema',
+    type: 'array',
+    description: 'A list of event creators',
+    items: {
+        type: 'string',
+        description:
+            "Name of the user. If the user has no set name, the API falls back to using the user's username (if they have one) or email (if neither name or username is set).",
+        example: 'User',
+    },
+
+    components: {
+        schemas: {},
+    },
+} as const;
+
+export type EventCreatorsSchema = FromSchema<typeof eventCreatorsSchema>;

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -69,6 +69,7 @@ export * from './environment-project-schema';
 export * from './environment-schema';
 export * from './environments-project-schema';
 export * from './environments-schema';
+export * from './event-creators-schema';
 export * from './event-schema';
 export * from './event-search-response-schema';
 export * from './events-schema';

--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -134,7 +134,7 @@ export default class EventController extends Controller {
                     description:
                         'Returns a list of all users that have created events in the system.',
                     responses: {
-                        200: createResponseSchema('eventFlagCreatorsSchema'),
+                        200: createResponseSchema('eventCreatorsSchema'),
                         ...getStandardResponses(401, 403, 404),
                     },
                 }),

--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -21,6 +21,11 @@ import { getStandardResponses } from '../../../lib/openapi/util/standard-respons
 import { createRequestSchema } from '../../openapi/util/create-request-schema';
 import type { DeprecatedSearchEventsSchema } from '../../openapi/spec/deprecated-search-events-schema';
 import type { IFlagResolver } from '../../types/experimental';
+import type { IAuthRequest } from '../unleash-types';
+import {
+    eventCreatorsSchema,
+    type ProjectFlagCreatorsSchema,
+} from '../../openapi';
 
 const ANON_KEYS = ['email', 'username', 'createdBy'];
 const version = 1 as const;
@@ -45,7 +50,7 @@ export default class EventController extends Controller {
 
         this.route({
             method: 'get',
-            path: '',
+            path: '/events',
             handler: this.getEvents,
             permission: ADMIN,
             middleware: [
@@ -76,7 +81,7 @@ export default class EventController extends Controller {
 
         this.route({
             method: 'get',
-            path: '/:featureName',
+            path: '/events/:featureName',
             handler: this.getEventsForToggle,
             permission: NONE,
             middleware: [
@@ -97,7 +102,7 @@ export default class EventController extends Controller {
 
         this.route({
             method: 'post',
-            path: '/search',
+            path: '/events/search',
             handler: this.deprecatedSearchEvents,
             permission: NONE,
             middleware: [
@@ -112,6 +117,26 @@ export default class EventController extends Controller {
                         'deprecatedSearchEventsSchema',
                     ),
                     responses: { 200: createResponseSchema('eventsSchema') },
+                }),
+            ],
+        });
+
+        this.route({
+            method: 'get',
+            path: '/event-creators',
+            handler: this.getEventCreators,
+            permission: NONE,
+            middleware: [
+                this.openApiService.validPath({
+                    tags: ['Events'],
+                    operationId: 'getEventCreators',
+                    summary: 'Get a list of all users that have created events',
+                    description:
+                        'Returns a list of all users that have created events in the system.',
+                    responses: {
+                        200: createResponseSchema('eventFlagCreatorsSchema'),
+                        ...getStandardResponses(401, 403, 404),
+                    },
                 }),
             ],
         });
@@ -195,6 +220,20 @@ export default class EventController extends Controller {
             res,
             featureEventsSchema.$id,
             response,
+        );
+    }
+
+    async getEventCreators(
+        req: IAuthRequest,
+        res: Response<ProjectFlagCreatorsSchema>,
+    ): Promise<void> {
+        const flagCreators = await this.eventService.getEventCreators();
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            eventCreatorsSchema.$id,
+            serializeDates(flagCreators),
         );
     }
 }

--- a/src/lib/routes/admin-api/index.ts
+++ b/src/lib/routes/admin-api/index.ts
@@ -61,7 +61,7 @@ export class AdminApi extends Controller {
             '/strategies',
             new StrategyController(config, services).router,
         );
-        this.app.use('/events', new EventController(config, services).router);
+        this.app.use('', new EventController(config, services).router);
         this.app.use(
             '/playground',
             new PlaygroundController(config, services).router,

--- a/src/lib/routes/admin-api/search/index.ts
+++ b/src/lib/routes/admin-api/search/index.ts
@@ -20,5 +20,10 @@ export class SearchApi extends Controller {
             '/events',
             new EventSearchController(config, services).router,
         );
+
+        this.app.use(
+            '/events',
+            new EventSearchController(config, services).router,
+        );
     }
 }

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -43,4 +43,5 @@ export interface IEventStore
     query(operations: IQueryOperations[]): Promise<IEvent[]>;
     queryCount(operations: IQueryOperations[]): Promise<number>;
     setCreatedByUserId(batchSize: number): Promise<number | undefined>;
+    getEventCreators(): Promise<Array<{ id: number; name: string }>>;
 }

--- a/src/test/e2e/api/admin/event.e2e.test.ts
+++ b/src/test/e2e/api/admin/event.e2e.test.ts
@@ -152,35 +152,6 @@ test('can search for events', async () => {
         });
 });
 
-test('Can filter by project', async () => {
-    await eventService.storeEvent({
-        type: FEATURE_CREATED,
-        project: 'something-else',
-        data: { id: 'some-other-feature' },
-        tags: [],
-        createdBy: 'test-user',
-        createdByUserId: TEST_USER_ID,
-        ip: '127.0.0.1',
-    });
-    await eventService.storeEvent({
-        type: FEATURE_CREATED,
-        project: 'default',
-        data: { id: 'feature' },
-        tags: [],
-        createdBy: 'test-user',
-        environment: 'test',
-        createdByUserId: TEST_USER_ID,
-        ip: '127.0.0.1',
-    });
-    await app.request
-        .get('/api/admin/events?project=default')
-        .expect(200)
-        .expect((res) => {
-            expect(res.body.events).toHaveLength(1);
-            expect(res.body.events[0].data.id).toEqual('feature');
-        });
-});
-
 test('event creators - if system user, return system name, else should return name from database if user exists, else from events table', async () => {
     const user = await db.stores.userStore.insert({ name: 'database-user' });
     const events: IBaseEvent[] = [

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -15,6 +15,10 @@ class FakeEventStore implements IEventStore {
         this.events = [];
     }
 
+    getEventCreators(): Promise<{ id: number; name: string }[]> {
+        throw new Error('Method not implemented.');
+    }
+
     getMaxRevisionId(): Promise<number> {
         return Promise.resolve(1);
     }


### PR DESCRIPTION
Adds an endpoint to return all event creators.

An interesting point is that it does not return the user object, but just created_by as a string. This is because we do not store user IDs for events, as they are not strictly bound to a user object, but rather a historical user with the name X.