### PR TITLE
fix: extend feature_toggle_update counter with details about action

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -66,7 +66,6 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
-    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -66,6 +66,7 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
+    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -141,7 +141,7 @@ test('should collect metrics for updated toggles', async () => {
 
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(
-        /feature_toggle_update_total\{toggle="TestToggle",project="default",environment="default",environmentType="production"\} 1/,
+        /feature_toggle_update_total\{toggle="TestToggle",project="default",environment="default",environmentType="production",action="updated"\} 1/,
     );
 });
 
@@ -166,7 +166,7 @@ test('should set environmentType when toggle is flipped', async () => {
     const metrics = await prometheusRegister.metrics();
 
     expect(metrics).toMatch(
-        /feature_toggle_update_total\{toggle="TestToggle",project="default",environment="testEnvironment",environmentType="testType"\} 1/,
+        /feature_toggle_update_total\{toggle="TestToggle",project="default",environment="testEnvironment",environmentType="testType",action="updated"\} 1/,
     );
 });
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -102,7 +102,13 @@ export default class MetricsMonitor {
         const featureFlagUpdateTotal = createCounter({
             name: 'feature_toggle_update_total',
             help: 'Number of times a toggle has been updated. Environment label would be "n/a" when it is not available, e.g. when a feature flag is created.',
-            labelNames: ['toggle', 'project', 'environment', 'environmentType'],
+            labelNames: [
+                'toggle',
+                'project',
+                'environment',
+                'environmentType',
+                'action',
+            ],
         });
         const featureFlagUsageTotal = createCounter({
             name: 'feature_toggle_usage_total',
@@ -782,6 +788,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'n/a',
                 environmentType: 'n/a',
+                action: 'created',
             });
         });
         eventStore.on(FEATURE_VARIANTS_UPDATED, ({ featureName, project }) => {
@@ -790,6 +797,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'n/a',
                 environmentType: 'n/a',
+                action: 'updated',
             });
         });
         eventStore.on(FEATURE_METADATA_UPDATED, ({ featureName, project }) => {
@@ -798,6 +806,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'n/a',
                 environmentType: 'n/a',
+                action: 'updated',
             });
         });
         eventStore.on(FEATURE_UPDATED, ({ featureName, project }) => {
@@ -806,6 +815,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'default',
                 environmentType: 'production',
+                action: 'updated',
             });
         });
         eventStore.on(
@@ -820,6 +830,7 @@ export default class MetricsMonitor {
                     project,
                     environment,
                     environmentType,
+                    action: 'updated',
                 });
             },
         );
@@ -835,6 +846,7 @@ export default class MetricsMonitor {
                     project,
                     environment,
                     environmentType,
+                    action: 'updated',
                 });
             },
         );
@@ -850,6 +862,7 @@ export default class MetricsMonitor {
                     project,
                     environment,
                     environmentType,
+                    action: 'updated',
                 });
             },
         );
@@ -865,6 +878,7 @@ export default class MetricsMonitor {
                     project,
                     environment,
                     environmentType,
+                    action: 'updated',
                 });
             },
         );
@@ -880,6 +894,7 @@ export default class MetricsMonitor {
                     project,
                     environment,
                     environmentType,
+                    action: 'updated',
                 });
             },
         );
@@ -889,6 +904,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'n/a',
                 environmentType: 'n/a',
+                action: 'archived',
             });
         });
         eventStore.on(FEATURE_REVIVED, ({ featureName, project }) => {
@@ -897,6 +913,7 @@ export default class MetricsMonitor {
                 project,
                 environment: 'n/a',
                 environmentType: 'n/a',
+                action: 'revived',
             });
         });
         eventStore.on(PROJECT_CREATED, () => {


### PR DESCRIPTION
Ideally `feature_lifecycle_stage_entered{stage="archived"}` would allow me to see how many flags are archived per week. 
It seems like the numbers for this is a bit off, and wanted to extend our current `feature_toggle_update` counter with action details. 