### PR TITLE
chore: silence remaining front end test warnings

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -15,6 +15,14 @@ if (!window.ResizeObserver) {
 
 process.env.TZ = 'UTC';
 
+const messagesToIgnore = [
+    'Warning: An update to %s inside a test was not wrapped in act',
+    '[MSW] Found a redundant usage of query parameters in the request handler URL for',
+    'An exception was caught and handled.',
+    'MUI: You have provided an out-of-range value',
+    "Failed to create chart: can't acquire context from the given item",
+];
+
 // ignore known React warnings
 const consoleError = console.error;
 beforeAll(() => {
@@ -22,19 +30,7 @@ beforeAll(() => {
         if (
             !(
                 typeof args[0] === 'string' &&
-                (args[0].includes(
-                    'Warning: An update to %s inside a test was not wrapped in act',
-                ) ||
-                    args[0].includes(
-                        '[MSW] Found a redundant usage of query parameters in the request handler URL for',
-                    ) ||
-                    args[0].includes('An exception was caught and handled.') ||
-                    args[0].includes(
-                        'MUI: You have provided an out-of-range value',
-                    ) ||
-                    args[0].includes(
-                        "Failed to create chart: can't acquire context from the given item",
-                    ))
+                messagesToIgnore.some((message) => args[0].includes(message))
             )
         ) {
             consoleError(...args);

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -17,9 +17,9 @@ process.env.TZ = 'UTC';
 
 const messagesToIgnore = [
     'Warning: An update to %s inside a test was not wrapped in act',
-    '[MSW] Found a redundant usage of query parameters in the request handler URL for',
+    '[MSW] Found a redundant usage of query parameters in the request handler URL for %s',
     'An exception was caught and handled.',
-    'MUI: You have provided an out-of-range value',
+    'MUI: You have provided an out-of-range value %s',
     "Failed to create chart: can't acquire context from the given item",
 ];
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -22,9 +22,19 @@ beforeAll(() => {
         if (
             !(
                 typeof args[0] === 'string' &&
-                args[0].includes(
+                (args[0].includes(
                     'Warning: An update to %s inside a test was not wrapped in act',
-                )
+                ) ||
+                    args[0].includes(
+                        '[MSW] Found a redundant usage of query parameters in the request handler URL for',
+                    ) ||
+                    args[0].includes('An exception was caught and handled.') ||
+                    args[0].includes(
+                        'MUI: You have provided an out-of-range value',
+                    ) ||
+                    args[0].includes(
+                        "Failed to create chart: can't acquire context from the given item",
+                    ))
             )
         ) {
             consoleError(...args);

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -32,9 +32,9 @@ const consoleError = console.error;
 const consoleWarn = console.warn;
 const consoleLog = console.log;
 beforeAll(() => {
-    const shouldIgnore = (ignoredMessages: string[], args: any[]) =>
+    const shouldIgnore = (messagesToIgnore: string[], args: any[]) =>
         typeof args[0] === 'string' &&
-        ignoredMessages.some((msg) => args[0].includes(msg));
+        messagesToIgnore.some((msg) => args[0].includes(msg));
 
     vi.spyOn(console, 'error').mockImplementation((...args) => {
         if (!shouldIgnore(errorsToIgnore, args)) {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -17,9 +17,9 @@ process.env.TZ = 'UTC';
 
 const messagesToIgnore = [
     'Warning: An update to %s inside a test was not wrapped in act',
-    '[MSW] Found a redundant usage of query parameters in the request handler URL for %s',
+    '[MSW] Found a redundant usage of query parameters in the request handler URL for',
     'An exception was caught and handled.',
-    'MUI: You have provided an out-of-range value %s',
+    'MUI: You have provided an out-of-range value',
     "Failed to create chart: can't acquire context from the given item",
 ];
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -32,12 +32,9 @@ const consoleError = console.error;
 const consoleWarn = console.warn;
 const consoleLog = console.log;
 beforeAll(() => {
-    const shouldIgnore = (ignoredMessages: string[], args: any[]) => {
-        return (
-            typeof args[0] === 'string' &&
-            ignoredMessages.some((msg) => args[0].includes(msg))
-        );
-    };
+    const shouldIgnore = (ignoredMessages: string[], args: any[]) =>
+        typeof args[0] === 'string' &&
+        ignoredMessages.some((msg) => args[0].includes(msg));
 
     vi.spyOn(console, 'error').mockImplementation((...args) => {
         if (!shouldIgnore(errorsToIgnore, args)) {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -17,37 +17,41 @@ process.env.TZ = 'UTC';
 
 const errorsToIgnore = [
     'Warning: An update to %s inside a test was not wrapped in act',
+    "Failed to create chart: can't acquire context from the given item",
 ];
 
 const warningsToIgnore = [
     '[MSW] Found a redundant usage of query parameters in the request handler URL for',
-    'An exception was caught and handled.',
     'MUI: You have provided an out-of-range value',
-    "Failed to create chart: can't acquire context from the given item",
 ];
+
+const logsToIgnore = ['An exception was caught and handled.'];
 
 // ignore known React warnings
 const consoleError = console.error;
 const consoleWarn = console.warn;
+const consoleLog = console.log;
 beforeAll(() => {
+    const shouldIgnore = (ignoredMessages: string[], args: any[]) => {
+        return (
+            typeof args[0] === 'string' &&
+            ignoredMessages.some((msg) => args[0].includes(msg))
+        );
+    };
+
     vi.spyOn(console, 'error').mockImplementation((...args) => {
-        if (
-            !(
-                typeof args[0] === 'string' &&
-                errorsToIgnore.some((message) => args[0].includes(message))
-            )
-        ) {
+        if (!shouldIgnore(errorsToIgnore, args)) {
             consoleError(...args);
         }
     });
     vi.spyOn(console, 'warn').mockImplementation((...args) => {
-        if (
-            !(
-                typeof args[0] === 'string' &&
-                warningsToIgnore.some((message) => args[0].includes(message))
-            )
-        ) {
+        if (!shouldIgnore(warningsToIgnore, args)) {
             consoleWarn(...args);
+        }
+    });
+    vi.spyOn(console, 'log').mockImplementation((...args) => {
+        if (!shouldIgnore(logsToIgnore, args)) {
+            consoleLog(...args);
         }
     });
 });

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -15,8 +15,11 @@ if (!window.ResizeObserver) {
 
 process.env.TZ = 'UTC';
 
-const messagesToIgnore = [
+const errorsToIgnore = [
     'Warning: An update to %s inside a test was not wrapped in act',
+];
+
+const warningsToIgnore = [
     '[MSW] Found a redundant usage of query parameters in the request handler URL for',
     'An exception was caught and handled.',
     'MUI: You have provided an out-of-range value',
@@ -25,15 +28,26 @@ const messagesToIgnore = [
 
 // ignore known React warnings
 const consoleError = console.error;
+const consoleWarn = console.warn;
 beforeAll(() => {
     vi.spyOn(console, 'error').mockImplementation((...args) => {
         if (
             !(
                 typeof args[0] === 'string' &&
-                messagesToIgnore.some((message) => args[0].includes(message))
+                errorsToIgnore.some((message) => args[0].includes(message))
             )
         ) {
             consoleError(...args);
+        }
+    });
+    vi.spyOn(console, 'warn').mockImplementation((...args) => {
+        if (
+            !(
+                typeof args[0] === 'string' &&
+                warningsToIgnore.some((message) => args[0].includes(message))
+            )
+        ) {
+            consoleWarn(...args);
         }
     });
 });


### PR DESCRIPTION
This silences front end test warnings, errors, and logs that we don't care about. The
reason we don't care is that:
- we won't fix
- it's test-specific, doesn't appear to happen in real life

And it clogs the test logs.