### PR TITLE
feat: include favorite projects in personal dashboard

### DIFF
--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -81,6 +81,13 @@ const createProject = async (name: string, user: IUser) => {
     return project;
 };
 
+const favoriteProject = async (projectName = 'default') => {
+    await app.request
+        .post(`/api/admin/projects/${projectName}/favorites`)
+        .set('Content-Type', 'application/json')
+        .expect(200);
+};
+
 test('should return personal dashboard with membered projects', async () => {
     const { body: user1 } = await loginUser('user1@test.com');
     const projectA = await createProject('Project A', user1);
@@ -118,6 +125,36 @@ test('should return personal dashboard with membered projects', async () => {
             {
                 name: projectC.name,
                 id: projectC.id,
+                health: 100,
+                memberCount: 1,
+                featureCount: 0,
+            },
+        ],
+    });
+});
+
+test('should return personal dashboard with user favorited projects', async () => {
+    const { body: user1 } = await loginUser('user1@test.com');
+    const projectA = await createProject('Project A', user1);
+
+    await loginUser('user2@test.com');
+    await favoriteProject(projectA.id);
+
+    const { body } = await app.request.get(`/api/admin/personal-dashboard`);
+
+    expect(body).toMatchObject({
+        projects: [
+            {
+                name: 'Default',
+                id: 'default',
+                health: 100,
+                memberCount: 0,
+                featureCount: 0,
+            },
+            {
+                name: projectA.name,
+                id: projectA.id,
+                health: 100,
                 memberCount: 1,
                 featureCount: 0,
             },

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -71,12 +71,13 @@ export class PersonalDashboardService {
     }
 
     async getPersonalProjects(userId: number): Promise<PersonalProject[]> {
-        // TODO: add favorite projects in addition to membership projects
-        const userProjectIds =
-            await this.projectReadModel.getProjectsByUser(userId);
+        const [userProjectIds, userFavoritedProjectIds] = await Promise.all([
+            this.projectReadModel.getProjectsByUser(userId),
+            this.projectReadModel.getProjectsFavoritedByUser(userId),
+        ]);
 
         const projects = await this.projectReadModel.getProjectsForAdminUi({
-            ids: userProjectIds,
+            ids: [...new Set([...userProjectIds, ...userFavoritedProjectIds])],
             archived: false,
         });
 

--- a/src/lib/features/project/fake-project-read-model.ts
+++ b/src/lib/features/project/fake-project-read-model.ts
@@ -17,4 +17,7 @@ export class FakeProjectReadModel implements IProjectReadModel {
     getProjectsByUser(): Promise<string[]> {
         return Promise.resolve([]);
     }
+    getProjectsFavoritedByUser(): Promise<string[]> {
+        return Promise.resolve([]);
+    }
 }

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -38,4 +38,5 @@ export interface IProjectReadModel {
         featureName: string,
     ): Promise<{ project: string; createdAt: Date } | null>;
     getProjectsByUser(userId: number): Promise<string[]>;
+    getProjectsFavoritedByUser(userId: number): Promise<string[]>;
 }

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -284,4 +284,16 @@ export class ProjectReadModel implements IProjectReadModel {
             .pluck('project');
         return projects;
     }
+
+    async getProjectsFavoritedByUser(userId: number): Promise<string[]> {
+        const favoritedProjects = await this.db
+            .select('favorite_projects.project')
+            .from('favorite_projects')
+            .leftJoin('projects', 'favorite_projects.project', 'projects.id')
+            .where('favorite_projects.user_id', userId)
+            .andWhere('projects.archived_at', null)
+            .pluck('project');
+
+        return favoritedProjects;
+    }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Including user favorited projects in personal dashboard even when use is not a member of those projects.

Created a new `getProjectsFavoritedByUser` method instead of touching `getProjectsByUser` that is used in user profile and notifications. Personal dashboard service is combining user membership projects and user favorited projects.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
