### PR TITLE
fix: Update avatar usage in change requests

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/AddCommentField.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import type { FC } from 'react';
-import { Box, styled, TextField, Tooltip } from '@mui/material';
+import { Box, styled, TextField } from '@mui/material';
 import { StyledAvatar } from './StyledAvatar';
 import type { IUser } from 'interfaces/user';
 
@@ -18,9 +18,7 @@ export const AddCommentField: FC<{
 }> = ({ user, commentText, onTypeComment, children }) => (
     <>
         <AddCommentWrapper>
-            <Tooltip title={user?.name || user?.username}>
-                <StyledAvatar src={user?.imageUrl || ''} />
-            </Tooltip>
+            <StyledAvatar user={user} />
             <TextField
                 variant='outlined'
                 placeholder='Add your comment here'

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { Markdown } from 'component/common/Markdown/Markdown';
 import Paper from '@mui/material/Paper';
-import { Box, styled, Typography, Tooltip } from '@mui/material';
+import { Box, styled, Typography } from '@mui/material';
 import TimeAgo from 'react-timeago';
 import { StyledAvatar } from './StyledAvatar';
 import type { IChangeRequestComment } from '../../changeRequest.types';
@@ -29,9 +29,7 @@ export const ChangeRequestComment: FC<{ comment: IChangeRequestComment }> = ({
     comment,
 }) => (
     <ChangeRequestCommentWrapper>
-        <Tooltip title={comment.createdBy.username}>
-            <StyledAvatar src={comment.createdBy.imageUrl} />
-        </Tooltip>
+        <StyledAvatar user={comment.createdBy} />
         <CommentPaper variant='outlined'>
             <CommentHeader>
                 <Box>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/StyledAvatar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/StyledAvatar.tsx
@@ -1,6 +1,7 @@
-import { Avatar, styled } from '@mui/material';
+import { styled } from '@mui/material';
+import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 
-export const StyledAvatar = styled(Avatar)(({ theme }) => ({
+export const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
     height: '32px',
     width: '32px',
     marginTop: theme.spacing(1),

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.styles.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.styles.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material';
-import { Avatar, Box, Card, Paper, Typography } from '@mui/material';
+import { Box, Card, Paper, Typography } from '@mui/material';
+import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 
 export const StyledPaper = styled(Paper)(({ theme }) => ({
     padding: theme.spacing(3, 4),
@@ -29,7 +30,7 @@ export const StyledCard = styled(Card)(({ theme }) => ({
     backgroundColor: theme.palette.background.elevation2,
 }));
 
-export const StyledAvatar = styled(Avatar)(({ theme }) => ({
+export const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
     height: '24px',
     width: '24px',
 }));

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.styles.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.styles.tsx
@@ -33,4 +33,5 @@ export const StyledCard = styled(Card)(({ theme }) => ({
 export const StyledAvatar = styled(UserAvatar)(({ theme }) => ({
     height: '24px',
     width: '24px',
+    marginInline: 0,
 }));

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
@@ -51,9 +51,7 @@ export const ChangeRequestHeader: FC<{ changeRequest: ChangeRequestType }> = ({
                     })}
                 >
                     <Tooltip title={changeRequest?.createdBy?.username}>
-                        <StyledAvatar
-                            src={changeRequest?.createdBy?.imageUrl}
-                        />
+                        <StyledAvatar user={changeRequest?.createdBy} />
                     </Tooltip>
                 </Box>
                 <Typography

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewers/ChangeRequestReviewer.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestReviewers/ChangeRequestReviewer.tsx
@@ -40,7 +40,7 @@ export const ChangeRequestApprover: FC<IChangeRequestReviewerProps> = ({
 }) => {
     return (
         <StyledBox>
-            <StyledAvatar src={imageUrl} />
+            <StyledAvatar user={{ name, imageUrl }} />
             <ReviewerName variant='body1'>{name}</ReviewerName>
             <StyledSuccessIcon />
         </StyledBox>
@@ -53,7 +53,7 @@ export const ChangeRequestRejector: FC<IChangeRequestReviewerProps> = ({
 }) => {
     return (
         <StyledBox>
-            <StyledAvatar src={imageUrl} />
+            <StyledAvatar user={{ name, imageUrl }} />
             <ReviewerName variant='body1'>{name}</ReviewerName>
             <StyledErrorIcon />
         </StyledBox>


### PR DESCRIPTION
Turns out there was (at least) one other avatar instance we missed in
[ previous update ](https://github.com/Unleash/unleash/pull/7681):
change request avatars.

They don't use the existing UserAvatar component, so didn't show up in
the dependency graph. This change makes it so that those avatars also
use the user avatar component (and send all the info that we need).


Before: 
![image](https://github.com/user-attachments/assets/42ee2dae-ff7d-4829-873e-7d8136f3ab10)

After:
![image](https://github.com/user-attachments/assets/c449eb3f-f8f0-4113-9a06-36635085537c)


To show that the overall layout is the same, here's before:
![image](https://github.com/user-attachments/assets/05ec7d0a-ad4e-4bfa-90b4-0041827ecf6f)

and after:
![image](https://github.com/user-attachments/assets/1f081e3f-7cd4-4717-80ad-2046a90e4dc3)
