### PR TITLE
task: make count column bigint. (#8183)

### DIFF
--- a/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
@@ -119,7 +119,7 @@ const variantRowReducerV2 = (acc, tokenRow) => {
         };
     }
     if (variant) {
-        acc[key].variants[variant] = count;
+        acc[key].variants[variant] = Number(count);
     }
 
     return acc;

--- a/src/migrations/20240919083625-client-metrics-env-variants-daily-to-bigint.js
+++ b/src/migrations/20240919083625-client-metrics-env-variants-daily-to-bigint.js
@@ -1,0 +1,7 @@
+exports.up = function(db, cb) {
+    db.runSql(`ALTER TABLE client_metrics_env_variants_daily ALTER COLUMN count TYPE BIGINT`, cb);
+};
+
+exports.down = function(db, cb) {
+    db.runSql(`ALTER TABLE client_metrics_env_variants_daily ALTER COLUMN count TYPE INT`, cb);
+};


### PR DESCRIPTION
We now have customers that exceed INT capacity, so we need to change this to BIGINT in client_metrics_env_variants_daily as well.

Even heavy users only have about 10000 rows here, so should be a quick enough operation.
