### PR TITLE
feat: add potentially stale filter to flags filter

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -44,6 +44,10 @@ export const ProjectOverviewFilters: VFC<IProjectOverviewFilters> = ({
                 label: 'Stale',
                 value: 'stale',
             },
+            {
+                label: 'Potentially stale',
+                value: 'potentiallyStale',
+            },
         ];
 
         const availableFilters: IFilterItem[] = [

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -44,10 +44,14 @@ export const ProjectOverviewFilters: VFC<IProjectOverviewFilters> = ({
                 label: 'Stale',
                 value: 'stale',
             },
-            {
-                label: 'Potentially stale',
-                value: 'potentiallyStale',
-            },
+            ...(simplifyProjectOverview
+                ? [
+                      {
+                          label: 'Potentially stale',
+                          value: 'potentiallyStale',
+                      },
+                  ]
+                : []),
         ];
 
         const availableFilters: IFilterItem[] = [

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -48,7 +48,7 @@ export const ProjectOverviewFilters: VFC<IProjectOverviewFilters> = ({
                 ? [
                       {
                           label: 'Potentially stale',
-                          value: 'potentiallyStale',
+                          value: 'potentially-stale',
                       },
                   ]
                 : []),

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -577,7 +577,7 @@ const applyStaleConditions = (
 
     const { values, operator } = staleConditions;
 
-    if (!values.includes('potentiallyStale')) {
+    if (!values.includes('potentially-stale')) {
         applyGenericQueryParams(query, [
             {
                 ...staleConditions,
@@ -591,7 +591,7 @@ const applyStaleConditions = (
 
     const valueSet = new Set(
         values.filter((value) =>
-            ['stale', 'active', 'potentiallyStale'].includes(value || ''),
+            ['stale', 'active', 'potentially-stale'].includes(value || ''),
         ),
     );
     const allSelected = valueSet.size === 3;

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1000,42 +1000,42 @@ test('should search features by potentially stale', async () => {
     };
 
     // single filters work
-    await check('IS:potentiallyStale', ['my_feature_c']);
-    // (stale or !potentiallyStale)
-    await check('IS_NOT:potentiallyStale', [
+    await check('IS:potentially-stale', ['my_feature_c']);
+    // (stale or !potentially-stale)
+    await check('IS_NOT:potentially-stale', [
         'my_feature_a',
         'my_feature_b',
         'my_feature_d',
     ]);
 
     // combo filters work
-    await check('IS_ANY_OF:active,potentiallyStale', [
+    await check('IS_ANY_OF:active,potentially-stale', [
         'my_feature_a',
         'my_feature_c',
     ]);
 
-    // (potentiallyStale OR stale)
-    await check('IS_ANY_OF:potentiallyStale,stale', [
+    // (potentially-stale OR stale)
+    await check('IS_ANY_OF:potentially-stale, stale', [
         'my_feature_b',
         'my_feature_c',
         'my_feature_d',
     ]);
 
-    await check('IS_ANY_OF:active,potentiallyStale,stale', [
+    await check('IS_ANY_OF:active,potentially-stale,stale', [
         'my_feature_a',
         'my_feature_b',
         'my_feature_c',
         'my_feature_d',
     ]);
 
-    await check('IS_NONE_OF:active,potentiallyStale,stale', []);
+    await check('IS_NONE_OF:active,potentially-stale,stale', []);
 
-    await check('IS_NONE_OF:active,potentiallyStale', [
+    await check('IS_NONE_OF:active,potentially-stale', [
         'my_feature_b',
         'my_feature_d',
     ]);
 
-    await check('IS_NONE_OF:potentiallyStale,stale', ['my_feature_a']);
+    await check('IS_NONE_OF:potentially-stale,stale', ['my_feature_a']);
 });
 
 test('should filter features by combined operators', async () => {


### PR DESCRIPTION
This PR adds the option to select potentially stale flags from the UI.

It also updates the name we use for parsing from the API: instead of `potentiallyStale` we use `potentially-stale`. This follows the precedent set by "kill switch" (which we send as 'kill-switch'), the only other multi-word option that I could find in our filters.