### PR TITLE
chore: add new parsing function for env var numbers

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -40,6 +40,7 @@ import {
 import {
     parseEnvVarBoolean,
     parseEnvVarNumber,
+    parseEnvVarNumberWithBounds,
     parseEnvVarStrings,
 } from './util/parseEnvVar';
 import {
@@ -653,61 +654,70 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             process.env.UNLEASH_SIGNAL_TOKENS_PER_ENDPOINT_LIMIT,
             5,
         ),
-        featureEnvironmentStrategies: Math.max(
-            1,
-            parseEnvVarNumber(
-                process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
-                options?.resourceLimits?.featureEnvironmentStrategies ?? 30,
-            ),
+        featureEnvironmentStrategies: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
+            {
+                min: 1,
+                optionsOverride:
+                    options?.resourceLimits?.featureEnvironmentStrategies,
+                fallback: 30,
+            },
         ),
-        constraintValues: Math.max(
-            1,
-            parseEnvVarNumber(
-                process.env.UNLEASH_CONSTRAINT_VALUES_LIMIT,
-                options?.resourceLimits?.constraintValues ?? 250,
-            ),
+        constraintValues: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_CONSTRAINT_VALUES_LIMIT,
+            {
+                min: 1,
+                optionsOverride: options?.resourceLimits?.constraintValues,
+                fallback: 250,
+            },
         ),
-        constraints: Math.max(
-            0,
-            parseEnvVarNumber(
-                process.env.UNLEASH_CONSTRAINTS_LIMIT,
-                options?.resourceLimits?.constraints ?? 30,
-            ),
+        constraints: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_CONSTRAINTS_LIMIT,
+            {
+                min: 0,
+                optionsOverride: options?.resourceLimits?.constraints,
+                fallback: 30,
+            },
         ),
-        environments: Math.max(
-            1,
-            parseEnvVarNumber(
-                process.env.UNLEASH_ENVIRONMENTS_LIMIT,
-                options?.resourceLimits?.environments ?? 50,
-            ),
+        environments: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_ENVIRONMENTS_LIMIT,
+            {
+                min: 1,
+                optionsOverride: options?.resourceLimits?.environments,
+                fallback: 50,
+            },
         ),
-        projects: Math.max(
-            1,
-            parseEnvVarNumber(
-                process.env.UNLEASH_PROJECTS_LIMIT,
-                options?.resourceLimits?.projects ?? 500,
-            ),
+        projects: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_PROJECTS_LIMIT,
+            {
+                min: 1,
+                optionsOverride: options?.resourceLimits?.projects,
+                fallback: 500,
+            },
         ),
-        apiTokens: Math.max(
-            0,
-            parseEnvVarNumber(
-                process.env.UNLEASH_API_TOKENS_LIMIT,
-                options?.resourceLimits?.apiTokens ?? 2000,
-            ),
+        apiTokens: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_API_TOKENS_LIMIT,
+            {
+                min: 0,
+                optionsOverride: options?.resourceLimits?.apiTokens,
+                fallback: 2000,
+            },
         ),
-        segments: Math.max(
-            0,
-            parseEnvVarNumber(
-                process.env.UNLEASH_SEGMENTS_LIMIT,
-                options?.resourceLimits?.segments ?? 300,
-            ),
+        segments: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_SEGMENTS_LIMIT,
+            {
+                min: 0,
+                optionsOverride: options?.resourceLimits?.segments,
+                fallback: 300,
+            },
         ),
-        featureFlags: Math.max(
-            1,
-            parseEnvVarNumber(
-                process.env.UNLEASH_FEATURE_FLAGS_LIMIT,
-                options?.resourceLimits?.featureFlags ?? 5000,
-            ),
+        featureFlags: parseEnvVarNumberWithBounds(
+            process.env.UNLEASH_FEATURE_FLAGS_LIMIT,
+            {
+                min: 1,
+                optionsOverride: options?.resourceLimits?.featureFlags,
+                fallback: 5000,
+            },
         ),
     };
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -40,7 +40,6 @@ import {
 import {
     parseEnvVarBoolean,
     parseEnvVarNumber,
-    parseEnvVarNumberWithBounds,
     parseEnvVarStrings,
 } from './util/parseEnvVar';
 import {
@@ -654,69 +653,61 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             process.env.UNLEASH_SIGNAL_TOKENS_PER_ENDPOINT_LIMIT,
             5,
         ),
-        featureEnvironmentStrategies: parseEnvVarNumberWithBounds(
+        featureEnvironmentStrategies: parseEnvVarNumber(
             process.env.UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT,
+            30,
             {
                 min: 1,
                 optionsOverride:
                     options?.resourceLimits?.featureEnvironmentStrategies,
-                fallback: 30,
             },
         ),
-        constraintValues: parseEnvVarNumberWithBounds(
+        constraintValues: parseEnvVarNumber(
             process.env.UNLEASH_CONSTRAINT_VALUES_LIMIT,
+            250,
             {
                 min: 1,
                 optionsOverride: options?.resourceLimits?.constraintValues,
-                fallback: 250,
             },
         ),
-        constraints: parseEnvVarNumberWithBounds(
+        constraints: parseEnvVarNumber(
             process.env.UNLEASH_CONSTRAINTS_LIMIT,
+            30,
             {
                 min: 0,
                 optionsOverride: options?.resourceLimits?.constraints,
-                fallback: 30,
             },
         ),
-        environments: parseEnvVarNumberWithBounds(
+        environments: parseEnvVarNumber(
             process.env.UNLEASH_ENVIRONMENTS_LIMIT,
+            50,
             {
                 min: 1,
                 optionsOverride: options?.resourceLimits?.environments,
-                fallback: 50,
             },
         ),
-        projects: parseEnvVarNumberWithBounds(
-            process.env.UNLEASH_PROJECTS_LIMIT,
-            {
-                min: 1,
-                optionsOverride: options?.resourceLimits?.projects,
-                fallback: 500,
-            },
-        ),
-        apiTokens: parseEnvVarNumberWithBounds(
+        projects: parseEnvVarNumber(process.env.UNLEASH_PROJECTS_LIMIT, 500, {
+            min: 1,
+            optionsOverride: options?.resourceLimits?.projects,
+        }),
+        apiTokens: parseEnvVarNumber(
             process.env.UNLEASH_API_TOKENS_LIMIT,
+            2_000,
             {
                 min: 0,
                 optionsOverride: options?.resourceLimits?.apiTokens,
-                fallback: 2000,
             },
         ),
-        segments: parseEnvVarNumberWithBounds(
-            process.env.UNLEASH_SEGMENTS_LIMIT,
-            {
-                min: 0,
-                optionsOverride: options?.resourceLimits?.segments,
-                fallback: 300,
-            },
-        ),
-        featureFlags: parseEnvVarNumberWithBounds(
+        segments: parseEnvVarNumber(process.env.UNLEASH_SEGMENTS_LIMIT, 300, {
+            min: 0,
+            optionsOverride: options?.resourceLimits?.segments,
+        }),
+        featureFlags: parseEnvVarNumber(
             process.env.UNLEASH_FEATURE_FLAGS_LIMIT,
+            5_000,
             {
                 min: 1,
                 optionsOverride: options?.resourceLimits?.featureFlags,
-                fallback: 5000,
             },
         ),
     };

--- a/src/lib/util/parseEnvVar.test.ts
+++ b/src/lib/util/parseEnvVar.test.ts
@@ -1,6 +1,7 @@
 import {
     parseEnvVarBoolean,
     parseEnvVarNumber,
+    parseEnvVarNumberWithBounds,
     parseEnvVarStrings,
 } from './parseEnvVar';
 
@@ -38,4 +39,37 @@ test('parseEnvVarStringList', () => {
     expect(parseEnvVarStrings('a,b,c', [])).toEqual(['a', 'b', 'c']);
     expect(parseEnvVarStrings('a,b,c', [])).toEqual(['a', 'b', 'c']);
     expect(parseEnvVarStrings(' a,,,b,  c , ,', [])).toEqual(['a', 'b', 'c']);
+});
+
+describe('parseEnvVarNumberWithBounds', () => {
+    const parse = parseEnvVarNumberWithBounds;
+    test('works the same as parseEnvVarNumber', () => {
+        expect(parse('', { fallback: 1 })).toEqual(1);
+        expect(parse(' ', { fallback: 1 })).toEqual(1);
+        expect(parse('a', { fallback: 1 })).toEqual(1);
+        expect(parse('1', { fallback: 1 })).toEqual(1);
+        expect(parse('2', { fallback: 1 })).toEqual(2);
+        expect(parse('2e2', { fallback: 1 })).toEqual(2);
+        expect(parse('-1', { fallback: 1 })).toEqual(-1);
+    });
+
+    test('prefers options override over default value if present', () => {
+        expect(parse('', { fallback: 1, optionsOverride: 2 })).toEqual(2);
+    });
+
+    test('accepts 0 as options override', () => {
+        expect(parse('', { fallback: 1, optionsOverride: 0 })).toEqual(0);
+    });
+
+    test('prefers env var over options override', () => {
+        expect(parse('5', { fallback: 1, optionsOverride: 2 })).toEqual(5);
+    });
+
+    test('clamps the number to greater than or equal to the min number if provided', () => {
+        expect(parse('1', { fallback: 0, min: 2 })).toEqual(2);
+        expect(parse('', { fallback: 0, min: 2 })).toEqual(2);
+        expect(parse('', { fallback: 0, optionsOverride: 1, min: 2 })).toEqual(
+            2,
+        );
+    });
 });

--- a/src/lib/util/parseEnvVar.test.ts
+++ b/src/lib/util/parseEnvVar.test.ts
@@ -1,7 +1,6 @@
 import {
     parseEnvVarBoolean,
     parseEnvVarNumber,
-    parseEnvVarNumberWithBounds,
     parseEnvVarStrings,
 } from './parseEnvVar';
 
@@ -42,34 +41,23 @@ test('parseEnvVarStringList', () => {
 });
 
 describe('parseEnvVarNumberWithBounds', () => {
-    const parse = parseEnvVarNumberWithBounds;
-    test('works the same as parseEnvVarNumber', () => {
-        expect(parse('', { fallback: 1 })).toEqual(1);
-        expect(parse(' ', { fallback: 1 })).toEqual(1);
-        expect(parse('a', { fallback: 1 })).toEqual(1);
-        expect(parse('1', { fallback: 1 })).toEqual(1);
-        expect(parse('2', { fallback: 1 })).toEqual(2);
-        expect(parse('2e2', { fallback: 1 })).toEqual(2);
-        expect(parse('-1', { fallback: 1 })).toEqual(-1);
-    });
-
     test('prefers options override over default value if present', () => {
-        expect(parse('', { fallback: 1, optionsOverride: 2 })).toEqual(2);
+        expect(parseEnvVarNumber('', 1, { optionsOverride: 2 })).toEqual(2);
     });
 
     test('accepts 0 as options override', () => {
-        expect(parse('', { fallback: 1, optionsOverride: 0 })).toEqual(0);
+        expect(parseEnvVarNumber('', 1, { optionsOverride: 0 })).toEqual(0);
     });
 
     test('prefers env var over options override', () => {
-        expect(parse('5', { fallback: 1, optionsOverride: 2 })).toEqual(5);
+        expect(parseEnvVarNumber('5', 1, { optionsOverride: 2 })).toEqual(5);
     });
 
     test('clamps the number to greater than or equal to the min number if provided', () => {
-        expect(parse('1', { fallback: 0, min: 2 })).toEqual(2);
-        expect(parse('', { fallback: 0, min: 2 })).toEqual(2);
-        expect(parse('', { fallback: 0, optionsOverride: 1, min: 2 })).toEqual(
-            2,
-        );
+        expect(parseEnvVarNumber('1', 0, { min: 2 })).toEqual(2);
+        expect(parseEnvVarNumber('', 0, { min: 2 })).toEqual(2);
+        expect(
+            parseEnvVarNumber('', 0, { optionsOverride: 1, min: 2 }),
+        ).toEqual(2);
     });
 });

--- a/src/lib/util/parseEnvVar.ts
+++ b/src/lib/util/parseEnvVar.ts
@@ -38,3 +38,22 @@ export function parseEnvVarStrings(
 
     return defaultVal;
 }
+
+type parseEnvVarNumberWithBoundsOptions = {
+    fallback: number;
+    min?: number;
+    optionsOverride?: number;
+};
+
+export function parseEnvVarNumberWithBounds(
+    envVar: string | undefined,
+    { min, fallback, optionsOverride }: parseEnvVarNumberWithBoundsOptions,
+): number {
+    const parsed = parseEnvVarNumber(envVar, optionsOverride ?? fallback);
+
+    if (min) {
+        return Math.max(min, parsed);
+    }
+
+    return parsed;
+}

--- a/src/lib/util/parseEnvVar.ts
+++ b/src/lib/util/parseEnvVar.ts
@@ -1,14 +1,25 @@
 export function parseEnvVarNumber(
     envVar: string | undefined,
     defaultVal: number,
+    options?: { min?: number; optionsOverride?: number },
 ): number {
-    if (!envVar) {
-        return defaultVal;
-    }
-    const parsed = Number.parseInt(envVar, 10);
+    const parse = (fallback: number) => {
+        if (!envVar) {
+            return fallback;
+        }
+        const parsed = Number.parseInt(envVar, 10);
 
-    if (Number.isNaN(parsed)) {
-        return defaultVal;
+        if (Number.isNaN(parsed)) {
+            return fallback;
+        }
+
+        return parsed;
+    };
+
+    const parsed = parse(options?.optionsOverride ?? defaultVal);
+
+    if (options?.min) {
+        return Math.max(options?.min, parsed);
     }
 
     return parsed;
@@ -37,23 +48,4 @@ export function parseEnvVarStrings(
     }
 
     return defaultVal;
-}
-
-type parseEnvVarNumberWithBoundsOptions = {
-    fallback: number;
-    min?: number;
-    optionsOverride?: number;
-};
-
-export function parseEnvVarNumberWithBounds(
-    envVar: string | undefined,
-    { min, fallback, optionsOverride }: parseEnvVarNumberWithBoundsOptions,
-): number {
-    const parsed = parseEnvVarNumber(envVar, optionsOverride ?? fallback);
-
-    if (min) {
-        return Math.max(min, parsed);
-    }
-
-    return parsed;
 }


### PR DESCRIPTION
The new function builds on the old one, but adds a `min` option, so that you can set a lower bound for the result. The min value will also affect the default value and the options override if they are lower than the min value.

## Discussion points:

**Should it be its own function instead?** Maybe. I did that in the [first implementation](https://github.com/Unleash/unleash/pull/7947/commits/04ae667a677804f8e2cc2b5d1a6d7dd9c3f17a8b). It's valid, although I'd say it might be more [unwieldy when used](https://github.com/Unleash/unleash/pull/7947/commits/d881de3e10cd113beeff5fa61a89fcf60cd3ca92). Additionally having two functions for the same type might be confusing.

**What do we want the API to be**? I added an `optionsOverride`. Why not just use a single default and let the caller provide it correctly? As was pointed out in [#7938](https://github.com/Unleash/unleash/pull/7938), it's easy to put `optionsOverride || fallback`. But because `0` is falsy, it might lead to unexpected results. So by encapsulating that in the function, we avoid that.

## Non-goals

I have not added a `max` option because we don't have a use case for it right now and because it would introduce additional complexity: what if max is lower than min?