### PR TITLE
fix: don't allow . or .. in feature url

### DIFF
--- a/src/lib/routes/util.ts
+++ b/src/lib/routes/util.ts
@@ -13,7 +13,11 @@ export const customJoi = joi.extend((j) => ({
     },
     validate(value, helpers) {
         // Base validation regardless of the rules applied
-        if (encodeURIComponent(value) !== value) {
+        if (
+            encodeURIComponent(value) !== value ||
+            value === '..' ||
+            value === '.'
+        ) {
             // Generate an error, state and options need to be passed
             return { value, errors: helpers.error('isUrlFriendly.base') };
         }

--- a/src/lib/schema/feature-schema.test.ts
+++ b/src/lib/schema/feature-schema.test.ts
@@ -9,7 +9,29 @@ test('should require URL firendly name', () => {
     };
 
     const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual('"name" must be URL friendly');
+    expect(error?.details[0].message).toEqual('"name" must be URL friendly');
+});
+
+test("shouldn't allow . nor .. as name", () => {
+    const toggle1 = {
+        name: '.',
+        enabled: false,
+        impressionData: false,
+        strategies: [{ name: 'default' }],
+    };
+    const toggle2 = {
+        name: '..',
+        enabled: false,
+        impressionData: false,
+        strategies: [{ name: 'default' }],
+    };
+
+    expect(featureSchema.validate(toggle1).error?.details[0].message).toEqual(
+        '"name" must be URL friendly',
+    );
+    expect(featureSchema.validate(toggle2).error?.details[0].message).toEqual(
+        '"name" must be URL friendly',
+    );
 });
 
 test('should be valid toggle name', () => {
@@ -91,7 +113,7 @@ test('should not allow weightType=fix with floats', () => {
     };
 
     const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual('Weight only supports 1 decimal');
+    expect(error?.details[0].message).toEqual('Weight only supports 1 decimal');
 });
 
 test('should not allow weightType=fix with more than 1000', () => {
@@ -115,7 +137,7 @@ test('should not allow weightType=fix with more than 1000', () => {
     };
 
     const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual(
+    expect(error?.details[0].message).toEqual(
         '"variants[0].weight" must be less than or equal to 1000',
     );
 });
@@ -139,7 +161,7 @@ test('should disallow weightType=unknown', () => {
     };
 
     const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual(
+    expect(error?.details[0].message).toEqual(
         '"variants[0].weightType" must be one of [variable, fix]',
     );
 });
@@ -255,7 +277,7 @@ test('should not accept empty constraint values', () => {
     };
 
     const { error } = featureSchema.validate(toggle);
-    expect(error.details[0].message).toEqual(
+    expect(error?.details[0].message).toEqual(
         '"strategies[0].constraints[0].values[0]" is not allowed to be empty',
     );
 });
@@ -300,7 +322,7 @@ test('Filter queries should reject tag values with missing type prefix', () => {
         tag: ['simple', 'simple'],
     };
     const { error } = querySchema.validate(query);
-    expect(error.details[0].message).toEqual(
+    expect(error?.details[0].message).toEqual(
         '"tag[0]" with value "simple" fails to match the tag pattern',
     );
 });
@@ -318,7 +340,7 @@ test('Filter queries should reject project names that are not alphanum', () => {
         project: ['project name with space'],
     };
     const { error } = querySchema.validate(query);
-    expect(error.details[0].message).toEqual(
+    expect(error?.details[0].message).toEqual(
         '"project[0]" must be URL friendly',
     );
 });


### PR DESCRIPTION
We do some validation on flag names, but there's some cases that slip through. These are some cases that we should handle better.

With `..` as a name, you can't go into the flag in Unleash and you can't activate any environments because the it is interpreted as "go up a level".