### PR TITLE
feat: Change request applied diff for update strategy

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
@@ -47,7 +47,7 @@ testServerRoute(
     },
 );
 
-test('Editing strategy before change request is applied', async () => {
+test('Editing strategy before change request is applied diffs against current strategy', async () => {
     render(
         <StrategyChange
             featureName={feature}
@@ -88,7 +88,7 @@ test('Editing strategy before change request is applied', async () => {
     await screen.findByText(`+ parameters.rollout: "${changeRequestRollout}"`);
 });
 
-test('Editing strategy after change request is applied', async () => {
+test('Editing strategy after change request is applied diffs against the snapshot', async () => {
     render(
         <StrategyChange
             featureName='my_feature'

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
@@ -1,0 +1,130 @@
+import { render } from 'utils/testRenderer';
+import { StrategyChange } from './StrategyChange';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const server = testServerSetup();
+
+const feature = 'my_feature';
+const projectId = 'default';
+const environmentName = 'production';
+const snapshotRollout = '70';
+const currentRollout = '80';
+const changeRequestRollout = '90';
+const strategy = {
+    name: 'flexibleRollout',
+    constraints: [],
+    variants: [],
+    parameters: {
+        groupId: 'child_1',
+        stickiness: 'default',
+    },
+    segments: [],
+    id: '8e25e369-6424-4dad-b17f-5d32cceb2fbe',
+    disabled: false,
+};
+
+testServerRoute(
+    server,
+    `/api/admin/projects/${projectId}/features/${feature}`,
+    {
+        environments: [
+            {
+                name: environmentName,
+                strategies: [
+                    {
+                        ...strategy,
+                        title: 'current_title',
+                        parameters: {
+                            ...strategy.parameters,
+                            rollout: currentRollout,
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+);
+
+test('Editing strategy before change request is applied', async () => {
+    render(
+        <StrategyChange
+            featureName={feature}
+            environmentName={environmentName}
+            projectId={projectId}
+            changeRequestState='Approved'
+            change={{
+                action: 'updateStrategy',
+                id: 1,
+                payload: {
+                    ...strategy,
+                    title: 'change_request_title',
+                    parameters: {
+                        ...strategy.parameters,
+                        rollout: changeRequestRollout,
+                    },
+                    snapshot: {
+                        ...strategy,
+                        title: 'snapshot_title',
+                        parameters: {
+                            ...strategy.parameters,
+                            rollout: snapshotRollout,
+                        },
+                    },
+                },
+            }}
+        />,
+    );
+
+    await screen.findByText('Editing strategy:');
+    await screen.findByText('change_request_title');
+    await screen.findByText('current_title');
+    expect(screen.queryByText('snapshot_title')).not.toBeInTheDocument();
+
+    const viewDiff = await screen.findByText('View Diff');
+    userEvent.hover(viewDiff);
+    await screen.findByText(`- parameters.rollout: "${currentRollout}"`);
+    await screen.findByText(`+ parameters.rollout: "${changeRequestRollout}"`);
+});
+
+test('Editing strategy after change request is applied', async () => {
+    render(
+        <StrategyChange
+            featureName='my_feature'
+            environmentName='production'
+            projectId='default'
+            changeRequestState='Applied'
+            change={{
+                action: 'updateStrategy',
+                id: 1,
+                payload: {
+                    ...strategy,
+                    title: 'change_request_title',
+                    parameters: {
+                        ...strategy.parameters,
+                        rollout: changeRequestRollout,
+                    },
+                    snapshot: {
+                        ...strategy,
+                        title: 'snapshot_title',
+                        parameters: {
+                            ...strategy.parameters,
+                            rollout: snapshotRollout,
+                        },
+                    },
+                },
+            }}
+        />,
+    );
+
+    await screen.findByText('Editing strategy:');
+    await screen.findByText('change_request_title');
+    await screen.findByText('snapshot_title');
+    expect(screen.queryByText('current_title')).not.toBeInTheDocument();
+
+    const viewDiff = await screen.findByText('View Diff');
+    userEvent.hover(viewDiff);
+    await screen.findByText(`- parameters.rollout: "${snapshotRollout}"`);
+    await screen.findByText(`+ parameters.rollout: "${changeRequestRollout}"`);
+});

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
@@ -160,7 +160,7 @@ test('Deleting strategy before change request is applied diffs against current s
     await screen.findByText('- constraints (deleted)');
 });
 
-test('Deleting strategy before change request is applied diffs against the snapshot', async () => {
+test('Deleting strategy after change request is applied diffs against the snapshot', async () => {
     render(
         <StrategyChange
             featureName={feature}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -271,11 +271,19 @@ export const StrategyChange: VFC<{
                             />
                             <StrategyTooltipLink
                                 change={change}
-                                previousTitle={currentStrategy?.title}
+                                previousTitle={
+                                    changeRequestState === 'Applied'
+                                        ? change.payload.snapshot?.title
+                                        : currentStrategy?.title
+                                }
                             >
                                 <StrategyDiff
                                     change={change}
-                                    currentStrategy={currentStrategy}
+                                    currentStrategy={
+                                        changeRequestState === 'Applied'
+                                            ? change.payload.snapshot
+                                            : currentStrategy
+                                    }
                                 />
                             </StrategyTooltipLink>
                         </ChangeItemInfo>

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -51,10 +51,8 @@ export const StrategyDiff: FC<{
 };
 
 interface IStrategyTooltipLinkProps {
-    change:
-        | IChangeRequestAddStrategy
-        | IChangeRequestUpdateStrategy
-        | IChangeRequestDeleteStrategy;
+    name: string;
+    title?: string;
     previousTitle?: string;
     children?: React.ReactNode;
 }
@@ -80,29 +78,32 @@ const Truncated = styled('div')(() => ({
 }));
 
 export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
-    change,
+    name,
+    title,
     previousTitle,
     children,
-}) => (
-    <StyledContainer>
-        <GetFeatureStrategyIcon strategyName={change.payload.name} />
-        <Truncated>
-            <Typography component='span'>
-                {formatStrategyName(change.payload.name)}
-            </Typography>
-            <TooltipLink
-                tooltip={children}
-                tooltipProps={{
-                    maxWidth: 500,
-                    maxHeight: 600,
-                }}
-            >
-                <ViewDiff>View Diff</ViewDiff>
-            </TooltipLink>
-            <NameWithChangeInfo
-                newName={change.payload.title}
-                previousName={previousTitle}
-            />
-        </Truncated>
-    </StyledContainer>
-);
+}) => {
+    return (
+        <StyledContainer>
+            <GetFeatureStrategyIcon strategyName={name} />
+            <Truncated>
+                <Typography component='span'>
+                    {formatStrategyName(name)}
+                </Typography>
+                <TooltipLink
+                    tooltip={children}
+                    tooltipProps={{
+                        maxWidth: 500,
+                        maxHeight: 600,
+                    }}
+                >
+                    <ViewDiff>View Diff</ViewDiff>
+                </TooltipLink>
+                <NameWithChangeInfo
+                    newName={title}
+                    previousName={previousTitle}
+                />
+            </Truncated>
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -69,6 +69,11 @@ const StyledContainer: FC<{ children?: React.ReactNode }> = styled('div')(
     }),
 );
 
+const StyledViewDiff = styled('span')(({ theme }) => ({
+    color: theme.palette.primary.main,
+    marginLeft: theme.spacing(1),
+}));
+
 const Truncated = styled('div')(() => ({
     ...textTruncated,
     maxWidth: 500,
@@ -82,6 +87,9 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
     <StyledContainer>
         <GetFeatureStrategyIcon strategyName={change.payload.name} />
         <Truncated>
+            <Typography component='span'>
+                {formatStrategyName(change.payload.name)}
+            </Typography>
             <TooltipLink
                 tooltip={children}
                 tooltipProps={{
@@ -89,9 +97,7 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
                     maxHeight: 600,
                 }}
             >
-                <Typography component='span'>
-                    {formatStrategyName(change.payload.name)}
-                </Typography>
+                <StyledViewDiff>View Diff</StyledViewDiff>
             </TooltipLink>
             <NameWithChangeInfo
                 newName={change.payload.title}

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -69,7 +69,7 @@ const StyledContainer: FC<{ children?: React.ReactNode }> = styled('div')(
     }),
 );
 
-const StyledViewDiff = styled('span')(({ theme }) => ({
+const ViewDiff = styled('span')(({ theme }) => ({
     color: theme.palette.primary.main,
     marginLeft: theme.spacing(1),
 }));
@@ -97,7 +97,7 @@ export const StrategyTooltipLink: FC<IStrategyTooltipLinkProps> = ({
                     maxHeight: 600,
                 }}
             >
-                <StyledViewDiff>View Diff</StyledViewDiff>
+                <ViewDiff>View Diff</ViewDiff>
             </TooltipLink>
             <NameWithChangeInfo
                 newName={change.payload.title}

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -241,14 +241,15 @@ export type ChangeRequestAddStrategy = Pick<
 
 export type ChangeRequestEditStrategy = ChangeRequestAddStrategy & {
     id: string;
-    snapshot?: Omit<IFeatureStrategy, 'title'> & { title?: string };
+    snapshot?: IFeatureStrategy;
 };
 
 type ChangeRequestDeleteStrategy = {
     id: string;
-    name: string;
+    name?: string;
     title?: string;
     disabled?: boolean;
+    snapshot?: IFeatureStrategy;
 };
 
 export type ChangeRequestAction =

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -241,7 +241,7 @@ export type ChangeRequestAddStrategy = Pick<
 
 export type ChangeRequestEditStrategy = ChangeRequestAddStrategy & {
     id: string;
-    snapshot?: Omit<IFeatureStrategy, 'title'> & { title?: string | null };
+    snapshot?: Omit<IFeatureStrategy, 'title'> & { title?: string };
 };
 
 type ChangeRequestDeleteStrategy = {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, type VFC } from 'react';
+import { type FC, Fragment, useMemo } from 'react';
 import { Alert, Box, Chip, Link, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import PercentageCircle from 'component/common/PercentageCircle/PercentageCircle';
@@ -56,7 +56,7 @@ const CustomStrategyDeprecationWarning = () => (
     </Alert>
 );
 
-const NoItems: VFC = () => (
+const NoItems: FC = () => (
     <Box sx={{ px: 3, color: 'text.disabled' }}>
         This strategy does not have constraints or parameters.
     </Box>
@@ -73,7 +73,7 @@ const StyledValueSeparator = styled('span')(({ theme }) => ({
     color: theme.palette.neutral.main,
 }));
 
-export const StrategyExecution: VFC<IStrategyExecutionProps> = ({
+export const StrategyExecution: FC<IStrategyExecutionProps> = ({
     strategy,
 }) => {
     const { parameters, constraints = [] } = strategy;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Show correct title diff and payload diff (e.g. rollout %) when change request is applied
<img width="954" alt="Screenshot 2024-11-26 at 10 01 58" src="https://github.com/user-attachments/assets/3de238f4-d28f-41d7-9f10-866071109188">

Previously we were always comparing title and payload against the current strategy. But after the strategy is applied there's no diff anymore. What's more when the strategy is updated in future we're diffing against a future value. This PR always looks at the snapshot for change request when the change request is applied.
I added tests showing both cases in detail. 

There will be another PR in the backend to take a snapshot when the CR is being applied. 

Also we should add snapshots for deleted strategies since so that we can show diffs for them after applying CRs.
Update: added delete strategies improvements and extract method refactor in this PR

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
