### PR TITLE
feat: now code examples are joined into one

### DIFF
--- a/frontend/src/component/onboarding/dialog/snippets/flutter.md
+++ b/frontend/src/component/onboarding/dialog/snippets/flutter.md
@@ -3,7 +3,7 @@
 flutter pub add unleash_proxy_client_flutter
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```dart
 import 'package:unleash_proxy_client_flutter/unleash_proxy_client_flutter.dart';
 import 'dart:async';
@@ -14,10 +14,7 @@ final unleash = UnleashClient(
     appName: 'unleash-onboarding-flutter');
 
 unleash.start();
-```
 
-3\. Check feature flag status
-```dart
 Timer.periodic(Duration(seconds: 1), (Timer timer) {
    final flagStatus = unleash.isEnabled('<YOUR_FLAG>');
    print('Flag is ${unleash.isEnabled("<YOUR_FLAG>") ? "enabled" : "disabled"}');

--- a/frontend/src/component/onboarding/dialog/snippets/go.md
+++ b/frontend/src/component/onboarding/dialog/snippets/go.md
@@ -3,7 +3,7 @@
 go get github.com/Unleash/unleash-client-go/v3
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```go
 import (
     "github.com/Unleash/unleash-client-go/v3"
@@ -20,10 +20,7 @@ func init() {
         unleash.WithMetricsInterval(5*time.Second),
     )
 }
-```
 
-3\. Check feature flag status
-```go
 func main() {
     for {
         unleash.IsEnabled("<YOUR_FLAG>")

--- a/frontend/src/component/onboarding/dialog/snippets/java.md
+++ b/frontend/src/component/onboarding/dialog/snippets/java.md
@@ -7,7 +7,7 @@
 </dependency>
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```java
 UnleashConfig config = UnleashConfig.builder()
     .appName("unleash-onboarding-java")
@@ -18,10 +18,7 @@ UnleashConfig config = UnleashConfig.builder()
     .build();
 
 Unleash unleash = new DefaultUnleash(config);
-```
 
-3\. Check feature flag status
-```java
 while (true) {
     boolean featureEnabled = unleash.isEnabled("<YOUR_FLAG>");
     System.out.println("Feature enabled: " + featureEnabled);

--- a/frontend/src/component/onboarding/dialog/snippets/javascript.md
+++ b/frontend/src/component/onboarding/dialog/snippets/javascript.md
@@ -3,7 +3,7 @@
 npm install unleash-proxy-client
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```js
 const { UnleashClient } = require('unleash-proxy-client');
 
@@ -15,10 +15,7 @@ const unleash = new UnleashClient({
 });
 
 unleash.start();
-```
 
-3\. Check feature flag status
-```js
 setInterval(() => {
     console.log('Is enabled', unleash.isEnabled('<YOUR_FLAG>'));
 }, 1000);

--- a/frontend/src/component/onboarding/dialog/snippets/nodejs.md
+++ b/frontend/src/component/onboarding/dialog/snippets/nodejs.md
@@ -3,7 +3,7 @@
 npm install unleash-client
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```js
 const { initialize } = require('unleash-client');
 
@@ -13,10 +13,7 @@ const unleash = initialize({
   customHeaders: { Authorization: '<YOUR_API_TOKEN>' },
   metricsInterval: 5000,
 });
-```
 
-3\. Check feature flag status
-```js
 setInterval(() => {
   console.log('Is enabled', unleash.isEnabled('<YOUR_FLAG>'));
 }, 1000);

--- a/frontend/src/component/onboarding/dialog/snippets/php.md
+++ b/frontend/src/component/onboarding/dialog/snippets/php.md
@@ -18,10 +18,7 @@ $unleash = UnleashBuilder::create()
     ->withInstanceId('unleash-onboarding-instance')
     ->withMetricsInterval(5000)
     ->build();
-```
 
-3\. Check feature flag status
-```php
 while (true) {
     echo 'Feature flag is:  ' . $unleash->isEnabled('<YOUR_FLAG>') . PHP_EOL;
     sleep(1);

--- a/frontend/src/component/onboarding/dialog/snippets/python.md
+++ b/frontend/src/component/onboarding/dialog/snippets/python.md
@@ -3,7 +3,7 @@
 pip install UnleashClient
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```python
 from UnleashClient import UnleashClient
 import asyncio
@@ -15,10 +15,7 @@ client = UnleashClient(
     custom_headers={'Authorization': '<YOUR_API_TOKEN>'})
 
 client.initialize_client()
-```
 
-3\. Check feature flag status
-```python
 while True:
     print(client.is_enabled("<YOUR_FLAG>"))
     asyncio.run(asyncio.sleep(1))

--- a/frontend/src/component/onboarding/dialog/snippets/ruby.md
+++ b/frontend/src/component/onboarding/dialog/snippets/ruby.md
@@ -3,7 +3,7 @@
 gem install unleash
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```rb
 require 'unleash'
 
@@ -15,10 +15,7 @@ require 'unleash'
   refresh_interval: 3, # In production use interval of >15s
   metrics_interval: 3, # In production use interval of >15s
 )
-```
 
-3\. Check feature flag status
-```rb
 while true
   if @unleash.is_enabled?("<YOUR_FLAG>")
     puts "Flag is enabled"

--- a/frontend/src/component/onboarding/dialog/snippets/rust.md
+++ b/frontend/src/component/onboarding/dialog/snippets/rust.md
@@ -7,7 +7,7 @@ cargo add serde tokio --features full
 cargo add serde anyhow cfg cfg-if enum-map@~2.0.0 surf
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```rust
 use enum_map::Enum;
 use serde::{Deserialize, Serialize};

--- a/frontend/src/component/onboarding/dialog/snippets/swift.md
+++ b/frontend/src/component/onboarding/dialog/snippets/swift.md
@@ -4,7 +4,7 @@
 https://github.com/Unleash/unleash-proxy-client-swift.git
 ```
 
-2\. Initialize Unleash
+2\. Run Unleash
 ```swift
 import Foundation
 import UnleashProxyClientSwift
@@ -17,10 +17,7 @@ var unleash = UnleashProxyClientSwift.UnleashClient(
    context: [:])
 
 unleash.start()
-```
 
-3\. Check feature flag status
-```swift
 Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
     print("Is enabled", unleash.isEnabled(name: "<YOUR_FLAG>"))
 }


### PR DESCRIPTION
Joined all examples into one copyable example.

Did not do following ones, because they are using templates and probably will not work as joined.

1. React
2. Svelte
3. Vue

Also skipped, because those examples are not final yet.

1. .NET
2. Android


![image](https://github.com/user-attachments/assets/c8dabed4-21d0-4af9-900f-e77c5d069fe1)
