### PR TITLE
1-3145: counteract the MUI button's negative margin

### DIFF
--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -118,6 +118,10 @@ const ProjectStatusButton = styled(Button)(({ theme }) => ({
     },
 }));
 
+const ProjectStatusSvgWithMargin = styled(ProjectStatusSvg)(({ theme }) => ({
+    marginLeft: theme.spacing(0.5),
+}));
+
 export const Project = () => {
     const projectId = useRequiredPathParam('projectId');
     const { trackEvent } = usePlausibleTracker();
@@ -300,7 +304,7 @@ export const Project = () => {
                             {simplifyProjectOverview && (
                                 <ProjectStatusButton
                                     onClick={() => setProjectStatusOpen(true)}
-                                    startIcon={<ProjectStatusSvg />}
+                                    startIcon={<ProjectStatusSvgWithMargin />}
                                     data-loading-project
                                 >
                                     Project status


### PR DESCRIPTION
This change styles the project status svg for this by giving it a
negative margin in this case.

This isn't a native MUI icon, so handling it is a bit tricky. That
said, the ideal solution would be to make the icon conform better to
MUI standards, but this is a quick fix for now.

Before:
![image](https://github.com/user-attachments/assets/889ecbd0-9f08-4995-a54f-7fd770772c7c)

After:
![image](https://github.com/user-attachments/assets/d8b651a5-8834-414b-abf0-642c959d0c36)
