### PR TITLE
tests: add more tests for the lifecycle avg calculation query

### DIFF
--- a/src/lib/features/project-status/project-lifecycle-summary-read-model.ts
+++ b/src/lib/features/project-status/project-lifecycle-summary-read-model.ts
@@ -38,10 +38,10 @@ export class ProjectLifecycleSummaryReadModel
     }
 
     async getAverageTimeInEachStage(projectId: string): Promise<{
-        initial: number;
-        'pre-live': number;
-        live: number;
-        completed: number;
+        initial: number | null;
+        'pre-live': number | null;
+        live: number | null;
+        completed: number | null;
     }> {
         const q = this.db
             .with(
@@ -80,10 +80,10 @@ export class ProjectLifecycleSummaryReadModel
                 return acc;
             },
             {
-                initial: 0,
-                'pre-live': 0,
-                live: 0,
-                completed: 0,
+                initial: null,
+                'pre-live': null,
+                live: null,
+                completed: null,
             },
         );
     }

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -294,7 +294,7 @@ const config: Config = {
                     routeBasePath: '/',
                     remarkPlugins: [[pluginNpm2Yarn, { sync: true }]],
                     docItemComponent: '@theme/ApiItem',
-                    sidebarPath: './sidebars.ts'
+                    sidebarPath: './sidebars.ts',
                 },
                 theme: {
                     customCss: './src/css/custom.css',


### PR DESCRIPTION
This PR adds more tests to check a few more cases for the lifecycle calculation query. Specifically, it tests that:
- If we don't have any data for a stage, we return `null`.
- We filter on projects
- It correctly takes `0` days into account when calculating averages.