### PR TITLE
feat: get projects by ids

### DIFF
--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -1,5 +1,5 @@
 import type { ProjectMode } from '../../types';
-import type { IProjectQuery } from './project-store-type';
+import type { IProjectQuery, IProjectsQuery } from './project-store-type';
 
 export type ProjectForUi = {
     id: string;
@@ -28,7 +28,7 @@ export type ProjectForInsights = {
 
 export interface IProjectReadModel {
     getProjectsForAdminUi(
-        query?: IProjectQuery,
+        query?: IProjectQuery & IProjectsQuery,
         userId?: number,
     ): Promise<ProjectForUi[]>;
     getProjectsForInsights(

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -6,7 +6,7 @@ import type {
     ProjectForInsights,
     ProjectForUi,
 } from './project-read-model-type';
-import type { IProjectQuery } from './project-store-type';
+import type { IProjectQuery, IProjectsQuery } from './project-store-type';
 import metricsHelper from '../../util/metrics-helper';
 import type EventEmitter from 'events';
 import type { IProjectMembersCount } from './project-store';
@@ -79,7 +79,7 @@ export class ProjectReadModel implements IProjectReadModel {
     }
 
     async getProjectsForAdminUi(
-        query?: IProjectQuery,
+        query?: IProjectQuery & IProjectsQuery,
         userId?: number,
     ): Promise<ProjectForUi[]> {
         const projectTimer = this.timer('getProjectsForAdminUi');
@@ -112,6 +112,9 @@ export class ProjectReadModel implements IProjectReadModel {
 
         if (query?.id) {
             projects = projects.where(`${TABLE}.id`, query.id);
+        }
+        if (query?.ids) {
+            projects = projects.whereIn(`${TABLE}.id`, query.ids);
         }
 
         let selectColumns = [

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -152,6 +152,11 @@ test('should create new project', async () => {
     expect(project.name).toEqual(ret.name);
     expect(project.description).toEqual(ret.description);
     expect(ret.createdAt).toBeTruthy();
+
+    const projectsById = await projectService.getProjects({ id: 'test' });
+    const projectsByIds = await projectService.getProjects({ ids: ['test'] });
+    expect(projectsById).toMatchObject([{ id: 'test' }]);
+    expect(projectsByIds).toMatchObject([{ id: 'test' }]);
 });
 
 test('should create new private project', async () => {

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -83,6 +83,7 @@ import type {
     IProjectApplicationsSearchParams,
     IProjectEnterpriseSettingsUpdate,
     IProjectQuery,
+    IProjectsQuery,
 } from './project-store-type';
 import type { IProjectFlagCreatorsReadModel } from './project-flag-creators-read-model.type';
 import { throwExceedsLimitError } from '../../error/exceeds-limit-error';
@@ -230,13 +231,13 @@ export default class ProjectService {
     }
 
     async getProjects(
-        query?: IProjectQuery,
+        query?: IProjectQuery & IProjectsQuery,
         userId?: number,
     ): Promise<ProjectForUi[]> {
-        const getProjects = () =>
-            this.projectReadModel.getProjectsForAdminUi(query, userId);
-
-        const projects = await getProjects();
+        const projects = await this.projectReadModel.getProjectsForAdminUi(
+            query,
+            userId,
+        );
 
         if (userId) {
             const projectAccess =

--- a/src/lib/features/project/project-store-type.ts
+++ b/src/lib/features/project/project-store-type.ts
@@ -48,6 +48,10 @@ export interface IProjectQuery {
     archived?: boolean;
 }
 
+export interface IProjectsQuery {
+    ids?: string[];
+}
+
 export type ProjectEnvironment = {
     environment: string;
     changeRequestEnabled?: boolean;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding ability to read projects by multiple ids.

Background:
In the personal dashboard we need to return a list of user projects with health/flags counts/members count (that a user is a member of or favorited). My plan is to have a separate query to read user project ids and then pass those ids to the existing query. This way we can orchestrate the desired behavior in a service without writing new complex queries. 

<img width="494" alt="Screenshot 2024-09-26 at 10 38 54" src="https://github.com/user-attachments/assets/ea0026d2-e87d-451e-8527-b14698a6f2bf">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I considered changing query param id to query param ids (plural) in place, but since we use the single id in a few places I find it safer to add a new property and not touch the existing code. 