### PR TITLE
fix: now health widget will match will chart

### DIFF
--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
@@ -161,7 +161,7 @@ describe('useFilteredFlagTrends', () => {
             stale: 0,
             potentiallyStale: 0,
             averageUsers: 0,
-            averageHealth: undefined,
+            averageHealth: 100,
             medianTimeToProduction: undefined,
         });
     });
@@ -214,7 +214,7 @@ describe('useFilteredFlagTrends', () => {
             stale: 0,
             potentiallyStale: 0,
             averageUsers: 0,
-            averageHealth: undefined,
+            averageHealth: 100,
             medianTimeToProduction: 5,
         });
     });

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.test.ts
@@ -161,7 +161,7 @@ describe('useFilteredFlagTrends', () => {
             stale: 0,
             potentiallyStale: 0,
             averageUsers: 0,
-            averageHealth: 100,
+            averageHealth: '100',
             medianTimeToProduction: undefined,
         });
     });
@@ -214,7 +214,7 @@ describe('useFilteredFlagTrends', () => {
             stale: 0,
             potentiallyStale: 0,
             averageUsers: 0,
-            averageHealth: 100,
+            averageHealth: '100',
             medianTimeToProduction: 5,
         });
     });

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -70,7 +70,7 @@ export const useFilteredFlagsSummary = (
             averageUsers,
             averageHealth: sum.total
                 ? ((sum.active / (sum.total || 1)) * 100).toFixed(0)
-                : 100,
+                : '100',
             medianTimeToProduction,
         };
     }, [filteredProjectFlagTrends]);

--- a/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
+++ b/frontend/src/component/insights/hooks/useFilteredFlagsSummary.ts
@@ -70,7 +70,7 @@ export const useFilteredFlagsSummary = (
             averageUsers,
             averageHealth: sum.total
                 ? ((sum.active / (sum.total || 1)) * 100).toFixed(0)
-                : undefined,
+                : 100,
             medianTimeToProduction,
         };
     }, [filteredProjectFlagTrends]);


### PR DESCRIPTION
Now it will match with chart if no data.

Previous

![image](https://github.com/user-attachments/assets/48d9c19b-962f-45b9-ab6e-defacd53d90e)



Now

![image](https://github.com/user-attachments/assets/f0132890-9491-4f0e-a88b-e5444ca3eb6b)
