### PR TITLE
fix: invalid spreading of keys into table rows everywhere

### DIFF
--- a/frontend/src/component/admin/billing/BillingHistory/BillingHistory.tsx
+++ b/frontend/src/component/admin/billing/BillingHistory/BillingHistory.tsx
@@ -104,13 +104,19 @@ export const BillingHistory: VFC<IBillingHistoryProps> = ({
                 <TableBody {...getTableBodyProps()}>
                     {rows.map((row) => {
                         prepareRow(row);
+                        const { key, ...rowProps } = row.getRowProps();
                         return (
-                            <TableRow hover {...row.getRowProps()}>
-                                {row.cells.map((cell) => (
-                                    <TableCell {...cell.getCellProps()}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                ))}
+                            <TableRow hover key={key} {...rowProps}>
+                                {row.cells.map((cell) => {
+                                    const { key, ...cellProps } =
+                                        cell.getCellProps();
+
+                                    return (
+                                        <TableCell key={key} {...cellProps}>
+                                            {cell.render('Cell')}
+                                        </TableCell>
+                                    );
+                                })}
                             </TableRow>
                         );
                     })}

--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
@@ -323,16 +323,19 @@ export const ChangeRequestsTabs = ({
                     <TableBody {...getTableBodyProps()}>
                         {rows.map((row) => {
                             prepareRow(row);
+                            const { key, ...rowProps } = row.getRowProps();
                             return (
-                                <TableRow hover {...row.getRowProps()}>
-                                    {row.cells.map((cell) => (
-                                        <TableCell
-                                            {...cell.getCellProps()}
-                                            padding='none'
-                                        >
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    ))}
+                                <TableRow hover key={key} {...rowProps}>
+                                    {row.cells.map((cell) => {
+                                        const { key, ...cellProps } =
+                                            cell.getCellProps();
+
+                                        return (
+                                            <TableCell key={key} {...cellProps}>
+                                                {cell.render('Cell')}
+                                            </TableCell>
+                                        );
+                                    })}
                                 </TableRow>
                             );
                         })}

--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
@@ -16,8 +16,6 @@ export const ProjectChangeRequests = () => {
 
     const { changeRequests, loading } = useProjectChangeRequests(projectId);
 
-    console.log('changeRequests', changeRequests);
-
     if (isOss() || isPro()) {
         return (
             <PageContent sx={{ justifyContent: 'center' }}>

--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ProjectChangeRequests.tsx
@@ -16,6 +16,8 @@ export const ProjectChangeRequests = () => {
 
     const { changeRequests, loading } = useProjectChangeRequests(projectId);
 
+    console.log('changeRequests', changeRequests);
+
     if (isOss() || isPro()) {
         return (
             <PageContent sx={{ justifyContent: 'center' }}>

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentTableSingle.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentTableSingle.tsx
@@ -97,13 +97,19 @@ export const EnvironmentTableSingle = ({
             <TableBody {...getTableBodyProps()}>
                 {rows.map((row) => {
                     prepareRow(row);
+                    const { key, ...rowProps } = row.getRowProps();
                     return (
-                        <TableRow hover {...row.getRowProps()}>
-                            {row.cells.map((cell) => (
-                                <TableCell {...cell.getCellProps()}>
-                                    {cell.render('Cell')}
-                                </TableCell>
-                            ))}
+                        <TableRow hover key={key} {...rowProps}>
+                            {row.cells.map((cell) => {
+                                const { key, ...cellProps } =
+                                    cell.getCellProps();
+
+                                return (
+                                    <TableCell key={key} {...cellProps}>
+                                        {cell.render('Cell')}
+                                    </TableCell>
+                                );
+                            })}
                         </TableRow>
                     );
                 })}

--- a/frontend/src/component/featureTypes/FeatureTypesList.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypesList.tsx
@@ -157,13 +157,19 @@ export const FeatureTypesList = () => {
                 <TableBody {...getTableBodyProps()}>
                     {rows.map((row) => {
                         prepareRow(row);
+                        const { key, ...rowProps } = row.getRowProps();
                         return (
-                            <TableRow hover {...row.getRowProps()}>
-                                {row.cells.map((cell) => (
-                                    <TableCell {...cell.getCellProps()}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                ))}
+                            <TableRow hover key={key} {...rowProps}>
+                                {row.cells.map((cell) => {
+                                    const { key, ...cellProps } =
+                                        cell.getCellProps();
+
+                                    return (
+                                        <TableCell key={key} {...cellProps}>
+                                            {cell.render('Cell')}
+                                        </TableCell>
+                                    );
+                                })}
                             </TableRow>
                         );
                     })}

--- a/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
@@ -95,16 +95,23 @@ export const VariantInformation: VFC<IVariantInformationProps> = ({
                         }
 
                         prepareRow(row);
+                        const { key, ...rowProps } = row.getRowProps();
                         return (
-                            <TableRow hover {...row.getRowProps()}>
-                                {row.cells.map((cell: any) => (
-                                    <TableCell
-                                        {...cell.getCellProps()}
-                                        style={styles}
-                                    >
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                ))}
+                            <TableRow hover key={key} {...rowProps}>
+                                {row.cells.map((cell: any) => {
+                                    const { key, ...cellProps } =
+                                        cell.getCellProps();
+
+                                    return (
+                                        <TableCell
+                                            key={key}
+                                            {...cellProps}
+                                            style={styles}
+                                        >
+                                            {cell.render('Cell')}
+                                        </TableCell>
+                                    );
+                                })}
                             </TableRow>
                         );
                     })}

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
@@ -191,13 +191,19 @@ export const ChangeRequestTable = (props: TableProps) => {
             <TableBody {...getTableBodyProps()}>
                 {rows.map((row) => {
                     prepareRow(row);
+                    const { key, ...rowProps } = row.getRowProps();
                     return (
-                        <TableRow hover {...row.getRowProps()}>
-                            {row.cells.map((cell) => (
-                                <TableCell {...cell.getCellProps()}>
-                                    {cell.render('Cell')}
-                                </TableCell>
-                            ))}
+                        <TableRow hover key={key} {...rowProps}>
+                            {row.cells.map((cell) => {
+                                const { key, ...cellProps } =
+                                    cell.getCellProps();
+
+                                return (
+                                    <TableCell key={key} {...cellProps}>
+                                        {cell.render('Cell')}
+                                    </TableCell>
+                                );
+                            })}
                         </TableRow>
                     );
                 })}

--- a/frontend/src/component/project/Project/ProjectDoraMetrics/ProjectDoraMetrics.tsx
+++ b/frontend/src/component/project/Project/ProjectDoraMetrics/ProjectDoraMetrics.tsx
@@ -213,13 +213,19 @@ export const ProjectDoraMetrics = () => {
                     <TableBody {...getTableBodyProps()}>
                         {rows.map((row) => {
                             prepareRow(row);
+                            const { key, ...rowProps } = row.getRowProps();
                             return (
-                                <TableRow hover {...row.getRowProps()}>
-                                    {row.cells.map((cell) => (
-                                        <TableCell {...cell.getCellProps()}>
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    ))}
+                                <TableRow hover key={key} {...rowProps}>
+                                    {row.cells.map((cell) => {
+                                        const { key, ...cellProps } =
+                                            cell.getCellProps();
+
+                                        return (
+                                            <TableCell key={key} {...cellProps}>
+                                                {cell.render('Cell')}
+                                            </TableCell>
+                                        );
+                                    })}
                                 </TableRow>
                             );
                         })}

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -251,13 +251,18 @@ export const ChangeRequestTable: VFC = () => {
                 <TableBody {...getTableBodyProps()}>
                     {rows.map((row) => {
                         prepareRow(row);
+                        const { key, ...rowProps } = row.getRowProps();
                         return (
-                            <TableRow hover {...row.getRowProps()}>
-                                {row.cells.map((cell) => (
-                                    <TableCell {...cell.getCellProps()}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                ))}
+                            <TableRow hover key={key} {...rowProps}>
+                                {row.cells.map((cell) => {
+                                    const { key, ...cellProps } =
+                                        cell.getCellProps();
+                                    return (
+                                        <TableCell key={key} {...cellProps}>
+                                            {cell.render('Cell')}
+                                        </TableCell>
+                                    );
+                                })}
                             </TableRow>
                         );
                     })}

--- a/frontend/src/component/project/ProjectEnvironment/EnvironmentHideDialog/ProjectEnvironmentTableSingle/ProjectEnvironmentTableSingle.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/EnvironmentHideDialog/ProjectEnvironmentTableSingle/ProjectEnvironmentTableSingle.tsx
@@ -76,13 +76,19 @@ export const ProjectEnvironmentTableSingle = ({
             <TableBody {...getTableBodyProps()}>
                 {rows.map((row) => {
                     prepareRow(row);
+                    const { key, ...rowProps } = row.getRowProps();
                     return (
-                        <TableRow hover {...row.getRowProps()}>
-                            {row.cells.map((cell) => (
-                                <TableCell {...cell.getCellProps()}>
-                                    {cell.render('Cell')}
-                                </TableCell>
-                            ))}
+                        <TableRow hover key={key} {...rowProps}>
+                            {row.cells.map((cell) => {
+                                const { key, ...cellProps } =
+                                    cell.getCellProps();
+
+                                return (
+                                    <TableCell key={key} {...cellProps}>
+                                        {cell.render('Cell')}
+                                    </TableCell>
+                                );
+                            })}
                         </TableRow>
                     );
                 })}

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -274,13 +274,22 @@ const ProjectEnvironmentList = () => {
                         <TableBody {...getTableBodyProps()}>
                             {rows.map((row) => {
                                 prepareRow(row);
+                                const { key, ...rowProps } = row.getRowProps();
                                 return (
-                                    <TableRow hover {...row.getRowProps()}>
-                                        {row.cells.map((cell) => (
-                                            <TableCell {...cell.getCellProps()}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        ))}
+                                    <TableRow hover key={key} {...rowProps}>
+                                        {row.cells.map((cell) => {
+                                            const { key, ...cellProps } =
+                                                cell.getCellProps();
+
+                                            return (
+                                                <TableCell
+                                                    key={key}
+                                                    {...cellProps}
+                                                >
+                                                    {cell.render('Cell')}
+                                                </TableCell>
+                                            );
+                                        })}
                                     </TableRow>
                                 );
                             })}

--- a/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
+++ b/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
@@ -136,18 +136,30 @@ export const SegmentTable = () => {
                                 <TableBody {...getTableBodyProps()}>
                                     {rows.map((row) => {
                                         prepareRow(row);
+                                        const { key, ...rowProps } =
+                                            row.getRowProps();
                                         return (
                                             <TableRow
                                                 hover
-                                                {...row.getRowProps()}
+                                                key={key}
+                                                {...rowProps}
                                             >
-                                                {row.cells.map((cell) => (
-                                                    <TableCell
-                                                        {...cell.getCellProps()}
-                                                    >
-                                                        {cell.render('Cell')}
-                                                    </TableCell>
-                                                ))}
+                                                {row.cells.map((cell) => {
+                                                    const {
+                                                        key,
+                                                        ...cellProps
+                                                    } = cell.getCellProps();
+                                                    return (
+                                                        <TableCell
+                                                            key={key}
+                                                            {...cellProps}
+                                                        >
+                                                            {cell.render(
+                                                                'Cell',
+                                                            )}
+                                                        </TableCell>
+                                                    );
+                                                })}
                                             </TableRow>
                                         );
                                     })}

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -409,13 +409,22 @@ export const StrategiesList = () => {
                         <TableBody {...getTableBodyProps()}>
                             {rows.map((row) => {
                                 prepareRow(row);
+                                const { key, ...rowProps } = row.getRowProps();
                                 return (
-                                    <TableRow hover {...row.getRowProps()}>
-                                        {row.cells.map((cell) => (
-                                            <TableCell {...cell.getCellProps()}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        ))}
+                                    <TableRow hover key={key} {...rowProps}>
+                                        {row.cells.map((cell) => {
+                                            const { key, ...cellProps } =
+                                                cell.getCellProps();
+
+                                            return (
+                                                <TableCell
+                                                    key={key}
+                                                    {...cellProps}
+                                                >
+                                                    {cell.render('Cell')}
+                                                </TableCell>
+                                            );
+                                        })}
                                     </TableRow>
                                 );
                             })}
@@ -460,13 +469,22 @@ export const StrategiesList = () => {
                         <TableBody {...customGetTableBodyProps()}>
                             {customRows.map((row) => {
                                 customPrepareRow(row);
+                                const { key, ...rowProps } = row.getRowProps();
                                 return (
-                                    <TableRow hover {...row.getRowProps()}>
-                                        {row.cells.map((cell) => (
-                                            <TableCell {...cell.getCellProps()}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        ))}
+                                    <TableRow hover key={key} {...rowProps}>
+                                        {row.cells.map((cell) => {
+                                            const { key, ...cellProps } =
+                                                cell.getCellProps();
+
+                                            return (
+                                                <TableCell
+                                                    key={key}
+                                                    {...cellProps}
+                                                >
+                                                    {cell.render('Cell')}
+                                                </TableCell>
+                                            );
+                                        })}
                                     </TableRow>
                                 );
                             })}


### PR DESCRIPTION
This commit fixes invalid prop spreading warnings in all the table rows I
could find through a quick search in the code base.

The issue is that you can't spread the "key" prop into a component. It *must* be an explicit prop.

The process is the same everywhere:
1. Instead of spreading `row.getRowProps()` into the component, we extract and split it: `const {key, ...rowProps} = row.getRowProps()`.
2. Do the same thing for cellProps.