### PR TITLE
chore: add migration for release-plans-definitions that removes fk on users(id)

### DIFF
--- a/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
+++ b/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
@@ -1,0 +1,11 @@
+exports.up = function(db, cb) {
+    db.runSql(`
+        ALTER TABLE release_plan_definitions DROP CONSTRAINT release_plan_definitions_created_by_user_id_fkey;
+    `, cb)
+};
+
+exports.down = function(db, cb) {
+    db.runSql(`
+        ALTER TABLE release_plan_definitions ADD CONSTRAINT release_plan_definitions_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+    `, cb);
+};

--- a/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
+++ b/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
@@ -1,11 +1,13 @@
 exports.up = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions DROP CONSTRAINT release_plan_definitions_created_by_user_id_fkey;
+        CREATE INDEX idx_release_plan_definitions_created_by_user_id ON release_plan_definitions (created_by_user_id);
     `, cb)
 };
 
 exports.down = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions ADD CONSTRAINT release_plan_definitions_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+        DROP INDEX idx_release_plan_definitions_created_by_user_id;
     `, cb);
 };


### PR DESCRIPTION
Removes a fk constraint release-plans-definitions->created_by_user_id on users table so we can delete users even if they have created release-plans/templates

Also adds an index on created_by_user_id