### PR TITLE
fix: react-timeago issue

### DIFF
--- a/frontend/src/component/application/ApplicationChart.tsx
+++ b/frontend/src/component/application/ApplicationChart.tsx
@@ -307,6 +307,7 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                             <StyledCell>
                                                 {environment.lastSeen && (
                                                     <TimeAgo
+                                                        key={`${environment.lastSeen}`}
                                                         minPeriod={60}
                                                         date={
                                                             new Date(

--- a/frontend/src/component/archive/ArchiveTable/FeatureArchivedCell/FeatureArchivedCell.tsx
+++ b/frontend/src/component/archive/ArchiveTable/FeatureArchivedCell/FeatureArchivedCell.tsx
@@ -38,6 +38,7 @@ export const FeatureArchivedCell: VFC<IFeatureArchivedCellProps> = ({
             >
                 <Typography noWrap variant='body2' data-loading>
                     <TimeAgo
+                        key={`${archivedAt}`}
                         date={new Date(archivedAt)}
                         title=''
                         live={false}

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestComments/ChangeRequestComment.tsx
@@ -37,6 +37,7 @@ export const ChangeRequestComment: FC<{ comment: IChangeRequestComment }> = ({
                     <Typography color='text.secondary' component='span'>
                         commented{' '}
                         <TimeAgo
+                            key={`${comment.createdAt}`}
                             minPeriod={60}
                             date={new Date(comment.createdAt)}
                         />

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestHeader/ChangeRequestHeader.tsx
@@ -40,6 +40,7 @@ export const ChangeRequestHeader: FC<{ changeRequest: ChangeRequestType }> = ({
                 >
                     Created{' '}
                     <TimeAgo
+                        key={`${changeRequest.createdAt}`}
                         minPeriod={60}
                         date={new Date(changeRequest.createdAt)}
                     />{' '}

--- a/frontend/src/component/common/Notifications/Notification.tsx
+++ b/frontend/src/component/common/Notifications/Notification.tsx
@@ -158,6 +158,7 @@ export const Notification = ({
 
                     <StyledTimeAgoTypography>
                         <TimeAgo
+                            key={`${notification.createdAt}`}
                             date={new Date(notification.createdAt)}
                             minPeriod={60}
                         />

--- a/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureSeenCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureSeenCell/FeatureSeenCell.tsx
@@ -98,6 +98,7 @@ export const FeatureSeenCell: VFC<IFeatureSeenCellProps> = ({
             condition={Boolean(lastSeenAt)}
             show={
                 <TimeAgo
+                    key={`${lastSeenAt}`}
                     date={lastSeenAt!}
                     title=''
                     live={false}

--- a/frontend/src/component/common/Table/cells/FeatureSeenCell/LastSeenTooltip.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureSeenCell/LastSeenTooltip.tsx
@@ -99,6 +99,7 @@ export const LastSeenTooltip = ({
                                         condition={Boolean(lastSeenAt)}
                                         show={
                                             <TimeAgo
+                                                key={`${lastSeenAt}`}
                                                 date={lastSeenAt!}
                                                 title=''
                                                 live={false}

--- a/frontend/src/component/common/Table/cells/TimeAgoCell/TimeAgoCell.tsx
+++ b/frontend/src/component/common/Table/cells/TimeAgoCell/TimeAgoCell.tsx
@@ -1,6 +1,6 @@
 import { Tooltip, Typography } from '@mui/material';
 import { useLocationSettings } from 'hooks/useLocationSettings';
-import type { VFC } from 'react';
+import type { FC } from 'react';
 import { formatDateYMD } from 'utils/formatDate';
 import { TextCell } from '../TextCell/TextCell';
 import TimeAgo from 'react-timeago';
@@ -13,7 +13,7 @@ interface ITimeAgoCellProps {
     dateFormat?: (value: string | number | Date, locale: string) => string;
 }
 
-export const TimeAgoCell: VFC<ITimeAgoCellProps> = ({
+export const TimeAgoCell: FC<ITimeAgoCellProps> = ({
     value,
     live = false,
     emptyText,
@@ -35,7 +35,12 @@ export const TimeAgoCell: VFC<ITimeAgoCellProps> = ({
                     variant='body2'
                     data-loading
                 >
-                    <TimeAgo date={new Date(value)} live={live} title={''} />
+                    <TimeAgo
+                        key={`${value}`}
+                        date={new Date(value)}
+                        live={live}
+                        title={''}
+                    />
                 </Typography>
             </Tooltip>
         </TextCell>

--- a/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureEnvironmentSeen/FeatureEnvironmentSeen.tsx
@@ -89,6 +89,7 @@ export const FeatureEnvironmentSeen = ({
         <>
             {lastSeen ? (
                 <TimeAgo
+                    key={`${lastSeen}`}
                     date={lastSeen}
                     title=''
                     live={false}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleTooltip.tsx
@@ -117,6 +117,7 @@ const LastSeenIcon: FC<{
 
     return (
         <TimeAgo
+            key={`${lastSeen}`}
             date={lastSeen}
             title=''
             live={false}
@@ -230,6 +231,7 @@ const Environments: FC<{
                         </CenteredBox>
                         <CenteredBox>
                             <TimeAgo
+                                key={`${environment.lastSeenAt}`}
                                 minPeriod={60}
                                 date={environment.lastSeenAt}
                             />

--- a/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
+++ b/frontend/src/component/project/NewProjectCard/ProjectArchiveCard.tsx
@@ -91,6 +91,7 @@ export const ProjectArchiveCard: FC<ProjectArchiveCardProps> = ({
                                     <p data-loading>
                                         Archived:{' '}
                                         <TimeAgo
+                                            key={`${archivedAt}`}
                                             minPeriod={60}
                                             date={
                                                 new Date(archivedAt as string)


### PR DESCRIPTION
## About the changes


There is a bug I'm fixing, when sometimes time values for "last seen" appear to be in the future, like "in X seconds".
![image](https://github.com/user-attachments/assets/bcbbe0cf-f7f5-4e92-9991-48038fe15e9e)

Turns out `react-timeago` dependency has an issue, where it doesn't refresh current time when new value is passed (https://github.com/nmn/react-timeago/issues/181).

Temporary solution to this, is to force re-rendering by providing a component `key`.

For a long term solution, I'd like to drop this dependency, and replace it with [date-fns/formatDistanceToNow](https://date-fns.org/v3.6.0/docs/formatDistanceToNow).