### PR TITLE
chore: minor cleanup of project health and status

### DIFF
--- a/src/lib/domain/project-health/project-health.ts
+++ b/src/lib/domain/project-health/project-health.ts
@@ -1,5 +1,9 @@
 import { hoursToMilliseconds } from 'date-fns';
-import type { IFeatureToggleStore, IProjectHealthReport } from '../../types';
+import type {
+    IFeatureToggleStore,
+    IProject,
+    IProjectHealthReport,
+} from '../../types';
 import type {
     IFeatureType,
     IFeatureTypeStore,
@@ -67,11 +71,11 @@ export const calculateProjectHealthRating =
         featureTypeStore: IFeatureTypeStore,
         featureToggleStore: IFeatureToggleStore,
     ) =>
-    async (projectId: string): Promise<number> => {
+    async ({ id }: Pick<IProject, 'id'>): Promise<number> => {
         const featureTypes = await featureTypeStore.getAll();
 
         const toggles = await featureToggleStore.getAll({
-            project: projectId,
+            project: id,
             archived: false,
         });
 

--- a/src/lib/domain/project-health/project-health.ts
+++ b/src/lib/domain/project-health/project-health.ts
@@ -1,6 +1,9 @@
 import { hoursToMilliseconds } from 'date-fns';
-import type { IProjectHealthReport } from '../../types';
-import type { IFeatureType } from '../../types/stores/feature-type-store';
+import type { IFeatureToggleStore, IProjectHealthReport } from '../../types';
+import type {
+    IFeatureType,
+    IFeatureTypeStore,
+} from '../../types/stores/feature-type-store';
 
 type IPartialFeatures = Array<{
     stale?: boolean;
@@ -58,3 +61,19 @@ export const calculateHealthRating = (
 
     return rating;
 };
+
+export const calculateProjectHealthRating =
+    (
+        featureTypeStore: IFeatureTypeStore,
+        featureToggleStore: IFeatureToggleStore,
+    ) =>
+    async (projectId: string): Promise<number> => {
+        const featureTypes = await featureTypeStore.getAll();
+
+        const toggles = await featureToggleStore.getAll({
+            project: projectId,
+            archived: false,
+        });
+
+        return calculateHealthRating(toggles, featureTypes);
+    };

--- a/src/lib/features/project-status/project-status-service.ts
+++ b/src/lib/features/project-status/project-status-service.ts
@@ -69,7 +69,7 @@ export class ProjectStatusService {
             calculateProjectHealthRating(
                 this.featureTypeStore,
                 this.featureToggleStore,
-            )(projectId),
+            )({ id: projectId }),
             this.projectLifecycleSummaryReadModel.getProjectLifecycleSummary(
                 projectId,
             ),

--- a/src/lib/features/project-status/project-status-service.ts
+++ b/src/lib/features/project-status/project-status-service.ts
@@ -1,4 +1,4 @@
-import { calculateHealthRating } from '../../domain/project-health/project-health';
+import { calculateProjectHealthRating } from '../../domain/project-health/project-health';
 import type { ProjectStatusSchema } from '../../openapi';
 import type {
     IApiTokenStore,
@@ -52,17 +52,6 @@ export class ProjectStatusService {
         this.featureToggleStore = featureToggleStore;
     }
 
-    private async calculateHealthRating(projectId: string): Promise<number> {
-        const featureTypes = await this.featureTypeStore.getAll();
-
-        const toggles = await this.featureToggleStore.getAll({
-            project: projectId,
-            archived: false,
-        });
-
-        return calculateHealthRating(toggles, featureTypes);
-    }
-
     async getProjectStatus(projectId: string): Promise<ProjectStatusSchema> {
         const [
             members,
@@ -77,7 +66,10 @@ export class ProjectStatusService {
             this.apiTokenStore.countProjectTokens(projectId),
             this.segmentStore.getProjectSegmentCount(projectId),
             this.eventStore.getProjectRecentEventActivity(projectId),
-            this.calculateHealthRating(projectId),
+            calculateProjectHealthRating(
+                this.featureTypeStore,
+                this.featureToggleStore,
+            )(projectId),
             this.projectLifecycleSummaryReadModel.getProjectLifecycleSummary(
                 projectId,
             ),

--- a/src/lib/routes/admin-api/project/health-report.ts
+++ b/src/lib/routes/admin-api/project/health-report.ts
@@ -42,6 +42,9 @@ export default class ProjectHealthReport extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    deprecated: config.flagResolver.isEnabled(
+                        'simplifyProjectOverview',
+                    ),
                     operationId: 'getProjectHealthReport',
                     summary: 'Get a health report for a project.',
                     description:

--- a/src/lib/services/project-health-service.ts
+++ b/src/lib/services/project-health-service.ts
@@ -1,7 +1,7 @@
 import type { IUnleashStores } from '../types/stores';
 import type { IUnleashConfig } from '../types/option';
 import type { Logger } from '../logger';
-import type { IProjectHealthReport } from '../types/model';
+import type { IProject, IProjectHealthReport } from '../types/model';
 import type { IFeatureToggleStore } from '../features/feature-toggle/types/feature-toggle-store-type';
 import type { IFeatureTypeStore } from '../types/stores/feature-type-store';
 import type { IProjectStore } from '../features/project/project-store-type';
@@ -22,7 +22,7 @@ export default class ProjectHealthService {
 
     private projectService: ProjectService;
 
-    calculateHealthRating: (projectId: string) => Promise<number>;
+    calculateHealthRating: ({ id }: Pick<IProject, 'id'>) => Promise<number>;
 
     constructor(
         {
@@ -75,7 +75,7 @@ export default class ProjectHealthService {
 
         await Promise.all(
             projects.map(async (project) => {
-                const newHealth = await this.calculateHealthRating(project.id);
+                const newHealth = await this.calculateHealthRating(project);
                 await this.projectStore.updateHealth({
                     id: project.id,
                     health: newHealth,

--- a/src/lib/services/project-health-service.ts
+++ b/src/lib/services/project-health-service.ts
@@ -22,7 +22,7 @@ export default class ProjectHealthService {
 
     private projectService: ProjectService;
 
-    calculateHealthRating: ({ id }: Pick<IProject, 'id'>) => Promise<number>;
+    calculateHealthRating: (project: IProject) => Promise<number>;
 
     constructor(
         {

--- a/src/lib/services/project-health-service.ts
+++ b/src/lib/services/project-health-service.ts
@@ -22,6 +22,8 @@ export default class ProjectHealthService {
 
     private projectService: ProjectService;
 
+    calculateHealthRating: (projectId: string) => Promise<number>;
+
     constructor(
         {
             projectStore,
@@ -40,6 +42,10 @@ export default class ProjectHealthService {
         this.featureToggleStore = featureToggleStore;
 
         this.projectService = projectService;
+        this.calculateHealthRating = calculateProjectHealthRating(
+            this.featureTypeStore,
+            this.featureToggleStore,
+        );
     }
 
     async getProjectHealthReport(
@@ -69,10 +75,7 @@ export default class ProjectHealthService {
 
         await Promise.all(
             projects.map(async (project) => {
-                const newHealth = await calculateProjectHealthRating(
-                    this.featureTypeStore,
-                    this.featureToggleStore,
-                )(project.id);
+                const newHealth = await this.calculateHealthRating(project.id);
                 await this.projectStore.updateHealth({
                     id: project.id,
                     health: newHealth,


### PR DESCRIPTION
This PR:
- conditionally deprecates the project health report endpoint. We only use this for technical debt dashboard that we're removing. Now it's deprecated once you turn the simplifiy flag on.
- extracts the calculate project health function into the project health functions file in the appropriate domain folder. That same function is now shared by the project health service and the project status service.

For the last point, it's a little outside of how we normally do things, because it takes its stores as arguments, but it slots in well in that file. An option would be to make a project health read model and then wire that up in a couple places. It's more code, but probably closer to how we do things in general. That said, I wanted to suggest this because it's quick and easy (why do much work when little work do trick?). 