### PR TITLE
chore: hide release plan template permissions behind feature flag

### DIFF
--- a/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
+++ b/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
@@ -79,15 +79,13 @@ export const RolePermissionCategories = ({
     return useMemo(
         () => (
             <>
-                {categories.map(({ label, type, permissions }) => {
-                    if (
-                        label === 'Release plan templates' &&
-                        !releasePlansEnabled
-                    ) {
-                        return null;
-                    }
-
-                    return (
+                {categories
+                    .filter(
+                        ({ label }) =>
+                            releasePlansEnabled ||
+                            label !== 'Release plan templates',
+                    )
+                    .map(({ label, type, permissions }) => (
                         <RolePermissionCategory
                             key={label}
                             title={`${label} permissions`}
@@ -114,8 +112,7 @@ export const RolePermissionCategories = ({
                             }
                             onCheckAll={() => onCheckAll(permissions)}
                         />
-                    );
-                })}
+                    ))}
             </>
         ),
         [categories, checkedPermissions],

--- a/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
+++ b/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
@@ -18,6 +18,7 @@ import {
 } from 'utils/permissions';
 import { RolePermissionCategory } from './RolePermissionCategory';
 import { useMemo } from 'react';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IPermissionCategoriesProps {
     type: PredefinedRoleType;
@@ -39,6 +40,8 @@ export const RolePermissionCategories = ({
         revalidateOnReconnect: false,
         revalidateOnFocus: false,
     });
+
+    const releasePlansEnabled = useUiFlag('releasePlans');
 
     const isProjectRole = PROJECT_ROLE_TYPES.includes(type);
 
@@ -76,31 +79,43 @@ export const RolePermissionCategories = ({
     return useMemo(
         () => (
             <>
-                {categories.map(({ label, type, permissions }) => (
-                    <RolePermissionCategory
-                        key={label}
-                        title={`${label} permissions`}
-                        context={label.toLowerCase()}
-                        Icon={
-                            type === PROJECT_PERMISSION_TYPE ? (
-                                <TopicIcon color='disabled' sx={{ mr: 1 }} />
-                            ) : type === ENVIRONMENT_PERMISSION_TYPE ? (
-                                <CloudCircleIcon
-                                    color='disabled'
-                                    sx={{ mr: 1 }}
-                                />
-                            ) : (
-                                <UserIcon color='disabled' sx={{ mr: 1 }} />
-                            )
-                        }
-                        permissions={permissions}
-                        checkedPermissions={checkedPermissions}
-                        onPermissionChange={(permission: IPermission) =>
-                            onPermissionChange(permission)
-                        }
-                        onCheckAll={() => onCheckAll(permissions)}
-                    />
-                ))}
+                {categories.map(({ label, type, permissions }) => {
+                    if (
+                        label === 'Release plan templates' &&
+                        !releasePlansEnabled
+                    ) {
+                        return null;
+                    }
+
+                    return (
+                        <RolePermissionCategory
+                            key={label}
+                            title={`${label} permissions`}
+                            context={label.toLowerCase()}
+                            Icon={
+                                type === PROJECT_PERMISSION_TYPE ? (
+                                    <TopicIcon
+                                        color='disabled'
+                                        sx={{ mr: 1 }}
+                                    />
+                                ) : type === ENVIRONMENT_PERMISSION_TYPE ? (
+                                    <CloudCircleIcon
+                                        color='disabled'
+                                        sx={{ mr: 1 }}
+                                    />
+                                ) : (
+                                    <UserIcon color='disabled' sx={{ mr: 1 }} />
+                                )
+                            }
+                            permissions={permissions}
+                            checkedPermissions={checkedPermissions}
+                            onPermissionChange={(permission: IPermission) =>
+                                onPermissionChange(permission)
+                            }
+                            onCheckAll={() => onCheckAll(permissions)}
+                        />
+                    );
+                })}
             </>
         ),
         [categories, checkedPermissions],


### PR DESCRIPTION
Hides config of release plan template permissions behind a feature flag.
It's not the prettiest, it checks the label of the section and checks the flag. Happy to take thoughts on improving this

Does not hide any of the template permissions in the permission explanation in the table from roles that have been configured with these permissions even if flag is false.
Enabled permissions do not get removed if re-saved after flag has been turned off