### PR TITLE
fix: fix project settings path for oss

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -197,6 +197,7 @@ export const Project = () => {
     const activeTab = [...filteredTabs]
         .reverse()
         .find((tab) => pathname.startsWith(tab.path));
+
     useEffect(() => {
         const created = params.get('created');
         const edited = params.get('edited');

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -70,6 +70,7 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
 interface ITab {
     title: string;
     path: string;
+    ossPath?: string;
     name: string;
     flag?: keyof UiFlags;
     new?: boolean;
@@ -181,6 +182,7 @@ export const Project = () => {
         {
             title: 'Project settings',
             path: `${basePath}/settings`,
+            ossPath: `${basePath}/settings/api-access`,
             name: 'settings',
         },
     ];
@@ -327,7 +329,11 @@ export const Project = () => {
                                                 },
                                             });
                                         }
-                                        navigate(tab.path);
+                                        navigate(
+                                            isOss && tab.ossPath
+                                                ? tab.ossPath
+                                                : tab.path,
+                                        );
                                     }}
                                     data-testid={`TAB_${tab.title}`}
                                     iconPosition={

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -330,7 +330,7 @@ export const Project = () => {
                                             });
                                         }
                                         navigate(
-                                            isOss && tab.ossPath
+                                            isOss() && tab.ossPath
                                                 ? tab.ossPath
                                                 : tab.path,
                                         );

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -180,7 +180,7 @@ export const Project = () => {
         },
         {
             title: 'Project settings',
-            path: `${basePath}/settings${isOss() ? '/environments' : ''}`,
+            path: `${basePath}/settings`,
             name: 'settings',
         },
     ];
@@ -197,7 +197,6 @@ export const Project = () => {
     const activeTab = [...filteredTabs]
         .reverse()
         .find((tab) => pathname.startsWith(tab.path));
-
     useEffect(() => {
         const created = params.get('created');
         const edited = params.get('edited');

--- a/frontend/src/component/project/Project/ProjectSettings/Settings/Settings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/Settings/Settings.tsx
@@ -10,6 +10,7 @@ import {
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
 import EditProject from './EditProject/EditProject';
+import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
@@ -19,6 +20,17 @@ export const Settings = () => {
     const { hasAccess } = useContext(AccessContext);
     const { isOss } = useUiConfig();
     usePageTitle(`Project configuration – ${projectName}`);
+
+    if (isOss()) {
+        return (
+            <PageContent
+                header={<PageHeader title='General settings' />}
+                sx={{ justifyContent: 'center' }}
+            >
+                <PremiumFeature feature='project-settings' />
+            </PageContent>
+        );
+    }
 
     if (!hasAccess([UPDATE_PROJECT, PROJECT_SETTINGS_READ], projectId)) {
         return (

--- a/frontend/src/component/project/Project/ProjectSettings/Settings/Settings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/Settings/Settings.tsx
@@ -10,7 +10,6 @@ import {
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
 import EditProject from './EditProject/EditProject';
-import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 
@@ -20,17 +19,6 @@ export const Settings = () => {
     const { hasAccess } = useContext(AccessContext);
     const { isOss } = useUiConfig();
     usePageTitle(`Project configuration – ${projectName}`);
-
-    if (isOss()) {
-        return (
-            <PageContent
-                header={<PageHeader title='General settings' />}
-                sx={{ justifyContent: 'center' }}
-            >
-                <PremiumFeature feature='project-settings' />
-            </PageContent>
-        );
-    }
 
     if (!hasAccess([UPDATE_PROJECT, PROJECT_SETTINGS_READ], projectId)) {
         return (


### PR DESCRIPTION
**Issue fix:** Resolves #8618, where environments were incorrectly appended to the route.
**Change:** Introduces `ossPath` specifically for OSS users, as OSS lacks the default `/settings` path, starting instead from `api-access`.