### PR TITLE
chore: handle aggregation queries sequentially follow up

### DIFF
--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -59,6 +59,10 @@ export const scheduleServices = async (
         'updateLastSeen',
     );
 
+    // TODO this works fine for keeping labeledAppCounts up to date, but
+    // it would be nice if we can keep client_apps_total prometheus metric
+    // up to date. We'd need to have access to DbMetricsMonitor, which is
+    // where the metric is registered and call an update only for that metric
     schedulerService.schedule(
         instanceStatsService.getLabeledAppCounts.bind(instanceStatsService),
         minutesToMilliseconds(5),

--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -60,7 +60,7 @@ export const scheduleServices = async (
     );
 
     schedulerService.schedule(
-        instanceStatsService.refreshAppCountSnapshot.bind(instanceStatsService),
+        instanceStatsService.getLabeledAppCounts.bind(instanceStatsService),
         minutesToMilliseconds(5),
         'refreshAppCountSnapshot',
     );

--- a/src/lib/metrics-gauge.test.ts
+++ b/src/lib/metrics-gauge.test.ts
@@ -1,0 +1,114 @@
+import { register } from 'prom-client';
+import { createTestConfig } from '../test/config/test-config';
+import type { IUnleashConfig } from './types';
+import { DbMetricsMonitor } from './metrics-gauge';
+
+const prometheusRegister = register;
+let config: IUnleashConfig;
+let dbMetrics: DbMetricsMonitor;
+
+beforeAll(async () => {
+    config = createTestConfig({
+        server: {
+            serverMetrics: true,
+        },
+    });
+});
+
+beforeEach(async () => {
+    dbMetrics = new DbMetricsMonitor(config);
+});
+
+test('should collect registered metrics', async () => {
+    dbMetrics.registerGaugeDbMetric({
+        name: 'my_metric',
+        help: 'This is the answer to life, the univers, and everything',
+        labelNames: [],
+        query: () => Promise.resolve(42),
+        map: (result) => ({ value: result }),
+    });
+
+    await dbMetrics.refreshDbMetrics();
+
+    const metrics = await prometheusRegister.metrics();
+    expect(metrics).toMatch(/my_metric 42/);
+});
+
+test('should collect registered metrics with labels', async () => {
+    dbMetrics.registerGaugeDbMetric({
+        name: 'life_the_universe_and_everything',
+        help: 'This is the answer to life, the univers, and everything',
+        labelNames: ['test'],
+        query: () => Promise.resolve(42),
+        map: (result) => ({ value: result, labels: { test: 'case' } }),
+    });
+
+    await dbMetrics.refreshDbMetrics();
+
+    const metrics = await prometheusRegister.metrics();
+    expect(metrics).toMatch(
+        /life_the_universe_and_everything\{test="case"\} 42/,
+    );
+});
+
+test('should collect multiple registered metrics with and without labels', async () => {
+    dbMetrics.registerGaugeDbMetric({
+        name: 'my_first_metric',
+        help: 'This is the answer to life, the univers, and everything',
+        labelNames: [],
+        query: () => Promise.resolve(42),
+        map: (result) => ({ value: result }),
+    });
+
+    dbMetrics.registerGaugeDbMetric({
+        name: 'my_other_metric',
+        help: 'This is Eulers number',
+        labelNames: ['euler'],
+        query: () => Promise.resolve(Math.E),
+        map: (result) => ({ value: result, labels: { euler: 'number' } }),
+    });
+
+    await dbMetrics.refreshDbMetrics();
+
+    const metrics = await prometheusRegister.metrics();
+    expect(metrics).toMatch(/my_first_metric 42/);
+    expect(metrics).toMatch(/my_other_metric\{euler="number"\} 2.71828/);
+});
+
+test('should support different label and value pairs', async () => {
+    dbMetrics.registerGaugeDbMetric({
+        name: 'multi_dimensional',
+        help: 'This metric has different values for different labels',
+        labelNames: ['version', 'range'],
+        query: () => Promise.resolve(2),
+        map: (result) => [
+            { value: result, labels: { version: '1', range: 'linear' } },
+            {
+                value: result * result,
+                labels: { version: '2', range: 'square' },
+            },
+            { value: result / 2, labels: { version: '3', range: 'half' } },
+        ],
+    });
+
+    await dbMetrics.refreshDbMetrics();
+
+    const metrics = await prometheusRegister.metrics();
+    expect(metrics).toMatch(
+        /multi_dimensional\{version="1",range="linear"\} 2\nmulti_dimensional\{version="2",range="square"\} 4\nmulti_dimensional\{version="3",range="half"\} 1/,
+    );
+    expect(
+        await dbMetrics.findValue('multi_dimensional', { range: 'linear' }),
+    ).toBe(2);
+    expect(
+        await dbMetrics.findValue('multi_dimensional', { range: 'half' }),
+    ).toBe(1);
+    expect(
+        await dbMetrics.findValue('multi_dimensional', { range: 'square' }),
+    ).toBe(4);
+    expect(
+        await dbMetrics.findValue('multi_dimensional', { range: 'x' }),
+    ).toBeUndefined();
+    expect(await dbMetrics.findValue('multi_dimensional')).toBe(2); // first match
+    expect(await dbMetrics.findValue('other')).toBeUndefined();
+});

--- a/src/lib/metrics-gauge.ts
+++ b/src/lib/metrics-gauge.ts
@@ -64,10 +64,11 @@ export class DbMetricsMonitor {
     }
 
     refreshDbMetrics = async () => {
-        const tasks = Array.from(this.updaters.values()).map(
-            (updater) => updater.task,
+        const tasks = Array.from(this.updaters.entries()).map(
+            ([name, updater]) => ({ name, task: updater.task }),
         );
-        for (const task of tasks) {
+        for (const { name, task } of tasks) {
+            this.log.debug(`Refreshing metric ${name}`);
             await task();
         }
     };

--- a/src/lib/metrics-gauge.ts
+++ b/src/lib/metrics-gauge.ts
@@ -22,17 +22,19 @@ export class DbMetricsMonitor {
 
     constructor() {}
 
-    registerGaugeDbMetric<T>(definition: GaugeDefinition<T>) {
+    registerGaugeDbMetric<T>(definition: GaugeDefinition<T>): Task {
         const gauge = createGauge(definition);
         this.gauges.set(definition.name, gauge);
-        this.tasks.add(async () => {
+        const task = async () => {
             const result = await definition.query();
-            if (result) {
+            if (result !== null && result !== undefined) {
                 const { count, labels } = definition.map(result);
                 gauge.reset();
                 gauge.labels(labels).set(count);
             }
-        });
+        };
+        this.tasks.add(task);
+        return task;
     }
 
     refreshDbMetrics = async () => {

--- a/src/lib/metrics-gauge.ts
+++ b/src/lib/metrics-gauge.ts
@@ -4,15 +4,11 @@ import { createGauge, type Gauge } from './util/metrics';
 
 type RestrictedRecord<T extends readonly string[]> = Record<T[number], string>;
 type Query<R> = () => Promise<R | undefined | null>;
-type MapResult<R> = (result: R) =>
-    | {
-          count: number;
-          labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
-      }
-    | {
-          count: number;
-          labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
-      }[];
+type MetricValue<R> = {
+    count: number;
+    labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
+};
+type MapResult<R> = (result: R) => MetricValue<R> | MetricValue<R>[];
 
 type GaugeDefinition<T> = {
     name: string;

--- a/src/lib/metrics-gauge.ts
+++ b/src/lib/metrics-gauge.ts
@@ -1,11 +1,18 @@
+import type { Logger } from './logger';
+import type { IUnleashConfig } from './types';
 import { createGauge, type Gauge } from './util/metrics';
 
 type RestrictedRecord<T extends readonly string[]> = Record<T[number], string>;
 type Query<R> = () => Promise<R | undefined | null>;
-type MapResult<R> = (result: R) => {
-    count: number;
-    labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
-};
+type MapResult<R> = (result: R) =>
+    | {
+          count: number;
+          labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
+      }
+    | {
+          count: number;
+          labels: RestrictedRecord<GaugeDefinition<R>['labelNames']>;
+      }[];
 
 type GaugeDefinition<T> = {
     name: string;
@@ -19,18 +26,31 @@ type Task = () => Promise<void>;
 export class DbMetricsMonitor {
     private tasks: Set<Task> = new Set();
     private gauges: Map<string, Gauge<string>> = new Map();
+    private logger: Logger;
 
-    constructor() {}
+    constructor(config: IUnleashConfig) {
+        this.logger = config.getLogger('gauge-metrics');
+    }
+
+    private asArray<T>(value: T | T[]): T[] {
+        return Array.isArray(value) ? value : [value];
+    }
 
     registerGaugeDbMetric<T>(definition: GaugeDefinition<T>): Task {
         const gauge = createGauge(definition);
         this.gauges.set(definition.name, gauge);
         const task = async () => {
-            const result = await definition.query();
-            if (result !== null && result !== undefined) {
-                const { count, labels } = definition.map(result);
-                gauge.reset();
-                gauge.labels(labels).set(count);
+            try {
+                const result = await definition.query();
+                if (result !== null && result !== undefined) {
+                    const results = this.asArray(definition.map(result));
+                    gauge.reset();
+                    for (const r of results) {
+                        gauge.labels(r.labels).set(r.count);
+                    }
+                }
+            } catch (e) {
+                this.logger.warn(`Failed to refresh ${definition.name}`, e);
             }
         };
         this.tasks.add(task);

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -212,6 +212,7 @@ test('should collect metrics for function timings', async () => {
 });
 
 test('should collect metrics for feature flag size', async () => {
+    await statsService.dbMetrics.refreshDbMetrics();
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/feature_toggles_total\{version="(.*)"\} 0/);
 });
@@ -222,7 +223,7 @@ test('should collect metrics for archived feature flag size', async () => {
 });
 
 test('should collect metrics for total client apps', async () => {
-    await statsService.refreshAppCountSnapshot();
+    await statsService.dbMetrics.refreshDbMetrics();
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/client_apps_total\{range="(.*)"\} 0/);
 });

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -15,7 +15,11 @@ import {
     FEATURE_UPDATED,
     PROJECT_ENVIRONMENT_REMOVED,
 } from './types/events';
-import { createMetricsMonitor } from './metrics';
+import {
+    createMetricsMonitor,
+    registerPrometheusMetrics,
+    registerPrometheusPostgresMetrics,
+} from './metrics';
 import createStores from '../test/fixtures/store';
 import { InstanceStatsService } from './features/instance-stats/instance-stats-service';
 import VersionService from './services/version-service';
@@ -46,6 +50,7 @@ let schedulerService: SchedulerService;
 let featureLifeCycleStore: IFeatureLifecycleStore;
 let featureLifeCycleReadModel: IFeatureLifecycleReadModel;
 let db: ITestDb;
+let refreshDbMetrics: () => Promise<void>;
 
 beforeAll(async () => {
     const config = createTestConfig({
@@ -102,16 +107,16 @@ beforeAll(async () => {
         },
     };
 
-    await monitor.startMonitoring(
-        config,
-        stores,
-        '4.0.0',
-        eventBus,
-        statsService,
-        schedulerService,
-        // @ts-ignore - We don't want a full knex implementation for our tests, it's enough that it actually yields the numbers we want.
-        metricsDbConf,
-    );
+    const { collectDbMetrics, collectStaticCounters } =
+        registerPrometheusMetrics(
+            config,
+            stores,
+            '4.0.0',
+            eventBus,
+            statsService,
+        );
+    refreshDbMetrics = collectDbMetrics;
+    await collectStaticCounters();
 });
 
 afterAll(async () => {
@@ -212,7 +217,7 @@ test('should collect metrics for function timings', async () => {
 });
 
 test('should collect metrics for feature flag size', async () => {
-    await statsService.dbMetrics.refreshDbMetrics();
+    await refreshDbMetrics();
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/feature_toggles_total\{version="(.*)"\} 0/);
 });
@@ -223,12 +228,13 @@ test('should collect metrics for archived feature flag size', async () => {
 });
 
 test('should collect metrics for total client apps', async () => {
-    await statsService.dbMetrics.refreshDbMetrics();
+    await refreshDbMetrics();
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/client_apps_total\{range="(.*)"\} 0/);
 });
 
 test('Should collect metrics for database', async () => {
+    registerPrometheusPostgresMetrics(db.rawDatabase, eventBus, '15.0.0');
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(/db_pool_max/);
     expect(metrics).toMatch(/db_pool_min/);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -460,30 +460,6 @@ export default class MetricsMonitor {
                         .set(stage.duration);
                 });
 
-                eventBus.on(
-                    events.STAGE_ENTERED,
-                    (entered: { stage: string; feature: string }) => {
-                        if (flagResolver.isEnabled('trackLifecycleMetrics')) {
-                            logger.info(
-                                `STAGE_ENTERED listened ${JSON.stringify(entered)}`,
-                            );
-                        }
-                        featureLifecycleStageEnteredCounter.increment({
-                            stage: entered.stage,
-                        });
-                    },
-                );
-
-                eventBus.on(
-                    events.EXCEEDS_LIMIT,
-                    ({
-                        resource,
-                        limit,
-                    }: { resource: string; limit: number }) => {
-                        exceedsLimitErrorCounter.increment({ resource, limit });
-                    },
-                );
-
                 featureLifecycleStageCountByProject.reset();
                 stageCountByProjectResult.forEach((stageResult) =>
                     featureLifecycleStageCountByProject
@@ -721,6 +697,27 @@ export default class MetricsMonitor {
             hoursToMilliseconds(2),
             'collectStaticCounters',
             0, // no jitter
+        );
+
+        eventBus.on(
+            events.EXCEEDS_LIMIT,
+            ({ resource, limit }: { resource: string; limit: number }) => {
+                exceedsLimitErrorCounter.increment({ resource, limit });
+            },
+        );
+
+        eventBus.on(
+            events.STAGE_ENTERED,
+            (entered: { stage: string; feature: string }) => {
+                if (flagResolver.isEnabled('trackLifecycleMetrics')) {
+                    logger.info(
+                        `STAGE_ENTERED listened ${JSON.stringify(entered)}`,
+                    );
+                }
+                featureLifecycleStageEnteredCounter.increment({
+                    stage: entered.stage,
+                });
+            },
         );
 
         eventBus.on(

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -367,6 +367,55 @@ export function registerPrometheusMetrics(
         help: 'Rate limits (per minute) for METHOD/ENDPOINT pairs',
         labelNames: ['endpoint', 'method'],
     });
+    rateLimits
+        .labels({
+            endpoint: '/api/client/metrics',
+            method: 'POST',
+        })
+        .set(config.metricsRateLimiting.clientMetricsMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/api/client/register',
+            method: 'POST',
+        })
+        .set(config.metricsRateLimiting.clientRegisterMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/api/frontend/metrics',
+            method: 'POST',
+        })
+        .set(config.metricsRateLimiting.frontendMetricsMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/api/frontend/register',
+            method: 'POST',
+        })
+        .set(config.metricsRateLimiting.frontendRegisterMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/api/admin/user-admin',
+            method: 'POST',
+        })
+        .set(config.rateLimiting.createUserMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/auth/simple',
+            method: 'POST',
+        })
+        .set(config.rateLimiting.simpleLoginMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/auth/reset/password-email',
+            method: 'POST',
+        })
+        .set(config.rateLimiting.passwordResetMaxPerMinute);
+    rateLimits
+        .labels({
+            endpoint: '/api/signal-endpoint/:name',
+            method: 'POST',
+        })
+        .set(config.rateLimiting.callSignalEndpointMaxPerSecond * 60);
+
     const featureCreatedByMigration = createCounter({
         name: 'feature_created_by_migration_count',
         help: 'Feature createdBy migration count',
@@ -1005,62 +1054,6 @@ export function registerPrometheusMetrics(
 
                 oidcEnabled.reset();
                 oidcEnabled.set((await instanceStatsService.hasOIDC()) ? 1 : 0);
-
-                rateLimits.reset();
-                rateLimits
-                    .labels({
-                        endpoint: '/api/client/metrics',
-                        method: 'POST',
-                    })
-                    .set(config.metricsRateLimiting.clientMetricsMaxPerMinute);
-                rateLimits
-                    .labels({
-                        endpoint: '/api/client/register',
-                        method: 'POST',
-                    })
-                    .set(config.metricsRateLimiting.clientRegisterMaxPerMinute);
-                rateLimits
-                    .labels({
-                        endpoint: '/api/frontend/metrics',
-                        method: 'POST',
-                    })
-                    .set(
-                        config.metricsRateLimiting.frontendMetricsMaxPerMinute,
-                    );
-                rateLimits
-                    .labels({
-                        endpoint: '/api/frontend/register',
-                        method: 'POST',
-                    })
-                    .set(
-                        config.metricsRateLimiting.frontendRegisterMaxPerMinute,
-                    );
-                rateLimits
-                    .labels({
-                        endpoint: '/api/admin/user-admin',
-                        method: 'POST',
-                    })
-                    .set(config.rateLimiting.createUserMaxPerMinute);
-                rateLimits
-                    .labels({
-                        endpoint: '/auth/simple',
-                        method: 'POST',
-                    })
-                    .set(config.rateLimiting.simpleLoginMaxPerMinute);
-                rateLimits
-                    .labels({
-                        endpoint: '/auth/reset/password-email',
-                        method: 'POST',
-                    })
-                    .set(config.rateLimiting.passwordResetMaxPerMinute);
-                rateLimits
-                    .labels({
-                        endpoint: '/api/signal-endpoint/:name',
-                        method: 'POST',
-                    })
-                    .set(
-                        config.rateLimiting.callSignalEndpointMaxPerSecond * 60,
-                    );
             } catch (e) {}
         },
     };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -124,7 +124,7 @@ export default class MetricsMonitor {
             help: 'Number of feature flags',
             labelNames: ['version'],
             query: () => instanceStatsService.getToggleCount(),
-            map: (count) => ({ count, labels: { version } }),
+            map: (value) => ({ value, labels: { version } }),
         })();
 
         dbMetrics.registerGaugeDbMetric({
@@ -134,7 +134,7 @@ export default class MetricsMonitor {
             query: () =>
                 stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
             map: (result) => ({
-                count: result.count,
+                value: result.count,
                 labels: {
                     environment: result.environment,
                     feature: result.feature,
@@ -149,7 +149,7 @@ export default class MetricsMonitor {
             query: () =>
                 stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
             map: (result) => ({
-                count: result.count,
+                value: result.count,
                 labels: { feature: result.feature },
             }),
         });
@@ -268,7 +268,7 @@ export default class MetricsMonitor {
             query: () => instanceStatsService.getLabeledAppCounts(),
             map: (result) =>
                 Object.entries(result).map(([range, count]) => ({
-                    count,
+                    value: count,
                     labels: { range },
                 })),
         })();

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -117,13 +117,16 @@ export default class MetricsMonitor {
             help: 'Number of times a feature flag has been used',
             labelNames: ['toggle', 'active', 'appName'],
         });
-        dbMetrics.registerGaugeDbMetric({
+
+        // schedule and execute immediately
+        await dbMetrics.registerGaugeDbMetric({
             name: 'feature_toggles_total',
             help: 'Number of feature flags',
             labelNames: ['version'],
             query: () => instanceStatsService.getToggleCount(),
             map: (count) => ({ count, labels: { version } }),
-        });
+        })();
+
         dbMetrics.registerGaugeDbMetric({
             name: 'max_feature_environment_strategies',
             help: 'Maximum number of environment strategies in one feature',

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -117,10 +117,12 @@ export default class MetricsMonitor {
             help: 'Number of times a feature flag has been used',
             labelNames: ['toggle', 'active', 'appName'],
         });
-        const featureFlagsTotal = createGauge({
+        dbMetrics.registerGaugeDbMetric({
             name: 'feature_toggles_total',
             help: 'Number of feature flags',
             labelNames: ['version'],
+            query: () => instanceStatsService.getToggleCount(),
+            map: (count) => ({ count, labels: { version } }),
         });
         dbMetrics.registerGaugeDbMetric({
             name: 'max_feature_environment_strategies',
@@ -445,9 +447,6 @@ export default class MetricsMonitor {
                         ? stores.onboardingReadModel.getProjectsOnboardingMetrics()
                         : Promise.resolve([]),
                 ]);
-
-                featureFlagsTotal.reset();
-                featureFlagsTotal.labels({ version }).set(stats.featureToggles);
 
                 featureTogglesArchivedTotal.reset();
                 featureTogglesArchivedTotal.set(stats.archivedFeatureToggles);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -37,393 +37,707 @@ import {
 } from './util/metrics';
 import type { SchedulerService } from './services';
 import type { IClientMetricsEnv } from './features/metrics/client-metrics/client-metrics-store-v2-type';
-import { DbMetricsMonitor } from './metrics-gauge';
 
-export default class MetricsMonitor {
-    constructor() {}
+export function registerPrometheusMetrics(
+    config: IUnleashConfig,
+    stores: IUnleashStores,
+    version: string,
+    eventBus: EventEmitter,
+    instanceStatsService: InstanceStatsService,
+) {
+    const resolveEnvironmentType = async (
+        environment: string,
+        cachedEnvironments: () => Promise<IEnvironment[]>,
+    ): Promise<string> => {
+        const environments = await cachedEnvironments();
+        const env = environments.find((e) => e.name === environment);
 
-    async startMonitoring(
-        config: IUnleashConfig,
-        stores: IUnleashStores,
-        version: string,
-        eventBus: EventEmitter,
-        instanceStatsService: InstanceStatsService,
-        schedulerService: SchedulerService,
-        db: Knex,
-    ): Promise<void> {
-        if (!config.server.serverMetrics) {
-            return Promise.resolve();
+        if (env) {
+            return env.type;
+        } else {
+            return 'unknown';
+        }
+    };
+
+    const { eventStore, environmentStore } = stores;
+    const { flagResolver } = config;
+    const dbMetrics = instanceStatsService.dbMetrics;
+
+    const cachedEnvironments: () => Promise<IEnvironment[]> = memoizee(
+        async () => environmentStore.getAll(),
+        {
+            promise: true,
+            maxAge: hoursToMilliseconds(1),
+        },
+    );
+
+    const requestDuration = createSummary({
+        name: 'http_request_duration_milliseconds',
+        help: 'App response time',
+        labelNames: ['path', 'method', 'status', 'appName'],
+        percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+        maxAgeSeconds: 600,
+        ageBuckets: 5,
+    });
+    const schedulerDuration = createSummary({
+        name: 'scheduler_duration_seconds',
+        help: 'Scheduler duration time',
+        labelNames: ['jobId'],
+        percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+        maxAgeSeconds: 600,
+        ageBuckets: 5,
+    });
+    const dbDuration = createSummary({
+        name: 'db_query_duration_seconds',
+        help: 'DB query duration time',
+        labelNames: ['store', 'action'],
+        percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+        maxAgeSeconds: 600,
+        ageBuckets: 5,
+    });
+    const functionDuration = createSummary({
+        name: 'function_duration_seconds',
+        help: 'Function duration time',
+        labelNames: ['functionName', 'className'],
+        percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
+        maxAgeSeconds: 600,
+        ageBuckets: 5,
+    });
+    const featureFlagUpdateTotal = createCounter({
+        name: 'feature_toggle_update_total',
+        help: 'Number of times a toggle has been updated. Environment label would be "n/a" when it is not available, e.g. when a feature flag is created.',
+        labelNames: [
+            'toggle',
+            'project',
+            'environment',
+            'environmentType',
+            'action',
+        ],
+    });
+    const featureFlagUsageTotal = createCounter({
+        name: 'feature_toggle_usage_total',
+        help: 'Number of times a feature flag has been used',
+        labelNames: ['toggle', 'active', 'appName'],
+    });
+
+    dbMetrics.registerGaugeDbMetric({
+        name: 'feature_toggles_total',
+        help: 'Number of feature flags',
+        labelNames: ['version'],
+        query: () =>
+            stores.featureToggleStore.count({
+                archived: false,
+            }),
+        map: (value) => ({ value, labels: { version } }),
+    });
+
+    dbMetrics.registerGaugeDbMetric({
+        name: 'max_feature_environment_strategies',
+        help: 'Maximum number of environment strategies in one feature',
+        labelNames: ['feature', 'environment'],
+        query: () =>
+            stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
+        map: (result) => ({
+            value: result.count,
+            labels: {
+                environment: result.environment,
+                feature: result.feature,
+            },
+        }),
+    });
+
+    dbMetrics.registerGaugeDbMetric({
+        name: 'max_feature_strategies',
+        help: 'Maximum number of strategies in one feature',
+        labelNames: ['feature'],
+        query: () =>
+            stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
+        map: (result) => ({
+            value: result.count,
+            labels: { feature: result.feature },
+        }),
+    });
+
+    const maxConstraintValues = createGauge({
+        name: 'max_constraint_values',
+        help: 'Maximum number of constraint values used in a single constraint',
+        labelNames: ['feature', 'environment'],
+    });
+    const maxConstraintsPerStrategy = createGauge({
+        name: 'max_strategy_constraints',
+        help: 'Maximum number of constraints used on a single strategy',
+        labelNames: ['feature', 'environment'],
+    });
+    const largestProjectEnvironment = createGauge({
+        name: 'largest_project_environment_size',
+        help: 'The largest project environment size (bytes) based on strategies, constraints, variants and parameters',
+        labelNames: ['project', 'environment'],
+    });
+    const largestFeatureEnvironment = createGauge({
+        name: 'largest_feature_environment_size',
+        help: 'The largest feature environment size (bytes) base on strategies, constraints, variants and parameters',
+        labelNames: ['feature', 'environment'],
+    });
+
+    const featureTogglesArchivedTotal = createGauge({
+        name: 'feature_toggles_archived_total',
+        help: 'Number of archived feature flags',
+    });
+    const usersTotal = createGauge({
+        name: 'users_total',
+        help: 'Number of users',
+    });
+    const serviceAccounts = createGauge({
+        name: 'service_accounts_total',
+        help: 'Number of service accounts',
+    });
+    const apiTokens = createGauge({
+        name: 'api_tokens_total',
+        help: 'Number of API tokens',
+        labelNames: ['type'],
+    });
+    const enabledMetricsBucketsPreviousDay = createGauge({
+        name: 'enabled_metrics_buckets_previous_day',
+        help: 'Number of hourly enabled/disabled metric buckets in the previous day',
+    });
+    const variantMetricsBucketsPreviousDay = createGauge({
+        name: 'variant_metrics_buckets_previous_day',
+        help: 'Number of hourly variant metric buckets in the previous day',
+    });
+    const usersActive7days = createGauge({
+        name: 'users_active_7',
+        help: 'Number of users active in the last 7 days',
+    });
+    const usersActive30days = createGauge({
+        name: 'users_active_30',
+        help: 'Number of users active in the last 30 days',
+    });
+    const usersActive60days = createGauge({
+        name: 'users_active_60',
+        help: 'Number of users active in the last 60 days',
+    });
+    const usersActive90days = createGauge({
+        name: 'users_active_90',
+        help: 'Number of users active in the last 90 days',
+    });
+    const projectsTotal = createGauge({
+        name: 'projects_total',
+        help: 'Number of projects',
+        labelNames: ['mode'],
+    });
+    const environmentsTotal = createGauge({
+        name: 'environments_total',
+        help: 'Number of environments',
+    });
+    const groupsTotal = createGauge({
+        name: 'groups_total',
+        help: 'Number of groups',
+    });
+
+    const rolesTotal = createGauge({
+        name: 'roles_total',
+        help: 'Number of roles',
+    });
+
+    const customRootRolesTotal = createGauge({
+        name: 'custom_root_roles_total',
+        help: 'Number of custom root roles',
+    });
+
+    const customRootRolesInUseTotal = createGauge({
+        name: 'custom_root_roles_in_use_total',
+        help: 'Number of custom root roles in use',
+    });
+
+    const segmentsTotal = createGauge({
+        name: 'segments_total',
+        help: 'Number of segments',
+    });
+
+    const contextTotal = createGauge({
+        name: 'context_total',
+        help: 'Number of context',
+    });
+
+    const strategiesTotal = createGauge({
+        name: 'strategies_total',
+        help: 'Number of strategies',
+    });
+
+    dbMetrics.registerGaugeDbMetric({
+        name: 'client_apps_total',
+        help: 'Number of registered client apps aggregated by range by last seen',
+        labelNames: ['range'],
+        query: async () => {
+            const [t7d, t30d, allTime] = await Promise.all([
+                stores.clientInstanceStore.getDistinctApplicationsCount(7),
+                stores.clientInstanceStore.getDistinctApplicationsCount(30),
+                stores.clientInstanceStore.getDistinctApplicationsCount(),
+            ]);
+            return {
+                '7d': t7d,
+                '30d': t30d,
+                allTime,
+            };
+        },
+        map: (result) =>
+            Object.entries(result).map(([range, count]) => ({
+                value: count,
+                labels: { range },
+            })),
+    });
+
+    const samlEnabled = createGauge({
+        name: 'saml_enabled',
+        help: 'Whether SAML is enabled',
+    });
+
+    const oidcEnabled = createGauge({
+        name: 'oidc_enabled',
+        help: 'Whether OIDC is enabled',
+    });
+
+    const clientSdkVersionUsage = createCounter({
+        name: 'client_sdk_versions',
+        help: 'Which sdk versions are being used',
+        labelNames: [
+            'sdk_name',
+            'sdk_version',
+            'platform_name',
+            'platform_version',
+            'yggdrasil_version',
+            'spec_version',
+        ],
+    });
+
+    const productionChanges30 = createGauge({
+        name: 'production_changes_30',
+        help: 'Changes made to production environment last 30 days',
+        labelNames: ['environment'],
+    });
+    const productionChanges60 = createGauge({
+        name: 'production_changes_60',
+        help: 'Changes made to production environment last 60 days',
+        labelNames: ['environment'],
+    });
+    const productionChanges90 = createGauge({
+        name: 'production_changes_90',
+        help: 'Changes made to production environment last 90 days',
+        labelNames: ['environment'],
+    });
+
+    const rateLimits = createGauge({
+        name: 'rate_limits',
+        help: 'Rate limits (per minute) for METHOD/ENDPOINT pairs',
+        labelNames: ['endpoint', 'method'],
+    });
+    const featureCreatedByMigration = createCounter({
+        name: 'feature_created_by_migration_count',
+        help: 'Feature createdBy migration count',
+    });
+    const eventCreatedByMigration = createCounter({
+        name: 'event_created_by_migration_count',
+        help: 'Event createdBy migration count',
+    });
+    const proxyRepositoriesCreated = createCounter({
+        name: 'proxy_repositories_created',
+        help: 'Proxy repositories created',
+    });
+    const frontendApiRepositoriesCreated = createCounter({
+        name: 'frontend_api_repositories_created',
+        help: 'Frontend API repositories created',
+    });
+    const mapFeaturesForClientDuration = createHistogram({
+        name: 'map_features_for_client_duration',
+        help: 'Duration of mapFeaturesForClient function',
+    });
+
+    const featureLifecycleStageDuration = createGauge({
+        name: 'feature_lifecycle_stage_duration',
+        labelNames: ['stage', 'project_id'],
+        help: 'Duration of feature lifecycle stages',
+    });
+
+    const onboardingDuration = createGauge({
+        name: 'onboarding_duration',
+        labelNames: ['event'],
+        help: 'firstLogin, secondLogin, firstFeatureFlag, firstPreLive, firstLive from first user creation',
+    });
+    const projectOnboardingDuration = createGauge({
+        name: 'project_onboarding_duration',
+        labelNames: ['event', 'project'],
+        help: 'firstFeatureFlag, firstPreLive, firstLive from project creation',
+    });
+
+    const featureLifecycleStageCountByProject = createGauge({
+        name: 'feature_lifecycle_stage_count_by_project',
+        help: 'Count features in a given stage by project id',
+        labelNames: ['stage', 'project_id'],
+    });
+
+    const featureLifecycleStageEnteredCounter = createCounter({
+        name: 'feature_lifecycle_stage_entered',
+        help: 'Count how many features entered a given stage',
+        labelNames: ['stage'],
+    });
+
+    const projectActionsCounter = createCounter({
+        name: 'project_actions_count',
+        help: 'Count project actions',
+        labelNames: ['action'],
+    });
+
+    const projectEnvironmentsDisabled = createCounter({
+        name: 'project_environments_disabled',
+        help: 'How many "environment disabled" events we have received for each project',
+        labelNames: ['project_id'],
+    });
+
+    const orphanedTokensTotal = createGauge({
+        name: 'orphaned_api_tokens_total',
+        help: 'Number of API tokens without a project',
+    });
+
+    const orphanedTokensActive = createGauge({
+        name: 'orphaned_api_tokens_active',
+        help: 'Number of API tokens without a project, last seen within 3 months',
+    });
+
+    const legacyTokensTotal = createGauge({
+        name: 'legacy_api_tokens_total',
+        help: 'Number of API tokens with v1 format',
+    });
+
+    const legacyTokensActive = createGauge({
+        name: 'legacy_api_tokens_active',
+        help: 'Number of API tokens with v1 format, last seen within 3 months',
+    });
+
+    const exceedsLimitErrorCounter = createCounter({
+        name: 'exceeds_limit_error',
+        help: 'The number of exceeds limit errors registered by this instance.',
+        labelNames: ['resource', 'limit'],
+    });
+
+    const requestOriginCounter = createCounter({
+        name: 'request_origin_counter',
+        help: 'Number of authenticated requests, including origin information.',
+        labelNames: ['type', 'method', 'source'],
+    });
+
+    const resourceLimit = createGauge({
+        name: 'resource_limit',
+        help: 'The maximum number of resources allowed.',
+        labelNames: ['resource'],
+    });
+
+    const addonEventsHandledCounter = createCounter({
+        name: 'addon_events_handled',
+        help: 'Events handled by addons and the result.',
+        labelNames: ['result', 'destination'],
+    });
+
+    // register event listeners
+    eventBus.on(
+        events.EXCEEDS_LIMIT,
+        ({ resource, limit }: { resource: string; limit: number }) => {
+            exceedsLimitErrorCounter.increment({ resource, limit });
+        },
+    );
+
+    eventBus.on(
+        events.STAGE_ENTERED,
+        (entered: { stage: string; feature: string }) => {
+            if (flagResolver.isEnabled('trackLifecycleMetrics')) {
+                logger.info(
+                    `STAGE_ENTERED listened ${JSON.stringify(entered)}`,
+                );
+            }
+            featureLifecycleStageEnteredCounter.increment({
+                stage: entered.stage,
+            });
+        },
+    );
+
+    eventBus.on(
+        events.REQUEST_TIME,
+        ({ path, method, time, statusCode, appName }) => {
+            requestDuration
+                .labels({
+                    path,
+                    method,
+                    status: statusCode,
+                    appName,
+                })
+                .observe(time);
+        },
+    );
+
+    eventBus.on(events.SCHEDULER_JOB_TIME, ({ jobId, time }) => {
+        schedulerDuration.labels(jobId).observe(time);
+    });
+
+    eventBus.on(events.FUNCTION_TIME, ({ functionName, className, time }) => {
+        functionDuration
+            .labels({
+                functionName,
+                className,
+            })
+            .observe(time);
+    });
+
+    eventBus.on(events.EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {
+        eventCreatedByMigration.inc(updated);
+    });
+
+    eventBus.on(events.FEATURES_CREATED_BY_PROCESSED, ({ updated }) => {
+        featureCreatedByMigration.inc(updated);
+    });
+
+    eventBus.on(events.DB_TIME, ({ store, action, time }) => {
+        dbDuration
+            .labels({
+                store,
+                action,
+            })
+            .observe(time);
+    });
+
+    eventBus.on(events.PROXY_REPOSITORY_CREATED, () => {
+        proxyRepositoriesCreated.inc();
+    });
+
+    eventBus.on(events.FRONTEND_API_REPOSITORY_CREATED, () => {
+        frontendApiRepositoriesCreated.inc();
+    });
+
+    eventBus.on(events.PROXY_FEATURES_FOR_TOKEN_TIME, ({ duration }) => {
+        mapFeaturesForClientDuration.observe(duration);
+    });
+
+    events.onMetricEvent(
+        eventBus,
+        events.REQUEST_ORIGIN,
+        ({ type, method, source }) => {
+            if (flagResolver.isEnabled('originMiddleware')) {
+                requestOriginCounter.increment({ type, method, source });
+            }
+        },
+    );
+
+    eventStore.on(FEATURE_CREATED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'n/a',
+            environmentType: 'n/a',
+            action: 'created',
+        });
+    });
+    eventStore.on(FEATURE_VARIANTS_UPDATED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'n/a',
+            environmentType: 'n/a',
+            action: 'updated',
+        });
+    });
+    eventStore.on(FEATURE_METADATA_UPDATED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'n/a',
+            environmentType: 'n/a',
+            action: 'updated',
+        });
+    });
+    eventStore.on(FEATURE_UPDATED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'default',
+            environmentType: 'production',
+            action: 'updated',
+        });
+    });
+    eventStore.on(
+        FEATURE_STRATEGY_ADD,
+        async ({ featureName, project, environment }) => {
+            const environmentType = await resolveEnvironmentType(
+                environment,
+                cachedEnvironments,
+            );
+            featureFlagUpdateTotal.increment({
+                toggle: featureName,
+                project,
+                environment,
+                environmentType,
+                action: 'updated',
+            });
+        },
+    );
+    eventStore.on(
+        FEATURE_STRATEGY_REMOVE,
+        async ({ featureName, project, environment }) => {
+            const environmentType = await resolveEnvironmentType(
+                environment,
+                cachedEnvironments,
+            );
+            featureFlagUpdateTotal.increment({
+                toggle: featureName,
+                project,
+                environment,
+                environmentType,
+                action: 'updated',
+            });
+        },
+    );
+    eventStore.on(
+        FEATURE_STRATEGY_UPDATE,
+        async ({ featureName, project, environment }) => {
+            const environmentType = await resolveEnvironmentType(
+                environment,
+                cachedEnvironments,
+            );
+            featureFlagUpdateTotal.increment({
+                toggle: featureName,
+                project,
+                environment,
+                environmentType,
+                action: 'updated',
+            });
+        },
+    );
+    eventStore.on(
+        FEATURE_ENVIRONMENT_DISABLED,
+        async ({ featureName, project, environment }) => {
+            const environmentType = await resolveEnvironmentType(
+                environment,
+                cachedEnvironments,
+            );
+            featureFlagUpdateTotal.increment({
+                toggle: featureName,
+                project,
+                environment,
+                environmentType,
+                action: 'updated',
+            });
+        },
+    );
+    eventStore.on(
+        FEATURE_ENVIRONMENT_ENABLED,
+        async ({ featureName, project, environment }) => {
+            const environmentType = await resolveEnvironmentType(
+                environment,
+                cachedEnvironments,
+            );
+            featureFlagUpdateTotal.increment({
+                toggle: featureName,
+                project,
+                environment,
+                environmentType,
+                action: 'updated',
+            });
+        },
+    );
+    eventStore.on(FEATURE_ARCHIVED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'n/a',
+            environmentType: 'n/a',
+            action: 'archived',
+        });
+    });
+    eventStore.on(FEATURE_REVIVED, ({ featureName, project }) => {
+        featureFlagUpdateTotal.increment({
+            toggle: featureName,
+            project,
+            environment: 'n/a',
+            environmentType: 'n/a',
+            action: 'revived',
+        });
+    });
+    eventStore.on(PROJECT_CREATED, () => {
+        projectActionsCounter.increment({ action: PROJECT_CREATED });
+    });
+    eventStore.on(PROJECT_ARCHIVED, () => {
+        projectActionsCounter.increment({ action: PROJECT_ARCHIVED });
+    });
+    eventStore.on(PROJECT_REVIVED, () => {
+        projectActionsCounter.increment({ action: PROJECT_REVIVED });
+    });
+    eventStore.on(PROJECT_DELETED, () => {
+        projectActionsCounter.increment({ action: PROJECT_DELETED });
+    });
+
+    const logger = config.getLogger('metrics.ts');
+    eventBus.on(CLIENT_METRICS, (metrics: IClientMetricsEnv[]) => {
+        try {
+            for (const metric of metrics) {
+                featureFlagUsageTotal.increment(
+                    {
+                        toggle: metric.featureName,
+                        active: 'true',
+                        appName: metric.appName,
+                    },
+                    metric.yes,
+                );
+                featureFlagUsageTotal.increment(
+                    {
+                        toggle: metric.featureName,
+                        active: 'false',
+                        appName: metric.appName,
+                    },
+                    metric.no,
+                );
+            }
+        } catch (e) {
+            logger.warn('Metrics registration failed', e);
+        }
+    });
+
+    eventStore.on(CLIENT_REGISTER, (heartbeatEvent: ISdkHeartbeat) => {
+        if (!heartbeatEvent.sdkName || !heartbeatEvent.sdkVersion) {
+            return;
         }
 
-        const { eventStore, environmentStore } = stores;
-        const { flagResolver } = config;
-        const dbMetrics = new DbMetricsMonitor(config);
+        if (flagResolver.isEnabled('extendedMetrics')) {
+            clientSdkVersionUsage.increment({
+                sdk_name: heartbeatEvent.sdkName,
+                sdk_version: heartbeatEvent.sdkVersion,
+                platform_name:
+                    heartbeatEvent.metadata?.platformName ?? 'not-set',
+                platform_version:
+                    heartbeatEvent.metadata?.platformVersion ?? 'not-set',
+                yggdrasil_version:
+                    heartbeatEvent.metadata?.yggdrasilVersion ?? 'not-set',
+                spec_version: heartbeatEvent.metadata?.specVersion ?? 'not-set',
+            });
+        } else {
+            clientSdkVersionUsage.increment({
+                sdk_name: heartbeatEvent.sdkName,
+                sdk_version: heartbeatEvent.sdkVersion,
+                platform_name: 'not-set',
+                platform_version: 'not-set',
+                yggdrasil_version: 'not-set',
+                spec_version: 'not-set',
+            });
+        }
+    });
 
-        const cachedEnvironments: () => Promise<IEnvironment[]> = memoizee(
-            async () => environmentStore.getAll(),
-            {
-                promise: true,
-                maxAge: hoursToMilliseconds(1),
-            },
-        );
+    eventStore.on(PROJECT_ENVIRONMENT_REMOVED, ({ project }) => {
+        projectEnvironmentsDisabled.increment({ project_id: project });
+    });
 
-        collectDefaultMetrics();
+    eventBus.on(events.ADDON_EVENTS_HANDLED, ({ result, destination }) => {
+        addonEventsHandledCounter.increment({ result, destination });
+    });
 
-        const requestDuration = createSummary({
-            name: 'http_request_duration_milliseconds',
-            help: 'App response time',
-            labelNames: ['path', 'method', 'status', 'appName'],
-            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
-            maxAgeSeconds: 600,
-            ageBuckets: 5,
-        });
-        const schedulerDuration = createSummary({
-            name: 'scheduler_duration_seconds',
-            help: 'Scheduler duration time',
-            labelNames: ['jobId'],
-            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
-            maxAgeSeconds: 600,
-            ageBuckets: 5,
-        });
-        const dbDuration = createSummary({
-            name: 'db_query_duration_seconds',
-            help: 'DB query duration time',
-            labelNames: ['store', 'action'],
-            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
-            maxAgeSeconds: 600,
-            ageBuckets: 5,
-        });
-        const functionDuration = createSummary({
-            name: 'function_duration_seconds',
-            help: 'Function duration time',
-            labelNames: ['functionName', 'className'],
-            percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
-            maxAgeSeconds: 600,
-            ageBuckets: 5,
-        });
-        const featureFlagUpdateTotal = createCounter({
-            name: 'feature_toggle_update_total',
-            help: 'Number of times a toggle has been updated. Environment label would be "n/a" when it is not available, e.g. when a feature flag is created.',
-            labelNames: [
-                'toggle',
-                'project',
-                'environment',
-                'environmentType',
-                'action',
-            ],
-        });
-        const featureFlagUsageTotal = createCounter({
-            name: 'feature_toggle_usage_total',
-            help: 'Number of times a feature flag has been used',
-            labelNames: ['toggle', 'active', 'appName'],
-        });
-
-        // schedule and execute immediately
-        await dbMetrics.registerGaugeDbMetric({
-            name: 'feature_toggles_total',
-            help: 'Number of feature flags',
-            labelNames: ['version'],
-            query: () => instanceStatsService.getToggleCount(),
-            map: (value) => ({ value, labels: { version } }),
-        })();
-
-        dbMetrics.registerGaugeDbMetric({
-            name: 'max_feature_environment_strategies',
-            help: 'Maximum number of environment strategies in one feature',
-            labelNames: ['feature', 'environment'],
-            query: () =>
-                stores.featureStrategiesReadModel.getMaxFeatureEnvironmentStrategies(),
-            map: (result) => ({
-                value: result.count,
-                labels: {
-                    environment: result.environment,
-                    feature: result.feature,
-                },
-            }),
-        });
-
-        dbMetrics.registerGaugeDbMetric({
-            name: 'max_feature_strategies',
-            help: 'Maximum number of strategies in one feature',
-            labelNames: ['feature'],
-            query: () =>
-                stores.featureStrategiesReadModel.getMaxFeatureStrategies(),
-            map: (result) => ({
-                value: result.count,
-                labels: { feature: result.feature },
-            }),
-        });
-
-        const maxConstraintValues = createGauge({
-            name: 'max_constraint_values',
-            help: 'Maximum number of constraint values used in a single constraint',
-            labelNames: ['feature', 'environment'],
-        });
-        const maxConstraintsPerStrategy = createGauge({
-            name: 'max_strategy_constraints',
-            help: 'Maximum number of constraints used on a single strategy',
-            labelNames: ['feature', 'environment'],
-        });
-        const largestProjectEnvironment = createGauge({
-            name: 'largest_project_environment_size',
-            help: 'The largest project environment size (bytes) based on strategies, constraints, variants and parameters',
-            labelNames: ['project', 'environment'],
-        });
-        const largestFeatureEnvironment = createGauge({
-            name: 'largest_feature_environment_size',
-            help: 'The largest feature environment size (bytes) base on strategies, constraints, variants and parameters',
-            labelNames: ['feature', 'environment'],
-        });
-
-        const featureTogglesArchivedTotal = createGauge({
-            name: 'feature_toggles_archived_total',
-            help: 'Number of archived feature flags',
-        });
-        const usersTotal = createGauge({
-            name: 'users_total',
-            help: 'Number of users',
-        });
-        const serviceAccounts = createGauge({
-            name: 'service_accounts_total',
-            help: 'Number of service accounts',
-        });
-        const apiTokens = createGauge({
-            name: 'api_tokens_total',
-            help: 'Number of API tokens',
-            labelNames: ['type'],
-        });
-        const enabledMetricsBucketsPreviousDay = createGauge({
-            name: 'enabled_metrics_buckets_previous_day',
-            help: 'Number of hourly enabled/disabled metric buckets in the previous day',
-        });
-        const variantMetricsBucketsPreviousDay = createGauge({
-            name: 'variant_metrics_buckets_previous_day',
-            help: 'Number of hourly variant metric buckets in the previous day',
-        });
-        const usersActive7days = createGauge({
-            name: 'users_active_7',
-            help: 'Number of users active in the last 7 days',
-        });
-        const usersActive30days = createGauge({
-            name: 'users_active_30',
-            help: 'Number of users active in the last 30 days',
-        });
-        const usersActive60days = createGauge({
-            name: 'users_active_60',
-            help: 'Number of users active in the last 60 days',
-        });
-        const usersActive90days = createGauge({
-            name: 'users_active_90',
-            help: 'Number of users active in the last 90 days',
-        });
-        const projectsTotal = createGauge({
-            name: 'projects_total',
-            help: 'Number of projects',
-            labelNames: ['mode'],
-        });
-        const environmentsTotal = createGauge({
-            name: 'environments_total',
-            help: 'Number of environments',
-        });
-        const groupsTotal = createGauge({
-            name: 'groups_total',
-            help: 'Number of groups',
-        });
-
-        const rolesTotal = createGauge({
-            name: 'roles_total',
-            help: 'Number of roles',
-        });
-
-        const customRootRolesTotal = createGauge({
-            name: 'custom_root_roles_total',
-            help: 'Number of custom root roles',
-        });
-
-        const customRootRolesInUseTotal = createGauge({
-            name: 'custom_root_roles_in_use_total',
-            help: 'Number of custom root roles in use',
-        });
-
-        const segmentsTotal = createGauge({
-            name: 'segments_total',
-            help: 'Number of segments',
-        });
-
-        const contextTotal = createGauge({
-            name: 'context_total',
-            help: 'Number of context',
-        });
-
-        const strategiesTotal = createGauge({
-            name: 'strategies_total',
-            help: 'Number of strategies',
-        });
-
-        // execute immediately to get initial values
-        await dbMetrics.registerGaugeDbMetric({
-            name: 'client_apps_total',
-            help: 'Number of registered client apps aggregated by range by last seen',
-            labelNames: ['range'],
-            query: () => instanceStatsService.getLabeledAppCounts(),
-            map: (result) =>
-                Object.entries(result).map(([range, count]) => ({
-                    value: count,
-                    labels: { range },
-                })),
-        })();
-
-        const samlEnabled = createGauge({
-            name: 'saml_enabled',
-            help: 'Whether SAML is enabled',
-        });
-
-        const oidcEnabled = createGauge({
-            name: 'oidc_enabled',
-            help: 'Whether OIDC is enabled',
-        });
-
-        const clientSdkVersionUsage = createCounter({
-            name: 'client_sdk_versions',
-            help: 'Which sdk versions are being used',
-            labelNames: [
-                'sdk_name',
-                'sdk_version',
-                'platform_name',
-                'platform_version',
-                'yggdrasil_version',
-                'spec_version',
-            ],
-        });
-
-        const productionChanges30 = createGauge({
-            name: 'production_changes_30',
-            help: 'Changes made to production environment last 30 days',
-            labelNames: ['environment'],
-        });
-        const productionChanges60 = createGauge({
-            name: 'production_changes_60',
-            help: 'Changes made to production environment last 60 days',
-            labelNames: ['environment'],
-        });
-        const productionChanges90 = createGauge({
-            name: 'production_changes_90',
-            help: 'Changes made to production environment last 90 days',
-            labelNames: ['environment'],
-        });
-
-        const rateLimits = createGauge({
-            name: 'rate_limits',
-            help: 'Rate limits (per minute) for METHOD/ENDPOINT pairs',
-            labelNames: ['endpoint', 'method'],
-        });
-        const featureCreatedByMigration = createCounter({
-            name: 'feature_created_by_migration_count',
-            help: 'Feature createdBy migration count',
-        });
-        const eventCreatedByMigration = createCounter({
-            name: 'event_created_by_migration_count',
-            help: 'Event createdBy migration count',
-        });
-        const proxyRepositoriesCreated = createCounter({
-            name: 'proxy_repositories_created',
-            help: 'Proxy repositories created',
-        });
-        const frontendApiRepositoriesCreated = createCounter({
-            name: 'frontend_api_repositories_created',
-            help: 'Frontend API repositories created',
-        });
-        const mapFeaturesForClientDuration = createHistogram({
-            name: 'map_features_for_client_duration',
-            help: 'Duration of mapFeaturesForClient function',
-        });
-
-        const featureLifecycleStageDuration = createGauge({
-            name: 'feature_lifecycle_stage_duration',
-            labelNames: ['stage', 'project_id'],
-            help: 'Duration of feature lifecycle stages',
-        });
-
-        const onboardingDuration = createGauge({
-            name: 'onboarding_duration',
-            labelNames: ['event'],
-            help: 'firstLogin, secondLogin, firstFeatureFlag, firstPreLive, firstLive from first user creation',
-        });
-        const projectOnboardingDuration = createGauge({
-            name: 'project_onboarding_duration',
-            labelNames: ['event', 'project'],
-            help: 'firstFeatureFlag, firstPreLive, firstLive from project creation',
-        });
-
-        const featureLifecycleStageCountByProject = createGauge({
-            name: 'feature_lifecycle_stage_count_by_project',
-            help: 'Count features in a given stage by project id',
-            labelNames: ['stage', 'project_id'],
-        });
-
-        const featureLifecycleStageEnteredCounter = createCounter({
-            name: 'feature_lifecycle_stage_entered',
-            help: 'Count how many features entered a given stage',
-            labelNames: ['stage'],
-        });
-
-        const projectActionsCounter = createCounter({
-            name: 'project_actions_count',
-            help: 'Count project actions',
-            labelNames: ['action'],
-        });
-
-        const projectEnvironmentsDisabled = createCounter({
-            name: 'project_environments_disabled',
-            help: 'How many "environment disabled" events we have received for each project',
-            labelNames: ['project_id'],
-        });
-
-        const orphanedTokensTotal = createGauge({
-            name: 'orphaned_api_tokens_total',
-            help: 'Number of API tokens without a project',
-        });
-
-        const orphanedTokensActive = createGauge({
-            name: 'orphaned_api_tokens_active',
-            help: 'Number of API tokens without a project, last seen within 3 months',
-        });
-
-        const legacyTokensTotal = createGauge({
-            name: 'legacy_api_tokens_total',
-            help: 'Number of API tokens with v1 format',
-        });
-
-        const legacyTokensActive = createGauge({
-            name: 'legacy_api_tokens_active',
-            help: 'Number of API tokens with v1 format, last seen within 3 months',
-        });
-
-        const exceedsLimitErrorCounter = createCounter({
-            name: 'exceeds_limit_error',
-            help: 'The number of exceeds limit errors registered by this instance.',
-            labelNames: ['resource', 'limit'],
-        });
-
-        const requestOriginCounter = createCounter({
-            name: 'request_origin_counter',
-            help: 'Number of authenticated requests, including origin information.',
-            labelNames: ['type', 'method', 'source'],
-        });
-
-        const resourceLimit = createGauge({
-            name: 'resource_limit',
-            help: 'The maximum number of resources allowed.',
-            labelNames: ['resource'],
-        });
-
-        const addonEventsHandledCounter = createCounter({
-            name: 'addon_events_handled',
-            help: 'Events handled by addons and the result.',
-            labelNames: ['result', 'destination'],
-        });
-
-        async function collectStaticCounters() {
+    // return an update function (temporarily) to allow for manual refresh
+    return {
+        collectStaticCounters: async () => {
             try {
                 dbMetrics.refreshDbMetrics();
 
@@ -691,329 +1005,60 @@ export default class MetricsMonitor {
                         config.rateLimiting.callSignalEndpointMaxPerSecond * 60,
                     );
             } catch (e) {}
+        },
+    };
+}
+export default class MetricsMonitor {
+    constructor() {}
+
+    async startMonitoring(
+        config: IUnleashConfig,
+        stores: IUnleashStores,
+        version: string,
+        eventBus: EventEmitter,
+        instanceStatsService: InstanceStatsService,
+        schedulerService: SchedulerService,
+        db: Knex,
+    ): Promise<void> {
+        if (!config.server.serverMetrics) {
+            return Promise.resolve();
         }
+
+        collectDefaultMetrics();
+
+        const { collectStaticCounters } = registerPrometheusMetrics(
+            config,
+            stores,
+            version,
+            eventBus,
+            instanceStatsService,
+        );
+
+        await this.registerPrometheusDbMetrics(
+            db,
+            eventBus,
+            stores.settingStore,
+        );
 
         await schedulerService.schedule(
             collectStaticCounters.bind(this),
             hoursToMilliseconds(2),
             'collectStaticCounters',
         );
-
-        eventBus.on(
-            events.EXCEEDS_LIMIT,
-            ({ resource, limit }: { resource: string; limit: number }) => {
-                exceedsLimitErrorCounter.increment({ resource, limit });
-            },
-        );
-
-        eventBus.on(
-            events.STAGE_ENTERED,
-            (entered: { stage: string; feature: string }) => {
-                if (flagResolver.isEnabled('trackLifecycleMetrics')) {
-                    logger.info(
-                        `STAGE_ENTERED listened ${JSON.stringify(entered)}`,
-                    );
-                }
-                featureLifecycleStageEnteredCounter.increment({
-                    stage: entered.stage,
-                });
-            },
-        );
-
-        eventBus.on(
-            events.REQUEST_TIME,
-            ({ path, method, time, statusCode, appName }) => {
-                requestDuration
-                    .labels({
-                        path,
-                        method,
-                        status: statusCode,
-                        appName,
-                    })
-                    .observe(time);
-            },
-        );
-
-        eventBus.on(events.SCHEDULER_JOB_TIME, ({ jobId, time }) => {
-            schedulerDuration.labels(jobId).observe(time);
-        });
-
-        eventBus.on(
-            events.FUNCTION_TIME,
-            ({ functionName, className, time }) => {
-                functionDuration
-                    .labels({
-                        functionName,
-                        className,
-                    })
-                    .observe(time);
-            },
-        );
-
-        eventBus.on(events.EVENTS_CREATED_BY_PROCESSED, ({ updated }) => {
-            eventCreatedByMigration.inc(updated);
-        });
-
-        eventBus.on(events.FEATURES_CREATED_BY_PROCESSED, ({ updated }) => {
-            featureCreatedByMigration.inc(updated);
-        });
-
-        eventBus.on(events.DB_TIME, ({ store, action, time }) => {
-            dbDuration
-                .labels({
-                    store,
-                    action,
-                })
-                .observe(time);
-        });
-
-        eventBus.on(events.PROXY_REPOSITORY_CREATED, () => {
-            proxyRepositoriesCreated.inc();
-        });
-
-        eventBus.on(events.FRONTEND_API_REPOSITORY_CREATED, () => {
-            frontendApiRepositoriesCreated.inc();
-        });
-
-        eventBus.on(events.PROXY_FEATURES_FOR_TOKEN_TIME, ({ duration }) => {
-            mapFeaturesForClientDuration.observe(duration);
-        });
-
-        events.onMetricEvent(
-            eventBus,
-            events.REQUEST_ORIGIN,
-            ({ type, method, source }) => {
-                if (flagResolver.isEnabled('originMiddleware')) {
-                    requestOriginCounter.increment({ type, method, source });
-                }
-            },
-        );
-
-        eventStore.on(FEATURE_CREATED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'n/a',
-                environmentType: 'n/a',
-                action: 'created',
-            });
-        });
-        eventStore.on(FEATURE_VARIANTS_UPDATED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'n/a',
-                environmentType: 'n/a',
-                action: 'updated',
-            });
-        });
-        eventStore.on(FEATURE_METADATA_UPDATED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'n/a',
-                environmentType: 'n/a',
-                action: 'updated',
-            });
-        });
-        eventStore.on(FEATURE_UPDATED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'default',
-                environmentType: 'production',
-                action: 'updated',
-            });
-        });
-        eventStore.on(
-            FEATURE_STRATEGY_ADD,
-            async ({ featureName, project, environment }) => {
-                const environmentType = await this.resolveEnvironmentType(
-                    environment,
-                    cachedEnvironments,
-                );
-                featureFlagUpdateTotal.increment({
-                    toggle: featureName,
-                    project,
-                    environment,
-                    environmentType,
-                    action: 'updated',
-                });
-            },
-        );
-        eventStore.on(
-            FEATURE_STRATEGY_REMOVE,
-            async ({ featureName, project, environment }) => {
-                const environmentType = await this.resolveEnvironmentType(
-                    environment,
-                    cachedEnvironments,
-                );
-                featureFlagUpdateTotal.increment({
-                    toggle: featureName,
-                    project,
-                    environment,
-                    environmentType,
-                    action: 'updated',
-                });
-            },
-        );
-        eventStore.on(
-            FEATURE_STRATEGY_UPDATE,
-            async ({ featureName, project, environment }) => {
-                const environmentType = await this.resolveEnvironmentType(
-                    environment,
-                    cachedEnvironments,
-                );
-                featureFlagUpdateTotal.increment({
-                    toggle: featureName,
-                    project,
-                    environment,
-                    environmentType,
-                    action: 'updated',
-                });
-            },
-        );
-        eventStore.on(
-            FEATURE_ENVIRONMENT_DISABLED,
-            async ({ featureName, project, environment }) => {
-                const environmentType = await this.resolveEnvironmentType(
-                    environment,
-                    cachedEnvironments,
-                );
-                featureFlagUpdateTotal.increment({
-                    toggle: featureName,
-                    project,
-                    environment,
-                    environmentType,
-                    action: 'updated',
-                });
-            },
-        );
-        eventStore.on(
-            FEATURE_ENVIRONMENT_ENABLED,
-            async ({ featureName, project, environment }) => {
-                const environmentType = await this.resolveEnvironmentType(
-                    environment,
-                    cachedEnvironments,
-                );
-                featureFlagUpdateTotal.increment({
-                    toggle: featureName,
-                    project,
-                    environment,
-                    environmentType,
-                    action: 'updated',
-                });
-            },
-        );
-        eventStore.on(FEATURE_ARCHIVED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'n/a',
-                environmentType: 'n/a',
-                action: 'archived',
-            });
-        });
-        eventStore.on(FEATURE_REVIVED, ({ featureName, project }) => {
-            featureFlagUpdateTotal.increment({
-                toggle: featureName,
-                project,
-                environment: 'n/a',
-                environmentType: 'n/a',
-                action: 'revived',
-            });
-        });
-        eventStore.on(PROJECT_CREATED, () => {
-            projectActionsCounter.increment({ action: PROJECT_CREATED });
-        });
-        eventStore.on(PROJECT_ARCHIVED, () => {
-            projectActionsCounter.increment({ action: PROJECT_ARCHIVED });
-        });
-        eventStore.on(PROJECT_REVIVED, () => {
-            projectActionsCounter.increment({ action: PROJECT_REVIVED });
-        });
-        eventStore.on(PROJECT_DELETED, () => {
-            projectActionsCounter.increment({ action: PROJECT_DELETED });
-        });
-
-        const logger = config.getLogger('metrics.ts');
-        eventBus.on(CLIENT_METRICS, (metrics: IClientMetricsEnv[]) => {
-            try {
-                for (const metric of metrics) {
-                    featureFlagUsageTotal.increment(
-                        {
-                            toggle: metric.featureName,
-                            active: 'true',
-                            appName: metric.appName,
-                        },
-                        metric.yes,
-                    );
-                    featureFlagUsageTotal.increment(
-                        {
-                            toggle: metric.featureName,
-                            active: 'false',
-                            appName: metric.appName,
-                        },
-                        metric.no,
-                    );
-                }
-            } catch (e) {
-                logger.warn('Metrics registration failed', e);
-            }
-        });
-
-        eventStore.on(CLIENT_REGISTER, (heartbeatEvent: ISdkHeartbeat) => {
-            if (!heartbeatEvent.sdkName || !heartbeatEvent.sdkVersion) {
-                return;
-            }
-
-            if (flagResolver.isEnabled('extendedMetrics')) {
-                clientSdkVersionUsage.increment({
-                    sdk_name: heartbeatEvent.sdkName,
-                    sdk_version: heartbeatEvent.sdkVersion,
-                    platform_name:
-                        heartbeatEvent.metadata?.platformName ?? 'not-set',
-                    platform_version:
-                        heartbeatEvent.metadata?.platformVersion ?? 'not-set',
-                    yggdrasil_version:
-                        heartbeatEvent.metadata?.yggdrasilVersion ?? 'not-set',
-                    spec_version:
-                        heartbeatEvent.metadata?.specVersion ?? 'not-set',
-                });
-            } else {
-                clientSdkVersionUsage.increment({
-                    sdk_name: heartbeatEvent.sdkName,
-                    sdk_version: heartbeatEvent.sdkVersion,
-                    platform_name: 'not-set',
-                    platform_version: 'not-set',
-                    yggdrasil_version: 'not-set',
-                    spec_version: 'not-set',
-                });
-            }
-        });
-
-        eventStore.on(PROJECT_ENVIRONMENT_REMOVED, ({ project }) => {
-            projectEnvironmentsDisabled.increment({ project_id: project });
-        });
-
-        eventBus.on(events.ADDON_EVENTS_HANDLED, ({ result, destination }) => {
-            addonEventsHandledCounter.increment({ result, destination });
-        });
-
-        await this.configureDbMetrics(
-            db,
-            eventBus,
-            schedulerService,
-            stores.settingStore,
+        await schedulerService.schedule(
+            async () =>
+                this.registerPoolMetrics.bind(this, db.client.pool, eventBus),
+            minutesToMilliseconds(1),
+            'registerPoolMetrics',
+            0, // no jitter
         );
 
         return Promise.resolve();
     }
 
-    async configureDbMetrics(
+    async registerPrometheusDbMetrics(
         db: Knex,
         eventBus: EventEmitter,
-        schedulerService: SchedulerService,
         settingStore: ISettingStore,
     ): Promise<void> {
         if (db?.client) {
@@ -1051,17 +1096,6 @@ export default class MetricsMonitor {
                 dbPoolPendingAcquires.set(data.pendingAcquires);
             });
 
-            await schedulerService.schedule(
-                async () =>
-                    this.registerPoolMetrics.bind(
-                        this,
-                        db.client.pool,
-                        eventBus,
-                    ),
-                minutesToMilliseconds(1),
-                'registerPoolMetrics',
-                0, // no jitter
-            );
             const postgresVersion = await settingStore.postgresVersion();
             const database_version = createGauge({
                 name: 'postgres_version',
@@ -1084,26 +1118,8 @@ export default class MetricsMonitor {
             // eslint-disable-next-line no-empty
         } catch (e) {}
     }
-
-    async resolveEnvironmentType(
-        environment: string,
-        cachedEnvironments: () => Promise<IEnvironment[]>,
-    ): Promise<string> {
-        const environments = await cachedEnvironments();
-        const env = environments.find((e) => e.name === environment);
-
-        if (env) {
-            return env.type;
-        } else {
-            return 'unknown';
-        }
-    }
 }
 
 export function createMetricsMonitor(): MetricsMonitor {
     return new MetricsMonitor();
 }
-
-module.exports = {
-    createMetricsMonitor,
-};

--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -11,6 +11,7 @@ import { registerPrometheusMetrics } from '../../../../lib/metrics';
 let app: IUnleashTest;
 let db: ITestDb;
 let stores: IUnleashStores;
+let refreshDbMetrics: () => Promise<void>;
 
 beforeAll(async () => {
     db = await dbInit('instance_admin_api_serial', getLogger);
@@ -28,13 +29,14 @@ beforeAll(async () => {
         db.rawDatabase,
     );
 
-    registerPrometheusMetrics(
+    const { collectDbMetrics } = registerPrometheusMetrics(
         app.config,
         stores,
         undefined as unknown as string,
         app.config.eventBus,
         app.services.instanceStatsService,
     );
+    refreshDbMetrics = collectDbMetrics;
 });
 
 afterAll(async () => {
@@ -48,7 +50,7 @@ test('should return instance statistics', async () => {
         createdByUserId: 9999,
     });
 
-    await app.services.instanceStatsService.dbMetrics.refreshDbMetrics();
+    await refreshDbMetrics();
 
     return app.request
         .get('/api/admin/instance-admin/statistics')

--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -6,6 +6,7 @@ import {
 import getLogger from '../../../fixtures/no-logger';
 import type { IUnleashStores } from '../../../../lib/types';
 import { ApiTokenType } from '../../../../lib/types/models/api-token';
+import { registerPrometheusMetrics } from '../../../../lib/metrics';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -26,6 +27,14 @@ beforeAll(async () => {
         },
         db.rawDatabase,
     );
+
+    registerPrometheusMetrics(
+        app.config,
+        stores,
+        undefined as unknown as string,
+        app.config.eventBus,
+        app.services.instanceStatsService,
+    );
 });
 
 afterAll(async () => {
@@ -38,6 +47,8 @@ test('should return instance statistics', async () => {
         name: 'TestStats1',
         createdByUserId: 9999,
     });
+
+    await app.services.instanceStatsService.dbMetrics.refreshDbMetrics();
 
     return app.request
         .get('/api/admin/instance-admin/statistics')


### PR DESCRIPTION
This is a follow up on https://github.com/Unleash/unleash/pull/8446
- migrating some metrics (check the commits)
- moving event listener registration outside metric calculation (every 2 hs we are adding new listeners)
- adding jitter to metric refresh
- manually executing some of the tasks immediately to avoid changing the test logic (with jitter now we'd have to force or wait until the first execution of the scheduled task that collect the metrics). We might decide to change this later after the migration
- try catch the execution of the task
- register metrics now "just registers" and returns functions for refreshing metrics. In the future, we'll return an object with the ability of independently updating specific metrics so we can tweak the frequency of updates
