### PR TITLE
1-3073: close sidebar when you click a link within it

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -106,7 +106,17 @@ const CloseRow = styled('div')(({ theme }) => ({
 
 export const ProjectStatusModal = ({ open, close }: Props) => {
     return (
-        <DynamicSidebarModal open={open} onClose={close} label='Project status'>
+        <DynamicSidebarModal
+            open={open}
+            onClose={close}
+            label='Project status'
+            onClick={(e: React.SyntheticEvent) => {
+                if (e.target instanceof HTMLAnchorElement) {
+                    // close sidebar when you click a link inside it
+                    close();
+                }
+            }}
+        >
             <ModalContentContainer>
                 <HeaderRow>
                     <StyledProjectStatusSvg aria-hidden='true' />

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -112,7 +112,6 @@ export const ProjectStatusModal = ({ open, close }: Props) => {
             label='Project status'
             onClick={(e: React.SyntheticEvent) => {
                 if (e.target instanceof HTMLAnchorElement) {
-                    // close sidebar when you click a link inside it
                     close();
                 }
             }}


### PR DESCRIPTION
This change makes it so that the project status sidebar will close
when you follow a link within it. We do that by using JS event
bubbling and attaching a handler on the modal parent. We can listen
for events and check whether the target is an anchor and, if so, close
the modal.