### PR TITLE
fix: exclude archived features in segments count

### DIFF
--- a/src/lib/features/segment/admin-segment.e2e.test.ts
+++ b/src/lib/features/segment/admin-segment.e2e.test.ts
@@ -602,14 +602,30 @@ test('Should show usage in features and projects', async () => {
     );
     const [feature] = await fetchFeatures();
     const [strategy] = await fetchFeatureStrategies(feature.name);
-    //@ts-ignore
-    await addSegmentsToStrategy([segment.id], strategy.id);
 
-    const segments = await fetchSegments();
-    expect(segments).toMatchObject([
+    const unusedSegments = await fetchSegments();
+    expect(unusedSegments).toMatchObject([
+        {
+            usedInFeatures: 0,
+            usedInProjects: 0,
+        },
+    ]);
+
+    await addSegmentsToStrategy([segment.id], strategy.id);
+    const usedSegments = await fetchSegments();
+    expect(usedSegments).toMatchObject([
         {
             usedInFeatures: 1,
             usedInProjects: 1,
+        },
+    ]);
+
+    await app.archiveFeature(feature.name, feature.project);
+    const segmentsWithArchivedFeatures = await fetchSegments();
+    expect(segmentsWithArchivedFeatures).toMatchObject([
+        {
+            usedInFeatures: 0,
+            usedInProjects: 0,
         },
     ]);
 });

--- a/src/lib/features/segment/segment-store.test.ts
+++ b/src/lib/features/segment/segment-store.test.ts
@@ -48,7 +48,7 @@ describe('usage counting', () => {
         await db.rawDatabase.table('change_requests').delete();
     });
 
-    test('segment usage in active CRs is counted if we ask for it', async () => {
+    test('segment usage in active CRs is counted iff we ask for it', async () => {
         const CR_ID = 54321;
 
         const flag1 = await db.stores.featureToggleStore.create('default', {

--- a/src/lib/features/segment/segment-store.test.ts
+++ b/src/lib/features/segment/segment-store.test.ts
@@ -48,7 +48,7 @@ describe('usage counting', () => {
         await db.rawDatabase.table('change_requests').delete();
     });
 
-    test('segment usage in active CRs is counted iff we ask for it', async () => {
+    test('segment usage in active CRs is counted if we ask for it', async () => {
         const CR_ID = 54321;
 
         const flag1 = await db.stores.featureToggleStore.create('default', {

--- a/src/lib/features/segment/segment-store.ts
+++ b/src/lib/features/segment/segment-store.ts
@@ -16,6 +16,7 @@ import { isDefined } from '../../util';
 const T = {
     segments: 'segments',
     featureStrategies: 'feature_strategies',
+    features: 'features',
     featureStrategySegment: 'feature_strategy_segment',
 };
 
@@ -123,17 +124,15 @@ export default class SegmentStore implements ISegmentStore {
 
     private async getAllWithoutChangeRequestUsageData(): Promise<ISegment[]> {
         const rows: ISegmentRow[] = await this.db
-            .select(
-                this.prefixColumns(),
-                'used_in_projects',
-                'used_in_features',
-            )
-            .countDistinct(
-                `${T.featureStrategies}.project_name AS used_in_projects`,
-            )
-            .countDistinct(
-                `${T.featureStrategies}.feature_name AS used_in_features`,
-            )
+            .select([
+                ...this.prefixColumns(),
+                this.db.raw(
+                    `count(distinct case when ${T.features}.archived_at is null then ${T.featureStrategies}.project_name end) as used_in_projects`,
+                ),
+                this.db.raw(
+                    `count(distinct case when ${T.features}.archived_at is null then ${T.featureStrategies}.feature_name end) as used_in_features`,
+                ),
+            ])
             .from(T.segments)
             .leftJoin(
                 T.featureStrategySegment,
@@ -144,6 +143,11 @@ export default class SegmentStore implements ISegmentStore {
                 T.featureStrategies,
                 `${T.featureStrategies}.id`,
                 `${T.featureStrategySegment}.feature_strategy_id`,
+            )
+            .leftJoin(
+                T.features,
+                `${T.featureStrategies}.feature_name`,
+                `${T.features}.name`,
             )
             .groupBy(this.prefixColumns())
             .orderBy('name', 'asc');


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Exclude archived feature flags from the segment usage count calculations

Making sure this list count
<img width="723" alt="Screenshot 2024-08-15 at 10 09 36" src="https://github.com/user-attachments/assets/941b0ef5-70ec-4f5b-8829-fed872e6dbb4">
matches this strategy values
<img width="473" alt="Screenshot 2024-08-15 at 10 09 20" src="https://github.com/user-attachments/assets/788a0a2d-03a9-4278-ae61-ef3e127a6643">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
