### PR TITLE
fix: set a dynamic yesterday date instead of a fixed one.

### DIFF
--- a/src/lib/features/project-status/projects-status.e2e.test.ts
+++ b/src/lib/features/project-status/projects-status.e2e.test.ts
@@ -79,17 +79,18 @@ test('project insights should return correct count for each day', async () => {
     const yesterdayEvent = events.find(
         (e) => e.data.featureName === 'yesterday-event',
     );
-    await db.rawDatabase.raw(
-        `UPDATE events SET created_at = '2024-11-03' where id = ?`,
-        [yesterdayEvent?.id],
-    );
+
+    const { todayString, yesterdayString } = getCurrentDateStrings();
+
+    await db.rawDatabase.raw(`UPDATE events SET created_at = ? where id = ?`, [
+        yesterdayString,
+        yesterdayEvent?.id,
+    ]);
 
     const { body } = await app.request
         .get('/api/admin/projects/default/status')
         .expect('Content-Type', /json/)
         .expect(200);
-
-    const { todayString, yesterdayString } = getCurrentDateStrings();
 
     expect(body).toMatchObject({
         activityCountByDate: [


### PR DESCRIPTION
This was an oversight. The test would always fail after 2024-11-04,
because yesterday is no longer 2024-11-03. This way, we're using the
same string in both places.