### PR TITLE
fix: fix status sidebar top padding

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -36,10 +36,12 @@ const HeaderRow = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1.5),
+    marginInlineEnd: theme.spacing(5), // to account for the close button
 }));
 
 const StyledProjectStatusSvg = styled(ProjectStatusSvg)(({ theme }) => ({
     fill: theme.palette.primary.main,
+    flex: 'none',
 }));
 
 const ModalHeader = styled('h3')(({ theme }) => ({

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -18,7 +18,8 @@ const ModalContentContainer = styled('section')(({ theme }) => ({
     flexFlow: 'column',
     gap: theme.spacing(4),
     paddingInline: theme.spacing(4),
-    paddingBlock: theme.spacing(10),
+    paddingBlockStart: theme.spacing(3.5),
+    paddingBlockEnd: theme.spacing(10),
 }));
 
 const WidgetContainer = styled('div')(({ theme }) => ({

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectStatusModal.tsx
@@ -18,7 +18,7 @@ const ModalContentContainer = styled('section')(({ theme }) => ({
     flexFlow: 'column',
     gap: theme.spacing(4),
     paddingInline: theme.spacing(4),
-    paddingBlockStart: theme.spacing(3.5),
+    paddingBlockStart: 30, // align with the close button
     paddingBlockEnd: theme.spacing(10),
 }));
 


### PR DESCRIPTION
This PR improves handling of very narrow screens for the project status header:
- Add a right margin so that it won't overlap with the close button.
- Make it so the icon in the header doesn't shrink.