### PR TITLE
feat: add onboarding status to personal dashboard api

### DIFF
--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -18,7 +18,6 @@ import { Badge } from '../common/Badge/Badge';
 import { ConnectSDK, CreateFlag } from './ConnectSDK';
 import { WelcomeDialog } from './WelcomeDialog';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
-import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { ProjectSetupComplete } from './ProjectSetupComplete';
 import { usePersonalDashboard } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboard';
 import { getFeatureTypeIcons } from 'utils/getFeatureTypeIcons';
@@ -182,13 +181,11 @@ export const PersonalDashboard = () => {
         personalDashboard?.projects || [],
     );
 
-    // TODO: since we use this one only for the onboarding status, we can add th eonboarding status to the personal dashboard project details API
-    const { project: activeProjectOverview, loading } =
-        useProjectOverview(activeProject);
     const { personalDashboardProjectDetails, loading: loadingDetails } =
         usePersonalDashboardProjectDetails(activeProject);
 
-    const stage = activeProjectOverview?.onboardingStatus.status ?? 'loading';
+    const stage =
+        personalDashboardProjectDetails?.onboardingStatus.status ?? 'loading';
 
     const [welcomeDialog, setWelcomeDialog] = useLocalStorageState<
         'open' | 'closed'

--- a/frontend/src/openapi/models/personalDashboardProjectDetailsSchema.ts
+++ b/frontend/src/openapi/models/personalDashboardProjectDetailsSchema.ts
@@ -6,6 +6,7 @@
 import type { PersonalDashboardProjectDetailsSchemaLatestEventsItem } from './personalDashboardProjectDetailsSchemaLatestEventsItem';
 import type { PersonalDashboardProjectDetailsSchemaOwners } from './personalDashboardProjectDetailsSchemaOwners';
 import type { PersonalDashboardProjectDetailsSchemaRolesItem } from './personalDashboardProjectDetailsSchemaRolesItem';
+import type { ProjectOverviewSchemaOnboardingStatus } from './projectOverviewSchemaOnboardingStatus';
 
 /**
  * Project details in personal dashboard
@@ -20,4 +21,5 @@ export interface PersonalDashboardProjectDetailsSchema {
      * @minItems 1
      */
     roles: PersonalDashboardProjectDetailsSchemaRolesItem[];
+    onboardingStatus: ProjectOverviewSchemaOnboardingStatus;
 }

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -14,6 +14,8 @@ import { FakePrivateProjectChecker } from '../private-project/fakePrivateProject
 import { PrivateProjectChecker } from '../private-project/privateProjectChecker';
 import { AccountStore } from '../../db/account-store';
 import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
+import { OnboardingReadModel } from '../onboarding/onboarding-read-model';
+import { FakeOnboardingReadModel } from '../onboarding/fake-onboarding-read-model';
 
 export const createPersonalDashboardService = (
     db: Db,
@@ -24,6 +26,7 @@ export const createPersonalDashboardService = (
         new PersonalDashboardReadModel(db),
         new ProjectOwnersReadModel(db),
         new ProjectReadModel(db, config.eventBus, config.flagResolver),
+        new OnboardingReadModel(db),
         new EventStore(db, config.getLogger),
         new FeatureEventFormatterMd({
             unleashUrl: config.server.unleashUrl,
@@ -39,6 +42,7 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         new FakePersonalDashboardReadModel(),
         new FakeProjectOwnersReadModel(),
         new FakeProjectReadModel(),
+        new FakeOnboardingReadModel(),
         new FakeEventStore(),
         new FeatureEventFormatterMd({
             unleashUrl: config.server.unleashUrl,

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -191,6 +191,10 @@ test('should return personal dashboard project details', async () => {
     expect(body).toMatchObject({
         owners: [{}],
         roles: [{}],
+        onboardingStatus: {
+            status: 'first-flag-created',
+            feature: 'log_feature_a',
+        },
         latestEvents: [
             {
                 createdBy: 'new_user@test.com',

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -1,13 +1,15 @@
 import type { FromSchema } from 'json-schema-to-ts';
 import { projectSchema } from './project-schema';
+import { projectOverviewSchema } from './project-overview-schema';
 
 export const personalDashboardProjectDetailsSchema = {
     $id: '#/components/schemas/personalDashboardProjectDetailsSchema',
     type: 'object',
     description: 'Project details in personal dashboard',
     additionalProperties: false,
-    required: ['owners', 'roles', 'latestEvents'],
+    required: ['owners', 'roles', 'latestEvents', 'onboardingStatus'],
     properties: {
+        onboardingStatus: projectOverviewSchema.properties.onboardingStatus,
         latestEvents: {
             type: 'array',
             description: 'The latest events for the project.',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Exposing project onboarding status in the personal dashboard project details API.
It allows to stop making separate API calls to personal dashboard API and project overview API.

Manually updated orval types. Separate PR will autogenerate new types.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
