### PR TITLE
fix: add migration to normalize api token types

### DIFF
--- a/src/migrations/20240823091442-normalize-token-types.js
+++ b/src/migrations/20240823091442-normalize-token-types.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = (db, cb) => {
+    db.runSql(
+        `
+        UPDATE api_tokens
+        SET type = 'client'
+        WHERE type = 'CLIENT';
+
+        UPDATE api_tokens
+        SET type = 'admin'
+        WHERE type = 'ADMIN';
+
+        UPDATE api_tokens
+        SET type = 'frontend'
+        WHERE type = 'FRONTEND';
+        `,
+        cb,
+    );
+};
+
+exports.down = () => {  }

--- a/src/migrations/20240823091442-normalize-token-types.js
+++ b/src/migrations/20240823091442-normalize-token-types.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.up = (db, cb) => {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE api_tokens

--- a/src/migrations/20240823091442-normalize-token-types.js
+++ b/src/migrations/20240823091442-normalize-token-types.js
@@ -19,6 +19,6 @@ exports.up = function (db, cb) {
     );
 };
 
-exports.down = function (db, callback) {
-    db.runSql(``, callback);
+exports.down = function (db, cb) {
+    db.runSql(``, cb);
 };

--- a/src/migrations/20240823091442-normalize-token-types.js
+++ b/src/migrations/20240823091442-normalize-token-types.js
@@ -19,4 +19,6 @@ exports.up = (db, cb) => {
     );
 };
 
-exports.down = () => {  }
+exports.down = function (db, callback) {
+    db.runSql(``, callback);
+};


### PR DESCRIPTION
Adds a migration to normalize api token types already in the database, to remove any weird casing issues as currently demonstrated on sandbox

![image](https://github.com/user-attachments/assets/ad14db22-114d-4de2-b952-722df9ae84a4)

This is a companion piece to #7972 