### PR TITLE
chore: patch text when trying to add a root role group

### DIFF
--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -267,7 +267,7 @@ export const ProjectAccessAssign = ({
 
     const createRootGroupWarning = (group?: IGroup): string | undefined => {
         if (group && Boolean(group.rootRole)) {
-            return 'This group has an Admin or Editor role associated with it. Groups with a root role association cannot be assigned to projects, and users in this group already have the role applied globally.';
+            return 'This group has a root role associated with it. Groups with a root role association cannot be assigned to projects, and users in this group already have the role applied globally.';
         }
     };
 


### PR DESCRIPTION
This changes the warning on adding group root roles to cover all roles rather than just Editor or Admin. This got opened to Viewers in a 2K line monster PR that was mostly refactor so I'm assuming this was an accident but it's not a dangerous accident

## Discussion

Okay so why change the warning rather than change the code?

Two reasons.
1) This has been like this for a year and a half. It was changed before the feature entered GA, so users are probably used to it by now. Seems rude to take things away and it's harmless to keep it
2) It's consistent with everything else to have all 3 roles displayed and removes an edge case in the code