### PR TITLE
chore: impl empty results for fake project read model

### DIFF
--- a/src/lib/features/project/fake-project-read-model.ts
+++ b/src/lib/features/project/fake-project-read-model.ts
@@ -6,9 +6,9 @@ import type {
 
 export class FakeProjectReadModel implements IProjectReadModel {
     getProjectsForAdminUi(): Promise<ProjectForUi[]> {
-        throw new Error('Method not implemented.');
+        return Promise.resolve([]);
     }
     getProjectsForInsights(): Promise<ProjectForInsights[]> {
-        throw new Error('Method not implemented.');
+        return Promise.resolve([]);
     }
 }


### PR DESCRIPTION
Implements empty responses for the fake project read model. Instead of throwing a not implemented error, we'll return empty results.

This makes some of the tests in enterprise pass.