### PR TITLE
chore: strip +main from package version

### DIFF
--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -116,7 +116,7 @@ jobs:
           cache: 'yarn'
       - name: upgrade package version
         run: |
-          jq --arg version "${{ github.event.inputs.version }}+main" '.version=$version' package.json > package.json.tmp
+          jq --arg version "${{ github.event.inputs.version }}" '.version=$version' package.json > package.json.tmp
           mv package.json.tmp package.json
       - name: checkout changelog from ${{ github.ref_name }}
         run: git checkout origin/${{ github.ref_name }} -- CHANGELOG.md
@@ -129,7 +129,7 @@ jobs:
       - name: push changes
         run: |
           git add package.json CHANGELOG.md
-          git commit -m "chore: bump version to ${{ github.event.inputs.version }}+main"
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
           git push origin main
 
   publish-docker:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unleash-server",
   "description": "Unleash is an enterprise ready feature toggles service. It provides different strategies for handling feature toggles.",
-  "version": "6.1.12+main",
+  "version": "6.1.12",
   "keywords": [
     "unleash",
     "feature toggle",


### PR DESCRIPTION
This is not needed anymore as we are not publishing to npm from main.