### PR TITLE
fix: serialize API token data correctly in instance stats

### DIFF
--- a/src/lib/openapi/spec/instance-admin-stats-schema.ts
+++ b/src/lib/openapi/spec/instance-admin-stats-schema.ts
@@ -227,19 +227,19 @@ export const instanceAdminStatsSchema = {
                 admin: {
                     type: 'number',
                     description: 'The number of admin tokens.',
-                    minumum: 0,
+                    minimum: 0,
                     example: 5,
                 },
                 client: {
                     type: 'number',
                     description: 'The number of client tokens.',
-                    minumum: 0,
+                    minimum: 0,
                     example: 5,
                 },
                 frontend: {
                     type: 'number',
                     description: 'The number of frontend tokens.',
-                    minumum: 0,
+                    minimum: 0,
                     example: 5,
                 },
             },

--- a/src/lib/openapi/spec/instance-admin-stats-schema.ts
+++ b/src/lib/openapi/spec/instance-admin-stats-schema.ts
@@ -220,6 +220,30 @@ export const instanceAdminStatsSchema = {
             example: 0,
             minimum: 0,
         },
+        apiTokens: {
+            type: 'object',
+            description: 'The number of API tokens in Unleash, split by type',
+            properties: {
+                admin: {
+                    type: 'number',
+                    description: 'The number of admin tokens.',
+                    minumum: 0,
+                    example: 5,
+                },
+                client: {
+                    type: 'number',
+                    description: 'The number of client tokens.',
+                    minumum: 0,
+                    example: 5,
+                },
+                frontend: {
+                    type: 'number',
+                    description: 'The number of frontend tokens.',
+                    minumum: 0,
+                    example: 5,
+                },
+            },
+        },
         sum: {
             type: 'string',
             description:

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -150,8 +150,8 @@ class InstanceAdminController extends Controller {
     }
 
     async getStatisticsCSV(
-        req: AuthedRequest,
-        res: Response<UiConfigSchema>,
+        _: AuthedRequest,
+        res: Response<InstanceAdminStatsSchema>,
     ): Promise<void> {
         const instanceStats = await this.instanceStatsService.getSignedStats();
         const fileName = `unleash-${

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -156,7 +156,13 @@ class InstanceAdminController extends Controller {
         }-${Date.now()}.csv`;
 
         const json2csvParser = new Parser();
-        const csv = json2csvParser.parse(instanceStats);
+        const apiTokensObj = Object.fromEntries(
+            instanceStats.apiTokens.entries(),
+        );
+        const csv = json2csvParser.parse({
+            ...instanceStats,
+            apiTokens: apiTokensObj,
+        });
 
         res.contentType('csv');
         res.attachment(fileName);

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -15,6 +15,8 @@ import {
     createCsvResponseSchema,
     createResponseSchema,
 } from '../../openapi/util/create-response-schema';
+import type { InstanceAdminStatsSchema } from '../../openapi';
+import { serializeDates } from '../../types';
 
 class InstanceAdminController extends Controller {
     private instanceStatsService: InstanceStatsService;
@@ -129,11 +131,20 @@ class InstanceAdminController extends Controller {
     }
 
     async getStatistics(
-        req: AuthedRequest,
-        res: Response<InstanceStatsSigned>,
+        _: AuthedRequest,
+        res: Response<InstanceAdminStatsSchema>,
     ): Promise<void> {
         const instanceStats = await this.instanceStatsService.getSignedStats();
-        res.json(instanceStats);
+        const apiTokensObj = Object.fromEntries(
+            instanceStats.apiTokens.entries(),
+        );
+        res.json(
+            serializeDates({
+                ...instanceStats,
+
+                apiTokens: apiTokensObj,
+            }),
+        );
     }
 
     async getStatisticsCSV(

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -141,7 +141,6 @@ class InstanceAdminController extends Controller {
         res.json(
             serializeDates({
                 ...instanceStats,
-
                 apiTokens: apiTokensObj,
             }),
         );

--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -76,6 +76,13 @@ test('api tokens are serialized correctly', async () => {
     expect(body).toMatchObject({
         apiTokens: { client: 1, admin: 1, frontend: 1 },
     });
+
+    const { text: csv } = await app.request
+        .get('/api/admin/instance-admin/statistics/csv')
+        .expect('Content-Type', /text\/csv/)
+        .expect(200);
+
+    expect(csv).toMatch(/{""client"":1,""admin"":1,""frontend"":1}/);
 });
 
 test('should return instance statistics with correct number of projects', async () => {

--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -108,7 +108,7 @@ test('should return signed instance statistics', async () => {
         });
 });
 
-test('should return instance statistics as CVS', async () => {
+test('should return instance statistics as CSV', async () => {
     await stores.featureToggleStore.create('default', {
         name: 'TestStats2',
         createdByUserId: 9999,


### PR DESCRIPTION
Turns out we've been trying to return API token data in instance stats for a while, but that the serialization has failed. Serializing a JS map just yields an empty object. 

This PR fixes that serialization and also adds API tokens to the instance stats schema (it wasn't before, but we did return it). Adding it to the schema is also part of making resource usage visible as part of the soft limits project.