### PR TITLE
chore: Unleash AI API hook

### DIFF
--- a/frontend/src/hooks/api/actions/useAIApi/useAIApi.ts
+++ b/frontend/src/hooks/api/actions/useAIApi/useAIApi.ts
@@ -1,0 +1,36 @@
+import useAPI from '../useApi/useApi';
+
+const ENDPOINT = 'api/admin/ai';
+
+export type ChatMessage = {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+};
+
+export const useAIApi = () => {
+    const { makeRequest, createRequest, errors, loading } = useAPI({
+        propagateErrors: true,
+    });
+
+    const chat = async (messages: ChatMessage[]): Promise<ChatMessage[]> => {
+        const requestId = 'chat';
+
+        const req = createRequest(`${ENDPOINT}/chat`, {
+            method: 'POST',
+            body: JSON.stringify({
+                messages,
+            }),
+            requestId,
+        });
+
+        const response = await makeRequest(req.caller, req.id);
+        const { messages: newMessages } = await response.json();
+        return newMessages;
+    };
+
+    return {
+        chat,
+        errors,
+        loading,
+    };
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "yarn run clean && concurrently \"yarn:copy-templates\" \"yarn:build:frontend\" \"yarn:build:backend\"",
     "dev:backend": "TZ=UTC NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",
     "dev:frontend": "wait-on tcp:4242 && yarn --cwd ./frontend run dev",
+    "dev:frontend:cloud": "UNLEASH_BASE_PATH=/demo/ yarn run dev:frontend",
     "dev": "concurrently \"yarn:dev:backend\" \"yarn:dev:frontend\"",
     "prepare:backend": "concurrently \"yarn:copy-templates\" \"yarn:build:backend\"",
     "start:dev": "yarn run clean && TZ=UTC NODE_ENV=development tsc-watch --strictNullChecks false --onSuccess \"node dist/server-dev.js\"",


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2791/create-a-useaiapi-react-hook

Implements a basic Unleash AI API React hook that fits our initial needs for interacting with this API through our frontend.

Also adds a new nice-to-have script to run the frontend set to the `demo` base path, which matches our Cloud defaults. This way you can run the latest local cloud with the latest local frontend in an easy way.