### PR TITLE
chore: update SCSS preprocessor API to modern-compiler

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -23,6 +23,13 @@ const vitestConfig = vitestDefineConfig({
         environment: 'jsdom',
         exclude: [...configDefaults.exclude, '**/cypress/**'],
     },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api: 'modern-compiler'
+            }
+        }
+    }
 });
 
 export default mergeConfig(


### PR DESCRIPTION
Configured SCSS preprocessor options to use the `modern-compiler` API, aligning with the new Sass API standards and preparing for Dart Sass 2.0.0. This change prevents deprecation warnings and ensures future compatibility by transitioning away from the legacy JS API.


https://sass-lang.com/documentation/breaking-changes/legacy-js-api/

Got rid of 
![Screenshot from 2024-11-05 15-25-09](https://github.com/user-attachments/assets/c13827de-6ab4-40ab-af4c-d1a4f8cb7b3e)

