### PR TITLE
fix: invert logic

### DIFF
--- a/frontend/src/component/environments/CreateEnvironmentButton/CreateEnvironmentButton.tsx
+++ b/frontend/src/component/environments/CreateEnvironmentButton/CreateEnvironmentButton.tsx
@@ -10,7 +10,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 
 export const CreateEnvironmentButton = () => {
     const navigate = useNavigate();
-    const disabled = useUiFlag('EEA');
+    const disabled = !useUiFlag('EEA');
 
     const endIcon = disabled ? (
         <ThemeMode


### PR DESCRIPTION
The EEA flag is present in enterprise instances which currently is blocking enterprise customers from accessing this button. This PR inverts the logic that was changed in #7796.