### PR TITLE
test: reduce noise from test warnings

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
 import 'regenerator-runtime';
+import { beforeAll, vi } from 'vitest';
 
 class ResizeObserver {
     observe() {}
@@ -13,3 +14,20 @@ if (!window.ResizeObserver) {
 }
 
 process.env.TZ = 'UTC';
+
+// ignore known React warnings
+const consoleError = console.error;
+beforeAll(() => {
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+        if (
+            !(
+                typeof args[0] === 'string' &&
+                args[0].includes(
+                    'Warning: An update to %s inside a test was not wrapped in act',
+                )
+            )
+        ) {
+            consoleError(...args);
+        }
+    });
+});

--- a/frontend/src/utils/testServer.ts
+++ b/frontend/src/utils/testServer.ts
@@ -4,7 +4,13 @@ import { http, HttpResponse } from 'msw';
 export const testServerSetup = (): SetupServer => {
     const server = setupServer();
 
-    beforeAll(() => server.listen());
+    beforeAll(() =>
+        server.listen({
+            onUnhandledRequest() {
+                return HttpResponse.error();
+            },
+        }),
+    );
     afterAll(() => server.close());
     afterEach(() => server.resetHandlers());
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Reducing noise in frontend tests

Most of the console warn logs we get in frontend tests are:
* wrap React in act warnings (since we use react testing library it shouldn't be needed)
* MSW HTTP mock not setup

The first warning will be hopefully gone with those issues fixed:
* https://github.com/testing-library/react-testing-library/issues/1338
* https://github.com/testing-library/react-testing-library/issues/1216

The second warning we can ignore since we don't need to setup every HTTP interaction to make our tests pass and returning error by default should be fine.

By reducing those warning we are left with the important warnings that we can act upon

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
