### PR TITLE
feat: start using event service composition root

### DIFF
--- a/src/lib/features/access/createAccessService.ts
+++ b/src/lib/features/access/createAccessService.ts
@@ -4,16 +4,18 @@ import { AccountStore } from '../../db/account-store';
 import RoleStore from '../../db/role-store';
 import EnvironmentStore from '../project-environments/environment-store';
 import { AccessStore } from '../../db/access-store';
-import { AccessService, EventService, GroupService } from '../../services';
+import { AccessService, GroupService } from '../../services';
 import FakeGroupStore from '../../../test/fixtures/fake-group-store';
 import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
 import FakeRoleStore from '../../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../project-environments/fake-environment-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import type { IAccessStore, IEventStore, IRoleStore } from '../../types';
-import { createEventsService } from '../events/createEventsService';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createAccessService = (
     db: Db,
@@ -48,18 +50,14 @@ export const createFakeAccessService = (
     accessStore: IAccessStore;
     roleStore: IRoleStore;
 } => {
-    const { getLogger, flagResolver } = config;
+    const { getLogger } = config;
     const eventStore = new FakeEventStore();
     const groupStore = new FakeGroupStore();
     const accountStore = new FakeAccountStore();
     const roleStore = new FakeRoleStore();
     const environmentStore = new FakeEnvironmentStore();
     const accessStore = new FakeAccessStore(roleStore);
-    const featureTagStore = new FakeFeatureTagStore();
-    const eventService = new EventService(
-        { eventStore, featureTagStore },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/access/createAccessService.ts
+++ b/src/lib/features/access/createAccessService.ts
@@ -57,7 +57,7 @@ export const createFakeAccessService = (
     const roleStore = new FakeRoleStore();
     const environmentStore = new FakeEnvironmentStore();
     const accessStore = new FakeAccessStore(roleStore);
-    const eventService = createFakeEventsService(config);
+    const eventService = createFakeEventsService(config, { eventStore });
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/events/createEventsService.ts
+++ b/src/lib/features/events/createEventsService.ts
@@ -5,6 +5,10 @@ import EventStore from './event-store';
 import FeatureTagStore from '../../db/feature-tag-store';
 import { EventService } from '../../services';
 import type { IUnleashConfig } from '../../types';
+import {
+    createFakePrivateProjectChecker,
+    createPrivateProjectChecker,
+} from '../private-project/createPrivateProjectChecker';
 
 export const createEventsService: (
     db: Db,
@@ -16,12 +20,22 @@ export const createEventsService: (
         config.eventBus,
         config.getLogger,
     );
-    return new EventService({ eventStore, featureTagStore }, config);
+    const privateProjectChecker = createPrivateProjectChecker(db, config);
+    return new EventService(
+        { eventStore, featureTagStore },
+        config,
+        privateProjectChecker,
+    );
 };
 
 export const createFakeEventsService: (config: IUnleashConfig) => EventService =
     (config) => {
         const eventStore = new FakeEventStore();
         const featureTagStore = new FakeFeatureTagStore();
-        return new EventService({ eventStore, featureTagStore }, config);
+        const fakePrivateProjectChecker = createFakePrivateProjectChecker();
+        return new EventService(
+            { eventStore, featureTagStore },
+            config,
+            fakePrivateProjectChecker,
+        );
     };

--- a/src/lib/features/events/createEventsService.ts
+++ b/src/lib/features/events/createEventsService.ts
@@ -4,7 +4,7 @@ import type { Db } from '../../db/db';
 import EventStore from './event-store';
 import FeatureTagStore from '../../db/feature-tag-store';
 import { EventService } from '../../services';
-import type { IUnleashConfig } from '../../types';
+import type { IUnleashConfig, IUnleashStores } from '../../types';
 import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
@@ -28,14 +28,17 @@ export const createEventsService: (
     );
 };
 
-export const createFakeEventsService: (config: IUnleashConfig) => EventService =
-    (config) => {
-        const eventStore = new FakeEventStore();
-        const featureTagStore = new FakeFeatureTagStore();
-        const fakePrivateProjectChecker = createFakePrivateProjectChecker();
-        return new EventService(
-            { eventStore, featureTagStore },
-            config,
-            fakePrivateProjectChecker,
-        );
-    };
+export const createFakeEventsService: (
+    config: IUnleashConfig,
+    stores?: IUnleashStores,
+) => EventService = (config, stores) => {
+    const eventStore = stores?.eventStore || new FakeEventStore();
+    const featureTagStore =
+        stores?.featureTagStore || new FakeFeatureTagStore();
+    const fakePrivateProjectChecker = createFakePrivateProjectChecker();
+    return new EventService(
+        { eventStore, featureTagStore },
+        config,
+        fakePrivateProjectChecker,
+    );
+};

--- a/src/lib/features/events/createEventsService.ts
+++ b/src/lib/features/events/createEventsService.ts
@@ -4,7 +4,7 @@ import type { Db } from '../../db/db';
 import EventStore from './event-store';
 import FeatureTagStore from '../../db/feature-tag-store';
 import { EventService } from '../../services';
-import type { IUnleashConfig, IUnleashStores } from '../../types';
+import type { IUnleashConfig } from '../../types';
 import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
@@ -30,7 +30,10 @@ export const createEventsService: (
 
 export const createFakeEventsService: (
     config: IUnleashConfig,
-    stores?: IUnleashStores,
+    stores?: {
+        eventStore?: FakeEventStore;
+        featureTagStore?: FakeFeatureTagStore;
+    },
 ) => EventService = (config, stores) => {
     const eventStore = stores?.eventStore || new FakeEventStore();
     const featureTagStore =

--- a/src/lib/features/events/createEventsService.ts
+++ b/src/lib/features/events/createEventsService.ts
@@ -4,7 +4,11 @@ import type { Db } from '../../db/db';
 import EventStore from './event-store';
 import FeatureTagStore from '../../db/feature-tag-store';
 import { EventService } from '../../services';
-import type { IUnleashConfig } from '../../types';
+import type {
+    IEventStore,
+    IFeatureTagStore,
+    IUnleashConfig,
+} from '../../types';
 import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
@@ -31,8 +35,8 @@ export const createEventsService: (
 export const createFakeEventsService: (
     config: IUnleashConfig,
     stores?: {
-        eventStore?: FakeEventStore;
-        featureTagStore?: FakeFeatureTagStore;
+        eventStore?: IEventStore;
+        featureTagStore?: IFeatureTagStore;
     },
 ) => EventService = (config, stores) => {
     const eventStore = stores?.eventStore || new FakeEventStore();

--- a/src/lib/features/events/event-created-by-migration.test.ts
+++ b/src/lib/features/events/event-created-by-migration.test.ts
@@ -2,10 +2,14 @@ import EventStore from './event-store';
 import getLogger from '../../../test/fixtures/no-logger';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import { EventEmitter } from 'stream';
-import EventService from './event-service';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
+import { createFakeEventsService } from './createEventsService';
+import type { IUnleashConfig } from '../../types';
+import { createTestConfig } from '../../../test/config/test-config';
 
 let db: ITestDb;
+
+const config: IUnleashConfig = createTestConfig();
 
 beforeAll(async () => {
     db = await dbInit('events_test', getLogger);
@@ -122,10 +126,7 @@ test('emits events with details on amount of updated rows', async () => {
     const store = new EventStore(db.rawDatabase, getLogger);
 
     const eventBus = new EventEmitter();
-    const service = new EventService(
-        { eventStore: store, featureTagStore: db.stores.featureTagStore },
-        { getLogger, eventBus },
-    );
+    const service = createFakeEventsService(config);
     let triggered = false;
 
     eventBus.on(EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {

--- a/src/lib/features/events/event-created-by-migration.test.ts
+++ b/src/lib/features/events/event-created-by-migration.test.ts
@@ -3,9 +3,9 @@ import getLogger from '../../../test/fixtures/no-logger';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import { EventEmitter } from 'stream';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
-import { createEventsService } from './createEventsService';
 import type { IUnleashConfig } from '../../types';
 import { createTestConfig } from '../../../test/config/test-config';
+import EventService from './event-service';
 
 let db: ITestDb;
 
@@ -126,7 +126,11 @@ test('emits events with details on amount of updated rows', async () => {
     const store = new EventStore(db.rawDatabase, getLogger);
 
     const eventBus = new EventEmitter();
-    const service = createEventsService(db.rawDatabase, config);
+    const service = new EventService(
+        { eventStore: store, featureTagStore: db.stores.featureTagStore },
+        { getLogger, eventBus },
+        {} as any,
+    );
     let triggered = false;
 
     eventBus.on(EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {

--- a/src/lib/features/events/event-created-by-migration.test.ts
+++ b/src/lib/features/events/event-created-by-migration.test.ts
@@ -3,7 +3,7 @@ import getLogger from '../../../test/fixtures/no-logger';
 import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
 import { EventEmitter } from 'stream';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
-import { createFakeEventsService } from './createEventsService';
+import { createEventsService } from './createEventsService';
 import type { IUnleashConfig } from '../../types';
 import { createTestConfig } from '../../../test/config/test-config';
 
@@ -126,7 +126,7 @@ test('emits events with details on amount of updated rows', async () => {
     const store = new EventStore(db.rawDatabase, getLogger);
 
     const eventBus = new EventEmitter();
-    const service = createFakeEventsService(config);
+    const service = createEventsService(db.rawDatabase, config);
     let triggered = false;
 
     eventBus.on(EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -14,6 +14,7 @@ import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
 import { endOfDay, formatISO } from 'date-fns';
+import type { IPrivateProjectChecker } from '../private-project/privateProjectCheckerType';
 
 export default class EventService {
     private logger: Logger;
@@ -21,6 +22,8 @@ export default class EventService {
     private eventStore: IEventStore;
 
     private featureTagStore: IFeatureTagStore;
+
+    private privateProjectChecker: IPrivateProjectChecker;
 
     private eventBus: EventEmitter;
 
@@ -30,9 +33,11 @@ export default class EventService {
             featureTagStore,
         }: Pick<IUnleashStores, 'eventStore' | 'featureTagStore'>,
         { getLogger, eventBus }: Pick<IUnleashConfig, 'getLogger' | 'eventBus'>,
+        privateProjectChecker: IPrivateProjectChecker,
     ) {
         this.logger = getLogger('services/event-service.ts');
         this.eventStore = eventStore;
+        this.privateProjectChecker = privateProjectChecker;
         this.featureTagStore = featureTagStore;
         this.eventBus = eventBus;
     }

--- a/src/lib/features/export-import-toggles/createExportImportService.ts
+++ b/src/lib/features/export-import-toggles/createExportImportService.ts
@@ -12,7 +12,6 @@ import ContextFieldStore from '../../db/context-field-store';
 import FeatureStrategiesStore from '../feature-toggle/feature-toggle-strategies-store';
 import {
     ContextService,
-    EventService,
     FeatureTagService,
     StrategyService,
     TagTypeService,
@@ -32,7 +31,6 @@ import FakeTagTypeStore from '../tag-type/fake-tag-type-store';
 import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import FakeContextFieldStore from '../../../test/fixtures/fake-context-field-store';
-import FakeEventStore from '../../../test/fixtures/fake-event-store';
 import FakeFeatureStrategiesStore from '../feature-toggle/fakes/fake-feature-strategies-store';
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
 import FakeStrategiesStore from '../../../test/fixtures/fake-strategies-store';
@@ -48,7 +46,10 @@ import {
     createDependentFeaturesService,
     createFakeDependentFeaturesService,
 } from '../dependent-features/createDependentFeaturesService';
-import { createEventsService } from '../events/createEventsService';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 import { SegmentReadModel } from '../segment/segment-read-model';
 import { FakeSegmentReadModel } from '../segment/fake-segment-read-model';
 
@@ -64,20 +65,13 @@ export const createFakeExportImportTogglesService = (
     const featureTagStore = new FakeFeatureTagStore();
     const strategyStore = new FakeStrategiesStore();
     const contextFieldStore = new FakeContextFieldStore();
-    const eventStore = new FakeEventStore();
     const featureStrategiesStore = new FakeFeatureStrategiesStore();
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
     const { accessService } = createFakeAccessService(config);
     const { featureToggleService } = createFakeFeatureToggleService(config);
     const privateProjectChecker = createFakePrivateProjectChecker();
 
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore,
-        },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
 
     const featureTagService = new FeatureTagService(
         {

--- a/src/lib/features/feature-lifecycle/createFeatureLifecycle.ts
+++ b/src/lib/features/feature-lifecycle/createFeatureLifecycle.ts
@@ -7,16 +7,16 @@ import EventStore from '../../db/event-store';
 import type { Db } from '../../db/db';
 import { FeatureLifecycleStore } from './feature-lifecycle-store';
 import EnvironmentStore from '../project-environments/environment-store';
-import EventService from '../events/event-service';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
-import FeatureTagStore from '../../db/feature-tag-store';
 import { FeatureEnvironmentStore } from '../../db/feature-environment-store';
 import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-environment-store';
-import EventEmitter from 'events';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createFeatureLifecycleService =
     (config: IUnleashConfig) => (db: Db) => {
-        const { eventBus, getLogger, flagResolver } = config;
+        const { eventBus, getLogger } = config;
         const eventStore = new EventStore(db, getLogger);
         const featureLifecycleStore = new FeatureLifecycleStore(db);
         const environmentStore = new EnvironmentStore(db, eventBus, getLogger);
@@ -25,15 +25,7 @@ export const createFeatureLifecycleService =
             eventBus,
             getLogger,
         );
-        const featureTagStore = new FeatureTagStore(
-            db,
-            config.eventBus,
-            config.getLogger,
-        );
-        const eventService = new EventService(
-            { eventStore, featureTagStore },
-            { getLogger, eventBus: new EventEmitter() },
-        );
+        const eventService = createEventsService(db, config);
         const featureLifecycleService = new FeatureLifecycleService(
             {
                 eventStore,
@@ -55,10 +47,7 @@ export const createFakeFeatureLifecycleService = (config: IUnleashConfig) => {
     const featureLifecycleStore = new FakeFeatureLifecycleStore();
     const environmentStore = new FakeEnvironmentStore();
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const featureLifecycleService = new FeatureLifecycleService(
         {
             eventStore,

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -1,6 +1,5 @@
 import {
     AccessService,
-    EventService,
     FeatureToggleService,
     GroupService,
 } from '../../services';
@@ -51,7 +50,10 @@ import {
     createDependentFeaturesService,
     createFakeDependentFeaturesService,
 } from '../dependent-features/createDependentFeaturesService';
-import { createEventsService } from '../events/createEventsService';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 import { EventEmitter } from 'stream';
 import { FeatureLifecycleReadModel } from '../feature-lifecycle/feature-lifecycle-read-model';
 import { FakeFeatureLifecycleReadModel } from '../feature-lifecycle/fake-feature-lifecycle-read-model';
@@ -176,10 +178,7 @@ export const createFakeFeatureToggleService = (config: IUnleashConfig) => {
     const featureTagStore = new FakeFeatureTagStore();
     const roleStore = new FakeRoleStore();
     const environmentStore = new FakeEnvironmentStore();
-    const eventService = new EventService(
-        { eventStore, featureTagStore },
-        { getLogger, eventBus: new EventEmitter() },
-    );
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(
         { groupStore, accountStore },
         { getLogger },

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -23,9 +23,13 @@ import {
     PermissionError,
 } from '../../../error';
 import type { ISegmentService } from '../../segment/segment-service-interface';
-import { createFeatureToggleService, createSegmentService } from '../..';
+import {
+    createFakeEventsService,
+    createFeatureToggleService,
+    createSegmentService,
+} from '../..';
 import { insertLastSeenAt } from '../../../../test/e2e/helpers/test-helper';
-import { EventService } from '../../../services';
+import type { EventService } from '../../../services';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -60,7 +64,7 @@ beforeAll(async () => {
 
     service = createFeatureToggleService(db.rawDatabase, config);
 
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
 });
 
 afterAll(async () => {

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../error';
 import type { ISegmentService } from '../../segment/segment-service-interface';
 import {
-    createFakeEventsService,
+    createEventsService,
     createFeatureToggleService,
     createSegmentService,
 } from '../..';
@@ -64,7 +64,7 @@ beforeAll(async () => {
 
     service = createFeatureToggleService(db.rawDatabase, config);
 
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
 });
 
 afterAll(async () => {

--- a/src/lib/features/project-environments/createEnvironmentService.ts
+++ b/src/lib/features/project-environments/createEnvironmentService.ts
@@ -1,8 +1,5 @@
 import type { Db } from '../../db/db';
 import type { IUnleashConfig } from '../../types';
-import { EventService } from '../../services';
-import FakeEventStore from '../../../test/fixtures/fake-event-store';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import EnvironmentService from './environment-service';
 import EnvironmentStore from './environment-store';
 import FeatureStrategiesStore from '../feature-toggle/feature-toggle-strategies-store';
@@ -12,7 +9,10 @@ import FakeFeatureEnvironmentStore from '../../../test/fixtures/fake-feature-env
 import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 import FakeFeatureStrategiesStore from '../feature-toggle/fakes/fake-feature-strategies-store';
 import FakeEnvironmentStore from './fake-environment-store';
-import { createEventsService } from '../events/createEventsService';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createEnvironmentService =
     (config: IUnleashConfig) =>
@@ -52,19 +52,11 @@ export const createEnvironmentService =
 export const createFakeEnvironmentService = (
     config: IUnleashConfig,
 ): EnvironmentService => {
-    const eventStore = new FakeEventStore();
-    const featureTagStore = new FakeFeatureTagStore();
     const featureEnvironmentStore = new FakeFeatureEnvironmentStore();
     const projectStore = new FakeProjectStore();
     const featureStrategiesStore = new FakeFeatureStrategiesStore();
     const environmentStore = new FakeEnvironmentStore();
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore,
-        },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
 
     return new EnvironmentService(
         {

--- a/src/lib/features/project-environments/environment-service.test.ts
+++ b/src/lib/features/project-environments/environment-service.test.ts
@@ -8,7 +8,8 @@ import {
     SYSTEM_USER_AUDIT,
 } from '../../types';
 import NameExistsError from '../../error/name-exists-error';
-import { EventService } from '../../services';
+import type { EventService } from '../../services';
+import { createFakeEventsService } from '../events/createEventsService';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -19,7 +20,7 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('environment_service_serial', config.getLogger);
     stores = db.stores;
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
     service = new EnvironmentService(stores, config, eventService);
 });
 afterAll(async () => {

--- a/src/lib/features/project-environments/environment-service.test.ts
+++ b/src/lib/features/project-environments/environment-service.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../types';
 import NameExistsError from '../../error/name-exists-error';
 import type { EventService } from '../../services';
+import { createEventsService } from '../events/createEventsService';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -19,7 +20,7 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('environment_service_serial', config.getLogger);
     stores = db.stores;
-    eventService = createEventsService(db, config);
+    eventService = createEventsService(db.rawDatabase, config);
     service = new EnvironmentService(stores, config, eventService);
 });
 afterAll(async () => {

--- a/src/lib/features/project-environments/environment-service.test.ts
+++ b/src/lib/features/project-environments/environment-service.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../../types';
 import NameExistsError from '../../error/name-exists-error';
 import type { EventService } from '../../services';
-import { createFakeEventsService } from '../events/createEventsService';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -20,7 +19,7 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('environment_service_serial', config.getLogger);
     stores = db.stores;
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db, config);
     service = new EnvironmentService(stores, config, eventService);
 });
 afterAll(async () => {

--- a/src/lib/features/project-insights/project-insights-service.e2e.test.ts
+++ b/src/lib/features/project-insights/project-insights-service.e2e.test.ts
@@ -10,7 +10,7 @@ import type {
 import { FeatureEnvironmentEvent } from '../../../lib/types/events';
 import { subDays } from 'date-fns';
 import {
-    createFakeEventsService,
+    createEventsService,
     createFeatureToggleService,
     createProjectService,
 } from '../../../lib/features';
@@ -48,7 +48,7 @@ beforeAll(async () => {
     const config = createTestConfig({
         getLogger,
     });
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
 
     featureToggleService = createFeatureToggleService(db.rawDatabase, config);
 

--- a/src/lib/features/project-insights/project-insights-service.e2e.test.ts
+++ b/src/lib/features/project-insights/project-insights-service.e2e.test.ts
@@ -3,13 +3,14 @@ import getLogger from '../../../test/fixtures/no-logger';
 import type FeatureToggleService from '../../../lib/features/feature-toggle/feature-toggle-service';
 import type ProjectService from '../../../lib/features/project/project-service';
 import { createTestConfig } from '../../../test/config/test-config';
-import {
+import type {
     EventService,
-    type ProjectInsightsService,
+    ProjectInsightsService,
 } from '../../../lib/services';
 import { FeatureEnvironmentEvent } from '../../../lib/types/events';
 import { subDays } from 'date-fns';
 import {
+    createFakeEventsService,
     createFeatureToggleService,
     createProjectService,
 } from '../../../lib/features';
@@ -47,7 +48,7 @@ beforeAll(async () => {
     const config = createTestConfig({
         getLogger,
     });
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
 
     featureToggleService = createFeatureToggleService(db.rawDatabase, config);
 

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -6,7 +6,6 @@ import EnvironmentStore from '../project-environments/environment-store';
 import {
     type AccessService,
     ApiTokenService,
-    EventService,
     FavoritesService,
     GroupService,
     ProjectService,
@@ -39,13 +38,16 @@ import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
 import { ProjectOwnersReadModel } from './project-owners-read-model';
 import { FakeProjectOwnersReadModel } from './fake-project-owners-read-model';
 import { FakeProjectFlagCreatorsReadModel } from './fake-project-flag-creators-read-model';
 import { ProjectFlagCreatorsReadModel } from './project-flag-creators-read-model';
 import FakeApiTokenStore from '../../../test/fixtures/fake-api-token-store';
 import { ApiTokenStore } from '../../db/api-token-store';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createProjectService = (
     db: Db,
@@ -88,13 +90,7 @@ export const createProjectService = (
         eventBus,
         getLogger,
     );
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore: new FakeFeatureTagStore(),
-        },
-        config,
-    );
+    const eventService = createEventsService(db, config);
     const favoriteService = new FavoritesService(
         {
             favoriteFeaturesStore,
@@ -166,13 +162,8 @@ export const createFakeProjectService = (
     const favoriteFeaturesStore = new FakeFavoriteFeaturesStore();
     const favoriteProjectsStore = new FakeFavoriteProjectsStore();
     const apiTokenStore = new FakeApiTokenStore();
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore: new FakeFeatureTagStore(),
-        },
-        config,
-    );
+    const privateProjectChecker = createFakePrivateProjectChecker();
+    const eventService = createFakeEventsService(config);
     const favoriteService = new FavoritesService(
         {
             favoriteFeaturesStore,
@@ -186,8 +177,6 @@ export const createFakeProjectService = (
         { getLogger },
         eventService,
     );
-
-    const privateProjectChecker = createFakePrivateProjectChecker();
 
     const apiTokenService = new ApiTokenService(
         { apiTokenStore, environmentStore },

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -9,11 +9,12 @@ import { RoleName } from '../../types/model';
 import { randomId } from '../../util/random-id';
 import EnvironmentService from '../project-environments/environment-service';
 import IncompatibleProjectError from '../../error/incompatible-project-error';
-import { type ApiTokenService, EventService } from '../../services';
+import type { ApiTokenService, EventService } from '../../services';
 import { FeatureEnvironmentEvent } from '../../types/events';
 import { addDays, subDays } from 'date-fns';
 import {
     createAccessService,
+    createFakeEventsService,
     createFeatureToggleService,
     createProjectService,
 } from '../index';
@@ -83,7 +84,7 @@ beforeAll(async () => {
         getLogger,
         experimental: { flags: { archiveProjects: true } },
     });
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
     accessService = createAccessService(db.rawDatabase, config);
 
     featureToggleService = createFeatureToggleService(db.rawDatabase, config);

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -14,7 +14,7 @@ import { FeatureEnvironmentEvent } from '../../types/events';
 import { addDays, subDays } from 'date-fns';
 import {
     createAccessService,
-    createFakeEventsService,
+    createEventsService,
     createFeatureToggleService,
     createProjectService,
 } from '../index';
@@ -84,7 +84,7 @@ beforeAll(async () => {
         getLogger,
         experimental: { flags: { archiveProjects: true } },
     });
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
     accessService = createAccessService(db.rawDatabase, config);
 
     featureToggleService = createFeatureToggleService(db.rawDatabase, config);

--- a/src/lib/features/segment/createSegmentService.ts
+++ b/src/lib/features/segment/createSegmentService.ts
@@ -1,6 +1,5 @@
 import type { Db, IUnleashConfig } from '../../server-impl';
-import { EventService, SegmentService } from '../../services';
-import FakeEventStore from '../../../test/fixtures/fake-event-store';
+import { SegmentService } from '../../services';
 import type { ISegmentService } from './segment-service-interface';
 import FeatureStrategiesStore from '../feature-toggle/feature-toggle-strategies-store';
 import SegmentStore from './segment-store';
@@ -18,8 +17,10 @@ import {
     createFakePrivateProjectChecker,
     createPrivateProjectChecker,
 } from '../private-project/createPrivateProjectChecker';
-import FakeFeatureTagStore from '../../../test/fixtures/fake-feature-tag-store';
-import { createEventsService } from '../events/createEventsService';
+import {
+    createEventsService,
+    createFakeEventsService,
+} from '../events/createEventsService';
 
 export const createSegmentService = (
     db: Db,
@@ -63,7 +64,6 @@ export const createSegmentService = (
 export const createFakeSegmentService = (
     config: IUnleashConfig,
 ): ISegmentService => {
-    const eventStore = new FakeEventStore();
     const segmentStore = new FakeSegmentStore();
     const featureStrategiesStore = new FakeFeatureStrategiesStore();
     const changeRequestAccessReadModel = createFakeChangeRequestAccessService();
@@ -72,13 +72,7 @@ export const createFakeSegmentService = (
 
     const privateProjectChecker = createFakePrivateProjectChecker();
 
-    const eventService = new EventService(
-        {
-            eventStore,
-            featureTagStore: new FakeFeatureTagStore(),
-        },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
 
     return new SegmentService(
         { segmentStore, featureStrategiesStore },

--- a/src/lib/middleware/cors-origin-middleware.test.ts
+++ b/src/lib/middleware/cors-origin-middleware.test.ts
@@ -4,14 +4,11 @@ import { createTestConfig } from '../../test/config/test-config';
 import FakeEventStore from '../../test/fixtures/fake-event-store';
 import { randomId } from '../util/random-id';
 import FakeProjectStore from '../../test/fixtures/fake-project-store';
-import {
-    EventService,
-    FrontendApiService,
-    SettingService,
-} from '../../lib/services';
+import { FrontendApiService, SettingService } from '../../lib/services';
 import { type ISettingStore, TEST_AUDIT_USER } from '../../lib/types';
 import { frontendSettingsKey } from '../../lib/types/settings/frontend-settings';
 import FakeFeatureTagStore from '../../test/fixtures/fake-feature-tag-store';
+import { createFakeEventsService } from '../features';
 
 const TEST_USER_ID = -9999;
 const createSettingService = (
@@ -26,7 +23,7 @@ const createSettingService = (
         projectStore: new FakeProjectStore(),
     };
 
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
 
     const services = {
         settingService: new SettingService(stores, config, eventService),

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -14,10 +14,17 @@ import AddonService from './addon-service';
 import type { IAddonDto } from '../types/stores/addon-store';
 import SimpleAddon from './addon-service-test-simple-addon';
 import type { IAddonProviders } from '../addons';
-import EventService from '../features/events/event-service';
-import { type IFlagResolver, SYSTEM_USER, TEST_AUDIT_USER } from '../types';
-import EventEmitter from 'node:events';
-import { IntegrationEventsService } from '../internals';
+import {
+    type IFlagResolver,
+    type IUnleashConfig,
+    SYSTEM_USER,
+    TEST_AUDIT_USER,
+} from '../types';
+import {
+    createFakeEventsService,
+    IntegrationEventsService,
+} from '../internals';
+import { createTestConfig } from '../../test/config/test-config';
 
 const MASKED_VALUE = '*****';
 
@@ -25,12 +32,11 @@ const TEST_USER_ID = -9999;
 
 let addonProvider: IAddonProviders;
 
+const config: IUnleashConfig = createTestConfig();
+
 function getSetup() {
     const stores = createStores();
-    const eventService = new EventService(stores, {
-        getLogger,
-        eventBus: new EventEmitter(),
-    });
+    const eventService = createFakeEventsService(config);
     const tagTypeService = new TagTypeService(
         stores,
         { getLogger },

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -20,10 +20,7 @@ import {
     SYSTEM_USER,
     TEST_AUDIT_USER,
 } from '../types';
-import {
-    createFakeEventsService,
-    IntegrationEventsService,
-} from '../internals';
+import { IntegrationEventsService } from '../internals';
 import { createTestConfig } from '../../test/config/test-config';
 
 const MASKED_VALUE = '*****';
@@ -36,7 +33,7 @@ const config: IUnleashConfig = createTestConfig();
 
 function getSetup() {
     const stores = createStores();
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db, config);
     const tagTypeService = new TagTypeService(
         stores,
         { getLogger },

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -20,7 +20,10 @@ import {
     SYSTEM_USER,
     TEST_AUDIT_USER,
 } from '../types';
-import { IntegrationEventsService } from '../internals';
+import {
+    createFakeEventsService,
+    IntegrationEventsService,
+} from '../internals';
 import { createTestConfig } from '../../test/config/test-config';
 
 const MASKED_VALUE = '*****';
@@ -33,7 +36,7 @@ const config: IUnleashConfig = createTestConfig();
 
 function getSetup() {
     const stores = createStores();
-    const eventService = createEventsService(db, config);
+    const eventService = createFakeEventsService(config);
     const tagTypeService = new TagTypeService(
         stores,
         { getLogger },

--- a/src/lib/services/feature-service-potentially-stale.test.ts
+++ b/src/lib/services/feature-service-potentially-stale.test.ts
@@ -43,6 +43,7 @@ test('Should only store events for potentially stale on', async () => {
             featureTagStore: new FakeFeatureTagStore(),
         },
         config,
+        {},
     );
 
     const featureToggleService = new FeatureToggleService(

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -116,8 +116,6 @@ import {
     createInstanceStatsService,
 } from '../features/instance-stats/createInstanceStatsService';
 import { InactiveUsersService } from '../users/inactive/inactive-users-service';
-import { SegmentReadModel } from '../features/segment/segment-read-model';
-import { FakeSegmentReadModel } from '../features/segment/fake-segment-read-model';
 import {
     createFakeFrontendApiService,
     createFrontendApiService,
@@ -155,7 +153,7 @@ export const createServices = (
 
     const eventService = db
         ? createEventsService(db, config)
-        : createFakeEventsService(config);
+        : createFakeEventsService(config, stores);
     const groupService = new GroupService(stores, config, eventService);
     const accessService = new AccessService(
         stores,
@@ -180,9 +178,6 @@ export const createServices = (
     const featureLifecycleReadModel = db
         ? new FeatureLifecycleReadModel(db, config.flagResolver)
         : new FakeFeatureLifecycleReadModel();
-    const segmentReadModel = db
-        ? new SegmentReadModel(db)
-        : new FakeSegmentReadModel();
 
     const contextService = new ContextService(
         stores,

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -64,7 +64,9 @@ import {
 import ConfigurationRevisionService from '../features/feature-toggle/configuration-revision-service';
 import {
     createEnvironmentService,
+    createEventsService,
     createFakeEnvironmentService,
+    createFakeEventsService,
     createFakeProjectService,
     createFeatureLifecycleService,
     createFeatureToggleService,
@@ -147,7 +149,13 @@ export const createServices = (
     config: IUnleashConfig,
     db?: Db,
 ): IUnleashServices => {
-    const eventService = new EventService(stores, config);
+    const privateProjectChecker = db
+        ? createPrivateProjectChecker(db, config)
+        : createFakePrivateProjectChecker();
+
+    const eventService = db
+        ? createEventsService(db, config)
+        : createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     const accessService = new AccessService(
         stores,
@@ -166,9 +174,6 @@ export const createServices = (
         config,
         lastSeenService,
     );
-    const privateProjectChecker = db
-        ? createPrivateProjectChecker(db, config)
-        : createFakePrivateProjectChecker();
     const dependentFeaturesReadModel = db
         ? new DependentFeaturesReadModel(db)
         : new FakeDependentFeaturesReadModel();

--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -14,9 +14,8 @@ import User from '../types/user';
 import FakeResetTokenStore from '../../test/fixtures/fake-reset-token-store';
 import SettingService from './setting-service';
 import FakeSettingStore from '../../test/fixtures/fake-setting-store';
-import EventService from '../features/events/event-service';
-import FakeFeatureTagStore from '../../test/fixtures/fake-feature-tag-store';
 import { extractAuditInfoFromUser } from '../util';
+import { createFakeEventsService } from '../features';
 
 const config: IUnleashConfig = createTestConfig();
 
@@ -34,10 +33,7 @@ test('Should create new user', async () => {
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
     const emailService = new EmailService(config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -99,10 +95,7 @@ describe('Default admin initialization', () => {
 
         const sessionStore = new FakeSessionStore();
         const sessionService = new SessionService({ sessionStore }, config);
-        const eventService = new EventService(
-            { eventStore, featureTagStore: new FakeFeatureTagStore() },
-            config,
-        );
+        const eventService = createFakeEventsService(config);
         const settingService = new SettingService(
             {
                 settingStore: new FakeSettingStore(),
@@ -168,10 +161,7 @@ describe('Default admin initialization', () => {
         const emailService = new EmailService(config);
         const sessionStore = new FakeSessionStore();
         const sessionService = new SessionService({ sessionStore }, config);
-        const eventService = new EventService(
-            { eventStore, featureTagStore: new FakeFeatureTagStore() },
-            config,
-        );
+        const eventService = createFakeEventsService(config);
         const settingService = new SettingService(
             {
                 settingStore: new FakeSettingStore(),
@@ -210,10 +200,7 @@ test('Should be a valid password', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -248,10 +235,7 @@ test('Password must be at least 10 chars', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -288,10 +272,7 @@ test('The password must contain at least one uppercase letter.', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -330,10 +311,7 @@ test('The password must contain at least one number', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -371,10 +349,7 @@ test('The password must contain at least one special character', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -412,10 +387,7 @@ test('Should be a valid password with special chars', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -450,10 +422,7 @@ test('Should send password reset email if user exists', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),
@@ -504,10 +473,7 @@ test('Should throttle password reset email', async () => {
     const emailService = new EmailService(config);
     const sessionStore = new FakeSessionStore();
     const sessionService = new SessionService({ sessionStore }, config);
-    const eventService = new EventService(
-        { eventStore, featureTagStore: new FakeFeatureTagStore() },
-        config,
-    );
+    const eventService = createFakeEventsService(config);
     const settingService = new SettingService(
         {
             settingStore: new FakeSettingStore(),

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -8,7 +8,7 @@ import {
     type IUnleashTest,
     setupAppWithCustomConfig,
 } from '../../helpers/test-helper';
-import { createFakeEventsService } from '../../../../lib/features';
+import { createEventsService } from '../../../../lib/features';
 import { createTestConfig } from '../../../config/test-config';
 
 let app: IUnleashTest;
@@ -28,7 +28,7 @@ beforeAll(async () => {
         },
     });
 
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
 });
 
 afterAll(async () => {

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -1,19 +1,22 @@
 import type { EventSearchQueryParameters } from '../../../../lib/openapi/spec/event-search-query-parameters';
 import dbInit, { type ITestDb } from '../../helpers/database-init';
 
-import { FEATURE_CREATED } from '../../../../lib/types';
-import { EventService } from '../../../../lib/services';
-import EventEmitter from 'events';
+import { FEATURE_CREATED, type IUnleashConfig } from '../../../../lib/types';
+import type { EventService } from '../../../../lib/services';
 import getLogger from '../../../fixtures/no-logger';
 import {
     type IUnleashTest,
     setupAppWithCustomConfig,
 } from '../../helpers/test-helper';
+import { createFakeEventsService } from '../../../../lib/features';
+import { createTestConfig } from '../../../config/test-config';
 
 let app: IUnleashTest;
 let db: ITestDb;
 let eventService: EventService;
 const TEST_USER_ID = -9999;
+
+const config: IUnleashConfig = createTestConfig();
 
 beforeAll(async () => {
     db = await dbInit('event_search', getLogger);
@@ -25,10 +28,7 @@ beforeAll(async () => {
         },
     });
 
-    eventService = new EventService(db.stores, {
-        getLogger,
-        eventBus: new EventEmitter(),
-    });
+    eventService = createFakeEventsService(config);
 });
 
 afterAll(async () => {

--- a/src/test/e2e/api/admin/event.e2e.test.ts
+++ b/src/test/e2e/api/admin/event.e2e.test.ts
@@ -8,7 +8,7 @@ import { FEATURE_CREATED, type IBaseEvent } from '../../../../lib/types/events';
 import { randomId } from '../../../../lib/util/random-id';
 import type { EventService } from '../../../../lib/services';
 import { type IUnleashConfig, SYSTEM_USER } from '../../../../lib/types';
-import { createFakeEventsService } from '../../../../lib/features';
+import { createEventsService } from '../../../../lib/features';
 import { createTestConfig } from '../../../config/test-config';
 
 let app: IUnleashTest;
@@ -27,7 +27,7 @@ beforeAll(async () => {
             },
         },
     });
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
 });
 
 beforeEach(async () => {

--- a/src/test/e2e/api/admin/event.e2e.test.ts
+++ b/src/test/e2e/api/admin/event.e2e.test.ts
@@ -6,14 +6,18 @@ import dbInit, { type ITestDb } from '../../helpers/database-init';
 import getLogger from '../../../fixtures/no-logger';
 import { FEATURE_CREATED, type IBaseEvent } from '../../../../lib/types/events';
 import { randomId } from '../../../../lib/util/random-id';
-import { EventService } from '../../../../lib/services';
-import EventEmitter from 'events';
-import { SYSTEM_USER } from '../../../../lib/types';
+import type { EventService } from '../../../../lib/services';
+import { type IUnleashConfig, SYSTEM_USER } from '../../../../lib/types';
+import { createFakeEventsService } from '../../../../lib/features';
+import { createTestConfig } from '../../../config/test-config';
 
 let app: IUnleashTest;
 let db: ITestDb;
 let eventService: EventService;
 const TEST_USER_ID = -9999;
+
+const config: IUnleashConfig = createTestConfig();
+
 beforeAll(async () => {
     db = await dbInit('event_api_serial', getLogger);
     app = await setupAppWithCustomConfig(db.stores, {
@@ -23,10 +27,7 @@ beforeAll(async () => {
             },
         },
     });
-    eventService = new EventService(db.stores, {
-        getLogger,
-        eventBus: new EventEmitter(),
-    });
+    eventService = createFakeEventsService(config);
 });
 
 beforeEach(async () => {

--- a/src/test/e2e/api/admin/feature-type.test.ts
+++ b/src/test/e2e/api/admin/feature-type.test.ts
@@ -12,13 +12,17 @@ let db: ITestDb;
 
 beforeAll(async () => {
     db = await dbInit('feature_type_api_serial', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {
-        experimental: {
-            flags: {
-                strictSchemaValidation: true,
+    app = await setupAppWithCustomConfig(
+        db.stores,
+        {
+            experimental: {
+                flags: {
+                    strictSchemaValidation: true,
+                },
             },
         },
-    });
+        db.rawDatabase,
+    );
 });
 
 afterAll(async () => {

--- a/src/test/e2e/api/admin/feature.auth.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.auth.e2e.test.ts
@@ -15,7 +15,11 @@ afterAll(async () => {
 test('creates new feature flag with createdBy', async () => {
     expect.assertions(1);
 
-    const { request, destroy } = await setupAppWithAuth(db.stores);
+    const { request, destroy } = await setupAppWithAuth(
+        db.stores,
+        {},
+        db.rawDatabase,
+    );
 
     // Login
     await request.post('/auth/demo/login').send({

--- a/src/test/e2e/api/admin/feature.custom-auth.e2e.test.ts
+++ b/src/test/e2e/api/admin/feature.custom-auth.e2e.test.ts
@@ -50,7 +50,12 @@ test('creates new feature flag with createdBy', async () => {
             next();
         });
     };
-    const { request, destroy } = await setupAppWithCustomAuth(stores, preHook);
+    const { request, destroy } = await setupAppWithCustomAuth(
+        stores,
+        preHook,
+        {},
+        db.rawDatabase,
+    );
 
     // create flag
     await request

--- a/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
+++ b/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
@@ -21,7 +21,7 @@ import SettingService from '../../../../lib/services/setting-service';
 import FakeSettingStore from '../../../fixtures/fake-setting-store';
 import { GroupService } from '../../../../lib/services/group-service';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../../lib/types';
-import { createFakeEventsService } from '../../../../lib/features';
+import { createEventsService } from '../../../../lib/features';
 
 let app: IUnleashTest;
 let stores: IUnleashStores;
@@ -54,7 +54,7 @@ beforeAll(async () => {
     db = await dbInit('reset_password_api_serial', getLogger);
     stores = db.stores;
     app = await setupApp(stores);
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db.rawDatabase, config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
+++ b/src/test/e2e/api/auth/reset-password-controller.e2e.test.ts
@@ -20,8 +20,8 @@ import { RoleName } from '../../../../lib/types/model';
 import SettingService from '../../../../lib/services/setting-service';
 import FakeSettingStore from '../../../fixtures/fake-setting-store';
 import { GroupService } from '../../../../lib/services/group-service';
-import { EventService } from '../../../../lib/services';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../../lib/types';
+import { createFakeEventsService } from '../../../../lib/features';
 
 let app: IUnleashTest;
 let stores: IUnleashStores;
@@ -54,7 +54,7 @@ beforeAll(async () => {
     db = await dbInit('reset_password_api_serial', getLogger);
     stores = db.stores;
     app = await setupApp(stores);
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/api/auth/simple-password-provider.e2e.test.ts
+++ b/src/test/e2e/api/auth/simple-password-provider.e2e.test.ts
@@ -16,7 +16,7 @@ import { RoleName } from '../../../../lib/types/model';
 import SettingService from '../../../../lib/services/setting-service';
 import { GroupService } from '../../../../lib/services/group-service';
 import ResetTokenService from '../../../../lib/services/reset-token-service';
-import { EventService } from '../../../../lib/services';
+import { createFakeEventsService } from '../../../../lib/features';
 
 let app: IUnleashTest;
 let stores: IUnleashStores;
@@ -39,7 +39,7 @@ beforeAll(async () => {
     db = await dbInit('simple_password_provider_api_serial', getLogger);
     stores = db.stores;
     app = await setupApp(stores);
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     const accessService = new AccessService(
         stores,

--- a/src/test/e2e/api/auth/simple-password-provider.e2e.test.ts
+++ b/src/test/e2e/api/auth/simple-password-provider.e2e.test.ts
@@ -16,7 +16,7 @@ import { RoleName } from '../../../../lib/types/model';
 import SettingService from '../../../../lib/services/setting-service';
 import { GroupService } from '../../../../lib/services/group-service';
 import ResetTokenService from '../../../../lib/services/reset-token-service';
-import { createFakeEventsService } from '../../../../lib/features';
+import { createEventsService } from '../../../../lib/features';
 
 let app: IUnleashTest;
 let stores: IUnleashStores;
@@ -39,7 +39,7 @@ beforeAll(async () => {
     db = await dbInit('simple_password_provider_api_serial', getLogger);
     stores = db.stores;
     app = await setupApp(stores);
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db.rawDatabase, config);
     const groupService = new GroupService(stores, config, eventService);
     const accessService = new AccessService(
         stores,

--- a/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
@@ -14,14 +14,18 @@ const testUser = { name: 'test', id: -9999 } as User;
 
 beforeAll(async () => {
     db = await dbInit('feature_304_api_client', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {
-        experimental: {
-            flags: {
-                strictSchemaValidation: true,
-                optimal304: true,
+    app = await setupAppWithCustomConfig(
+        db.stores,
+        {
+            experimental: {
+                flags: {
+                    strictSchemaValidation: true,
+                    optimal304: true,
+                },
             },
         },
-    });
+        db.rawDatabase,
+    );
     await app.services.featureToggleService.createFeatureToggle(
         'default',
         {

--- a/src/test/e2e/features-created-by-user-id-data-migration.e2e.test.ts
+++ b/src/test/e2e/features-created-by-user-id-data-migration.e2e.test.ts
@@ -1,7 +1,10 @@
 import type { EventEmitter } from 'stream';
-import { createFeatureToggleService } from '../../lib/features';
+import {
+    createFakeEventsService,
+    createFeatureToggleService,
+} from '../../lib/features';
 import { FEATURES_CREATED_BY_PROCESSED } from '../../lib/metric-events';
-import { EventService, type FeatureToggleService } from '../../lib/services';
+import type { EventService, FeatureToggleService } from '../../lib/services';
 import {
     ADMIN_TOKEN_USER,
     type IUnleashConfig,
@@ -29,7 +32,7 @@ beforeAll(async () => {
 
     service = createFeatureToggleService(db.rawDatabase, config);
 
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
 });
 
 afterAll(async () => {

--- a/src/test/e2e/features-created-by-user-id-data-migration.e2e.test.ts
+++ b/src/test/e2e/features-created-by-user-id-data-migration.e2e.test.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from 'stream';
 import {
-    createFakeEventsService,
+    createEventsService,
     createFeatureToggleService,
 } from '../../lib/features';
 import { FEATURES_CREATED_BY_PROCESSED } from '../../lib/metric-events';
@@ -32,7 +32,7 @@ beforeAll(async () => {
 
     service = createFeatureToggleService(db.rawDatabase, config);
 
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
 });
 
 afterAll(async () => {

--- a/src/test/e2e/services/addon-service.e2e.test.ts
+++ b/src/test/e2e/services/addon-service.e2e.test.ts
@@ -8,7 +8,7 @@ import SimpleAddon from '../../../lib/services/addon-service-test-simple-addon';
 import TagTypeService from '../../../lib/features/tag-type/tag-type-service';
 import { FEATURE_CREATED } from '../../../lib/types/events';
 import { IntegrationEventsService } from '../../../lib/services';
-import { createFakeEventsService } from '../../../lib/features';
+import { createEventsService } from '../../../lib/features';
 
 const addonProvider = { simple: new SimpleAddon() };
 
@@ -23,7 +23,7 @@ beforeAll(async () => {
     });
     db = await dbInit('addon_service_serial', getLogger);
     stores = db.stores;
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db.rawDatabase, config);
     const tagTypeService = new TagTypeService(stores, config, eventService);
     const integrationEventsService = new IntegrationEventsService(
         stores,

--- a/src/test/e2e/services/addon-service.e2e.test.ts
+++ b/src/test/e2e/services/addon-service.e2e.test.ts
@@ -7,7 +7,8 @@ import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import SimpleAddon from '../../../lib/services/addon-service-test-simple-addon';
 import TagTypeService from '../../../lib/features/tag-type/tag-type-service';
 import { FEATURE_CREATED } from '../../../lib/types/events';
-import { EventService, IntegrationEventsService } from '../../../lib/services';
+import { IntegrationEventsService } from '../../../lib/services';
+import { createFakeEventsService } from '../../../lib/features';
 
 const addonProvider = { simple: new SimpleAddon() };
 
@@ -22,7 +23,7 @@ beforeAll(async () => {
     });
     db = await dbInit('addon_service_serial', getLogger);
     stores = db.stores;
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const tagTypeService = new TagTypeService(stores, config, eventService);
     const integrationEventsService = new IntegrationEventsService(
         stores,

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -9,10 +9,7 @@ import {
 import { DEFAULT_ENV } from '../../../lib/util/constants';
 import { addDays } from 'date-fns';
 import type ProjectService from '../../../lib/features/project/project-service';
-import {
-    createFakeEventsService,
-    createProjectService,
-} from '../../../lib/features';
+import { createProjectService } from '../../../lib/features';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import { createApiTokenService } from '../../../lib/features/api-tokens/createApiTokenService';
 
@@ -32,7 +29,6 @@ beforeAll(async () => {
     });
     db = await dbInit('api_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = createFakeEventsService(config);
     const project = {
         id: 'test-project',
         name: 'Test Project',

--- a/src/test/e2e/services/api-token-service.e2e.test.ts
+++ b/src/test/e2e/services/api-token-service.e2e.test.ts
@@ -9,8 +9,10 @@ import {
 import { DEFAULT_ENV } from '../../../lib/util/constants';
 import { addDays } from 'date-fns';
 import type ProjectService from '../../../lib/features/project/project-service';
-import { createProjectService } from '../../../lib/features';
-import { EventService } from '../../../lib/services';
+import {
+    createFakeEventsService,
+    createProjectService,
+} from '../../../lib/features';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import { createApiTokenService } from '../../../lib/features/api-tokens/createApiTokenService';
 
@@ -30,7 +32,7 @@ beforeAll(async () => {
     });
     db = await dbInit('api_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const project = {
         id: 'test-project',
         name: 'Test Project',

--- a/src/test/e2e/services/edge-service.e2e.test.ts
+++ b/src/test/e2e/services/edge-service.e2e.test.ts
@@ -8,10 +8,7 @@ import {
 import { DEFAULT_ENV } from '../../../lib/util/constants';
 import { addDays, subDays } from 'date-fns';
 import type ProjectService from '../../../lib/features/project/project-service';
-import {
-    createFakeEventsService,
-    createProjectService,
-} from '../../../lib/features';
+import { createProjectService } from '../../../lib/features';
 import { EdgeService } from '../../../lib/services';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import { createApiTokenService } from '../../../lib/features/api-tokens/createApiTokenService';
@@ -32,7 +29,6 @@ beforeAll(async () => {
     });
     db = await dbInit('api_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = createFakeEventsService(config);
     const project = {
         id: 'test-project',
         name: 'Test Project',

--- a/src/test/e2e/services/edge-service.e2e.test.ts
+++ b/src/test/e2e/services/edge-service.e2e.test.ts
@@ -8,8 +8,11 @@ import {
 import { DEFAULT_ENV } from '../../../lib/util/constants';
 import { addDays, subDays } from 'date-fns';
 import type ProjectService from '../../../lib/features/project/project-service';
-import { createProjectService } from '../../../lib/features';
-import { EdgeService, EventService } from '../../../lib/services';
+import {
+    createFakeEventsService,
+    createProjectService,
+} from '../../../lib/features';
+import { EdgeService } from '../../../lib/services';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
 import { createApiTokenService } from '../../../lib/features/api-tokens/createApiTokenService';
 
@@ -29,7 +32,7 @@ beforeAll(async () => {
     });
     db = await dbInit('api_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const project = {
         id: 'test-project',
         name: 'Test Project',

--- a/src/test/e2e/services/group-service.e2e.test.ts
+++ b/src/test/e2e/services/group-service.e2e.test.ts
@@ -2,13 +2,14 @@ import dbInit, { type ITestDb } from '../helpers/database-init';
 import getLogger from '../../fixtures/no-logger';
 import { createTestConfig } from '../../config/test-config';
 import { GroupService } from '../../../lib/services/group-service';
-import { EventService } from '../../../lib/services';
+import type { EventService } from '../../../lib/services';
 import {
     type IGroupStore,
     type IUnleashStores,
     type IUser,
     TEST_AUDIT_USER,
 } from '../../../lib/types';
+import { createFakeEventsService } from '../../../lib/features';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -28,7 +29,7 @@ beforeAll(async () => {
     const config = createTestConfig({
         getLogger,
     });
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
     groupService = new GroupService(stores, config, eventService);
     groupStore = stores.groupStore;
 

--- a/src/test/e2e/services/group-service.e2e.test.ts
+++ b/src/test/e2e/services/group-service.e2e.test.ts
@@ -9,7 +9,7 @@ import {
     type IUser,
     TEST_AUDIT_USER,
 } from '../../../lib/types';
-import { createFakeEventsService } from '../../../lib/features';
+import { createEventsService } from '../../../lib/features';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -29,7 +29,7 @@ beforeAll(async () => {
     const config = createTestConfig({
         getLogger,
     });
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
     groupService = new GroupService(stores, config, eventService);
     groupStore = stores.groupStore;
 

--- a/src/test/e2e/services/reset-token-service.e2e.test.ts
+++ b/src/test/e2e/services/reset-token-service.e2e.test.ts
@@ -12,8 +12,8 @@ import type { IUser, IUserWithRootRole } from '../../../lib/types/user';
 import SettingService from '../../../lib/services/setting-service';
 import FakeSettingStore from '../../fixtures/fake-setting-store';
 import { GroupService } from '../../../lib/services/group-service';
-import { EventService } from '../../../lib/services';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
+import { createFakeEventsService } from '../../../lib/features';
 
 const config: IUnleashConfig = createTestConfig();
 
@@ -29,7 +29,7 @@ let sessionService: SessionService;
 beforeAll(async () => {
     db = await dbInit('reset_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/services/reset-token-service.e2e.test.ts
+++ b/src/test/e2e/services/reset-token-service.e2e.test.ts
@@ -13,7 +13,7 @@ import SettingService from '../../../lib/services/setting-service';
 import FakeSettingStore from '../../fixtures/fake-setting-store';
 import { GroupService } from '../../../lib/services/group-service';
 import { type IUnleashStores, TEST_AUDIT_USER } from '../../../lib/types';
-import { createFakeEventsService } from '../../../lib/features';
+import { createEventsService } from '../../../lib/features';
 
 const config: IUnleashConfig = createTestConfig();
 
@@ -29,7 +29,7 @@ let sessionService: SessionService;
 beforeAll(async () => {
     db = await dbInit('reset_token_service_serial', getLogger);
     stores = db.stores;
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db.rawDatabase, config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/services/setting-service.test.ts
+++ b/src/test/e2e/services/setting-service.test.ts
@@ -8,7 +8,7 @@ import {
     SETTING_UPDATED,
 } from '../../../lib/types/events';
 import { TEST_AUDIT_USER } from '../../../lib/types';
-import { createFakeEventsService } from '../../../lib/features';
+import { createEventsService } from '../../../lib/features';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -19,7 +19,7 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('setting_service_serial', config.getLogger);
     stores = db.stores;
-    const eventService = createFakeEventsService(config);
+    const eventService = createEventsService(db.rawDatabase, config);
     service = new SettingService(stores, config, eventService);
 });
 beforeEach(async () => {

--- a/src/test/e2e/services/setting-service.test.ts
+++ b/src/test/e2e/services/setting-service.test.ts
@@ -7,8 +7,8 @@ import {
     SETTING_DELETED,
     SETTING_UPDATED,
 } from '../../../lib/types/events';
-import { EventService } from '../../../lib/services';
 import { TEST_AUDIT_USER } from '../../../lib/types';
+import { createFakeEventsService } from '../../../lib/features';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -19,7 +19,7 @@ beforeAll(async () => {
     const config = createTestConfig();
     db = await dbInit('setting_service_serial', config.getLogger);
     stores = db.stores;
-    const eventService = new EventService(stores, config);
+    const eventService = createFakeEventsService(config);
     service = new SettingService(stores, config, eventService);
 });
 beforeEach(async () => {

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -15,7 +15,7 @@ import { addDays, minutesToMilliseconds } from 'date-fns';
 import { GroupService } from '../../../lib/services/group-service';
 import { BadDataError } from '../../../lib/error';
 import PasswordMismatch from '../../../lib/error/password-mismatch';
-import { EventService } from '../../../lib/services';
+import type { EventService } from '../../../lib/services';
 import {
     CREATE_ADDON,
     type IUnleashStores,
@@ -28,6 +28,7 @@ import {
 } from '../../../lib/types';
 import { CUSTOM_ROOT_ROLE_TYPE } from '../../../lib/util';
 import { PasswordPreviouslyUsedError } from '../../../lib/error/password-previously-used';
+import { createFakeEventsService } from '../../../lib/features';
 
 let db: ITestDb;
 let stores: IUnleashStores;
@@ -45,7 +46,7 @@ beforeAll(async () => {
     db = await dbInit('user_service_serial', getLogger);
     stores = db.stores;
     const config = createTestConfig();
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../lib/types';
 import { CUSTOM_ROOT_ROLE_TYPE } from '../../../lib/util';
 import { PasswordPreviouslyUsedError } from '../../../lib/error/password-previously-used';
-import { createFakeEventsService } from '../../../lib/features';
+import { createEventsService } from '../../../lib/features';
 
 let db: ITestDb;
 let stores: IUnleashStores;
@@ -46,7 +46,7 @@ beforeAll(async () => {
     db = await dbInit('user_service_serial', getLogger);
     stores = db.stores;
     const config = createTestConfig();
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/users/inactive/inactive-users-service.test.ts
+++ b/src/test/e2e/users/inactive/inactive-users-service.test.ts
@@ -15,7 +15,7 @@ import { ADMIN, type IUnleashStores, type IUser } from '../../../../lib/types';
 import type { InactiveUsersService } from '../../../../lib/users/inactive/inactive-users-service';
 import { createInactiveUsersService } from '../../../../lib/users';
 import { extractAuditInfoFromUser } from '../../../../lib/util';
-import { createFakeEventsService } from '../../../../lib/features';
+import { createEventsService } from '../../../../lib/features';
 
 let db: ITestDb;
 let stores: IUnleashStores;
@@ -38,7 +38,7 @@ beforeAll(async () => {
     db = await dbInit('inactive_user_service_serial', getLogger);
     stores = db.stores;
     const config = createTestConfig();
-    eventService = createFakeEventsService(config);
+    eventService = createEventsService(db.rawDatabase, config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,

--- a/src/test/e2e/users/inactive/inactive-users-service.test.ts
+++ b/src/test/e2e/users/inactive/inactive-users-service.test.ts
@@ -4,7 +4,7 @@ import { createTestConfig } from '../../../config/test-config';
 import {
     AccessService,
     EmailService,
-    EventService,
+    type EventService,
     GroupService,
 } from '../../../../lib/services';
 import ResetTokenService from '../../../../lib/services/reset-token-service';
@@ -15,6 +15,7 @@ import { ADMIN, type IUnleashStores, type IUser } from '../../../../lib/types';
 import type { InactiveUsersService } from '../../../../lib/users/inactive/inactive-users-service';
 import { createInactiveUsersService } from '../../../../lib/users';
 import { extractAuditInfoFromUser } from '../../../../lib/util';
+import { createFakeEventsService } from '../../../../lib/features';
 
 let db: ITestDb;
 let stores: IUnleashStores;
@@ -37,7 +38,7 @@ beforeAll(async () => {
     db = await dbInit('inactive_user_service_serial', getLogger);
     stores = db.stores;
     const config = createTestConfig();
-    eventService = new EventService(stores, config);
+    eventService = createFakeEventsService(config);
     const groupService = new GroupService(stores, config, eventService);
     accessService = new AccessService(
         stores,


### PR DESCRIPTION
During adding privateProjectsChecker, I saw that events composition root is not used almost at all. 
Refactored code so we do not call new EventService anymore.