### PR TITLE
fix: make gaps 1px instead of 2px

### DIFF
--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -11,7 +11,7 @@ const ContentGrid = styled('article')(({ theme }) => {
         borderRadius: `${theme.shape.borderRadiusLarge}px`,
         overflow: 'hidden',
         border: `0.5px solid ${theme.palette.divider}`,
-        gap: `2px`,
+        gap: `1px`,
         display: 'flex',
         flexFlow: 'column nowrap',
 


### PR DESCRIPTION
This PR reduces the gaps/borders between items in the dashboard grids to 1px.

This screenie has both: 1px for the top grid (projects), 2px for the bottom one (flags):
![image](https://github.com/user-attachments/assets/cb4ef3bb-9253-4a0c-9557-8abf15379871)
