### PR TITLE
fix: vertically center owners and roles content

### DIFF
--- a/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
+++ b/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
@@ -19,6 +19,7 @@ const Wrapper = styled('div')(({ theme }) => ({
 const InfoSection = styled('div')(({ theme }) => ({
     display: 'flex',
     gap: theme.spacing(1),
+    alignItems: 'center',
 }));
 
 export const RoleAndOwnerInfo = ({ roles, owners }: Props) => {


### PR DESCRIPTION
This change fixes the vertical alignment of the owners and roles
content.

Before:
![image](https://github.com/user-attachments/assets/369a738d-06de-4d40-8b2e-a6fff5127714)

After:
![image](https://github.com/user-attachments/assets/4359c47d-d1d5-47b8-9af4-c722fe46fd79)
