### PR TITLE
test: skip vercel toolbar in e2e tests

### DIFF
--- a/frontend/cypress/global.d.ts
+++ b/frontend/cypress/global.d.ts
@@ -93,5 +93,14 @@ declare namespace Cypress {
             environment: IEnvironment,
             options?: Partial<Cypress.RequestOptions>,
         ): Chainable;
+        visit(
+            options: Partial<Cypress.VisitOptions & PopulatePreloadsOptions> & {
+                url: string;
+            },
+        ): Cypress.Chainable<Cypress.AUTWindow>;
+        visit(
+            url: string,
+            options?: Partial<Cypress.VisitOptions & PopulatePreloadsOptions>,
+        ): Cypress.Chainable<Cypress.AUTWindow>;
     }
 }

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -58,7 +58,7 @@ Cypress.Commands.add(
     updateFlexibleRolloutStrategy_UI,
 );
 Cypress.Commands.add('createEnvironment_API', createEnvironment_API);
-Cypress.Commands.overwrite('visit', (originalFn, options) => {
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
     if (!options.headers) {
         options.headers = {};
     }
@@ -66,5 +66,5 @@ Cypress.Commands.overwrite('visit', (originalFn, options) => {
     // Add the x-vercel-skip-toolbar header. See: https://vercel.com/docs/workflow-collaboration/vercel-toolbar/managing-toolbar#disable-toolbar-for-automation
     options.headers['x-vercel-skip-toolbar'] = '1';
 
-    return originalFn(options);
+    return originalFn(url, options);
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -58,7 +58,7 @@ Cypress.Commands.add(
     updateFlexibleRolloutStrategy_UI,
 );
 Cypress.Commands.add('createEnvironment_API', createEnvironment_API);
-Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
     if (!options.headers) {
         options.headers = {};
     }

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -58,3 +58,13 @@ Cypress.Commands.add(
     updateFlexibleRolloutStrategy_UI,
 );
 Cypress.Commands.add('createEnvironment_API', createEnvironment_API);
+Cypress.Commands.overwrite('visit', (originalFn, options) => {
+    if (!options.headers) {
+        options.headers = {};
+    }
+
+    // Add the x-vercel-skip-toolbar header. See: https://vercel.com/docs/workflow-collaboration/vercel-toolbar/managing-toolbar#disable-toolbar-for-automation
+    options.headers['x-vercel-skip-toolbar'] = '1';
+
+    return originalFn(options);
+});


### PR DESCRIPTION
Some e2e Cypress tests were failing due to the Vercel live feedback toolbar covering interactive elements, preventing test actions from completing: https://github.com/Unleash/unleash/actions/runs/11048512034/job/30692949711#step:4:136

This PR addresses the issue by disabling the Vercel toolbar specifically during Cypress tests. This is done by setting the `x-vercel-skip-toolbar` header, which Vercel provides to prevent the toolbar from interfering with automated tests. You can find more information about this feature in the Vercel documentation: [Disable Toolbar for Automation](https://vercel.com/docs/workflow-collaboration/vercel-toolbar/managing-toolbar#disable-toolbar-for-automation).

Specific type declarations were needed due to https://github.com/cypress-io/cypress/issues/19564