### PR TITLE
feat: display the build number as extra data

### DIFF
--- a/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
+++ b/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
@@ -13,17 +13,19 @@ interface IApiDetailsProps {
 
 export const ApiDetails = (props: IApiDetailsProps): ReactElement => {
     const instanceId = props.uiConfig.versionInfo?.instanceId;
-    const currentVersion = formatCurrentVersion(props.uiConfig);
+    const { name, version, buildNumber } = formatCurrentVersion(props.uiConfig);
     const environment = props.uiConfig.environment;
     const updateNotification = formatUpdateNotification(props.uiConfig);
 
+    const buildInfo = buildNumber ? <small> ({buildNumber})</small> : '';
     return (
         <section title='API details'>
             <FooterTitle>
-                {currentVersion}{' '}
+                {name} {version}
+                {buildInfo}
                 <ConditionallyRender
                     condition={Boolean(environment)}
-                    show={<small>({environment})</small>}
+                    show={<small> ({environment})</small>}
                 />
             </FooterTitle>
             <ConditionallyRender

--- a/frontend/src/component/menu/Footer/ApiDetails/apidetails.helpers.tsx
+++ b/frontend/src/component/menu/Footer/ApiDetails/apidetails.helpers.tsx
@@ -8,18 +8,20 @@ export interface IPartialUiConfig {
     versionInfo?: IVersionInfo;
 }
 
-export const formatCurrentVersion = (uiConfig: IPartialUiConfig): string => {
+export const formatCurrentVersion = (
+    uiConfig: IPartialUiConfig,
+): { name: string; version: string; buildNumber?: string } => {
     const current = uiConfig.versionInfo?.current;
-
-    if (current?.enterprise) {
-        return `${uiConfig.name} ${current.enterprise}`;
-    }
-
-    if (current?.oss) {
-        return `${uiConfig.name} ${current.oss}`;
-    }
-
-    return `${uiConfig.name} ${uiConfig.version}`;
+    const [version, buildNumber] = (
+        current?.enterprise ||
+        current?.oss ||
+        uiConfig.version
+    ).split('+');
+    return {
+        name: uiConfig.name,
+        version,
+        buildNumber,
+    };
 };
 
 export const formatUpdateNotification = (


### PR DESCRIPTION
## About the changes
Show the build number between parenthesis separated from the version.

When there's no build number:
![image](https://github.com/user-attachments/assets/408c6953-9af5-4c8d-88e2-50eb17016ee1)

When there is:
![image](https://github.com/user-attachments/assets/b5481294-651a-422c-9699-b93b3d8cf4be)
