### PR TITLE
chore: change integration events api tag to addons

### DIFF
--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -185,7 +185,7 @@ Note: passing \`null\` as a value for the description property will set it to an
             permission: ADMIN,
             middleware: [
                 openApiService.validPath({
-                    tags: ['Unstable'],
+                    tags: ['Addons'],
                     operationId: 'getIntegrationEvents',
                     summary:
                         'Get integration events for a specific integration configuration.',


### PR DESCRIPTION
Changes the OpenAPI tag used for integration events to be 'Addons' like the rest of the addon APIs