### PR TITLE
chore: rename personal dashboard menu item to dashboard

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
@@ -165,7 +165,7 @@ export const PrimaryNavigationList: FC<{
             {personalDashboardUIEnabled ? (
                 <DynamicListItem
                     href='/personal'
-                    text='Personal Dashboard'
+                    text='Dashboard'
                     onClick={() => onClick('/personal')}
                     selected={activeItem === '/personal'}
                 >

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`returns all baseRoutes 1`] = `
       "mobile": true,
     },
     "path": "/personal",
-    "title": "Personal Dashboard",
+    "title": "Dashboard",
     "type": "protected",
   },
   {

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -62,7 +62,7 @@ export const routes: IRoute[] = [
     // Personal Dashboard
     {
         path: '/personal',
-        title: 'Personal Dashboard',
+        title: 'Dashboard',
         component: PersonalDashboard,
         type: 'protected',
         menu: { mobile: true },


### PR DESCRIPTION
This change updates the title for the personal dashboard menu item to
be just "dashboard"

Before:
![image](https://github.com/user-attachments/assets/d04be63c-ad1f-471b-8ab1-5e781063716c)

After:
![image](https://github.com/user-attachments/assets/dc4a39b6-5b30-455d-b20a-6f04f84962d7)
