### PR TITLE
fix: update playground SDK to increase the possible random numbers used for stickiness id

### DIFF
--- a/src/lib/features/playground/feature-evaluator/strategy/flexible-rollout-strategy.ts
+++ b/src/lib/features/playground/feature-evaluator/strategy/flexible-rollout-strategy.ts
@@ -10,7 +10,7 @@ const STICKINESS = {
 
 export default class FlexibleRolloutStrategy extends Strategy {
     private randomGenerator: Function = () =>
-        `${Math.round(Math.random() * 100) + 1}`;
+        `${Math.round(Math.random() * 10_000) + 1}`;
 
     constructor(radnomGenerator?: Function) {
         super('flexibleRollout');


### PR DESCRIPTION
Same fix as done in some other sdks, such as the node one at
https://github.com/Unleash/unleash-client-node/pull/417o

Fixes an issue where 1% rollout would not yield any results with
random rollout for certain group ids