### PR TITLE
chore: better show hide event timeline tooltips

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeader.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeader.tsx
@@ -119,7 +119,7 @@ export const EventTimelineHeader = ({
                         </StyledFilter>
                     )}
                 />
-                <Tooltip title='Hide timeline' arrow>
+                <Tooltip title='Hide event timeline' arrow>
                     <IconButton
                         aria-label='close'
                         size='small'

--- a/frontend/src/component/menu/Header/HeaderEventTimelineButton.tsx
+++ b/frontend/src/component/menu/Header/HeaderEventTimelineButton.tsx
@@ -44,7 +44,10 @@ export const HeaderEventTimelineButton = () => {
     if (!eventTimeline) return null;
 
     return (
-        <Tooltip title={showTimeline ? 'Hide timeline' : 'Show timeline'} arrow>
+        <Tooltip
+            title={showTimeline ? 'Hide event timeline' : 'Show event timeline'}
+            arrow
+        >
             <StyledHeaderEventTimelineButton
                 highlighted={highlighted}
                 onClick={() => {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2753/improve-current-showhide-tooltips-to-be-more-specific-about-the

Improves the "show" and "hide" tooltips of this feature to have a slightly more specific text. This is not just any timeline, this is the **event timeline**.

- "Hide timeline" -> "Hide event timeline"
- "Show timeline" -> "Show event timeline"