### PR TITLE
1-3095: small UI tweaks sidebar boxes

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -10,7 +10,7 @@ const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
-    height: '175px',
+    gap: theme.spacing(4),
     display: 'flex',
     flexFlow: 'column',
     justifyContent: 'space-between',

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -5,6 +5,7 @@ import useLoading from 'hooks/useLoading';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import type { FC } from 'react';
 import { PrettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber';
+import type { ProjectStatusSchemaLifecycleSummary } from 'openapi';
 const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
@@ -89,6 +90,13 @@ export const ProjectLifecycleSummary = () => {
         loading,
         '[data-loading-project-lifecycle-summary=true]',
     );
+    const flagWord = (stage: keyof ProjectStatusSchemaLifecycleSummary) => {
+        if (data?.lifecycleSummary[stage].currentFlags === 1) {
+            return 'flag';
+        } else {
+            return 'flags';
+        }
+    };
     return (
         <Wrapper ref={loadingRef}>
             <LifecycleBox>
@@ -103,7 +111,7 @@ export const ProjectLifecycleSummary = () => {
                             stage={{ name: 'initial' }}
                         />
                     </Counter>
-                    <span>flags in initial</span>
+                    <span>{flagWord('initial')} in initial</span>
                 </p>
                 <AverageDaysStat
                     averageDays={data?.lifecycleSummary.initial.averageDays}
@@ -121,7 +129,7 @@ export const ProjectLifecycleSummary = () => {
                             stage={{ name: 'pre-live' }}
                         />
                     </Counter>
-                    <span>flags in pre-live</span>
+                    <span>{flagWord('preLive')} in pre-live</span>
                 </p>
                 <AverageDaysStat
                     averageDays={data?.lifecycleSummary.preLive.averageDays}
@@ -139,7 +147,7 @@ export const ProjectLifecycleSummary = () => {
                             stage={{ name: 'live' }}
                         />
                     </Counter>
-                    <span>flags in live</span>
+                    <span>{flagWord('live')} in live</span>
                 </p>
                 <AverageDaysStat
                     averageDays={data?.lifecycleSummary.live.averageDays}
@@ -159,7 +167,7 @@ export const ProjectLifecycleSummary = () => {
                             stage={{ name: 'completed' }}
                         />
                     </Counter>
-                    <span>flags in cleanup</span>
+                    <span>{flagWord('completed')} in cleanup</span>
                 </p>
                 <AverageDaysStat
                     averageDays={data?.lifecycleSummary.completed.averageDays}
@@ -177,7 +185,7 @@ export const ProjectLifecycleSummary = () => {
                             stage={{ name: 'archived' }}
                         />
                     </Counter>
-                    <span>flags in archived</span>
+                    <span>{flagWord('archived')} in archived</span>
                 </p>
                 <Stats>
                     <dt>This month</dt>

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -9,7 +9,6 @@ const LifecycleBox = styled('li')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     border: `2px solid ${theme.palette.divider}`,
-    width: '180px',
     height: '175px',
     display: 'flex',
     flexFlow: 'column',
@@ -19,7 +18,7 @@ const LifecycleBox = styled('li')(({ theme }) => ({
 const Wrapper = styled('ul')(({ theme }) => ({
     display: 'grid',
     listStyle: 'none',
-    gridTemplateColumns: 'repeat(auto-fit, 180px)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
     gap: theme.spacing(1),
     justifyContent: 'center',
 }));

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -22,6 +22,7 @@ const Wrapper = styled('ul')(({ theme }) => ({
     gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
     gap: theme.spacing(1),
     justifyContent: 'center',
+    padding: 0,
 }));
 
 const Counter = styled('span')({

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material';
-import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
+import { DynamicSidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { ProjectResources } from './ProjectResources';
 import { ProjectActivity } from './ProjectActivity';
 import { ProjectHealth } from './ProjectHealth';
@@ -34,7 +34,7 @@ const HealthRow = styled('div')(({ theme }) => ({
 
 export const ProjectStatusModal = ({ open, close }: Props) => {
     return (
-        <SidebarModal open={open} onClose={close} label='Project status'>
+        <DynamicSidebarModal open={open} onClose={close} label='Project status'>
             <ModalContentContainer>
                 <HealthRow>
                     <ProjectHealth />
@@ -45,6 +45,6 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
 
                 <ProjectLifecycleSummary />
             </ModalContentContainer>
-        </SidebarModal>
+        </DynamicSidebarModal>
     );
 };


### PR DESCRIPTION
This PR fixes three minor UI issues:
1. The modal is too wide. Turns out that `SidebarModal` has a fixed width of 1300. `DynamicSidebarModal` does not, so that switch makes it much leaner.
2. The lifecycle boxes should grow in width to fill whatever space they have available. 
3. If you have 1 flag in any of the stages, we should say "1 flag" instead of "1 flags".

Sidebar before:
![image](https://github.com/user-attachments/assets/d33d82ca-e04b-416d-b731-9a37f8df3b08)


Sidebar after:
![image](https://github.com/user-attachments/assets/060be979-484a-4481-8781-d171b4211b45)


The lifecycle boxes at their very widest:
![image](https://github.com/user-attachments/assets/817e437f-a0ee-4a85-9018-16ff84cb3819)