### PR TITLE
fix: display tick values for chart Y axis

### DIFF
--- a/frontend/src/component/personalDashboard/createChartOptions.ts
+++ b/frontend/src/component/personalDashboard/createChartOptions.ts
@@ -7,6 +7,7 @@ import {
     formatDateYMD,
     formatDateYMDHM,
 } from '../../utils/formatDate';
+import { formatTickValue } from 'component/common/Chart/formatTickValue';
 
 const formatVariantEntry = (
     variant: [string, number],
@@ -168,7 +169,15 @@ export const createBarChartOptions = (
                     },
                 },
             },
-            y: scales ? scales.y : {},
+            y: {
+                ...(scales?.y ?? {}),
+                ticks: {
+                    ...(scales?.y?.ticks ?? {}),
+                    color: theme.palette.text.secondary,
+                    callback: formatTickValue,
+                    display: true,
+                },
+            },
         },
         elements,
         interaction,


### PR DESCRIPTION
This PR adds back in ticks for the Y axis of the chart. The ticks were removed when updating the no content chart and this was an oversight.