### PR TITLE
fix: display feature naming patterns in dialog

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
@@ -33,14 +33,14 @@ export const StyledHeader = styled(Typography)({
     fontWeight: 'lighter',
 });
 
-export const ProjectNameContainer = styled('div')(({ theme }) => ({
+export const NameContainer = styled('div')(({ theme }) => ({
     gridArea: 'project-name',
     display: 'flex',
     flexFlow: 'column nowrap',
     gap: theme.spacing(4),
 }));
 
-export const ProjectDescriptionContainer = styled('div')({
+export const DescriptionContainer = styled('div')({
     gridArea: 'project-description',
 });
 

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
@@ -33,9 +33,12 @@ export const StyledHeader = styled(Typography)({
     fontWeight: 'lighter',
 });
 
-export const ProjectNameContainer = styled('div')({
+export const ProjectNameContainer = styled('div')(({ theme }) => ({
     gridArea: 'project-name',
-});
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    gap: theme.spacing(4),
+}));
 
 export const ProjectDescriptionContainer = styled('div')({
     gridArea: 'project-description',

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.styles.tsx
@@ -37,7 +37,7 @@ export const NameContainer = styled('div')(({ theme }) => ({
     gridArea: 'project-name',
     display: 'flex',
     flexFlow: 'column nowrap',
-    gap: theme.spacing(4),
+    gap: theme.spacing(2),
 }));
 
 export const DescriptionContainer = styled('div')({

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
@@ -15,6 +15,11 @@ import {
 import { Button } from '@mui/material';
 import { CreateButton } from 'component/common/CreateButton/CreateButton';
 import type { IPermissionButtonProps } from 'component/common/PermissionButton/PermissionButton';
+import type { FeatureNamingType } from 'interfaces/project';
+import { ConditionallyRender } from '../ConditionallyRender/ConditionallyRender';
+import { NamingPatternInfo } from './NamingPatternInfo';
+
+type NamingPattern = FeatureNamingType;
 
 type FormProps = {
     createButtonProps: IPermissionButtonProps;
@@ -30,12 +35,14 @@ type FormProps = {
     setDescription: (newDescription: string) => void;
     setName: (newName: string) => void;
     validateName?: () => void;
+    namingPattern?: NamingPattern;
 };
 
 export const DialogFormTemplate: React.FC<FormProps> = ({
     Limit,
     handleSubmit,
     name,
+    namingPattern,
     setName,
     description,
     setDescription,
@@ -47,6 +54,8 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
     createButtonProps,
     validateName = () => {},
 }) => {
+    const displayNamingPattern = Boolean(namingPattern?.pattern);
+
     return (
         <StyledForm onSubmit={handleSubmit}>
             <TopGrid>
@@ -56,6 +65,11 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                     <StyledInput
                         label={`${resource} name`}
                         aria-required
+                        aria-details={
+                            displayNamingPattern
+                                ? 'naming-pattern-info'
+                                : undefined
+                        }
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                         error={Boolean(errors.name)}
@@ -73,6 +87,13 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                         }}
                         data-testid='FORM_NAME_INPUT'
                         size='medium'
+                    />
+
+                    <ConditionallyRender
+                        condition={displayNamingPattern}
+                        show={
+                            <NamingPatternInfo featureNaming={namingPattern!} />
+                        }
                     />
                 </ProjectNameContainer>
                 <ProjectDescriptionContainer>

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
@@ -91,9 +91,7 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
 
                     <ConditionallyRender
                         condition={displayNamingPattern}
-                        show={
-                            <NamingPatternInfo featureNaming={namingPattern!} />
-                        }
+                        show={<NamingPatternInfo naming={namingPattern!} />}
                     />
                 </ProjectNameContainer>
                 <ProjectDescriptionContainer>

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
@@ -2,8 +2,8 @@ import type { FormEventHandler } from 'react';
 import theme from 'themes/theme';
 import {
     ConfigButtons,
-    ProjectDescriptionContainer,
-    ProjectNameContainer,
+    DescriptionContainer,
+    NameContainer,
     StyledForm,
     StyledHeader,
     StyledInput,
@@ -61,7 +61,7 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
             <TopGrid>
                 <IconWrapper>{Icon}</IconWrapper>
                 <StyledHeader variant='h2'>Create {resource}</StyledHeader>
-                <ProjectNameContainer>
+                <NameContainer>
                     <StyledInput
                         label={`${resource} name`}
                         aria-required
@@ -93,8 +93,8 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                         condition={displayNamingPattern}
                         show={<NamingPatternInfo naming={namingPattern!} />}
                     />
-                </ProjectNameContainer>
-                <ProjectDescriptionContainer>
+                </NameContainer>
+                <DescriptionContainer>
                     <StyledInput
                         size='medium'
                         className='description'
@@ -111,7 +111,7 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                         }}
                         data-testid='FORM_DESCRIPTION_INPUT'
                     />
-                </ProjectDescriptionContainer>
+                </DescriptionContainer>
             </TopGrid>
 
             <ConfigButtons>{configButtons}</ConfigButtons>

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -39,10 +39,15 @@ type Props = {
 };
 
 export const NamingPatternInfo: React.FC<Props> = ({ naming }) => {
+    const controlId = 'naming-pattern-info-summary';
     return (
         <StyledFlagNamingInfo>
             <StyledAccordion>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <AccordionSummary
+                    id={controlId}
+                    aria-controls={controlId}
+                    expandIcon={<ExpandMoreIcon />}
+                >
                     Name must match:&nbsp;<code>^{naming.pattern}$</code>
                 </AccordionSummary>
                 <AccordionDetails>

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -24,33 +24,33 @@ const StyledFlagNamingInfo = styled('article')(({ theme }) => ({
 }));
 
 type Props = {
-    featureNaming: FeatureNamingType;
+    naming: FeatureNamingType;
 };
 
-export const NamingPatternInfo: React.FC<Props> = ({ featureNaming }) => {
+export const NamingPatternInfo: React.FC<Props> = ({ naming }) => {
     return (
         <StyledFlagNamingInfo>
             <p>The name must match this pattern:</p>
             <dl id='naming-pattern-info'>
                 <dt>Pattern</dt>
                 <dd>
-                    <code>^{featureNaming.pattern}$</code>
+                    <code>^{naming.pattern}$</code>
                 </dd>
                 <ConditionallyRender
-                    condition={Boolean(featureNaming?.example)}
+                    condition={Boolean(naming?.example)}
                     show={
                         <>
                             <dt>Example</dt>
-                            <dd>{featureNaming?.example}</dd>
+                            <dd>{naming?.example}</dd>
                         </>
                     }
                 />
                 <ConditionallyRender
-                    condition={Boolean(featureNaming?.description)}
+                    condition={Boolean(naming?.description)}
                     show={
                         <>
                             <dt>Description</dt>
-                            <dd>{featureNaming?.description}</dd>
+                            <dd>{naming?.description}</dd>
                         </>
                     }
                 />

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -43,7 +43,7 @@ export const NamingPatternInfo: React.FC<Props> = ({ naming }) => {
         <StyledFlagNamingInfo>
             <StyledAccordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    Must match: <code>^{naming.pattern}$</code>
+                    Name must match: <code>^{naming.pattern}$</code>
                 </AccordionSummary>
                 <AccordionDetails>
                     <p>The name must match this pattern:</p>

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -1,10 +1,15 @@
-import { styled } from '@mui/material';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    styled,
+} from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { FeatureNamingType } from 'interfaces/project';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 const StyledFlagNamingInfo = styled('article')(({ theme }) => ({
     fontSize: theme.typography.body2.fontSize,
-    padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadius,
     marginInlineStart: theme.spacing(1.5),
     backgroundColor: `${theme.palette.background.elevation2}`,
@@ -23,6 +28,12 @@ const StyledFlagNamingInfo = styled('article')(({ theme }) => ({
     },
 }));
 
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
+    backgroundColor: 'inherit',
+    boxShadow: 'none',
+    margin: 0,
+}));
+
 type Props = {
     naming: FeatureNamingType;
 };
@@ -30,31 +41,38 @@ type Props = {
 export const NamingPatternInfo: React.FC<Props> = ({ naming }) => {
     return (
         <StyledFlagNamingInfo>
-            <p>The name must match this pattern:</p>
-            <dl id='naming-pattern-info'>
-                <dt>Pattern</dt>
-                <dd>
-                    <code>^{naming.pattern}$</code>
-                </dd>
-                <ConditionallyRender
-                    condition={Boolean(naming?.example)}
-                    show={
-                        <>
-                            <dt>Example</dt>
-                            <dd>{naming?.example}</dd>
-                        </>
-                    }
-                />
-                <ConditionallyRender
-                    condition={Boolean(naming?.description)}
-                    show={
-                        <>
-                            <dt>Description</dt>
-                            <dd>{naming?.description}</dd>
-                        </>
-                    }
-                />
-            </dl>
+            <StyledAccordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    Must match: <code>^{naming.pattern}$</code>
+                </AccordionSummary>
+                <AccordionDetails>
+                    <p>The name must match this pattern:</p>
+                    <dl id='naming-pattern-info'>
+                        <dt>Pattern</dt>
+                        <dd>
+                            <code>^{naming.pattern}$</code>
+                        </dd>
+                        <ConditionallyRender
+                            condition={Boolean(naming?.example)}
+                            show={
+                                <>
+                                    <dt>Example</dt>
+                                    <dd>{naming?.example}</dd>
+                                </>
+                            }
+                        />
+                        <ConditionallyRender
+                            condition={Boolean(naming?.description)}
+                            show={
+                                <>
+                                    <dt>Description</dt>
+                                    <dd>{naming?.description}</dd>
+                                </>
+                            }
+                        />
+                    </dl>
+                </AccordionDetails>
+            </StyledAccordion>
         </StyledFlagNamingInfo>
     );
 };

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -43,7 +43,7 @@ export const NamingPatternInfo: React.FC<Props> = ({ naming }) => {
         <StyledFlagNamingInfo>
             <StyledAccordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    Name must match: <code>^{naming.pattern}$</code>
+                    Name must match:&nbsp;<code>^{naming.pattern}$</code>
                 </AccordionSummary>
                 <AccordionDetails>
                     <p>The name must match this pattern:</p>

--- a/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NamingPatternInfo.tsx
@@ -1,0 +1,60 @@
+import { styled } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import type { FeatureNamingType } from 'interfaces/project';
+
+const StyledFlagNamingInfo = styled('article')(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    padding: theme.spacing(2),
+    borderRadius: theme.shape.borderRadius,
+    marginInlineStart: theme.spacing(1.5),
+    backgroundColor: `${theme.palette.background.elevation2}`,
+    dl: {
+        display: 'grid',
+        gridTemplateColumns: 'max-content auto',
+        rowGap: theme.spacing(1),
+        columnGap: 0,
+    },
+    dt: {
+        color: theme.palette.text.secondary,
+        '&::after': { content: '":"' },
+    },
+    dd: {
+        marginInlineStart: theme.spacing(2),
+    },
+}));
+
+type Props = {
+    featureNaming: FeatureNamingType;
+};
+
+export const NamingPatternInfo: React.FC<Props> = ({ featureNaming }) => {
+    return (
+        <StyledFlagNamingInfo>
+            <p>The name must match this pattern:</p>
+            <dl id='naming-pattern-info'>
+                <dt>Pattern</dt>
+                <dd>
+                    <code>^{featureNaming.pattern}$</code>
+                </dd>
+                <ConditionallyRender
+                    condition={Boolean(featureNaming?.example)}
+                    show={
+                        <>
+                            <dt>Example</dt>
+                            <dd>{featureNaming?.example}</dd>
+                        </>
+                    }
+                />
+                <ConditionallyRender
+                    condition={Boolean(featureNaming?.description)}
+                    show={
+                        <>
+                            <dt>Description</dt>
+                            <dd>{featureNaming?.description}</dd>
+                        </>
+                    }
+                />
+            </dl>
+        </StyledFlagNamingInfo>
+    );
+};

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -227,6 +227,7 @@ const CreateFeatureDialogContent = ({
                         tooltipProps: { title: limitMessage, arrow: true },
                     }}
                     description={description}
+                    namingPattern={projectInfo.featureNaming}
                     errors={errors}
                     handleSubmit={handleSubmit}
                     Icon={<FlagIcon />}


### PR DESCRIPTION
Updates the dialog form template to include a `namingPattern` prop that can be used to display the naming pattern of whatever the form is used for.

Also updates the create feature dialog to display the naming pattern in the current project.

The naming pattern component re-uses the pattern that we have in place for feature naming patterns, but puts it in an expandable dialog instead. 

Screenies:

Naming pattern closed:
![image](https://github.com/user-attachments/assets/145e4268-1aa0-4c1b-8f08-97857447e2f5)

![image](https://github.com/user-attachments/assets/1613c846-e7d4-41c8-a1c8-a66ab87b6e5f)



Naming pattern open:
![image](https://github.com/user-attachments/assets/1aa37162-500b-4b83-926f-07aa777e8017)
