### PR TITLE
feat(onboarding): add links to examples

### DIFF
--- a/frontend/src/component/onboarding/flow/SdkExample.tsx
+++ b/frontend/src/component/onboarding/flow/SdkExample.tsx
@@ -20,39 +20,37 @@ const StyledLink = styled(Link)({
 
 const repositoryUrl =
     'https://github.com/Unleash/unleash-sdk-examples/tree/main';
-const exampleDirectories: Record<SdkName, string> = {
-    Android: 'Android',
-    '.NET': 'Csharp',
-    Flutter: 'Flutter',
-    Go: 'Go',
-    Java: 'Java',
-    JavaScript: 'JavaScript',
-    'Node.js': 'NodeJS',
-    PHP: 'PHP',
-    Python: 'Python',
-    React: 'React',
-    Ruby: 'Ruby',
-    Rust: 'Rust',
-    Svelte: 'Svelte',
-    Swift: 'Swift',
-    Vue: 'Vue',
-};
+
+type exampleDirectories =
+    | 'Android'
+    | '.NET'
+    | 'Flutter'
+    | 'Go'
+    | 'Java'
+    | 'JavaScript'
+    | 'Node.js'
+    | 'PHP'
+    | 'Python'
+    | 'React'
+    | 'Ruby'
+    | 'Rust'
+    | 'Svelte'
+    | 'Swift'
+    | 'Vue';
 
 export const SdkExample = () => {
     const sdkOptions = allSdks.map((sdk) => ({
         key: sdk.name,
         label: sdk.name,
     }));
-
-    const [selectedSdk, setSelectedSdk] = useLocalStorageState<SdkName>(
-        'onboarding-sdk-example',
-        sdkOptions[0].key,
-    );
-
+    const [selectedSdk, setSelectedSdk] =
+        useLocalStorageState<exampleDirectories>(
+            'onboarding-sdk-example',
+            sdkOptions[0].key,
+        );
     const onChange = (event: SelectChangeEvent) => {
         setSelectedSdk(event.target.value as SdkName);
     };
-    const selectedExample = exampleDirectories[selectedSdk];
 
     return (
         <>
@@ -70,10 +68,7 @@ export const SdkExample = () => {
                     width: '60%',
                 }}
             />
-            <StyledLink
-                to={`${repositoryUrl}/${selectedExample}`}
-                target='_blank'
-            >
+            <StyledLink to={`${repositoryUrl}/${selectedSdk}`} target='_blank'>
                 Go to example
             </StyledLink>
         </>

--- a/frontend/src/component/onboarding/flow/SdkExample.tsx
+++ b/frontend/src/component/onboarding/flow/SdkExample.tsx
@@ -1,8 +1,8 @@
 import { type SelectChangeEvent, styled, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
-import Select from '../../common/select';
-import { useState } from 'react';
-import { allSdks } from '../dialog/sharedTypes';
+import { useLocalStorageState } from 'hooks/useLocalStorageState';
+import Select from 'component/common/select';
+import { allSdks, type SdkName } from '../dialog/sharedTypes';
 
 const TitleContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -18,17 +18,42 @@ const StyledLink = styled(Link)({
     textDecoration: 'none',
 });
 
+const repositoryUrl =
+    'https://github.com/Unleash/unleash-sdk-examples/tree/main';
+const exampleDirectories: Record<SdkName, string> = {
+    Android: 'Android',
+    '.NET': 'Csharp',
+    Flutter: 'Flutter',
+    Go: 'Go',
+    Java: 'Java',
+    JavaScript: 'JavaScript',
+    'Node.js': 'NodeJS',
+    PHP: 'PHP',
+    Python: 'Python',
+    React: 'React',
+    Ruby: 'Ruby',
+    Rust: 'Rust',
+    Svelte: 'Svelte',
+    Swift: 'Swift',
+    Vue: 'Vue',
+};
+
 export const SdkExample = () => {
     const sdkOptions = allSdks.map((sdk) => ({
         key: sdk.name,
         label: sdk.name,
     }));
 
-    const [selectedSdk, setSelectedSdk] = useState<string>(sdkOptions[0].key);
+    const [selectedSdk, setSelectedSdk] = useLocalStorageState<SdkName>(
+        'onboarding-sdk-example',
+        sdkOptions[0].key,
+    );
 
     const onChange = (event: SelectChangeEvent) => {
-        setSelectedSdk(event.target.value);
+        setSelectedSdk(event.target.value as SdkName);
     };
+    const selectedExample = exampleDirectories[selectedSdk];
+
     return (
         <>
             <TitleContainer>View SDK Example</TitleContainer>
@@ -45,7 +70,12 @@ export const SdkExample = () => {
                     width: '60%',
                 }}
             />
-            <StyledLink to={``}>Go to example</StyledLink>
+            <StyledLink
+                to={`${repositoryUrl}/${selectedExample}`}
+                target='_blank'
+            >
+                Go to example
+            </StyledLink>
         </>
     );
 };


### PR DESCRIPTION
## About the changes
Links from Unleash UI to [Unleash/unleash-sdk-examples](https://github.com/Unleash/unleash-sdk-examples)

https://linear.app/unleash/issue/1-2869/add-codesandbox-links-to-unleashunleash