### PR TITLE
migration(producitivty-report): cascade user unsubscription

### DIFF
--- a/src/migrations/20241105123918-add-cascade-for-user-unsubscription.js
+++ b/src/migrations/20241105123918-add-cascade-for-user-unsubscription.js
@@ -1,0 +1,16 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+    ALTER TABLE user_unsubscription DROP CONSTRAINT user_unsubscription_user_id_fkey;
+    ALTER TABLE user_unsubscription
+        ADD CONSTRAINT user_unsubscription_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE;
+`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql('', cb);
+};


### PR DESCRIPTION
Remove opt-outs for deleted users. This is useful in tests, where we delete users permanently.