### PR TITLE
chore: removes setup badge from personal dashboard

### DIFF
--- a/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
+++ b/frontend/src/component/personalDashboard/ContentGridNoProjects.tsx
@@ -108,7 +108,7 @@ export const ContentGridNoProjects: React.FC<Props> = ({ owners, admins }) => {
     return (
         <ContentGridContainer>
             <ProjectGrid>
-                <GridItem gridArea='title'>
+                <GridItem gridArea='header'>
                     <Typography variant='h3'>My projects</Typography>
                 </GridItem>
                 <GridItem gridArea='onboarding'>

--- a/frontend/src/component/personalDashboard/Grid.tsx
+++ b/frontend/src/component/personalDashboard/Grid.tsx
@@ -41,7 +41,7 @@ export const ProjectGrid = styled(ContentGrid)(
         gridTemplateColumns: '1fr 1fr 1fr',
         display: 'grid',
         gridTemplateAreas: `
-                "title onboarding onboarding"
+                "header header header"
                 "projects box1 box2"
                 ". owners owners"
             `,

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -7,7 +7,6 @@ import {
     ListItemButton,
     Typography,
 } from '@mui/material';
-import { Badge } from '../common/Badge/Badge';
 import { ProjectIcon } from '../common/ProjectIcon/ProjectIcon';
 import LinkIcon from '@mui/icons-material/ArrowForward';
 import { ProjectSetupComplete } from './ProjectSetupComplete';
@@ -190,22 +189,8 @@ export const MyProjects = forwardRef<
         return (
             <ContentGridContainer ref={ref}>
                 <ProjectGrid>
-                    <GridItem gridArea='title'>
+                    <GridItem gridArea='header'>
                         <Typography variant='h3'>My projects</Typography>
-                    </GridItem>
-                    <GridItem
-                        gridArea='onboarding'
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'flex-end',
-                        }}
-                    >
-                        {setupIncomplete ? (
-                            <Badge color='warning'>Setup incomplete</Badge>
-                        ) : null}
-                        {error ? (
-                            <Badge color='error'>Setup state unknown</Badge>
-                        ) : null}
                     </GridItem>
                     <SpacedGridItem gridArea='projects'>
                         <List

--- a/frontend/src/component/personalDashboard/PersonalDashboard.test.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.test.tsx
@@ -159,7 +159,6 @@ test('Render personal dashboard for a new project', async () => {
 
     await screen.findByText('Welcome Unleash User');
     await screen.findByText('projectName');
-    await screen.findByText('Setup incomplete');
     await screen.findByText('3'); // members
     await screen.findByText('0'); // features
     await screen.findByText('100%'); // health

--- a/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
+++ b/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
@@ -66,8 +66,8 @@ export const RoleAndOwnerInfo = ({ roles, owners }: Props) => {
                         </Typography>
                         <Roles>
                             {firstRoles.map((role) => (
-                                <li>
-                                    <RoleBadge key={role} color='secondary'>
+                                <li key={role}>
+                                    <RoleBadge color='secondary'>
                                         {role}
                                     </RoleBadge>
                                 </li>
@@ -79,7 +79,7 @@ export const RoleAndOwnerInfo = ({ roles, owners }: Props) => {
                                         title={
                                             <TooltipRoles>
                                                 {extraRoles.map((role) => (
-                                                    <li>
+                                                    <li key={role}>
                                                         <RoleBadge>
                                                             {role}
                                                         </RoleBadge>


### PR DESCRIPTION
The badge has been removed from the onboarding flow, so we don't need
to show it here. This also prepares it for the collapsible sections.