### PR TITLE
1-3131: db migration to make potentially stale non-nullable

### DIFF
--- a/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
+++ b/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        UPDATE features SET potentially_stale = FALSE WHERE potentially_stale IS NULL;
+        ALTER TABLE features ALTER COLUMN potentially_stale SET NOT NULL;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE features ALTER COLUMN potentially_stale DROP NOT NULL;
+        `,
+        cb,
+    );
+};
+

--- a/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
+++ b/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
@@ -8,6 +8,8 @@ exports.up = function (db, cb) {
         WHERE potentially_stale IS NULL;
 
         ALTER TABLE features
+        ALTER COLUMN potentially_stale SET DEFAULT FALSE;
+        ALTER TABLE features
         ALTER COLUMN potentially_stale SET NOT NULL;
         `,
         cb
@@ -17,6 +19,8 @@ exports.up = function (db, cb) {
 exports.down = function (db, cb) {
     db.runSql(
         `
+        ALTER TABLE features
+        ALTER COLUMN potentially_stale DROP DEFAULT;
         ALTER TABLE features
         ALTER COLUMN potentially_stale DROP NOT NULL;
         `,

--- a/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
+++ b/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
@@ -3,19 +3,23 @@
 exports.up = function (db, cb) {
     db.runSql(
         `
-        UPDATE features SET potentially_stale = FALSE WHERE potentially_stale IS NULL;
-        ALTER TABLE features ALTER COLUMN potentially_stale SET NOT NULL;
+        UPDATE features
+        SET potentially_stale = FALSE
+        WHERE potentially_stale IS NULL;
+
+        ALTER TABLE features
+        ALTER COLUMN potentially_stale SET NOT NULL;
         `,
-        cb,
+        cb
     );
 };
 
 exports.down = function (db, cb) {
     db.runSql(
         `
-        ALTER TABLE features ALTER COLUMN potentially_stale DROP NOT NULL;
+        ALTER TABLE features
+        ALTER COLUMN potentially_stale DROP NOT NULL;
         `,
-        cb,
+        cb
     );
 };
-


### PR DESCRIPTION
This change adds a db migration to make the potentially_stale column
non-nullable. It'll set any NULL values to `false`.

In the down-migration, make the column nullable again.