### PR TITLE
refactor: sessions for user without error

### DIFF
--- a/src/lib/db/session-store.ts
+++ b/src/lib/db/session-store.ts
@@ -43,9 +43,7 @@ export default class SessionStore implements ISessionStore {
         if (rows && rows.length > 0) {
             return rows.map(this.rowToSession);
         }
-        throw new NotFoundError(
-            `Could not find sessions for user with id ${userId}`,
-        );
+        return [];
     }
 
     async get(sid: string): Promise<ISession> {

--- a/src/lib/services/session-service.ts
+++ b/src/lib/services/session-service.ts
@@ -37,11 +37,8 @@ export default class SessionService {
         userId: number,
         maxSessions: number,
     ): Promise<void> {
-        let userSessions: ISession[] = [];
-        try {
-            // this method may throw errors when no session
-            userSessions = await this.sessionStore.getSessionsForUser(userId);
-        } catch (e) {}
+        const userSessions: ISession[] =
+            await this.sessionStore.getSessionsForUser(userId);
         const newestFirst = userSessions.sort((a, b) =>
             compareDesc(a.createdAt, b.createdAt),
         );

--- a/src/test/e2e/services/session-service.e2e.test.ts
+++ b/src/test/e2e/services/session-service.e2e.test.ts
@@ -95,9 +95,8 @@ test('Can delete sessions by user', async () => {
     const sessions = await sessionService.getActiveSessions();
     expect(sessions.length).toBe(2);
     await sessionService.deleteSessionsForUser(2);
-    await expect(async () => {
-        await sessionService.getSessionsForUser(2);
-    }).rejects.toThrow(NotFoundError);
+    const noSessions = await sessionService.getSessionsForUser(2);
+    expect(noSessions.length).toBe(0);
 });
 
 test('Can delete session by sid', async () => {

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -357,9 +357,8 @@ test("deleting a user should delete the user's sessions", async () => {
     const userSessions = await sessionService.getSessionsForUser(user.id);
     expect(userSessions.length).toBe(1);
     await userService.deleteUser(user.id, TEST_AUDIT_USER);
-    await expect(async () =>
-        sessionService.getSessionsForUser(user.id),
-    ).rejects.toThrow(NotFoundError);
+    const noSessions = await sessionService.getSessionsForUser(user.id);
+    expect(noSessions.length).toBe(0);
 });
 
 test('updating a user without an email should not strip the email', async () => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Method that queries sessions for users returns empty array when no sessions. Previously it was throwing an error. Since it's not an exceptional scenario returning an empty list seems to be less surprising at call site (especially with a list semantics on the return side). 

Note: this method was used only in tests and my new code that I currently work on. The method is not used in the enterprise repo.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
