### PR TITLE
fix: allow you to add spaces to role descriptions

### DIFF
--- a/frontend/src/component/admin/roles/RoleForm/useRoleForm.test.ts
+++ b/frontend/src/component/admin/roles/RoleForm/useRoleForm.test.ts
@@ -14,14 +14,14 @@ describe('trim names and description', () => {
         expect(result.current.name).toBe('my role');
     });
 
-    test('description is trimmed before being set', () => {
+    test('description is not trimmed before being set', () => {
         const { result } = renderHook(() => useRoleForm());
 
         act(() => {
             result.current.setDescription('  my description    ');
         });
 
-        expect(result.current.description).toBe('my description');
+        expect(result.current.description).toBe('  my description    ');
     });
 
     test('name that is just whitespace triggers an error', () => {

--- a/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
+++ b/frontend/src/component/admin/roles/RoleForm/useRoleForm.ts
@@ -29,8 +29,6 @@ export const useRoleForm = (
     const [name, setName] = useState(initialName);
     const setTrimmedName = (newName: string) => setName(newName.trim());
     const [description, setDescription] = useState(initialDescription);
-    const setTrimmedDescription = (newDescription: string) =>
-        setDescription(newDescription.trim());
     const [checkedPermissions, setCheckedPermissions] =
         useState<ICheckedPermissions>({});
     const [errors, setErrors] = useState<IRoleFormErrors>(DEFAULT_ERRORS);
@@ -147,7 +145,7 @@ export const useRoleForm = (
         setName: setTrimmedName,
         validateName,
         description,
-        setDescription: setTrimmedDescription,
+        setDescription,
         validateDescription,
         checkedPermissions,
         setCheckedPermissions,


### PR DESCRIPTION
This fixes a bug where we didn't allow spaces in role descriptions.
The bug came about because we wanted to disallow empty descriptions,
but that means we need to trim them before validating, not necessarily
before setting it.

However, that does mean that you can have descriptions with leading
and trailing spaces now, but that's probably fine.

To fix this, we'd have to do the trimming of the description only at
submission time, I think.