### PR TITLE
fix: error logger catchall

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -197,12 +197,6 @@ export default async function getApp(
         services.openApiService.useErrorHandler(app);
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-        app.use(errorHandler());
-    } else {
-        app.use(catchAllErrorHandler(config.getLogger));
-    }
-
     app.get(`${baseUriPath}`, (req, res) => {
         res.set('Content-Type', 'text/html');
         res.send(indexHTML);
@@ -228,6 +222,12 @@ export default async function getApp(
         }
         res.send(indexHTML);
     });
+
+    if (process.env.NODE_ENV !== 'production') {
+        app.use(errorHandler());
+    } else {
+        app.use(catchAllErrorHandler(config.getLogger));
+    }
 
     return app;
 }


### PR DESCRIPTION
## About the changes
Some specially crafted URLs log 500 errors, instead of 400. This change should catch it in last middleware registered of an Express app.

Closes [1-3027/bug-logger-not-catching-unparsed-urls-correctly](https://linear.app/unleash/issue/1-3027/bug-logger-not-catching-unparsed-urls-correctly)
