### PR TITLE
fix: same site api call with session cookie

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -31,6 +31,7 @@ import NotFoundError from './error/notfound-error';
 import { bearerTokenMiddleware } from './middleware/bearer-token-middleware';
 import { auditAccessMiddleware } from './middleware';
 import { originMiddleware } from './middleware/origin-middleware';
+import { unlessHasHeader } from './middleware/unless-has-header-middleware';
 
 export default async function getApp(
     config: IUnleashConfig,
@@ -90,7 +91,7 @@ export default async function getApp(
         ),
     );
     if (unleashSession) {
-        app.use(unleashSession);
+        app.use(unlessHasHeader('authorization', unleashSession));
     }
     app.use(secureHeaders(config));
     app.use(express.urlencoded({ extended: true }));

--- a/src/lib/middleware/unless-has-header-middleware.ts
+++ b/src/lib/middleware/unless-has-header-middleware.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from 'express';
+
+export const unlessHasHeader =
+    (header: string, middleware: RequestHandler): RequestHandler =>
+    (req, res, next) => {
+        if (req.headers[header]) {
+            return next();
+        } else {
+            return middleware(req, res, next);
+        }
+    };


### PR DESCRIPTION
## About the changes
When a web app is hosted in the same domain as Unleash UI and the web app uses unleash SDK to make requests to Unleash, the browser automatically includes the cookie in the request headers if:

    - The request URL matches the cookie's Path attribute (which it does in this case).
    - The request is sent to the same domain (which it is, since both apps are under the same domain).

This PR aims to limit the scope of unleashSession for those URLs that are not APIs. This is an alternative to https://github.com/Unleash/unleash/pull/8435

Closes #8029