### PR TITLE
chore: reorganize product data in footer

### DIFF
--- a/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
+++ b/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
@@ -17,15 +17,11 @@ export const ApiDetails = (props: IApiDetailsProps): ReactElement => {
     const environment = props.uiConfig.environment;
     const updateNotification = formatUpdateNotification(props.uiConfig);
 
-    const buildInfo = buildNumber ? <small> ({buildNumber})</small> : '';
+    const buildInfo = buildNumber ? <small>({buildNumber})</small> : '';
     return (
         <section title='API details'>
             <FooterTitle>
-                {name} {version} {buildInfo}
-                <ConditionallyRender
-                    condition={Boolean(environment)}
-                    show={<small> ({environment})</small>}
-                />
+                {name} {environment ? environment : ''} {version} {buildInfo}
             </FooterTitle>
             <ConditionallyRender
                 condition={Boolean(updateNotification)}

--- a/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
@@ -11,12 +11,9 @@ exports[`renders correctly with empty version 1`] = `
       >
         Unleash
          
+        test
          
-        <small>
-           (
-          test
-          )
-        </small>
+         
       </h2>
       <br />
       <small>
@@ -46,13 +43,10 @@ exports[`renders correctly with ui-config 1`] = `
       >
         Unleash
          
+        test
+         
         1.1.0
          
-        <small>
-           (
-          test
-          )
-        </small>
       </h2>
       <br />
       <small>
@@ -81,6 +75,7 @@ exports[`renders correctly with versionInfo 1`] = `
         class="css-gtu1fw"
       >
         Unleash
+         
          
         1.2.3
          
@@ -117,6 +112,7 @@ exports[`renders correctly without uiConfig 1`] = `
         class="css-gtu1fw"
       >
         Unleash
+         
          
         1.1.0
          

--- a/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`should render DrawerMenu 1`] = `
           >
             Unleash
              
+             
             5.x
              
           </h2>
@@ -569,6 +570,7 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
             className="css-gtu1fw"
           >
             Unleash
+             
              
             5.x
              


### PR DESCRIPTION
## About the changes
Instead of having the plan at the end, move it next to the product name and display the build number at last