### PR TITLE
fix: Also display strategy variant information on default strategies

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
@@ -8,7 +8,6 @@ import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview
 import type { ProjectEnvironmentType } from 'interfaces/environments';
 import { useMemo } from 'react';
 import type { CreateFeatureStrategySchema } from 'openapi';
-import { Box } from '@mui/material';
 import SplitPreviewSlider from 'component/feature/StrategyTypes/SplitPreviewSlider/SplitPreviewSlider';
 
 interface ProjectEnvironmentDefaultStrategyProps {
@@ -78,15 +77,9 @@ const ProjectEnvironmentDefaultStrategy = ({
             >
                 <StrategyExecution strategy={strategy} />
 
-                {strategy.variants &&
-                    strategy.variants.length > 0 &&
-                    (strategy.disabled ? (
-                        <Box sx={{ opacity: '0.5' }}>
-                            <SplitPreviewSlider variants={strategy.variants} />
-                        </Box>
-                    ) : (
-                        <SplitPreviewSlider variants={strategy.variants} />
-                    ))}
+                {strategy.variants && strategy.variants.length > 0 ? (
+                    <SplitPreviewSlider variants={strategy.variants} />
+                ) : null}
             </StrategyItemContainer>
         </>
     );

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
@@ -8,6 +8,8 @@ import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview
 import type { ProjectEnvironmentType } from 'interfaces/environments';
 import { useMemo } from 'react';
 import type { CreateFeatureStrategySchema } from 'openapi';
+import { Box } from '@mui/material';
+import SplitPreviewSlider from 'component/feature/StrategyTypes/SplitPreviewSlider/SplitPreviewSlider';
 
 interface ProjectEnvironmentDefaultStrategyProps {
     environment: ProjectEnvironmentType;
@@ -75,6 +77,16 @@ const ProjectEnvironmentDefaultStrategy = ({
                 }
             >
                 <StrategyExecution strategy={strategy} />
+
+                {strategy.variants &&
+                    strategy.variants.length > 0 &&
+                    (strategy.disabled ? (
+                        <Box sx={{ opacity: '0.5' }}>
+                            <SplitPreviewSlider variants={strategy.variants} />
+                        </Box>
+                    ) : (
+                        <SplitPreviewSlider variants={strategy.variants} />
+                    ))}
             </StrategyItemContainer>
         </>
     );


### PR DESCRIPTION
This change copies (and then simplifies) the strategy variant display logic from
`frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx`
and inserts it into the `ProjectEnvironmentDefaultStrategy` component.

Before:
![image](https://github.com/user-attachments/assets/c00098c3-3161-4a89-a6cf-8db711b4fb3e)


After:
![image](https://github.com/user-attachments/assets/4fdd46f1-97a4-4344-98e1-16c842947a1c)
