### PR TITLE
feat: allow editing root role/description on SCIM group

### DIFF
--- a/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
+++ b/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
@@ -106,6 +106,7 @@ export const CreateGroup = () => {
                 handleSubmit={handleSubmit}
                 handleCancel={handleCancel}
                 mode={CREATE}
+                isScimGroup={false}
             >
                 <Button
                     type='submit'

--- a/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
+++ b/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
@@ -149,6 +149,7 @@ export const EditGroup = ({
                 handleSubmit={handleSubmit}
                 handleCancel={handleCancel}
                 mode={EDIT}
+                isScimGroup={isScimGroup}
             >
                 <Tooltip title={isScimGroup ? scimGroupTooltip : ''} arrow>
                     <div>
@@ -156,7 +157,7 @@ export const EditGroup = ({
                             type='submit'
                             variant='contained'
                             color='primary'
-                            disabled={isScimGroup || !isValid}
+                            disabled={!isValid}
                             data-testid={UG_SAVE_BTN_ID}
                         >
                             Save

--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -261,7 +261,6 @@ export const Group: VFC = () => {
                                             ? scimGroupTooltip
                                             : 'Edit group',
                                     }}
-                                    disabled={isScimGroup}
                                 >
                                     <Edit />
                                 </PermissionIconButton>

--- a/frontend/src/component/admin/groups/GroupForm/GroupForm.tsx
+++ b/frontend/src/component/admin/groups/GroupForm/GroupForm.tsx
@@ -81,6 +81,7 @@ interface IGroupForm {
     mappingsSSO: string[];
     users: IGroupUser[];
     rootRole: number | null;
+    isScimGroup: boolean;
     setName: (name: string) => void;
     setDescription: React.Dispatch<React.SetStateAction<string>>;
     setMappingsSSO: React.Dispatch<React.SetStateAction<string[]>>;
@@ -99,6 +100,7 @@ export const GroupForm: FC<IGroupForm> = ({
     mappingsSSO,
     users,
     rootRole,
+    isScimGroup,
     setName,
     setDescription,
     setMappingsSSO,
@@ -138,6 +140,7 @@ export const GroupForm: FC<IGroupForm> = ({
                     onChange={(e) => setName(e.target.value)}
                     data-testid={UG_NAME_ID}
                     required
+                    disabled={isScimGroup}
                 />
                 <StyledInputDescription>
                     How would you describe your group?
@@ -152,7 +155,7 @@ export const GroupForm: FC<IGroupForm> = ({
                     data-testid={UG_DESC_ID}
                 />
                 <ConditionallyRender
-                    condition={isGroupSyncingEnabled}
+                    condition={isGroupSyncingEnabled && !isScimGroup}
                     show={
                         <>
                             <StyledInputDescription>

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions/GroupCardActions.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions/GroupCardActions.tsx
@@ -74,7 +74,6 @@ export const GroupCardActions: FC<IGroupCardActions> = ({
                         aria-expanded={open ? 'true' : undefined}
                         onClick={handleClick}
                         type='button'
-                        disabled={isScimGroup}
                     >
                         <MoreVert />
                     </IconButton>
@@ -103,6 +102,7 @@ export const GroupCardActions: FC<IGroupCardActions> = ({
                         </ListItemText>
                     </MenuItem>
                     <MenuItem
+                        disabled={isScimGroup}
                         onClick={() => {
                             onEditUsers();
                             handleClose();
@@ -122,6 +122,7 @@ export const GroupCardActions: FC<IGroupCardActions> = ({
                             onRemove();
                             handleClose();
                         }}
+                        disabled={isScimGroup}
                     >
                         <ListItemIcon>
                             <Delete />

--- a/frontend/src/component/admin/groups/group-constants.ts
+++ b/frontend/src/component/admin/groups/group-constants.ts
@@ -1,2 +1,2 @@
 export const scimGroupTooltip =
-    'This group is managed by your SCIM provider, only the role can be changed manually';
+    'This group is managed by your SCIM provider, only the role and description can be changed manually';

--- a/frontend/src/component/admin/groups/group-constants.ts
+++ b/frontend/src/component/admin/groups/group-constants.ts
@@ -1,2 +1,2 @@
 export const scimGroupTooltip =
-    'This group is managed by your SCIM provider and cannot be changed manually';
+    'This group is managed by your SCIM provider, only the role can be changed manually';

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -231,6 +231,22 @@ export class GroupService {
                 throw new NameExistsError('Group name already exists');
             }
         }
+
+        if (existingGroup && Boolean(existingGroup.scimId)) {
+            const {
+                description: _existingDescription,
+                rootRole: _existingRootRole,
+                ...existingConstantProperties
+            } = existingGroup;
+            const { description, rootRole, ...newConstantProperties } = group;
+
+            if (
+                JSON.stringify(existingConstantProperties) !==
+                JSON.stringify(newConstantProperties)
+            ) {
+                throw new BadDataError('Cannot change SCIM group properties');
+            }
+        }
     }
 
     async getRolesForProject(projectId: string): Promise<IGroupRole[]> {

--- a/src/test/e2e/services/group-service.e2e.test.ts
+++ b/src/test/e2e/services/group-service.e2e.test.ts
@@ -262,3 +262,101 @@ test('adding a nonexistent role to a group should fail', async () => {
         'Request validation failed: your request body or params contain invalid data: Incorrect role id 100',
     );
 });
+
+test('trying to modify a SCIM group name should fail', async () => {
+    const group = await groupStore.create({
+        name: 'scim_group',
+        description: 'scim_group',
+    });
+
+    await db.rawDatabase('groups').where({ id: group.id }).update({
+        scim_id: 'some-faux-uuid',
+        scim_external_id: 'external-id',
+    });
+
+    await expect(() => {
+        return groupService.updateGroup(
+            {
+                id: group.id,
+                name: 'new_name',
+                users: [],
+                rootRole: 100,
+                createdAt: new Date(),
+                createdBy: 'test',
+            },
+            TEST_AUDIT_USER,
+        );
+    }).rejects.toThrow(
+        'Request validation failed: your request body or params contain invalid data: Cannot update the name of a SCIM group',
+    );
+});
+
+test('trying to modify users in a SCIM group should fail', async () => {
+    const group = await groupStore.create({
+        name: 'another_scim_group',
+        description: 'scim_group',
+    });
+
+    await db.rawDatabase('groups').where({ id: group.id }).update({
+        scim_id: 'some-other-faux-uuid',
+        scim_external_id: 'some-external-id',
+    });
+
+    await expect(() => {
+        return groupService.updateGroup(
+            {
+                id: group.id,
+                name: 'new_name',
+                users: [
+                    {
+                        user: {
+                            id: 1,
+                            isAPI: false,
+                            permissions: [],
+                        },
+                    },
+                ],
+                rootRole: 100,
+                createdAt: new Date(),
+                createdBy: 'test',
+            },
+            TEST_AUDIT_USER,
+        );
+    }).rejects.toThrow(
+        'Request validation failed: your request body or params contain invalid data: Cannot update the name of a SCIM group',
+    );
+});
+
+test('can modify a SCIM group description and root role', async () => {
+    const group = await groupStore.create({
+        name: 'yet_another_scim_group',
+        description: 'scim_group',
+    });
+
+    await db.rawDatabase('groups').where({ id: group.id }).update({
+        scim_id: 'completely-different-faux-uuid',
+        scim_external_id: 'totally-not-the-same-external-id',
+    });
+
+    await groupService.updateGroup(
+        {
+            id: group.id,
+            name: 'yet_another_scim_group',
+            description: 'new description',
+            users: [],
+            rootRole: 1,
+            createdAt: new Date(),
+            createdBy: 'test',
+        },
+        TEST_AUDIT_USER,
+    );
+
+    const updatedGroup = await groupService.getGroup(group.id);
+    expect(updatedGroup).toMatchObject({
+        description: 'new description',
+        id: group.id,
+        mappingsSSO: [],
+        name: 'yet_another_scim_group',
+        rootRole: 1,
+    });
+});


### PR DESCRIPTION
This relaxes validation on modifying SCIM groups.

From a UI perspective, users are now allowed to access the edit screen for SCIM groups (previously you couldn't click the relevant UI elements and if you navigated manually you'd just get the save button disabled). Now instead updating the name is disabled and modifying the SSO mappings is hidden. The usual places that previously blocked you from changing users are still disabled.

On the backend, validation has been relaxed to allow some editing of groups, so long as you're not changing the name or modifying the users (effectively the only two properties SCIM cares about).