### PR TITLE
fix: use the correct env vars for initial admin account

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -317,8 +317,8 @@ const defaultVersionOption: IVersionOption = {
 };
 
 const parseEnvVarInitialAdminUser = (): UsernameAdminUser | undefined => {
-    const username = process.env.INITIAL_ADMIN_USER_USERNAME;
-    const password = process.env.INITIAL_ADMIN_USER_PASSWORD;
+    const username = process.env.UNLEASH_DEFAULT_ADMIN_USERNAME;
+    const password = process.env.UNLEASH_DEFAULT_ADMIN_PASSWORD;
     return username && password ? { username, password } : undefined;
 };
 

--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -185,6 +185,23 @@ describe('Default admin initialization', () => {
             'The combination of password and username you provided is invalid',
         );
     });
+
+    test('Should use the correct environment variables when initializing the default admin account', async () => {
+        jest.resetModules();
+
+        process.env.UNLEASH_DEFAULT_ADMIN_USERNAME = CUSTOM_ADMIN_USERNAME;
+        process.env.UNLEASH_DEFAULT_ADMIN_PASSWORD = CUSTOM_ADMIN_PASSWORD;
+
+        const createTestConfig =
+            require('../../test/config/test-config').createTestConfig;
+
+        const config = createTestConfig();
+
+        expect(config.authentication.initialAdminUser).toStrictEqual({
+            username: CUSTOM_ADMIN_USERNAME,
+            password: CUSTOM_ADMIN_PASSWORD,
+        });
+    });
 });
 
 test('Should be a valid password', async () => {


### PR DESCRIPTION
https://github.com/Unleash/unleash/pull/7795 mistakenly changed the initial admin account environment variables to be:

 - `INITIAL_ADMIN_USER_USERNAME`
 - `INITIAL_ADMIN_USER_PASSWORD`

Instead of the previous:

 - `UNLEASH_DEFAULT_ADMIN_USERNAME`
 - `UNLEASH_DEFAULT_ADMIN_PASSWORD`

See: https://github.com/Unleash/unleash/pull/7795/files?diff=unified&w=0#diff-a38cc7ae9f963264333b6535498970a33e046dba50a6af554f438343a6edd2ddR319-R334

This PR reverts them back to the correct environment variable names and adds a test to prevent something similar from happening in the future.