### PR TITLE
chore: remove unused flag

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -31,7 +31,6 @@ export type IFlagKey =
     | 'celebrateUnleash'
     | 'featureSearchFeedback'
     | 'featureSearchFeedbackPosting'
-    | 'edgeBulkMetrics'
     | 'extendedUsageMetrics'
     | 'adminTokenKillSwitch'
     | 'feedbackComments'
@@ -165,10 +164,6 @@ const flags: IFlags = {
     ),
     encryptEmails: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_ENCRYPT_EMAILS,
-        false,
-    ),
-    edgeBulkMetrics: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_EDGE_BULK_METRICS,
         false,
     ),
     extendedUsageMetrics: parseEnvVarBoolean(


### PR DESCRIPTION
We validated that all customers have migrated

QQ: for self-hosted are we switching from false to true? Should we have an intermediate release just flipping the value?
Answer: No, the code was removed long time ago so this configuration has no effect