### PR TITLE
feat: add index on events created at

### DIFF
--- a/src/migrations/20240812120954-add-archived-at-to-projects.js
+++ b/src/migrations/20240812120954-add-archived-at-to-projects.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+        CREATE INDEX idx_events_created_at_desc ON events (created_at DESC);
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+        DROP INDEX IF EXISTS idx_events_created_at_desc;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
After adding an index, the time for the new event search on 100k events decreased from 5000ms to 4ms. This improvement is due to the query using an index scan instead of a sequence scan. 