### PR TITLE
feat: open unleash concepts

### DIFF
--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -31,17 +31,12 @@ import { RoleAndOwnerInfo } from './RoleAndOwnerInfo';
 import { ContentGridNoProjects } from './ContentGridNoProjects';
 import { LatestProjectEvents } from './LatestProjectEvents';
 import { usePersonalDashboardProjectDetails } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails';
+import HelpOutline from '@mui/icons-material/HelpOutline';
 
-const ScreenExplanation = styled(Typography)(({ theme }) => ({
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(8),
-    maxWidth: theme.spacing(45),
-}));
-
-const StyledHeaderTitle = styled(Typography)(({ theme }) => ({
-    fontSize: theme.typography.h2.fontSize,
-    fontWeight: 'normal',
-    marginBottom: theme.spacing(2),
+const ScreenExplanation = styled('div')(({ theme }) => ({
+    marginBottom: theme.spacing(4),
+    display: 'flex',
+    alignItems: 'center',
 }));
 
 const ContentGrid = styled(Grid)(({ theme }) => ({
@@ -196,8 +191,8 @@ export const PersonalDashboard = () => {
     const stage = activeProjectOverview?.onboardingStatus.status ?? 'loading';
 
     const [welcomeDialog, setWelcomeDialog] = useLocalStorageState<
-        'seen' | 'not_seen'
-    >('welcome-dialog:v1', 'not_seen');
+        'open' | 'closed'
+    >('welcome-dialog:v1', 'open');
 
     const noProjects = projects.length === 0;
 
@@ -207,10 +202,19 @@ export const PersonalDashboard = () => {
                 Welcome {name}
             </Typography>
             <ScreenExplanation>
-                Here are some tasks we think would be useful in order to get the
-                most of Unleash
+                <p>
+                    Here are some tasks we think would be useful in order to get
+                    the most of Unleash
+                </p>
+                <IconButton
+                    size={'small'}
+                    title='Key concepts'
+                    onClick={() => setWelcomeDialog('open')}
+                >
+                    <HelpOutline />
+                </IconButton>
             </ScreenExplanation>
-            <StyledHeaderTitle>Your resources</StyledHeaderTitle>
+
             {noProjects ? (
                 <ContentGridNoProjects
                     owners={[{ ownerType: 'system' }]}
@@ -366,8 +370,8 @@ export const PersonalDashboard = () => {
                 </SpacedGridItem>
             </ContentGrid>
             <WelcomeDialog
-                open={welcomeDialog !== 'seen'}
-                onClose={() => setWelcomeDialog('seen')}
+                open={welcomeDialog === 'open'}
+                onClose={() => setWelcomeDialog('closed')}
             />
         </div>
     );

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -204,7 +204,7 @@ export const PersonalDashboard = () => {
             <ScreenExplanation>
                 <p>
                     Here are some tasks we think would be useful in order to get
-                    the most of Unleash
+                    the most out of Unleash
                 </p>
                 <IconButton
                     size={'small'}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Added ability to open Unleash concepts not only when you first visit but also when clicking on the info icon.
<img width="1588" alt="Screenshot 2024-09-30 at 13 12 29" src="https://github.com/user-attachments/assets/123c5706-3476-4847-8ad9-b7c16f3bcccc">

<img width="1860" alt="Screenshot 2024-09-30 at 13 12 34" src="https://github.com/user-attachments/assets/bd10c0a4-42be-45d0-b713-436141597750">

Other: 
* making welcome part more compact to avoid scrolling when visiting a personal dashboard
* renamed modal state to open/closed since it can be seen multiple times now

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
