### PR TITLE
fix: now only one onboarding screen will be shown at time

### DIFF
--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
@@ -170,7 +170,7 @@ export const ConnectSdkDialog = ({
                                 ) : null}
 
                                 <Button variant='contained' onClick={onFinish}>
-                                    Next
+                                    Complete
                                 </Button>
                             </NextStepSectionSpacedContainer>
                         </Navigation>

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -430,7 +430,9 @@ export const ProjectFeatureToggles = ({
                 }
             />
             <ConditionallyRender
-                condition={setupCompletedState === 'show-setup'}
+                condition={
+                    setupCompletedState === 'show-setup' && !isOnboarding
+                }
                 show={
                     <ProjectOnboarded
                         projectId={projectId}


### PR DESCRIPTION
Makes the button more clear. 

Now both **onboarding** started and **onboarding finished** screens will not be shown in the same time.