### PR TITLE
feat: android/swift slow metric info

### DIFF
--- a/frontend/src/component/onboarding/dialog/snippets/android.md
+++ b/frontend/src/component/onboarding/dialog/snippets/android.md
@@ -58,6 +58,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 ```
+ℹ️ **Info:** The Android SDK takes at least 60 seconds to post metrics to Unleash.
 
 ---
 ---

--- a/frontend/src/component/onboarding/dialog/snippets/swift.md
+++ b/frontend/src/component/onboarding/dialog/snippets/swift.md
@@ -12,7 +12,6 @@ import UnleashProxyClientSwift
 var unleash = UnleashProxyClientSwift.UnleashClient(
    unleashUrl: "<YOUR_API_URL>",
    clientKey: "<YOUR_API_TOKEN>", // in production use environment variable
-   refreshInterval: 5, // in production remove this or increase to >=5
    appName: "unleash-onboarding-swift",
    context: [:])
 
@@ -22,3 +21,4 @@ Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
     print("Is enabled", unleash.isEnabled(name: "<YOUR_FLAG>"))
 }
 ```
+ℹ️ **Info:** The Swift SDK takes at least 60 seconds to post metrics to Unleash.


### PR DESCRIPTION
Two corner cases, android and swift do not post metrics before default time. Adding small info box for them.

![image](https://github.com/user-attachments/assets/cad643ba-cdb7-4585-aab3-02cd86f17c74)
