### PR TITLE
task: explicitly allows Artistic-2.0 license

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,5 +17,5 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC0-1.0, Unlicense, BlueOak-1.0.0, CC-BY-4.0
+          allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC0-1.0, Unlicense, BlueOak-1.0.0, CC-BY-4.0, Artistic-2.0
           comment-summary-in-pr: always

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -522,7 +522,7 @@ const sidebars: SidebarsConfig = {
                         description: 'Provisioning how-to guides.',
                         slug: '/how-to/provisioning',
                     },
-                }, 
+                },
                 {
                     type: 'category',
                     label: 'Unleash Edge',
@@ -629,9 +629,7 @@ const sidebars: SidebarsConfig = {
                                 description: 'Environments how-to guides.',
                                 slug: '/how-to/env',
                             },
-                            items: [
-                                'how-to/how-to-environment-import-export',
-                            ],
+                            items: ['how-to/how-to-environment-import-export'],
                         },
                         {
                             label: 'Users and permissions',
@@ -650,9 +648,9 @@ const sidebars: SidebarsConfig = {
                                     'Users and permission how-to guides.',
                                 slug: '/how-to/users-and-permissions',
                             },
-                        }
+                        },
                     ],
-                },    
+                },
             ],
         },
         {


### PR DESCRIPTION
Due to our use of docusaurus and the openapi plugin we need to allow Artistic-2.0, Having read the license, it allows for free use of the licensed code, provided the license is included when distributing, but does not require a relicensing of products using the licensed code.