### PR TITLE
feat: update feature completed payload to have boolean instead of string

### DIFF
--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
@@ -186,9 +186,7 @@ export class FeatureLifecycleService {
             new FeatureCompletedEvent({
                 project: projectId,
                 featureName: feature,
-                data: {
-                    kept: status.status === 'kept',
-                },
+                data: { ...status, kept: status.status === 'kept' },
                 auditUser,
             }),
         );

--- a/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle-service.ts
@@ -186,7 +186,9 @@ export class FeatureLifecycleService {
             new FeatureCompletedEvent({
                 project: projectId,
                 featureName: feature,
-                data: status,
+                data: {
+                    kept: status.status === 'kept',
+                },
                 auditUser,
             }),
         );

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -10,6 +10,7 @@ import type { IApiToken } from './models/api-token';
 import type { IAuditUser, IUserWithRootRole } from './user';
 import type { ITagType } from '../features/tag-type/tag-type-store-type';
 import type { IFeatureAndTag } from './stores/feature-tag-store';
+import type { FeatureLifecycleCompletedSchema } from '../openapi';
 
 export const APPLICATION_CREATED = 'application-created' as const;
 
@@ -748,17 +749,13 @@ export class FeatureTagImport extends BaseEvent {
 
 export class FeatureCompletedEvent extends BaseEvent {
     readonly featureName: string;
-    readonly data: {
-        kept: boolean;
-    };
+    readonly data: FeatureLifecycleCompletedSchema & { kept: boolean };
     readonly project: string;
 
     constructor(p: {
         project: string;
         featureName: string;
-        data: {
-            kept: boolean;
-        };
+        data: FeatureLifecycleCompletedSchema & { kept: boolean };
         auditUser: IAuditUser;
     }) {
         super(FEATURE_COMPLETED, p.auditUser);

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -8,7 +8,6 @@ import type {
 } from './model';
 import type { IApiToken } from './models/api-token';
 import type { IAuditUser, IUserWithRootRole } from './user';
-import type { FeatureLifecycleCompletedSchema } from '../openapi';
 import type { ITagType } from '../features/tag-type/tag-type-store-type';
 import type { IFeatureAndTag } from './stores/feature-tag-store';
 
@@ -749,13 +748,17 @@ export class FeatureTagImport extends BaseEvent {
 
 export class FeatureCompletedEvent extends BaseEvent {
     readonly featureName: string;
-    readonly data: FeatureLifecycleCompletedSchema;
+    readonly data: {
+        kept: boolean;
+    };
     readonly project: string;
 
     constructor(p: {
         project: string;
         featureName: string;
-        data: FeatureLifecycleCompletedSchema;
+        data: {
+            kept: boolean;
+        };
         auditUser: IAuditUser;
     }) {
         super(FEATURE_COMPLETED, p.auditUser);


### PR DESCRIPTION
For easy gitar integration, we need to have boolean in the event payload.
We might rethink it when we add variants, but currently enabled with variants is not used.