### PR TITLE
chore: remove project segments gate for oss users

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSegments/ProjectSegments.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSegments/ProjectSegments.tsx
@@ -1,10 +1,6 @@
-import { PageContent } from 'component/common/PageContent/PageContent';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { SegmentTable } from 'component/segments/SegmentTable/SegmentTable';
-import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { CreateSegment } from 'component/segments/CreateSegment/CreateSegment';
 import { EditSegment } from 'component/segments/EditSegment/EditSegment';
@@ -15,21 +11,9 @@ import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview
 export const ProjectSegments = () => {
     const projectId = useRequiredPathParam('projectId');
     const projectName = useProjectOverviewNameOrId(projectId);
-    const { isOss } = useUiConfig();
     const navigate = useNavigate();
 
     usePageTitle(`Project segments – ${projectName}`);
-
-    if (isOss()) {
-        return (
-            <PageContent
-                header={<PageHeader titleElement='Segments' />}
-                sx={{ justifyContent: 'center' }}
-            >
-                <PremiumFeature feature='segments' />
-            </PageContent>
-        );
-    }
 
     return (
         <Routes>

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
@@ -53,10 +53,10 @@ export const ProjectSettings = () => {
             id: 'api-access',
             label: 'API access',
         },
-        ...paidTabs({
+        {
             id: 'segments',
             label: 'Segments',
-        }),
+        },
         {
             id: 'environments',
             label: 'Environments',


### PR DESCRIPTION
This change opens up the project segments page to OSS users. They
could navigate to it explicitly before, but would be told it was a
premium feature (which it is not (since 5.5)).

After this, it'll show up in the settings sidebar as for
pro/enterprise, and you'll get the actual segments table instead of
"this is a premium feature" message.

![image](https://github.com/user-attachments/assets/1fb0213a-4541-4f01-8f61-48725f4602e1)
