### PR TITLE
chore: clear onboarding events

### DIFF
--- a/src/migrations/20240903152133-clear-onboarding-events.js
+++ b/src/migrations/20240903152133-clear-onboarding-events.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+            DELETE FROM onboarding_events_instance;
+            DELETE FROM onboarding_events_project;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        ``,
+        cb);
+};


### PR DESCRIPTION
Clearing onboarding tables, because the data is invalid and we want to start tracking all of this for only new customers.
This migration must be applied after the new logic is implemented.