### PR TITLE
refactor: use css grid for flags and no content grid

### DIFF
--- a/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
+++ b/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
@@ -8,7 +8,7 @@ import {
     ContentGridContainer,
     EmptyGridItem,
     ProjectGrid,
-    SpacedGridItem2,
+    SpacedGridItem,
 } from './Grid';
 
 const PaddedEmptyGridItem = styled(EmptyGridItem)(({ theme }) => ({
@@ -70,13 +70,13 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
     return (
         <ContentGridContainer>
             <ProjectGrid>
-                <SpacedGridItem2 gridArea='title'>
+                <SpacedGridItem gridArea='title'>
                     <Typography variant='h3'>My projects</Typography>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='onboarding'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='onboarding'>
                     <Typography>Potential next steps</Typography>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='projects'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='projects'>
                     <GridContent>
                         <Typography>
                             You don't currently have access to any projects in
@@ -91,8 +91,8 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
                             projects in the system and ask the owner for access.
                         </Typography>
                     </GridContent>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='box1'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='box1'>
                     <GridContent>
                         <TitleContainer>
                             <NeutralCircleContainer>1</NeutralCircleContainer>
@@ -133,8 +133,8 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
                             )}
                         </BoxMainContent>
                     </GridContent>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='box2'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='box2'>
                     <GridContent>
                         <TitleContainer>
                             <NeutralCircleContainer>2</NeutralCircleContainer>
@@ -157,7 +157,7 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
                             )}
                         </BoxMainContent>
                     </GridContent>
-                </SpacedGridItem2>
+                </SpacedGridItem>
                 <EmptyGridItem />
                 <PaddedEmptyGridItem gridArea='owners' />
             </ProjectGrid>

--- a/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
+++ b/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
@@ -11,6 +11,10 @@ import {
     SpacedGridItem2,
 } from './Grid';
 
+const PaddedEmptyGridItem = styled(EmptyGridItem)(({ theme }) => ({
+    padding: theme.spacing(4),
+}));
+
 const TitleContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'row',
@@ -155,7 +159,7 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
                     </GridContent>
                 </SpacedGridItem2>
                 <EmptyGridItem />
-                <EmptyGridItem />
+                <PaddedEmptyGridItem gridArea='owners' />
             </ProjectGrid>
         </ContentGridContainer>
     );

--- a/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
+++ b/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
@@ -1,19 +1,15 @@
-import { Grid, Typography, styled } from '@mui/material';
+import { Typography, styled } from '@mui/material';
 import { AvatarGroupFromOwners } from 'component/common/AvatarGroupFromOwners/AvatarGroupFromOwners';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 import type { PersonalDashboardSchemaAdminsItem } from 'openapi/models/personalDashboardSchemaAdminsItem';
 import type { PersonalDashboardSchemaProjectOwnersItem } from 'openapi/models/personalDashboardSchemaProjectOwnersItem';
 import { Link } from 'react-router-dom';
-
-const ContentGrid = styled(Grid)(({ theme }) => ({
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: `${theme.shape.borderRadiusLarge}px`,
-}));
-
-const SpacedGridItem = styled(Grid)(({ theme }) => ({
-    padding: theme.spacing(4),
-    border: `0.5px solid ${theme.palette.divider}`,
-}));
+import {
+    ContentGridContainer,
+    EmptyGridItem,
+    ProjectGrid,
+    SpacedGridItem2,
+} from './Grid';
 
 const TitleContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -68,96 +64,99 @@ type Props = {
 
 export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
     return (
-        <ContentGrid container columns={{ lg: 12, md: 1 }}>
-            <SpacedGridItem item lg={4} md={1}>
-                <Typography variant='h3'>My projects</Typography>
-            </SpacedGridItem>
-            <SpacedGridItem item lg={8} md={1}>
-                <Typography>Potential next steps</Typography>
-            </SpacedGridItem>
-            <SpacedGridItem item lg={4} md={1}>
-                <GridContent>
-                    <Typography>
-                        You don't currently have access to any projects in the
-                        system.
-                    </Typography>
-                    <Typography>
-                        To get started, you can{' '}
-                        <Link to='/projects?create=true'>
-                            create your own project
-                        </Link>
-                        . Alternatively, you can review the available projects
-                        in the system and ask the owner for access.
-                    </Typography>
-                </GridContent>
-            </SpacedGridItem>
-            <SpacedGridItem item lg={4} md={1}>
-                <GridContent>
-                    <TitleContainer>
-                        <NeutralCircleContainer>1</NeutralCircleContainer>
-                        Contact Unleash admin
-                    </TitleContainer>
-                    <BoxMainContent>
-                        {admins.length ? (
-                            <>
+        <ContentGridContainer>
+            <ProjectGrid>
+                <SpacedGridItem2 gridArea='title'>
+                    <Typography variant='h3'>My projects</Typography>
+                </SpacedGridItem2>
+                <SpacedGridItem2 gridArea='onboarding'>
+                    <Typography>Potential next steps</Typography>
+                </SpacedGridItem2>
+                <SpacedGridItem2 gridArea='projects'>
+                    <GridContent>
+                        <Typography>
+                            You don't currently have access to any projects in
+                            the system.
+                        </Typography>
+                        <Typography>
+                            To get started, you can{' '}
+                            <Link to='/projects?create=true'>
+                                create your own project
+                            </Link>
+                            . Alternatively, you can review the available
+                            projects in the system and ask the owner for access.
+                        </Typography>
+                    </GridContent>
+                </SpacedGridItem2>
+                <SpacedGridItem2 gridArea='box1'>
+                    <GridContent>
+                        <TitleContainer>
+                            <NeutralCircleContainer>1</NeutralCircleContainer>
+                            Contact Unleash admin
+                        </TitleContainer>
+                        <BoxMainContent>
+                            {admins.length ? (
+                                <>
+                                    <p>
+                                        Your Unleash administrator
+                                        {admins.length > 1 ? 's are' : ' is'}:
+                                    </p>
+                                    <AdminList>
+                                        {admins.map((admin) => {
+                                            return (
+                                                <AdminListItem key={admin.id}>
+                                                    <UserAvatar
+                                                        sx={{
+                                                            margin: 0,
+                                                        }}
+                                                        user={admin}
+                                                    />
+                                                    <Typography>
+                                                        {admin.name ||
+                                                            admin.username ||
+                                                            admin.email}
+                                                    </Typography>
+                                                </AdminListItem>
+                                            );
+                                        })}
+                                    </AdminList>
+                                </>
+                            ) : (
                                 <p>
-                                    Your Unleash administrator
-                                    {admins.length > 1 ? 's are' : ' is'}:
+                                    You have no Unleash administrators to
+                                    contact.
                                 </p>
-                                <AdminList>
-                                    {admins.map((admin) => {
-                                        return (
-                                            <AdminListItem key={admin.id}>
-                                                <UserAvatar
-                                                    sx={{
-                                                        margin: 0,
-                                                    }}
-                                                    user={admin}
-                                                />
-                                                <Typography>
-                                                    {admin.name ||
-                                                        admin.username ||
-                                                        admin.email}
-                                                </Typography>
-                                            </AdminListItem>
-                                        );
-                                    })}
-                                </AdminList>
-                            </>
-                        ) : (
-                            <p>
-                                You have no Unleash administrators to contact.
-                            </p>
-                        )}
-                    </BoxMainContent>
-                </GridContent>
-            </SpacedGridItem>
-            <SpacedGridItem item lg={4} md={1}>
-                <GridContent>
-                    <TitleContainer>
-                        <NeutralCircleContainer>2</NeutralCircleContainer>
-                        Ask a project owner to add you to their project
-                    </TitleContainer>
-                    <BoxMainContent>
-                        {owners.length ? (
-                            <>
-                                <p>Project owners in Unleash:</p>
-                                <AvatarGroupFromOwners
-                                    users={owners}
-                                    avatarLimit={9}
-                                />
-                            </>
-                        ) : (
-                            <p>
-                                There are no project owners in Unleash to ask
-                                for access.
-                            </p>
-                        )}
-                    </BoxMainContent>
-                </GridContent>
-            </SpacedGridItem>
-            <SpacedGridItem item lg={4} md={1} />
-            <SpacedGridItem item lg={8} md={1} />
-        </ContentGrid>
+                            )}
+                        </BoxMainContent>
+                    </GridContent>
+                </SpacedGridItem2>
+                <SpacedGridItem2 gridArea='box2'>
+                    <GridContent>
+                        <TitleContainer>
+                            <NeutralCircleContainer>2</NeutralCircleContainer>
+                            Ask a project owner to add you to their project
+                        </TitleContainer>
+                        <BoxMainContent>
+                            {owners.length ? (
+                                <>
+                                    <p>Project owners in Unleash:</p>
+                                    <AvatarGroupFromOwners
+                                        users={owners}
+                                        avatarLimit={9}
+                                    />
+                                </>
+                            ) : (
+                                <p>
+                                    There are no project owners in Unleash to
+                                    ask for access.
+                                </p>
+                            )}
+                        </BoxMainContent>
+                    </GridContent>
+                </SpacedGridItem2>
+                <EmptyGridItem />
+                <EmptyGridItem />
+            </ProjectGrid>
+        </ContentGridContainer>
     );
 };

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -64,8 +64,11 @@ export const SpacedGridItem2 = styled('div', {
     gridArea,
 }));
 
-export const EmptyGridItem = styled('div')(({ theme }) => ({
+export const EmptyGridItem = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'gridArea',
+})<{ gridArea?: string }>(({ theme, gridArea }) => ({
     display: 'none',
+    gridArea,
 
     ...withContainerQueryFallback({
         display: 'block',

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -64,15 +64,9 @@ export const SpacedGridItem2 = styled('div')(({ theme }) => ({
 export const EmptyGridItem = styled('div')(({ theme }) => ({
     display: 'none',
 
-    '@container (min-width: 1000px)': {
+    ...withContainerQueryFallback({
         display: 'block',
-    },
-
-    '@supports not (container-type: inline-size)': {
-        [theme.breakpoints.up('lg')]: {
-            display: 'block',
-        },
-    },
+    })(theme),
 }));
 
 export const ContentGrid = styled(Grid)(({ theme }) => ({

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -57,8 +57,11 @@ export const FlagGrid = styled(ContentGrid2)(({ theme }) =>
     })(theme),
 );
 
-export const SpacedGridItem2 = styled('div')(({ theme }) => ({
+export const SpacedGridItem2 = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'gridArea',
+})<{ gridArea: string }>(({ theme, gridArea }) => ({
     padding: theme.spacing(4),
+    gridArea,
 }));
 
 export const EmptyGridItem = styled('div')(({ theme }) => ({

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, styled } from '@mui/material';
+import { Box, styled } from '@mui/material';
 import type { Theme } from '@mui/material/styles/createTheme';
 
 export const ContentGridContainer = styled('div')({
@@ -57,7 +57,7 @@ export const FlagGrid = styled(ContentGrid2)(({ theme }) =>
     })(theme),
 );
 
-export const SpacedGridItem2 = styled('div', {
+export const SpacedGridItem = styled('div', {
     shouldForwardProp: (prop) => prop !== 'gridArea',
 })<{ gridArea: string }>(({ theme, gridArea }) => ({
     padding: theme.spacing(4),
@@ -73,16 +73,6 @@ export const EmptyGridItem = styled('div', {
     ...withContainerQueryFallback({
         display: 'block',
     })(theme),
-}));
-
-export const ContentGrid = styled(Grid)(({ theme }) => ({
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: `${theme.shape.borderRadiusLarge}px`,
-}));
-
-export const SpacedGridItem = styled(Grid)(({ theme }) => ({
-    padding: theme.spacing(4),
-    border: `0.5px solid ${theme.palette.divider}`,
 }));
 
 export const ListItemBox = styled(Box)(({ theme }) => ({

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -48,11 +48,11 @@ export const ProjectGrid = styled(ContentGrid2)(({ theme }) =>
 
 export const FlagGrid = styled(ContentGrid2)(({ theme }) =>
     withContainerQueryFallback({
-        gridTemplateColumns: '1fr 2fr',
+        gridTemplateColumns: '1fr 1fr 1fr',
         display: 'grid',
         gridTemplateAreas: `
-                "title lifecycle"
-                "flags chart"
+                "title lifecycle lifecycle"
+                "flags chart chart"
             `,
     })(theme),
 );

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -5,7 +5,7 @@ export const ContentGridContainer = styled('div')({
     containerType: 'inline-size',
 });
 
-const ContentGrid2 = styled('article')(({ theme }) => {
+const ContentGrid = styled('article')(({ theme }) => {
     return {
         backgroundColor: theme.palette.divider,
         borderRadius: `${theme.shape.borderRadiusLarge}px`,
@@ -21,21 +21,23 @@ const ContentGrid2 = styled('article')(({ theme }) => {
     };
 });
 
-const withContainerQueryFallback = (css: object) => (theme: Theme) => {
-    const containerBreakpoint = '1000px';
-    const screenBreakpoint = theme.breakpoints.up('lg');
+const onWideContainer =
+    (css: object) =>
+    ({ theme }: { theme: Theme }) => {
+        const containerBreakpoint = '1000px';
+        const screenBreakpoint = theme.breakpoints.up('lg');
 
-    return {
-        [`@container (min-width: ${containerBreakpoint})`]: css,
+        return {
+            [`@container (min-width: ${containerBreakpoint})`]: css,
 
-        '@supports not (container-type: inline-size)': {
-            [screenBreakpoint]: css,
-        },
+            '@supports not (container-type: inline-size)': {
+                [screenBreakpoint]: css,
+            },
+        };
     };
-};
 
-export const ProjectGrid = styled(ContentGrid2)(({ theme }) =>
-    withContainerQueryFallback({
+export const ProjectGrid = styled(ContentGrid)(
+    onWideContainer({
         gridTemplateColumns: '1fr 1fr 1fr',
         display: 'grid',
         gridTemplateAreas: `
@@ -43,18 +45,18 @@ export const ProjectGrid = styled(ContentGrid2)(({ theme }) =>
                 "projects box1 box2"
                 ". owners owners"
             `,
-    })(theme),
+    }),
 );
 
-export const FlagGrid = styled(ContentGrid2)(({ theme }) =>
-    withContainerQueryFallback({
+export const FlagGrid = styled(ContentGrid)(
+    onWideContainer({
         gridTemplateColumns: '1fr 1fr 1fr',
         display: 'grid',
         gridTemplateAreas: `
                 "title lifecycle lifecycle"
                 "flags chart chart"
             `,
-    })(theme),
+    }),
 );
 
 export const SpacedGridItem = styled('div', {
@@ -70,9 +72,9 @@ export const EmptyGridItem = styled('div', {
     display: 'none',
     gridArea,
 
-    ...withContainerQueryFallback({
+    ...onWideContainer({
         display: 'block',
-    })(theme),
+    })({ theme }),
 }));
 
 export const ListItemBox = styled(Box)(({ theme }) => ({

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -21,8 +21,21 @@ const ContentGrid2 = styled('article')(({ theme }) => {
     };
 });
 
-export const ProjectGrid = styled(ContentGrid2)(({ theme }) => ({
-    '@container (min-width: 1000px)': {
+const withContainerQueryFallback = (css: object) => (theme: Theme) => {
+    const containerBreakpoint = '1000px';
+    const screenBreakpoint = theme.breakpoints.up('lg');
+
+    return {
+        [`@container (min-width: ${containerBreakpoint})`]: css,
+
+        '@supports not (container-type: inline-size)': {
+            [screenBreakpoint]: css,
+        },
+    };
+};
+
+export const ProjectGrid = styled(ContentGrid2)(({ theme }) =>
+    withContainerQueryFallback({
         gridTemplateColumns: '1fr 1fr 1fr',
         display: 'grid',
         gridTemplateAreas: `
@@ -30,20 +43,19 @@ export const ProjectGrid = styled(ContentGrid2)(({ theme }) => ({
                 "projects box1 box2"
                 ". owners owners"
             `,
-    },
+    })(theme),
+);
 
-    '@supports not (container-type: inline-size)': {
-        [theme.breakpoints.up('lg')]: {
-            gridTemplateColumns: '1fr 1fr 1fr',
-            display: 'grid',
-            gridTemplateAreas: `
-                "title onboarding onboarding"
-                "projects box1 box2"
-                ". owners owners"
+export const FlagGrid = styled(ContentGrid2)(({ theme }) =>
+    withContainerQueryFallback({
+        gridTemplateColumns: '1fr 2fr',
+        display: 'grid',
+        gridTemplateAreas: `
+                "title lifecycle"
+                "flags chart"
             `,
-        },
-    },
-}));
+    })(theme),
+);
 
 export const SpacedGridItem2 = styled('div')(({ theme }) => ({
     padding: theme.spacing(4),

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -82,29 +82,15 @@ export const MyProjects: FC<{
     return (
         <ContentGridContainer>
             <ProjectGrid>
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'title',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='title'>
                     <Typography variant='h3'>My projects</Typography>
                 </SpacedGridItem2>
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'onboarding',
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='onboarding'>
                     {setupIncomplete ? (
                         <Badge color='warning'>Setup incomplete</Badge>
                     ) : null}
                 </SpacedGridItem2>
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'projects',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='projects'>
                     <List
                         disablePadding={true}
                         sx={{ maxHeight: '400px', overflow: 'auto' }}
@@ -150,11 +136,7 @@ export const MyProjects: FC<{
                         })}
                     </List>
                 </SpacedGridItem2>
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'box1',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='box1'>
                     {activeProjectStage === 'onboarded' &&
                     personalDashboardProjectDetails ? (
                         <ProjectSetupComplete
@@ -170,11 +152,7 @@ export const MyProjects: FC<{
                         <ExistingFlag project={activeProject} />
                     ) : null}
                 </SpacedGridItem2>
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'box2',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='box2'>
                     {activeProjectStage === 'onboarded' &&
                     personalDashboardProjectDetails ? (
                         <LatestProjectEvents
@@ -188,11 +166,7 @@ export const MyProjects: FC<{
                     ) : null}
                 </SpacedGridItem2>
                 <EmptyGridItem />
-                <SpacedGridItem2
-                    sx={{
-                        gridArea: 'owners',
-                    }}
-                >
+                <SpacedGridItem2 gridArea='owners'>
                     {personalDashboardProjectDetails ? (
                         <RoleAndOwnerInfo
                             roles={personalDashboardProjectDetails.roles.map(

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -26,7 +26,7 @@ import {
     ListItemBox,
     listItemStyle,
     ProjectGrid,
-    SpacedGridItem2,
+    SpacedGridItem,
 } from './Grid';
 
 const ActiveProjectDetails: FC<{
@@ -82,15 +82,15 @@ export const MyProjects: FC<{
     return (
         <ContentGridContainer>
             <ProjectGrid>
-                <SpacedGridItem2 gridArea='title'>
+                <SpacedGridItem gridArea='title'>
                     <Typography variant='h3'>My projects</Typography>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='onboarding'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='onboarding'>
                     {setupIncomplete ? (
                         <Badge color='warning'>Setup incomplete</Badge>
                     ) : null}
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='projects'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='projects'>
                     <List
                         disablePadding={true}
                         sx={{ maxHeight: '400px', overflow: 'auto' }}
@@ -135,8 +135,8 @@ export const MyProjects: FC<{
                             );
                         })}
                     </List>
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='box1'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='box1'>
                     {activeProjectStage === 'onboarded' &&
                     personalDashboardProjectDetails ? (
                         <ProjectSetupComplete
@@ -151,8 +151,8 @@ export const MyProjects: FC<{
                     {activeProjectStage === 'first-flag-created' ? (
                         <ExistingFlag project={activeProject} />
                     ) : null}
-                </SpacedGridItem2>
-                <SpacedGridItem2 gridArea='box2'>
+                </SpacedGridItem>
+                <SpacedGridItem gridArea='box2'>
                     {activeProjectStage === 'onboarded' &&
                     personalDashboardProjectDetails ? (
                         <LatestProjectEvents
@@ -164,9 +164,9 @@ export const MyProjects: FC<{
                     {setupIncomplete || activeProjectStage === 'loading' ? (
                         <ConnectSDK project={activeProject} />
                     ) : null}
-                </SpacedGridItem2>
+                </SpacedGridItem>
                 <EmptyGridItem />
-                <SpacedGridItem2 gridArea='owners'>
+                <SpacedGridItem gridArea='owners'>
                     {personalDashboardProjectDetails ? (
                         <RoleAndOwnerInfo
                             roles={personalDashboardProjectDetails.roles.map(
@@ -175,7 +175,7 @@ export const MyProjects: FC<{
                             owners={personalDashboardProjectDetails.owners}
                         />
                     ) : null}
-                </SpacedGridItem2>
+                </SpacedGridItem>
             </ProjectGrid>
         </ContentGridContainer>
     );

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -28,7 +28,7 @@ import {
     FlagGrid,
     ListItemBox,
     listItemStyle,
-    SpacedGridItem2,
+    SpacedGridItem,
 } from './Grid';
 import { ContentGridNoProjects } from './ContentGridNoProjects';
 
@@ -183,10 +183,10 @@ export const PersonalDashboard = () => {
 
             <ContentGridContainer>
                 <FlagGrid sx={{ mt: 2 }}>
-                    <SpacedGridItem2 gridArea='title'>
+                    <SpacedGridItem gridArea='title'>
                         <Typography variant='h3'>My feature flags</Typography>
-                    </SpacedGridItem2>
-                    <SpacedGridItem2
+                    </SpacedGridItem>
+                    <SpacedGridItem
                         gridArea='lifecycle'
                         sx={{ display: 'flex', justifyContent: 'flex-end' }}
                     >
@@ -197,8 +197,8 @@ export const PersonalDashboard = () => {
                                 onArchive={refetchDashboard}
                             />
                         ) : null}
-                    </SpacedGridItem2>
-                    <SpacedGridItem2 gridArea='flags'>
+                    </SpacedGridItem>
+                    <SpacedGridItem gridArea='flags'>
                         {personalDashboard &&
                         personalDashboard.flags.length > 0 ? (
                             <List
@@ -222,15 +222,15 @@ export const PersonalDashboard = () => {
                                 flags. Once you do, they will show up here.
                             </Typography>
                         )}
-                    </SpacedGridItem2>
+                    </SpacedGridItem>
 
-                    <SpacedGridItem2 gridArea='chart'>
+                    <SpacedGridItem gridArea='chart'>
                         {activeFlag ? (
                             <FlagMetricsChart flag={activeFlag} />
                         ) : (
                             <PlaceholderFlagMetricsChart />
                         )}
-                    </SpacedGridItem2>
+                    </SpacedGridItem>
                 </FlagGrid>
             </ContentGridContainer>
             <WelcomeDialog

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -24,10 +24,11 @@ import HelpOutline from '@mui/icons-material/HelpOutline';
 import useLoading from '../../hooks/useLoading';
 import { MyProjects } from './MyProjects';
 import {
-    ContentGrid,
+    ContentGridContainer,
+    FlagGrid,
     ListItemBox,
     listItemStyle,
-    SpacedGridItem,
+    SpacedGridItem2,
 } from './Grid';
 import { ContentGridNoProjects } from './ContentGridNoProjects';
 
@@ -180,55 +181,58 @@ export const PersonalDashboard = () => {
                 />
             )}
 
-            <ContentGrid container columns={{ lg: 12, md: 1 }} sx={{ mt: 2 }}>
-                <SpacedGridItem item lg={4} md={1}>
-                    <Typography variant='h3'>My feature flags</Typography>
-                </SpacedGridItem>
-                <SpacedGridItem
-                    item
-                    lg={8}
-                    md={1}
-                    sx={{ display: 'flex', justifyContent: 'flex-end' }}
-                >
-                    {activeFlag ? (
-                        <FlagExposure
-                            project={activeFlag.project}
-                            flagName={activeFlag.name}
-                            onArchive={refetchDashboard}
-                        />
-                    ) : null}
-                </SpacedGridItem>
-                <SpacedGridItem item lg={4} md={1}>
-                    {personalDashboard && personalDashboard.flags.length > 0 ? (
-                        <List
-                            disablePadding={true}
-                            sx={{ maxHeight: '400px', overflow: 'auto' }}
-                        >
-                            {personalDashboard.flags.map((flag) => (
-                                <FlagListItem
-                                    key={flag.name}
-                                    flag={flag}
-                                    selected={flag.name === activeFlag?.name}
-                                    onClick={() => setActiveFlag(flag)}
-                                />
-                            ))}
-                        </List>
-                    ) : (
-                        <Typography>
-                            You have not created or favorited any feature flags.
-                            Once you do, they will show up here.
-                        </Typography>
-                    )}
-                </SpacedGridItem>
+            <ContentGridContainer>
+                <FlagGrid sx={{ mt: 2 }}>
+                    <SpacedGridItem2 gridArea='title'>
+                        <Typography variant='h3'>My feature flags</Typography>
+                    </SpacedGridItem2>
+                    <SpacedGridItem2
+                        gridArea='lifecycle'
+                        sx={{ display: 'flex', justifyContent: 'flex-end' }}
+                    >
+                        {activeFlag ? (
+                            <FlagExposure
+                                project={activeFlag.project}
+                                flagName={activeFlag.name}
+                                onArchive={refetchDashboard}
+                            />
+                        ) : null}
+                    </SpacedGridItem2>
+                    <SpacedGridItem2 gridArea='flags'>
+                        {personalDashboard &&
+                        personalDashboard.flags.length > 0 ? (
+                            <List
+                                disablePadding={true}
+                                sx={{ maxHeight: '400px', overflow: 'auto' }}
+                            >
+                                {personalDashboard.flags.map((flag) => (
+                                    <FlagListItem
+                                        key={flag.name}
+                                        flag={flag}
+                                        selected={
+                                            flag.name === activeFlag?.name
+                                        }
+                                        onClick={() => setActiveFlag(flag)}
+                                    />
+                                ))}
+                            </List>
+                        ) : (
+                            <Typography>
+                                You have not created or favorited any feature
+                                flags. Once you do, they will show up here.
+                            </Typography>
+                        )}
+                    </SpacedGridItem2>
 
-                <SpacedGridItem item lg={8} md={1}>
-                    {activeFlag ? (
-                        <FlagMetricsChart flag={activeFlag} />
-                    ) : (
-                        <PlaceholderFlagMetricsChart />
-                    )}
-                </SpacedGridItem>
-            </ContentGrid>
+                    <SpacedGridItem2 gridArea='chart'>
+                        {activeFlag ? (
+                            <FlagMetricsChart flag={activeFlag} />
+                        ) : (
+                            <PlaceholderFlagMetricsChart />
+                        )}
+                    </SpacedGridItem2>
+                </FlagGrid>
+            </ContentGridContainer>
             <WelcomeDialog
                 open={welcomeDialog === 'open'}
                 onClose={() => setWelcomeDialog('closed')}


### PR DESCRIPTION
This PR uses the new CSS grid layout for the flag grid and the no content grid.

In doing so, it also improves how you use the grid item (giving them a `gridArea` prop) and extracts the breakpoint handling so that all sections that use breakpoints use the same breakpoints.

As with the previous PR, here's screenies of the same screen width, but with open and closed sidebar:
Open:
![image](https://github.com/user-attachments/assets/2d41d412-5072-4c66-9a48-e7aa0d8cff45)

Closed:
![image](https://github.com/user-attachments/assets/994e3f2c-6f4c-4db1-9f10-e1d1a4d96540)

