### PR TITLE
fix: allow you to save default strategies with the right permissions

### DIFF
--- a/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
+++ b/frontend/src/component/feature/StrategyTypes/StrategyVariants.tsx
@@ -27,7 +27,15 @@ export const StrategyVariants: FC<{
     projectId: string;
     environment: string;
     editable?: boolean;
-}> = ({ strategy, setStrategy, projectId, environment, editable }) => {
+    permission?: string | string[];
+}> = ({
+    strategy,
+    setStrategy,
+    projectId,
+    environment,
+    editable,
+    permission = UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+}) => {
     const { trackEvent } = usePlausibleTracker();
     const [variantsEdit, setVariantsEdit] = useState<IFeatureVariantEdit[]>([]);
     const theme = useTheme();
@@ -153,7 +161,7 @@ export const StrategyVariants: FC<{
             <PermissionButton
                 onClick={addVariant}
                 variant='outlined'
-                permission={UPDATE_FEATURE_ENVIRONMENT_VARIANTS}
+                permission={permission}
                 projectId={projectId}
                 environmentId={environment}
                 data-testid='ADD_STRATEGY_VARIANT_BUTTON'

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -19,6 +19,7 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { ProjectDefaultStrategyForm } from './ProjectDefaultStrategyForm';
 import type { CreateFeatureStrategySchema } from 'openapi';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import { UPDATE_PROJECT } from '@server/types/permissions';
 
 export const useDefaultStrategy = (
     projectId: string,
@@ -154,7 +155,7 @@ const EditDefaultStrategy = () => {
                 environmentId={environmentId}
                 onSubmit={onSubmit}
                 loading={loading}
-                permission={PROJECT_DEFAULT_STRATEGY_WRITE}
+                permission={[PROJECT_DEFAULT_STRATEGY_WRITE, UPDATE_PROJECT]}
                 errors={errors}
                 isChangeRequest={false}
             />

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -6,7 +6,7 @@ import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
 import { useEffect, useState } from 'react';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
-import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { PROJECT_DEFAULT_STRATEGY_WRITE } from 'component/providers/AccessProvider/permissions';
 import type { IStrategy } from 'interfaces/strategy';
 import { useRequiredQueryParam } from 'hooks/useRequiredQueryParam';
 import type { ISegment } from 'interfaces/segment';
@@ -154,7 +154,7 @@ const EditDefaultStrategy = () => {
                 environmentId={environmentId}
                 onSubmit={onSubmit}
                 loading={loading}
-                permission={UPDATE_FEATURE_STRATEGY}
+                permission={PROJECT_DEFAULT_STRATEGY_WRITE}
                 errors={errors}
                 isChangeRequest={false}
             />

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectDefaultStrategyForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectDefaultStrategyForm.tsx
@@ -21,11 +21,15 @@ import { FeatureStrategyConstraints } from 'component/feature/FeatureStrategy/Fe
 import { FeatureStrategyType } from 'component/feature/FeatureStrategy/FeatureStrategyType/FeatureStrategyType';
 import { FeatureStrategyTitle } from 'component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyTitle/FeatureStrategyTitle';
 import { StrategyVariants } from 'component/feature/StrategyTypes/StrategyVariants';
+import {
+    PROJECT_DEFAULT_STRATEGY_WRITE,
+    UPDATE_PROJECT,
+} from '@server/types/permissions';
 
 interface IProjectDefaultStrategyFormProps {
     projectId: string;
     environmentId: string;
-    permission: string;
+    permission: string | string[];
     onSubmit: () => void;
     onCancel?: () => void;
     loading: boolean;
@@ -186,6 +190,10 @@ export const ProjectDefaultStrategyForm = ({
                         setStrategy={setStrategy}
                         environment={environmentId}
                         projectId={projectId}
+                        permission={[
+                            PROJECT_DEFAULT_STRATEGY_WRITE,
+                            UPDATE_PROJECT,
+                        ]}
                     />
                 }
             />

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
@@ -1,13 +1,16 @@
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { StrategyItemContainer } from 'component/common/StrategyItemContainer/StrategyItemContainer';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
-import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
 import { Link } from 'react-router-dom';
 import Edit from '@mui/icons-material/Edit';
 import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution';
 import type { ProjectEnvironmentType } from 'interfaces/environments';
 import { useMemo } from 'react';
 import type { CreateFeatureStrategySchema } from 'openapi';
+import {
+    PROJECT_DEFAULT_STRATEGY_WRITE,
+    UPDATE_PROJECT,
+} from '@server/types/permissions';
 
 interface ProjectEnvironmentDefaultStrategyProps {
     environment: ProjectEnvironmentType;
@@ -59,7 +62,10 @@ const ProjectEnvironmentDefaultStrategy = ({
                 actions={
                     <>
                         <PermissionIconButton
-                            permission={UPDATE_FEATURE_STRATEGY}
+                            permission={[
+                                PROJECT_DEFAULT_STRATEGY_WRITE,
+                                UPDATE_PROJECT,
+                            ]}
                             environmentId={environmentId}
                             projectId={projectId}
                             component={Link}


### PR DESCRIPTION
Allow you to edit default strategies in the UI if you have the update_project or project_default_strategy_write permissions. These are the same permissions that we use in the API.

Previously, we used the update_feature_strategy permission here, but that one is intended to be used for updating strategies belonging to actual flags.

One of the trickier bits here is that we use the `StrategyVariants` component, which previously had baked in the permission required (update_feature_environment_variants). Because the permissions are different for the default strategy, I updated the component to make it configurable, but for the default to be the old permission (so that other uses aren't affected).