### PR TITLE
feat: release plans nav menu item and icon suggestion

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/IconRenderer.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/IconRenderer.tsx
@@ -27,6 +27,7 @@ import BillingIcon from '@mui/icons-material/CreditCardOutlined';
 import EventLogIcon from '@mui/icons-material/EventNoteOutlined';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
+import LaunchIcon from '@mui/icons-material/Launch';
 import type { FC } from 'react';
 
 // TODO: move to routes
@@ -56,6 +57,7 @@ const icons: Record<string, typeof SvgIcon> = {
     '/admin/cors': CorsIcon,
     '/admin/billing': BillingIcon,
     '/history': EventLogIcon,
+    '/releases-management': LaunchIcon,
     GitHub: GitHubIcon,
     Documentation: LibraryBooksIcon,
 };

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -232,6 +232,20 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
+    "enterprise": true,
+    "flag": "releasePlans",
+    "menu": {
+      "advanced": true,
+      "mode": [
+        "enterprise",
+      ],
+    },
+    "path": "/releases-management",
+    "title": "Release management",
+    "type": "protected",
+  },
+  {
+    "component": [Function],
     "menu": {},
     "parent": "/environments",
     "path": "/environments/create",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -48,6 +48,7 @@ import { Application } from 'component/application/Application';
 import { Signals } from 'component/signals/Signals';
 import { LazyCreateProject } from '../project/Project/CreateProject/LazyCreateProject';
 import { PersonalDashboard } from '../personalDashboard/PersonalDashboard';
+import { ReleaseManagement } from 'component/releases/ReleaseManagement';
 
 export const routes: IRoute[] = [
     // Splash
@@ -245,6 +246,15 @@ export const routes: IRoute[] = [
         component: StrategiesList,
         type: 'protected',
         menu: { mobile: true, advanced: true },
+    },
+    {
+        path: '/releases-management',
+        title: 'Release management',
+        component: ReleaseManagement,
+        type: 'protected',
+        menu: { advanced: true, mode: ['enterprise'] },
+        flag: 'releasePlans',
+        enterprise: true,
     },
     {
         path: '/environments/create',

--- a/frontend/src/component/releases/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement.tsx
@@ -1,0 +1,3 @@
+export const ReleaseManagement = () => {
+    return null;
+};

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     personalDashboardUI?: boolean;
     purchaseAdditionalEnvironments?: boolean;
     unleashAI?: boolean;
+    releasePlans?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,7 +57,7 @@ process.nextTick(async () => {
                         unleashAI: true,
                         webhookDomainLogging: true,
                         addonUsageMetrics: true,
-                        releasePlans: true,
+                        releasePlans: false,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Adds a `Release management` item to the nav menu and an empty releasemgmt page component.
Temporarily suggests the MUI `Launch` icon as the release mgmt link icon.

![image](https://github.com/user-attachments/assets/8e34b232-bb9d-4d8c-8ca5-034ac2713134)
