### PR TITLE
feat: deleting release-plan templates

### DIFF
--- a/frontend/src/component/releases/ReleaseManagement/TemplateDeleteDialog.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/TemplateDeleteDialog.tsx
@@ -1,0 +1,34 @@
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
+
+interface ITemplateDeleteDialogProps {
+    template?: IReleasePlanTemplate;
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    onConfirm: (template: IReleasePlanTemplate) => void;
+}
+
+export const TemplateDeleteDialog: React.FC<ITemplateDeleteDialogProps> = ({
+    template,
+    open,
+    setOpen,
+    onConfirm,
+}) => {
+    return (
+        <Dialogue
+            title='Delete release plan template?'
+            open={open}
+            primaryButtonText='Delete template'
+            secondaryButtonText='Cancel'
+            onClick={() => onConfirm(template!)}
+            onClose={() => {
+                setOpen(false);
+            }}
+        >
+            <p>
+                You are about to delete release plan template:{' '}
+                <strong>{template?.name}</strong>
+            </p>
+        </Dialogue>
+    );
+};

--- a/frontend/src/hooks/api/actions/useReleasePlanTemplatesApi/useReleasePlanTemplatesApi.ts
+++ b/frontend/src/hooks/api/actions/useReleasePlanTemplatesApi/useReleasePlanTemplatesApi.ts
@@ -1,0 +1,23 @@
+import useAPI from '../useApi/useApi';
+
+export const useReleasePlanTemplatesApi = () => {
+    const { makeRequest, makeLightRequest, createRequest, errors, loading } =
+        useAPI({
+            propagateErrors: true,
+        });
+
+    const deleteReleasePlanTemplate = async (id: string) => {
+        const path = `api/admin/release-plan-templates/${id}`;
+        const req = createRequest(path, {
+            method: 'DELETE',
+        });
+
+        return makeRequest(req.caller, req.id);
+    };
+
+    return {
+        deleteReleasePlanTemplate,
+    };
+};
+
+export default useReleasePlanTemplatesApi;


### PR DESCRIPTION
Deleting release plan templates (with confirmation dialog)
We should probably look at permission model for this, I'll make a note of that

![image](https://github.com/user-attachments/assets/de2e1439-16b7-49bd-a1cf-abf5f78dff27)
