### PR TITLE
feat: productivity report subscription UI

### DIFF
--- a/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.tsx
@@ -1,0 +1,63 @@
+import { Box, Switch } from '@mui/material';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useState } from 'react';
+import { useEmailSubscriptionApi } from 'hooks/api/actions/useEmailSubscriptionApi/useEmailSubscriptionApi';
+import useToast from 'hooks/useToast';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+
+export const ProductivityEmailSubscription = () => {
+    // TODO: read data from user profile when available
+    const [receiveProductivityReportEmail, setReceiveProductivityReportEmail] =
+        useState(false);
+    const {
+        subscribe,
+        unsubscribe,
+        loading: changingSubscriptionStatus,
+    } = useEmailSubscriptionApi();
+    const { setToastData, setToastApiError } = useToast();
+    const { trackEvent } = usePlausibleTracker();
+
+    return (
+        <Box>
+            Productivity Email Subscription
+            <Switch
+                onChange={async () => {
+                    try {
+                        if (receiveProductivityReportEmail) {
+                            await unsubscribe('productivity-report');
+                            setToastData({
+                                title: 'Unsubscribed from productivity report',
+                                type: 'success',
+                            });
+                            trackEvent('productivity-report', {
+                                props: {
+                                    eventType: 'subscribe',
+                                },
+                            });
+                        } else {
+                            await subscribe('productivity-report');
+                            setToastData({
+                                title: 'Subscribed to productivity report',
+                                type: 'success',
+                            });
+                            trackEvent('productivity-report', {
+                                props: {
+                                    eventType: 'unsubscribe',
+                                },
+                            });
+                        }
+                    } catch (error) {
+                        setToastApiError(formatUnknownError(error));
+                    }
+
+                    setReceiveProductivityReportEmail(
+                        !receiveProductivityReportEmail,
+                    );
+                }}
+                name='productivity-email'
+                checked={receiveProductivityReportEmail}
+                disabled={changingSubscriptionStatus}
+            />
+        </Box>
+    );
+};

--- a/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
@@ -19,7 +19,7 @@ import { useNavigate } from 'react-router-dom';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { RoleBadge } from 'component/common/RoleBadge/RoleBadge';
-import { useUiFlag } from '../../../../hooks/useUiFlag';
+import { useUiFlag } from 'hooks/useUiFlag';
 import { ProductivityEmailSubscription } from './ProductivityEmailSubscription';
 
 const StyledHeader = styled('div')(({ theme }) => ({

--- a/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
@@ -19,6 +19,8 @@ import { useNavigate } from 'react-router-dom';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { RoleBadge } from 'component/common/RoleBadge/RoleBadge';
+import { useUiFlag } from '../../../../hooks/useUiFlag';
+import { ProductivityEmailSubscription } from './ProductivityEmailSubscription';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -121,6 +123,8 @@ export const ProfileTab = ({ user }: IProfileTabProps) => {
         setLocationSettings({ locale });
     };
 
+    const productivityReportEmailEnabled = useUiFlag('productivityReportEmail');
+
     return (
         <>
             <StyledHeader>
@@ -187,7 +191,7 @@ export const ProfileTab = ({ user }: IProfileTabProps) => {
                     </Box>
                 </StyledAccess>
                 <StyledDivider />
-                <StyledSectionLabel>Settings</StyledSectionLabel>
+                <StyledSectionLabel>Date/Time Settings</StyledSectionLabel>
                 <Typography variant='body2'>
                     This is the format used across the system for time and date
                 </Typography>
@@ -215,6 +219,13 @@ export const ProfileTab = ({ user }: IProfileTabProps) => {
                         })}
                     </Select>
                 </StyledFormControl>
+                {productivityReportEmailEnabled ? (
+                    <>
+                        <StyledDivider />
+                        <StyledSectionLabel>Email Settings</StyledSectionLabel>
+                        <ProductivityEmailSubscription />
+                    </>
+                ) : null}
             </PageContent>
         </>
     );

--- a/frontend/src/hooks/api/actions/useEmailSubscriptionApi/useEmailSubscriptionApi.ts
+++ b/frontend/src/hooks/api/actions/useEmailSubscriptionApi/useEmailSubscriptionApi.ts
@@ -1,0 +1,32 @@
+import useAPI from '../useApi/useApi';
+
+export const useEmailSubscriptionApi = () => {
+    const { makeRequest, createRequest, errors, loading } = useAPI({
+        propagateErrors: true,
+    });
+
+    const subscribe = async (subscriptionName: string) => {
+        const path = `api/admin/email-subscription/${subscriptionName}`;
+        const req = createRequest(path, {
+            method: 'PUT',
+        });
+
+        await makeRequest(req.caller, req.id);
+    };
+
+    const unsubscribe = async (subscriptionName: string) => {
+        const path = `api/admin/email-subscription/${subscriptionName}`;
+        const req = createRequest(path, {
+            method: 'DELETE',
+        });
+
+        await makeRequest(req.caller, req.id);
+    };
+
+    return {
+        subscribe,
+        unsubscribe,
+        errors,
+        loading,
+    };
+};

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -72,7 +72,8 @@ export type CustomEvents =
     | 'personal-dashboard'
     | 'order-environments'
     | 'unleash-ai-chat'
-    | 'project-navigation';
+    | 'project-navigation'
+    | 'productivity-report';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -94,6 +94,7 @@ export type UiFlags = {
     releasePlans?: boolean;
     'enterprise-payg'?: boolean;
     simplifyProjectOverview?: boolean;
+    productivityReportEmail?: boolean;
 };
 
 export interface IVersionInfo {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Productivity report subscription management UI
<img width="1085" alt="Screenshot 2024-11-04 at 13 11 32" src="https://github.com/user-attachments/assets/5bfd4080-fefc-4b8e-a93f-5787460a24f0">

Details:
* MUI Switch toggle to control subscription status
* toasts after success and error
* sending subscribe/unsubscribe requests on toggle 
* initial state and state updates to-be-implemented after we add subscription information to user profile API
* plausible tracking of subscribe/unsubscribe actions (goal already added to plausible)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
