### PR TITLE
fix: prevent rendering too many hooks error

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -94,11 +94,14 @@ const TabText = styled('span')(({ theme }) => ({
 }));
 
 const ChangeRequestsLabel = () => {
+    const simplifyProjectOverview = useUiFlag('simplifyProjectOverview');
     const projectId = useRequiredPathParam('projectId');
     const { total } = useActionableChangeRequests(projectId);
 
+    const count = simplifyProjectOverview ? 0 : (total ?? 0);
+
     return (
-        <StyledCounterBadge badgeContent={total ?? 0} color='primary'>
+        <StyledCounterBadge badgeContent={count} color='primary'>
             <TabText>Change requests</TabText>
         </StyledCounterBadge>
     );
@@ -167,7 +170,7 @@ export const Project = () => {
             path: `${basePath}/change-requests`,
             name: 'change-request',
             isEnterprise: true,
-            label: simplifyProjectOverview ? ChangeRequestsLabel : undefined,
+            label: ChangeRequestsLabel,
         },
         {
             title: 'Applications',


### PR DESCRIPTION
We found an issue where we'd get a minified react error referencing the LazyProjectExport component.

We suspect that the issue might be the conditional rendering of this component, so the fix is to always render it, but to use the flag to check whether we should show the count or not.