### PR TITLE
fix: fix events with no-project projects

### DIFF
--- a/src/migrations/20240821141555-segment-no-project-cleanup.js
+++ b/src/migrations/20240821141555-segment-no-project-cleanup.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+        UPDATE events
+        SET project = NULL
+        WHERE type = 'segment-created'
+          AND project = 'no-project'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM projects
+            WHERE name = 'no-project'
+        );
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        ``,
+        callback,
+    );
+};


### PR DESCRIPTION
Fixes issue where `segment-created `events had fake project name **no-project** attached.

In total for previous 4 months, all segments created that were global segments, have this issue.

https://github.com/Unleash/unleash/pull/6872/files#diff-68dcd43b31d35a8a80c73bca1f2a9626b0234dd0b76920a6881b81fa04708268R135