### PR TITLE
chore: timeline event group icon when events are all same type

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
@@ -83,7 +83,7 @@ export const EventTimelineEventCircle = ({
 }: IEventTimelineEventCircleProps) => {
     if (
         group.length === 1 ||
-        group.every((event) => event.type === group[0].type)
+        !group.some(({ type }) => type !== group[0].type)
     ) {
         const event = group[0];
 

--- a/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
@@ -81,7 +81,10 @@ export const EventTimelineEventCircle = ({
     group,
     ...props
 }: IEventTimelineEventCircleProps) => {
-    if (group.length === 1) {
+    if (
+        group.length === 1 ||
+        group.every((event) => event.type === group[0].type)
+    ) {
         const event = group[0];
 
         return (


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2726/groups-should-show-the-timeline-event-type-icon-when-all-events-inside

Displays the event type icon for the group when all events within the group share the same type.

![image](https://github.com/user-attachments/assets/9fc68b2b-da01-423e-b767-05ce87098b27)

![image](https://github.com/user-attachments/assets/76c3a6d6-1bae-499c-aeec-006ead30cea6)