### PR TITLE
fix: when backporting we don't want to push latest docker tag (#7961)

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -12,6 +12,11 @@ on:
         description: "Which version to release"
         type: 'string'
         required: true
+      is-latest-version:
+        description: Is this the latest version? If latest we'll update the version docker
+        required: true
+        type: boolean
+        default: true
   workflow_dispatch:
 
 jobs:
@@ -39,6 +44,7 @@ jobs:
         with:
           images: |
             unleashorg/unleash-server
+          flavor: latest=${{ github.event.inputs.is-latest-version }}
           tags: |
             # only enabled for workflow dispatch except main (assume its a release):
             type=semver,pattern={{ version }},enable=${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }},value=${{ inputs.version }}

--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -18,8 +18,8 @@ on:
         required: true
         type: boolean
         default: true
-      update-version-function:
-        description: Should we update the version function to use this version?
+      is-latest-version:
+        description: Is this the latest version? If latest we'll update the version function, docker and npm latest
         required: true
         type: boolean
         default: true
@@ -138,6 +138,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ github.event.inputs.version }}
+      is-latest-version: ${{ github.event.inputs.is-latest-version == 'true' }}
 
   publish-npm:
     needs: build
@@ -154,7 +155,7 @@ jobs:
 
   update-version-checker:
     needs: publish-docker
-    if: ${{ github.event.inputs.update-version-function == 'true' }}
+    if: ${{ github.event.inputs.is-latest-version == 'true' }}
     uses: ./.github/workflows/update_version_for_version_checker.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Backporting fixes to old versions usually pushes the docker latest tag as well. We only want to do this if the version we're releasing is the latest
