### PR TITLE
fix: only ask for project details if we have a project ID

### DIFF
--- a/frontend/src/hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails.ts
+++ b/frontend/src/hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails.ts
@@ -1,7 +1,7 @@
-import useSWR from 'swr';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import type { PersonalDashboardProjectDetailsSchema } from 'openapi';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 
 export interface IPersonalDashboardProjectDetailsOutput {
     personalDashboardProjectDetails?: PersonalDashboardProjectDetailsSchema;
@@ -13,7 +13,16 @@ export interface IPersonalDashboardProjectDetailsOutput {
 export const usePersonalDashboardProjectDetails = (
     project: string,
 ): IPersonalDashboardProjectDetailsOutput => {
-    const { data, error, mutate } = useSWR(
+    const { data, error, mutate } = useConditionalSWR(
+        Boolean(project),
+        {
+            latestEvents: [],
+            onboardingStatus: {
+                status: 'onboarding-started',
+            },
+            owners: [],
+            roles: [],
+        },
         formatApiPath(`api/admin/personal-dashboard/${project}`),
         fetcher,
     );


### PR DESCRIPTION
This switches to using conditional SWR to fetch project details only
when you provide a project. This fixes an issue where we'd make
requests for `api/admin/personal-dashboard/undefined` (which will be a
404 in the future).