### PR TITLE
feat: add timestamps to project events

### DIFF
--- a/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
+++ b/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { Markdown } from '../common/Markdown/Markdown';
 import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
 import { UserAvatar } from '../common/UserAvatar/UserAvatar';
-import { styled } from '@mui/material';
+import { Typography, styled } from '@mui/material';
 
 const Events = styled('ul')(({ theme }) => ({
     padding: 0,
@@ -18,25 +18,51 @@ const Event = styled('li')(({ theme }) => ({
     marginBottom: theme.spacing(4),
 }));
 
+const TitleContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: theme.spacing(2),
+    alignItems: 'center',
+}));
+
+const ActionBox = styled('article')(({ theme }) => ({
+    padding: theme.spacing(0, 2),
+    display: 'flex',
+    gap: theme.spacing(3),
+    flexDirection: 'column',
+}));
+
 export const LatestProjectEvents: FC<{
     latestEvents: PersonalDashboardProjectDetailsSchema['latestEvents'];
 }> = ({ latestEvents }) => {
     return (
-        <Events>
-            {latestEvents.map((event) => {
-                return (
-                    <Event key={event.id}>
-                        <UserAvatar
-                            src={event.createdByImageUrl}
-                            sx={{ mt: 1 }}
-                        />
-                        <Markdown>
-                            {event.summary ||
-                                'No preview available for this event'}
-                        </Markdown>
-                    </Event>
-                );
-            })}
-        </Events>
+        <ActionBox>
+            <TitleContainer>
+                <Typography
+                    sx={{
+                        fontWeight: 'bold',
+                    }}
+                    component='h4'
+                >
+                    Latest Events
+                </Typography>
+            </TitleContainer>
+            <Events>
+                {latestEvents.map((event) => {
+                    return (
+                        <Event key={event.id}>
+                            <UserAvatar
+                                src={event.createdByImageUrl}
+                                sx={{ mt: 1 }}
+                            />
+                            <Markdown>
+                                {event.summary ||
+                                    'No preview available for this event'}
+                            </Markdown>
+                        </Event>
+                    );
+                })}
+            </Events>
+        </ActionBox>
     );
 };

--- a/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
+++ b/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
@@ -3,6 +3,8 @@ import { Markdown } from '../common/Markdown/Markdown';
 import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
 import { UserAvatar } from '../common/UserAvatar/UserAvatar';
 import { Typography, styled } from '@mui/material';
+import { formatDateYMDHM } from 'utils/formatDate';
+import { useLocationSettings } from 'hooks/useLocationSettings';
 
 const Events = styled('ul')(({ theme }) => ({
     padding: 0,
@@ -16,6 +18,10 @@ const Event = styled('li')(({ theme }) => ({
     gap: theme.spacing(2),
     alignItems: 'center',
     marginBottom: theme.spacing(4),
+
+    '*': {
+        fontWeight: 'normal',
+    },
 }));
 
 const TitleContainer = styled('div')(({ theme }) => ({
@@ -32,9 +38,16 @@ const ActionBox = styled('article')(({ theme }) => ({
     flexDirection: 'column',
 }));
 
+const Timestamp = styled('time')(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.fontSize,
+    marginBottom: theme.spacing(1),
+}));
+
 export const LatestProjectEvents: FC<{
     latestEvents: PersonalDashboardProjectDetailsSchema['latestEvents'];
 }> = ({ latestEvents }) => {
+    const { locationSettings } = useLocationSettings();
     return (
         <ActionBox>
             <TitleContainer>
@@ -55,10 +68,18 @@ export const LatestProjectEvents: FC<{
                                 src={event.createdByImageUrl}
                                 sx={{ mt: 1 }}
                             />
-                            <Markdown>
-                                {event.summary ||
-                                    'No preview available for this event'}
-                            </Markdown>
+                            <div>
+                                <Timestamp dateTime={event.createdAt}>
+                                    {formatDateYMDHM(
+                                        event.createdAt,
+                                        locationSettings.locale,
+                                    )}
+                                </Timestamp>
+                                <Markdown>
+                                    {event.summary ||
+                                        'No preview available for this event'}
+                                </Markdown>
+                            </div>
                         </Event>
                     );
                 })}

--- a/frontend/src/openapi/models/personalDashboardProjectDetailsSchemaLatestEventsItem.ts
+++ b/frontend/src/openapi/models/personalDashboardProjectDetailsSchemaLatestEventsItem.ts
@@ -22,4 +22,5 @@ export type PersonalDashboardProjectDetailsSchemaLatestEventsItem = {
      * @nullable
      */
     summary: string | null;
+    createdAt: string;
 };

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.e2e.test.ts
@@ -237,6 +237,8 @@ test('should return personal dashboard project details', async () => {
         `/api/admin/personal-dashboard/${project.id}`,
     );
 
+    const timestampPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
     expect(body).toMatchObject({
         owners: [
             {
@@ -268,24 +270,28 @@ test('should return personal dashboard project details', async () => {
         },
         latestEvents: [
             {
+                createdAt: expect.stringMatching(timestampPattern),
                 createdBy: 'new_user@test.com',
                 summary: expect.stringContaining(
                     '**new_user@test.com** created **[log_feature_c]',
                 ),
             },
             {
+                createdAt: expect.stringMatching(timestampPattern),
                 createdBy: 'new_user@test.com',
                 summary: expect.stringContaining(
                     '**new_user@test.com** created **[log_feature_b]',
                 ),
             },
             {
+                createdAt: expect.stringMatching(timestampPattern),
                 createdBy: 'new_user@test.com',
                 summary: expect.stringContaining(
                     '**new_user@test.com** created **[log_feature_a]',
                 ),
             },
             {
+                createdAt: expect.stringMatching(timestampPattern),
                 createdBy: 'unknown',
                 summary: expect.stringContaining(
                     'triggered **project-access-added**',

--- a/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-controller.ts
@@ -1,4 +1,9 @@
-import { type IUnleashConfig, type IUnleashServices, NONE } from '../../types';
+import {
+    type IUnleashConfig,
+    type IUnleashServices,
+    NONE,
+    serializeDates,
+} from '../../types';
 import type { OpenApiService } from '../../services';
 import {
     createResponseSchema,
@@ -114,9 +119,9 @@ export default class PersonalDashboardController extends Controller {
             200,
             res,
             personalDashboardProjectDetailsSchema.$id,
-            {
+            serializeDates({
                 ...projectDetails,
-            },
+            }),
         );
     }
 }

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -23,6 +23,19 @@ import type { PersonalDashboardProjectDetailsSchema } from '../../openapi';
 import type { IRoleWithProject } from '../../types/stores/access-store';
 import { NotFoundError } from '../../error';
 
+type PersonalDashboardProjectDetailsUnserialized = Omit<
+    PersonalDashboardProjectDetailsSchema,
+    'latestEvents'
+> & {
+    latestEvents: {
+        createdBy: string;
+        summary: string;
+        createdByImageUrl: string;
+        id: number;
+        createdAt: Date;
+    }[];
+};
+
 export class PersonalDashboardService {
     private personalDashboardReadModel: IPersonalDashboardReadModel;
 
@@ -105,7 +118,7 @@ export class PersonalDashboardService {
     async getPersonalProjectDetails(
         userId: number,
         projectId: string,
-    ): Promise<PersonalDashboardProjectDetailsSchema> {
+    ): Promise<PersonalDashboardProjectDetailsUnserialized> {
         const onboardingStatus =
             await this.onboardingReadModel.getOnboardingStatusForProject(
                 projectId,
@@ -119,6 +132,7 @@ export class PersonalDashboardService {
 
         const formatEvents = (recentEvents: IEvent[]) =>
             recentEvents.map((event) => ({
+                createdAt: event.createdAt,
                 summary: this.featureEventFormatter.format(event).text,
                 createdBy: event.createdBy,
                 id: event.id,

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -89,7 +89,13 @@ export const personalDashboardProjectDetailsSchema = {
                 type: 'object',
                 description: 'An event summary',
                 additionalProperties: false,
-                required: ['summary', 'createdBy', 'createdByImageUrl', 'id'],
+                required: [
+                    'summary',
+                    'createdBy',
+                    'createdByImageUrl',
+                    'id',
+                    'createdAt',
+                ],
                 properties: {
                     id: {
                         type: 'integer',
@@ -111,6 +117,12 @@ export const personalDashboardProjectDetailsSchema = {
                         type: 'string',
                         description: `URL used for the user profile image of the event author`,
                         example: 'https://example.com/242x200.png',
+                    },
+                    createdAt: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'When the event was recorded',
+                        example: '2021-09-01T12:00:00Z',
                     },
                 },
             },


### PR DESCRIPTION
This PR adds timestamps to project events and displays them in the "latest events" box in the project details view.

It also changes the font weight of events to be only normal.

![image](https://github.com/user-attachments/assets/69ee4052-fe96-4fc9-ae45-0818acb0570a)
