### PR TITLE
fix: don't show link stubs in slack notifications

### DIFF
--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -132,6 +132,7 @@ export default class SlackAppAddon extends Addon {
                     channel: name,
                     text,
                     blocks,
+                    unfurl_links: false,
                 });
             });
 


### PR DESCRIPTION
Slack is trying to add not useful link previews 

![image](https://github.com/user-attachments/assets/fd95a0a1-0833-4d04-a631-d554f17fd457)

_"just, don't"_