### PR TITLE
feat: now pay as you go billing banner has link

### DIFF
--- a/frontend/src/component/common/InstanceStatus/InstanceStatusBar.tsx
+++ b/frontend/src/component/common/InstanceStatus/InstanceStatusBar.tsx
@@ -13,6 +13,7 @@ import {
     isTrialInstance,
 } from 'utils/instanceTrial';
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import useUiConfig from '../../../hooks/api/getters/useUiConfig/useUiConfig';
 
 const StyledWarningBar = styled('aside')(({ theme }) => ({
     position: 'relative',
@@ -132,13 +133,17 @@ const StatusBarExpiresLater = ({ instanceStatus }: IInstanceStatusBarProps) => {
 
 const BillingLink = ({ instanceStatus }: IInstanceStatusBarProps) => {
     const { hasAccess } = useContext(AccessContext);
+    const { uiConfig } = useUiConfig();
     const navigate = useNavigate();
 
     if (!hasAccess(ADMIN)) {
         return null;
     }
 
-    if (instanceStatus.plan === InstancePlan.ENTERPRISE) {
+    if (
+        instanceStatus.plan === InstancePlan.ENTERPRISE &&
+        uiConfig.billing !== 'pay-as-you-go'
+    ) {
         return null;
     }
 


### PR DESCRIPTION
My intuition wanted to click on it to start paying, but it did not work. Changed condition to show it for pay as you go.

![image](https://github.com/user-attachments/assets/d14ad947-ce4a-48cb-8bbd-c1d6dfb84a0a)
