### PR TITLE
fix: count lifecycle more accurately

### DIFF
--- a/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
+++ b/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
@@ -89,8 +89,8 @@ export class ProjectLifecycleSummaryReadModel
                     .groupBy('fl.feature');
             })
             .from('latest_stage as ls')
-            .innerJoin('feature_lifecycles as fl', function () {
-                this.on('ls.feature', '=', 'fl.feature').andOn(
+            .innerJoin('feature_lifecycles as fl', (qb) => {
+                qb.on('ls.feature', '=', 'fl.feature').andOn(
                     'ls.max_created_at',
                     '=',
                     'fl.created_at',

--- a/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
+++ b/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
@@ -81,7 +81,21 @@ export class ProjectLifecycleSummaryReadModel
     }
 
     async getCurrentFlagsInEachStage(projectId: string): Promise<FlagsInStage> {
-        const query = this.db('feature_lifecycles as fl')
+        const query = this.db
+            .with('latest_stage', (qb) => {
+                qb.select('fl.feature')
+                    .max('fl.created_at as max_created_at')
+                    .from('feature_lifecycles as fl')
+                    .groupBy('fl.feature');
+            })
+            .from('latest_stage as ls')
+            .innerJoin('feature_lifecycles as fl', function () {
+                this.on('ls.feature', '=', 'fl.feature').andOn(
+                    'ls.max_created_at',
+                    '=',
+                    'fl.created_at',
+                );
+            })
             .innerJoin('features as f', 'fl.feature', 'f.name')
             .where('f.project', projectId)
             .whereNot('fl.stage', 'archived')


### PR DESCRIPTION
This PR fixes three things that were wrong with the lifecycle summary count query:

1. When counting the number of flags in each stage, it does not take into account whether a flag has moved out of that stage. So if you have a flag that's gone through initial -> pre-live -> live, it'll be counted for each one of those steps, not just the last one.

2. Some flags that have been archived don't have the corresponding archived state row in the db. This causes them to count towards their other recorded lifecycle stages, even when they shouldn't. This is related to the previous one, but slightly different. Cross-reference the features table's archived_at to make sure it hasn't been archived

3. The archived number should probably be all flags ever archived in the project, regardless of whether they were archived before or after feature lifecycles. So we should check the feature table's archived_at flag for the count there instead