### PR TITLE
feat: static link to archived flags in archived project

### DIFF
--- a/frontend/src/component/project/NewProjectCard/NewProjectCard.styles.ts
+++ b/frontend/src/component/project/NewProjectCard/NewProjectCard.styles.ts
@@ -38,6 +38,7 @@ export const StyledDivHeader = styled('div')(({ theme }) => ({
     ...flexRow,
     width: '100%',
     marginBottom: theme.spacing(2),
+    gap: theme.spacing(1),
 }));
 
 export const StyledCardTitle = styled('h3')(({ theme }) => ({
@@ -89,7 +90,7 @@ export const StyledIconBox = styled(Box)(({ theme }) => ({
     display: 'grid',
     placeItems: 'center',
     padding: theme.spacing(0, 0.5, 0, 1),
-    marginRight: theme.spacing(2),
+    marginRight: theme.spacing(1),
     alignSelf: 'baseline',
     color: theme.palette.primary.main,
     height: '100%',

--- a/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
@@ -104,21 +104,13 @@ export const ProjectArchiveCard: FC<ProjectArchiveCardProps> = ({
                         }
                     />
                     <ConditionallyRender
-                        condition={typeof archivedFeaturesCount !== 'undefined'}
+                        condition={true}
                         show={
                             <Link
                                 component={RouterLink}
                                 to={`/archive?search=project%3A${encodeURI(id)}`}
                             >
-                                <StyledParagraphInfo disabled data-loading>
-                                    {archivedFeaturesCount}
-                                </StyledParagraphInfo>
-                                <p data-loading>
-                                    archived{' '}
-                                    {archivedFeaturesCount === 1
-                                        ? 'flag'
-                                        : 'flags'}
-                                </p>
+                                <p>View archived flags</p>
                             </Link>
                         }
                     />

--- a/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
@@ -103,17 +103,12 @@ export const ProjectArchiveCard: FC<ProjectArchiveCardProps> = ({
                             </Tooltip>
                         }
                     />
-                    <ConditionallyRender
-                        condition={true}
-                        show={
-                            <Link
-                                component={RouterLink}
-                                to={`/archive?search=project%3A${encodeURI(id)}`}
-                            >
-                                <p>View archived flags</p>
-                            </Link>
-                        }
-                    />
+                    <Link
+                        component={RouterLink}
+                        to={`/archive?search=project%3A${encodeURI(id)}`}
+                    >
+                        <p>View archived flags</p>
+                    </Link>
                 </StyledDivInfo>
             </StyledProjectCardBody>
             <ProjectCardFooter id={id} disabled owners={owners}>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

A link to archived project archived flags is always there without a number of archived flags (we decided not to expose it for now). 
<img width="1369" alt="Screenshot 2024-08-19 at 10 51 59" src="https://github.com/user-attachments/assets/1eb146d3-2d92-4981-a582-eef9f8a4ea27">

I decided to choose a link similar to view archive link in the flag search
<img width="1532" alt="Screenshot 2024-08-19 at 10 54 08" src="https://github.com/user-attachments/assets/458f33d4-00d9-4070-8278-fa098eb9a047">

I also played with the card title link but it  felt like it leads you to full project information that we don't want to show for the archived projects.


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
