### PR TITLE
chore: remove debug logs

### DIFF
--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -964,16 +964,6 @@ export default class ProjectService {
                 (role) => role.permissions,
             );
 
-            this.logger.info('-----------');
-            this.logger.info(
-                `filteredUserPermissions:  ${JSON.stringify(filteredUserPermissions, null, 2)}`,
-            );
-            this.logger.info(
-                `rolesToBeAssignedPermissions,
-                ${JSON.stringify(rolesToBeAssignedPermissions, null, 2)}`,
-            );
-            this.logger.info('-----------');
-
             return canGrantProjectRole(
                 filteredUserPermissions,
                 rolesToBeAssignedPermissions,


### PR DESCRIPTION
We used these logs to debug an issue in sandbox regarding permissions. They are no longer needed.