### PR TITLE
feat: archived toggles do not show switch

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
@@ -96,4 +96,6 @@ export const PlaceholderFeatureToggleCell = () => (
         <div data-loading>toggle</div>
     </StyledSwitchContainer>
 );
-export const ArchivedFeatureToggleCell = () => <StyledDiv>-</StyledDiv>;
+export const ArchivedFeatureToggleCell = () => (
+    <StyledDiv aria-hidden='true'>-</StyledDiv>
+);

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
@@ -22,6 +22,12 @@ const StyledSwitchContainer = styled('div', {
     }),
 }));
 
+const StyledDiv = styled('div')(({ theme }) => ({
+    flexGrow: 0,
+    ...flexRow,
+    justifyContent: 'center',
+}));
+
 interface IFeatureToggleCellProps {
     projectId: string;
     environmentName: string;
@@ -90,3 +96,4 @@ export const PlaceholderFeatureToggleCell = () => (
         <div data-loading>toggle</div>
     </StyledSwitchContainer>
 );
+export const ArchivedFeatureToggleCell = () => <StyledDiv>-</StyledDiv>;

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -26,6 +26,7 @@ import { createColumnHelper, useReactTable } from '@tanstack/react-table';
 import { withTableState } from 'utils/withTableState';
 import type { FeatureSearchResponseSchema } from 'openapi';
 import {
+    ArchivedFeatureToggleCell,
     FeatureToggleCell,
     PlaceholderFeatureToggleCell,
 } from './FeatureToggleCell/FeatureToggleCell';
@@ -292,6 +293,7 @@ export const ProjectFeatureToggles = ({
 
                 return columnHelper.accessor(
                     (row) => ({
+                        archived: row.archivedAt !== null,
                         featureId: row.name,
                         environment: row.environments?.find(
                             (featureEnvironment) =>
@@ -317,10 +319,15 @@ export const ProjectFeatureToggles = ({
                                 featureId,
                                 environment,
                                 someEnabledEnvironmentHasVariants,
+                                archived,
                             } = getValue();
+
+                            console.log(getValue());
 
                             return isPlaceholder ? (
                                 <PlaceholderFeatureToggleCell />
+                            ) : archived ? (
+                                <ArchivedFeatureToggleCell />
                             ) : (
                                 <FeatureToggleCell
                                     value={environment?.enabled || false}

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -322,8 +322,6 @@ export const ProjectFeatureToggles = ({
                                 archived,
                             } = getValue();
 
-                            console.log(getValue());
-
                             return isPlaceholder ? (
                                 <PlaceholderFeatureToggleCell />
                             ) : archived ? (


### PR DESCRIPTION
Archived toggles will not show switch anymore, but a dash.

![Screenshot from 2024-11-08 11-41-17](https://github.com/user-attachments/assets/d43de8ff-13c3-4f70-8f8f-b7e5bbc4d0bc)
