### PR TITLE
chore: add eventTimeline feature flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -90,6 +90,7 @@ export type UiFlags = {
     archiveProjects?: boolean;
     projectListImprovements?: boolean;
     onboardingUI?: boolean;
+    eventTimeline?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -63,7 +63,8 @@ export type IFlagKey =
     | 'addonUsageMetrics'
     | 'onboardingMetrics'
     | 'onboardingUI'
-    | 'projectRoleAssignment';
+    | 'projectRoleAssignment'
+    | 'eventTimeline';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -310,6 +311,10 @@ const flags: IFlags = {
     ),
     projectRoleAssignment: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PROJECT_ROLE_ASSIGNMENT,
+        false,
+    ),
+    eventTimeline: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_EVENT_TIMELINE,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,7 +57,6 @@ process.nextTick(async () => {
                         addonUsageMetrics: true,
                         onboardingMetrics: true,
                         onboardingUI: true,
-                        eventTimeline: true,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,7 @@ process.nextTick(async () => {
                         addonUsageMetrics: true,
                         onboardingMetrics: true,
                         onboardingUI: true,
+                        eventTimeline: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2658/create-eventtimeline-feature-flag

Adds a new `eventTimeline` feature flag for the new event timeline feature.

I think `eventTimeline` is an appropriate name given the feature description and the way it is evolving, but I'm open to suggestions. ~~This also assumes that this feature will target OSS.~~ Confirmed that this will be a premium feature.