### PR TITLE
fix: fix two disabled tooltips

### DIFF
--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ArchiveButton.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ArchiveButton.tsx
@@ -53,14 +53,16 @@ export const ArchiveButton: VFC<IArchiveButtonProps> = ({
         <>
             <PermissionHOC projectId={projectId} permission={DELETE_FEATURE}>
                 {({ hasAccess }) => (
-                    <Button
-                        disabled={!hasAccess || isDialogOpen}
-                        variant='outlined'
-                        size='small'
-                        onClick={() => setIsDialogOpen(true)}
-                    >
-                        Archive
-                    </Button>
+                    <span>
+                        <Button
+                            disabled={!hasAccess || isDialogOpen}
+                            variant='outlined'
+                            size='small'
+                            onClick={() => setIsDialogOpen(true)}
+                        >
+                            Archive
+                        </Button>
+                    </span>
                 )}
             </PermissionHOC>
             <FeatureArchiveDialog

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -96,14 +96,16 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         <>
             <PermissionHOC projectId={projectId} permission={UPDATE_FEATURE}>
                 {({ hasAccess }) => (
-                    <Button
-                        disabled={!hasAccess || isOpen}
-                        variant='outlined'
-                        size='small'
-                        onClick={() => setIsOpen(true)}
-                    >
-                        Tags
-                    </Button>
+                    <span>
+                        <Button
+                            disabled={!hasAccess || isOpen}
+                            variant='outlined'
+                            size='small'
+                            onClick={() => setIsOpen(true)}
+                        >
+                            Tags
+                        </Button>
+                    </span>
                 )}
             </PermissionHOC>
             <ManageBulkTagsDialog


### PR DESCRIPTION
Fix this warning:

> MUI: You are providing a disabled button child to the Tooltip component.
> A disabled element does not fire events.
> Tooltip needs to listen to the child element’s events to display the title.
> Add a simple wrapper element, such as a span.