### PR TITLE
fix: when running on main we need to use latest=auto

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           images: |
             unleashorg/unleash-server
-          flavor: latest=${{ github.event.inputs.is-latest-version }}
+          flavor: latest=${{ github.event.inputs.is-latest-version || 'auto' }}
           tags: |
             # only enabled for workflow dispatch except main (assume its a release):
             type=semver,pattern={{ version }},enable=${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }},value=${{ inputs.version }}


### PR DESCRIPTION
This fixes this error: https://github.com/Unleash/unleash/actions/runs/10505976248/job/29104652388
![image](https://github.com/user-attachments/assets/14477e20-1185-4aab-8a25-b88fdb0ae181)
