### PR TITLE
fix: user header layout on narrow screens

### DIFF
--- a/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBar.tsx
+++ b/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBar.tsx
@@ -1,6 +1,15 @@
 import type { VFC } from 'react';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { InviteLinkBarContent } from './InviteLinkBarContent';
+import { styled } from '@mui/material';
+
+const Bar = styled('article')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row wrap',
+    gap: theme.spacing(2),
+    justifyContent: 'space-between',
+    alignItems: 'center',
+}));
 
 export const InviteLinkBar: VFC = () => {
     const { trackEvent } = usePlausibleTracker();
@@ -14,5 +23,9 @@ export const InviteLinkBar: VFC = () => {
         });
     };
 
-    return <InviteLinkBarContent onActionClick={onInviteLinkActionClick} />;
+    return (
+        <Bar>
+            <InviteLinkBarContent onActionClick={onInviteLinkActionClick} />
+        </Bar>
+    );
 };

--- a/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBarContent.tsx
+++ b/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBarContent.tsx
@@ -7,7 +7,6 @@ import { LinkField } from '../LinkField/LinkField';
 import { add, formatDistanceToNowStrict, isAfter, parseISO } from 'date-fns';
 import { formatDateYMD } from 'utils/formatDate';
 import { useLocationSettings } from 'hooks/useLocationSettings';
-import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 interface IInviteLinkBarContentProps {
     onActionClick?: (inviteLink?: string) => void;
@@ -35,7 +34,6 @@ export const InviteLinkBarContent = ({
     const navigate = useNavigate();
     const { data, loading } = useInviteTokens();
     const ref = useLoading(loading);
-    const { trackEvent } = usePlausibleTracker();
     const inviteToken =
         data?.tokens?.find((token) => token.name === 'default') ?? null;
     const inviteLink = inviteToken?.url;

--- a/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBarContent.tsx
+++ b/frontend/src/component/admin/users/InviteLinkBar/InviteLinkBarContent.tsx
@@ -22,12 +22,6 @@ export const StyledBox = styled(Box)(() => ({
     flexDirection: 'column',
 }));
 
-export const StyledButtonBox = styled(Box)(() => ({
-    display: 'flex',
-    alignItems: 'center',
-    flexGrow: 1,
-}));
-
 export const InviteLinkBarContent = ({
     onActionClick,
 }: IInviteLinkBarContentProps) => {
@@ -108,22 +102,13 @@ export const InviteLinkBarContent = ({
                     }
                 />
             </StyledBox>
-            <StyledButtonBox
-                sx={{
-                    justifyContent: {
-                        xs: 'center',
-                        md: 'flex-end',
-                    },
-                }}
+            <Button
+                variant='outlined'
+                onClick={onInviteLinkActionClick}
+                data-loading
             >
-                <Button
-                    variant='outlined'
-                    onClick={onInviteLinkActionClick}
-                    data-loading
-                >
-                    {inviteLink ? 'Update' : 'Create'} invite link
-                </Button>
-            </StyledButtonBox>
+                {inviteLink ? 'Update' : 'Create'} invite link
+            </Button>
         </>
     );
 };

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -24,7 +24,7 @@ const StyledCaption = styled('figcaption')(({ theme }) => ({
     fontSize: theme.typography.body2.fontSize,
     display: 'flex',
     flexFlow: 'row wrap',
-    gap: theme.spacing(2),
+    gap: theme.spacing(1),
     justifyContent: 'space-between',
 }));
 

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -1,4 +1,4 @@
-import { Box, styled, Typography } from '@mui/material';
+import { Box, styled } from '@mui/material';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { useState } from 'react';
 import { LicensedUsersSidebar } from './LicensedUsersSidebar';
@@ -30,47 +30,67 @@ const StyledButton = styled('button')(({ theme }) => ({
     padding: 0,
 }));
 
-const InvisibleParagraph = styled('p')({
+const InvisibleParagraph = styled('dl')(({ theme }) => ({
     display: 'contents',
-});
+    '& dt': {
+        gridArea: 'c',
+        display: 'flex',
+        flexFlow: 'row wrap',
+        gap: theme.spacing(2),
+        justifyContent: 'space-between',
+    },
+    '& dd': {
+        gridArea: 'a',
+        display: 'flex',
+        flexFlow: 'row wrap',
+        gap: theme.spacing(2),
+        justifyContent: 'space-between',
+    },
+}));
+
+const Grid = styled('div')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateAreas: `
+        'a'
+        'c'
+    `,
+    gap: theme.spacing(2),
+}));
 
 export const LicensedUsersBox = () => {
     const [licensedUsersChartOpen, setLicensedUsersChartOpen] = useState(false);
     return (
         <StyledContainer>
-            <StyledColumn>
+            <Grid>
                 <InvisibleParagraph>
-                    <Typography
-                        variant='body1'
-                        fontWeight='bold'
-                        component='span'
-                    >
-                        11/25
-                    </Typography>
-                    <Typography variant='body2' component='span'>
-                        Seats used last 30 days
-                    </Typography>
+                    <dt>
+                        <span>Seats used last 30 days</span>
+                        <StyledButton
+                            onClick={() => {
+                                setLicensedUsersChartOpen(true);
+                            }}
+                        >
+                            View graph over time
+                        </StyledButton>
+                    </dt>
+                    <dd>
+                        <span>11/25</span>
+                        <HelpIcon
+                            // sx={{ gridArea: 'b' }}
+                            htmlTooltip
+                            tooltip={
+                                <Box>
+                                    A licensed seat is a unique user that had
+                                    access to your instance within the last 30
+                                    days, and thereby occupied a seat.
+                                </Box>
+                            }
+                        />
+                    </dd>
                 </InvisibleParagraph>
-            </StyledColumn>
-            <RightColumn>
-                <HelpIcon
-                    htmlTooltip
-                    tooltip={
-                        <Box>
-                            A licensed seat is a unique user that had access to
-                            your instance within the last 30 days, and thereby
-                            occupied a seat.
-                        </Box>
-                    }
-                />
+            </Grid>
 
-                <StyledButton
-                    onClick={() => {
-                        setLicensedUsersChartOpen(true);
-                    }}
-                >
-                    View graph over time
-                </StyledButton>
+            <RightColumn>
                 <LicensedUsersSidebar
                     open={licensedUsersChartOpen}
                     close={() => setLicensedUsersChartOpen(false)}

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -21,6 +21,7 @@ const TopRow = styled('div')(({ theme }) => ({
 }));
 
 const StyledCaption = styled('figcaption')(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
     display: 'flex',
     flexFlow: 'row wrap',
     gap: theme.spacing(2),
@@ -32,11 +33,10 @@ const Figure = styled('figure')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'column',
     justifyContent: 'center',
-    // gap: theme.spacing(2),
 }));
 
 const MainMetric = styled('span')(({ theme }) => ({
-    fontSize: theme.typography.h2.fontSize,
+    fontSize: theme.typography.body1.fontSize,
     fontWeight: 'bold',
 }));
 

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -5,7 +5,7 @@ import { LicensedUsersSidebar } from './LicensedUsersSidebar';
 
 const StyledContainer = styled(Box)(({ theme }) => ({
     display: 'flex',
-    flexDirection: 'row',
+    flexFlow: 'row wrap',
     width: '100%',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -3,99 +3,68 @@ import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { useState } from 'react';
 import { LicensedUsersSidebar } from './LicensedUsersSidebar';
 
-const StyledContainer = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    flexFlow: 'row wrap',
-    width: '100%',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-}));
-
-const StyledColumn = styled(Box)({
-    display: 'flex',
-    flexDirection: 'column',
-});
-
-const RightColumn = styled(StyledColumn)({
-    alignItems: 'flex-end',
-});
-
 const StyledButton = styled('button')(({ theme }) => ({
     background: 'none',
     border: 'none',
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: 'inherit',
     textDecoration: 'underline',
     color: theme.palette.primary.main,
     cursor: 'pointer',
     padding: 0,
 }));
 
-const InvisibleParagraph = styled('dl')(({ theme }) => ({
-    display: 'contents',
-    '& dt': {
-        gridArea: 'c',
-        display: 'flex',
-        flexFlow: 'row wrap',
-        gap: theme.spacing(2),
-        justifyContent: 'space-between',
-    },
-    '& dd': {
-        gridArea: 'a',
-        display: 'flex',
-        flexFlow: 'row wrap',
-        gap: theme.spacing(2),
-        justifyContent: 'space-between',
-    },
+const TopRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
 }));
 
-const Grid = styled('div')(({ theme }) => ({
-    display: 'grid',
-    gridTemplateAreas: `
-        'a'
-        'c'
-    `,
+const StyledCaption = styled('figcaption')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row wrap',
+    gap: theme.spacing(2),
+    justifyContent: 'space-between',
+}));
+
+const Grid = styled('figure')(({ theme }) => ({
+    margin: 0,
+    display: 'flex',
+    flexFlow: 'column',
     gap: theme.spacing(2),
 }));
 
 export const LicensedUsersBox = () => {
     const [licensedUsersChartOpen, setLicensedUsersChartOpen] = useState(false);
     return (
-        <StyledContainer>
-            <Grid>
-                <InvisibleParagraph>
-                    <dt>
-                        <span>Seats used last 30 days</span>
-                        <StyledButton
-                            onClick={() => {
-                                setLicensedUsersChartOpen(true);
-                            }}
-                        >
-                            View graph over time
-                        </StyledButton>
-                    </dt>
-                    <dd>
-                        <span>11/25</span>
-                        <HelpIcon
-                            // sx={{ gridArea: 'b' }}
-                            htmlTooltip
-                            tooltip={
-                                <Box>
-                                    A licensed seat is a unique user that had
-                                    access to your instance within the last 30
-                                    days, and thereby occupied a seat.
-                                </Box>
-                            }
-                        />
-                    </dd>
-                </InvisibleParagraph>
-            </Grid>
-
-            <RightColumn>
-                <LicensedUsersSidebar
-                    open={licensedUsersChartOpen}
-                    close={() => setLicensedUsersChartOpen(false)}
+        <Grid>
+            <TopRow>
+                <span>11/25</span>
+                <HelpIcon
+                    htmlTooltip
+                    tooltip={
+                        <Box>
+                            A licensed seat is a unique user that had access to
+                            your instance within the last 30 days, and thereby
+                            occupied a seat.
+                        </Box>
+                    }
                 />
-            </RightColumn>
-        </StyledContainer>
+            </TopRow>
+
+            <StyledCaption>
+                <span>Seats used in the last 30 days</span>
+                <StyledButton
+                    onClick={() => {
+                        setLicensedUsersChartOpen(true);
+                    }}
+                >
+                    View graph over time
+                </StyledButton>
+            </StyledCaption>
+            <LicensedUsersSidebar
+                open={licensedUsersChartOpen}
+                close={() => setLicensedUsersChartOpen(false)}
+            />
+        </Grid>
     );
 };

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -11,6 +11,7 @@ const StyledButton = styled('button')(({ theme }) => ({
     color: theme.palette.primary.main,
     cursor: 'pointer',
     padding: 0,
+    textAlign: 'left',
 }));
 
 const TopRow = styled('div')(({ theme }) => ({
@@ -26,19 +27,25 @@ const StyledCaption = styled('figcaption')(({ theme }) => ({
     justifyContent: 'space-between',
 }));
 
-const Grid = styled('figure')(({ theme }) => ({
+const Figure = styled('figure')(({ theme }) => ({
     margin: 0,
     display: 'flex',
     flexFlow: 'column',
-    gap: theme.spacing(2),
+    justifyContent: 'center',
+    // gap: theme.spacing(2),
+}));
+
+const MainMetric = styled('span')(({ theme }) => ({
+    fontSize: theme.typography.h2.fontSize,
+    fontWeight: 'bold',
 }));
 
 export const LicensedUsersBox = () => {
     const [licensedUsersChartOpen, setLicensedUsersChartOpen] = useState(false);
     return (
-        <Grid>
+        <Figure>
             <TopRow>
-                <span>11/25</span>
+                <MainMetric>11/25</MainMetric>
                 <HelpIcon
                     htmlTooltip
                     tooltip={
@@ -65,6 +72,6 @@ export const LicensedUsersBox = () => {
                 open={licensedUsersChartOpen}
                 close={() => setLicensedUsersChartOpen(false)}
             />
-        </Grid>
+        </Figure>
     );
 };

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, styled, Typography } from '@mui/material';
+import { Box, styled, Typography } from '@mui/material';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { useState } from 'react';
 import { LicensedUsersSidebar } from './LicensedUsersSidebar';
@@ -20,14 +20,14 @@ const RightColumn = styled(StyledColumn)({
     alignItems: 'flex-end',
 });
 
-const StyledButton = styled(Button)(({ theme }) => ({
-    fontSize: theme.spacing(1.75),
+const StyledButton = styled('button')(({ theme }) => ({
+    background: 'none',
+    border: 'none',
+    fontSize: theme.typography.body2.fontSize,
     textDecoration: 'underline',
-    textAlign: 'right',
-    '&:hover': {
-        backgroundColor: theme.palette.background.paper,
-    },
-    fontWeight: theme.typography.h4.fontWeight,
+    color: theme.palette.primary.main,
+    cursor: 'pointer',
+    padding: 0,
 }));
 
 const InvisibleParagraph = styled('p')({

--- a/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
@@ -18,6 +18,9 @@ const StyledElement = styled(Box)(({ theme }) => ({
     border: '2px solid',
     borderColor: theme.palette.divider,
     flex: 'auto',
+    display: 'flex',
+    flexFlow: 'column',
+    justifyContent: 'center',
 }));
 
 export const UsersHeader = () => {

--- a/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
@@ -21,7 +21,6 @@ const StyledElement = styled(Box)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2, 3, 2, 2),
     borderRadius: `${theme.shape.borderRadiusLarge}px`,
-    display: 'flex',
     border: '2px solid',
     borderColor: theme.palette.divider,
 }));
@@ -29,7 +28,7 @@ const StyledElement = styled(Box)(({ theme }) => ({
 export const UsersHeader = () => {
     const licensedUsers = useUiFlag('licensedUsers');
     const { isOss } = useUiConfig();
-    const licensedUsersEnabled = licensedUsers && !isOss();
+    const licensedUsersEnabled = true; //licensedUsers && !isOss();
 
     return (
         <StyledContainer licensedUsersEnabled={licensedUsersEnabled}>

--- a/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
@@ -23,7 +23,7 @@ const StyledElement = styled(Box)(({ theme }) => ({
     borderRadius: `${theme.shape.borderRadiusLarge}px`,
     display: 'flex',
     border: '2px solid',
-    borderColor: theme.palette.background.alternative,
+    borderColor: theme.palette.divider,
 }));
 
 export const UsersHeader = () => {

--- a/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
@@ -4,18 +4,12 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { LicensedUsersBox } from './LicensedUsersBox';
 
-interface StyledContainerProps {
-    licensedUsersEnabled: boolean;
-}
-
-const StyledContainer = styled(Box)<StyledContainerProps>(
-    ({ theme, licensedUsersEnabled }) => ({
-        display: 'grid',
-        gridTemplateColumns: licensedUsersEnabled ? '60% 40%' : '100%',
-        gap: theme.spacing(2),
-        paddingBottom: theme.spacing(3),
-    }),
-);
+const StyledContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row',
+    gap: theme.spacing(2),
+    paddingBottom: theme.spacing(3),
+}));
 
 const StyledElement = styled(Box)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -23,15 +17,16 @@ const StyledElement = styled(Box)(({ theme }) => ({
     borderRadius: `${theme.shape.borderRadiusLarge}px`,
     border: '2px solid',
     borderColor: theme.palette.divider,
+    flex: 'auto',
 }));
 
 export const UsersHeader = () => {
     const licensedUsers = useUiFlag('licensedUsers');
     const { isOss } = useUiConfig();
-    const licensedUsersEnabled = true; //licensedUsers && !isOss();
+    const licensedUsersEnabled = licensedUsers && !isOss();
 
     return (
-        <StyledContainer licensedUsersEnabled={licensedUsersEnabled}>
+        <StyledContainer>
             <StyledElement>
                 <InviteLinkBar />
             </StyledElement>


### PR DESCRIPTION
This PR throws in a number of fixes to the UsersHeader's invite link and licensed users components:

- Change the border colors from the primary purple to being a standard border color
- Fix text / button wrapping in the invite link component. It now wraps such that the button goes onto the row below the text if it cannot fit on the same row. The text within the button will not wrap until it absolutely has to (and is on its own line).
- Fix the wrapping behavior of the licensed users box: the bottom row ("seats used 30 days" and "view graph over time") will now wrap at the same time as the other button in the other box.
- Fix some text sizes within the licensed users box
- Fix the button to look more like a link in the licensed users box

Most of it is pretty standard fare, but I've taken a slightly different route when it comes to the licensed users box component.

I switched the whole component to be a "figure" instead of an article. I was trying to figure out how I could make it behave the way we wanted visually while still linking the "seats over 30 days" to the "11 /25" counter text. The examples on MDN use things such as code snippets, poems, quotes, etc, in addition to the more common image elements. And in a way, 11/25 is a figure representing the number of seats used, so I went with that for now. That said, I'd be very interested to hear some other takes on this.

Now, because the `figcaption` has to be the first or last element of a `figure` element, I had to include the "open sidebar" button inside the caption, which isn't ideal. But I can live with it, I think.

Before:
![image](https://github.com/user-attachments/assets/60e14aad-89d6-4f04-b6f9-1eafb178639c)
![image](https://github.com/user-attachments/assets/61f6dee0-4a4f-428e-9e01-d68a78644a89)
![image](https://github.com/user-attachments/assets/c405d929-a53f-4d33-a6b2-9f73fa1260b4)

After:
![image](https://github.com/user-attachments/assets/d55817f1-5500-46c6-afd3-e7e7f38e3cec)
![image](https://github.com/user-attachments/assets/65dbf4ee-cd06-404f-b82c-09bcf65250e9)
![image](https://github.com/user-attachments/assets/c82a2dc7-3f9b-4ba2-9d16-1d0376c7bd2a)
