### PR TITLE
feat: prevent revive flag/flags in archived project

### DIFF
--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -773,3 +773,40 @@ test('Should not allow to add flags to archived projects', async () => {
         ),
     );
 });
+
+test('Should not allow to revive flags to archived projects', async () => {
+    const project = await stores.projectStore.create({
+        id: 'archivedProjectWithFlag',
+        name: 'archivedProjectWithFlag',
+    });
+    const flag = await service.createFeatureToggle(
+        project.id,
+        {
+            name: 'archiveFlag',
+        },
+        TEST_AUDIT_USER,
+    );
+
+    await service.archiveToggle(
+        flag.name,
+        { email: 'test@example.com' } as User,
+        TEST_AUDIT_USER,
+    );
+    await stores.projectStore.archive(project.id);
+
+    await expect(
+        service.reviveFeature(flag.name, TEST_AUDIT_USER),
+    ).rejects.toEqual(
+        new NotFoundError(
+            `Active project with id archivedProjectWithFlag does not exist`,
+        ),
+    );
+
+    await expect(
+        service.reviveFeatures([flag.name], project.id, TEST_AUDIT_USER),
+    ).rejects.toEqual(
+        new NotFoundError(
+            `Active project with id archivedProjectWithFlag does not exist`,
+        ),
+    );
+});


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Prevent people from reviving features in archived project

<img width="1431" alt="Screenshot 2024-08-09 at 16 14 13" src="https://github.com/user-attachments/assets/32e8d37c-79c2-4ec9-b22b-8beb67153d8a">


Details:
* added a validation method that checks if there's an active project
* covering single feature and batch revive
* currently we don't distinguish between deleted and archived and we always say that active project was not found. We may consider splitting this into not found and invalid operation in future

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
