### PR TITLE
feat: add project owners to personal dashboard project payload

### DIFF
--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -110,7 +110,11 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'root',
                     },
                 ],
-                owners: [],
+                owners: [
+                    {
+                        ownerType: 'system',
+                    },
+                ],
             },
             {
                 name: projectA.name,
@@ -122,7 +126,15 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'project',
                     },
                 ],
-                owners: [],
+                owners: [
+                    {
+                        email: 'user1@test.com',
+                        imageUrl:
+                            'https://gravatar.com/avatar/a8cc79d8407a64b0d8982df34e3525afd298a479fe68f300651380730dbf23e9?s=42&d=retro&r=g',
+                        name: 'user1@test.com',
+                        ownerType: 'user',
+                    },
+                ],
             },
             {
                 name: projectC.name,
@@ -134,7 +146,15 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'project',
                     },
                 ],
-                owners: [],
+                owners: [
+                    {
+                        email: 'user2@test.com',
+                        imageUrl:
+                            'https://gravatar.com/avatar/706150f3ef810ea66acb30c6d55f1a7e545338747072609e47df71c7c7ccc6a4?s=42&d=retro&r=g',
+                        name: 'user2@test.com',
+                        ownerType: 'user',
+                    },
+                ],
             },
         ],
     });
@@ -184,7 +204,11 @@ test('should return projects where users are part of a group', async () => {
                         type: 'root',
                     },
                 ],
-                owners: [],
+                owners: [
+                    {
+                        ownerType: 'system',
+                    },
+                ],
             },
             {
                 name: projectA.name,
@@ -201,7 +225,19 @@ test('should return projects where users are part of a group', async () => {
                         type: 'project',
                     },
                 ],
-                owners: [],
+                owners: [
+                    {
+                        email: 'user1@test.com',
+                        imageUrl:
+                            'https://gravatar.com/avatar/a8cc79d8407a64b0d8982df34e3525afd298a479fe68f300651380730dbf23e9?s=42&d=retro&r=g',
+                        name: 'user1@test.com',
+                        ownerType: 'user',
+                    },
+                    {
+                        name: 'groupA',
+                        ownerType: 'group',
+                    },
+                ],
             },
         ],
     });

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -110,6 +110,7 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'root',
                     },
                 ],
+                owners: [],
             },
             {
                 name: projectA.name,
@@ -121,6 +122,7 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'project',
                     },
                 ],
+                owners: [],
             },
             {
                 name: projectC.name,
@@ -132,6 +134,7 @@ test('should return personal dashboard with membered projects', async () => {
                         type: 'project',
                     },
                 ],
+                owners: [],
             },
         ],
     });
@@ -181,6 +184,7 @@ test('should return projects where users are part of a group', async () => {
                         type: 'root',
                     },
                 ],
+                owners: [],
             },
             {
                 name: projectA.name,
@@ -197,6 +201,7 @@ test('should return projects where users are part of a group', async () => {
                         type: 'project',
                     },
                 ],
+                owners: [],
             },
         ],
     });

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
@@ -1,3 +1,5 @@
+import type { ProjectOwners } from '../project/project-owners-read-model.type';
+
 export type PersonalFeature = { name: string; type: string; project: string };
 export type PersonalProject = {
     name: string;
@@ -7,6 +9,7 @@ export type PersonalProject = {
         id: number;
         type: 'custom' | 'project' | 'root' | 'custom-root';
     }[];
+    owners: ProjectOwners;
 };
 
 export interface IPersonalDashboardReadModel {

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
@@ -9,6 +9,8 @@ export type PersonalProject = {
         id: number;
         type: 'custom' | 'project' | 'root' | 'custom-root';
     }[];
+};
+export type PersonalProjectWithOwners = PersonalProject & {
     owners: ProjectOwners;
 };
 

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
@@ -1,5 +1,4 @@
 import type { Db } from '../../db/db';
-import type { IProjectOwnersReadModel } from '../project/project-owners-read-model.type';
 import type {
     IPersonalDashboardReadModel,
     PersonalFeature,
@@ -15,11 +14,8 @@ type IntermediateProjectResult = Omit<PersonalProject, 'roles'> & {
 export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
     private db: Db;
 
-    private projectOwnersReadModel: IProjectOwnersReadModel;
-
-    constructor(db: Db, ProjectOwnersReadModel: IProjectOwnersReadModel) {
+    constructor(db: Db) {
         this.db = db;
-        this.projectOwnersReadModel = ProjectOwnersReadModel;
     }
 
     async getPersonalProjects(userId: number): Promise<PersonalProject[]> {
@@ -92,10 +88,7 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
             },
         );
         projectList.sort((a, b) => a.name.localeCompare(b.name));
-        const withOwners =
-            await this.projectOwnersReadModel.addOwners(projectList);
-
-        return withOwners;
+        return projectList;
     }
 
     async getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
@@ -80,7 +80,6 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
             (project: IntermediateProjectResult) => {
                 const roles = Object.values(project.roles);
                 roles.sort((a, b) => a.id - b.id);
-
                 return {
                     ...project,
                     roles,

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -1,21 +1,36 @@
+import type { IProjectOwnersReadModel } from '../project/project-owners-read-model.type';
 import type {
     IPersonalDashboardReadModel,
     PersonalFeature,
-    PersonalProject,
+    PersonalProjectWithOwners,
 } from './personal-dashboard-read-model-type';
 
 export class PersonalDashboardService {
     private personalDashboardReadModel: IPersonalDashboardReadModel;
 
-    constructor(personalDashboardReadModel: IPersonalDashboardReadModel) {
+    private projectOwnersReadModel: IProjectOwnersReadModel;
+
+    constructor(
+        personalDashboardReadModel: IPersonalDashboardReadModel,
+        projectOwnersReadModel: IProjectOwnersReadModel,
+    ) {
         this.personalDashboardReadModel = personalDashboardReadModel;
+        this.projectOwnersReadModel = projectOwnersReadModel;
     }
 
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
         return this.personalDashboardReadModel.getPersonalFeatures(userId);
     }
 
-    getPersonalProjects(userId: number): Promise<PersonalProject[]> {
-        return this.personalDashboardReadModel.getPersonalProjects(userId);
+    async getPersonalProjects(
+        userId: number,
+    ): Promise<PersonalProjectWithOwners[]> {
+        const projects =
+            await this.personalDashboardReadModel.getPersonalProjects(userId);
+
+        const withOwners =
+            await this.projectOwnersReadModel.addOwners(projects);
+
+        return withOwners;
     }
 }

--- a/src/lib/features/project/fake-project-owners-read-model.ts
+++ b/src/lib/features/project/fake-project-owners-read-model.ts
@@ -1,13 +1,12 @@
 import type {
     IProjectOwnersReadModel,
-    IProjectForUiWithOwners,
+    WithProjectOwners,
 } from './project-owners-read-model.type';
-import type { ProjectForUi } from './project-read-model-type';
 
 export class FakeProjectOwnersReadModel implements IProjectOwnersReadModel {
-    async addOwners(
-        projects: ProjectForUi[],
-    ): Promise<IProjectForUiWithOwners[]> {
+    async addOwners<T extends { id: string }>(
+        projects: T[],
+    ): Promise<WithProjectOwners<T>> {
         return projects.map((project) => ({
             ...project,
             owners: [{ ownerType: 'system' }],

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -63,7 +63,10 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
 
             const data: UserProjectOwner = {
                 ownerType: 'user',
-                name: user?.name || user?.username,
+                name:
+                    user?.name ||
+                    user?.username ||
+                    processSensitiveData(user?.email),
                 email: processSensitiveData(user?.email),
                 imageUrl: generateImageUrl(user),
             };

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -6,7 +6,7 @@ import type {
     IProjectOwnersReadModel,
     ProjectOwnersDictionary,
     UserProjectOwner,
-    ProjectOwners,
+    WithProjectOwners,
 } from './project-owners-read-model.type';
 
 const T = {
@@ -15,10 +15,6 @@ const T = {
     ROLES: 'roles',
     USERS: 'users',
 };
-
-type WithProjectOwners<T extends { id: string }> = (T & {
-    owners: ProjectOwners;
-})[];
 
 export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
     private db: Db;

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -4,11 +4,10 @@ import { anonymise, generateImageUrl } from '../../util';
 import type {
     GroupProjectOwner,
     IProjectOwnersReadModel,
-    IProjectForUiWithOwners,
     ProjectOwnersDictionary,
     UserProjectOwner,
+    ProjectOwners,
 } from './project-owners-read-model.type';
-import type { ProjectForUi } from './project-read-model-type';
 
 const T = {
     ROLE_USER: 'role_user',
@@ -17,6 +16,10 @@ const T = {
     USERS: 'users',
 };
 
+type WithProjectOwners<T extends { id: string }> = (T & {
+    owners: ProjectOwners;
+})[];
+
 export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
     private db: Db;
 
@@ -24,10 +27,10 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
         this.db = db;
     }
 
-    static addOwnerData(
-        projects: ProjectForUi[],
+    static addOwnerData<T extends { id: string }>(
+        projects: T[],
         owners: ProjectOwnersDictionary,
-    ): IProjectForUiWithOwners[] {
+    ): WithProjectOwners<T> {
         return projects.map((project) => ({
             ...project,
             owners: owners[project.id] || [{ ownerType: 'system' }],
@@ -138,10 +141,10 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
         return dict;
     }
 
-    async addOwners(
-        projects: ProjectForUi[],
+    async addOwners<T extends { id: string }>(
+        projects: T[],
         anonymizeProjectOwners: boolean = false,
-    ): Promise<IProjectForUiWithOwners[]> {
+    ): Promise<WithProjectOwners<T>> {
         const owners = await this.getAllProjectOwners(anonymizeProjectOwners);
 
         return ProjectOwnersReadModel.addOwnerData(projects, owners);

--- a/src/lib/features/project/project-owners-read-model.type.ts
+++ b/src/lib/features/project/project-owners-read-model.type.ts
@@ -11,7 +11,7 @@ export type GroupProjectOwner = {
     ownerType: 'group';
     name: string;
 };
-type ProjectOwners =
+export type ProjectOwners =
     | [SystemOwner]
     | Array<UserProjectOwner | GroupProjectOwner>;
 

--- a/src/lib/features/project/project-owners-read-model.type.ts
+++ b/src/lib/features/project/project-owners-read-model.type.ts
@@ -21,9 +21,13 @@ export type IProjectForUiWithOwners = ProjectForUi & {
     owners: ProjectOwners;
 };
 
+export type WithProjectOwners<T extends { id: string }> = (T & {
+    owners: ProjectOwners;
+})[];
+
 export interface IProjectOwnersReadModel {
-    addOwners(
-        projects: ProjectForUi[],
+    addOwners<T extends { id: string }>(
+        projects: T[],
         anonymizeProjectOwners?: boolean,
-    ): Promise<IProjectForUiWithOwners[]>;
+    ): Promise<WithProjectOwners<T>>;
 }

--- a/src/lib/openapi/spec/personal-dashboard-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-schema.ts
@@ -1,4 +1,5 @@
 import type { FromSchema } from 'json-schema-to-ts';
+import { projectSchema } from './project-schema';
 
 export const personalDashboardSchema = {
     $id: '#/components/schemas/personalDashboardSchema',
@@ -24,6 +25,7 @@ export const personalDashboardSchema = {
                         example: 'My Project',
                         description: 'The name of the project',
                     },
+                    owners: projectSchema.properties.owners,
                     roles: {
                         type: 'array',
                         description:

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -149,6 +149,7 @@ import { OnboardingService } from '../features/onboarding/onboarding-service';
 import { PersonalDashboardService } from '../features/personal-dashboard/personal-dashboard-service';
 import { PersonalDashboardReadModel } from '../features/personal-dashboard/personal-dashboard-read-model';
 import { FakePersonalDashboardReadModel } from '../features/personal-dashboard/fake-personal-dashboard-read-model';
+import { ProjectOwnersReadModel } from '../features/project/project-owners-read-model';
 
 export const createServices = (
     stores: IUnleashStores,
@@ -406,7 +407,7 @@ export const createServices = (
 
     const personalDashboardService = new PersonalDashboardService(
         db
-            ? new PersonalDashboardReadModel(db)
+            ? new PersonalDashboardReadModel(db, new ProjectOwnersReadModel(db))
             : new FakePersonalDashboardReadModel(),
     );
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -150,6 +150,7 @@ import { PersonalDashboardService } from '../features/personal-dashboard/persona
 import { PersonalDashboardReadModel } from '../features/personal-dashboard/personal-dashboard-read-model';
 import { FakePersonalDashboardReadModel } from '../features/personal-dashboard/fake-personal-dashboard-read-model';
 import { ProjectOwnersReadModel } from '../features/project/project-owners-read-model';
+import { FakeProjectOwnersReadModel } from '../features/project/fake-project-owners-read-model';
 
 export const createServices = (
     stores: IUnleashStores,
@@ -407,8 +408,10 @@ export const createServices = (
 
     const personalDashboardService = new PersonalDashboardService(
         db
-            ? new PersonalDashboardReadModel(db, new ProjectOwnersReadModel(db))
+            ? new PersonalDashboardReadModel(db)
             : new FakePersonalDashboardReadModel(),
+
+        db ? new ProjectOwnersReadModel(db) : new FakeProjectOwnersReadModel(),
     );
 
     return {


### PR DESCRIPTION
This PR adds project owner information to the personal dashboard's project payload.

To do so, it uses the existing project owners read model.

I've had to make a few changes to the project owners read model to accomodate this:
- make the input type to `addOwners` more lenient. We only need the project ids, so we can make that the only required property
- fall back to using email as the name if the user has no name or username (such as if you sign up with the demo auth)

## Discussion points

Should we pass the anonymize emails flag here? I've got a vague memory that we actually anonymize them in the db now, so we don't need to here, but I can't remember exactly. (Update: emails are encrypted on creation in demo; this shouldn't be necessary: https://unleash-internal.slack.com/archives/C046LV6HH6W/p1722514435046269)

I've also used a shortcut for populating the schema: just copied in the property from the project schema. Should we write it out in full?