### PR TITLE
fix: always provide empty segments list in feature env strategies

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -855,6 +855,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             constraints: r.constraints || [],
             variants: r.strategy_variants || [],
             parameters: r.parameters,
+            segments: [],
             sortOrder: r.sort_order,
             id: r.strategy_id,
             title: r.strategy_title || '',

--- a/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
@@ -3055,7 +3055,7 @@ test('should create a strategy with segments', async () => {
                 (strat) => strat.id === strategyOne.id,
             );
 
-            expect(strategy.segments).toBe(undefined);
+            expect(strategy.segments).toEqual([]);
         });
 });
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When reading feature env strategies and there's no segments it returns empty list of segments now. Previously it was undefined leading to overly verbose change request diffs.

<img width="669" alt="Screenshot 2024-08-14 at 16 06 14" src="https://github.com/user-attachments/assets/1ac6121b-1d6c-48c6-b4ce-3f26c53c6694">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
