### PR TITLE
fix: some integrations only counted errors not all results

### DIFF
--- a/src/lib/addons/datadog.ts
+++ b/src/lib/addons/datadog.ts
@@ -113,14 +113,14 @@ export default class DatadogAddon extends Addon {
             state = 'failed';
             const failedMessage = `Datadog Events API request failed with status code: ${res.status}.`;
             stateDetails.push(failedMessage);
-            if (this.flagResolver.isEnabled('addonUsageMetrics')) {
-                this.eventBus.emit(ADDON_EVENTS_HANDLED, {
-                    result: state,
-                    destination: 'datadog',
-                });
-            }
-
             this.logger.warn(failedMessage);
+        }
+
+        if (this.flagResolver.isEnabled('addonUsageMetrics')) {
+            this.eventBus.emit(ADDON_EVENTS_HANDLED, {
+                result: state,
+                destination: 'datadog',
+            });
         }
 
         this.registerEvent({

--- a/src/lib/addons/slack-app.ts
+++ b/src/lib/addons/slack-app.ts
@@ -179,6 +179,9 @@ export default class SlackAppAddon extends Addon {
             stateDetails.push(eventErrorMessage);
             this.logger.warn(eventErrorMessage);
             const errorMessage = this.parseError(error);
+            stateDetails.push(errorMessage);
+            this.logger.warn(errorMessage, error);
+        } finally {
             if (this.flagResolver.isEnabled('addonUsageMetrics')) {
                 this.eventBus.emit(ADDON_EVENTS_HANDLED, {
                     result: state,
@@ -186,9 +189,6 @@ export default class SlackAppAddon extends Addon {
                 });
             }
 
-            stateDetails.push(errorMessage);
-            this.logger.warn(errorMessage, error);
-        } finally {
             this.registerEvent({
                 integrationId,
                 state,

--- a/src/lib/addons/slack.ts
+++ b/src/lib/addons/slack.ts
@@ -131,14 +131,14 @@ export default class SlackAddon extends Addon {
             state = 'successWithErrors';
             const successWithErrorsMessage = `Some (${failedRequests.length} of ${results.length}) Slack webhook requests failed. Status codes: ${codes}.`;
             stateDetails.push(successWithErrorsMessage);
-            if (this.flagResolver.isEnabled('addonUsageMetrics')) {
-                this.eventBus.emit(ADDON_EVENTS_HANDLED, {
-                    result: state,
-                    destination: 'slack',
-                });
-            }
-
             this.logger.warn(successWithErrorsMessage);
+        }
+
+        if (this.flagResolver.isEnabled('addonUsageMetrics')) {
+            this.eventBus.emit(ADDON_EVENTS_HANDLED, {
+                result: state,
+                destination: 'slack',
+            });
         }
 
         this.registerEvent({

--- a/src/lib/addons/teams.ts
+++ b/src/lib/addons/teams.ts
@@ -107,14 +107,14 @@ export default class TeamsAddon extends Addon {
             state = 'failed';
             const failedMessage = `Teams webhook request failed with status code: ${res.status}.`;
             stateDetails.push(failedMessage);
-            if (this.flagResolver.isEnabled('addonUsageMetrics')) {
-                this.eventBus.emit(ADDON_EVENTS_HANDLED, {
-                    result: state,
-                    destination: 'teams',
-                });
-            }
-
             this.logger.warn(failedMessage);
+        }
+
+        if (this.flagResolver.isEnabled('addonUsageMetrics')) {
+            this.eventBus.emit(ADDON_EVENTS_HANDLED, {
+                result: state,
+                destination: 'teams',
+            });
         }
 
         this.registerEvent({


### PR DESCRIPTION
Moves the addon/integration result metrics-counting to the finally block / outside the result successful if-else, to capture not just failed runs but successful runs as well