### PR TITLE
fix: normalize casing for API token types before insert 

### DIFF
--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -330,12 +330,22 @@ export class ApiTokenService {
         return this.insertNewApiToken(createNewToken, SYSTEM_USER_AUDIT);
     }
 
+    private normalizeTokenType(token: IApiTokenCreate): IApiTokenCreate {
+        const { type, ...rest } = token;
+        return {
+            ...rest,
+            type: type.toLowerCase() as ApiTokenType,
+        };
+    }
+
     private async insertNewApiToken(
         newApiToken: IApiTokenCreate,
         auditUser: IAuditUser,
     ): Promise<IApiToken> {
         try {
-            const token = await this.store.insert(newApiToken);
+            const token = await this.store.insert(
+                this.normalizeTokenType(newApiToken),
+            );
             this.activeTokens.push(token);
             await this.eventService.storeEvent(
                 new ApiTokenCreatedEvent({


### PR DESCRIPTION
Fixes a bug where if you had API keys using different casing for the same type, they'd come out as different types in the API token count map. To get around it, we normalize the keys to lowercase before inserting them into the map, taking into account any previous values that might have existed for that type.

Should fix issues like this:
![image](https://github.com/user-attachments/assets/1fe218ed-7729-4a06-9a10-f4c8c7831bf8)
