### PR TITLE
chore: minor cleanup in new project read model

### DIFF
--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -66,7 +66,7 @@ export class ProjectReadModel implements IProjectReadModel {
         query?: IProjectQuery,
         userId?: number,
     ): Promise<ProjectForUi[]> {
-        const projectTimer = this.timer('getProjectsForProjectList');
+        const projectTimer = this.timer('getProjectsForAdminUi');
         let projects = this.db(TABLE)
             .leftJoin('features', 'features.project', 'projects.id')
             .leftJoin(

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -129,10 +129,8 @@ export class ProjectReadModel implements IProjectReadModel {
         const projectsWithFeatureCount =
             projectAndFeatureCount.map(mapProjectForUi);
         projectTimer();
-        const memberTimer = this.timer('getMemberCount');
 
         const memberCount = await this.getMembersCount();
-        memberTimer();
         const memberMap = new Map<string, number>(
             memberCount.map((c) => [c.project, Number(c.count)]),
         );
@@ -193,10 +191,8 @@ export class ProjectReadModel implements IProjectReadModel {
             mapProjectForInsights,
         );
         projectTimer();
-        const memberTimer = this.timer('getMemberCount');
 
         const memberCount = await this.getMembersCount();
-        memberTimer();
         const memberMap = new Map<string, number>(
             memberCount.map((c) => [c.project, Number(c.count)]),
         );
@@ -210,6 +206,7 @@ export class ProjectReadModel implements IProjectReadModel {
     }
 
     private async getMembersCount(): Promise<IProjectMembersCount[]> {
+        const memberTimer = this.timer('getMemberCount');
         const members = await this.db
             .select('project')
             .from((db) => {
@@ -231,6 +228,8 @@ export class ProjectReadModel implements IProjectReadModel {
             })
             .groupBy('project')
             .count('user_id');
+
+        memberTimer();
         return members;
     }
 }

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -206,7 +206,7 @@ export class ProjectReadModel implements IProjectReadModel {
     }
 
     private async getMembersCount(): Promise<IProjectMembersCount[]> {
-        const memberTimer = this.timer('getMemberCount');
+        const memberTimer = this.timer('getMembersCount');
         const members = await this.db
             .select('project')
             .from((db) => {


### PR DESCRIPTION
This PR touches up a few small things in the project read model.

Fixes:
Use the right method name in the query/method timer for `getProjectsForAdminUi`. I'd forgotten to change the timer name from the original method name.

Spells the method name correctly for the `getMembersCount` timer (it used to be `getMemberCount`, but the method is callled `getMembersCount` with a plural s).

Changes:
Call the `getMembersCount` timer from within the `getMembersCount` method itself. Instead of setting that timer up from two different places, we can call it in the method we're timing. This wasn't a problem previously, because the method was only called from a single place. Assuming we always wanna time that query, it makes more sense to put the timing in the actual method.