### PR TITLE
feat: email will be stored hashed now for all users

### DIFF
--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -108,7 +108,9 @@ class UserStore implements IUserStore {
     }
 
     async insert(user: ICreateUser): Promise<User> {
-        const emailHash = this.db.raw('md5(?)', [user.email]);
+        const emailHash = user.email
+            ? this.db.raw('md5(?)', [user.email])
+            : null;
         const rows = await this.db(TABLE)
             .insert({
                 ...mapUserToColumns(user),

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -108,8 +108,13 @@ class UserStore implements IUserStore {
     }
 
     async insert(user: ICreateUser): Promise<User> {
+        const emailHash = this.db.raw('md5(?)', [user.email]);
         const rows = await this.db(TABLE)
-            .insert({ ...mapUserToColumns(user), created_at: new Date() })
+            .insert({
+                ...mapUserToColumns(user),
+                email_hash: emailHash,
+                created_at: new Date(),
+            })
             .returning(USER_COLUMNS);
         return rowToUser(rows[0]);
     }

--- a/src/migrations/20241112113555-user-email-hash.js
+++ b/src/migrations/20241112113555-user-email-hash.js
@@ -1,7 +1,10 @@
 exports.up = (db, cb) => {
   db.runSql(`
       ALTER TABLE users
-          ADD COLUMN IF NOT EXISTS email_hash CHAR(128);
+          ADD COLUMN IF NOT EXISTS email_hash VARCHAR(32);
+
+      UPDATE users
+      SET email_hash = md5(email::text);
   `, cb);
 
 };

--- a/src/migrations/20241112113555-user-email-hash.js
+++ b/src/migrations/20241112113555-user-email-hash.js
@@ -1,0 +1,15 @@
+exports.up = (db, cb) => {
+  db.runSql(`
+      ALTER TABLE users
+          ADD COLUMN IF NOT EXISTS email_hash CHAR(128);
+  `, cb);
+
+};
+
+exports.down = (db, cb) => {
+  db.runSql(`
+      ALTER TABLE users
+          DROP COLUMN IF EXISTS email_hash;
+  `, cb);
+};
+

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -18,6 +18,7 @@ import { randomId } from '../../../../lib/util/random-id';
 import { omitKeys } from '../../../../lib/util/omit-keys';
 import type { ISessionStore } from '../../../../lib/types/stores/session-store';
 import type { IUnleashStores } from '../../../../lib/types';
+import { createHash } from 'crypto';
 
 let stores: IUnleashStores;
 let db: ITestDb;
@@ -404,4 +405,26 @@ test('Anonymises name, username and email fields if anonymiseEventLog flag is se
     expect(body.users[0].email).toEqual('aeb83743e@unleash.run');
     expect(body.users[0].name).toEqual('3a8b17647@unleash.run');
     expect(body.users[0].username).toEqual(''); // Not set, so anonymise should return the empty string.
+});
+
+test('creates user with email md5 hash', async () => {
+    await app.request
+        .post('/api/admin/user-admin')
+        .send({
+            email: `hasher@getunleash.ai`,
+            name: `Some Name Hash`,
+            rootRole: editorRole.id,
+        })
+        .set('Content-Type', 'application/json');
+
+    const user = await db
+        .rawDatabase('users')
+        .where({ email: 'hasher@getunleash.ai' })
+        .first(['email_hash']);
+
+    const expectedHash = createHash('md5')
+        .update('hasher@getunleash.ai')
+        .digest('hex');
+
+    expect(user.email_hash).toBe(expectedHash);
 });


### PR DESCRIPTION
Adding email_hash column to users table.
We will update all existing users to have hashed email. 
All new users will also get the hash.

We are fine to use md5, because we just need uniqueness. We have emails in events table stored anyways, so it is not sensitive. 