### PR TITLE
fix: center health widgets and text

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectHealth.tsx
@@ -19,7 +19,7 @@ const TextContainer = styled('div')(({ theme }) => ({
 
 const ChartRow = styled('div')(({ theme }) => ({
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: theme.spacing(2),
 }));
 


### PR DESCRIPTION
This change updates how the health widgets are aligned with their
text. They used to be aligned towards the top; now, they're centered.

Before:
![image](https://github.com/user-attachments/assets/d3a8fba1-5599-49ee-81ec-0bbe903b8321)
![image](https://github.com/user-attachments/assets/86aca09e-a878-4311-b075-a70aa25cbc8f)

After:
![image](https://github.com/user-attachments/assets/bd404fd0-e137-42f9-8279-be5e1e6fdab7)
![image](https://github.com/user-attachments/assets/44d080bb-12c9-446a-8852-7ae0bd87b552)
