### PR TITLE
fix: docker warnings.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=20.16.0-alpine
 
-FROM node:$NODE_VERSION as builder
+FROM node:$NODE_VERSION AS builder
 
 WORKDIR /unleash
 
@@ -21,9 +21,9 @@ RUN yarn workspaces focus -A --production
 
 FROM node:$NODE_VERSION
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
-ENV TZ UTC
+ENV TZ=UTC
 
 WORKDIR /unleash
 


### PR DESCRIPTION
 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 24)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
