### PR TITLE
fix: after encryption some emails end up being too long

### DIFF
--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -220,7 +220,11 @@ class UserService {
         }
 
         if (email) {
-            Joi.assert(email, Joi.string().email(), 'Email');
+            Joi.assert(
+                email,
+                Joi.string().email({ ignoreLength: true }),
+                'Email',
+            );
         }
 
         const exists = await this.store.hasUser({ username, email });
@@ -264,7 +268,11 @@ class UserService {
         const preUser = await this.getUser(id);
 
         if (email) {
-            Joi.assert(email, Joi.string().email(), 'Email');
+            Joi.assert(
+                email,
+                Joi.string().email({ ignoreLength: true }),
+                'Email',
+            );
         }
 
         if (rootRole) {
@@ -373,14 +381,22 @@ class UserService {
         } catch (e) {
             // User does not exists. Create if 'autoCreate' is enabled
             if (autoCreate) {
-                user = await this.createUser(
-                    {
-                        email,
-                        name,
-                        rootRole: rootRole || RoleName.EDITOR,
-                    },
-                    SYSTEM_USER_AUDIT,
-                );
+                console.log('autoCreate');
+                try {
+                    user = await this.createUser(
+                        {
+                            email,
+                            name,
+                            rootRole: rootRole || RoleName.EDITOR,
+                        },
+                        SYSTEM_USER_AUDIT,
+                    );
+                } catch (e) {
+                    console.log(
+                        `Failed to create user with email: ${email}`,
+                        e,
+                    );
+                }
             } else {
                 throw e;
             }
@@ -390,8 +406,11 @@ class UserService {
     }
 
     async loginDemoAuthDefaultAdmin(): Promise<IUser> {
+        console.log('loginDemoAuthDefaultAdmin');
         const user = await this.store.getByQuery({ id: 1 });
+        console.log('user', user);
         await this.store.successfullyLogin(user);
+        console.log('user success login');
         return user;
     }
 

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -381,22 +381,14 @@ class UserService {
         } catch (e) {
             // User does not exists. Create if 'autoCreate' is enabled
             if (autoCreate) {
-                console.log('autoCreate');
-                try {
-                    user = await this.createUser(
-                        {
-                            email,
-                            name,
-                            rootRole: rootRole || RoleName.EDITOR,
-                        },
-                        SYSTEM_USER_AUDIT,
-                    );
-                } catch (e) {
-                    console.log(
-                        `Failed to create user with email: ${email}`,
-                        e,
-                    );
-                }
+                user = await this.createUser(
+                    {
+                        email,
+                        name,
+                        rootRole: rootRole || RoleName.EDITOR,
+                    },
+                    SYSTEM_USER_AUDIT,
+                );
             } else {
                 throw e;
             }
@@ -406,11 +398,8 @@ class UserService {
     }
 
     async loginDemoAuthDefaultAdmin(): Promise<IUser> {
-        console.log('loginDemoAuthDefaultAdmin');
         const user = await this.store.getByQuery({ id: 1 });
-        console.log('user', user);
         await this.store.successfullyLogin(user);
-        console.log('user success login');
         return user;
     }
 

--- a/src/lib/types/user.test.ts
+++ b/src/lib/types/user.test.ts
@@ -39,8 +39,17 @@ test('Should create user with only email defined', () => {
 
 test('Should require valid email', () => {
     expect(() => {
-        new User({ id: 11, email: 'some@' }); // eslint-disable-line
-    }).toThrowError(Error('Email "value" must be a valid email'));
+        new User({ id: 11, email: 'some@' });
+    }).toThrow(Error('Email "value" must be a valid email'));
+});
+
+test('Should allow long emails on demo', () => {
+    expect(() => {
+        new User({
+            id: 11,
+            email: '0a1c1b6a59a582fdbe853739eefc599dxd1eb365eee385e345b5fc41f59172022a8f69c09f61121d8b4a155b792314ee@unleash.run',
+        });
+    }).not.toThrow();
 });
 
 test('Should create user with only username defined', () => {

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -83,7 +83,7 @@ export default class User implements IUser {
         if (!id) {
             throw new ValidationError('Id is required', [], undefined);
         }
-        Joi.assert(email, Joi.string().email(), 'Email');
+        Joi.assert(email, Joi.string().email({ ignoreLength: true }), 'Email');
         Joi.assert(username, Joi.string(), 'Username');
         Joi.assert(name, Joi.string(), 'Name');
 


### PR DESCRIPTION
Encountered this case after encrypting an already long email address. This should mitigate the issue in demo instance. I don't think it's a big issue to ignore the length when validating an email address cause this is already limited at the DB layer by the column length