### PR TITLE
fix: don't show link stubs in slack notifications (#7810)

### DIFF
--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -132,6 +132,7 @@ export default class SlackAppAddon extends Addon {
                     channel: name,
                     text,
                     blocks,
+                    unfurl_links: false,
                 });
             });
 


### PR DESCRIPTION
https://github.com/Unleash/unleash/pull/7810
