### PR TITLE
feat: return project roles

### DIFF
--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -16,6 +16,8 @@ import { AccountStore } from '../../db/account-store';
 import { FakeAccountStore } from '../../../test/fixtures/fake-account-store';
 import { OnboardingReadModel } from '../onboarding/onboarding-read-model';
 import { FakeOnboardingReadModel } from '../onboarding/fake-onboarding-read-model';
+import { AccessStore } from '../../db/access-store';
+import FakeAccessStore from '../../../test/fixtures/fake-access-store';
 
 export const createPersonalDashboardService = (
     db: Db,
@@ -34,6 +36,7 @@ export const createPersonalDashboardService = (
         }),
         new PrivateProjectChecker(stores, config),
         new AccountStore(db, config.getLogger),
+        new AccessStore(db, config.eventBus, config.getLogger),
     );
 };
 
@@ -50,5 +53,6 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         }),
         new FakePrivateProjectChecker(),
         new FakeAccountStore(),
+        new FakeAccessStore(),
     );
 };

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -215,14 +215,15 @@ test('should return projects where users are part of a group', async () => {
 });
 
 test('should return personal dashboard project details', async () => {
-    await loginUser('new_user@test.com');
+    const { body: user } = await loginUser('new_user@test.com');
 
-    await app.createFeature('log_feature_a');
-    await app.createFeature('log_feature_b');
-    await app.createFeature('log_feature_c');
+    const project = await createProject(`x${randomId()}`, user);
+    await app.createFeature('log_feature_a', project.id);
+    await app.createFeature('log_feature_b', project.id);
+    await app.createFeature('log_feature_c', project.id);
 
     const { body } = await app.request.get(
-        `/api/admin/personal-dashboard/default`,
+        `/api/admin/personal-dashboard/${project.id}`,
     );
 
     expect(body).toMatchObject({
@@ -249,6 +250,12 @@ test('should return personal dashboard project details', async () => {
                 createdBy: 'new_user@test.com',
                 summary: expect.stringContaining(
                     '**new_user@test.com** created **[log_feature_a]',
+                ),
+            },
+            {
+                createdBy: 'audit user',
+                summary: expect.stringContaining(
+                    `**audit user** created project **[${project.id}]`,
                 ),
             },
         ],

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
@@ -106,6 +106,7 @@ export default class PersonalDashboardController extends Controller {
 
         const projectDetails =
             await this.personalDashboardService.getPersonalProjectDetails(
+                user.id,
                 req.params.projectId,
             );
 
@@ -115,8 +116,6 @@ export default class PersonalDashboardController extends Controller {
             personalDashboardProjectDetailsSchema.$id,
             {
                 ...projectDetails,
-                owners: [{ ownerType: 'user', name: 'placeholder' }],
-                roles: [{ name: 'placeholder', id: 0, type: 'project' }],
             },
         );
     }

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -136,8 +136,6 @@ export class PersonalDashboardService {
                 type: role.type as PersonalDashboardProjectDetailsSchema['roles'][number]['type'],
             }));
 
-        console.log('project roles', projectRoles);
-
         return {
             latestEvents: formattedEvents,
             onboardingStatus,

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -12,7 +12,7 @@ import FakeGroupStore from '../../test/fixtures/fake-group-store';
 import { FakeAccountStore } from '../../test/fixtures/fake-account-store';
 import FakeRoleStore from '../../test/fixtures/fake-role-store';
 import FakeEnvironmentStore from '../features/project-environments/fake-environment-store';
-import AccessStoreMock from '../../test/fixtures/fake-access-store';
+import FakeAccessStore from '../../test/fixtures/fake-access-store';
 import { GroupService } from '../services/group-service';
 import type { IRole } from '../../lib/types/stores/access-store';
 import {
@@ -271,7 +271,7 @@ test('throws error when trying to delete a project role in use by group', async 
     const accountStore = new FakeAccountStore();
     const roleStore = new FakeRoleStore();
     const environmentStore = new FakeEnvironmentStore();
-    const accessStore = new AccessStoreMock();
+    const accessStore = new FakeAccessStore();
     accessStore.getGroupIdsForRole = groupIdResultOverride;
     accessStore.getUserIdsForRole = async (): Promise<number[]> => {
         return [];

--- a/src/test/fixtures/fake-access-store.ts
+++ b/src/test/fixtures/fake-access-store.ts
@@ -19,7 +19,7 @@ import {
 import FakeRoleStore from './fake-role-store';
 import type { PermissionRef } from '../../lib/services/access-service';
 
-class AccessStoreMock implements IAccessStore {
+export class FakeAccessStore implements IAccessStore {
     fakeRolesStore: IRoleStore;
 
     userToRoleMap: Map<number, number> = new Map();
@@ -327,6 +327,6 @@ class AccessStoreMock implements IAccessStore {
     }
 }
 
-module.exports = AccessStoreMock;
+module.exports = FakeAccessStore;
 
-export default AccessStoreMock;
+export default FakeAccessStore;


### PR DESCRIPTION
This PR updates the personal dashboard project endpoint to return owners and roles. It also adds the impl for getting roles (via the access store).

I'm filtering the roles for a project to only include project roles for now, but we might wanna change this later.

Tests and UI update will follow.