### PR TITLE
1-3093: round the project health

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -32,7 +32,6 @@ export const ProjectHealth = () => {
     const {
         data: { averageHealth },
     } = useProjectStatus(projectId);
-    const averageHealthRounded = Math.round(averageHealth);
     const { isOss } = useUiConfig();
     const theme = useTheme();
     const radius = 40;
@@ -42,7 +41,7 @@ export const ProjectHealth = () => {
     const gapLength = 0.3;
     const filledLength = 1 - gapLength;
     const offset = 0.75 - gapLength / 2;
-    const healthLength = (averageHealthRounded / 100) * circumference * 0.7;
+    const healthLength = (averageHealth / 100) * circumference * 0.7;
 
     return (
         <HealthContainer>
@@ -76,12 +75,12 @@ export const ProjectHealth = () => {
                         fill={theme.palette.text.primary}
                         fontSize='24px'
                     >
-                        {averageHealthRounded}%
+                        {averageHealth}%
                     </text>
                 </StyledSVG>
                 <Typography variant='body2'>
                     On average, your project health has remained at{' '}
-                    {averageHealthRounded}% the last 4 weeks
+                    {averageHealth}% the last 4 weeks
                 </Typography>
             </ChartRow>
             <DescriptionText variant='body2'>

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -32,6 +32,7 @@ export const ProjectHealth = () => {
     const {
         data: { averageHealth },
     } = useProjectStatus(projectId);
+    const averageHealthRounded = Math.round(averageHealth);
     const { isOss } = useUiConfig();
     const theme = useTheme();
     const radius = 40;
@@ -41,7 +42,7 @@ export const ProjectHealth = () => {
     const gapLength = 0.3;
     const filledLength = 1 - gapLength;
     const offset = 0.75 - gapLength / 2;
-    const healthLength = (averageHealth / 100) * circumference * 0.7;
+    const healthLength = (averageHealthRounded / 100) * circumference * 0.7;
 
     return (
         <HealthContainer>
@@ -75,12 +76,12 @@ export const ProjectHealth = () => {
                         fill={theme.palette.text.primary}
                         fontSize='24px'
                     >
-                        {averageHealth}%
+                        {averageHealthRounded}%
                     </text>
                 </StyledSVG>
                 <Typography variant='body2'>
                     On average, your project health has remained at{' '}
-                    {averageHealth}% the last 4 weeks
+                    {averageHealthRounded}% the last 4 weeks
                 </Typography>
             </ChartRow>
             <DescriptionText variant='body2'>

--- a/src/lib/features/project-status/project-status-service.ts
+++ b/src/lib/features/project-status/project-status-service.ts
@@ -72,7 +72,7 @@ export class ProjectStatusService {
                 segments,
             },
             activityCountByDate,
-            averageHealth,
+            averageHealth: Math.round(averageHealth),
             lifecycleSummary,
         };
     }

--- a/src/lib/features/project-status/projects-status.e2e.test.ts
+++ b/src/lib/features/project-status/projects-status.e2e.test.ts
@@ -259,16 +259,16 @@ test('project health should be correct average', async () => {
 });
 
 test('project health stats should round to nearest integer', async () => {
-    await insertHealthScore('2024-04', 7);
+    await insertHealthScore('2024-04', 6);
 
-    await insertHealthScore('2024-05', 4);
+    await insertHealthScore('2024-05', 5);
 
     const { body } = await app.request
         .get('/api/admin/projects/default/status')
         .expect('Content-Type', /json/)
         .expect(200);
 
-    expect(body.averageHealth).toBe(5);
+    expect(body.averageHealth).toBe(6);
 });
 
 test('project status contains lifecycle data', async () => {

--- a/src/lib/features/project-status/projects-status.e2e.test.ts
+++ b/src/lib/features/project-status/projects-status.e2e.test.ts
@@ -69,6 +69,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
     await db.stores.clientMetricsStoreV2.deleteAll();
+    await db.rawDatabase('flag_trends').delete();
 });
 
 test('project insights should return correct count for each day', async () => {
@@ -255,6 +256,19 @@ test('project health should be correct average', async () => {
         .expect(200);
 
     expect(body.averageHealth).toBe(40);
+});
+
+test('project health stats should round to nearest integer', async () => {
+    await insertHealthScore('2024-04', 7);
+
+    await insertHealthScore('2024-05', 4);
+
+    const { body } = await app.request
+        .get('/api/admin/projects/default/status')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+    expect(body.averageHealth).toBe(5);
 });
 
 test('project status contains lifecycle data', async () => {


### PR DESCRIPTION
This PR rounds the average health score we show for a project. With fractional numbers, it'd often overflow the graph. It also doesn't really give you much extra info, so we can round it. The rounding is then used both in the text, in the graph, and to calculate the graph fill percentage.

Before:
![image](https://github.com/user-attachments/assets/8d0fea3d-411d-42fb-bd80-d2683a63cdf2)

After:
![image](https://github.com/user-attachments/assets/f5c51742-8a2c-4b1a-bca3-7e812b9a1072)

