### PR TITLE
chore: allow you to use the options object to override *all* the new resource limits

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -657,56 +657,56 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             1,
             parseEnvVarNumber(
                 process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
-                options?.resourceLimits?.featureEnvironmentStrategies || 30,
+                options?.resourceLimits?.featureEnvironmentStrategies ?? 30,
             ),
         ),
         constraintValues: Math.max(
             1,
             parseEnvVarNumber(
                 process.env.UNLEASH_CONSTRAINT_VALUES_LIMIT,
-                options?.resourceLimits?.constraintValues || 250,
+                options?.resourceLimits?.constraintValues ?? 250,
             ),
         ),
         constraints: Math.max(
             0,
             parseEnvVarNumber(
                 process.env.UNLEASH_CONSTRAINTS_LIMIT,
-                options?.resourceLimits?.constraints || 30,
+                options?.resourceLimits?.constraints ?? 30,
             ),
         ),
         environments: Math.max(
             0,
             parseEnvVarNumber(
                 process.env.UNLEASH_ENVIRONMENTS_LIMIT,
-                options?.resourceLimits?.environments || 50,
+                options?.resourceLimits?.environments ?? 50,
             ),
         ),
         projects: Math.max(
             1,
             parseEnvVarNumber(
                 process.env.UNLEASH_PROJECTS_LIMIT,
-                options?.resourceLimits?.projects || 500,
+                options?.resourceLimits?.projects ?? 500,
             ),
         ),
         apiTokens: Math.max(
             0,
             parseEnvVarNumber(
                 process.env.UNLEASH_API_TOKENS_LIMIT,
-                options?.resourceLimits?.apiTokens || 2000,
+                options?.resourceLimits?.apiTokens ?? 2000,
             ),
         ),
         segments: Math.max(
             0,
             parseEnvVarNumber(
                 process.env.UNLEASH_SEGMENTS_LIMIT,
-                options?.resourceLimits?.segments || 300,
+                options?.resourceLimits?.segments ?? 300,
             ),
         ),
         featureFlags: Math.max(
             1,
             parseEnvVarNumber(
                 process.env.UNLEASH_FEATURE_FLAGS_LIMIT,
-                options?.resourceLimits?.featureFlags || 5000,
+                options?.resourceLimits?.featureFlags ?? 5000,
             ),
         ),
     };

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -657,7 +657,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             1,
             parseEnvVarNumber(
                 process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
-                30,
+                options?.resourceLimits?.featureEnvironmentStrategies || 30,
             ),
         ),
         constraintValues: Math.max(
@@ -669,23 +669,38 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ),
         constraints: Math.max(
             0,
-            parseEnvVarNumber(process.env.UNLEASH_CONSTRAINTS_LIMIT, 30),
+            parseEnvVarNumber(
+                process.env.UNLEASH_CONSTRAINTS_LIMIT,
+                options?.resourceLimits?.constraints || 30,
+            ),
         ),
-        environments: parseEnvVarNumber(
-            process.env.UNLEASH_ENVIRONMENTS_LIMIT,
-            50,
+        environments: Math.max(
+            0,
+            parseEnvVarNumber(
+                process.env.UNLEASH_ENVIRONMENTS_LIMIT,
+                options?.resourceLimits?.environments || 50,
+            ),
         ),
         projects: Math.max(
             1,
-            parseEnvVarNumber(process.env.UNLEASH_PROJECTS_LIMIT, 500),
+            parseEnvVarNumber(
+                process.env.UNLEASH_PROJECTS_LIMIT,
+                options?.resourceLimits?.projects || 500,
+            ),
         ),
         apiTokens: Math.max(
             0,
-            parseEnvVarNumber(process.env.UNLEASH_API_TOKENS_LIMIT, 2000),
+            parseEnvVarNumber(
+                process.env.UNLEASH_API_TOKENS_LIMIT,
+                options?.resourceLimits?.apiTokens || 2000,
+            ),
         ),
         segments: Math.max(
             0,
-            parseEnvVarNumber(process.env.UNLEASH_SEGMENTS_LIMIT, 300),
+            parseEnvVarNumber(
+                process.env.UNLEASH_SEGMENTS_LIMIT,
+                options?.resourceLimits?.segments || 300,
+            ),
         ),
         featureFlags: Math.max(
             1,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -675,7 +675,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             ),
         ),
         environments: Math.max(
-            0,
+            1,
             parseEnvVarNumber(
                 process.env.UNLEASH_ENVIRONMENTS_LIMIT,
                 options?.resourceLimits?.environments ?? 50,

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -144,7 +144,17 @@ export interface IUnleashOptions {
     dailyMetricsStorageDays?: number;
     rateLimiting?: Partial<IRateLimiting>;
     resourceLimits?: Partial<
-        Pick<ResourceLimitsSchema, 'constraintValues' | 'featureFlags'>
+        Pick<
+            ResourceLimitsSchema,
+            | 'apiTokens'
+            | 'constraintValues'
+            | 'constraints'
+            | 'environments'
+            | 'featureEnvironmentStrategies'
+            | 'featureFlags'
+            | 'projects'
+            | 'segments'
+        >
     >;
 }
 


### PR DESCRIPTION
This allows us to use different limits for enterprise self-hosted and hosted