### PR TITLE
chore: remove the projects? Property from ICreateGroupModel

### DIFF
--- a/src/lib/types/group.ts
+++ b/src/lib/types/group.ts
@@ -36,7 +36,6 @@ export interface IGroupModel extends IGroup {
 
 export interface ICreateGroupModel extends Omit<IGroup, 'id'> {
     users?: ICreateGroupUserModel[];
-    projects?: string[];
 }
 
 export interface IGroupProject {


### PR DESCRIPTION
This property does not seem to be used anywhere, so we can remove it.

Can't find any references in code here or in enterprise. Let's try it and see if it breaks.