### PR TITLE
refactor: use promise.all instead of sequential awaited calls

### DIFF
--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -131,7 +131,6 @@ export class PersonalDashboardService {
                         },
                     ])
                     .then(formatEvents),
-
                 this.onboardingReadModel.getOnboardingStatusForProject(
                     projectId,
                 ),

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -12,6 +12,7 @@ import type { IPrivateProjectChecker } from '../private-project/privateProjectCh
 import type {
     IAccessStore,
     IAccountStore,
+    IEvent,
     IEventStore,
     IOnboardingReadModel,
     MinimalUser,
@@ -19,6 +20,7 @@ import type {
 import type { FeatureEventFormatter } from '../../addons/feature-event-formatter-md';
 import { generateImageUrl } from '../../util';
 import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
+import type { IRoleWithProject } from '../../types/stores/access-store';
 
 export class PersonalDashboardService {
     private personalDashboardReadModel: IPersonalDashboardReadModel;
@@ -103,7 +105,7 @@ export class PersonalDashboardService {
         userId: number,
         projectId: string,
     ): Promise<PersonalDashboardProjectDetailsSchema> {
-        const formatEvents = (recentEvents) =>
+        const formatEvents = (recentEvents: IEvent[]) =>
             recentEvents.map((event) => ({
                 summary: this.featureEventFormatter.format(event).text,
                 createdBy: event.createdBy,
@@ -111,7 +113,7 @@ export class PersonalDashboardService {
                 createdByImageUrl: generateImageUrl({ email: event.createdBy }),
             }));
 
-        const filterRoles = (allRoles) =>
+        const filterRoles = (allRoles: IRoleWithProject[]) =>
             allRoles
                 .filter((role) => ['project', 'custom'].includes(role.type))
                 .map((role) => ({


### PR DESCRIPTION
This PR follows up on a comment made in https://github.com/Unleash/unleash/pull/8314 and groups sequential awaited calls into a single Promise.all instead.