### PR TITLE
fix: don't always fetch all flags on project flag screen

### DIFF
--- a/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
+++ b/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
@@ -18,8 +18,8 @@ import useProjectOverview, {
     featuresCount,
 } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { useGlobalFeatureSearch } from '../FeatureToggleList/useGlobalFeatureSearch';
 import { Limit } from 'component/common/Limit/Limit';
-import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(2),
@@ -104,11 +104,8 @@ const CreateFeature = () => {
 
     const { createFeatureToggle, loading } = useFeatureApi();
 
-    const {
-        insights: {
-            flags: { total: totalFlags },
-        },
-    } = useInsights();
+    const { total: totalFlags, loading: loadingTotalFlagCount } =
+        useGlobalFeatureSearch();
 
     const resourceLimitsEnabled = useUiFlag('resourceLimits');
 

--- a/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
+++ b/frontend/src/component/feature/CreateFeature/CreateFeature.tsx
@@ -18,8 +18,8 @@ import useProjectOverview, {
     featuresCount,
 } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { useGlobalFeatureSearch } from '../FeatureToggleList/useGlobalFeatureSearch';
 import { Limit } from 'component/common/Limit/Limit';
+import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(2),
@@ -104,8 +104,11 @@ const CreateFeature = () => {
 
     const { createFeatureToggle, loading } = useFeatureApi();
 
-    const { total: totalFlags, loading: loadingTotalFlagCount } =
-        useGlobalFeatureSearch();
+    const {
+        insights: {
+            flags: { total: totalFlags },
+        },
+    } = useInsights();
 
     const resourceLimitsEnabled = useUiFlag('resourceLimits');
 

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -80,6 +80,17 @@ export const CreateFeatureDialog = ({
     open,
     onClose,
 }: ICreateFeatureDialogProps) => {
+    if (open) {
+        // wrap the inner component so that we only fetch data etc
+        // when the dialog is actually open.
+        return <CreateFeatureDialogContent open={open} onClose={onClose} />;
+    }
+};
+
+const CreateFeatureDialogContent = ({
+    open,
+    onClose,
+}: ICreateFeatureDialogProps) => {
     const { setToastData, setToastApiError } = useToast();
     const { setShowFeedback } = useContext(UIContext);
     const { uiConfig, isOss } = useUiConfig();
@@ -158,7 +169,7 @@ export const CreateFeatureDialog = ({
     };
 
     const { total: totalFlags, loading: loadingTotalFlagCount } =
-        useGlobalFeatureSearch();
+        useGlobalFeatureSearch(1);
 
     const { project: projectInfo } = useProjectOverview(project);
     const { tags: allTags } = useAllTags();


### PR DESCRIPTION
There's a bug where the UI will fetch all features every time you load a project screen (including every time you filter the project results).

The reason is that the create flag dialog was rendered (just not open) every time. To solve it, we instead wrap it in an extra component that prevents all the fetching and setup from running when the dialog isn't open.

Additionally, we'll lower the page size for the global fetch limit to 1, so that we send less data.

(There's a bug in place that prevents the page size from working at the moment, but I'll address that in a follow-up)