### PR TITLE
fix: add foreign key constraint to role_permissions table

### DIFF
--- a/src/lib/features/access/createAccessService.ts
+++ b/src/lib/features/access/createAccessService.ts
@@ -1,4 +1,4 @@
-import type { Db, IUnleashConfig } from '../../server-impl';
+import type { Db, IUnleashConfig, Knex } from '../../server-impl';
 import GroupStore from '../../db/group-store';
 import { AccountStore } from '../../db/account-store';
 import RoleStore from '../../db/role-store';
@@ -17,6 +17,11 @@ import {
     createFakeEventsService,
 } from '../events/createEventsService';
 
+// We need this function to satisfy the type expectations of withTransactional
+export const curriedCreateAccessService =
+    (config: IUnleashConfig) => (db: Knex) =>
+        createAccessService(db, config);
+
 export const createAccessService = (
     db: Db,
     config: IUnleashConfig,
@@ -33,6 +38,7 @@ export const createAccessService = (
         { getLogger },
         eventService,
     );
+
     return new AccessService(
         { accessStore, accountStore, roleStore, environmentStore },
         { getLogger },

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -108,6 +108,15 @@ export interface AccessWithRoles {
 
 const isProjectPermission = (permission) => PROJECT_ADMIN.includes(permission);
 
+export const cleanPermissions = (permissions: PermissionRef[] | undefined) => {
+    return permissions?.map((permission) => {
+        if (permission.environment === '') {
+            return { ...permission, environment: null };
+        }
+        return permission;
+    });
+};
+
 export class AccessService {
     private store: IAccessStore;
 
@@ -721,7 +730,8 @@ export class AccessService {
             roleType,
         };
 
-        const rolePermissions = role.permissions;
+        const rolePermissions = cleanPermissions(role.permissions);
+
         const newRole = await this.roleStore.create(baseRole);
         if (rolePermissions) {
             if (roleType === CUSTOM_ROOT_ROLE_TYPE) {
@@ -770,7 +780,9 @@ export class AccessService {
             description: role.description,
             roleType,
         };
-        const rolePermissions = role.permissions;
+
+        const rolePermissions = cleanPermissions(role.permissions);
+
         const updatedRole = await this.roleStore.update(baseRole);
         const existingPermissions = await this.store.getPermissionsForRole(
             role.id,

--- a/src/lib/services/clean-permissions.test.ts
+++ b/src/lib/services/clean-permissions.test.ts
@@ -1,0 +1,59 @@
+import { cleanPermissions } from './access-service';
+
+test('should convert all empty strings to null', () => {
+    const permissions = [
+        {
+            name: 'UPDATE_PROJECT',
+            environment: '',
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: '',
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: '',
+        },
+    ];
+
+    const result = cleanPermissions(permissions);
+
+    expect(result).toEqual([
+        {
+            name: 'UPDATE_PROJECT',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: null,
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: null,
+        },
+    ]);
+});

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,4 +1,5 @@
 import type {
+    IUnleash,
     IUnleashConfig,
     IUnleashServices,
     IUnleashStores,
@@ -65,12 +66,14 @@ import ConfigurationRevisionService from '../features/feature-toggle/configurati
 import {
     createEnvironmentService,
     createEventsService,
+    createFakeAccessService,
     createFakeEnvironmentService,
     createFakeEventsService,
     createFakeProjectService,
     createFeatureLifecycleService,
     createFeatureToggleService,
     createProjectService,
+    curriedCreateAccessService,
 } from '../features';
 import EventAnnouncerService from './event-announcer-service';
 import { createGroupService } from '../features/group/createGroupService';
@@ -166,6 +169,11 @@ export const createServices = (
         groupService,
         eventService,
     );
+
+    const transactionalAccessService = db
+        ? withTransactional(curriedCreateAccessService(config), db)
+        : withFakeTransactional(createFakeAccessService(config).accessService);
+
     const apiTokenService = db
         ? createApiTokenService(db, config)
         : createFakeApiTokenService(config).apiTokenService;
@@ -403,6 +411,7 @@ export const createServices = (
 
     return {
         accessService,
+        transactionalAccessService,
         accountService,
         addonService,
         eventAnnouncerService,

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -419,7 +419,7 @@ export interface IPermission {
     name: string;
     displayName: string;
     type: string;
-    environment?: string;
+    environment?: string | null;
 }
 
 export interface IEnvironmentPermission {

--- a/src/lib/types/services.ts
+++ b/src/lib/types/services.ts
@@ -58,6 +58,7 @@ import type { IntegrationEventsService } from '../features/integration-events/in
 import type { OnboardingService } from '../features/onboarding/onboarding-service';
 
 export interface IUnleashServices {
+    transactionalAccessService: WithTransactional<AccessService>;
     accessService: AccessService;
     accountService: AccountService;
     addonService: AddonService;

--- a/src/migrations/20240917071436-add-foreign-key-to-role-permissions.js
+++ b/src/migrations/20240917071436-add-foreign-key-to-role-permissions.js
@@ -1,0 +1,20 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        UPDATE role_permission SET environment = null where environment = '';
+        DELETE FROM role_permission WHERE environment IS NOT NULL AND environment NOT IN (SELECT name FROM environments);
+        ALTER TABLE role_permission ADD CONSTRAINT fk_role_permission_environment FOREIGN KEY (environment) REFERENCES environments(name) ON DELETE CASCADE;
+        `,
+        cb
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE role_permission
+        DROP CONSTRAINT IF EXISTS fk_role_permission_environment;
+        `,
+        cb
+    );
+};


### PR DESCRIPTION
# Background

#8084 surfaced an issue with permissions. 22 months ago we added a permission that replaced UPDATE_FEATURE_VARIANTS with UPDATE_FEATURE_ENVIRONMENT_VARIANTS. 17 months later we added this permission to logic in enterprise related to creating and deleting environments. In between those 17 months, if we created and deleted an environment the UPDATE_FEATURE_ENVIRONMENT_VARIANTS permission would not be deleted, and it would hang around associated to an environment that no longer existed. 

This also applies for environment permissions that are not automatically applied to built in roles, such as: SKIP_CHANGE_REQUEST, APPLY_CHANGE_REQUEST and APPROVE_CHANGE_REQUEST. Creating a custom role with these permissions in a specific environment and then deleting the environment would also cause these permissions to hang around forever in the database.

Further complicating the situation, many of permissions in the database have empty strings in the environment column instead of null.

# Solution

This PR attempts to solve the situation by doing the following: 

We create a migration that first (1) converts all empty string values in the role_permission table to null, then (2) delete all permissions in role_permission where environment is not null and environments value does not exist in the name column of the environments table and (3) finally add the foreign key constraint on role_permission environments column that references name column in environments table with an on delete cascade.

Secondly, we guard all incoming data when we create or update a role by cleaning the permissions and setting environment to null in the access service, to keep backwards compatability and because the UI is currently sending empty string values.

Thirdly, we add a transaction around updating and creating a role since these are not atomic actions. Especially update is dangerous because we first wipe all permissions, then re-add all the new permissions. Failing to re-add the permissions puts the role in a state where it has lost all permissions.
