### PR TITLE
chore: enables github docker cache

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -68,3 +68,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: NODE_VERSION=${{ matrix.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
So, since we updated to build-push-action@v6 we're now getting a nice summary of the build on the summary page of the action. It pointed out that we're caching 0% of our docker build. Since we probably change our own code more often than we change our dependencies, sharing the initial yarn install step between builds from cache seems to be a good idea.