### PR TITLE
fix: active flags double stale flags

### DIFF
--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -192,7 +192,7 @@ export class ProjectReadModel implements IProjectReadModel {
                 'projects.id, projects.health, ' +
                     'count(features.name) FILTER (WHERE features.archived_at is null) AS number_of_features, ' +
                     'count(features.name) FILTER (WHERE features.archived_at is null and features.stale IS TRUE) AS stale_feature_count, ' +
-                    'count(features.name) FILTER (WHERE features.archived_at is null and features.potentially_stale IS TRUE) AS potentially_stale_feature_count',
+                    'count(features.name) FILTER (WHERE features.archived_at is null and features.potentially_stale IS TRUE and features.stale IS FALSE) AS potentially_stale_feature_count',
             ),
             'project_stats.avg_time_to_prod_current_window',
             'projects.archived_at',


### PR DESCRIPTION
Do not count stale flags as potentially stale flags to remove duplicates.
Stale flags feel like more superior state and it should not show up under potentially stale.