### PR TITLE
fix: correctly filter for `to` dates

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -184,16 +184,22 @@ export default class EventService {
         }
 
         if (params.to) {
-            const [_, value] = params.to.split(':');
-            const inclusiveDate = formatISO(addDays(new Date(value), 1), {
-                representation: 'date',
-            });
+            const parsed = parseSearchOperatorValue('created_at', params.to);
+            if (parsed) {
+                const values = parsed.values
+                    .filter((v): v is string => v !== null)
+                    .map((date) =>
+                        formatISO(addDays(new Date(date), 1), {
+                            representation: 'date',
+                        }),
+                    );
 
-            queryParams.push({
-                field: `created_at`,
-                operator: 'IS_BEFORE',
-                values: [inclusiveDate],
-            });
+                queryParams.push({
+                    field: parsed.field,
+                    operator: 'IS_BEFORE',
+                    values,
+                });
+            }
         }
 
         if (params.createdBy) {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -13,7 +13,7 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
-import { endOfDay, formatISO } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import type { IPrivateProjectChecker } from '../private-project/privateProjectCheckerType';
 import type { ProjectAccess } from '../private-project/privateProjectStore';
 import type { IAccessReadModel } from '../access/access-read-model-type';
@@ -184,11 +184,14 @@ export default class EventService {
         }
 
         if (params.to) {
+            const [operator, value] = params.to.split(':');
+            const inclusiveDate = formatISO(addDays(new Date(value), 1), {
+                representation: 'date',
+            });
+
             const parsed = parseSearchOperatorValue(
                 'created_at',
-                formatISO(endOfDay(new Date(params.to)), {
-                    representation: 'date',
-                }),
+                `${operator}:${inclusiveDate}`,
             );
 
             if (parsed) {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -13,7 +13,7 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
-import { addDays, formatISO } from 'date-fns';
+import { endOfDay, formatISO } from 'date-fns';
 import type { IPrivateProjectChecker } from '../private-project/privateProjectCheckerType';
 import type { ProjectAccess } from '../private-project/privateProjectStore';
 import type { IAccessReadModel } from '../access/access-read-model-type';
@@ -185,9 +185,7 @@ export default class EventService {
 
         if (params.to) {
             const [operator, value] = params.to.split(':');
-            const inclusiveDate = formatISO(addDays(new Date(value), 1), {
-                representation: 'date',
-            });
+            const inclusiveDate = formatISO(endOfDay(new Date(value)));
 
             const parsed = parseSearchOperatorValue(
                 'created_at',

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -184,23 +184,16 @@ export default class EventService {
         }
 
         if (params.to) {
-            const [operator, value] = params.to.split(':');
+            const [_, value] = params.to.split(':');
             const inclusiveDate = formatISO(addDays(new Date(value), 1), {
                 representation: 'date',
             });
 
-            const parsed = parseSearchOperatorValue(
-                'created_at',
-                `${operator}:${inclusiveDate}`,
-            );
-
-            if (parsed) {
-                queryParams.push({
-                    field: parsed.field,
-                    operator: 'IS_BEFORE',
-                    values: parsed.values,
-                });
-            }
+            queryParams.push({
+                field: `created_at`,
+                operator: 'IS_BEFORE',
+                values: [inclusiveDate],
+            });
         }
 
         if (params.createdBy) {

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -13,7 +13,7 @@ import { ApiTokenType } from '../../types/models/api-token';
 import { EVENTS_CREATED_BY_PROCESSED } from '../../metric-events';
 import type { IQueryParam } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import { parseSearchOperatorValue } from '../feature-search/search-utils';
-import { endOfDay, formatISO } from 'date-fns';
+import { addDays, formatISO } from 'date-fns';
 import type { IPrivateProjectChecker } from '../private-project/privateProjectCheckerType';
 import type { ProjectAccess } from '../private-project/privateProjectStore';
 import type { IAccessReadModel } from '../access/access-read-model-type';
@@ -185,7 +185,9 @@ export default class EventService {
 
         if (params.to) {
             const [operator, value] = params.to.split(':');
-            const inclusiveDate = formatISO(endOfDay(new Date(value)));
+            const inclusiveDate = formatISO(addDays(new Date(value), 1), {
+                representation: 'date',
+            });
 
             const parsed = parseSearchOperatorValue(
                 'created_at',


### PR DESCRIPTION
This change fixes a bug in the event filter's `to` query parameter.

The problem was that in an attempt to make it inclusive, we also
stripped it of the `IS:` prefix, which meant it had no effect. This
change fixes that by first splitting the value, fixing only the
date (because we want it to include the entire day), and then joining
it back together.