### PR TITLE
docs: recommend PG v13 or later

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Before you begin:
 - Have you read the [code of conduct](CODE_OF_CONDUCT.md)?
 - Check out the [existing issues](https://github.com/unleash/Unleash/issues)
 - Browse the [developer-guide](./website/docs/contributing/developer-guide.md) for tips on environment setup, running the tests, and running Unleash from source.
-- You need 
+- You need
   - Node 20
   - corepack enabled `corepack enable`
 
@@ -36,7 +36,7 @@ Follow the steps in [the "how to run the project" section](#how-to-run-the-proje
 
 ### Make your update:
 
-Make your changes to the file(s) you'd like to update. You'll need **Node.js v18** and PostgreSQL 14 to run Unleash locally. [See more details](https://github.com/Unleash/unleash/tree/master/website/docs/contributing/developer-guide.md)
+Make your changes to the file(s) you'd like to update. You'll need **Node.js v18** and PostgreSQL 13+ to run Unleash locally. [See more details](https://github.com/Unleash/unleash/tree/master/website/docs/contributing/developer-guide.md)
 
 ### Open a pull request
 
@@ -159,7 +159,7 @@ To run the e2e tests, you'll need a running Postgres instance that you can conne
 docker run --name unleash-postgres -p 5432:5432 -e POSTGRES_USER=unleash_user -e POSTGRES_PASSWORD=password -e POSTGRES_DB=unleash_test -d postgres:15
 ```
 
-Unleash will attempt to connect using the connection string in `src/test/e2e/helpers/database-config.ts` or the environment variable `TEST_DATABASE_URL`. 
+Unleash will attempt to connect using the connection string in `src/test/e2e/helpers/database-config.ts` or the environment variable `TEST_DATABASE_URL`.
 
 ## Nice to know
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Follow the steps in [the "how to run the project" section](#how-to-run-the-proje
 
 ### Make your update:
 
-Make your changes to the file(s) you'd like to update. You'll need **Node.js v18** and PostgreSQL 13+ to run Unleash locally. [See more details](https://github.com/Unleash/unleash/tree/master/website/docs/contributing/developer-guide.md)
+Make your changes to the files you'd like to update. You'll need **Node.js v18.0+** and PostgreSQL v13.0+ to run Unleash locally. [See more details](https://github.com/Unleash/unleash/tree/master/website/docs/contributing/developer-guide.md)
 
 ### Open a pull request
 

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -26,7 +26,7 @@ yarn dev
 
 ## PostgreSQL {#postgresql}
 
-To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v13.x or newer) locally.
+To run and develop Unleash, you need to have PostgreSQL v13.0+ locally.
 
 Unleash currently also work with PostgreSQL v13+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v13. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
 

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -28,7 +28,7 @@ yarn dev
 
 To run and develop Unleash, you need to have PostgreSQL v13.0+ locally.
 
-Unleash currently also work with PostgreSQL v13+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v13. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
+Unleash currently also works with PostgreSQL v13.0+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v13. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
 
 ### Create a local unleash databases in postgres {#create-a-local-unleash-databases-in-postgres}
 

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -15,7 +15,7 @@ We have created a set of ADRs to help guide the development of the backend:
 
 Before developing on this project you will need two things:
 
-- PostgreSQL 14.x or newer
+- PostgreSQL 13.x+
 - Node.js 20.x or newer
 
 ```sh

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -15,7 +15,7 @@ We have created a set of ADRs to help guide the development of the backend:
 
 Before developing on this project you will need two things:
 
-- PostgreSQL 13.x+
+- PostgreSQL 13.0+
 - Node.js 20.x or newer
 
 ```sh

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -26,9 +26,9 @@ yarn dev
 
 ## PostgreSQL {#postgresql}
 
-To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v14.x or newer) locally.
+To run and develop unleash, you need to have PostgreSQL database (PostgreSQL v13.x or newer) locally.
 
-Unleash currently also work with PostgreSQL v14+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v12. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
+Unleash currently also work with PostgreSQL v13+, but this might change in a future feature release, and we have stopped running automatic integration tests below PostgreSQL v13. The current recommendation is to use a role with Owner privileges since Unleash uses Postgres functions to simplify our database usage.
 
 ### Create a local unleash databases in postgres {#create-a-local-unleash-databases-in-postgres}
 

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -16,7 +16,7 @@ We have created a set of ADRs to help guide the development of the backend:
 Before developing on this project you will need two things:
 
 - PostgreSQL 13.0+
-- Node.js 20.x or newer
+- Node.js v20.0+
 
 ```sh
 corepack enable

--- a/website/docs/using-unleash/deploy/database-setup.md
+++ b/website/docs/using-unleash/deploy/database-setup.md
@@ -2,7 +2,7 @@
 title: Database Setup
 ---
 
-To run Unleash you need to have PostgreSQL database (PostgreSQL v13.x or newer).
+To run Unleash you need to have PostgreSQL database (PostgreSQL v13.x+).
 
 1. Create a local unleash databases in PostgreSQL
 

--- a/website/docs/using-unleash/deploy/database-setup.md
+++ b/website/docs/using-unleash/deploy/database-setup.md
@@ -2,7 +2,7 @@
 title: Database Setup
 ---
 
-To run Unleash you need to have PostgreSQL database (PostgreSQL v13.x+).
+To run Unleash you need to have PostgreSQL v13.0+.
 
 1. Create a local unleash databases in PostgreSQL
 

--- a/website/docs/using-unleash/deploy/database-setup.md
+++ b/website/docs/using-unleash/deploy/database-setup.md
@@ -2,7 +2,7 @@
 title: Database Setup
 ---
 
-To run Unleash you need to have PostgreSQL database (PostgreSQL v14.x or newer).
+To run Unleash you need to have PostgreSQL database (PostgreSQL v13.x or newer).
 
 1. Create a local unleash databases in PostgreSQL
 

--- a/website/docs/using-unleash/deploy/getting-started.md
+++ b/website/docs/using-unleash/deploy/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 You will need:
 
 - [Node.js](https://nodejs.org/en/download/) (version 18 or later)
-- [PostgreSQL](https://www.postgresql.org/download/) (version 10 or later)
+- [PostgreSQL](https://www.postgresql.org/download/) (version 13 or later)
 - [Create an unleash user and database](./database-setup).
 
 ## Start Unleash server {#start-unleash-server}

--- a/website/docs/using-unleash/deploy/getting-started.md
+++ b/website/docs/using-unleash/deploy/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 You will need:
 
 - [Node.js](https://nodejs.org/en/download/) (version 18 or later)
-- [PostgreSQL](https://www.postgresql.org/download/) (version 13 or later)
+- [PostgreSQL](https://www.postgresql.org/download/) (version 13+)
 - [Create an unleash user and database](./database-setup).
 
 ## Start Unleash server {#start-unleash-server}

--- a/website/docs/using-unleash/deploy/getting-started.md
+++ b/website/docs/using-unleash/deploy/getting-started.md
@@ -9,7 +9,7 @@ title: Getting Started
 You will need:
 
 - [Node.js](https://nodejs.org/en/download/) v18.0+
-- [PostgreSQL](https://www.postgresql.org/download/) (version 13+)
+- [PostgreSQL](https://www.postgresql.org/download/) v13.0+
 - [Create an unleash user and database](./database-setup).
 
 ## Start Unleash server {#start-unleash-server}

--- a/website/docs/using-unleash/deploy/getting-started.md
+++ b/website/docs/using-unleash/deploy/getting-started.md
@@ -8,7 +8,7 @@ title: Getting Started
 
 You will need:
 
-- [Node.js](https://nodejs.org/en/download/) (version 18 or later)
+- [Node.js](https://nodejs.org/en/download/) v18.0+
 - [PostgreSQL](https://www.postgresql.org/download/) (version 13+)
 - [Create an unleash user and database](./database-setup).
 


### PR DESCRIPTION
Unify on PG v13, we had one place recommending v10, release notes for v6 saying we dropped support for v10 through v12 and mentioning 13, and a place mentioning 14 or newer.

fixes: #8265 