### PR TITLE
feat: emails sent table migration

### DIFF
--- a/src/migrations/20241024081537-sent-emails-table.js
+++ b/src/migrations/20241024081537-sent-emails-table.js
@@ -1,6 +1,6 @@
 exports.up = function(db, cb) {
     db.runSql(`
-    CREATE TABLE IF NOT EXISTS sent_emails
+    CREATE TABLE IF NOT EXISTS emails_sent
     (
         id VARCHAR(255) NOT NULL,
         type VARCHAR(255) NOT NULL,
@@ -12,5 +12,5 @@ exports.up = function(db, cb) {
 };
 
 exports.down = function(db, cb) {
-    db.runSql(`DROP TABLE sent_emails;`, cb);
+    db.runSql(`DROP TABLE emails_sent;`, cb);
 };

--- a/src/migrations/20241024081537-sent-emails-table.js
+++ b/src/migrations/20241024081537-sent-emails-table.js
@@ -1,0 +1,16 @@
+exports.up = function(db, cb) {
+    db.runSql(`
+    CREATE TABLE IF NOT EXISTS sent_emails
+    (
+        id VARCHAR(255) NOT NULL,
+        type VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT now(),
+        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+        PRIMARY KEY (id, type)
+    );
+`, cb)
+};
+
+exports.down = function(db, cb) {
+    db.runSql(`DROP TABLE sent_emails;`, cb);
+};


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Background: we need to send emails for productivity report every month. We need to guarantee at most once delivery semantics.

Solution: Create sent_emails table. There's a potential vector of change that involves more email types so I optimize for this use case.
<img width="817" alt="Screenshot 2024-10-24 at 10 31 50" src="https://github.com/user-attachments/assets/258e03ac-b465-4e9f-b9f9-4300adae8935">

Proposed structure:
* id is similar to trends ids YYYY-MM and indicates that we have already sent a report for 2024-10
* type is the email type and it accommodates different email types
* created_at is the exact date we sent out the email (useful for tracking if we sent out emails when we intend)
* payload - so that we know what dynamic data was provided in the template (it allows re-sent capability in future and debugging)

Note: this PR will be merged once we used it in sample code that gives us feedback that the structure is solid.


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
