### PR TITLE
fix: text overflow on project users access page

### DIFF
--- a/frontend/src/component/common/Table/cells/RoleCell/RoleCell.tsx
+++ b/frontend/src/component/common/Table/cells/RoleCell/RoleCell.tsx
@@ -4,6 +4,7 @@ import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
 import { RoleDescription } from 'component/common/RoleDescription/RoleDescription';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { styled } from '@mui/material';
+import { Truncator } from 'component/common/Truncator/Truncator';
 
 const StyledRoleDescriptions = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -13,6 +14,10 @@ const StyledRoleDescriptions = styled('div')(({ theme }) => ({
         borderBottom: `1px solid ${theme.palette.divider}`,
         paddingBottom: theme.spacing(1),
     },
+}));
+
+const StyledTruncator = styled(Truncator)(() => ({
+    display: 'block', // Fix for ellipsis not showing up
 }));
 
 type TSingleRoleProps = {
@@ -50,7 +55,7 @@ export const RoleCell: VFC<TRoleCellProps> = ({ role, roles, value }) => {
                         </StyledRoleDescriptions>
                     }
                 >
-                    {value}
+                    <StyledTruncator>{value}</StyledTruncator>
                 </TooltipLink>
             </TextCell>
         );

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
@@ -173,7 +173,7 @@ export const ProjectAccessTable: VFC = () => {
                     row: { original: IProjectAccess };
                     value: string;
                 }) => <RoleCell value={value} roles={row.entity.roles} />,
-                maxWidth: 125,
+                maxWidth: 175,
                 filterName: 'role',
             },
             {


### PR DESCRIPTION
Remove scrollbar in project settings - user roles

before:
![image](https://github.com/user-attachments/assets/c8150b0d-8238-4170-a4a4-9ac16ede83e6)

after:
![image](https://github.com/user-attachments/assets/1a752799-0d55-4eef-a0a1-0070af379414)
