### PR TITLE
security: move orval to dev dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -128,6 +128,7 @@
   "resolutions": {
     "@codemirror/state": "6.4.1",
     "@xmldom/xmldom": "^0.9.0",
+    "jsonpath-plus": "10.0.0",
     "json5": "^2.2.2",
     "vite": "5.4.9",
     "semver": "7.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,6 +94,7 @@
     "lodash.omit": "4.5.0",
     "millify": "^6.0.0",
     "msw": "2.4.12",
+    "orval": "^6.31.0",
     "pkginfo": "0.4.1",
     "plausible-tracker": "0.3.9",
     "prop-types": "15.8.1",
@@ -123,9 +124,6 @@
     "vite-tsconfig-paths": "4.3.2",
     "vitest": "1.4.0",
     "whatwg-fetch": "3.6.20"
-  },
-  "optionalDependencies": {
-    "orval": "^6.17.0"
   },
   "resolutions": {
     "@codemirror/state": "6.4.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7938,7 +7938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"orval@npm:^6.17.0":
+"orval@npm:^6.31.0":
   version: 6.31.0
   resolution: "orval@npm:6.31.0"
   dependencies:
@@ -10138,7 +10138,7 @@ __metadata:
     lodash.omit: "npm:4.5.0"
     millify: "npm:^6.0.0"
     msw: "npm:2.4.12"
-    orval: "npm:^6.17.0"
+    orval: "npm:^6.31.0"
     pkginfo: "npm:0.4.1"
     plausible-tracker: "npm:0.3.9"
     prop-types: "npm:15.8.1"
@@ -10168,9 +10168,6 @@ __metadata:
     vite-tsconfig-paths: "npm:4.3.2"
     vitest: "npm:1.4.0"
     whatwg-fetch: "npm:3.6.20"
-  dependenciesMeta:
-    orval:
-      optional: true
   languageName: unknown
   linkType: soft
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1523,7 +1523,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsep-plugin/regex@npm:^1.0.1":
+"@jsep-plugin/assignment@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jsep-plugin/assignment@npm:1.2.1"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 10c0/f056a318c4a545ef2376f0dc248f0f9f43548e792fd7f6260b04c93985a1985aeb734af6712b90c9cb09cf74cf092f45492ca0b066db2973a5c949567aceb7fc
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.1, @jsep-plugin/regex@npm:^1.0.3":
   version: 1.0.3
   resolution: "@jsep-plugin/regex@npm:1.0.3"
   peerDependencies:
@@ -6629,6 +6638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsep@npm:^1.3.9":
+  version: 1.3.9
+  resolution: "jsep@npm:1.3.9"
+  checksum: 10c0/7c57727c98de797a319d00f74c19fa96f4760fbced428b00a86a01124412815c07ec1757806c09b9576f35461ecd04f717fa2a64954ff22f1d93d152bc5ecf16
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:^2.5.1":
   version: 2.5.2
   resolution: "jsesc@npm:2.5.2"
@@ -6721,17 +6737,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:7.1.0":
-  version: 7.1.0
-  resolution: "jsonpath-plus@npm:7.1.0"
-  checksum: 10c0/3a74b39f434c6496191eaa2820331407d89868b59cfbb9458c0f665e6877a67125b506d68c887746420660e7a3c4f279367182bec38093f3a0129f3757c85c48
-  languageName: node
-  linkType: hard
-
-"jsonpath-plus@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "jsonpath-plus@npm:6.0.1"
-  checksum: 10c0/ecbe5caad723a42e1cc4a28058ca837eba00d36075766a7f3cf828491648e3b64d9fa0d5a64dd868e7c3180b1f9fcec565c32a1c05b34bef9f88c3c0c7acd1a2
+"jsonpath-plus@npm:10.0.0":
+  version: 10.0.0
+  resolution: "jsonpath-plus@npm:10.0.0"
+  dependencies:
+    "@jsep-plugin/assignment": "npm:^1.2.1"
+    "@jsep-plugin/regex": "npm:^1.0.3"
+    jsep: "npm:^1.3.9"
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: 10c0/0bd0ad79397f319c8543f090a944ea08c933c13d69ad5213f202f738ef4abd46de57c917844a83e2e89643cadbfc2e327a402c01eaf50bd1870882d50a4a8b95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Looking at https://github.com/Unleash/unleash/security/dependabot/204 it seems that the dependency comes from orval that should not be needed in production:

```shell
$ yarn why  --recursive jsonpath-plus                
└─ unleash-frontend-local@workspace:.
   └─ orval@npm:6.31.0 (via npm:^6.31.0)
      ├─ @orval/angular@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      │     └─ @ibm-cloud/openapi-ruleset@npm:1.17.0 (via npm:^1.14.2)
      │        ├─ @stoplight/spectral-formats@npm:1.6.0 (via npm:^1.6.0)
      │        │  └─ @stoplight/spectral-core@npm:1.18.3 (via npm:^1.8.0)
      │        │     ├─ jsonpath-plus@npm:7.1.0 (via npm:7.1.0)
      │        │     └─ nimma@npm:0.2.2 (via npm:0.2.2)
      │        │        └─ jsonpath-plus@npm:6.0.1 (via npm:^6.0.1)
      │        ├─ @stoplight/spectral-functions@npm:1.8.0 (via npm:^1.7.2)
      │        │  ├─ @stoplight/spectral-core@npm:1.18.3 (via npm:^1.7.0)
      │        │  └─ @stoplight/spectral-formats@npm:1.6.0 (via npm:^1.0.0)
      │        └─ @stoplight/spectral-rulesets@npm:1.19.1 (via npm:^1.18.1)
      │           ├─ @stoplight/spectral-core@npm:1.18.3 (via npm:^1.8.1)
      │           ├─ @stoplight/spectral-formats@npm:1.6.0 (via npm:^1.5.0)
      │           └─ @stoplight/spectral-functions@npm:1.8.0 (via npm:^1.5.1)
      ├─ @orval/axios@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/fetch@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/hono@npm:6.31.0 (via npm:6.31.0)
      │  ├─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/zod@npm:6.31.0 (via npm:6.31.0)
      │     └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/mock@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/query@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      ├─ @orval/swr@npm:6.31.0 (via npm:6.31.0)
      │  └─ @orval/core@npm:6.31.0 (via npm:6.31.0)
      └─ @orval/zod@npm:6.31.0 (via npm:6.31.0)
```

These are dependencies that are optional for your project. If they fail to install, the installation process will continue without error, but they will be included if they can be successfully installed.

By default, optionalDependencies are installed in both environments, including production.