### PR TITLE
fix: layout content width on large screens

### DIFF
--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -117,7 +117,7 @@ export const MainLayout = forwardRef<HTMLDivElement, IMainLayoutProps>(
         const { isChangeRequestConfiguredInAnyEnv } = useChangeRequestsEnabled(
             projectId || '',
         );
-        const eventTimeline = useUiFlag('eventTimeline'); // && !isOss();
+        const eventTimeline = useUiFlag('eventTimeline') && !isOss();
         const { open: showTimeline, setOpen: setShowTimeline } =
             useEventTimeline();
 

--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -67,6 +67,9 @@ const NewMainLayoutContent = styled(Grid)(({ theme }) => ({
     margin: '0 auto',
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
+    [theme.breakpoints.up(1856)]: {
+        width: '100%',
+    },
     [theme.breakpoints.down(1856)]: {
         marginLeft: theme.spacing(7),
         marginRight: theme.spacing(7),
@@ -114,7 +117,7 @@ export const MainLayout = forwardRef<HTMLDivElement, IMainLayoutProps>(
         const { isChangeRequestConfiguredInAnyEnv } = useChangeRequestsEnabled(
             projectId || '',
         );
-        const eventTimeline = useUiFlag('eventTimeline') && !isOss();
+        const eventTimeline = useUiFlag('eventTimeline'); // && !isOss();
         const { open: showTimeline, setOpen: setShowTimeline } =
             useEventTimeline();
 


### PR DESCRIPTION
I believe the changes in https://github.com/Unleash/unleash/pull/8234, more specifically [this change](https://github.com/Unleash/unleash/pull/8234/files#diff-3a5e0763fe1effa9cd485763fecf0633ce8f0877c9d1971e6bd5c5abe7426364L64), have caused the main layout content to no longer stretch to its maximum relative width on larger screens.

This adjustment seems to resolve this issue, ensuring proper behavior on larger screens without introducing any overflow issues on smaller screens.