### PR TITLE
chore: add OpenAI API key configuration

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -32,6 +32,7 @@ export interface IUiConfig {
     resourceLimits: ResourceLimitsSchema;
     oidcConfiguredThroughEnv?: boolean;
     samlConfiguredThroughEnv?: boolean;
+    unleashAIAvailable?: boolean;
 }
 
 export interface IProclamationToast {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -94,6 +94,7 @@ exports[`should create default config 1`] = `
     "frontendMetricsMaxPerMinute": 6000,
     "frontendRegisterMaxPerMinute": 6000,
   },
+  "openAIAPIKey": undefined,
   "preHook": undefined,
   "preRouterHook": undefined,
   "prometheusApi": undefined,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -711,6 +711,8 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         ),
     };
 
+    const openAIAPIKey = process.env.OPENAI_API_KEY;
+
     return {
         db,
         session,
@@ -749,6 +751,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         rateLimiting,
         feedbackUriPath,
         dailyMetricsStorageDays,
+        openAIAPIKey,
     };
 }
 

--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -180,6 +180,11 @@ export const uiConfigSchema = {
                 'Whether the SAML configuration is set through environment variables or not.',
             example: false,
         },
+        unleashAIAvailable: {
+            type: 'boolean',
+            description: 'Whether Unleash AI is available.',
+            example: false,
+        },
     },
     components: {
         schemas: {

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -152,6 +152,7 @@ class ConfigController extends Controller {
             disablePasswordAuth,
             maintenanceMode,
             feedbackUriPath: this.config.feedbackUriPath,
+            unleashAIAvailable: this.config.openAIAPIKey !== undefined,
         };
 
         this.openApiService.respondWithValidation(

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -273,4 +273,5 @@ export interface IUnleashConfig {
     isEnterprise: boolean;
     rateLimiting: IRateLimiting;
     feedbackUriPath?: string;
+    openAIAPIKey?: string;
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2787/add-openai-api-key-to-our-configuration

Adds the OpenAI API key to our configuration and exposes a new `unleashAIAvailable` boolean in our UI config to let our frontend know that we have configured this. This can be used together with our flag to decide whether we should enable our experiment for our users.