### PR TITLE
fix: break words first, break all second

### DIFF
--- a/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
+++ b/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
@@ -45,8 +45,12 @@ const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
 }));
 
 const StyledMarkdown = styled(Markdown)(({ theme }) => ({
-    wordBreak: 'break-all',
+    wordBreak: 'break-word',
 }));
+
+const BreakLongWordsFallback = styled('div')({
+    wordBreak: 'break-all',
+});
 
 export const LatestProjectEvents: FC<{
     latestEvents: PersonalDashboardProjectDetailsSchema['latestEvents'];
@@ -77,10 +81,12 @@ export const LatestProjectEvents: FC<{
                                         locationSettings.locale,
                                     )}
                                 </Timestamp>
-                                <StyledMarkdown>
-                                    {event.summary ||
-                                        'No preview available for this event'}
-                                </StyledMarkdown>
+                                <BreakLongWordsFallback>
+                                    <StyledMarkdown>
+                                        {event.summary ||
+                                            'No preview available for this event'}
+                                    </StyledMarkdown>
+                                </BreakLongWordsFallback>
                             </div>
                         </Event>
                     );

--- a/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
+++ b/frontend/src/component/personalDashboard/LatestProjectEvents.tsx
@@ -44,12 +44,8 @@ const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
     marginTop: theme.spacing(0.5),
 }));
 
-const StyledMarkdown = styled(Markdown)(({ theme }) => ({
-    wordBreak: 'break-word',
-}));
-
-const BreakLongWordsFallback = styled('div')({
-    wordBreak: 'break-all',
+const StyledMarkdown = styled(Markdown)({
+    overflowWrap: 'anywhere',
 });
 
 export const LatestProjectEvents: FC<{
@@ -81,12 +77,10 @@ export const LatestProjectEvents: FC<{
                                         locationSettings.locale,
                                     )}
                                 </Timestamp>
-                                <BreakLongWordsFallback>
-                                    <StyledMarkdown>
-                                        {event.summary ||
-                                            'No preview available for this event'}
-                                    </StyledMarkdown>
-                                </BreakLongWordsFallback>
+                                <StyledMarkdown>
+                                    {event.summary ||
+                                        'No preview available for this event'}
+                                </StyledMarkdown>
                             </div>
                         </Event>
                     );


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

For the events markdown we want to prioritize breaking on words, but for very long strings we want to break on anything.
<img width="389" alt="Screenshot 2024-10-21 at 14 47 21" src="https://github.com/user-attachments/assets/b2528bc0-2d9b-416c-b6e8-e98ea18eecc9">


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
