### PR TITLE
fix: text color in timeline event group for light mode

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventGroup.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventGroup.tsx
@@ -26,6 +26,7 @@ interface IEventTimelineEventProps {
 const StyledBadge = styled(Badge)(({ theme }) => ({
     '.MuiBadge-badge': {
         backgroundColor: theme.palette.background.alternative,
+        color: theme.palette.primary.contrastText,
     },
 }));
 


### PR DESCRIPTION
The recent fix to dark mode's background color for events also
caused an issue with the text color in light mode. This change makes
it so that the text color is correct in both instances.

Before (light):
<img width="77" alt="image" src="https://github.com/user-attachments/assets/d17a9b90-4d6c-4e41-a84c-b673b02a7313">


After (light + dark):
<img width="77" alt="image" src="https://github.com/user-attachments/assets/7fca426d-eaae-44e1-a4b4-61728b09fa79">
<img width="77" alt="image" src="https://github.com/user-attachments/assets/baf07ddb-3b89-4418-97d8-a19bb6646c3f">
