### PR TITLE
feat: user loging event emitting with login order

### DIFF
--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -10,6 +10,7 @@ const FRONTEND_API_REPOSITORY_CREATED = 'frontend_api_repository_created';
 const PROXY_REPOSITORY_CREATED = 'proxy_repository_created';
 const PROXY_FEATURES_FOR_TOKEN_TIME = 'proxy_features_for_token_time';
 const STAGE_ENTERED = 'stage-entered' as const;
+const USER_LOGIN = 'user-login' as const;
 const EXCEEDS_LIMIT = 'exceeds-limit' as const;
 const REQUEST_ORIGIN = 'request_origin' as const;
 const ADDON_EVENTS_HANDLED = 'addon-event-handled' as const;
@@ -25,6 +26,7 @@ type MetricEvent =
     | typeof PROXY_REPOSITORY_CREATED
     | typeof PROXY_FEATURES_FOR_TOKEN_TIME
     | typeof STAGE_ENTERED
+    | typeof USER_LOGIN
     | typeof EXCEEDS_LIMIT
     | typeof REQUEST_ORIGIN;
 
@@ -70,6 +72,7 @@ export {
     PROXY_REPOSITORY_CREATED,
     PROXY_FEATURES_FOR_TOKEN_TIME,
     STAGE_ENTERED,
+    USER_LOGIN,
     EXCEEDS_LIMIT,
     REQUEST_ORIGIN,
     ADDON_EVENTS_HANDLED,

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -35,7 +35,7 @@ export interface IUserStore extends Store<IUser, number> {
     ): Promise<void>;
     getPasswordsPreviouslyUsed(userId: number): Promise<string[]>;
     incLoginAttempts(user: IUser): Promise<void>;
-    successfullyLogin(user: IUser): Promise<void>;
+    successfullyLogin(user: IUser): Promise<number>;
     count(): Promise<number>;
     countServiceAccounts(): Promise<number>;
 }

--- a/src/test/e2e/stores/user-store.e2e.test.ts
+++ b/src/test/e2e/stores/user-store.e2e.test.ts
@@ -7,7 +7,9 @@ let stores: IUnleashStores;
 let db: ITestDb;
 
 beforeAll(async () => {
-    db = await dbInit('user_store_serial', getLogger);
+    db = await dbInit('user_store_serial', getLogger, {
+        experimental: { flags: { onboardingMetrics: true } },
+    });
     stores = db.stores;
 });
 
@@ -106,6 +108,19 @@ test('should reset user after successful login', async () => {
 
     expect(storedUser.loginAttempts).toBe(0);
     expect(storedUser.seenAt! >= user.seenAt!).toBe(true);
+});
+
+test('should return first login order for every new user', async () => {
+    const store = stores.userStore;
+    const user1 = await store.insert({ email: 'user1@mail.com' });
+    const user2 = await store.insert({ email: 'user2@mail.com' });
+    const user3 = await store.insert({ email: 'user3@mail.com' });
+
+    expect(await store.successfullyLogin(user1)).toBe(0);
+    expect(await store.successfullyLogin(user1)).toBe(0);
+    expect(await store.successfullyLogin(user2)).toBe(1);
+    expect(await store.successfullyLogin(user1)).toBe(0);
+    expect(await store.successfullyLogin(user3)).toBe(2);
 });
 
 test('should only update specified fields on user', async () => {

--- a/src/test/e2e/stores/user-store.e2e.test.ts
+++ b/src/test/e2e/stores/user-store.e2e.test.ts
@@ -17,6 +17,10 @@ afterAll(async () => {
     await db.destroy();
 });
 
+beforeEach(async () => {
+    await stores.userStore.deleteAll();
+});
+
 test('should have no users', async () => {
     const users = await stores.userStore.getAll();
     expect(users).toEqual([]);

--- a/src/test/fixtures/fake-user-store.ts
+++ b/src/test/fixtures/fake-user-store.ts
@@ -108,10 +108,11 @@ class UserStoreMock implements IUserStore {
         return Promise.resolve();
     }
 
-    async successfullyLogin(user: User): Promise<void> {
+    async successfullyLogin(user: User): Promise<number> {
         if (!this.exists(user.id)) {
             throw new Error('No such user');
         }
+        return 0;
     }
 
     buildSelectUser(): any {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We can emit user login events with the extra information if it's the first user, second user etc. who logged into Unleash.
This will make onboarding metrics easier to implement by encapsulation login order logic inside the user subdomain.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
