### PR TITLE
fix: console warnings and errors related to event timeline and strategy form

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeader.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineHeader/EventTimelineHeader.tsx
@@ -96,7 +96,7 @@ export const EventTimelineHeader = ({
             <EventTimelineHeaderTip />
             <StyledCol>
                 <ConditionallyRender
-                    condition={Boolean(environment)}
+                    condition={Boolean(environment) && environments.length > 0}
                     show={() => (
                         <StyledFilter
                             select

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -171,11 +171,11 @@ const EnvironmentIconBox = styled(Box)(({ theme }) => ({
     alignItems: 'center',
 }));
 
-const EnvironmentTypography = styled(Typography)<{ enabled: boolean }>(
-    ({ theme, enabled }) => ({
-        fontWeight: enabled ? 'bold' : 'normal',
-    }),
-);
+const EnvironmentTypography = styled(Typography, {
+    shouldForwardProp: (prop) => prop !== 'enabled',
+})<{ enabled: boolean }>(({ enabled }) => ({
+    fontWeight: enabled ? 'bold' : 'normal',
+}));
 
 const EnvironmentTypographyHeader = styled(Typography)(({ theme }) => ({
     marginRight: theme.spacing(0.5),


### PR DESCRIPTION
Fixes browser console warnings and errors related to the event timeline and strategy form.

- **Event Timeline**: Addressed a warning where the environment filter rendered with a default environment value (production) before environments were fully loaded.
- **Strategy Form**: Resolved an error caused by forwarding the enabled prop as a boolean.