### PR TITLE
fix: handle empty strings on permissions gracefully in access service

### DIFF
--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -108,6 +108,17 @@ export interface AccessWithRoles {
 
 const isProjectPermission = (permission) => PROJECT_ADMIN.includes(permission);
 
+export const cleanPermissionEnvironment = (
+    permissions: PermissionRef[] | undefined,
+) => {
+    return permissions?.map((permission) => {
+        if (permission.environment === '') {
+            return { ...permission, environment: null };
+        }
+        return permission;
+    });
+};
+
 export class AccessService {
     private store: IAccessStore;
 
@@ -721,7 +732,7 @@ export class AccessService {
             roleType,
         };
 
-        const rolePermissions = role.permissions;
+        const rolePermissions = cleanPermissionEnvironment(role.permissions);
         const newRole = await this.roleStore.create(baseRole);
         if (rolePermissions) {
             if (roleType === CUSTOM_ROOT_ROLE_TYPE) {
@@ -770,7 +781,7 @@ export class AccessService {
             description: role.description,
             roleType,
         };
-        const rolePermissions = role.permissions;
+        const rolePermissions = cleanPermissionEnvironment(role.permissions);
         const updatedRole = await this.roleStore.update(baseRole);
         const existingPermissions = await this.store.getPermissionsForRole(
             role.id,

--- a/src/lib/services/clean-permission-environment.test.ts
+++ b/src/lib/services/clean-permission-environment.test.ts
@@ -1,0 +1,117 @@
+import { cleanPermissionEnvironment } from './access-service';
+
+test('should convert all empty strings to null', () => {
+    const permissions = [
+        {
+            name: 'UPDATE_PROJECT',
+            environment: '',
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: '',
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: '',
+        },
+    ];
+
+    const result = cleanPermissionEnvironment(permissions);
+
+    expect(result).toEqual([
+        {
+            name: 'UPDATE_PROJECT',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: null,
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: null,
+        },
+    ]);
+});
+
+test('should handle some permissions already having null values', () => {
+    const permissions = [
+        {
+            name: 'UPDATE_PROJECT',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: null,
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: '',
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: '',
+        },
+    ];
+
+    const result = cleanPermissionEnvironment(permissions);
+
+    expect(result).toEqual([
+        {
+            name: 'UPDATE_PROJECT',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_FEATURE_VARIANTS',
+            environment: null,
+        },
+        {
+            name: 'READ_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'CREATE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'DELETE_PROJECT_API_TOKEN',
+            environment: null,
+        },
+        {
+            name: 'UPDATE_PROJECT_SEGMENT',
+            environment: null,
+        },
+    ]);
+});

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -419,7 +419,7 @@ export interface IPermission {
     name: string;
     displayName: string;
     type: string;
-    environment?: string;
+    environment?: string | null;
 }
 
 export interface IEnvironmentPermission {


### PR DESCRIPTION
Splitting #8271 into smaller pieces. This first PR will focus on making access service handle empty string inputs gracefully and converting them to null before inserting them into the database.