### PR TITLE
task: added unique index for release plan templates

### DIFF
--- a/src/migrations/20241125080935-add-unique-idx-to-release-plan-discriminator.js
+++ b/src/migrations/20241125080935-add-unique-idx-to-release-plan-discriminator.js
@@ -1,0 +1,15 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `CREATE UNIQUE INDEX idx_uniq_release_plan_definitions_discriminator_template
+         ON release_plan_definitions(name)
+         WHERE discriminator = 'template'`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `DROP INDEX IF EXISTS idx_uniq_release_plan_definitions_discriminator_template`,
+        cb,
+    );
+};


### PR DESCRIPTION
We want to prevent our users from defining multiple templates with the same name. So this adds a unique index on the name column when discriminator is template.