### PR TITLE
docs: add enterprise awareness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Unleash is the most popular open source solution for feature flagging on GitHub.
 
 <br/>
 
+## Start with Unleash Enterprise
+
+Unleash provides an Enterprise offering that offers the following capabilities:
+* Single Sign On
+* Change request (Pull request for flag configuration)
+* SCIM Support (Automatic user provisioning)
+* Unlimited Environments and Projects
+* Role based access control
+* Service accounts
+
+[Start with a 14 day free trial](https://www.getunleash.io/plans/enterprise-payg)
+
 ## Getting Started with Unleash
 
 ### 1. Setting Up Unleash


### PR DESCRIPTION
Adds a section in the README.md on Enterprise capabilities and link to PAYG