### PR TITLE
chore: flag for webhook domain logging

### DIFF
--- a/src/lib/addons/webhook.ts
+++ b/src/lib/addons/webhook.ts
@@ -111,10 +111,12 @@ export default class Webhook extends Addon {
             });
         }
 
-        const domain = new URL(url).hostname;
-        this.logger.info(`Webhook invoked`, {
-            domain,
-        });
+        if (this.flagResolver.isEnabled('webhookDomainLogging')) {
+            const domain = new URL(url).hostname;
+            this.logger.info(`Webhook invoked`, {
+                domain,
+            });
+        }
 
         this.registerEvent({
             integrationId,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -62,7 +62,8 @@ export type IFlagKey =
     | 'personalDashboardUI'
     | 'trackLifecycleMetrics'
     | 'purchaseAdditionalEnvironments'
-    | 'unleashAI';
+    | 'unleashAI'
+    | 'webhookDomainLogging';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -305,6 +306,10 @@ const flags: IFlags = {
     ),
     unleashAI: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_UNLEASH_AI,
+        false,
+    ),
+    webhookDomainLogging: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENT_WEBHOOK_DOMAIN_LOGGING,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,7 @@ process.nextTick(async () => {
                         personalDashboardUI: true,
                         purchaseAdditionalEnvironments: true,
                         unleashAI: true,
+                        webhookDomainLogging: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Introduces a flag for webhook info-logging of invocations against domain. This should be on for our cloud customers but default to off so it doesn't clutter logs of OSS/Selfhosted