### PR TITLE
feat: Add PROJECT_ARCHIVED event to send message to Slack

### DIFF
--- a/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
+++ b/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
@@ -184,6 +184,14 @@ exports[`Should format specialised text for events when no specific text for str
 }
 `;
 
+exports[`Should format specialised text for events when project archived 1`] = `
+{
+  "label": "Project archived",
+  "text": "*user@company.com* archived project *my-other-project*",
+  "url": "unleashUrl/projects-archive",
+}
+`;
+
 exports[`Should format specialised text for events when rollout percentage changed 1`] = `
 {
   "label": "Flag strategy updated",

--- a/src/lib/addons/feature-event-formatter-md-events.ts
+++ b/src/lib/addons/feature-event-formatter-md-events.ts
@@ -57,6 +57,7 @@ import {
     CHANGE_REQUEST_SCHEDULED_APPLICATION_FAILURE,
     CHANGE_REQUEST_SCHEDULE_SUSPENDED,
     FEATURE_COMPLETED,
+    PROJECT_ARCHIVED,
 } from '../types';
 
 interface IEventData {
@@ -305,6 +306,11 @@ export const EVENT_MAP: Record<string, IEventData> = {
         label: 'Project created',
         action: '{{b}}{{user}}{{b}} created project {{b}}{{project}}{{b}}',
         path: '/projects',
+    },
+    [PROJECT_ARCHIVED]: {
+        label: 'Project archived',
+        action: '{{b}}{{user}}{{b}} archived project {{b}}{{event.project}}{{b}}',
+        path: '/projects-archive',
     },
     [PROJECT_DELETED]: {
         label: 'Project deleted',

--- a/src/lib/addons/feature-event-formatter-md.test.ts
+++ b/src/lib/addons/feature-event-formatter-md.test.ts
@@ -585,9 +585,9 @@ const testCases: [string, IEvent][] = [
             tags: [],
             featureName: undefined,
             project: 'my-other-project',
-            environment: 'production'            
+            environment: 'production',
         },
-    ],    
+    ],
 ];
 
 testCases.forEach(([description, event]) =>

--- a/src/lib/addons/feature-event-formatter-md.test.ts
+++ b/src/lib/addons/feature-event-formatter-md.test.ts
@@ -7,6 +7,7 @@ import {
     FEATURE_STRATEGY_REMOVE,
     FEATURE_STRATEGY_UPDATE,
     type IEvent,
+    PROJECT_ARCHIVED,
     SYSTEM_USER_ID,
 } from '../types';
 
@@ -571,6 +572,22 @@ const testCases: [string, IEvent][] = [
             environment: 'production',
         },
     ],
+    [
+        'when project archived',
+        {
+            id: 922,
+            type: PROJECT_ARCHIVED,
+            createdBy: 'user@company.com',
+            createdByUserId: SYSTEM_USER_ID,
+            createdAt: new Date('2024-11-25T10:33:59.459Z'),
+            data: null,
+            preData: null,
+            tags: [],
+            featureName: undefined,
+            project: 'my-other-project',
+            environment: 'production'            
+        },
+    ],    
 ];
 
 testCases.forEach(([description, event]) =>

--- a/src/lib/addons/slack-app-definition.ts
+++ b/src/lib/addons/slack-app-definition.ts
@@ -56,6 +56,7 @@ import {
     CHANGE_REQUEST_SCHEDULED,
     CHANGE_REQUEST_SCHEDULED_APPLICATION_SUCCESS,
     CHANGE_REQUEST_SCHEDULED_APPLICATION_FAILURE,
+    PROJECT_ARCHIVED,
 } from '../types/events';
 import type { IAddonDefinition } from '../types/model';
 
@@ -139,6 +140,7 @@ const slackAppDefinition: IAddonDefinition = {
         BANNER_UPDATED,
         BANNER_DELETED,
         PROJECT_CREATED,
+        PROJECT_ARCHIVED,
         PROJECT_DELETED,
         SEGMENT_CREATED,
         SEGMENT_DELETED,

--- a/website/docs/reference/integrations/slack-app.mdx
+++ b/website/docs/reference/integrations/slack-app.mdx
@@ -72,6 +72,7 @@ You can choose to trigger updates for the following events:
 - group-deleted
 - group-updated
 - project-created
+- project-archived
 - project-deleted
 - segment-created
 - segment-deleted


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

### Summary

- Add `PROJECT_ARCHIVED` event on `EVENT_MAP` to use
- Add a test case for `PROJECT_ARCHIVED` event formatting 
- Add `PROJECT_ARCHIVED` event when users choose which events they send to Slack
- Fix Slack integration document by adding `PROJECT_ARCHIVED`

### Example

The example message looks like the image below. I covered my email with a black rectangle to protect my privacy 😄 
The link refers `/projects-archive` to see archived projects.

<img width="529" alt="Slack message example" src="https://github.com/user-attachments/assets/938c639f-f04a-49af-9b4a-4632cdea9ca7">

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

I considered the reason why Unleash didn't implement to send `PROJECT_ARCHIVED` message to Slack integration.

One thing I assumed that it is impossible to create a new project with open source codes, which means it is only enabled in the enterprise plan. However, [document](https://docs.getunleash.io/reference/integrations/slack-app#events) explains that users can send `PROJECT_CREATED` and `PROJECT_DELETED` events to Slack, which are also available only in the enterprise plan, hence it means we need to embrace all worthwhile events.

I think it is reasonable to add `PROJECT_ARCHIVED` event to Slack integration because users, especially operators, need to track them through Slack by separating steps, `_CREATED`, `_ARCHIVED`, and `_DELETED`. 