### PR TITLE
fix: search events by user ID, not by user name

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -177,7 +177,7 @@ export default class EventService {
 
         if (params.createdBy) {
             const parsed = parseSearchOperatorValue(
-                'created_by',
+                'created_by_user_id',
                 params.createdBy,
             );
             if (parsed) queryParams.push(parsed);

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -183,7 +183,7 @@ test('should filter events by created by', async () => {
     await eventService.storeEvent({
         type: FEATURE_CREATED,
         createdBy: 'admin1@example.com',
-        createdByUserId: TEST_USER_ID,
+        createdByUserId: TEST_USER_ID + 1,
         ip: '127.0.0.1',
     });
 
@@ -194,7 +194,7 @@ test('should filter events by created by', async () => {
         ip: '127.0.0.1',
     });
 
-    const { body } = await searchEvents({ createdBy: 'IS:admin2@example.com' });
+    const { body } = await searchEvents({ createdBy: `IS:${TEST_USER_ID}` });
 
     expect(body).toMatchObject({
         events: [


### PR DESCRIPTION
Changes the event search handling, so that searching by user uses the user's ID, not the "createdBy" name in the event. This aligns better with what the OpenAPI schema describes it.