### PR TITLE
fix: update the customer success email for limits

### DIFF
--- a/frontend/src/component/common/Limit/Limit.tsx
+++ b/frontend/src/component/common/Limit/Limit.tsx
@@ -89,8 +89,8 @@ export const Limit: FC<{
         <>
             If you need more than <strong>{limit}</strong> {shortName ?? name},
             please reach out to us at{' '}
-            <a href='mailto:cs@getunleash.io?subject=Increase limit'>
-                cs@getunleash.io
+            <a href='mailto:customersuccess@getunleash.io?subject=Increase limit'>
+                customersuccess@getunleash.io
             </a>
         </>
     );


### PR DESCRIPTION
The previously used email address doesn't actually exist 😳 It was taken from the sketches and we just never verified it.