### PR TITLE
fix: spacing between lifecycle metrics and env/period selector

### DIFF
--- a/frontend/src/component/personalDashboard/FlagMetricsChart.tsx
+++ b/frontend/src/component/personalDashboard/FlagMetricsChart.tsx
@@ -200,7 +200,7 @@ const ExposureAndMetricsRow = styled('div')(({ theme }) => ({
     justifyContent: 'space-between',
     flexFlow: 'row wrap',
     width: '100%',
-    gap: theme.spacing(1),
+    gap: theme.spacing(4),
 }));
 
 export const PlaceholderFlagMetricsChartWithWrapper: React.FC<{


### PR DESCRIPTION
This PR fixes a spacing issues between the lifecycle metrics and the environment/period selector. They're now grouped better by proximity.