### PR TITLE
fix: return 404 if the project doesn't exist

### DIFF
--- a/src/lib/features/onboarding/fake-onboarding-read-model.ts
+++ b/src/lib/features/onboarding/fake-onboarding-read-model.ts
@@ -19,9 +19,7 @@ export class FakeOnboardingReadModel implements IOnboardingReadModel {
         return Promise.resolve([]);
     }
 
-    getOnboardingStatusForProject(
-        projectId: string,
-    ): Promise<OnboardingStatus> {
-        throw new Error('Method not implemented.');
+    async getOnboardingStatusForProject(): Promise<OnboardingStatus | null> {
+        return null;
     }
 }

--- a/src/lib/features/onboarding/onboarding-read-model-type.ts
+++ b/src/lib/features/onboarding/onboarding-read-model-type.ts
@@ -26,5 +26,7 @@ export type ProjectOnboarding = {
 export interface IOnboardingReadModel {
     getInstanceOnboardingMetrics(): Promise<InstanceOnboarding>;
     getProjectsOnboardingMetrics(): Promise<Array<ProjectOnboarding>>;
-    getOnboardingStatusForProject(projectId: string): Promise<OnboardingStatus>;
+    getOnboardingStatusForProject(
+        projectId: string,
+    ): Promise<OnboardingStatus | null>;
 }

--- a/src/lib/features/onboarding/onboarding-read-model.ts
+++ b/src/lib/features/onboarding/onboarding-read-model.ts
@@ -83,11 +83,10 @@ export class OnboardingReadModel implements IOnboardingReadModel {
     async getOnboardingStatusForProject(
         projectId: string,
     ): Promise<OnboardingStatus | null> {
-        const projectExistsResult = await this.db.raw(
-            `SELECT EXISTS(SELECT 1 FROM projects WHERE id = ?) AS projectExists`,
-            [projectId],
-        );
-        const { projectExists } = projectExistsResult.rows[0];
+        const projectExists = await this.db('projects')
+            .select(1)
+            .where('id', projectId)
+            .first();
 
         if (!projectExists) {
             return null;

--- a/src/lib/features/onboarding/onboarding-read-model.ts
+++ b/src/lib/features/onboarding/onboarding-read-model.ts
@@ -82,7 +82,17 @@ export class OnboardingReadModel implements IOnboardingReadModel {
 
     async getOnboardingStatusForProject(
         projectId: string,
-    ): Promise<OnboardingStatus> {
+    ): Promise<OnboardingStatus | null> {
+        const projectExistsResult = await this.db.raw(
+            `SELECT EXISTS(SELECT 1 FROM projects WHERE id = ?) AS projectExists`,
+            [projectId],
+        );
+        const { projectExists } = projectExistsResult.rows[0];
+
+        if (!projectExists) {
+            return null;
+        }
+
         const feature = await this.db('features')
             .select('name')
             .where('project', projectId)

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -18,8 +18,6 @@ import { OnboardingReadModel } from '../onboarding/onboarding-read-model';
 import { FakeOnboardingReadModel } from '../onboarding/fake-onboarding-read-model';
 import { AccessStore } from '../../db/access-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
-import ProjectStore from '../project/project-store';
-import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 
 export const createPersonalDashboardService = (
     db: Db,
@@ -39,12 +37,6 @@ export const createPersonalDashboardService = (
         new PrivateProjectChecker(stores, config),
         new AccountStore(db, config.getLogger),
         new AccessStore(db, config.eventBus, config.getLogger),
-        new ProjectStore(
-            db,
-            config.eventBus,
-            config.getLogger,
-            config.flagResolver,
-        ),
     );
 };
 
@@ -62,6 +54,5 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         new FakePrivateProjectChecker(),
         new FakeAccountStore(),
         new FakeAccessStore(),
-        new FakeProjectStore(),
     );
 };

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -18,6 +18,8 @@ import { OnboardingReadModel } from '../onboarding/onboarding-read-model';
 import { FakeOnboardingReadModel } from '../onboarding/fake-onboarding-read-model';
 import { AccessStore } from '../../db/access-store';
 import FakeAccessStore from '../../../test/fixtures/fake-access-store';
+import ProjectStore from '../project/project-store';
+import FakeProjectStore from '../../../test/fixtures/fake-project-store';
 
 export const createPersonalDashboardService = (
     db: Db,
@@ -37,6 +39,12 @@ export const createPersonalDashboardService = (
         new PrivateProjectChecker(stores, config),
         new AccountStore(db, config.getLogger),
         new AccessStore(db, config.eventBus, config.getLogger),
+        new ProjectStore(
+            db,
+            config.eventBus,
+            config.getLogger,
+            config.flagResolver,
+        ),
     );
 };
 
@@ -54,5 +62,6 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         new FakePrivateProjectChecker(),
         new FakeAccountStore(),
         new FakeAccessStore(),
+        new FakeProjectStore(),
     );
 };

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -335,6 +335,14 @@ test('should return personal dashboard project details', async () => {
     });
 });
 
+test("should return 404 if the project doesn't exist", async () => {
+    await loginUser('new_user@test.com');
+
+    await app.request
+        .get(`/api/admin/personal-dashboard/${randomId()}`)
+        .expect(404);
+});
+
 test('should return Unleash admins', async () => {
     await loginUser('new_user@test.com');
     const adminRoleId = 1;

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -1546,7 +1546,9 @@ export default class ProjectService {
             updatedAt: project.updatedAt,
             archivedAt: project.archivedAt,
             createdAt: project.createdAt,
-            onboardingStatus,
+            onboardingStatus: onboardingStatus ?? {
+                status: 'onboarding-started',
+            },
             environments,
             featureTypeCounts,
             members,


### PR DESCRIPTION
This change adds a check for whether the project exists in the
database before trying to fetch data for it. If it doesn't exist,
you'll get a 404.