### PR TITLE
chore: disable flagOVerviewRedesign on OSS

### DIFF
--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -56,7 +56,7 @@ process.nextTick(async () => {
                         releasePlans: false,
                         simplifyProjectOverview: true,
                         showUserDeviceCount: true,
-                        flagOverviewRedesign: true,
+                        flagOverviewRedesign: false,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Disables the experimental flag overview redesign locally when doing dev in OSS