### PR TITLE
chore: addReleasePlan api hook use template id in payload

### DIFF
--- a/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
+++ b/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
@@ -12,12 +12,12 @@ export const useReleasePlansApi = () => {
         environment: string,
     ): Promise<void> => {
         const requestId = 'createReleasePlanTemplate';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans/${releasePlanTemplateId}`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans`;
         const req = createRequest(
             path,
             {
                 method: 'POST',
-                body: JSON.stringify({}),
+                body: JSON.stringify({ templateId: releasePlanTemplateId }),
             },
             requestId,
         );

--- a/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
+++ b/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
@@ -11,7 +11,7 @@ export const useReleasePlansApi = () => {
         projectId: string,
         environment: string,
     ): Promise<void> => {
-        const requestId = 'createReleasePlanTemplate';
+        const requestId = 'addReleasePlanToFeature';
         const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans`;
         const req = createRequest(
             path,


### PR DESCRIPTION
Updates the addReleasePlanToFeature api action to use a payload with templateId in instead of url
Also changes the requestId to something more sensible