### PR TITLE
feat: onboarding store

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -53,6 +53,7 @@ import { IntegrationEventsStore } from '../features/integration-events/integrati
 import { FeatureCollaboratorsReadModel } from '../features/feature-toggle/feature-collaborators-read-model';
 import { createProjectReadModel } from '../features/project/createProjectReadModel';
 import { OnboardingReadModel } from '../features/onboarding/onboarding-read-model';
+import { OnboardingStore } from '../features/onboarding/onboarding-store';
 
 export const createStores = (
     config: IUnleashConfig,
@@ -173,6 +174,7 @@ export const createStores = (
         featureLifecycleStore: new FeatureLifecycleStore(db),
         featureStrategiesReadModel: new FeatureStrategiesReadModel(db),
         onboardingReadModel: new OnboardingReadModel(db),
+        onboardingStore: new OnboardingStore(db),
         featureLifecycleReadModel: new FeatureLifecycleReadModel(
             db,
             config.flagResolver,

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -298,6 +298,15 @@ class UserStore implements IUserStore {
         const row = await this.activeUsers().where({ id }).first();
         return rowToUser(row);
     }
+
+    async getFirstUserDate(): Promise<Date | null> {
+        const firstInstanceUser = await this.db('users')
+            .select('created_at')
+            .orderBy('created_at', 'asc')
+            .first();
+
+        return firstInstanceUser ? firstInstanceUser.created_at : null;
+    }
 }
 
 module.exports = UserStore;

--- a/src/lib/features/onboarding/fake-onboarding-store.ts
+++ b/src/lib/features/onboarding/fake-onboarding-store.ts
@@ -1,0 +1,10 @@
+import type {
+    IOnboardingStore,
+    OnboardingEvent,
+} from './onboarding-store-type';
+
+export class FakeOnboardingStore implements IOnboardingStore {
+    async insert(event: OnboardingEvent): Promise<void> {
+        return;
+    }
+}

--- a/src/lib/features/onboarding/fake-onboarding-store.ts
+++ b/src/lib/features/onboarding/fake-onboarding-store.ts
@@ -1,10 +1,14 @@
 import type {
+    InstanceEvent,
     IOnboardingStore,
-    OnboardingEvent,
+    ProjectEvent,
 } from './onboarding-store-type';
 
 export class FakeOnboardingStore implements IOnboardingStore {
-    async insert(event: OnboardingEvent): Promise<void> {
-        return;
+    insertProjectEvent(event: ProjectEvent): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+    insertInstanceEvent(event: InstanceEvent): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 }

--- a/src/lib/features/onboarding/onboarding-service.e2e.test.ts
+++ b/src/lib/features/onboarding/onboarding-service.e2e.test.ts
@@ -7,7 +7,7 @@ import { createTestConfig } from '../../../test/config/test-config';
 
 let db: ITestDb;
 let stores: IUnleashStores;
-let onboardService: OnboardingService;
+let onboardingService: OnboardingService;
 
 beforeAll(async () => {
     db = await dbInit('onboarding_store', getLogger);
@@ -16,7 +16,7 @@ beforeAll(async () => {
     });
     stores = db.stores;
     const { userStore, onboardingStore, projectReadModel } = stores;
-    onboardService = new OnboardingService(
+    onboardingService = new OnboardingService(
         { onboardingStore, userStore, projectReadModel },
         config,
     );
@@ -43,23 +43,23 @@ test('Storing onboarding events', async () => {
     });
 
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'first-user-login' });
+    await onboardingService.insert({ type: 'first-user-login' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'second-user-login' });
+    await onboardingService.insert({ type: 'second-user-login' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'flag-created', flag: 'test' });
-    await onboardService.insert({ type: 'flag-created', flag: 'test' });
-    await onboardService.insert({ type: 'flag-created', flag: 'invalid' });
+    await onboardingService.insert({ type: 'flag-created', flag: 'test' });
+    await onboardingService.insert({ type: 'flag-created', flag: 'test' });
+    await onboardingService.insert({ type: 'flag-created', flag: 'invalid' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'pre-live', flag: 'test' });
-    await onboardService.insert({ type: 'pre-live', flag: 'test' });
-    await onboardService.insert({ type: 'pre-live', flag: 'invalid' });
+    await onboardingService.insert({ type: 'pre-live', flag: 'test' });
+    await onboardingService.insert({ type: 'pre-live', flag: 'test' });
+    await onboardingService.insert({ type: 'pre-live', flag: 'invalid' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'live', flag: 'test' });
+    await onboardingService.insert({ type: 'live', flag: 'test' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'live', flag: 'test' });
+    await onboardingService.insert({ type: 'live', flag: 'test' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardService.insert({ type: 'live', flag: 'invalid' });
+    await onboardingService.insert({ type: 'live', flag: 'invalid' });
 
     const { rows: instanceEvents } = await db.rawDatabase.raw(
         'SELECT * FROM onboarding_events_instance',

--- a/src/lib/features/onboarding/onboarding-service.ts
+++ b/src/lib/features/onboarding/onboarding-service.ts
@@ -1,0 +1,63 @@
+import type { IFlagResolver, IUnleashConfig } from '../../types';
+import type EventEmitter from 'events';
+import type { Logger } from '../../logger';
+import { STAGE_ENTERED, USER_LOGIN } from '../../metric-events';
+import type { NewStage } from '../feature-lifecycle/feature-lifecycle-store-type';
+import type { IOnboardingStore } from './onboarding-store-type';
+
+export class OnboardingService {
+    private flagResolver: IFlagResolver;
+
+    private eventBus: EventEmitter;
+
+    private logger: Logger;
+
+    private onboardingStore: IOnboardingStore;
+
+    constructor(
+        { onboardingStore }: { onboardingStore: IOnboardingStore },
+        {
+            flagResolver,
+            eventBus,
+            getLogger,
+        }: Pick<IUnleashConfig, 'flagResolver' | 'eventBus' | 'getLogger'>,
+    ) {
+        this.onboardingStore = onboardingStore;
+        this.flagResolver = flagResolver;
+        this.eventBus = eventBus;
+        this.logger = getLogger('onboarding/onboarding-service.ts');
+    }
+
+    listen() {
+        this.eventBus.on(USER_LOGIN, async (event: { loginOrder: number }) => {
+            if (!this.flagResolver.isEnabled('onboardingMetrics')) return;
+
+            if (event.loginOrder === 0) {
+                await this.onboardingStore.insert({ type: 'firstUserLogin' });
+            }
+            if (event.loginOrder === 1) {
+                await this.onboardingStore.insert({ type: 'secondUserLogin' });
+            }
+        });
+        this.eventBus.on(STAGE_ENTERED, async (stage: NewStage) => {
+            if (!this.flagResolver.isEnabled('onboardingMetrics')) return;
+
+            if (stage.stage === 'initial') {
+                await this.onboardingStore.insert({
+                    type: 'flagCreated',
+                    flag: stage.feature,
+                });
+            } else if (stage.stage === 'pre-live') {
+                await this.onboardingStore.insert({
+                    type: 'preLive',
+                    flag: stage.feature,
+                });
+            } else if (stage.stage === 'live') {
+                await this.onboardingStore.insert({
+                    type: 'live',
+                    flag: stage.feature,
+                });
+            }
+        });
+    }
+}

--- a/src/lib/features/onboarding/onboarding-service.ts
+++ b/src/lib/features/onboarding/onboarding-service.ts
@@ -33,10 +33,12 @@ export class OnboardingService {
             if (!this.flagResolver.isEnabled('onboardingMetrics')) return;
 
             if (event.loginOrder === 0) {
-                await this.onboardingStore.insert({ type: 'firstUserLogin' });
+                await this.onboardingStore.insert({ type: 'first-user-login' });
             }
             if (event.loginOrder === 1) {
-                await this.onboardingStore.insert({ type: 'secondUserLogin' });
+                await this.onboardingStore.insert({
+                    type: 'second-user-login',
+                });
             }
         });
         this.eventBus.on(STAGE_ENTERED, async (stage: NewStage) => {
@@ -44,12 +46,12 @@ export class OnboardingService {
 
             if (stage.stage === 'initial') {
                 await this.onboardingStore.insert({
-                    type: 'flagCreated',
+                    type: 'flag-created',
                     flag: stage.feature,
                 });
             } else if (stage.stage === 'pre-live') {
                 await this.onboardingStore.insert({
-                    type: 'preLive',
+                    type: 'pre-live',
                     flag: stage.feature,
                 });
             } else if (stage.stage === 'live') {

--- a/src/lib/features/onboarding/onboarding-store-type.ts
+++ b/src/lib/features/onboarding/onboarding-store-type.ts
@@ -1,10 +1,10 @@
 export type SharedEvent =
-    | { type: 'flagCreated'; flag: string }
-    | { type: 'preLive'; flag: string }
+    | { type: 'flag-created'; flag: string }
+    | { type: 'pre-live'; flag: string }
     | { type: 'live'; flag: string };
 export type InstanceEvent =
-    | { type: 'firstUserLogin' }
-    | { type: 'secondUserLogin' };
+    | { type: 'first-user-login' }
+    | { type: 'second-user-login' };
 export type OnboardingEvent = SharedEvent | InstanceEvent;
 
 export interface IOnboardingStore {

--- a/src/lib/features/onboarding/onboarding-store-type.ts
+++ b/src/lib/features/onboarding/onboarding-store-type.ts
@@ -1,12 +1,16 @@
-export type SharedEvent =
-    | { type: 'flag-created'; flag: string }
-    | { type: 'pre-live'; flag: string }
-    | { type: 'live'; flag: string };
+export type ProjectEvent =
+    | { type: 'flag-created'; project: string; timeToEvent: number }
+    | { type: 'pre-live'; project: string; timeToEvent: number }
+    | { type: 'live'; project: string; timeToEvent: number };
 export type InstanceEvent =
-    | { type: 'first-user-login' }
-    | { type: 'second-user-login' };
-export type OnboardingEvent = SharedEvent | InstanceEvent;
+    | { type: 'flag-created'; timeToEvent: number }
+    | { type: 'pre-live'; timeToEvent: number }
+    | { type: 'live'; timeToEvent: number }
+    | { type: 'first-user-login'; timeToEvent: number }
+    | { type: 'second-user-login'; timeToEvent: number };
 
 export interface IOnboardingStore {
-    insert(event: OnboardingEvent): Promise<void>;
+    insertProjectEvent(event: ProjectEvent): Promise<void>;
+
+    insertInstanceEvent(event: InstanceEvent): Promise<void>;
 }

--- a/src/lib/features/onboarding/onboarding-store-type.ts
+++ b/src/lib/features/onboarding/onboarding-store-type.ts
@@ -1,0 +1,12 @@
+export type SharedEvent =
+    | { type: 'flagCreated'; flag: string }
+    | { type: 'preLive'; flag: string }
+    | { type: 'live'; flag: string };
+export type InstanceEvent =
+    | { type: 'firstUserLogin' }
+    | { type: 'secondUserLogin' };
+export type OnboardingEvent = SharedEvent | InstanceEvent;
+
+export interface IOnboardingStore {
+    insert(event: OnboardingEvent): Promise<void>;
+}

--- a/src/lib/features/onboarding/onboarding-store.test.ts
+++ b/src/lib/features/onboarding/onboarding-store.test.ts
@@ -32,17 +32,17 @@ test('Storing onboarding events', async () => {
     });
 
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardingStore.insert({ type: 'firstUserLogin' });
+    await onboardingStore.insert({ type: 'first-user-login' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardingStore.insert({ type: 'secondUserLogin' });
+    await onboardingStore.insert({ type: 'second-user-login' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardingStore.insert({ type: 'flagCreated', flag: 'test' });
-    await onboardingStore.insert({ type: 'flagCreated', flag: 'test' });
-    await onboardingStore.insert({ type: 'flagCreated', flag: 'invalid' });
+    await onboardingStore.insert({ type: 'flag-created', flag: 'test' });
+    await onboardingStore.insert({ type: 'flag-created', flag: 'test' });
+    await onboardingStore.insert({ type: 'flag-created', flag: 'invalid' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
-    await onboardingStore.insert({ type: 'preLive', flag: 'test' });
-    await onboardingStore.insert({ type: 'preLive', flag: 'test' });
-    await onboardingStore.insert({ type: 'preLive', flag: 'invalid' });
+    await onboardingStore.insert({ type: 'pre-live', flag: 'test' });
+    await onboardingStore.insert({ type: 'pre-live', flag: 'test' });
+    await onboardingStore.insert({ type: 'pre-live', flag: 'invalid' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
     await onboardingStore.insert({ type: 'live', flag: 'test' });
     jest.advanceTimersByTime(minutesToMilliseconds(1));
@@ -54,19 +54,23 @@ test('Storing onboarding events', async () => {
         'SELECT * FROM onboarding_events_instance',
     );
     expect(instanceEvents).toMatchObject([
-        { event: 'firstUserLogin', time_to_event: 60 },
-        { event: 'secondUserLogin', time_to_event: 120 },
-        { event: 'firstFlag', time_to_event: 180 },
-        { event: 'firstPreLive', time_to_event: 240 },
-        { event: 'firstLive', time_to_event: 300 },
+        { event: 'first-user-login', time_to_event: 60 },
+        { event: 'second-user-login', time_to_event: 120 },
+        { event: 'first-flag', time_to_event: 180 },
+        { event: 'first-pre-live', time_to_event: 240 },
+        { event: 'first-live', time_to_event: 300 },
     ]);
 
     const { rows: projectEvents } = await db.rawDatabase.raw(
         'SELECT * FROM onboarding_events_project',
     );
     expect(projectEvents).toMatchObject([
-        { event: 'firstFlag', time_to_event: 180, project: 'test_project' },
-        { event: 'firstPreLive', time_to_event: 240, project: 'test_project' },
-        { event: 'firstLive', time_to_event: 300, project: 'test_project' },
+        { event: 'first-flag', time_to_event: 180, project: 'test_project' },
+        {
+            event: 'first-pre-live',
+            time_to_event: 240,
+            project: 'test_project',
+        },
+        { event: 'first-live', time_to_event: 300, project: 'test_project' },
     ]);
 });

--- a/src/lib/features/onboarding/onboarding-store.test.ts
+++ b/src/lib/features/onboarding/onboarding-store.test.ts
@@ -1,0 +1,72 @@
+import type { IUnleashStores } from '../../../lib/types';
+import dbInit, { type ITestDb } from '../../../test/e2e/helpers/database-init';
+import getLogger from '../../../test/fixtures/no-logger';
+import { minutesToMilliseconds } from 'date-fns';
+
+let db: ITestDb;
+let stores: IUnleashStores;
+
+beforeAll(async () => {
+    db = await dbInit('onboarding_store', getLogger);
+    stores = db.stores;
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+beforeEach(async () => {
+    jest.useRealTimers();
+});
+
+test('Storing onboarding events', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date());
+    const { userStore, onboardingStore, featureToggleStore, projectStore } =
+        stores;
+    const user = await userStore.insert({});
+    await projectStore.create({ id: 'test_project', name: 'irrelevant' });
+    await featureToggleStore.create('test_project', {
+        name: 'test',
+        createdByUserId: user.id,
+    });
+
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'firstUserLogin' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'secondUserLogin' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'flagCreated', flag: 'test' });
+    await onboardingStore.insert({ type: 'flagCreated', flag: 'test' });
+    await onboardingStore.insert({ type: 'flagCreated', flag: 'invalid' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'preLive', flag: 'test' });
+    await onboardingStore.insert({ type: 'preLive', flag: 'test' });
+    await onboardingStore.insert({ type: 'preLive', flag: 'invalid' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'live', flag: 'test' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'live', flag: 'test' });
+    jest.advanceTimersByTime(minutesToMilliseconds(1));
+    await onboardingStore.insert({ type: 'live', flag: 'invalid' });
+
+    const { rows: instanceEvents } = await db.rawDatabase.raw(
+        'SELECT * FROM onboarding_events_instance',
+    );
+    expect(instanceEvents).toMatchObject([
+        { event: 'firstUserLogin', time_to_event: 60 },
+        { event: 'secondUserLogin', time_to_event: 120 },
+        { event: 'firstFlag', time_to_event: 180 },
+        { event: 'firstPreLive', time_to_event: 240 },
+        { event: 'firstLive', time_to_event: 300 },
+    ]);
+
+    const { rows: projectEvents } = await db.rawDatabase.raw(
+        'SELECT * FROM onboarding_events_project',
+    );
+    expect(projectEvents).toMatchObject([
+        { event: 'firstFlag', time_to_event: 180, project: 'test_project' },
+        { event: 'firstPreLive', time_to_event: 240, project: 'test_project' },
+        { event: 'firstLive', time_to_event: 300, project: 'test_project' },
+    ]);
+});

--- a/src/lib/features/onboarding/onboarding-store.ts
+++ b/src/lib/features/onboarding/onboarding-store.ts
@@ -1,0 +1,136 @@
+import type { Db } from '../../db/db';
+import type {
+    IOnboardingStore,
+    OnboardingEvent,
+    SharedEvent,
+} from './onboarding-store-type';
+import { millisecondsToSeconds } from 'date-fns';
+
+type DBInstanceType = {
+    event:
+        | 'firstUserLogin'
+        | 'secondUserLogin'
+        | 'firstFlag'
+        | 'firstPreLive'
+        | 'firstLive';
+    time_to_event: number;
+};
+
+type DBProjectType = {
+    event: 'firstFlag' | 'firstPreLive' | 'firstLive';
+    time_to_event: number;
+    project: string;
+};
+
+const translateEvent = (
+    event: OnboardingEvent['type'],
+): DBInstanceType['event'] => {
+    if (event === 'flagCreated') {
+        return 'firstFlag';
+    }
+    if (event === 'preLive') {
+        return 'firstPreLive';
+    }
+    if (event === 'live') {
+        return 'firstLive';
+    }
+    return event as DBInstanceType['event'];
+};
+
+const calculateTimeDifferenceInSeconds = (date1?: Date, date2?: Date) => {
+    if (date1 && date2) {
+        const diffInMilliseconds = date2.getTime() - date1.getTime();
+        return millisecondsToSeconds(diffInMilliseconds);
+    }
+    return null;
+};
+
+export class OnboardingStore implements IOnboardingStore {
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    async insert(event: OnboardingEvent): Promise<void> {
+        await this.insertInstanceEvent(event);
+        if (
+            event.type !== 'firstUserLogin' &&
+            event.type !== 'secondUserLogin'
+        ) {
+            await this.insertProjectEvent(event);
+        }
+    }
+
+    private async insertInstanceEvent(event: OnboardingEvent): Promise<void> {
+        const dbEvent = translateEvent(event.type);
+        const exists = await this.db<DBInstanceType>(
+            'onboarding_events_instance',
+        )
+            .where({ event: dbEvent })
+            .first();
+
+        if (exists) return;
+
+        const firstInstanceUser = await this.db('users')
+            .select('created_at')
+            .orderBy('created_at', 'asc')
+            .first();
+
+        if (!firstInstanceUser) return;
+
+        const timeToEvent = calculateTimeDifferenceInSeconds(
+            firstInstanceUser.created_at,
+            new Date(),
+        );
+        if (timeToEvent === null) return;
+
+        await this.db('onboarding_events_instance').insert({
+            event: dbEvent,
+            time_to_event: timeToEvent,
+        });
+    }
+
+    private async insertProjectEvent(event: SharedEvent): Promise<void> {
+        const dbEvent = translateEvent(event.type) as DBProjectType['event'];
+
+        const projectRow = await this.db<{ project: string; name: string }>(
+            'features',
+        )
+            .select('project')
+            .where({ name: event.flag })
+            .first();
+
+        if (!projectRow) return;
+
+        const project = projectRow.project;
+
+        const exists = await this.db('onboarding_events_project')
+            .where({ event: dbEvent, project })
+            .first();
+
+        if (exists) return;
+
+        const projectCreatedAt = await this.db<{
+            created_at: Date;
+            id: string;
+        }>('projects')
+            .select('created_at')
+            .where({ id: project })
+            .first();
+
+        if (!projectCreatedAt) return;
+
+        const timeToEvent = calculateTimeDifferenceInSeconds(
+            projectCreatedAt.created_at,
+            new Date(),
+        );
+        if (timeToEvent === null) return;
+
+        await this.db<DBProjectType>('onboarding_events_project').insert({
+            event: dbEvent,
+            time_to_event: timeToEvent,
+            project: project,
+        });
+    }
+}

--- a/src/lib/features/onboarding/onboarding-store.ts
+++ b/src/lib/features/onboarding/onboarding-store.ts
@@ -8,11 +8,11 @@ import { millisecondsToSeconds } from 'date-fns';
 
 type DBInstanceType = {
     event:
-        | 'firstUserLogin'
-        | 'secondUserLogin'
-        | 'firstFlag'
-        | 'firstPreLive'
-        | 'firstLive';
+        | 'first-user-login'
+        | 'second-user-login'
+        | 'first-flag'
+        | 'first-pre-live'
+        | 'first-live';
     time_to_event: number;
 };
 
@@ -25,14 +25,14 @@ type DBProjectType = {
 const translateEvent = (
     event: OnboardingEvent['type'],
 ): DBInstanceType['event'] => {
-    if (event === 'flagCreated') {
-        return 'firstFlag';
+    if (event === 'flag-created') {
+        return 'first-flag';
     }
-    if (event === 'preLive') {
-        return 'firstPreLive';
+    if (event === 'pre-live') {
+        return 'first-pre-live';
     }
     if (event === 'live') {
-        return 'firstLive';
+        return 'first-live';
     }
     return event as DBInstanceType['event'];
 };
@@ -55,8 +55,8 @@ export class OnboardingStore implements IOnboardingStore {
     async insert(event: OnboardingEvent): Promise<void> {
         await this.insertInstanceEvent(event);
         if (
-            event.type !== 'firstUserLogin' &&
-            event.type !== 'secondUserLogin'
+            event.type !== 'first-user-login' &&
+            event.type !== 'second-user-login'
         ) {
             await this.insertProjectEvent(event);
         }

--- a/src/lib/features/project/fake-project-read-model.ts
+++ b/src/lib/features/project/fake-project-read-model.ts
@@ -5,10 +5,7 @@ import type {
 } from './project-read-model-type';
 
 export class FakeProjectReadModel implements IProjectReadModel {
-    getFeatureProject(): Promise<string | null> {
-        return Promise.resolve(null);
-    }
-    getProjectCreationTime(): Promise<Date | null> {
+    getFeatureProject(): Promise<{ project: string; createdAt: Date } | null> {
         return Promise.resolve(null);
     }
     getProjectsForAdminUi(): Promise<ProjectForUi[]> {

--- a/src/lib/features/project/fake-project-read-model.ts
+++ b/src/lib/features/project/fake-project-read-model.ts
@@ -5,6 +5,12 @@ import type {
 } from './project-read-model-type';
 
 export class FakeProjectReadModel implements IProjectReadModel {
+    getFeatureProject(): Promise<string | null> {
+        return Promise.resolve(null);
+    }
+    getProjectCreationTime(): Promise<Date | null> {
+        return Promise.resolve(null);
+    }
     getProjectsForAdminUi(): Promise<ProjectForUi[]> {
         return Promise.resolve([]);
     }

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -37,7 +37,6 @@ export interface IProjectReadModel {
     getProjectsForInsights(
         query?: IProjectQuery,
     ): Promise<ProjectForInsights[]>;
-    getProjectCreationTime(project: string): Promise<Date | null>;
     getFeatureProject(
         featureName: string,
     ): Promise<{ project: string; createdAt: Date } | null>;

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -37,4 +37,8 @@ export interface IProjectReadModel {
     getProjectsForInsights(
         query?: IProjectQuery,
     ): Promise<ProjectForInsights[]>;
+    getProjectCreationTime(project: string): Promise<Date | null>;
+    getFeatureProject(
+        featureName: string,
+    ): Promise<{ project: string; createdAt: Date } | null>;
 }

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -62,18 +62,6 @@ export class ProjectReadModel implements IProjectReadModel {
         this.flagResolver = flagResolver;
     }
 
-    async getProjectCreationTime(project: string): Promise<Date | null> {
-        const projectCreatedAt = await this.db<{
-            created_at: Date;
-            id: string;
-        }>('projects')
-            .select('created_at')
-            .where({ id: project })
-            .first();
-
-        return projectCreatedAt ? projectCreatedAt.created_at : null;
-    }
-
     async getFeatureProject(
         featureName: string,
     ): Promise<{ project: string; createdAt: Date } | null> {

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -77,28 +77,17 @@ export class ProjectReadModel implements IProjectReadModel {
     async getFeatureProject(
         featureName: string,
     ): Promise<{ project: string; createdAt: Date } | null> {
-        const projectRow = await this.db<{ project: string; name: string }>(
+        const result = await this.db<{ project: string; created_at: Date }>(
             'features',
         )
-            .select('project')
-            .where({ name: featureName })
+            .join('projects', 'features.project', '=', 'projects.id')
+            .select('features.project', 'projects.created_at')
+            .where('features.name', featureName)
             .first();
 
-        if (!projectRow) return null;
+        if (!result) return null;
 
-        const project = projectRow.project;
-
-        const projectCreatedAt = await this.db<{
-            created_at: Date;
-            id: string;
-        }>('projects')
-            .select('created_at')
-            .where({ id: project })
-            .first();
-
-        if (!projectCreatedAt) return null;
-
-        return { project, createdAt: projectCreatedAt.created_at };
+        return { project: result.project, createdAt: result.created_at };
     }
 
     async getProjectsForAdminUi(

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -62,6 +62,45 @@ export class ProjectReadModel implements IProjectReadModel {
         this.flagResolver = flagResolver;
     }
 
+    async getProjectCreationTime(project: string): Promise<Date | null> {
+        const projectCreatedAt = await this.db<{
+            created_at: Date;
+            id: string;
+        }>('projects')
+            .select('created_at')
+            .where({ id: project })
+            .first();
+
+        return projectCreatedAt ? projectCreatedAt.created_at : null;
+    }
+
+    async getFeatureProject(
+        featureName: string,
+    ): Promise<{ project: string; createdAt: Date } | null> {
+        const projectRow = await this.db<{ project: string; name: string }>(
+            'features',
+        )
+            .select('project')
+            .where({ name: featureName })
+            .first();
+
+        if (!projectRow) return null;
+
+        const project = projectRow.project;
+
+        const projectCreatedAt = await this.db<{
+            created_at: Date;
+            id: string;
+        }>('projects')
+            .select('created_at')
+            .where({ id: project })
+            .first();
+
+        if (!projectCreatedAt) return null;
+
+        return { project, createdAt: projectCreatedAt.created_at };
+    }
+
     async getProjectsForAdminUi(
         query?: IProjectQuery,
         userId?: number,

--- a/src/lib/features/project/project-store.ts
+++ b/src/lib/features/project/project-store.ts
@@ -302,7 +302,7 @@ class ProjectStore implements IProjectStore {
         project: IProjectInsert & IProjectSettings,
     ): Promise<IProject> {
         const row = await this.db(TABLE)
-            .insert(this.fieldToRow(project))
+            .insert({ ...this.fieldToRow(project), created_at: new Date() })
             .returning('*');
         const settingsRow = await this.db(SETTINGS_TABLE)
             .insert({

--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -50,6 +50,7 @@ import type { IntegrationEventsStore } from '../features/integration-events/inte
 import { IFeatureCollaboratorsReadModel } from '../features/feature-toggle/types/feature-collaborators-read-model-type';
 import type { IProjectReadModel } from '../features/project/project-read-model-type';
 import { IOnboardingReadModel } from '../features/onboarding/onboarding-read-model-type';
+import { IOnboardingStore } from '../features/onboarding/onboarding-store-type';
 
 export interface IUnleashStores {
     accessStore: IAccessStore;
@@ -104,6 +105,7 @@ export interface IUnleashStores {
     featureCollaboratorsReadModel: IFeatureCollaboratorsReadModel;
     projectReadModel: IProjectReadModel;
     onboardingReadModel: IOnboardingReadModel;
+    onboardingStore: IOnboardingStore;
 }
 
 export {
@@ -157,4 +159,5 @@ export {
     IOnboardingReadModel,
     type IntegrationEventsStore,
     type IProjectReadModel,
+    IOnboardingStore,
 };

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -34,6 +34,7 @@ export interface IUserStore extends Store<IUser, number> {
         disallowNPreviousPasswords: number,
     ): Promise<void>;
     getPasswordsPreviouslyUsed(userId: number): Promise<string[]>;
+    getFirstUserDate(): Promise<Date | null>;
     incLoginAttempts(user: IUser): Promise<void>;
     successfullyLogin(user: IUser): Promise<number>;
     count(): Promise<number>;

--- a/src/test/fixtures/fake-user-store.ts
+++ b/src/test/fixtures/fake-user-store.ts
@@ -17,6 +17,22 @@ class UserStoreMock implements IUserStore {
         this.previousPasswords = new Map();
     }
 
+    async getFirstUserDate(): Promise<Date | null> {
+        if (this.data.length === 0) {
+            return null;
+        }
+        const oldestUser = this.data.reduce((oldest, user) => {
+            if (!user.createdAt) {
+                return oldest;
+            }
+            return !oldest.createdAt || user.createdAt < oldest.createdAt
+                ? user
+                : oldest;
+        }, this.data[0]);
+
+        return oldestUser.createdAt || null;
+    }
+
     getPasswordsPreviouslyUsed(userId: number): Promise<string[]> {
         return Promise.resolve(this.previousPasswords.get(userId) || []);
     }

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -53,6 +53,7 @@ import { FakeLargestResourcesReadModel } from '../../lib/features/metrics/sizes/
 import { FakeFeatureCollaboratorsReadModel } from '../../lib/features/feature-toggle/fake-feature-collaborators-read-model';
 import { createFakeProjectReadModel } from '../../lib/features/project/createProjectReadModel';
 import { FakeOnboardingReadModel } from '../../lib/features/onboarding/fake-onboarding-read-model';
+import { FakeOnboardingStore } from '../../lib/features/onboarding/fake-onboarding-store';
 
 const db = {
     select: () => ({
@@ -115,6 +116,7 @@ const createStores: () => IUnleashStores = () => {
         integrationEventsStore: {} as IntegrationEventsStore,
         featureCollaboratorsReadModel: new FakeFeatureCollaboratorsReadModel(),
         projectReadModel: createFakeProjectReadModel(),
+        onboardingStore: new FakeOnboardingStore(),
     };
 };
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* adding onboarding service with SQL store implementation
* added project read model method and user store method (can extract to read model in a separate PR)
* fixed project create method to allow for date control from the code

Next PR:
* create tests that combine store and read model
* plug the service into the rest of the code
* create composition root for the service
* write service tests with in-memory store for the listen method testing

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
Naming convention:
* when events progress through the system they change meaning. e.g. lifecycle `initial` event arrived from the lifecycle subdomain. It is translated to `flag-created` in the onboarding subdomain. One we confirm it's the first flag created we store it as `first-flag` in the DB.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
