### PR TITLE
feat: add your projects (with roles) to personal dashboard api

### DIFF
--- a/src/lib/features/personal-dashboard/fake-personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/fake-personal-dashboard-read-model.ts
@@ -1,12 +1,17 @@
 import type {
     IPersonalDashboardReadModel,
     PersonalFeature,
+    PersonalProject,
 } from './personal-dashboard-read-model-type';
 
 export class FakePersonalDashboardReadModel
     implements IPersonalDashboardReadModel
 {
     async getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
+        return [];
+    }
+
+    async getPersonalProjects(userId: number): Promise<PersonalProject[]> {
         return [];
     }
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -79,20 +79,16 @@ const createProject = async (name: string, user: IUser) => {
 };
 
 test('should return personal dashboard with membered projects', async () => {
-    // create project A with user 1
-    // create project B with user 1
     const { body: user1 } = await loginUser('user1@test.com');
     const projectA = await createProject('Project A', user1);
     await createProject('Project B', user1);
 
-    // create project C with user 2
     const { body: user2 } = await loginUser('user2@test.com');
     const projectC = await createProject('Project C', user2);
 
-    // Add user 2 as a member of project A
     await app.services.projectService.addAccess(
         projectA.id,
-        [5],
+        [5], // member role
         [],
         [user2.id],
         user1,

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -54,7 +54,6 @@ test('should return personal dashboard with own flags and favorited flags', asyn
     const { body } = await app.request.get(`/api/admin/personal-dashboard`);
 
     expect(body).toMatchObject({
-        projects: [],
         flags: [
             { name: 'my_feature_d', type: 'release', project: 'default' },
             { name: 'my_feature_c', type: 'release', project: 'default' },

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -99,33 +99,42 @@ test('should return personal dashboard with membered projects', async () => {
         user1,
     );
 
-    // Add user 1 as an owner of project C
-    await app.services.projectService.addAccess(
-        projectC.id,
-        [4],
-        [],
-        [user1.id],
-        user2,
-    );
-
     const { body } = await app.request.get(`/api/admin/personal-dashboard`);
 
     expect(body).toMatchObject({
         projects: [
             {
+                name: 'Default',
+                id: 'default',
+                roles: [
+                    {
+                        name: 'Editor',
+                        id: 2,
+                        type: 'root',
+                    },
+                ],
+            },
+            {
                 name: projectA.name,
                 id: projectA.id,
-                owners: [{ id: user1.id, name: user1.email, imageUrl: '' }],
-                roles: ['member'],
+                roles: [
+                    {
+                        name: 'Member',
+                        id: 5,
+                        type: 'project',
+                    },
+                ],
             },
             {
                 name: projectC.name,
                 id: projectC.id,
-                owners: [
-                    { id: user2.id, name: user2.email, imageUrl: '' },
-                    { id: user1.id, name: user1.email, imageUrl: '' },
+                roles: [
+                    {
+                        name: 'Owner',
+                        id: 4,
+                        type: 'project',
+                    },
                 ],
-                roles: ['owner'],
             },
         ],
     });

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -4,6 +4,7 @@ import {
     setupAppWithAuth,
 } from '../../../test/e2e/helpers/test-helper';
 import getLogger from '../../../test/fixtures/no-logger';
+import type { IUser } from '../../types';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -60,4 +61,76 @@ test('should return personal dashboard with own flags and favorited flags', asyn
             { name: 'other_feature_b', type: 'release', project: 'default' },
         ],
     });
+});
+
+const createProject = async (name: string, user: IUser) => {
+    const auditUser = {
+        id: 1,
+        username: 'audit user',
+        ip: '127.0.0.1',
+    };
+    const project = await app.services.projectService.createProject(
+        {
+            name,
+        },
+        user,
+        auditUser,
+    );
+    return project;
+};
+
+test('should return personal dashboard with membered projects', async () => {
+    // create project A with user 1
+    // create project B with user 1
+    const { body: user1 } = await loginUser('user1@test.com');
+    const projectA = await createProject('Project A', user1);
+    await createProject('Project B', user1);
+
+    // create project C with user 2
+    const { body: user2 } = await loginUser('user2@test.com');
+    const projectC = await createProject('Project C', user2);
+
+    // Add user 2 as a member of project A
+    await app.services.projectService.addAccess(
+        projectA.id,
+        [5],
+        [],
+        [user2.id],
+        user1,
+    );
+
+    // Add user 1 as an owner of project C
+    await app.services.projectService.addAccess(
+        projectC.id,
+        [4],
+        [],
+        [user1.id],
+        user2,
+    );
+
+    const { body } = await app.request.get(`/api/admin/personal-dashboard`);
+
+    expect(body).toMatchObject({
+        projects: [
+            {
+                name: projectA.name,
+                id: projectA.id,
+                owners: [{ id: user1.id, name: user1.email, imageUrl: '' }],
+                roles: ['member'],
+            },
+            {
+                name: projectC.name,
+                id: projectC.id,
+                owners: [
+                    { id: user2.id, name: user2.email, imageUrl: '' },
+                    { id: user1.id, name: user1.email, imageUrl: '' },
+                ],
+                roles: ['owner'],
+            },
+        ],
+    });
+});
+
+test('should return projects where users are part of a group', () => {
+    // TODO
 });

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
@@ -63,11 +63,14 @@ export default class PersonalDashboardController extends Controller {
             user.id,
         );
 
+        const projects =
+            await this.personalDashboardService.getPersonalProjects(user.id);
+
         this.openApiService.respondWithValidation(
             200,
             res,
             personalDashboardSchema.$id,
-            { projects: [], flags },
+            { projects, flags },
         );
     }
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
@@ -2,7 +2,11 @@ export type PersonalFeature = { name: string; type: string; project: string };
 export type PersonalProject = {
     name: string;
     id: string;
-    roles: { name: string; id: number; type: 'custom' | 'project' }[];
+    roles: {
+        name: string;
+        id: number;
+        type: 'custom' | 'project' | 'root' | 'custom-root';
+    }[];
 };
 
 export interface IPersonalDashboardReadModel {

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
@@ -1,5 +1,11 @@
 export type PersonalFeature = { name: string; type: string; project: string };
+export type PersonalProject = {
+    name: string;
+    id: string;
+    roles: { name: string; id: number; type: 'custom' | 'project' }[];
+};
 
 export interface IPersonalDashboardReadModel {
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]>;
+    getPersonalProjects(userId: number): Promise<PersonalProject[]>;
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
@@ -23,7 +23,7 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
             .join('role_user', 'projects.id', 'role_user.project')
             .join('roles', 'role_user.role_id', 'roles.id')
             .where('role_user.user_id', userId)
-            .whereNull('project.archived_at')
+            .whereNull('projects.archived_at')
             .select(
                 'projects.name',
                 'projects.id',
@@ -31,12 +31,9 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
                 'roles.name as roleName',
                 'roles.type as roleType',
             )
-            .orderBy('projects.name', 'desc')
             .limit(100);
 
-        console.log(result);
-
-        return result.reduce((acc, row) => {
+        const dict = result.reduce((acc, row) => {
             if (acc[row.id]) {
                 acc[row.id].roles.push({
                     id: row.roleId,
@@ -58,6 +55,10 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
             }
             return acc;
         }, {});
+
+        const projectList: PersonalProject[] = Object.values(dict);
+        projectList.sort((a, b) => a.name.localeCompare(b.name));
+        return projectList;
     }
 
     async getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -1,6 +1,7 @@
 import type {
     IPersonalDashboardReadModel,
     PersonalFeature,
+    PersonalProject,
 } from './personal-dashboard-read-model-type';
 
 export class PersonalDashboardService {
@@ -12,5 +13,9 @@ export class PersonalDashboardService {
 
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
         return this.personalDashboardReadModel.getPersonalFeatures(userId);
+    }
+
+    getPersonalProjects(userId: number): Promise<PersonalProject[]> {
+        return this.personalDashboardReadModel.getPersonalProjects(userId);
     }
 }

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -13,7 +13,7 @@ export const personalDashboardSchema = {
             items: {
                 type: 'object',
                 additionalProperties: false,
-                required: ['id', 'name', 'roles'],
+                required: ['id', 'name', 'roles', 'owners'],
                 properties: {
                     id: {
                         type: 'string',

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -47,7 +47,12 @@ export const personalDashboardSchema = {
                                 },
                                 type: {
                                     type: 'string',
-                                    enum: ['custom', 'project'],
+                                    enum: [
+                                        'custom',
+                                        'project',
+                                        'root',
+                                        'custom-root',
+                                    ],
                                     example: 'project',
                                     description: 'The type of the role',
                                 },

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -1,5 +1,4 @@
 import type { FromSchema } from 'json-schema-to-ts';
-import { projectSchema } from './project-schema';
 
 export const personalDashboardSchema = {
     $id: '#/components/schemas/personalDashboardSchema',
@@ -13,7 +12,7 @@ export const personalDashboardSchema = {
             items: {
                 type: 'object',
                 additionalProperties: false,
-                required: ['id', 'name', 'roles', 'owners'],
+                required: ['id', 'name', 'roles'],
                 properties: {
                     id: {
                         type: 'string',
@@ -25,7 +24,6 @@ export const personalDashboardSchema = {
                         example: 'My Project',
                         description: 'The name of the project',
                     },
-                    owners: projectSchema.properties.owners,
                     roles: {
                         type: 'array',
                         description:

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -12,12 +12,47 @@ export const personalDashboardSchema = {
             items: {
                 type: 'object',
                 additionalProperties: false,
-                required: ['id'],
+                required: ['id', 'name', 'roles'],
                 properties: {
                     id: {
                         type: 'string',
                         example: 'my-project-id',
                         description: 'The id of the project',
+                    },
+                    name: {
+                        type: 'string',
+                        example: 'My Project',
+                        description: 'The name of the project',
+                    },
+                    roles: {
+                        type: 'array',
+                        description:
+                            'The list of roles that the user has in this project.',
+                        minItems: 1,
+                        items: {
+                            type: 'object',
+                            description: 'An Unleash role.',
+                            additionalProperties: false,
+                            required: ['name', 'id', 'type'],
+                            properties: {
+                                name: {
+                                    type: 'string',
+                                    example: 'Owner',
+                                    description: 'The name of the role',
+                                },
+                                id: {
+                                    type: 'integer',
+                                    example: 4,
+                                    description: 'The id of the role',
+                                },
+                                type: {
+                                    type: 'string',
+                                    enum: ['custom', 'project'],
+                                    example: 'project',
+                                    description: 'The type of the role',
+                                },
+                            },
+                        },
                     },
                 },
             },

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -1,4 +1,5 @@
 import type { FromSchema } from 'json-schema-to-ts';
+import { projectSchema } from './project-schema';
 
 export const personalDashboardSchema = {
     $id: '#/components/schemas/personalDashboardSchema',
@@ -24,6 +25,7 @@ export const personalDashboardSchema = {
                         example: 'My Project',
                         description: 'The name of the project',
                     },
+                    owners: projectSchema.properties.owners,
                     roles: {
                         type: 'array',
                         description:


### PR DESCRIPTION
This PR adds some of the necessary project data to the personal dashboard API: project names and ids, and the roles that the user has in each of these projects.

I have not added project owners yet, as that would increase the complexity a bit and I'd rather focus on that in a separate PR.

I have also not added projects you are part of through a group, though I have added a placeholder test for that. I will address this in a follow-up.