### PR TITLE
fix: give project_default_strategy_write the ability to update the default strategy

### DIFF
--- a/src/lib/features/project-environments/environments.ts
+++ b/src/lib/features/project-environments/environments.ts
@@ -5,6 +5,7 @@ import {
     type IUnleashServices,
     serializeDates,
     UPDATE_PROJECT,
+    PROJECT_DEFAULT_STRATEGY_WRITE,
 } from '../../types';
 import type { Logger } from '../../logger';
 import type EnvironmentService from './environment-service';
@@ -105,7 +106,7 @@ export default class EnvironmentsController extends Controller {
             method: 'post',
             path: `${PREFIX}/:environment/default-strategy`,
             handler: this.updateDefaultStrategyForProjectEnvironment,
-            permission: UPDATE_PROJECT,
+            permission: [UPDATE_PROJECT, PROJECT_DEFAULT_STRATEGY_WRITE],
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],


### PR DESCRIPTION
This appears to have been an oversight in the original implementation
of this endpoint. This seems to be the primary point of this
permission. Additionally, the docs mention that this permission should
allow you to do just that.

Note: I've not added any tests for this, because we don't typically add tests for it. If we have an example to follow, I'd be very happy to add it, though