### PR TITLE
chore: drop experimental from new signal meta properties

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimeline.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimeline.tsx
@@ -128,17 +128,17 @@ const getTimelineEvent = (
             sourceDescription,
             tokenName,
             payload: {
-                experimental_unleash_title,
-                experimental_unleash_description,
-                experimental_unleash_icon,
-                experimental_unleash_variant,
+                unleashTitle,
+                unleashDescription,
+                unleashIcon,
+                unleashVariant,
             },
         } = event;
 
-        const title = experimental_unleash_title || sourceName;
+        const title = unleashTitle || sourceName;
         const label = `Signal: ${title}`;
-        const summary = experimental_unleash_description
-            ? `Signal: **[${title}](/integrations/signals)** ${experimental_unleash_description}`
+        const summary = unleashDescription
+            ? `Signal: **[${title}](/integrations/signals)** ${unleashDescription}`
             : `Signal originated from **[${sourceName} (${tokenName})](/integrations/signals)** endpoint${sourceDescription ? `: ${sourceDescription}` : ''}`;
 
         return {
@@ -147,11 +147,9 @@ const getTimelineEvent = (
             type: 'signal',
             label,
             summary,
-            ...(isValidString(experimental_unleash_icon)
-                ? { icon: experimental_unleash_icon }
-                : {}),
-            ...(isValidString(experimental_unleash_variant)
-                ? { variant: experimental_unleash_variant }
+            ...(isValidString(unleashIcon) ? { icon: unleashIcon } : {}),
+            ...(isValidString(unleashVariant)
+                ? { variant: unleashVariant }
                 : {}),
         };
     }

--- a/frontend/src/component/layout/MainLayout/MainLayoutEventTimeline.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayoutEventTimeline.tsx
@@ -3,7 +3,6 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { EventTimeline } from 'component/events/EventTimeline/EventTimeline';
 import { useEventTimelineContext } from 'component/events/EventTimeline/EventTimelineContext';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { useUiFlag } from 'hooks/useUiFlag';
 import { useEffect, useState } from 'react';
 
 const StyledEventTimelineSlider = styled(Box)(({ theme }) => ({
@@ -21,10 +20,9 @@ const StyledEventTimelineWrapper = styled(Box)(({ theme }) => ({
 export const MainLayoutEventTimeline = () => {
     const { isOss } = useUiConfig();
     const { open: showTimeline } = useEventTimelineContext();
-    const eventTimelineEnabled = useUiFlag('eventTimeline') && !isOss();
     const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-    const open = showTimeline && eventTimelineEnabled;
+    const open = showTimeline && !isOss();
 
     useEffect(() => {
         setIsInitialLoad(false);

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
@@ -104,7 +104,6 @@ export const NewInUnleash = ({
     );
     const { isOss, isEnterprise } = useUiConfig();
     const signalsEnabled = useUiFlag('signals');
-    const eventTimelineEnabled = useUiFlag('eventTimeline');
 
     const { setHighlighted } = useEventTimelineContext();
 
@@ -159,7 +158,7 @@ export const NewInUnleash = ({
             },
             docsLink:
                 'https://docs.getunleash.io/reference/events#event-timeline',
-            show: !isOss() && eventTimelineEnabled,
+            show: !isOss(),
             longDescription: (
                 <>
                     <p>
@@ -174,7 +173,6 @@ export const NewInUnleash = ({
                     </p>
                 </>
             ),
-            beta: true,
         },
     ];
 

--- a/frontend/src/component/menu/Header/HeaderEventTimelineButton.tsx
+++ b/frontend/src/component/menu/Header/HeaderEventTimelineButton.tsx
@@ -3,7 +3,6 @@ import LinearScaleIcon from '@mui/icons-material/LinearScale';
 import { useEventTimelineContext } from 'component/events/EventTimeline/EventTimelineContext';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledHeaderEventTimelineButton = styled(IconButton, {
     shouldForwardProp: (prop) => prop !== 'highlighted',
@@ -34,14 +33,13 @@ const StyledHeaderEventTimelineButton = styled(IconButton, {
 export const HeaderEventTimelineButton = () => {
     const { trackEvent } = usePlausibleTracker();
     const { isOss } = useUiConfig();
-    const eventTimeline = useUiFlag('eventTimeline') && !isOss();
     const {
         open: showTimeline,
         setOpen: setShowTimeline,
         highlighted,
     } = useEventTimelineContext();
 
-    if (!eventTimeline) return null;
+    if (isOss()) return null;
 
     return (
         <Tooltip

--- a/src/lib/features/events/event-search-controller.ts
+++ b/src/lib/features/events/event-search-controller.ts
@@ -111,19 +111,15 @@ export default class EventSearchController extends Controller {
     }
 
     enrichEvents(events: IEvent[]): IEvent[] | IEnrichedEvent[] {
-        if (this.flagResolver.isEnabled('eventTimeline')) {
-            return events.map((event) => {
-                const { label, text: summary } =
-                    this.msgFormatter.format(event);
+        return events.map((event) => {
+            const { label, text: summary } = this.msgFormatter.format(event);
 
-                return {
-                    ...event,
-                    label,
-                    summary,
-                };
-            });
-        }
-        return events;
+            return {
+                ...event,
+                label,
+                summary,
+            };
+        });
     }
 
     maybeAnonymiseEvents(events: IEvent[]): IEvent[] {

--- a/src/lib/openapi/spec/event-schema.ts
+++ b/src/lib/openapi/spec/event-schema.ts
@@ -95,14 +95,12 @@ export const eventSchema = {
         label: {
             type: 'string',
             nullable: true,
-            description:
-                '**[Experimental]** The concise, human-readable name of the event.',
+            description: 'The concise, human-readable name of the event.',
         },
         summary: {
             type: 'string',
             nullable: true,
-            description:
-                '**[Experimental]** A markdown-formatted summary of the event.',
+            description: 'A markdown-formatted summary of the event.',
         },
     },
     components: {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -52,7 +52,6 @@ export type IFlagKey =
     | 'onboardingMetrics'
     | 'onboardingUI'
     | 'projectRoleAssignment'
-    | 'eventTimeline'
     | 'personalDashboardUI'
     | 'trackLifecycleMetrics'
     | 'purchaseAdditionalEnvironments'
@@ -265,10 +264,6 @@ const flags: IFlags = {
     ),
     projectRoleAssignment: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PROJECT_ROLE_ASSIGNMENT,
-        false,
-    ),
-    eventTimeline: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_EVENT_TIMELINE,
         false,
     ),
     personalDashboardUI: parseEnvVarBoolean(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2855/change-our-experimental-title-to-camelcase-and-maybe-remove

Drops "experimental" from the new signal meta properties and makes them camelCase instead.