### PR TITLE
feat: define activity labels

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
@@ -99,6 +99,9 @@ export const ProjectActivity = () => {
                         data={fullData}
                         maxLevel={4}
                         showWeekdayLabels={true}
+                        labels={{
+                            totalCount: '{{count}} activities in the last year',
+                        }}
                         renderBlock={(block, activity) => (
                             <Tooltip
                                 title={`${activity.count} activities on ${activity.date}`}


### PR DESCRIPTION
Now the label for total activities is more correct.

![image](https://github.com/user-attachments/assets/1748cf25-9605-4701-b4ab-6a16e9b760eb)
