### PR TITLE
docs: mention what the minimum values are if you override the limits

### DIFF
--- a/website/docs/reference/resource-limits.mdx
+++ b/website/docs/reference/resource-limits.mdx
@@ -3,8 +3,8 @@ title: Resource Limits
 ---
 import Figure from '@site/src/components/Figure/Figure.tsx'
 
-:::info Availability
-Resource limits are currently in beta for hosted customers.
+:::note Availability
+**Plan**: All plans | **Version**: `6.2+`
 :::
 
 <Figure caption="When you're close to reaching the limit for a resource, you'll see a warning in the Unleash UI. The warning will tell you what the limit is, how close you are to reaching it, and how you can increase the limit." img="/img/project-limit-warning.png" />

--- a/website/docs/reference/resource-limits.mdx
+++ b/website/docs/reference/resource-limits.mdx
@@ -38,19 +38,14 @@ Existing hosted customers who are already above the limits will have their limit
 
 With a few exceptions, all the limits can be overridden through the use of their respective environment variables. However, while it is possible to override these limits, we advise against it in most cases. If you feel that you're unable to do what you need to do because of the limits, we'd love to hear from you.
 
-Some of the limits have a lower threshold. If you try to set them lower than that threshold, Unleash will instead use the minimum value listed below:
+The following resources have a lower limit of 1:
+- feature flags
+- strategies
+- constraint values
+- projects
+- environments
 
-| Resource          | Minimum value |
-|-------------------|--------------:|
-| Feature flags     |             1 |
-| Strategies        |             1 |
-| Constraints       |             0 |
-| Constraint values |             1 |
-| Segments          |             0 |
-| API tokens        |             0 |
-| Projects          |             1 |
-| Environments      |             1 |
-
+If you try to set their limits lower than that, Unleash will automatically adjust them to 1.
 
 If you operate a self-hosted Unleash instance, you can adjust the limit yourself. For hosted users of Unleash, you'll need to reach out and talk to your Unleash contact.
 

--- a/website/docs/reference/resource-limits.mdx
+++ b/website/docs/reference/resource-limits.mdx
@@ -38,6 +38,20 @@ Existing hosted customers who are already above the limits will have their limit
 
 With a few exceptions, all the limits can be overridden through the use of their respective environment variables. However, while it is possible to override these limits, we advise against it in most cases. If you feel that you're unable to do what you need to do because of the limits, we'd love to hear from you.
 
+Some of the limits have a lower threshold. If you try to set them lower than that threshold, Unleash will instead use the minimum value listed below:
+
+| Resource          | Minimum value |
+|-------------------|--------------:|
+| Feature flags     |             1 |
+| Strategies        |             1 |
+| Constraints       |             0 |
+| Constraint values |             1 |
+| Segments          |             0 |
+| API tokens        |             0 |
+| Projects          |             1 |
+| Environments      |             1 |
+
+
 If you operate a self-hosted Unleash instance, you can adjust the limit yourself. For hosted users of Unleash, you'll need to reach out and talk to your Unleash contact.
 
 The only limits that can't be changed, are

--- a/website/docs/reference/resource-limits.mdx
+++ b/website/docs/reference/resource-limits.mdx
@@ -4,7 +4,7 @@ title: Resource Limits
 import Figure from '@site/src/components/Figure/Figure.tsx'
 
 :::note Availability
-**Plan**: All plans | **Version**: `6.2+`
+**Version**: `6.2+`
 :::
 
 <Figure caption="When you're close to reaching the limit for a resource, you'll see a warning in the Unleash UI. The warning will tell you what the limit is, how close you are to reaching it, and how you can increase the limit." img="/img/project-limit-warning.png" />


### PR DESCRIPTION
Adds a note to the resource limit docs about what the minimum values are for some of the core resources if you override the limits.

These resources have a controlled minimum value. The resources that are not listed in the new table, do not. I don't know what happen if you set -42 for segmentValues, for instance. So ... I've left them out 🤷

Happy to take suggestions on how to fix it 😄

Also updates the availability note in preparation for 6.2 GA