### PR TITLE
1-3059: add initial visuals for lifecycle summary

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon.tsx
@@ -10,16 +10,16 @@ export const FeatureLifecycleStageIcon: FC<{ stage: LifecycleStage }> = ({
     stage,
 }) => {
     if (stage.name === 'archived') {
-        return <ArchivedStageIcon />;
+        return <ArchivedStageIcon aria-hidden='true' />;
     } else if (stage.name === 'pre-live') {
-        return <PreLiveStageIcon />;
+        return <PreLiveStageIcon aria-hidden='true' />;
     } else if (stage.name === 'live') {
-        return <LiveStageIcon />;
+        return <LiveStageIcon aria-hidden='true' />;
     } else if (stage.name === 'completed' && stage.status === 'kept') {
-        return <CompletedStageIcon />;
+        return <CompletedStageIcon aria-hidden='true' />;
     } else if (stage.name === 'completed' && stage.status === 'discarded') {
-        return <CompletedStageIcon />;
+        return <CompletedStageIcon aria-hidden='true' />;
     } else {
-        return <InitialStageIcon />;
+        return <InitialStageIcon aria-hidden='true' />;
     }
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon.tsx
@@ -10,16 +10,16 @@ export const FeatureLifecycleStageIcon: FC<{ stage: LifecycleStage }> = ({
     stage,
 }) => {
     if (stage.name === 'archived') {
-        return <ArchivedStageIcon aria-hidden='true' />;
+        return <ArchivedStageIcon />;
     } else if (stage.name === 'pre-live') {
-        return <PreLiveStageIcon aria-hidden='true' />;
+        return <PreLiveStageIcon />;
     } else if (stage.name === 'live') {
-        return <LiveStageIcon aria-hidden='true' />;
+        return <LiveStageIcon />;
     } else if (stage.name === 'completed' && stage.status === 'kept') {
-        return <CompletedStageIcon aria-hidden='true' />;
+        return <CompletedStageIcon />;
     } else if (stage.name === 'completed' && stage.status === 'discarded') {
-        return <CompletedStageIcon aria-hidden='true' />;
+        return <CompletedStageIcon />;
     } else {
-        return <InitialStageIcon aria-hidden='true' />;
+        return <InitialStageIcon />;
     }
 };

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -1,54 +1,65 @@
-import { Typography, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { FeatureLifecycleStageIcon } from 'component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon';
 
 const LifecycleBox = styled('article')(({ theme }) => ({
-    padding: theme.spacing(3),
+    padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
     aspectRatio: '1/1',
-    display: 'grid',
-
-    gridTemplateAreas: `
-        "count icon"
-        "description description"
-        "stats stats"
-    `,
-
-    gridTemplateColumns: '1fr auto',
-}));
-
-const GridCell = styled('span', {
-    shouldForwardProp: (prop) => prop !== 'gridArea',
-})<{ gridArea: string }>(({ gridArea }) => ({
-    gridArea,
+    display: 'flex',
+    flexFlow: 'column',
+    justifyContent: 'space-between',
 }));
 
 const Wrapper = styled('article')(({ theme }) => ({
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+
+    gridTemplateColumns: 'repeat(auto-fit, 200px)',
     gap: theme.spacing(2),
+    justifyContent: 'center',
+}));
+
+const Counter = styled('span')({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+});
+
+const BigNumber = styled('span')(({ theme }) => ({
+    fontSize: `calc(2 * ${theme.typography.body1.fontSize})`,
+}));
+
+const Stats = styled('dl')(({ theme }) => ({
+    margin: 0,
+    fontSize: theme.typography.body2.fontSize,
+    '& dd': {
+        margin: 0,
+        fontWeight: 'bold',
+    },
 }));
 
 export const ProjectLifecycleSummary = () => {
     return (
         <Wrapper>
             <LifecycleBox>
-                <GridCell gridArea='count'>
-                    <Typography variant='h1' component='span'>
-                        15
-                    </Typography>
-                </GridCell>
-                <GridCell gridArea='icon'>
-                    <FeatureLifecycleStageIcon
-                        stage={{
-                            name: 'live',
-                            enteredStageAt: '',
-                            environments: [],
-                        }}
-                    />
-                </GridCell>
-                <GridCell gridArea='description'>flags in live</GridCell>
-                <GridCell gridArea='stats'>Avg. time in stage 10 days</GridCell>
+                <p>
+                    <Counter>
+                        <BigNumber>15</BigNumber>
+
+                        <FeatureLifecycleStageIcon
+                            stage={{
+                                name: 'live',
+                                enteredStageAt: '',
+                                environments: [],
+                            }}
+                        />
+                    </Counter>
+                    <span>flags in live</span>
+                </p>
+                <Stats>
+                    <dt>Avg. time in stage</dt>
+                    <dd>10 days</dd>
+                </Stats>
             </LifecycleBox>
             <LifecycleBox />
             <LifecycleBox />

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -1,0 +1,27 @@
+import { styled } from '@mui/material';
+
+const LifecycleBox = styled('article')(({ theme }) => ({
+    padding: theme.spacing(3),
+    borderRadius: theme.shape.borderRadiusExtraLarge,
+    border: `2px solid ${theme.palette.divider}`,
+    minWidth: '200px',
+    aspectRatio: '1/1',
+}));
+
+const Wrapper = styled('article')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+    gap: theme.spacing(2),
+}));
+
+export const ProjectLifecycleSummary = () => {
+    return (
+        <Wrapper>
+            <LifecycleBox />
+            <LifecycleBox />
+            <LifecycleBox />
+            <LifecycleBox />
+            <LifecycleBox />
+        </Wrapper>
+    );
+};

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -1,11 +1,14 @@
 import { styled } from '@mui/material';
 import { FeatureLifecycleStageIcon } from 'component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { Link } from 'react-router-dom';
 
 const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
-    aspectRatio: '1/1',
+    width: '170px',
+    height: '152px',
     display: 'flex',
     flexFlow: 'column',
     justifyContent: 'space-between',
@@ -14,8 +17,8 @@ const LifecycleBox = styled('li')(({ theme }) => ({
 const Wrapper = styled('ul')(({ theme }) => ({
     display: 'grid',
     listStyle: 'none',
-    gridTemplateColumns: 'repeat(auto-fit, 200px)',
-    gap: theme.spacing(2),
+    gridTemplateColumns: 'repeat(auto-fit, 170px)',
+    gap: theme.spacing(1),
     justifyContent: 'center',
 }));
 
@@ -38,7 +41,20 @@ const Stats = styled('dl')(({ theme }) => ({
     },
 }));
 
+const NegativeStat = styled('span')(({ theme }) => ({
+    color: theme.palette.warning.contrastText,
+}));
+
+const NoData = styled('span')({
+    fontWeight: 'normal',
+});
+
+const LinkNoUnderline = styled(Link)({
+    textDecoration: 'none',
+});
+
 export const ProjectLifecycleSummary = () => {
+    const projectId = useRequiredPathParam('projectId');
     return (
         <Wrapper>
             <LifecycleBox>
@@ -57,7 +73,9 @@ export const ProjectLifecycleSummary = () => {
                 </p>
                 <Stats>
                     <dt>Avg. time in stage</dt>
-                    <dd>21 days</dd>
+                    <dd>
+                        <NegativeStat>21 days</NegativeStat>
+                    </dd>
                 </Stats>
             </LifecycleBox>
             <LifecycleBox>
@@ -114,11 +132,20 @@ export const ProjectLifecycleSummary = () => {
                             }}
                         />
                     </Counter>
-                    <span>flags in cleanup</span>
+                    <span>
+                        <LinkNoUnderline
+                            to={`/projects/${projectId}/placeholder`}
+                        >
+                            flags
+                        </LinkNoUnderline>{' '}
+                        in cleanup
+                    </span>
                 </p>
                 <Stats>
                     <dt>Avg. time in stage</dt>
-                    <dd>No data</dd>
+                    <dd>
+                        <NoData>No data</NoData>
+                    </dd>
                 </Stats>
             </LifecycleBox>
             <LifecycleBox>

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -1,10 +1,26 @@
-import { styled } from '@mui/material';
+import { Typography, styled } from '@mui/material';
+import { FeatureLifecycleStageIcon } from 'component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon';
 
 const LifecycleBox = styled('article')(({ theme }) => ({
     padding: theme.spacing(3),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
     aspectRatio: '1/1',
+    display: 'grid',
+
+    gridTemplateAreas: `
+        "count icon"
+        "description description"
+        "stats stats"
+    `,
+
+    gridTemplateColumns: '1fr auto',
+}));
+
+const GridCell = styled('span', {
+    shouldForwardProp: (prop) => prop !== 'gridArea',
+})<{ gridArea: string }>(({ gridArea }) => ({
+    gridArea,
 }));
 
 const Wrapper = styled('article')(({ theme }) => ({
@@ -16,7 +32,24 @@ const Wrapper = styled('article')(({ theme }) => ({
 export const ProjectLifecycleSummary = () => {
     return (
         <Wrapper>
-            <LifecycleBox />
+            <LifecycleBox>
+                <GridCell gridArea='count'>
+                    <Typography variant='h1' component='span'>
+                        15
+                    </Typography>
+                </GridCell>
+                <GridCell gridArea='icon'>
+                    <FeatureLifecycleStageIcon
+                        stage={{
+                            name: 'live',
+                            enteredStageAt: '',
+                            environments: [],
+                        }}
+                    />
+                </GridCell>
+                <GridCell gridArea='description'>flags in live</GridCell>
+                <GridCell gridArea='stats'>Avg. time in stage 10 days</GridCell>
+            </LifecycleBox>
             <LifecycleBox />
             <LifecycleBox />
             <LifecycleBox />

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -63,6 +63,7 @@ export const ProjectLifecycleSummary = () => {
                         <BigNumber>15</BigNumber>
 
                         <FeatureLifecycleStageIcon
+                            aria-hidden='true'
                             stage={{
                                 name: 'initial',
                                 enteredStageAt: '',
@@ -84,6 +85,7 @@ export const ProjectLifecycleSummary = () => {
                         <BigNumber>3</BigNumber>
 
                         <FeatureLifecycleStageIcon
+                            aria-hidden='true'
                             stage={{
                                 name: 'pre-live',
                                 enteredStageAt: '',
@@ -104,6 +106,7 @@ export const ProjectLifecycleSummary = () => {
                         <BigNumber>2</BigNumber>
 
                         <FeatureLifecycleStageIcon
+                            aria-hidden='true'
                             stage={{
                                 name: 'live',
                                 enteredStageAt: '',
@@ -124,6 +127,7 @@ export const ProjectLifecycleSummary = () => {
                         <BigNumber>6</BigNumber>
 
                         <FeatureLifecycleStageIcon
+                            aria-hidden='true'
                             stage={{
                                 name: 'completed',
                                 enteredStageAt: '',
@@ -154,6 +158,7 @@ export const ProjectLifecycleSummary = () => {
                         <BigNumber>15</BigNumber>
 
                         <FeatureLifecycleStageIcon
+                            aria-hidden='true'
                             stage={{
                                 name: 'archived',
                                 enteredStageAt: '',

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -4,13 +4,12 @@ const LifecycleBox = styled('article')(({ theme }) => ({
     padding: theme.spacing(3),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
-    minWidth: '200px',
     aspectRatio: '1/1',
 }));
 
 const Wrapper = styled('article')(({ theme }) => ({
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
     gap: theme.spacing(2),
 }));
 

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material';
 import { FeatureLifecycleStageIcon } from 'component/feature/FeatureView/FeatureOverview/FeatureLifecycle/FeatureLifecycleStageIcon';
 
-const LifecycleBox = styled('article')(({ theme }) => ({
+const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
@@ -11,9 +11,9 @@ const LifecycleBox = styled('article')(({ theme }) => ({
     justifyContent: 'space-between',
 }));
 
-const Wrapper = styled('article')(({ theme }) => ({
+const Wrapper = styled('ul')(({ theme }) => ({
     display: 'grid',
-
+    listStyle: 'none',
     gridTemplateColumns: 'repeat(auto-fit, 200px)',
     gap: theme.spacing(2),
     justifyContent: 'center',
@@ -48,6 +48,45 @@ export const ProjectLifecycleSummary = () => {
 
                         <FeatureLifecycleStageIcon
                             stage={{
+                                name: 'initial',
+                                enteredStageAt: '',
+                            }}
+                        />
+                    </Counter>
+                    <span>flags in initial</span>
+                </p>
+                <Stats>
+                    <dt>Avg. time in stage</dt>
+                    <dd>21 days</dd>
+                </Stats>
+            </LifecycleBox>
+            <LifecycleBox>
+                <p>
+                    <Counter>
+                        <BigNumber>3</BigNumber>
+
+                        <FeatureLifecycleStageIcon
+                            stage={{
+                                name: 'pre-live',
+                                enteredStageAt: '',
+                                environments: [],
+                            }}
+                        />
+                    </Counter>
+                    <span>flags in pre-live</span>
+                </p>
+                <Stats>
+                    <dt>Avg. time in stage</dt>
+                    <dd>18 days</dd>
+                </Stats>
+            </LifecycleBox>
+            <LifecycleBox>
+                <p>
+                    <Counter>
+                        <BigNumber>2</BigNumber>
+
+                        <FeatureLifecycleStageIcon
+                            stage={{
                                 name: 'live',
                                 enteredStageAt: '',
                                 environments: [],
@@ -61,10 +100,46 @@ export const ProjectLifecycleSummary = () => {
                     <dd>10 days</dd>
                 </Stats>
             </LifecycleBox>
-            <LifecycleBox />
-            <LifecycleBox />
-            <LifecycleBox />
-            <LifecycleBox />
+            <LifecycleBox>
+                <p>
+                    <Counter>
+                        <BigNumber>6</BigNumber>
+
+                        <FeatureLifecycleStageIcon
+                            stage={{
+                                name: 'completed',
+                                enteredStageAt: '',
+                                environments: [],
+                                status: 'kept',
+                            }}
+                        />
+                    </Counter>
+                    <span>flags in cleanup</span>
+                </p>
+                <Stats>
+                    <dt>Avg. time in stage</dt>
+                    <dd>No data</dd>
+                </Stats>
+            </LifecycleBox>
+            <LifecycleBox>
+                <p>
+                    <Counter>
+                        <BigNumber>15</BigNumber>
+
+                        <FeatureLifecycleStageIcon
+                            stage={{
+                                name: 'archived',
+                                enteredStageAt: '',
+                            }}
+                        />
+                    </Counter>
+                    <span>flags in archived</span>
+                </p>
+                <Stats>
+                    <dt>This month</dt>
+                    <dd>3 flags archived</dd>
+                </Stats>
+            </LifecycleBox>
         </Wrapper>
     );
 };

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -7,8 +7,8 @@ const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
-    width: '170px',
-    height: '152px',
+    width: '180px',
+    height: '175px',
     display: 'flex',
     flexFlow: 'column',
     justifyContent: 'space-between',
@@ -17,7 +17,7 @@ const LifecycleBox = styled('li')(({ theme }) => ({
 const Wrapper = styled('ul')(({ theme }) => ({
     display: 'grid',
     listStyle: 'none',
-    gridTemplateColumns: 'repeat(auto-fit, 170px)',
+    gridTemplateColumns: 'repeat(auto-fit, 180px)',
     gap: theme.spacing(1),
     justifyContent: 'center',
 }));

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -2,6 +2,7 @@ import { styled } from '@mui/material';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { ProjectResources } from './ProjectResources';
 import { ProjectActivity } from './ProjectActivity';
+import { ProjectLifecycleSummary } from './ProjectLifecycleSummary';
 
 const ModalContentContainer = styled('div')(({ theme }) => ({
     minHeight: '100vh',
@@ -40,6 +41,8 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
                 </HealthRow>
 
                 <ProjectActivity />
+
+                <ProjectLifecycleSummary />
             </ModalContentContainer>
         </SidebarModal>
     );


### PR DESCRIPTION
Add rough implementation of the lifecycle summary components.

This PR adds components for all the different lifecycle stages. We don't have any data yet, so they're all hardcoded for now, just to get the visuals right. I'm expecting the lines of code to drop and to refactor/extract some structures as development continues.

For now, this is what they look like:

![image](https://github.com/user-attachments/assets/d7deacaa-83e1-46c2-bc28-8264416c1dd9)

Things to note:
- The lifecycle stage icon colors don't match up with the sketches, but they match up with what we currently have in the app. If we change them, we should change them together.
- This implementation does not contain the "Flag lifecycle" header or the "view graphs" link.