### PR TITLE
fix: link to unhealthy flags filter

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -165,7 +165,9 @@ export const ProjectHealth = () => {
                         flags and remove code from your code base to reduce
                         technical debt.
                     </Typography>
-                    <Link to={`/projects/${projectId}?state=IS%3Astale`}>
+                    <Link
+                        to={`/projects/${projectId}?state=IS_ANY_OF%3Astale%2Cpotentially-stale`}
+                    >
                         View unhealthy flags
                     </Link>
                 </TextContainer>


### PR DESCRIPTION
This change updates the "view unhealthy flags" link in the project
status sidebar to use the correct filter. The previous link was put in
before we had a filter for potentially stale, so this updates the link
to use that filter.