### PR TITLE
Fix: time to production

### DIFF
--- a/frontend/src/component/insights/componentsChart/TimeToProductionChart/TimeToProductionChart.tsx
+++ b/frontend/src/component/insights/componentsChart/TimeToProductionChart/TimeToProductionChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type VFC } from 'react';
+import { useMemo, type FC } from 'react';
 import 'chartjs-adapter-date-fns';
 import type { InstanceInsightsSchema } from 'openapi';
 import {
@@ -21,7 +21,7 @@ interface ITimeToProductionChartProps {
     isLoading?: boolean;
 }
 
-export const TimeToProductionChart: VFC<ITimeToProductionChartProps> = ({
+export const TimeToProductionChart: FC<ITimeToProductionChartProps> = ({
     projectFlagTrends,
     isAggregate,
     isLoading,
@@ -35,9 +35,20 @@ export const TimeToProductionChart: VFC<ITimeToProductionChartProps> = ({
         [projectsDatasets, isLoading],
     );
 
+    const filteredProjectsDatasets = useMemo(
+        () => ({
+            ...projectsDatasets,
+            datasets: projectsDatasets.datasets.map((dataset) => ({
+                ...dataset,
+                data: dataset.data.filter((item) => item.timeToProduction),
+            })),
+        }),
+        [projectsDatasets],
+    );
+
     const aggregatedPerDay = useMemo(() => {
         const result = medianTimeToProduction(
-            Object.values(projectsDatasets.datasets).flatMap(
+            Object.values(filteredProjectsDatasets.datasets).flatMap(
                 (item) => item.data,
             ),
         );
@@ -60,9 +71,9 @@ export const TimeToProductionChart: VFC<ITimeToProductionChartProps> = ({
                 },
             ],
         };
-    }, [JSON.stringify(projectsDatasets), theme]);
+    }, [JSON.stringify(filteredProjectsDatasets), theme]);
 
-    const data = isAggregate ? aggregatedPerDay : projectsDatasets;
+    const data = isAggregate ? aggregatedPerDay : filteredProjectsDatasets;
     const placeholderData = usePlaceholderData();
     return (
         <LineChart

--- a/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
+++ b/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
@@ -30,6 +30,22 @@ describe('calculate average time to production', () => {
                 created: new Date('2024-11-11T09:11:11.111Z'),
                 enabled: new Date('2024-11-11T09:11:11.112Z'),
             },
+            {
+                created: new Date('2024-12-12T09:12:11.121Z'),
+                enabled: new Date('2024-12-12T09:12:12.122Z'),
+            },
+        ]);
+
+        expect(timeToProduction).toBe(0.1);
+    });
+
+    test('should return more then 0 if feature was enabled instantly', () => {
+        const created = new Date('2024-11-11T09:11:11.111Z');
+        const timeToProduction = calculateAverageTimeToProd([
+            {
+                created,
+                enabled: created,
+            },
         ]);
 
         expect(timeToProduction).toBe(0.1);

--- a/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
+++ b/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
@@ -24,7 +24,7 @@ describe('calculate average time to production', () => {
         expect(timeToProduction).toBe(21);
     });
 
-    test('should return more then 0 if feature was enabled almost instantly', () => {
+    test('should return more than 0 if feature was enabled almost instantly', () => {
         const timeToProduction = calculateAverageTimeToProd([
             {
                 created: new Date('2024-11-11T09:11:11.111Z'),
@@ -39,7 +39,7 @@ describe('calculate average time to production', () => {
         expect(timeToProduction).toBe(0.1);
     });
 
-    test('should return more then 0 if feature was enabled instantly', () => {
+    test('should return more than 0 if feature was enabled instantly', () => {
         const created = new Date('2024-11-11T09:11:11.111Z');
         const timeToProduction = calculateAverageTimeToProd([
             {

--- a/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
+++ b/src/lib/features/feature-toggle/time-to-production/time-to-production.test.ts
@@ -23,4 +23,15 @@ describe('calculate average time to production', () => {
 
         expect(timeToProduction).toBe(21);
     });
+
+    test('should return more then 0 if feature was enabled almost instantly', () => {
+        const timeToProduction = calculateAverageTimeToProd([
+            {
+                created: new Date('2024-11-11T09:11:11.111Z'),
+                enabled: new Date('2024-11-11T09:11:11.112Z'),
+            },
+        ]);
+
+        expect(timeToProduction).toBe(0.1);
+    });
 });

--- a/src/lib/features/feature-toggle/time-to-production/time-to-production.ts
+++ b/src/lib/features/feature-toggle/time-to-production/time-to-production.ts
@@ -12,11 +12,9 @@ export const calculateAverageTimeToProd = (
     const timeToProdPerFeature = calculateTimeToProdForFeatures(items);
     if (timeToProdPerFeature.length) {
         const sum = timeToProdPerFeature.reduce((acc, curr) => acc + curr, 0);
-
         const avg = sum / Object.keys(items).length;
-        if (avg <= 0.1) return 0.1;
 
-        return Number(avg.toFixed(1));
+        return Number(avg.toFixed(1)) || 0.1;
     }
 
     return 0;

--- a/src/lib/features/feature-toggle/time-to-production/time-to-production.ts
+++ b/src/lib/features/feature-toggle/time-to-production/time-to-production.ts
@@ -13,7 +13,10 @@ export const calculateAverageTimeToProd = (
     if (timeToProdPerFeature.length) {
         const sum = timeToProdPerFeature.reduce((acc, curr) => acc + curr, 0);
 
-        return Number((sum / Object.keys(items).length).toFixed(1));
+        const avg = sum / Object.keys(items).length;
+        if (avg <= 0.1) return 0.1;
+
+        return Number(avg.toFixed(1));
     }
 
     return 0;


### PR DESCRIPTION
## About the changes
- filter out time to production data points of `0 days to production`
- allow for gathering data for quickly enabled feature flags