### PR TITLE
feat: prometheus now gets licensed users data

### DIFF
--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -359,3 +359,9 @@ test('should collect traffic_total metrics', async () => {
         await prometheusRegister.getSingleMetricAsString('traffic_total');
     expect(recordedMetric).toMatch(/traffic_total 0/);
 });
+
+test('should collect licensed_users metrics', async () => {
+    const recordedMetric =
+        await prometheusRegister.getSingleMetricAsString('licensed_users');
+    expect(recordedMetric).toMatch(/licensed_users 0/);
+});

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -650,6 +650,11 @@ export function registerPrometheusMetrics(
         resourceLimit.labels({ resource }).set(limit);
     }
 
+    const licensedUsers = createGauge({
+        name: 'licensed_users',
+        help: 'The number of licensed users.',
+    });
+
     const addonEventsHandledCounter = createCounter({
         name: 'addon_events_handled',
         help: 'Events handled by addons and the result.',
@@ -1017,6 +1022,11 @@ export function registerPrometheusMetrics(
                 usersActive60days.set(activeUsers.last60);
                 usersActive90days.reset();
                 usersActive90days.set(activeUsers.last90);
+
+                const licensedUsersStat =
+                    await instanceStatsService.getLicencedUsers();
+                licensedUsers.reset();
+                licensedUsers.set(licensedUsersStat);
 
                 const productionChanges =
                     await instanceStatsService.getProductionChanges();


### PR DESCRIPTION
We have the licensed users service implemented, this just spread the data to prometheus.