### PR TITLE
chore: make signals visible on event timeline for non admins

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeaderTip.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeaderTip.tsx
@@ -1,13 +1,12 @@
 import { Chip, styled } from '@mui/material';
-import AccessContext from 'contexts/AccessContext';
-import { useSignalEndpoints } from 'hooks/api/getters/useSignalEndpoints/useSignalEndpoints';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { useContext } from 'react';
 import { useEventTimelineContext } from '../EventTimelineContext';
 import { Link, useNavigate } from 'react-router-dom';
 import SensorsIcon from '@mui/icons-material/Sensors';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useSignalQuery } from 'hooks/api/getters/useSignalQuery/useSignalQuery';
+import { startOfDay, sub } from 'date-fns';
 
 const StyledTip = styled('div')({
     display: 'flex',
@@ -22,24 +21,30 @@ const StyledSignalIcon = styled(SensorsIcon)(({ theme }) => ({
 
 const signalsLink = '/integrations/signals';
 
+const toISODateString = (date: Date) => date.toISOString().split('T')[0];
+
 export const EventTimelineHeaderTip = () => {
     const navigate = useNavigate();
+    const { timeSpan } = useEventTimelineContext();
+    const endDate = new Date();
+    const startDate = sub(endDate, timeSpan.value);
+    const { signals, loading: signalsLoading } = useSignalQuery({
+        from: `IS:${toISODateString(startOfDay(startDate))}`,
+        to: `IS:${toISODateString(endDate)}`,
+    });
     const { signalsSuggestionSeen, setSignalsSuggestionSeen } =
         useEventTimelineContext();
 
     const { isEnterprise } = useUiConfig();
-    const { isAdmin } = useContext(AccessContext);
     const signalsEnabled = useUiFlag('signals');
-    const { signalEndpoints, loading } = useSignalEndpoints();
     const { trackEvent } = usePlausibleTracker();
 
     if (
         !signalsSuggestionSeen &&
         isEnterprise() &&
-        isAdmin &&
         signalsEnabled &&
-        !loading &&
-        signalEndpoints.length === 0
+        !signalsLoading &&
+        signals.length === 0
     ) {
         return (
             <StyledTip>

--- a/frontend/src/hooks/api/getters/useSignalQuery/useSignalQuery.ts
+++ b/frontend/src/hooks/api/getters/useSignalQuery/useSignalQuery.ts
@@ -1,12 +1,11 @@
 import type { SWRConfiguration } from 'swr';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useClearSWRCache } from 'hooks/useClearSWRCache';
 import type { ISignalQuerySignal } from 'interfaces/signal';
 import useUiConfig from '../useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
-import AccessContext from 'contexts/AccessContext';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 
 type SignalQueryParams = {
@@ -57,7 +56,6 @@ const createSignalQuery = () => {
         options: SWRConfiguration = {},
         cachePrefix: string = '',
     ): UseSignalsOutput => {
-        const { isAdmin } = useContext(AccessContext);
         const { isEnterprise } = useUiConfig();
         const signalsEnabled = useUiFlag('signals');
 
@@ -67,7 +65,7 @@ const createSignalQuery = () => {
 
         const { data, error, mutate, isLoading } =
             useConditionalSWR<SignalQueryResponse>(
-                isEnterprise() && isAdmin && signalsEnabled,
+                isEnterprise() && signalsEnabled,
                 fallbackData,
                 swrKey,
                 fetcher,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2743/open-the-signal-query-endpoint-to-everyone-not-only-admins

The new signal query endpoint is now open for every Unleash user, not only admins. 

This PR allows non-admins to view signals in the event timeline. It also updates the signals tooltip to be shown to all users, not just admins, under the following assumptions:

- `!signalsSuggestionSeen` - Current user has not dismissed the signals tip
- `isEnterprise()` - Enterprise instance
- `signalsEnabled` - The signals feature flag is enabled
- `!signalsLoading` - Signals have finished loading (avoids flickering)
- `signals.length === 0` - We can't find any signals in the selected timespan