### PR TITLE
feat: return latest project events

### DIFF
--- a/src/lib/addons/feature-event-formatter-md.ts
+++ b/src/lib/addons/feature-event-formatter-md.ts
@@ -7,7 +7,7 @@ import {
 } from '../types';
 import { EVENT_MAP } from './feature-event-formatter-md-events';
 
-interface IFormattedEventData {
+export interface IFormattedEventData {
     label: string;
     text: string;
     url?: string;

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -7,6 +7,9 @@ import { ProjectOwnersReadModel } from '../project/project-owners-read-model';
 import { FakeProjectOwnersReadModel } from '../project/fake-project-owners-read-model';
 import { ProjectReadModel } from '../project/project-read-model';
 import { FakeProjectReadModel } from '../project/fake-project-read-model';
+import EventStore from '../../db/event-store';
+import { FeatureEventFormatterMd } from '../../addons/feature-event-formatter-md';
+import FakeEventStore from '../../../test/fixtures/fake-event-store';
 
 export const createPersonalDashboardService = (
     db: Db,
@@ -16,13 +19,23 @@ export const createPersonalDashboardService = (
         new PersonalDashboardReadModel(db),
         new ProjectOwnersReadModel(db),
         new ProjectReadModel(db, config.eventBus, config.flagResolver),
+        new EventStore(db, config.getLogger),
+        new FeatureEventFormatterMd({
+            unleashUrl: config.server.unleashUrl,
+            formatStyle: 'markdown',
+        }),
     );
 };
 
-export const createFakePersonalDashboardService = () => {
+export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
     return new PersonalDashboardService(
         new FakePersonalDashboardReadModel(),
         new FakeProjectOwnersReadModel(),
         new FakeProjectReadModel(),
+        new FakeEventStore(),
+        new FeatureEventFormatterMd({
+            unleashUrl: config.server.unleashUrl,
+            formatStyle: 'markdown',
+        }),
     );
 };

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -194,18 +194,21 @@ test('should return personal dashboard project details', async () => {
         latestEvents: [
             {
                 createdBy: 'new_user@test.com',
-                summary:
-                    '**new_user@test.com** created **[log_feature_c](http://localhost:4242/projects/default/features/log_feature_c)** in project **[default](http://localhost:4242/projects/default)**',
+                summary: expect.stringContaining(
+                    '**new_user@test.com** created **[log_feature_c]',
+                ),
             },
             {
                 createdBy: 'new_user@test.com',
-                summary:
-                    '**new_user@test.com** created **[log_feature_b](http://localhost:4242/projects/default/features/log_feature_b)** in project **[default](http://localhost:4242/projects/default)**',
+                summary: expect.stringContaining(
+                    '**new_user@test.com** created **[log_feature_b]',
+                ),
             },
             {
                 createdBy: 'new_user@test.com',
-                summary:
-                    '**new_user@test.com** created **[log_feature_a](http://localhost:4242/projects/default/features/log_feature_a)** in project **[default](http://localhost:4242/projects/default)**',
+                summary: expect.stringContaining(
+                    '**new_user@test.com** created **[log_feature_a]',
+                ),
             },
             {
                 createdBy: 'unleash_system_user',

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -40,6 +40,7 @@ afterAll(async () => {
 beforeEach(async () => {
     await db.stores.featureToggleStore.deleteAll();
     await db.stores.userStore.deleteAll();
+    await db.stores.eventStore.deleteAll();
 });
 
 test('should return personal dashboard with own flags and favorited flags', async () => {
@@ -178,6 +179,11 @@ test('should return projects where users are part of a group', async () => {
 
 test('should return personal dashboard project details', async () => {
     await loginUser('new_user@test.com');
+
+    await app.createFeature('log_feature_a');
+    await app.createFeature('log_feature_b');
+    await app.createFeature('log_feature_c');
+
     const { body } = await app.request.get(
         `/api/admin/personal-dashboard/default`,
     );
@@ -185,5 +191,26 @@ test('should return personal dashboard project details', async () => {
     expect(body).toMatchObject({
         owners: [{}],
         roles: [{}],
+        latestEvents: [
+            {
+                createdBy: 'new_user@test.com',
+                summary:
+                    '**new_user@test.com** created **[log_feature_c](http://localhost:4242/projects/default/features/log_feature_c)** in project **[default](http://localhost:4242/projects/default)**',
+            },
+            {
+                createdBy: 'new_user@test.com',
+                summary:
+                    '**new_user@test.com** created **[log_feature_b](http://localhost:4242/projects/default/features/log_feature_b)** in project **[default](http://localhost:4242/projects/default)**',
+            },
+            {
+                createdBy: 'new_user@test.com',
+                summary:
+                    '**new_user@test.com** created **[log_feature_a](http://localhost:4242/projects/default/features/log_feature_a)** in project **[default](http://localhost:4242/projects/default)**',
+            },
+            {
+                createdBy: 'unleash_system_user',
+                summary: '**unleash_system_user** created user ****',
+            },
+        ],
     });
 });

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
@@ -104,11 +104,17 @@ export default class PersonalDashboardController extends Controller {
     ): Promise<void> {
         const user = req.user;
 
+        const projectDetails =
+            await this.personalDashboardService.getPersonalProjectDetails(
+                req.params.projectId,
+            );
+
         this.openApiService.respondWithValidation(
             200,
             res,
             personalDashboardProjectDetailsSchema.$id,
             {
+                ...projectDetails,
                 owners: [{ ownerType: 'user', name: 'placeholder' }],
                 roles: [{ name: 'placeholder', id: 0, type: 'project' }],
             },

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -8,6 +8,29 @@ export const personalDashboardProjectDetailsSchema = {
     additionalProperties: false,
     required: ['owners', 'roles'],
     properties: {
+        latestEvents: {
+            type: 'array',
+            description: 'The latest events for the project.',
+            items: {
+                type: 'object',
+                description: 'An event summary',
+                additionalProperties: false,
+                required: ['summary', 'createdBy'],
+                properties: {
+                    summary: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                            '**[Experimental]** A markdown-formatted summary of the event.',
+                    },
+                    createdBy: {
+                        type: 'string',
+                        description: 'Which user created this event',
+                        example: 'johndoe',
+                    },
+                },
+            },
+        },
         owners: projectSchema.properties.owners,
         roles: {
             type: 'array',

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -408,7 +408,7 @@ export const createServices = (
 
     const personalDashboardService = db
         ? createPersonalDashboardService(db, config)
-        : createFakePersonalDashboardService();
+        : createFakePersonalDashboardService(config);
 
     return {
         accessService,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Return last events from the project details API.

This will feed this part of the UI. createdBy goes to avatar and markdown summary into human readable description
<img width="351" alt="Screenshot 2024-09-27 at 12 02 18" src="https://github.com/user-attachments/assets/f58b3ebc-514f-411f-81b0-4b9f578f3ce0">

Details:
* use event store to get latest events
* use addon formatter that can prepare human readable summary
* I decided to call it latestEvents (also considered recentEvents, lastEvents). I choose this name consistently within this PR

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
