### PR TITLE
fix: only show addon delete button when editing addons

### DIFF
--- a/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
@@ -430,12 +430,19 @@ export const IntegrationForm: VFC<IntegrationFormProps> = ({
                             />
                         </div>
                     </StyledConfigurationSection>
-                    <Divider />
-                    <section>
-                        <IntegrationDelete
-                            id={(formValues as AddonSchema).id}
-                        />
-                    </section>
+                    <ConditionallyRender
+                        condition={editMode}
+                        show={
+                            <>
+                                <Divider />
+                                <section>
+                                    <IntegrationDelete
+                                        id={(formValues as AddonSchema).id}
+                                    />
+                                </section>
+                            </>
+                        }
+                    />
                 </StyledContainer>
             </StyledForm>
             <IntegrationEventsModal


### PR DESCRIPTION
Fixes so that delete button doesn't show up when creating integrations, only when editing them