### PR TITLE
feat: personal dashboard scrollbars and spacing

### DIFF
--- a/frontend/src/component/personalDashboard/ActionBox.tsx
+++ b/frontend/src/component/personalDashboard/ActionBox.tsx
@@ -2,7 +2,7 @@ import { styled } from '@mui/material';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
 const Container = styled('article')(({ theme }) => ({
-    padding: theme.spacing(4, 2),
+    padding: theme.spacing(1, 2),
     display: 'flex',
     gap: theme.spacing(3),
     flexDirection: 'column',

--- a/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
+++ b/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
@@ -44,6 +44,10 @@ const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
     marginTop: theme.spacing(0.5),
 }));
 
+const StyledMarkdown = styled(Markdown)(({ theme }) => ({
+    wordBreak: 'break-all',
+}));
+
 export const LatestProjectEvents: FC<{
     latestEvents: PersonalDashboardProjectDetailsSchema['latestEvents'];
 }> = ({ latestEvents }) => {
@@ -73,10 +77,10 @@ export const LatestProjectEvents: FC<{
                                         locationSettings.locale,
                                     )}
                                 </Timestamp>
-                                <Markdown>
+                                <StyledMarkdown>
                                     {event.summary ||
                                         'No preview available for this event'}
-                                </Markdown>
+                                </StyledMarkdown>
                             </div>
                         </Event>
                     );

--- a/frontend/src/component/personalDashboard/MyFlags.tsx
+++ b/frontend/src/component/personalDashboard/MyFlags.tsx
@@ -115,7 +115,6 @@ export const MyFlags: FC<Props> = ({
                             disablePadding={true}
                             sx={{
                                 height: '100%',
-                                overflow: 'auto',
                             }}
                         >
                             {flagData.flags.map((flag) => (

--- a/frontend/src/component/personalDashboard/SharedComponents.tsx
+++ b/frontend/src/component/personalDashboard/SharedComponents.tsx
@@ -106,7 +106,6 @@ export const listItemStyle = (theme: Theme) => ({
 });
 
 export const StyledList = styled(List)(({ theme }) => ({
-    overflowY: 'auto',
     maxHeight: '400px',
 
     ...onWideContainer({


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* Align scrollbars to the right of the container box in flag list and project list sections.
* remove padding at the top of the insights and events boxes (it will also affect create flag and connect sdk but they still look good)
* prevent long event markdown from x-overflow (saw this with prod data)

<img width="1327" alt="Screenshot 2024-10-21 at 13 05 00" src="https://github.com/user-attachments/assets/5548f8d7-4a1e-4ac3-9047-c72af600ad31">

<img width="1276" alt="Screenshot 2024-10-21 at 13 08 51" src="https://github.com/user-attachments/assets/c0ae6d1a-2287-425b-8f92-5facc4282bce">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
