### PR TITLE
feat: personal dashboard project avg health scores

### DIFF
--- a/src/lib/features/personal-dashboard/fake-personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/fake-personal-dashboard-read-model.ts
@@ -8,6 +8,13 @@ import type {
 export class FakePersonalDashboardReadModel
     implements IPersonalDashboardReadModel
 {
+    async getLatestHealthScores(
+        project: string,
+        count: number,
+    ): Promise<number[]> {
+        return [];
+    }
+
     async getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
         return [];
     }

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -227,6 +227,10 @@ test('should return personal dashboard project details', async () => {
     );
 
     expect(body).toMatchObject({
+        insights: {
+            avgHealthCurrentWindow: null,
+            avgHealthPastWindow: null,
+        },
         owners: [{}],
         roles: [{}],
         onboardingStatus: {
@@ -259,6 +263,41 @@ test('should return personal dashboard project details', async () => {
                 ),
             },
         ],
+    });
+
+    const insertHealthScore = (id: string, health: number) => {
+        const irrelevantFlagTrendDetails = {
+            total_flags: 10,
+            stale_flags: 10,
+            potentially_stale_flags: 10,
+        };
+        return db.rawDatabase('flag_trends').insert({
+            ...irrelevantFlagTrendDetails,
+            id,
+            project: project.id,
+            health,
+        });
+    };
+
+    await insertHealthScore('2024-01', 80);
+    await insertHealthScore('2024-02', 80);
+    await insertHealthScore('2024-03', 80);
+    await insertHealthScore('2024-04', 81);
+
+    await insertHealthScore('2024-05', 90);
+    await insertHealthScore('2024-06', 91);
+    await insertHealthScore('2024-07', 91);
+    await insertHealthScore('2024-08', 91);
+
+    const { body: bodyWithHealthScores } = await app.request.get(
+        `/api/admin/personal-dashboard/${project.id}`,
+    );
+
+    expect(bodyWithHealthScores).toMatchObject({
+        insights: {
+            avgHealthPastWindow: 80,
+            avgHealthCurrentWindow: 91,
+        },
     });
 });
 

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model-type.ts
@@ -21,4 +21,5 @@ export type PersonalProject = BasePersonalProject & {
 export interface IPersonalDashboardReadModel {
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]>;
     getPersonalProjects(userId: number): Promise<BasePersonalProject[]>;
+    getLatestHealthScores(project: string, count: number): Promise<number[]>;
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-read-model.ts
@@ -19,6 +19,19 @@ export class PersonalDashboardReadModel implements IPersonalDashboardReadModel {
         this.db = db;
     }
 
+    async getLatestHealthScores(
+        project: string,
+        count: number,
+    ): Promise<number[]> {
+        const results = await this.db<{ health: number }>('flag_trends')
+            .select('health')
+            .orderBy('created_at', 'desc')
+            .where('project', project)
+            .limit(count);
+
+        return results.map((row) => Number(row.health));
+    }
+
     async getPersonalProjects(userId: number): Promise<BasePersonalProject[]> {
         const result = await this.db<{
             name: string;

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -136,11 +136,39 @@ export class PersonalDashboardService {
                 type: role.type as PersonalDashboardProjectDetailsSchema['roles'][number]['type'],
             }));
 
+        const healthScores =
+            await this.personalDashboardReadModel.getLatestHealthScores(
+                projectId,
+                8,
+            );
+        let avgHealthCurrentWindow: number | null = null;
+        let avgHealthPastWindow: number | null = null;
+
+        if (healthScores.length >= 4) {
+            avgHealthCurrentWindow = Math.round(
+                healthScores
+                    .slice(0, 4)
+                    .reduce((acc, score) => acc + score, 0) / 4,
+            );
+        }
+
+        if (healthScores.length >= 8) {
+            avgHealthPastWindow = Math.round(
+                healthScores
+                    .slice(4, 8)
+                    .reduce((acc, score) => acc + score, 0) / 4,
+            );
+        }
+
         return {
             latestEvents: formattedEvents,
             onboardingStatus,
             owners,
             roles: projectRoles,
+            insights: {
+                avgHealthCurrentWindow,
+                avgHealthPastWindow,
+            },
         };
     }
 

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -7,8 +7,36 @@ export const personalDashboardProjectDetailsSchema = {
     type: 'object',
     description: 'Project details in personal dashboard',
     additionalProperties: false,
-    required: ['owners', 'roles', 'latestEvents', 'onboardingStatus'],
+    required: [
+        'owners',
+        'roles',
+        'latestEvents',
+        'onboardingStatus',
+        'insights',
+    ],
     properties: {
+        insights: {
+            type: 'object',
+            description: 'Insights for the project',
+            additionalProperties: false,
+            required: ['avgHealthCurrentWindow', 'avgHealthPastWindow'],
+            properties: {
+                avgHealthCurrentWindow: {
+                    type: 'number',
+                    description:
+                        'The average health score in the current window of the last 4 weeks',
+                    example: 80,
+                    nullable: true,
+                },
+                avgHealthPastWindow: {
+                    type: 'number',
+                    description:
+                        'The average health score in the previous 4 weeks before the current window',
+                    example: 70,
+                    nullable: true,
+                },
+            },
+        },
         onboardingStatus: projectOverviewSchema.properties.onboardingStatus,
         latestEvents: {
             type: 'array',


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

For pro and enterprise customers we can provide feedback on avg health score in the past 4 weeks vs current 4 weeks. 
The calculation is inspired by the avg health score indicator in the ios health app. 

This PR adds the calculation in the service and a query in the personal dashboard read model. I couldn't find a good home for this query so added it to the existing read model for now. 

As a result of this PR we can implement the following logic:

* For pro and enterprise users how have enough health scores show this view

<img width="801" alt="Screenshot 2024-10-02 at 09 28 31" src="https://github.com/user-attachments/assets/c0d873cc-b983-40d6-a0eb-76e6a7e78cdd">

In the next iteration it would be nice to add some visual indicators

<img width="236" alt="Screenshot 2024-10-02 at 09 31 40" src="https://github.com/user-attachments/assets/57b398f2-7696-4286-9475-85a385e534f4">


* For oss users and users without enough health scores (at least 8 weeks) show a default view

<img width="261" alt="Screenshot 2024-10-02 at 09 28 13" src="https://github.com/user-attachments/assets/88caed20-6b81-44ca-8157-642e4adc3f3a">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
