### PR TITLE
chore: add flags `projectListImprovements` and `useProjectReadModel`

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -94,6 +94,7 @@ export type UiFlags = {
     newEventSearch?: boolean;
     changeRequestPlayground?: boolean;
     archiveProjects?: boolean;
+    projectListImprovements?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -140,6 +140,7 @@ exports[`should create default config 1`] = `
       "originMiddleware": false,
       "outdatedSdksBanner": false,
       "personalAccessTokensKillSwitch": false,
+      "projectListImprovements": false,
       "projectOverviewRefactorFeedback": false,
       "queryMissingTokens": false,
       "removeUnsafeInlineStyleSrc": false,
@@ -150,6 +151,7 @@ exports[`should create default config 1`] = `
       "signals": false,
       "strictSchemaValidation": false,
       "useMemoizedActiveTokens": false,
+      "useProjectReadModel": false,
       "userAccessUIEnabled": false,
     },
     "externalResolver": {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -64,7 +64,9 @@ export type IFlagKey =
     | 'originMiddleware'
     | 'newEventSearch'
     | 'changeRequestPlayground'
-    | 'archiveProjects';
+    | 'archiveProjects'
+    | 'projectListImprovements'
+    | 'useProjectReadModel';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -311,6 +313,14 @@ const flags: IFlags = {
     ),
     archiveProjects: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_ARCHIVE_PROJECTS,
+        false,
+    ),
+    projectListImprovements: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PROJECT_LIST_IMPROVEMENTS,
+        false,
+    ),
+    useProjectReadModel: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_USE_PROJECT_READ_MODEL,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,8 @@ process.nextTick(async () => {
                         originMiddleware: true,
                         newEventSearch: true,
                         changeRequestPlayground: true,
+                        projectListImprovements: true,
+                        useProjectReadModel: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
These are both related to the work on the project list improvements project.

The `projectListImprovements` flag will be used to enable disable the
new project list improvements.

The `useProjectReadModel` flag will be used to enable/disable the use
of the new project read model and is mostly a safety feature.