### PR TITLE
refactor: use splash api to store splash state

### DIFF
--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -36,6 +36,8 @@ import {
 import { ContentGridNoProjects } from './ContentGridNoProjects';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
+import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 
 export const StyledCardTitle = styled('div')<{ lines?: number }>(
     ({ theme, lines = 2 }) => ({
@@ -265,6 +267,8 @@ const NoActiveFlagsInfo = styled('div')(({ theme }) => ({
 export const PersonalDashboard = () => {
     const { user } = useAuthUser();
     const { trackEvent } = usePlausibleTracker();
+    const { setSplashSeen } = useSplashApi();
+    const { splash } = useAuthSplash();
 
     const name = user?.name;
 
@@ -285,7 +289,7 @@ export const PersonalDashboard = () => {
 
     const [welcomeDialog, setWelcomeDialog] = useLocalStorageState<
         'open' | 'closed'
-    >('welcome-dialog:v1', 'open');
+    >('welcome-dialog:v1', splash?.personalDashboard ? 'closed' : 'open');
 
     const { personalDashboardProjectDetails, error: detailsError } =
         usePersonalDashboardProjectDetails(activeProject);
@@ -298,9 +302,6 @@ export const PersonalDashboard = () => {
     const projectStageRef = useLoading(
         !detailsError && activeProjectStage === 'loading',
     );
-
-    const [createFlagDialogOpen, setCreateFlagDialogOpen] =
-        React.useState(false);
 
     return (
         <MainContent>
@@ -449,7 +450,10 @@ export const PersonalDashboard = () => {
             </SectionAccordion>
             <WelcomeDialog
                 open={welcomeDialog === 'open'}
-                onClose={() => setWelcomeDialog('closed')}
+                onClose={() => {
+                    setSplashSeen('personalDashboard');
+                    setWelcomeDialog('closed');
+                }}
             />
         </MainContent>
     );

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -289,7 +289,7 @@ export const PersonalDashboard = () => {
 
     const [welcomeDialog, setWelcomeDialog] = useLocalStorageState<
         'open' | 'closed'
-    >('welcome-dialog:v1', splash?.personalDashboard ? 'closed' : 'open');
+    >('welcome-dialog:v1', splash?.personalDashboardKeyConcepts ? 'closed' : 'open');
 
     const { personalDashboardProjectDetails, error: detailsError } =
         usePersonalDashboardProjectDetails(activeProject);

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -291,7 +291,7 @@ export const PersonalDashboard = () => {
         'open' | 'closed'
     >(
         'welcome-dialog:v1',
-        splash?.personalDashboardKeyConcepts ? 'closed' : 'open'
+        splash?.personalDashboardKeyConcepts ? 'closed' : 'open',
     );
 
     const { personalDashboardProjectDetails, error: detailsError } =

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -289,7 +289,10 @@ export const PersonalDashboard = () => {
 
     const [welcomeDialog, setWelcomeDialog] = useLocalStorageState<
         'open' | 'closed'
-    >('welcome-dialog:v1', splash?.personalDashboardKeyConcepts ? 'closed' : 'open');
+    >(
+        'welcome-dialog:v1',
+        splash?.personalDashboardKeyConcepts ? 'closed' : 'open'
+    );
 
     const { personalDashboardProjectDetails, error: detailsError } =
         usePersonalDashboardProjectDetails(activeProject);

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -451,7 +451,7 @@ export const PersonalDashboard = () => {
             <WelcomeDialog
                 open={welcomeDialog === 'open'}
                 onClose={() => {
-                    setSplashSeen('personalDashboard');
+                    setSplashSeen('personalDashboardKeyConcepts');
                     setWelcomeDialog('closed');
                 }}
             />


### PR DESCRIPTION
To avoid showing the key concepts screen to users every time they log back in to Unleash (after logging out), store the state in the DB splash table.

The reason we need to do this is that we clear localstorage on logging out, so things like splash screens and certain other settings don't get stored.