### PR TITLE
fix: enterprise routes 404 when not logged in

### DIFF
--- a/frontend/src/component/App.tsx
+++ b/frontend/src/component/App.tsx
@@ -21,6 +21,7 @@ import { InternalBanners } from './banners/internalBanners/InternalBanners';
 import { ExternalBanners } from './banners/externalBanners/ExternalBanners';
 import { LicenseBanner } from './banners/internalBanners/LicenseBanner';
 import { Demo } from './demo/Demo';
+import { LoginRedirect } from './common/LoginRedirect/LoginRedirect';
 
 const StyledContainer = styled('div')(() => ({
     '& ul': {
@@ -46,6 +47,8 @@ export const App = () => {
             refetchUiConfig();
         }
     }, [authDetails, user]);
+
+    const isLoggedIn = Boolean(user?.id);
 
     return (
         <SWRProvider>
@@ -92,7 +95,13 @@ export const App = () => {
                                         />
                                         <Route
                                             path='*'
-                                            element={<NotFound />}
+                                            element={
+                                                isLoggedIn ? (
+                                                    <NotFound />
+                                                ) : (
+                                                    <LoginRedirect />
+                                                )
+                                            }
                                         />
                                     </Routes>
 


### PR DESCRIPTION
Evaluate `*` with login redirect before showing 404s.