### PR TITLE
feat: Add stale flags counter

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -25,9 +25,15 @@ const ChartRow = styled('div')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
-const StyledSVG = styled('svg')({
-    height: 100,
+const SVGWrapper = styled('div')(({ theme }) => ({
     flex: 'none',
+    height: 85,
+    width: 100,
+    position: 'relative',
+}));
+
+const StyledSVG = styled('svg')({
+    position: 'absolute',
 });
 
 const StyledLink = styled(Link)(({ theme }) => ({
@@ -60,38 +66,40 @@ export const ProjectHealth = () => {
     return (
         <HealthContainer>
             <ChartRow>
-                <StyledSVG viewBox='0 0 100 100'>
-                    <circle
-                        cx='50'
-                        cy='50'
-                        r={radius}
-                        fill='none'
-                        stroke={theme.palette.grey[300]}
-                        strokeWidth={strokeWidth}
-                        strokeDasharray={`${filledLength * circumference} ${gapLength * circumference}`}
-                        strokeDashoffset={offset * circumference}
-                    />
-                    <circle
-                        cx='50'
-                        cy='50'
-                        r={radius}
-                        fill='none'
-                        stroke={healthColor}
-                        strokeWidth={strokeWidth}
-                        strokeDasharray={`${healthLength} ${circumference - healthLength}`}
-                        strokeDashoffset={offset * circumference}
-                    />
-                    <text
-                        x='50'
-                        y='50'
-                        textAnchor='middle'
-                        dominantBaseline='middle'
-                        fill={theme.palette.text.primary}
-                        fontSize='24px'
-                    >
-                        {averageHealth}%
-                    </text>
-                </StyledSVG>
+                <SVGWrapper>
+                    <StyledSVG viewBox='0 0 100 100'>
+                        <circle
+                            cx='50'
+                            cy='50'
+                            r={radius}
+                            fill='none'
+                            stroke={theme.palette.grey[300]}
+                            strokeWidth={strokeWidth}
+                            strokeDasharray={`${filledLength * circumference} ${gapLength * circumference}`}
+                            strokeDashoffset={offset * circumference}
+                        />
+                        <circle
+                            cx='50'
+                            cy='50'
+                            r={radius}
+                            fill='none'
+                            stroke={healthColor}
+                            strokeWidth={strokeWidth}
+                            strokeDasharray={`${healthLength} ${circumference - healthLength}`}
+                            strokeDashoffset={offset * circumference}
+                        />
+                        <text
+                            x='50'
+                            y='50'
+                            textAnchor='middle'
+                            dominantBaseline='middle'
+                            fill={theme.palette.text.primary}
+                            fontSize='24px'
+                        >
+                            {averageHealth}%
+                        </text>
+                    </StyledSVG>
+                </SVGWrapper>
                 <TextContainer>
                     <Typography variant='body2'>
                         On average, your project health has remained at{' '}

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -10,6 +10,7 @@ const HealthContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(3),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     minWidth: '300px',
+    gridArea: 'health',
 }));
 
 const ChartRow = styled('div')(({ theme }) => ({

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -13,20 +13,22 @@ const HealthContainer = styled('div')(({ theme }) => ({
     gridArea: 'health',
 }));
 
+const TextContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+}));
+
 const ChartRow = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
+    gap: theme.spacing(2),
 }));
 
 const StyledSVG = styled('svg')({
-    width: 200,
     height: 100,
+    flex: 'none',
 });
-
-const DescriptionText = styled(Typography)(({ theme }) => ({
-    color: theme.palette.text.secondary,
-    marginBottom: theme.spacing(2),
-}));
 
 export const ProjectHealth = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -86,16 +88,16 @@ export const ProjectHealth = () => {
                         {averageHealth}%
                     </text>
                 </StyledSVG>
-                <Typography variant='body2'>
-                    On average, your project health has remained at{' '}
-                    {averageHealth}% the last 4 weeks
-                </Typography>
+                <TextContainer>
+                    <Typography variant='body2'>
+                        On average, your project health has remained at{' '}
+                        {averageHealth}% the last 4 weeks
+                    </Typography>
+                    {!isOss() && (
+                        <Link to='/insights'>View health over time</Link>
+                    )}
+                </TextContainer>
             </ChartRow>
-            <DescriptionText variant='body2'>
-                Remember to archive your stale feature flags to keep the project
-                health growing
-            </DescriptionText>
-            {!isOss() && <Link to='/insights'>View health over time</Link>}
         </HealthContainer>
     );
 };

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -30,6 +30,10 @@ const StyledSVG = styled('svg')({
     flex: 'none',
 });
 
+const StyledLink = styled(Link)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+}));
+
 export const ProjectHealth = () => {
     const projectId = useRequiredPathParam('projectId');
     const {
@@ -94,7 +98,9 @@ export const ProjectHealth = () => {
                         {averageHealth}% the last 4 weeks
                     </Typography>
                     {!isOss() && (
-                        <Link to='/insights'>View health over time</Link>
+                        <StyledLink to='/insights'>
+                            View health over time
+                        </StyledLink>
                     )}
                 </TextContainer>
             </ChartRow>

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -1,5 +1,4 @@
-import { useTheme, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled, useTheme, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectStatus';

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
@@ -14,6 +14,7 @@ const Wrapper = styled('article')(({ theme }) => ({
     padding: theme.spacing(3),
     borderRadius: theme.shape.borderRadiusExtraLarge,
     minWidth: '300px',
+    gridArea: 'resources',
 }));
 
 const ProjectResourcesInner = styled('div')(({ theme }) => ({

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
@@ -117,7 +117,7 @@ export const ProjectResources = () => {
     return (
         <Wrapper ref={loadingRef}>
             <ProjectResourcesInner>
-                <Typography variant='h3' sx={{ margin: 0 }}>
+                <Typography variant='h4' sx={{ margin: 0 }}>
                     Project resources
                 </Typography>
                 <ResourceList>

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
@@ -34,9 +34,9 @@ const ItemContent = styled('span')(({ theme }) => ({
 }));
 
 const onNarrowWidget = (css: object) => ({
-    '@container (max-width: 400px)': css,
+    '@container (max-width: 385px)': css,
     '@supports not (container-type: inline-size)': {
-        '@media (max-width: 400px)': css,
+        '@media (max-width: 385px)': css,
     },
 });
 
@@ -118,7 +118,7 @@ export const ProjectResources = () => {
         <Wrapper ref={loadingRef}>
             <ProjectResourcesInner>
                 <Typography variant='h3' sx={{ margin: 0 }}>
-                    Project Resources
+                    Project resources
                 </Typography>
                 <ResourceList>
                     <ListItem

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -27,7 +27,7 @@ const HealthContainer = styled('div')(({ theme }) => ({
         "stale resources"
     `,
     gridTemplateColumns: '1fr 1fr',
-    gap: theme.spacing(2),
+    gap: theme.spacing(1, 2),
 }));
 
 export const ProjectStatusModal = ({ open, close }: Props) => {
@@ -36,8 +36,8 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
             <ModalContentContainer>
                 <HealthContainer>
                     <ProjectHealth />
-                    <ProjectResources />
                     <StaleFlags />
+                    <ProjectResources />
                 </HealthContainer>
 
                 <ProjectActivity />

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -6,9 +6,10 @@ import { ProjectHealth } from './ProjectHealth';
 import { ProjectLifecycleSummary } from './ProjectLifecycleSummary';
 import { StaleFlags } from './StaleFlags';
 
-const ModalContentContainer = styled('div')(({ theme }) => ({
+const ModalContentContainer = styled('section')(({ theme }) => ({
     minHeight: '100vh',
-    maxWidth: 1000,
+    maxWidth: 1100,
+    width: '95vw',
     backgroundColor: theme.palette.background.default,
     padding: theme.spacing(4),
     display: 'flex',

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -1,9 +1,10 @@
-import { Box, styled, Typography } from '@mui/material';
+import { styled } from '@mui/material';
 import { DynamicSidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { ProjectResources } from './ProjectResources';
 import { ProjectActivity } from './ProjectActivity';
 import { ProjectHealth } from './ProjectHealth';
 import { ProjectLifecycleSummary } from './ProjectLifecycleSummary';
+import { StaleFlags } from './StaleFlags';
 
 const ModalContentContainer = styled('div')(({ theme }) => ({
     minHeight: '100vh',
@@ -26,7 +27,6 @@ const HealthContainer = styled('div')(({ theme }) => ({
         "stale resources"
     `,
     gridTemplateColumns: '1fr 1fr',
-    // padding: theme.spacing(2),
     gap: theme.spacing(2),
 }));
 
@@ -37,13 +37,7 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
                 <HealthContainer>
                     <ProjectHealth />
                     <ProjectResources />
-                    <Box gridArea='stale'>
-                        <Typography variant='h3'>Stale flags</Typography>
-                        <Typography>
-                            Flags that have not been used for a long time and
-                            can be archived.
-                        </Typography>
-                    </Box>
+                    <StaleFlags />
                 </HealthContainer>
 
                 <ProjectActivity />

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { Box, styled, Typography } from '@mui/material';
 import { DynamicSidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { ProjectResources } from './ProjectResources';
 import { ProjectActivity } from './ProjectActivity';
@@ -19,27 +19,32 @@ type Props = {
     close: () => void;
 };
 
-const HealthRow = styled('div')(({ theme }) => ({
-    display: 'flex',
-    flexFlow: 'row wrap',
-    padding: theme.spacing(2),
+const HealthContainer = styled('div')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateAreas: `
+        "health resources"
+        "stale resources"
+    `,
+    gridTemplateColumns: '1fr 1fr',
+    // padding: theme.spacing(2),
     gap: theme.spacing(2),
-    '&>*': {
-        // todo: reconsider this value when the health widget is
-        // implemented. It may not be right, but it works for the
-        // placeholder
-        flex: '30%',
-    },
 }));
 
 export const ProjectStatusModal = ({ open, close }: Props) => {
     return (
         <DynamicSidebarModal open={open} onClose={close} label='Project status'>
             <ModalContentContainer>
-                <HealthRow>
+                <HealthContainer>
                     <ProjectHealth />
                     <ProjectResources />
-                </HealthRow>
+                    <Box gridArea='stale'>
+                        <Typography variant='h3'>Stale flags</Typography>
+                        <Typography>
+                            Flags that have not been used for a long time and
+                            can be archived.
+                        </Typography>
+                    </Box>
+                </HealthContainer>
 
                 <ProjectActivity />
 

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -8,6 +8,7 @@ import { StaleFlags } from './StaleFlags';
 
 const ModalContentContainer = styled('div')(({ theme }) => ({
     minHeight: '100vh',
+    maxWidth: 1000,
     backgroundColor: theme.palette.background.default,
     padding: theme.spacing(4),
     display: 'flex',

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -21,7 +21,18 @@ type Props = {
     close: () => void;
 };
 
-const HealthContainer = styled('div')(({ theme }) => ({
+const onNarrowGrid = (css: object) => ({
+    '@container (max-width: 650px)': css,
+    '@supports not (container-type: inline-size)': {
+        '@media (max-width: 712px)': css,
+    },
+});
+
+const HealthContainer = styled('div')({
+    containerType: 'inline-size',
+});
+
+const HealthGrid = styled('div')(({ theme }) => ({
     display: 'grid',
     gridTemplateAreas: `
         "health resources"
@@ -29,6 +40,11 @@ const HealthContainer = styled('div')(({ theme }) => ({
     `,
     gridTemplateColumns: '1fr 1fr',
     gap: theme.spacing(1, 2),
+    ...onNarrowGrid({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing(1),
+    }),
 }));
 
 export const ProjectStatusModal = ({ open, close }: Props) => {
@@ -36,9 +52,11 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
         <DynamicSidebarModal open={open} onClose={close} label='Project status'>
             <ModalContentContainer>
                 <HealthContainer>
-                    <ProjectHealth />
-                    <StaleFlags />
-                    <ProjectResources />
+                    <HealthGrid>
+                        <ProjectHealth />
+                        <StaleFlags />
+                        <ProjectResources />
+                    </HealthGrid>
                 </HealthContainer>
 
                 <ProjectActivity />

--- a/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
@@ -15,7 +15,6 @@ const Wrapper = styled('article')(({ theme }) => ({
 
 const BigText = styled('span')(({ theme }) => ({
     fontSize: `calc(2 * ${theme.typography.body1.fontSize})`,
-    color: theme.palette.primary.main,
 }));
 
 const BigNumber: FC<{ value?: number }> = ({ value }) => {

--- a/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
@@ -11,10 +11,14 @@ const Wrapper = styled('article')(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusExtraLarge,
     minWidth: '300px',
     gridArea: 'stale',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
 }));
 
 const BigText = styled('span')(({ theme }) => ({
     fontSize: `calc(2 * ${theme.typography.body1.fontSize})`,
+    lineHeight: 0,
 }));
 
 const BigNumber: FC<{ value?: number }> = ({ value }) => {
@@ -41,7 +45,7 @@ export const StaleFlags = () => {
             </Typography>
             <Typography variant='body2'>
                 Remember to archive your stale feature flags to keep the project
-                health
+                healthy
             </Typography>
         </Wrapper>
     );

--- a/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
@@ -1,0 +1,17 @@
+import { Box, Typography } from '@mui/material';
+import { styled } from '@mui/material';
+
+const DescriptionText = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(2),
+}));
+
+export const StaleFlags = () => (
+    <Box gridArea='stale' sx={{ background: 'grey' }}>
+        <Typography variant='h3'>6 Stale flags</Typography>
+        <DescriptionText variant='body2'>
+            Remember to archive your stale feature flags to keep the project
+            health
+        </DescriptionText>
+    </Box>
+);

--- a/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/StaleFlags.tsx
@@ -1,17 +1,49 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { styled } from '@mui/material';
+import { PrettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
 
-const DescriptionText = styled(Typography)(({ theme }) => ({
-    color: theme.palette.text.secondary,
-    marginBottom: theme.spacing(2),
+const Wrapper = styled('article')(({ theme }) => ({
+    backgroundColor: theme.palette.envAccordion.expanded,
+    padding: theme.spacing(3),
+    borderRadius: theme.shape.borderRadiusExtraLarge,
+    minWidth: '300px',
+    gridArea: 'stale',
 }));
 
-export const StaleFlags = () => (
-    <Box gridArea='stale' sx={{ background: 'grey' }}>
-        <Typography variant='h3'>6 Stale flags</Typography>
-        <DescriptionText variant='body2'>
-            Remember to archive your stale feature flags to keep the project
-            health
-        </DescriptionText>
-    </Box>
-);
+const BigText = styled('span')(({ theme }) => ({
+    fontSize: `calc(2 * ${theme.typography.body1.fontSize})`,
+    color: theme.palette.primary.main,
+}));
+
+const BigNumber: FC<{ value?: number }> = ({ value }) => {
+    return (
+        <BigText>
+            <PrettifyLargeNumber
+                value={value ?? 0}
+                threshold={1000}
+                precision={1}
+            />
+        </BigText>
+    );
+};
+
+export const StaleFlags = () => {
+    const projectId = useRequiredPathParam('projectId');
+    return (
+        <Wrapper>
+            <Typography component='h4'>
+                <BigNumber value={6} />{' '}
+                <Link to={`/projects/${projectId}?state=IS%3Astale`}>
+                    stale flags
+                </Link>
+            </Typography>
+            <Typography variant='body2'>
+                Remember to archive your stale feature flags to keep the project
+                health
+            </Typography>
+        </Wrapper>
+    );
+};


### PR DESCRIPTION
This PR adds the stale flag component to the health grid. In doing so, it also reworks the layout of the health row (now a grid) and updates the health component.

In addition to removing the text from the component, I have adjust the SVG a bit to make it not shrink on smaller screens and have adjusted it's spacing, so that it's not full of dead space at the bottom. This makes it easier to style because it doesn't add 15px of invisible content.

This PR also touches up a few other visual issues I found, such as header level and sidebar width.

Wide:
![image](https://github.com/user-attachments/assets/acb57b17-eb7f-4b69-9bfa-1113bb748467)

Medium:
![image](https://github.com/user-attachments/assets/a57331b0-825f-4b20-9b05-3ecd81804f5d)

Narrow:
![image](https://github.com/user-attachments/assets/65c6e8d1-1783-4354-b71b-2867eabcc9ec)

