### PR TITLE
fix: show data for last 30 days where we say we do

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -240,10 +240,10 @@ export const ProjectLifecycleSummary = () => {
                     <span>{flagWord('archived')} in archived</span>
                 </p>
                 <Stats>
-                    <dt>This month</dt>
+                    <dt>Last 30 days</dt>
                     <dd data-loading-project-lifecycle-summary>
-                        {data?.lifecycleSummary.archived.currentFlags ?? 0}{' '}
-                        flags archived
+                        {data?.lifecycleSummary.archived.last30Days ?? 0} flags
+                        archived
                     </dd>
                 </Stats>
             </LifecycleBox>


### PR DESCRIPTION
This change updates the stat for archived flags "this month".

Turns out we were accessing the wrong property on the data object.

Additionally, changes the label to say "last 30 days" instead of "this
month"  because that's more accurate.