### PR TITLE
feat: store dashboard state

### DIFF
--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -81,7 +81,6 @@ const ProjectListItem: FC<{
 
     return (
         <ListItem
-            key={project.id}
             disablePadding={true}
             sx={{ mb: 1 }}
             ref={selected ? activeProjectRef : null}
@@ -151,6 +150,7 @@ export const MyProjects: FC<{
                         {projects.map((project) => {
                             return (
                                 <ProjectListItem
+                                    key={project.id}
                                     project={project}
                                     selected={project.id === activeProject}
                                     onClick={() => setActiveProject(project.id)}

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -14,7 +14,7 @@ import { ProjectSetupComplete } from './ProjectSetupComplete';
 import { ConnectSDK, CreateFlag, ExistingFlag } from './ConnectSDK';
 import { LatestProjectEvents } from './LatestProjectEvents';
 import { RoleAndOwnerInfo } from './RoleAndOwnerInfo';
-import type { FC } from 'react';
+import { useEffect, useRef, type FC } from 'react';
 import { StyledCardTitle } from './PersonalDashboard';
 import type {
     PersonalDashboardProjectDetailsSchema,
@@ -80,6 +80,17 @@ export const MyProjects: FC<{
         activeProjectStage === 'onboarding-started' ||
         activeProjectStage === 'first-flag-created';
 
+    const activeItemRef = useRef<HTMLLIElement>(null);
+
+    useEffect(() => {
+        if (activeItemRef.current) {
+            activeItemRef.current.scrollIntoView({
+                block: 'nearest',
+                inline: 'start',
+            });
+        }
+    }, []);
+
     return (
         <ContentGridContainer>
             <ProjectGrid>
@@ -108,6 +119,11 @@ export const MyProjects: FC<{
                                     key={project.id}
                                     disablePadding={true}
                                     sx={{ mb: 1 }}
+                                    ref={
+                                        project.id === activeProject
+                                            ? activeItemRef
+                                            : null
+                                    }
                                 >
                                     <ListItemButton
                                         sx={listItemStyle}

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -63,6 +63,52 @@ const ActiveProjectDetails: FC<{
     );
 };
 
+const ProjectListItem: FC<{
+    project: PersonalDashboardSchemaProjectsItem;
+    selected: boolean;
+    onClick: () => void;
+}> = ({ project, selected, onClick }) => {
+    const activeProjectRef = useRef<HTMLLIElement>(null);
+
+    useEffect(() => {
+        if (activeProjectRef.current) {
+            activeProjectRef.current.scrollIntoView({
+                block: 'nearest',
+                inline: 'start',
+            });
+        }
+    }, []);
+
+    return (
+        <ListItem
+            key={project.id}
+            disablePadding={true}
+            sx={{ mb: 1 }}
+            ref={selected ? activeProjectRef : null}
+        >
+            <ListItemButton
+                sx={listItemStyle}
+                selected={selected}
+                onClick={onClick}
+            >
+                <ListItemBox>
+                    <ProjectIcon color='primary' />
+                    <StyledCardTitle>{project.name}</StyledCardTitle>
+                    <IconButton
+                        component={Link}
+                        href={`projects/${project.id}`}
+                        size='small'
+                        sx={{ ml: 'auto' }}
+                    >
+                        <LinkIcon titleAccess={`projects/${project.id}`} />
+                    </IconButton>
+                </ListItemBox>
+                {selected ? <ActiveProjectDetails project={project} /> : null}
+            </ListItemButton>
+        </ListItem>
+    );
+};
+
 export const MyProjects: FC<{
     projects: PersonalDashboardSchemaProjectsItem[];
     personalDashboardProjectDetails?: PersonalDashboardProjectDetailsSchema;
@@ -79,17 +125,6 @@ export const MyProjects: FC<{
     const setupIncomplete =
         activeProjectStage === 'onboarding-started' ||
         activeProjectStage === 'first-flag-created';
-
-    const activeItemRef = useRef<HTMLLIElement>(null);
-
-    useEffect(() => {
-        if (activeItemRef.current) {
-            activeItemRef.current.scrollIntoView({
-                block: 'nearest',
-                inline: 'start',
-            });
-        }
-    }, []);
 
     return (
         <ContentGridContainer>
@@ -115,46 +150,11 @@ export const MyProjects: FC<{
                     >
                         {projects.map((project) => {
                             return (
-                                <ListItem
-                                    key={project.id}
-                                    disablePadding={true}
-                                    sx={{ mb: 1 }}
-                                    ref={
-                                        project.id === activeProject
-                                            ? activeItemRef
-                                            : null
-                                    }
-                                >
-                                    <ListItemButton
-                                        sx={listItemStyle}
-                                        selected={project.id === activeProject}
-                                        onClick={() =>
-                                            setActiveProject(project.id)
-                                        }
-                                    >
-                                        <ListItemBox>
-                                            <ProjectIcon color='primary' />
-                                            <StyledCardTitle>
-                                                {project.name}
-                                            </StyledCardTitle>
-                                            <IconButton
-                                                component={Link}
-                                                href={`projects/${project.id}`}
-                                                size='small'
-                                                sx={{ ml: 'auto' }}
-                                            >
-                                                <LinkIcon
-                                                    titleAccess={`projects/${project.id}`}
-                                                />
-                                            </IconButton>
-                                        </ListItemBox>
-                                        {project.id === activeProject ? (
-                                            <ActiveProjectDetails
-                                                project={project}
-                                            />
-                                        ) : null}
-                                    </ListItemButton>
-                                </ListItem>
+                                <ProjectListItem
+                                    project={project}
+                                    selected={project.id === activeProject}
+                                    onClick={() => setActiveProject(project.id)}
+                                />
                             );
                         })}
                     </List>

--- a/frontend/src/component/personalDashboard/PersonalDashboard.test.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.test.tsx
@@ -117,6 +117,9 @@ const setupNewProject = () => {
 // @ts-ignore
 HTMLCanvasElement.prototype.getContext = () => {};
 
+//scrollIntoView is not implemented in jsdom
+HTMLElement.prototype.scrollIntoView = () => {};
+
 test('Render personal dashboard for a long running project', async () => {
     setupLongRunningProject();
     render(<PersonalDashboard />);

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -8,7 +8,7 @@ import {
     styled,
     Typography,
 } from '@mui/material';
-import React, { type FC, useEffect, useState, useRef } from 'react';
+import React, { type FC, useEffect, useRef } from 'react';
 import LinkIcon from '@mui/icons-material/ArrowForward';
 import { WelcomeDialog } from './WelcomeDialog';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
@@ -101,18 +101,6 @@ const FlagListItem: FC<{
             </ListItemButton>
         </ListItem>
     );
-};
-
-const useActiveProject = (projects: PersonalDashboardSchemaProjectsItem[]) => {
-    const [activeProject, setActiveProject] = useState(projects[0]?.id);
-
-    useEffect(() => {
-        if (!activeProject && projects.length > 0) {
-            setActiveProject(projects[0].id);
-        }
-    }, [JSON.stringify(projects)]);
-
-    return [activeProject, setActiveProject] as const;
 };
 
 const useDashboardState = (

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -8,7 +8,7 @@ import {
     styled,
     Typography,
 } from '@mui/material';
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState, useRef } from 'react';
 import LinkIcon from '@mui/icons-material/ArrowForward';
 import { WelcomeDialog } from './WelcomeDialog';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
@@ -61,9 +61,24 @@ const FlagListItem: FC<{
     selected: boolean;
     onClick: () => void;
 }> = ({ flag, selected, onClick }) => {
+    const activeFlagRef = useRef<HTMLLIElement>(null);
+
+    useEffect(() => {
+        if (activeFlagRef.current) {
+            activeFlagRef.current.scrollIntoView({
+                block: 'nearest',
+                inline: 'start',
+            });
+        }
+    }, []);
     const IconComponent = getFeatureTypeIcons(flag.type);
     return (
-        <ListItem key={flag.name} disablePadding={true} sx={{ mb: 1 }}>
+        <ListItem
+            key={flag.name}
+            disablePadding={true}
+            sx={{ mb: 1 }}
+            ref={selected ? activeFlagRef : null}
+        >
             <ListItemButton
                 sx={listItemStyle}
                 selected={selected}

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -135,8 +135,18 @@ const useDashboardState = (
     );
 
     useEffect(() => {
-        const setDefaultFlag = !state.activeFlag && flags.length;
-        const setDefaultProject = !state.activeProject && projects.length;
+        const setDefaultFlag =
+            (!state.activeFlag && flags.length) ||
+            (state.activeFlag &&
+                flags.length &&
+                !flags.some((flag) => flag.name === state.activeFlag?.name));
+        const setDefaultProject =
+            (!state.activeProject && projects.length) ||
+            (state.activeProject &&
+                projects.length &&
+                !projects.some(
+                    (project) => project.id === state.activeProject,
+                ));
 
         if (setDefaultFlag || setDefaultProject) {
             setState({

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -124,17 +124,16 @@ const useDashboardState = (
 
     useEffect(() => {
         const setDefaultFlag =
-            (!state.activeFlag && flags.length) ||
-            (state.activeFlag &&
-                flags.length &&
-                !flags.some((flag) => flag.name === state.activeFlag?.name));
+            (!state.activeFlag ||
+                !flags.some((flag) => flag.name === state.activeFlag?.name)) &&
+            flags.length;
+
         const setDefaultProject =
-            (!state.activeProject && projects.length) ||
-            (state.activeProject &&
-                projects.length &&
+            (!state.activeProject ||
                 !projects.some(
                     (project) => project.id === state.activeProject,
-                ));
+                )) &&
+            projects.length;
 
         if (setDefaultFlag || setDefaultProject) {
             setState({

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -124,16 +124,15 @@ const useDashboardState = (
 
     useEffect(() => {
         const setDefaultFlag =
+            flags.length &&
             (!state.activeFlag ||
-                !flags.some((flag) => flag.name === state.activeFlag?.name)) &&
-            flags.length;
-
+                !flags.some((flag) => flag.name === state.activeFlag?.name));
         const setDefaultProject =
+            projects.length &&
             (!state.activeProject ||
                 !projects.some(
                     (project) => project.id === state.activeProject,
-                )) &&
-            projects.length;
+                ));
 
         if (setDefaultFlag || setDefaultProject) {
             setState({

--- a/frontend/src/hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails.ts
+++ b/frontend/src/hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails.ts
@@ -11,7 +11,7 @@ export interface IPersonalDashboardProjectDetailsOutput {
 }
 
 export const usePersonalDashboardProjectDetails = (
-    project: string,
+    project?: string,
 ): IPersonalDashboardProjectDetailsOutput => {
     const { data, error, mutate } = useConditionalSWR(
         Boolean(project),


### PR DESCRIPTION
This PR stores the dashboard state (selected project and flag) in localstorage so that you get taken back to the same project and flag when you refresh the page or navigate away and back.

It also handles scrolling the selected items into view in case they're below the fold.