### PR TITLE
fix: reduce integration events requests

### DIFF
--- a/frontend/src/component/integrations/IntegrationEvents/IntegrationEventsModal.tsx
+++ b/frontend/src/component/integrations/IntegrationEvents/IntegrationEventsModal.tsx
@@ -65,7 +65,7 @@ export const IntegrationEventsModal = ({
     const navigate = useNavigate();
     const { locationSettings } = useLocationSettings();
     const { integrationEvents, hasMore, loadMore, loading } =
-        useIntegrationEvents(addon?.id, 20, {
+        useIntegrationEvents(open ? addon?.id : undefined, 20, {
             refreshInterval: 5000,
         });
 


### PR DESCRIPTION
Cuts the total amount of integration event requests in half when browsing the integrations page, by only fetching the 20 latest events for each configured integration when it's actually needed (open modal).