### PR TITLE
feat: return project owners

### DIFF
--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -115,7 +115,7 @@ export class PersonalDashboardService {
         }));
 
         const owners =
-            await this.projectOwnersReadModel.getUserProjectOwners(projectId);
+            await this.projectOwnersReadModel.getProjectOwners(projectId);
 
         return {
             latestEvents: formattedEvents,

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -127,7 +127,6 @@ export class PersonalDashboardService {
 
         const owners =
             await this.projectOwnersReadModel.getUserProjectOwners(projectId);
-        // const roles = ..
 
         return {
             latestEvents: formattedEvents,

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -17,18 +17,7 @@ import type {
 } from '../../types';
 import type { FeatureEventFormatter } from '../../addons/feature-event-formatter-md';
 import { generateImageUrl } from '../../util';
-import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type';
 import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
-
-type PersonalProjectDetails = {
-    latestEvents: {
-        summary: string;
-        createdBy: string;
-        id: number;
-        createdByImageUrl: string;
-    }[];
-    onboardingStatus: OnboardingStatus;
-};
 
 export class PersonalDashboardService {
     private personalDashboardReadModel: IPersonalDashboardReadModel;

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -18,6 +18,7 @@ import type {
 import type { FeatureEventFormatter } from '../../addons/feature-event-formatter-md';
 import { generateImageUrl } from '../../util';
 import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type';
+import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
 
 type PersonalProjectDetails = {
     latestEvents: {
@@ -106,7 +107,7 @@ export class PersonalDashboardService {
 
     async getPersonalProjectDetails(
         projectId: string,
-    ): Promise<PersonalProjectDetails> {
+    ): Promise<PersonalDashboardProjectDetailsSchema> {
         const recentEvents = await this.eventStore.searchEvents(
             { limit: 4, offset: 0 },
             [{ field: 'project', operator: 'IS', values: [projectId] }],
@@ -124,7 +125,16 @@ export class PersonalDashboardService {
             createdByImageUrl: generateImageUrl({ email: event.createdBy }),
         }));
 
-        return { latestEvents: formattedEvents, onboardingStatus };
+        const owners =
+            await this.projectOwnersReadModel.getUserProjectOwners(projectId);
+        // const roles = ..
+
+        return {
+            latestEvents: formattedEvents,
+            onboardingStatus,
+            owners,
+            roles: [],
+        };
     }
 
     async getAdmins(): Promise<MinimalUser[]> {

--- a/src/lib/features/project/fake-project-owners-read-model.ts
+++ b/src/lib/features/project/fake-project-owners-read-model.ts
@@ -17,4 +17,8 @@ export class FakeProjectOwnersReadModel implements IProjectOwnersReadModel {
     async getAllUserProjectOwners(): Promise<UserProjectOwner[]> {
         return [];
     }
+
+    async getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]> {
+        return [];
+    }
 }

--- a/src/lib/features/project/fake-project-owners-read-model.ts
+++ b/src/lib/features/project/fake-project-owners-read-model.ts
@@ -19,7 +19,7 @@ export class FakeProjectOwnersReadModel implements IProjectOwnersReadModel {
         return [];
     }
 
-    async getUserProjectOwners(projectId: string): Promise<ProjectOwners> {
+    async getProjectOwners(): Promise<ProjectOwners> {
         return [];
     }
 }

--- a/src/lib/features/project/fake-project-owners-read-model.ts
+++ b/src/lib/features/project/fake-project-owners-read-model.ts
@@ -1,5 +1,6 @@
 import type {
     IProjectOwnersReadModel,
+    ProjectOwners,
     UserProjectOwner,
     WithProjectOwners,
 } from './project-owners-read-model.type';
@@ -18,7 +19,7 @@ export class FakeProjectOwnersReadModel implements IProjectOwnersReadModel {
         return [];
     }
 
-    async getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]> {
+    async getUserProjectOwners(projectId: string): Promise<ProjectOwners> {
         return [];
     }
 }

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -159,9 +159,10 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
     }
 
     async getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]> {
-        const allOwners = await this.getProjectOwnersDictionary();
-        return (allOwners[projectId] ?? []).filter(
-            (owner) => owner.ownerType === 'user',
-        ) as UserProjectOwner[];
+        const ownerRole = await this.db(T.ROLES)
+            .where({ name: RoleName.OWNER })
+            .first();
+        const usersDict = await this.getAllProjectUsersByRole(ownerRole.id);
+        return usersDict[projectId] ?? [];
     }
 }

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -157,4 +157,11 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
 
         return ProjectOwnersReadModel.addOwnerData(projects, owners);
     }
+
+    async getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]> {
+        const allOwners = await this.getProjectOwnersDictionary();
+        return (allOwners[projectId] ?? []).filter(
+            (owner) => owner.ownerType === 'user',
+        ) as UserProjectOwner[];
+    }
 }

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -4,6 +4,7 @@ import { generateImageUrl } from '../../util';
 import type {
     GroupProjectOwner,
     IProjectOwnersReadModel,
+    ProjectOwners,
     ProjectOwnersDictionary,
     UserProjectOwner,
     WithProjectOwners,
@@ -158,11 +159,8 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
         return ProjectOwnersReadModel.addOwnerData(projects, owners);
     }
 
-    async getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]> {
-        const ownerRole = await this.db(T.ROLES)
-            .where({ name: RoleName.OWNER })
-            .first();
-        const usersDict = await this.getAllProjectUsersByRole(ownerRole.id);
-        return usersDict[projectId] ?? [];
+    async getProjectOwners(projectId: string): Promise<ProjectOwners> {
+        const owners = await this.getProjectOwnersDictionary();
+        return owners[projectId] ?? [];
     }
 }

--- a/src/lib/features/project/project-owners-read-model.type.ts
+++ b/src/lib/features/project/project-owners-read-model.type.ts
@@ -30,7 +30,7 @@ export interface IProjectOwnersReadModel {
         projects: T[],
     ): Promise<WithProjectOwners<T>>;
 
-    getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]>;
+    getProjectOwners(projectId: string): Promise<ProjectOwners>;
 
     getAllUserProjectOwners(
         projects?: Set<string>,

--- a/src/lib/features/project/project-owners-read-model.type.ts
+++ b/src/lib/features/project/project-owners-read-model.type.ts
@@ -30,6 +30,8 @@ export interface IProjectOwnersReadModel {
         projects: T[],
     ): Promise<WithProjectOwners<T>>;
 
+    getUserProjectOwners(projectId: string): Promise<UserProjectOwner[]>;
+
     getAllUserProjectOwners(
         projects?: Set<string>,
     ): Promise<UserProjectOwner[]>;


### PR DESCRIPTION
This PR is part 1 of returning project owners and your project roles for the personal dashboard single-project endpoint.

It moves the responsibility of adding owners and roles to the project to the service from the controller and adds a new method to the project owners read model to take care of it.

I'll add roles and tests in follow-up PRs.