### PR TITLE
chore: allow openapi "date" format of strings

### DIFF
--- a/src/lib/openapi/validate.ts
+++ b/src/lib/openapi/validate.ts
@@ -17,6 +17,7 @@ const ajv = new Ajv({
     keywords: ['example', 'x-enforcer-exception-skip-codes'],
     formats: {
         'date-time': true,
+        date: true,
         uri: true,
     },
 });


### PR DESCRIPTION
This change opens up the possibility of using the "date" format for
strings in our OpenAPI spec. According to the official docs, [`date` is
a built-in string format](https://swagger.io/docs/specification/v3_0/data-models/data-types/#string-formats).