### PR TITLE
fix: import svg viewbox misalignment

### DIFF
--- a/frontend/src/assets/icons/import.svg
+++ b/frontend/src/assets/icons/import.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 16 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M10.58 10.08L12 11.5L8 15.5L4 11.5L5.42 10.08L7.01 11.67V0.5H8.99V11.67L10.58 10.08ZM16 19V8C16 6.89 15.1 6 14 6H11V8H14V19H2V8H5V6H2C0.889999 6 0 6.89 0 8V19C0 20.1 0.889999 21 2 21H14C15.1 21 16 20.1 16 19Z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
This change updates the import svg's viewbox. It was set to be 24 x
24, but the icon is only 16px wide, causing it to be shifted 4px to
the left, as shown in the following image:

![image](https://github.com/user-attachments/assets/bcaa0526-662b-4d85-b302-8c2dfa46f62d)

By shrinking the viewbox (but keeping the width the same), the icon is
now more correctly aligned:

![image](https://github.com/user-attachments/assets/d77b8b6d-ccc1-448d-bd61-675766b94d0e)
