### PR TITLE
feat: remove archive tooltip conditionally

### DIFF
--- a/frontend/src/component/filter/AddFilterButton.tsx
+++ b/frontend/src/component/filter/AddFilterButton.tsx
@@ -13,7 +13,7 @@ import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
 import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
-import { useAuthUser } from '../../hooks/api/getters/useAuth/useAuthUser';
+import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 
 const StyledButton = styled(Button)(({ theme }) => ({
     padding: theme.spacing(0, 1.25, 0, 1.25),

--- a/frontend/src/component/filter/AddFilterButton.tsx
+++ b/frontend/src/component/filter/AddFilterButton.tsx
@@ -13,6 +13,7 @@ import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
 import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
+import { useAuthUser } from '../../hooks/api/getters/useAuth/useAuthUser';
 
 const StyledButton = styled(Button)(({ theme }) => ({
     padding: theme.spacing(0, 1.25, 0, 1.25),
@@ -49,6 +50,7 @@ export const AddFilterButton = ({
 }: IAddFilterButtonProps) => {
     const projectId = useOptionalPathParam('projectId');
     const simplifyProjectOverview = useUiFlag('simplifyProjectOverview');
+    const { user } = useAuthUser();
     const { setSplashSeen } = useSplashApi();
     const { splash } = useAuthSplash();
 
@@ -72,6 +74,15 @@ export const AddFilterButton = ({
         setVisibleOptions(newVisibleOptions);
         handleClose();
     };
+
+    const isOldCustomer = (createdAt: string | undefined) => {
+        if (!createdAt) return false;
+        const cutoffDate = new Date('2024-11-08T00:00:00.000Z');
+        return new Date(createdAt) < cutoffDate;
+    };
+
+    const showArchiveTooltip =
+        simplifyProjectOverview && projectId && isOldCustomer(user?.createdAt);
 
     const ArchiveTooltip = () => {
         return (
@@ -97,7 +108,7 @@ export const AddFilterButton = ({
     };
     return (
         <div>
-            {simplifyProjectOverview && projectId ? (
+            {showArchiveTooltip ? (
                 <HtmlTooltip
                     placement='right'
                     arrow

--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -45,6 +45,7 @@ export default class MaintenanceService implements IMaintenanceStatus {
     }
 
     async getMaintenanceSetting(): Promise<MaintenanceSchema> {
+        this.logger.debug('getMaintenanceSetting called');
         return this.settingService.getWithDefault(maintenanceSettingsKey, {
             enabled: false,
         });

--- a/src/lib/features/maintenance/maintenance-service.ts
+++ b/src/lib/features/maintenance/maintenance-service.ts
@@ -45,7 +45,6 @@ export default class MaintenanceService implements IMaintenanceStatus {
     }
 
     async getMaintenanceSetting(): Promise<MaintenanceSchema> {
-        this.logger.debug('getMaintenanceSetting called');
         return this.settingService.getWithDefault(maintenanceSettingsKey, {
             enabled: false,
         });


### PR DESCRIPTION
The archived functionality has been moved into the feature list, and we are showing a tooltip. However, it doesn’t make sense to display it to new customers, as they wouldn’t be familiar with the previous behavior.

I've introduced a "new/old user" classification, where I’m setting 08.11.2024 as the dividing line. All customers created after 08.11.2024 will be considered new, and we won’t display the tooltip for them. Everyone else will be treated as old customers.

This approach means there will be a brief period from 08.11.2024 until the release date where any customers created during this time will be categorized as new, even if they still have access to the old archive. For simplicity, I’m willing to accept this risk, as it's likely that in 95% of cases, for those few customers (0–10), they won’t need the archive functionality immediately, so it’s acceptable not to display the tooltip for them.

This setup is temporary in our code base and will be removed with a feature flag.