### PR TITLE
1-3120: remove project connected environments

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectResources.tsx
@@ -5,7 +5,6 @@ import UsersIcon from '@mui/icons-material/Group';
 import { Link } from 'react-router-dom';
 import ApiKeyIcon from '@mui/icons-material/Key';
 import SegmentsIcon from '@mui/icons-material/DonutLarge';
-import ConnectedIcon from '@mui/icons-material/Cable';
 import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectStatus';
 import useLoading from 'hooks/useLoading';
 import { HealthGridTile } from './ProjectHealthGrid.styles';
@@ -90,7 +89,6 @@ const useProjectResources = (projectId: string) => {
         resources: {
             members: 0,
             apiTokens: 0,
-            connectedEnvironments: 0,
             segments: 0,
         },
     };
@@ -128,15 +126,6 @@ export const ProjectResources = () => {
                         icon={<ApiKeyIcon />}
                     >
                         {resources.apiTokens} API key(s)
-                    </ListItem>
-
-                    <ListItem
-                        linkUrl={`/projects/${projectId}/settings/placeholder`}
-                        linkText='View connections'
-                        icon={<ConnectedIcon />}
-                    >
-                        {resources.connectedEnvironments} connected
-                        environment(s)
                     </ListItem>
 
                     <ListItem

--- a/frontend/src/hooks/api/getters/useProjectStatus/useProjectStatus.ts
+++ b/frontend/src/hooks/api/getters/useProjectStatus/useProjectStatus.ts
@@ -7,7 +7,6 @@ const path = (projectId: string) => `api/admin/projects/${projectId}/status`;
 const placeholderData: ProjectStatusSchema = {
     activityCountByDate: [],
     resources: {
-        connectedEnvironments: 0,
         members: 0,
         apiTokens: 0,
         segments: 0,

--- a/frontend/src/openapi/models/projectStatusSchemaResources.ts
+++ b/frontend/src/openapi/models/projectStatusSchemaResources.ts
@@ -14,11 +14,6 @@ export type ProjectStatusSchemaResources = {
      */
     apiTokens: number;
     /**
-     * The number of environments that have received SDK traffic in this project.
-     * @minimum 0
-     */
-    connectedEnvironments: number;
-    /**
      * The number of users who have been granted roles in this project. Does not include users who have access via groups.
      * @minimum 0
      */

--- a/src/lib/features/project-status/project-status-service.ts
+++ b/src/lib/features/project-status/project-status-service.ts
@@ -44,7 +44,6 @@ export class ProjectStatusService {
 
     async getProjectStatus(projectId: string): Promise<ProjectStatusSchema> {
         const [
-            connectedEnvironments,
             members,
             apiTokens,
             segments,
@@ -53,7 +52,6 @@ export class ProjectStatusService {
             lifecycleSummary,
             staleFlagCount,
         ] = await Promise.all([
-            this.projectStore.getConnectedEnvironmentCountForProject(projectId),
             this.projectStore.getMembersCountByProject(projectId),
             this.apiTokenStore.countProjectTokens(projectId),
             this.segmentStore.getProjectSegmentCount(projectId),
@@ -74,7 +72,6 @@ export class ProjectStatusService {
 
         return {
             resources: {
-                connectedEnvironments,
                 members,
                 apiTokens,
                 segments,

--- a/src/lib/features/project-status/projects-status.e2e.test.ts
+++ b/src/lib/features/project-status/projects-status.e2e.test.ts
@@ -127,51 +127,6 @@ test('project insights should return correct count for each day', async () => {
     });
 });
 
-test('project status should return environments with connected SDKs', async () => {
-    const flagName = randomId();
-    await app.createFeature(flagName);
-
-    const envs =
-        await app.services.environmentService.getProjectEnvironments('default');
-    expect(envs.some((env) => env.name === 'default')).toBeTruthy();
-
-    const appName = 'blah';
-    const environment = 'default';
-    await db.stores.clientMetricsStoreV2.batchInsertMetrics([
-        {
-            featureName: `flag-doesnt-exist`,
-            appName,
-            environment,
-            timestamp: new Date(),
-            yes: 5,
-            no: 2,
-        },
-        {
-            featureName: flagName,
-            appName: `web2`,
-            environment,
-            timestamp: new Date(),
-            yes: 5,
-            no: 2,
-        },
-        {
-            featureName: flagName,
-            appName,
-            environment: 'not-a-real-env',
-            timestamp: new Date(),
-            yes: 2,
-            no: 2,
-        },
-    ]);
-
-    const { body } = await app.request
-        .get('/api/admin/projects/default/status')
-        .expect('Content-Type', /json/)
-        .expect(200);
-
-    expect(body.resources.connectedEnvironments).toBe(1);
-});
-
 test('project resources should contain the right data', async () => {
     const { body: noResourcesBody } = await app.request
         .get('/api/admin/projects/default/status')
@@ -182,7 +137,6 @@ test('project resources should contain the right data', async () => {
         members: 0,
         apiTokens: 0,
         segments: 0,
-        connectedEnvironments: 0,
     });
 
     const flagName = randomId();
@@ -239,7 +193,6 @@ test('project resources should contain the right data', async () => {
         members: 1,
         apiTokens: 1,
         segments: 1,
-        connectedEnvironments: 1,
     });
 });
 

--- a/src/lib/features/project/project-store-type.ts
+++ b/src/lib/features/project/project-store-type.ts
@@ -93,8 +93,6 @@ export interface IProjectStore extends Store<IProject, string> {
 
     getEnvironmentsForProject(id: string): Promise<ProjectEnvironment[]>;
 
-    getConnectedEnvironmentCountForProject(id: string): Promise<number>;
-
     getMembersCountByProject(projectId: string): Promise<number>;
 
     getMembersCountByProjectAfterDate(

--- a/src/lib/features/project/project-store.ts
+++ b/src/lib/features/project/project-store.ts
@@ -390,22 +390,6 @@ class ProjectStore implements IProjectStore {
         return rows.map(this.mapProjectEnvironmentRow);
     }
 
-    async getConnectedEnvironmentCountForProject(id: string): Promise<number> {
-        const [{ count }] = (await this.db
-            .countDistinct('cme.environment')
-            .from('client_metrics_env as cme')
-            .innerJoin('features', 'cme.feature_name', 'features.name')
-            .innerJoin('projects', 'features.project', 'projects.id')
-            .innerJoin(
-                'project_environments',
-                'cme.environment',
-                'project_environments.environment_name',
-            )
-            .where('features.project', id)) as { count: string }[];
-
-        return Number(count);
-    }
-
     async getMembersCountByProject(projectId: string): Promise<number> {
         const members = await this.db
             .from((db) => {

--- a/src/lib/openapi/spec/project-status-schema.test.ts
+++ b/src/lib/openapi/spec/project-status-schema.test.ts
@@ -31,7 +31,6 @@ test('projectStatusSchema', () => {
             { date: '2022-12-15', count: 5 },
         ],
         resources: {
-            connectedEnvironments: 2,
             apiTokens: 2,
             members: 1,
             segments: 0,

--- a/src/lib/openapi/spec/project-status-schema.ts
+++ b/src/lib/openapi/spec/project-status-schema.ts
@@ -52,20 +52,9 @@ export const projectStatusSchema = {
         resources: {
             type: 'object',
             additionalProperties: false,
-            required: [
-                'connectedEnvironments',
-                'apiTokens',
-                'members',
-                'segments',
-            ],
+            required: ['apiTokens', 'members', 'segments'],
             description: 'Key resources within the project',
             properties: {
-                connectedEnvironments: {
-                    type: 'integer',
-                    minimum: 0,
-                    description:
-                        'The number of environments that have received SDK traffic in this project.',
-                },
                 apiTokens: {
                     type: 'integer',
                     minimum: 0,

--- a/src/test/fixtures/fake-project-store.ts
+++ b/src/test/fixtures/fake-project-store.ts
@@ -214,8 +214,4 @@ export default class FakeProjectStore implements IProjectStore {
             project.id === id ? { ...project, archivedAt: null } : project,
         );
     }
-
-    async getConnectedEnvironmentCountForProject(): Promise<number> {
-        return 0;
-    }
 }


### PR DESCRIPTION
Remove everything related to the connected environment count for project status. We decided that because we don't have anywhere to link it to at the moment, we don't want to show it yet.