### PR TITLE
fix: no owners listed in personal dashboard for default project

### DIFF
--- a/frontend/src/openapi/models/personalDashboardProjectDetailsSchema.ts
+++ b/frontend/src/openapi/models/personalDashboardProjectDetailsSchema.ts
@@ -23,7 +23,6 @@ export interface PersonalDashboardProjectDetailsSchema {
     owners: PersonalDashboardProjectDetailsSchemaOwners;
     /**
      * The list of roles that the user has in this project.
-     * @minItems 1
      */
     roles: PersonalDashboardProjectDetailsSchemaRolesItem[];
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -389,3 +389,17 @@ test('should return Unleash admins', async () => {
         },
     ]);
 });
+
+test('should return System owner for default project if nothing else is set', async () => {
+    await loginUser('new_user@test.com');
+
+    const { body } = await app.request.get(
+        `/api/admin/personal-dashboard/default`,
+    );
+
+    expect(body.owners).toMatchObject([
+        {
+            ownerType: 'system',
+        },
+    ]);
+});

--- a/src/lib/features/project/project-owners-read-model.ts
+++ b/src/lib/features/project/project-owners-read-model.ts
@@ -161,6 +161,6 @@ export class ProjectOwnersReadModel implements IProjectOwnersReadModel {
 
     async getProjectOwners(projectId: string): Promise<ProjectOwners> {
         const owners = await this.getProjectOwnersDictionary();
-        return owners[projectId] ?? [];
+        return owners[projectId] ?? [{ ownerType: 'system' }];
     }
 }

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -119,7 +119,6 @@ export const personalDashboardProjectDetailsSchema = {
         roles: {
             type: 'array',
             description: 'The list of roles that the user has in this project.',
-            minItems: 1,
             items: {
                 type: 'object',
                 description: 'An Unleash role.',


### PR DESCRIPTION
This PR fixes a bug where the default project would have no listed owners. The issue was that the default project has no user owners by default, so we didn't get a result back when looking for user owners. Now we check whether we have any owners for that project, and if we don't, then we return the system user as an owner instead.

This also fixes an issue for the default project where you have no roles (because by default, you don't) by updating the schema to allow an empty list.