### PR TITLE
feat: release plans permission button for saving strategy

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
@@ -85,6 +85,7 @@ export const CreateReleasePlanTemplate = () => {
             formTitle='Create release plan template'
             formDescription='Create a release plan template to make it easier for you and your team to release features.'
             handleSubmit={handleSubmit}
+            permission={RELEASE_PLAN_TEMPLATE_CREATE}
         >
             <StyledButtonContainer>
                 <CreateButton

--- a/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
@@ -92,6 +92,7 @@ export const EditReleasePlanTemplate = () => {
             formDescription='Edit a release plan template that makes it easier for you and your team to release features.'
             handleSubmit={handleSubmit}
             loading={loading}
+            permission={RELEASE_PLAN_TEMPLATE_UPDATE}
         >
             <StyledButtonContainer>
                 <UpdateButton

--- a/frontend/src/component/releases/ReleasePlanTemplate/ReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/ReleasePlanTemplateAddStrategyForm.tsx
@@ -1,5 +1,6 @@
 import { Button, styled } from '@mui/material';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
 
 const StyledCancelButton = styled(Button)(({ theme }) => ({
     marginLeft: theme.spacing(3),
@@ -13,10 +14,12 @@ const StyledButtonContainer = styled('div')(() => ({
 
 interface IReleasePlanTemplateAddStrategyFormProps {
     onCancel: () => void;
+    permission: string;
 }
 
 export const ReleasePlanTemplateAddStrategyForm = ({
     onCancel,
+    permission,
 }: IReleasePlanTemplateAddStrategyFormProps) => {
     return (
         <FormTemplate
@@ -24,6 +27,14 @@ export const ReleasePlanTemplateAddStrategyForm = ({
             description='Add a strategy to your release plan template.'
         >
             <StyledButtonContainer>
+                <PermissionButton
+                    permission={permission}
+                    variant='contained'
+                    color='primary'
+                    type='submit'
+                >
+                    Save strategy
+                </PermissionButton>
                 <StyledCancelButton onClick={onCancel}>
                     Cancel
                 </StyledCancelButton>

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm.tsx
@@ -39,6 +39,7 @@ interface ITemplateFormProps {
     handleSubmit: (e: React.FormEvent) => void;
     loading?: boolean;
     children?: React.ReactNode;
+    permission: string;
 }
 
 export const TemplateForm: React.FC<ITemplateFormProps> = ({
@@ -54,6 +55,7 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
     formDescription,
     handleSubmit,
     children,
+    permission,
 }) => {
     const [addStrategyOpen, setAddStrategyOpen] = useState(false);
 
@@ -106,6 +108,7 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                         onCancel={() => {
                             setAddStrategyOpen(false);
                         }}
+                        permission={permission}
                     />
                 </SidebarModal>
             </StyledForm>


### PR DESCRIPTION
Adds a save strategy button with permissions for create and update