### PR TITLE
fix: missing page titles

### DIFF
--- a/frontend/src/component/admin/auth/AuthSettings.tsx
+++ b/frontend/src/component/admin/auth/AuthSettings.tsx
@@ -12,6 +12,7 @@ import { ADMIN } from '@server/types/permissions';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { useState } from 'react';
 import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
+import { usePageTitle } from 'hooks/usePageTitle';
 
 export const AuthSettings = () => {
     const { authenticationType } = useUiConfig().uiConfig;
@@ -46,6 +47,7 @@ export const AuthSettings = () => {
     }
 
     const [activeTab, setActiveTab] = useState(0);
+    usePageTitle(`Single sign-on: ${tabs[activeTab].label}`);
 
     return (
         <div>

--- a/frontend/src/component/admin/roles/RolesPage.tsx
+++ b/frontend/src/component/admin/roles/RolesPage.tsx
@@ -14,6 +14,7 @@ import Add from '@mui/icons-material/Add';
 import ResponsiveButton from 'component/common/ResponsiveButton/ResponsiveButton';
 import type { IRole } from 'interfaces/role';
 import { TabLink } from 'component/common/TabNav/TabLink';
+import { usePageTitle } from 'hooks/usePageTitle';
 
 const StyledHeader = styled('div')(() => ({
     display: 'flex',
@@ -31,6 +32,7 @@ const StyledActions = styled('div')({
 });
 
 export const RolesPage = () => {
+    usePageTitle('Roles');
     const { pathname } = useLocation();
 
     const { roles, projectRoles, loading } = useRoles();

--- a/frontend/src/component/featureTypes/FeatureTypesList.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypesList.tsx
@@ -5,7 +5,7 @@ import { sortTypes } from 'utils/sortTypes';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import useFeatureTypes from 'hooks/api/getters/useFeatureTypes/useFeatureTypes';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import {
     Table,
     TableBody,
@@ -150,18 +150,7 @@ export const FeatureTypesList = () => {
     return (
         <PageContent
             isLoading={loading}
-            header={
-                <PageHeader>
-                    <Typography
-                        component='h2'
-                        sx={(theme) => ({
-                            fontSize: theme.fontSizes.mainHeader,
-                        })}
-                    >
-                        Feature flag types
-                    </Typography>
-                </PageHeader>
-            }
+            header={<PageHeader title='Feature flag types' />}
         >
             <Table {...getTableProps()}>
                 <SortableTableHeader headerGroups={headerGroups} />

--- a/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
+++ b/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
@@ -69,6 +69,7 @@ export const InsightsHeader: VFC<DashboardHeaderProps> = ({ actions }) => {
     return (
         <>
             <PageHeader
+                title='Insights'
                 titleElement={
                     <Typography
                         variant='h1'

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -19,7 +19,7 @@ import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
 import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { useDashboardState } from './useDashboardState';
 import { MyFlags } from './MyFlags';
-import { usePageTitle } from '../../hooks/usePageTitle';
+import { usePageTitle } from 'hooks/usePageTitle';
 
 const WelcomeSection = styled('div')(({ theme }) => ({
     display: 'flex',

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -19,6 +19,7 @@ import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
 import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { useDashboardState } from './useDashboardState';
 import { MyFlags } from './MyFlags';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const WelcomeSection = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -103,8 +104,9 @@ export const PersonalDashboard = () => {
     const { trackEvent } = usePlausibleTracker();
     const { setSplashSeen } = useSplashApi();
     const { splash } = useAuthSplash();
-
     const name = user?.name;
+
+    usePageTitle(`Dashboard: ${name}`);
 
     const { personalDashboard, refetch: refetchDashboard } =
         usePersonalDashboard();

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -100,17 +100,15 @@ const CustomStrategyTitle: FC = () => (
     </Box>
 );
 
-const PredefinedStrategyTitle = () => {
-    return (
-        <Box>
-            <Subtitle
-                title='Predefined strategies'
-                description='Activation strategies let you enable a feature only for a specified audience. Different strategies use different parameters. Predefined strategies are bundled with Unleash.'
-                link='https://docs.getunleash.io/reference/activation-strategies'
-            />
-        </Box>
-    );
-};
+const PredefinedStrategyTitle = () => (
+    <Box>
+        <Subtitle
+            title='Predefined strategies'
+            description='Activation strategies let you enable a feature only for a specified audience. Different strategies use different parameters. Predefined strategies are bundled with Unleash.'
+            link='https://docs.getunleash.io/reference/activation-strategies'
+        />
+    </Box>
+);
 
 const StrategyDeprecationWarning = () => (
     <Alert severity='warning' sx={{ mb: 2 }}>
@@ -402,7 +400,7 @@ export const StrategiesList = () => {
                     <PageHeader
                         titleElement={<PredefinedStrategyTitle />}
                         title='Strategy types'
-                    ></PageHeader>
+                    />
                 }
             >
                 <Box>

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -31,6 +31,7 @@ import { Badge } from 'component/common/Badge/Badge';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { CustomStrategyInfo } from '../CustomStrategyInfo/CustomStrategyInfo';
 import { AddStrategyButton } from './AddStrategyButton/AddStrategyButton';
+import { usePageTitle } from 'hooks/usePageTitle';
 
 interface IDialogueMetaData {
     show: boolean;
@@ -100,15 +101,19 @@ const CustomStrategyTitle: FC = () => (
     </Box>
 );
 
-const PredefinedStrategyTitle = () => (
-    <Box>
-        <Subtitle
-            title='Predefined strategies'
-            description='Activation strategies let you enable a feature only for a specified audience. Different strategies use different parameters. Predefined strategies are bundled with Unleash.'
-            link='https://docs.getunleash.io/reference/activation-strategies'
-        />
-    </Box>
-);
+const PredefinedStrategyTitle = () => {
+    usePageTitle('Strategy types');
+
+    return (
+        <Box>
+            <Subtitle
+                title='Predefined strategies'
+                description='Activation strategies let you enable a feature only for a specified audience. Different strategies use different parameters. Predefined strategies are bundled with Unleash.'
+                link='https://docs.getunleash.io/reference/activation-strategies'
+            />
+        </Box>
+    );
+};
 
 const StrategyDeprecationWarning = () => (
     <Alert severity='warning' sx={{ mb: 2 }}>

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -31,7 +31,6 @@ import { Badge } from 'component/common/Badge/Badge';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { CustomStrategyInfo } from '../CustomStrategyInfo/CustomStrategyInfo';
 import { AddStrategyButton } from './AddStrategyButton/AddStrategyButton';
-import { usePageTitle } from 'hooks/usePageTitle';
 
 interface IDialogueMetaData {
     show: boolean;
@@ -102,8 +101,6 @@ const CustomStrategyTitle: FC = () => (
 );
 
 const PredefinedStrategyTitle = () => {
-    usePageTitle('Strategy types');
-
     return (
         <Box>
             <Subtitle
@@ -402,9 +399,10 @@ export const StrategiesList = () => {
             <PageContent
                 isLoading={loading}
                 header={
-                    <PageHeader>
-                        <PredefinedStrategyTitle />
-                    </PageHeader>
+                    <PageHeader
+                        titleElement={<PredefinedStrategyTitle />}
+                        title='Strategy types'
+                    ></PageHeader>
                 }
             >
                 <Box>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Fixing page titles:

<img width="236" alt="Screenshot 2024-10-18 at 12 44 37" src="https://github.com/user-attachments/assets/ef66c90b-7286-40b4-ac99-44834db59fa0">
<img width="234" alt="Screenshot 2024-10-18 at 12 44 28" src="https://github.com/user-attachments/assets/110d3823-1f11-4065-bb2d-ab3683bef8bb">
<img width="235" alt="Screenshot 2024-10-18 at 12 44 20" src="https://github.com/user-attachments/assets/d4953054-04af-49a7-9ba3-b4afb40cdca9">
<img width="231" alt="Screenshot 2024-10-18 at 12 44 13" src="https://github.com/user-attachments/assets/e1619575-d2bc-4528-ab4a-07c389b69537">
<img width="237" alt="Screenshot 2024-10-18 at 12 44 06" src="https://github.com/user-attachments/assets/b84bb0ca-a436-4aaa-a99f-49fc934e46a8">
<img width="232" alt="Screenshot 2024-10-18 at 12 43 59" src="https://github.com/user-attachments/assets/acce2be2-1d7d-4e9a-a378-64a136ba3a6b">

Details:
Pages using PageContent component with a header property automatically get their title set.
<img width="414" alt="Screenshot 2024-10-18 at 12 37 22" src="https://github.com/user-attachments/assets/c7b92dae-7ac4-4fbb-b1c3-19ff0f96b2e6">

All the other pages need explicit usePageTitle invocation.

I tried to add more info to the title where it makes sense:
* username in personal dashboard
* SSO method in SSO page

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
