### PR TITLE
feat(onboarding): Rust SDK snippet

### DIFF
--- a/frontend/src/component/onboarding/snippets/rust.md
+++ b/frontend/src/component/onboarding/snippets/rust.md
@@ -1,17 +1,52 @@
 1\. Install the SDK
 ```sh
-cargo add unleash-client
+cargo add unleash-api-client --features async-std,reqwest,surf
+cargo add serde --features derive
+cargo add serde reqwest --features json
+cargo add serde tokio --features full
+cargo add serde anyhow cfg cfg-if enum-map@~2.0.0 surf
 ```
 
 2\. Initialize Unleash
 ```rust
-let client = client::ClientBuilder::default()
-    .interval(500)
-    .into_client::<UserFeatures, reqwest::Client>(
-        "<YOUR_API_URL>",
-        "unleash-onboarding-rust",
-        "unleash-onboarding-instance",
-        "<YOUR_API_TOKEN>",
-    )?;
-client.register().await?;
+use enum_map::Enum;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::time::Duration;
+use tokio::time::sleep;
+use unleash_api_client::client::ClientBuilder;
+use unleash_api_client::Client;
+
+#[derive(Debug, Deserialize, Serialize, Enum, Clone)]
+enum Flags {
+    #[serde(rename = "<YOUR_FLAG>")]
+    TestFlag,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let client: Client<Flags, reqwest::Client> = ClientBuilder::default()
+        .interval(5000) // Polling & metrics interval - default 15000 (ms)
+        .into_client(
+            "<YOUR_API_URL>",
+            "unleash-onboarding-rust",
+            "unleash-onboarding-instance",
+            Some("<YOUR_API_TOKEN>".to_owned()),
+        )?;
+    client.register().await?;
+
+    let (_, _) = tokio::join!(client.poll_for_updates(), async {
+        sleep(Duration::from_millis(1000)).await;
+
+        let is_enabled = client.is_enabled(Flags::TestFlag, None, true);
+        println!("\nIs flag enabled: {}\n", is_enabled);
+
+        sleep(Duration::from_millis(5000)).await;
+
+        client.stop_poll().await;
+        Ok::<(), Box<dyn Error + Send + Sync>>(())
+    });
+
+    Ok(())
+}
 ```


### PR DESCRIPTION
A bit different then other examples - only way to run current state of Rust SDK is to have some kind of an opinionated setup around it.