### PR TITLE
fix: add request body schema in update segment endpoint

### DIFF
--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -198,6 +198,7 @@ export class SegmentsController extends Controller {
                         'Updates the content of the segment with the provided payload. Any fields not specified will be left untouched.',
                     tags: ['Segments'],
                     operationId: 'updateSegment',
+                    requestBody: createRequestSchema('upsertSegmentSchema'),
                     responses: {
                         204: emptyResponse,
                         ...getStandardResponses(400, 401, 403, 409, 415),

--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -195,7 +195,7 @@ export class SegmentsController extends Controller {
                 openApiService.validPath({
                     summary: 'Update segment by id',
                     description:
-                        'Updates the content of the segment with the provided payload. Any fields not specified will be left untouched.',
+                        'Updates the content of the segment with the provided payload. Requires `name` and `constraints` to be present. If `project` is not present, it will be set to `null`. Any other fields not specified will be left untouched.',
                     tags: ['Segments'],
                     operationId: 'updateSegment',
                     requestBody: createRequestSchema('upsertSegmentSchema'),


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2592/updateimprove-a-segment-via-api-call

Related to https://github.com/Unleash/unleash/issues/7987

This does not make the endpoint necessarily better - It's still a PUT that acts as a PUT in some ways (expects specific required fields to be present, resets the project to `null` if it's not included in the body) and a PATCH in others (ignores most fields if they're not included in the body). We need to have a more in-depth discussion about developing long-term strategies for our API and respective OpenAPI spec.

However this at least includes the proper schema for the request body, which is slightly better than before.