### PR TITLE
docs: remove mention of admin name and email env vars

### DIFF
--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -71,8 +71,6 @@ describe('Default admin initialization', () => {
     const DEFAULT_ADMIN_PASSWORD = 'unleash4all';
     const CUSTOM_ADMIN_USERNAME = 'custom-admin';
     const CUSTOM_ADMIN_PASSWORD = 'custom-password';
-    const CUSTOM_ADMIN_NAME = 'Custom Admin';
-    const CUSTOM_ADMIN_EMAIL = 'custom-admin@getunleash.io';
 
     let userService: UserService;
     const sendGettingStartedMailMock = jest.fn();

--- a/website/docs/using-unleash/deploy/getting-started.md
+++ b/website/docs/using-unleash/deploy/getting-started.md
@@ -36,13 +36,6 @@ If you'd like the default admin user to be created with a different username and
 - `UNLEASH_DEFAULT_ADMIN_USERNAME`
 - `UNLEASH_DEFAULT_ADMIN_PASSWORD`
 
-Alternatively, you can provide a name and email address for the initial admin user:
-
-- `UNLEASH_DEFAULT_ADMIN_NAME`
-- `UNLEASH_DEFAULT_ADMIN_EMAIL`
-
-Unleash will then create the admin account using the provided name and email address. Instead of setting an initial password during account creation, an email will be sent to the specified address with a link for the new admin user to securely set their password.
-
 The way of defining these variables may vary depending on how you run Unleash.
 
 


### PR DESCRIPTION
https://github.com/Unleash/unleash/pull/7795 mistakenly included a mention that these environment variables can be used:

- `UNLEASH_DEFAULT_ADMIN_NAME`
- `UNLEASH_DEFAULT_ADMIN_EMAIL`

However that's not really the case, since we decided to remove their respective implementation before merging that PR.