### PR TITLE
chore: remove the addonUsageMetrics flag

### DIFF
--- a/src/lib/addons/addon.ts
+++ b/src/lib/addons/addon.ts
@@ -94,12 +94,10 @@ export default abstract class Addon {
         integrationEvent: IntegrationEventWriteModel,
     ): Promise<void> {
         await this.integrationEventsService.registerEvent(integrationEvent);
-        if (this.flagResolver.isEnabled('addonUsageMetrics')) {
-            this.eventBus.emit(ADDON_EVENTS_HANDLED, {
-                result: integrationEvent.state,
-                destination: this.name,
-            });
-        }
+        this.eventBus.emit(ADDON_EVENTS_HANDLED, {
+            result: integrationEvent.state,
+            destination: this.name,
+        });
     }
 
     destroy?(): void;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -59,7 +59,6 @@ export type IFlagKey =
     | 'originMiddlewareRequestLogging'
     | 'unleashAI'
     | 'webhookDomainLogging'
-    | 'addonUsageMetrics'
     | 'releasePlans'
     | 'navigationSidebar'
     | 'productivityReportEmail';
@@ -293,10 +292,6 @@ const flags: IFlags = {
     ),
     webhookDomainLogging: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENT_WEBHOOK_DOMAIN_LOGGING,
-        false,
-    ),
-    addonUsageMetrics: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_ADDON_USAGE_METRICS,
         false,
     ),
     releasePlans: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -56,7 +56,6 @@ process.nextTick(async () => {
                         originMiddlewareRequestLogging: true,
                         unleashAI: true,
                         webhookDomainLogging: true,
-                        addonUsageMetrics: true,
                         releasePlans: false,
                     },
                 },


### PR DESCRIPTION
Removes the `addonUsageMetrics` flag, final part of closing integration metrics project for GA in 6.4