### PR TITLE
feat: make hide nav info always visible

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -137,6 +137,9 @@ export const NavigationSidebar = () => {
                 />
             )}
 
+            {/* this will push the show/hide to the bottom on short nav list */}
+            <Box sx={{ flex: 1 }} />
+
             <ShowHide
                 mode={mode}
                 onChange={() => {

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -52,6 +52,16 @@ export const StretchContainer = styled(Box)(({ theme }) => ({
     overflowAnchor: 'none',
 }));
 
+// This component is needed when the sticky item could overlap with nav items. You can replicate it on a short screen.
+const StickyContainer = styled(Box)(({ theme }) => ({
+    position: 'sticky',
+    paddingBottom: theme.spacing(1.5),
+    paddingTop: theme.spacing(1),
+    bottom: theme.spacing(0),
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `2px solid ${theme.palette.divider}`,
+}));
+
 export const NavigationSidebar = () => {
     const { routes } = useRoutes();
 
@@ -140,12 +150,14 @@ export const NavigationSidebar = () => {
             {/* this will push the show/hide to the bottom on short nav list */}
             <Box sx={{ flex: 1 }} />
 
-            <ShowHide
-                mode={mode}
-                onChange={() => {
-                    setMode(mode === 'full' ? 'mini' : 'full');
-                }}
-            />
+            <StickyContainer>
+                <ShowHide
+                    mode={mode}
+                    onChange={() => {
+                        setMode(mode === 'full' ? 'mini' : 'full');
+                    }}
+                />
+            </StickyContainer>
         </StretchContainer>
     );
 };

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -59,7 +59,7 @@ const StickyContainer = styled(Box)(({ theme }) => ({
     paddingTop: theme.spacing(1),
     bottom: theme.spacing(0),
     backgroundColor: theme.palette.background.paper,
-    borderTop: `2px solid ${theme.palette.divider}`,
+    borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
 export const NavigationSidebar = () => {

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -83,7 +83,6 @@ export const NavigationSidebar = () => {
 
     return (
         <StretchContainer>
-            <NewInUnleash mode={mode} onMiniModeClick={() => setMode('full')} />
             <PrimaryNavigationList
                 mode={mode}
                 onClick={setActiveItem}
@@ -151,6 +150,10 @@ export const NavigationSidebar = () => {
             <Box sx={{ flex: 1 }} />
 
             <StickyContainer>
+                <NewInUnleash
+                    mode={mode}
+                    onMiniModeClick={() => setMode('full')}
+                />
                 <ShowHide
                     mode={mode}
                     onChange={() => {

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
@@ -18,11 +18,16 @@ import { NewInUnleashItem } from './NewInUnleashItem';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 const StyledNewInUnleash = styled('div')(({ theme }) => ({
+    margin: theme.spacing(2, 0, 1, 0),
     borderRadius: theme.shape.borderRadiusMedium,
     [theme.breakpoints.down('lg')]: {
         margin: theme.spacing(2),
         marginBottom: theme.spacing(1),
     },
+}));
+
+const StyledListItem = styled(ListItem)(({ theme }) => ({
+    margin: theme.spacing(1, 0, 1, 0),
 }));
 
 const StyledNewInUnleashHeader = styled('p')(({ theme }) => ({
@@ -106,7 +111,7 @@ export const NewInUnleash = ({
 
     if (mode === 'mini' && onMiniModeClick) {
         return (
-            <ListItem disablePadding onClick={onMiniModeClick}>
+            <StyledListItem disablePadding onClick={onMiniModeClick}>
                 <StyledMiniItemButton dense>
                     <Tooltip title='New in Unleash' placement='right'>
                         <StyledMiniItemIcon>
@@ -119,7 +124,7 @@ export const NewInUnleash = ({
                         </StyledMiniItemIcon>
                     </Tooltip>
                 </StyledMiniItemButton>
-            </ListItem>
+            </StyledListItem>
         );
     }
 

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
@@ -16,7 +16,7 @@ const ShowHideRow = styled(Box, {
 }));
 
 // This component is needed when the sticky item could overlap with nav items. You can replicate it on a short screen.
-const ShowHideContainer = styled(Box)(({ theme }) => ({
+const StickyContainer = styled(Box)(({ theme }) => ({
     position: 'sticky',
     paddingBottom: theme.spacing(1.5),
     paddingTop: theme.spacing(1),
@@ -30,7 +30,7 @@ export const ShowHide: FC<{ mode: NavigationMode; onChange: () => void }> = ({
     onChange,
 }) => {
     return (
-        <ShowHideContainer>
+        <StickyContainer>
             <ShowHideRow onClick={onChange} mode={mode}>
                 {mode === 'full' && (
                     <Box
@@ -55,7 +55,7 @@ export const ShowHide: FC<{ mode: NavigationMode; onChange: () => void }> = ({
                     )}
                 </IconButton>
             </ShowHideRow>
-        </ShowHideContainer>
+        </StickyContainer>
     );
 };
 

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
@@ -15,47 +15,35 @@ const ShowHideRow = styled(Box, {
     cursor: 'pointer',
 }));
 
-// This component is needed when the sticky item could overlap with nav items. You can replicate it on a short screen.
-const StickyContainer = styled(Box)(({ theme }) => ({
-    position: 'sticky',
-    paddingBottom: theme.spacing(1.5),
-    paddingTop: theme.spacing(1),
-    bottom: theme.spacing(0),
-    backgroundColor: theme.palette.background.paper,
-    borderTop: `2px solid ${theme.palette.divider}`,
-}));
-
 export const ShowHide: FC<{ mode: NavigationMode; onChange: () => void }> = ({
     mode,
     onChange,
 }) => {
     return (
-        <StickyContainer>
-            <ShowHideRow onClick={onChange} mode={mode}>
-                {mode === 'full' && (
-                    <Box
-                        sx={(theme) => ({
-                            color: theme.palette.neutral.main,
-                            fontSize: 'small',
-                        })}
-                    >
-                        Hide (⌘ + B)
-                    </Box>
+        <ShowHideRow onClick={onChange} mode={mode}>
+            {mode === 'full' && (
+                <Box
+                    sx={(theme) => ({
+                        color: theme.palette.neutral.main,
+                        fontSize: 'small',
+                    })}
+                >
+                    Hide (⌘ + B)
+                </Box>
+            )}
+            <IconButton>
+                {mode === 'full' ? (
+                    <HideIcon color='primary' />
+                ) : (
+                    <Tooltip title='Expand (⌘ + B)' placement='right'>
+                        <ExpandIcon
+                            data-testid='expand-navigation'
+                            color='primary'
+                        />
+                    </Tooltip>
                 )}
-                <IconButton>
-                    {mode === 'full' ? (
-                        <HideIcon color='primary' />
-                    ) : (
-                        <Tooltip title='Expand (⌘ + B)' placement='right'>
-                            <ExpandIcon
-                                data-testid='expand-navigation'
-                                color='primary'
-                            />
-                        </Tooltip>
-                    )}
-                </IconButton>
-            </ShowHideRow>
-        </StickyContainer>
+            </IconButton>
+        </ShowHideRow>
     );
 };
 

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ShowHide.tsx
@@ -13,16 +13,16 @@ const ShowHideRow = styled(Box, {
     alignItems: 'center',
     padding: theme.spacing(0, 1, 0, mode === 'mini' ? 1.5 : 2),
     cursor: 'pointer',
-    position: 'sticky',
-    bottom: theme.spacing(2),
-    width: '100%',
 }));
 
 // This component is needed when the sticky item could overlap with nav items. You can replicate it on a short screen.
 const ShowHideContainer = styled(Box)(({ theme }) => ({
-    flexGrow: 1,
-    display: 'flex',
-    alignItems: 'end',
+    position: 'sticky',
+    paddingBottom: theme.spacing(1.5),
+    paddingTop: theme.spacing(1),
+    bottom: theme.spacing(0),
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `2px solid ${theme.palette.divider}`,
 }));
 
 export const ShowHide: FC<{ mode: NavigationMode; onChange: () => void }> = ({


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Make the hide nav text and shortcut visible from the get go even when the content list is long. Previously you had to scroll to the bottom of the nav to see the text and shortcut.
<img width="270" alt="Screenshot 2024-08-26 at 15 13 30" src="https://github.com/user-attachments/assets/83e4f0a2-411a-4876-8e53-99655a5c0dd3">

Make sure there's enough space for the link info from the browser
<img width="290" alt="Screenshot 2024-08-26 at 15 14 00" src="https://github.com/user-attachments/assets/81f98e27-d26f-4f79-ab65-7fa73abe5d43">

Add new in unleash to the bottom
<img width="258" alt="Screenshot 2024-08-26 at 15 47 19" src="https://github.com/user-attachments/assets/112553c8-c1bf-46bd-b0c0-19baeed00429">

Also works with hidden mode
<img width="100" alt="Screenshot 2024-08-26 at 15 47 26" src="https://github.com/user-attachments/assets/0276c99a-7dd9-4794-af77-0566a362bc3d">

And with long content 
<img width="257" alt="Screenshot 2024-08-26 at 15 47 46" src="https://github.com/user-attachments/assets/272f347c-32a8-4baf-a740-c78c2ea65362">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
