### PR TITLE
fix: show empty chart when we're loading flag metrics

### DIFF
--- a/frontend/src/component/personalDashboard/ConnectSDK.tsx
+++ b/frontend/src/component/personalDashboard/ConnectSDK.tsx
@@ -91,7 +91,6 @@ export const ExistingFlag: FC<{ project: string }> = ({ project }) => {
 export const ConnectSDK: FC<{ project: string }> = ({ project }) => {
     return (
         <ActionBox data-loading>
-            {' '}
             <TitleContainer>
                 <NeutralCircleContainer>2</NeutralCircleContainer>
                 Connect an SDK
@@ -104,7 +103,7 @@ export const ConnectSDK: FC<{ project: string }> = ({ project }) => {
                 </p>
             </div>
             <div>
-                <Button href={`projects/${project}`} variant='contained'>
+                <Button href={`/projects/${project}`} variant='contained'>
                     Go to project
                 </Button>
             </div>

--- a/frontend/src/component/personalDashboard/FlagMetricsChart.tsx
+++ b/frontend/src/component/personalDashboard/FlagMetricsChart.tsx
@@ -24,7 +24,6 @@ import {
 } from './createChartOptions';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { FlagExposure } from 'component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FlagExposure';
-import useLoading from 'hooks/useLoading';
 
 const defaultYes = [0, 14, 28, 21, 33, 31, 31, 22, 26, 37, 31, 14, 21, 14, 0];
 
@@ -216,9 +215,6 @@ export const FlagMetricsChart: FC<{
     );
 
     const noData = data.datasets[0].data.length === 0;
-
-    console.log('loading', loading);
-    const ref = useLoading(loading);
 
     return (
         <ChartContainer>


### PR DESCRIPTION
This PR makes it so that we show an empty chart when we're loading flag metrics, instead of showing the placeholder chart.

It uses a very simple version that may not be the same size as the standard chart (because it has no labels), but we can change that at a later date.

![image](https://github.com/user-attachments/assets/621ba1b9-e936-4c65-a77b-e1cd6debf865)
