### PR TITLE
fix: same site api call with session cookie

### DIFF
--- a/src/lib/middleware/authorization-middleware.ts
+++ b/src/lib/middleware/authorization-middleware.ts
@@ -4,7 +4,6 @@ import type { LogProvider } from '../logger';
 import { AuthenticationRequired } from '../server-impl';
 import UnauthorizedError from '../error/unauthorized-error';
 
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 const authorizationMiddleware = (
     getLogger: LogProvider,
     baseUriPath: string,
@@ -13,7 +12,7 @@ const authorizationMiddleware = (
     logger.debug('Enabling Authorization middleware');
 
     return async (req: IAuthRequest, res: Response, next: NextFunction) => {
-        if (req.session?.user) {
+        if (!req.user?.isAPI && req.session?.user) {
             req.user = req.session.user;
             return next();
         }


### PR DESCRIPTION
## About the changes
This fixes #8029. How to reproduce the issue is in the ticket.

The issue happens because when a web app is hosted in the same domain as Unleash UI and the web app uses unleash SDK to make requests to Unleash, the browser automatically includes the cookie in the request headers, because:

    - The request URL matches the cookie's Path attribute (which it does in this case).
    - The request is sent to the same domain (which it is, since both apps are under the same domain).

And this is by design in the HTTP cookie specification: https://datatracker.ietf.org/doc/html/rfc6265

This PR avoids overriding the API user with the session user if there's already an API user in the request. It's an alternative to https://github.com/Unleash/unleash/pull/8434

Closes #8029