### PR TITLE
feat: Make `disableMigration` option handled by environment variable

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -259,7 +259,7 @@ const defaultDbOptions: WithOptional<IDBOption, 'user' | 'password' | 'host'> =
             propagateCreateError: false,
         },
         schema: process.env.DATABASE_SCHEMA || 'public',
-        disableMigration: false,
+        disableMigration: parseEnvVarBoolean(process.env.DATABASE_DISABLE_MIGRATION, false),
         applicationName: process.env.DATABASE_APPLICATION_NAME || 'unleash',
     };
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -259,7 +259,10 @@ const defaultDbOptions: WithOptional<IDBOption, 'user' | 'password' | 'host'> =
             propagateCreateError: false,
         },
         schema: process.env.DATABASE_SCHEMA || 'public',
-        disableMigration: parseEnvVarBoolean(process.env.DATABASE_DISABLE_MIGRATION, false),
+        disableMigration: parseEnvVarBoolean(
+            process.env.DATABASE_DISABLE_MIGRATION,
+            false,
+        ),
         applicationName: process.env.DATABASE_APPLICATION_NAME || 'unleash',
     };
 

--- a/website/docs/using-unleash/deploy/configuring-unleash.mdx
+++ b/website/docs/using-unleash/deploy/configuring-unleash.mdx
@@ -383,6 +383,7 @@ Unleash options' `db` object.
 | `pool.idleTimeoutMillis` | `DATABASE_POOL_IDLE_TIMEOUT_MS`    | 30000                                            | The amount of time (in milliseconds) that a connection must be idle for before it is marked as a candidate for eviction.                                                       |
 | `applicationName`        | `DATABASE_APPLICATION_NAME`        | `unleash`                                        | The name of the application that created this Client instance.                                                                                                                 |
 | `schema`                 | `DATABASE_SCHEMA`                  | `public`                                         | The schema to use in the database.                                                                                                                                             |
+| `disableMigration`       | `DATABASE_DISABLE_MIGRATION`       | false                                            | The option not to use database migration.                                                                                                                                      |
 
 Alternatively, you can use a
 single-host [libpq connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

In some cases, people want to disable database migration. For example, some people or companies want to grant whole permissions to handle the schema by DBAs, not by application level hence I use `parseEnvVarBoolean` to handle `disableMigration` option by environment variable. I set the default value as `false` for the backward compatibility.

However, I wonder where to add test code of it because all the unit and e2e test is a kind of testing the whole configuration.
