### PR TITLE
fix: handle loading states for project details for a single project

### DIFF
--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -122,7 +122,10 @@ const ProjectListItem: FC<{
     );
 };
 
-type MyProjectsState = 'no projects' | 'projects' | 'projects with error';
+type MyProjectsState =
+    | 'no projects'
+    | 'projects'
+    | 'projects with error or loading';
 
 export const MyProjects = forwardRef<
     HTMLDivElement,
@@ -149,7 +152,7 @@ export const MyProjects = forwardRef<
         const state: MyProjectsState = projects.length
             ? personalDashboardProjectDetails
                 ? 'projects'
-                : 'projects with error'
+                : 'projects with error or loading'
             : 'no projects';
 
         const activeProjectStage =
@@ -190,7 +193,7 @@ export const MyProjects = forwardRef<
                         ),
                     };
 
-                case 'projects with error':
+                case 'projects with error or loading':
                     return {
                         list: (
                             <StyledList>
@@ -206,8 +209,19 @@ export const MyProjects = forwardRef<
                                 ))}
                             </StyledList>
                         ),
-                        box1: <DataError project={activeProject} />,
-                        box2: <ContactAdmins admins={admins} />,
+                        box1: (
+                            <div data-loading>
+                                <DataError
+                                    data-loading
+                                    project={activeProject}
+                                />
+                            </div>
+                        ),
+                        box2: (
+                            <div data-loading>
+                                <ContactAdmins admins={admins} />
+                            </div>
+                        ),
                     };
 
                 case 'projects': {

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -16,6 +16,7 @@ import { RoleAndOwnerInfo } from './RoleAndOwnerInfo';
 import { type ReactNode, useEffect, useRef, type FC } from 'react';
 import type {
     PersonalDashboardProjectDetailsSchema,
+    PersonalDashboardProjectDetailsSchemaRolesItem,
     PersonalDashboardSchemaAdminsItem,
     PersonalDashboardSchemaProjectOwnersItem,
     PersonalDashboardSchemaProjectsItem,
@@ -36,6 +37,8 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { Link } from 'react-router-dom';
 import { ActionBox } from './ActionBox';
 import useLoading from 'hooks/useLoading';
+import { NoProjectsContactAdmin } from './NoProjectsContactAdmin';
+import { AskOwnerToAddYouToTheirProject } from './AskOwnerToAddYouToTheirProject';
 
 const ActiveProjectDetails: FC<{
     project: PersonalDashboardSchemaProjectsItem;
@@ -149,7 +152,30 @@ export const MyProjects: React.FC<{
         box1: ReactNode;
         box2: ReactNode;
     } => {
-        const list = projects.length ? (
+        if (projects.length === 0) {
+            return {
+                list: (
+                    <ActionBox>
+                        <Typography>
+                            You don't currently have access to any projects in
+                            the system.
+                        </Typography>
+                        <Typography>
+                            To get started, you can{' '}
+                            <Link to='/projects?create=true'>
+                                create your own project
+                            </Link>
+                            . Alternatively, you can review the available
+                            projects in the system and ask the owner for access.
+                        </Typography>
+                    </ActionBox>
+                ),
+                box1: <NoProjectsContactAdmin admins={admins} />,
+                box2: <AskOwnerToAddYouToTheirProject owners={owners} />,
+            };
+        }
+
+        const list = (
             <StyledList>
                 {projects.map((project) => (
                     <ProjectListItem
@@ -160,21 +186,6 @@ export const MyProjects: React.FC<{
                     />
                 ))}
             </StyledList>
-        ) : (
-            <ActionBox>
-                <Typography>
-                    You don't currently have access to any projects in the
-                    system.
-                </Typography>
-                <Typography>
-                    To get started, you can{' '}
-                    <Link to='/projects?create=true'>
-                        create your own project
-                    </Link>
-                    . Alternatively, you can review the available projects in
-                    the system and ask the owner for access.
-                </Typography>
-            </ActionBox>
         );
 
         const [box1, box2] = (() => {
@@ -244,7 +255,9 @@ export const MyProjects: React.FC<{
                         roles={
                             personalDashboardProjectDetails.state === 'success'
                                 ? personalDashboardProjectDetails.data.roles.map(
-                                      (role) => role.name,
+                                      (
+                                          role: PersonalDashboardProjectDetailsSchemaRolesItem,
+                                      ) => role.name,
                                   )
                                 : []
                         }

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -130,15 +130,10 @@ export const PersonalDashboard = () => {
         splash?.personalDashboardKeyConcepts ? 'closed' : 'open',
     );
 
-    const { personalDashboardProjectDetails, error: detailsError } =
+    const { personalDashboardProjectDetails, loading: detailsLoading } =
         usePersonalDashboardProjectDetails(activeProject);
 
-    const activeProjectStage =
-        personalDashboardProjectDetails?.onboardingStatus.status ?? 'loading';
-
-    const projectStageRef = useLoading(
-        !detailsError && activeProjectStage === 'loading',
-    );
+    const loadingProjectDetailsRef = useLoading(detailsLoading);
 
     return (
         <MainContent>
@@ -192,7 +187,7 @@ export const PersonalDashboard = () => {
                     <MyProjects
                         owners={personalDashboard?.projectOwners ?? []}
                         admins={personalDashboard?.admins ?? []}
-                        ref={projectStageRef}
+                        ref={loadingProjectDetailsRef}
                         projects={projects}
                         activeProject={activeProject || ''}
                         setActiveProject={setActiveProject}

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -11,7 +11,6 @@ import { WelcomeDialog } from './WelcomeDialog';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
 import { usePersonalDashboard } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboard';
 import { usePersonalDashboardProjectDetails } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails';
-import useLoading from '../../hooks/useLoading';
 import { MyProjects } from './MyProjects';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
@@ -136,10 +135,6 @@ export const PersonalDashboard = () => {
             usePersonalDashboardProjectDetails(activeProject),
         );
 
-    const loadingProjectDetailsRef = useLoading(
-        personalDashboardProjectDetails.state === 'loading',
-    );
-
     return (
         <MainContent>
             <WelcomeSection>
@@ -192,7 +187,6 @@ export const PersonalDashboard = () => {
                     <MyProjects
                         owners={personalDashboard?.projectOwners ?? []}
                         admins={personalDashboard?.admins ?? []}
-                        ref={loadingProjectDetailsRef}
                         projects={projects}
                         activeProject={activeProject || ''}
                         setActiveProject={setActiveProject}

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -20,6 +20,7 @@ import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { useDashboardState } from './useDashboardState';
 import { MyFlags } from './MyFlags';
 import { usePageTitle } from 'hooks/usePageTitle';
+import { fromPersonalDashboardProjectDetailsOutput } from './RemoteData';
 
 const WelcomeSection = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -130,10 +131,14 @@ export const PersonalDashboard = () => {
         splash?.personalDashboardKeyConcepts ? 'closed' : 'open',
     );
 
-    const { personalDashboardProjectDetails, loading: detailsLoading } =
-        usePersonalDashboardProjectDetails(activeProject);
+    const personalDashboardProjectDetails =
+        fromPersonalDashboardProjectDetailsOutput(
+            usePersonalDashboardProjectDetails(activeProject),
+        );
 
-    const loadingProjectDetailsRef = useLoading(detailsLoading);
+    const loadingProjectDetailsRef = useLoading(
+        personalDashboardProjectDetails.state === 'loading',
+    );
 
     return (
         <MainContent>

--- a/frontend/src/component/personalDashboard/ProjectDetailsError.tsx
+++ b/frontend/src/component/personalDashboard/ProjectDetailsError.tsx
@@ -5,10 +5,7 @@ import { ActionBox } from './ActionBox';
 
 export const DataError: FC<{ project: string }> = ({ project }) => {
     return (
-        <ActionBox
-            data-loading
-            title={`Couldn't fetch data for project "${project}".`}
-        >
+        <ActionBox title={`Couldn't fetch data for project "${project}".`}>
             <p>
                 The API request to get data for this project returned with an
                 error.

--- a/frontend/src/component/personalDashboard/RemoteData.ts
+++ b/frontend/src/component/personalDashboard/RemoteData.ts
@@ -1,11 +1,10 @@
 import type { IPersonalDashboardProjectDetailsOutput } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails';
 import type { PersonalDashboardProjectDetailsSchema } from 'openapi';
 
-type RemoteData<T> = { refetch: () => void } & (
+export type RemoteData<T> =
     | { state: 'error'; error: Error }
     | { state: 'loading' }
-    | { state: 'success'; data: T }
-);
+    | { state: 'success'; data: T };
 
 export const fromPersonalDashboardProjectDetailsOutput = ({
     personalDashboardProjectDetails,

--- a/frontend/src/component/personalDashboard/RemoteData.ts
+++ b/frontend/src/component/personalDashboard/RemoteData.ts
@@ -1,0 +1,29 @@
+import type { IPersonalDashboardProjectDetailsOutput } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboardProjectDetails';
+import type { PersonalDashboardProjectDetailsSchema } from 'openapi';
+
+type RemoteData<T> = { refetch: () => void } & (
+    | { state: 'error'; error: Error }
+    | { state: 'loading' }
+    | { state: 'success'; data: T }
+);
+
+export const fromPersonalDashboardProjectDetailsOutput = ({
+    personalDashboardProjectDetails,
+    error,
+}: IPersonalDashboardProjectDetailsOutput): RemoteData<PersonalDashboardProjectDetailsSchema> => {
+    const converted = error
+        ? {
+              state: 'error',
+              error,
+          }
+        : personalDashboardProjectDetails
+          ? {
+                state: 'success',
+                data: personalDashboardProjectDetails,
+            }
+          : {
+                state: 'loading' as const,
+            };
+
+    return converted as RemoteData<PersonalDashboardProjectDetailsSchema>;
+};

--- a/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
+++ b/frontend/src/component/personalDashboard/RoleAndOwnerInfo.tsx
@@ -51,7 +51,7 @@ export const RoleAndOwnerInfo = ({ roles, owners }: Props) => {
     const firstRoles = roles.slice(0, 3);
     const extraRoles = roles.slice(3);
     return (
-        <Wrapper>
+        <Wrapper data-loading>
             <InfoSection>
                 {roles.length > 0 ? (
                     <>


### PR DESCRIPTION
This PR updates the use of references on the project details page to handle the loading state for a single project.

Now, if a project is loading, it'll show skeleton loaders for the relevant boxes:

![image](https://github.com/user-attachments/assets/a156cc88-e4bf-421a-8afe-2b46e26d5544)

I've also updated the state type we use for this to be more accurate. However, it feels like it's getting kinda messy they way we handle it now. I wouldn't mind refactoring the output of the hook into something more like this data type to make handling more explicit. (Shamelessly stolen from Elm, but iykyk)

```ts
type RemoteData<T> = 
  | { state: 'error', error: Error } 
  | { state: 'loading' } 
  | { state: 'success', data: T } 
```

Also, I had some issues with applying the `data-loading` attribute to components, where it seemed to work in some cases, but not in others. For instance, for `DataError` and `ContactAdmins`, it didn't work just setting `data-loading` on the component invocation in `MyProjects`, so I wrapped them both in data-loading divs instead. But happy to hear if there's a trick I missed.

After refactoring: 
![image](https://github.com/user-attachments/assets/03d655de-1ab8-4289-9f0c-d158ede8e116)
