### PR TITLE
chore: remove unused SCIM setting - assumeControlOfExisting

### DIFF
--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -50,7 +50,7 @@ export const ScimSettings = () => {
     const saveScimSettings = async (enabled: boolean) => {
         try {
             setEnabled(enabled);
-            await saveSettings({ enabled, assumeControlOfExisting: false });
+            await saveSettings({ enabled });
             if (enabled && !settings.hasToken) {
                 const token = await generateNewToken();
                 setNewToken(token);

--- a/frontend/src/hooks/api/getters/useScimSettings/useScimSettings.ts
+++ b/frontend/src/hooks/api/getters/useScimSettings/useScimSettings.ts
@@ -9,13 +9,11 @@ const ENDPOINT = 'api/admin/scim-settings';
 export type ScimSettings = {
     enabled: boolean;
     hasToken: boolean;
-    assumeControlOfExisting: boolean;
 };
 
 const DEFAULT_DATA: ScimSettings = {
     enabled: false,
     hasToken: false,
-    assumeControlOfExisting: false,
 };
 
 export const useScimSettings = () => {


### PR DESCRIPTION
This property is unused and should be removed.

This fixes a logged schema error:

```
Invalid response: {
    "schema": "#/components/schemas/scimSettingsSchema",
    "errors": [
        {
            "instancePath": "",
            "schemaPath": "#/required",
            "keyword": "required",
            "params": {
                "missingProperty": "assumeControlOfExisting"
            },
            "message": "must have required property 'assumeControlOfExisting'"
        }
    ]
}
```