### PR TITLE
Remove admonitions from Proxy docs

### DIFF
--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -136,8 +136,8 @@ export const OidcAuth = () => {
                         >
                             documentation
                         </a>{' '}
-                        to learn how to integrate with specific Open Id Connect
-                        providers (Okta, Keycloak, Google, etc). <br />
+                        to learn how to integrate with specific OpenID Connect
+                        providers (such as Okta and Keycloak). <br />
                         Callback URL:{' '}
                         <code>{uiConfig.unleashUrl}/auth/oidc/callback</code>
                     </Alert>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -128,7 +128,7 @@ export const SamlAuth = () => {
                             documentation
                         </a>{' '}
                         to learn how to integrate with specific SAML 2.0
-                        providers (Okta, Keycloak, etc). <br />
+                        providers (such as Okta, Keycloak, and Microsoft Entra ID). <br />
                         Callback URL:{' '}
                         <code>{uiConfig.unleashUrl}/auth/saml/callback</code>
                     </Alert>

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -128,7 +128,8 @@ export const SamlAuth = () => {
                             documentation
                         </a>{' '}
                         to learn how to integrate with specific SAML 2.0
-                        providers (such as Okta, Keycloak, and Microsoft Entra ID). <br />
+                        providers (such as Okta, Keycloak, and Microsoft Entra
+                        ID). <br />
                         Callback URL:{' '}
                         <code>{uiConfig.unleashUrl}/auth/saml/callback</code>
                     </Alert>

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -42,9 +42,8 @@ export const SsoGroupSettings = ({
                 <Grid item md={5}>
                     <strong>Enable Group Syncing</strong>
                     <p>
-                        Enables automatically syncing of users from the {' '}
-                        {ssoType}
-                        provider when a user logs in.
+                        Enables automatically syncing of users from the{' '}
+                        {ssoType} provider when a user logs in.
                     </p>
                 </Grid>
                 <Grid item md={6} style={{ padding: '20px' }}>

--- a/frontend/src/component/admin/auth/SsoGroupSettings.tsx
+++ b/frontend/src/component/admin/auth/SsoGroupSettings.tsx
@@ -42,7 +42,7 @@ export const SsoGroupSettings = ({
                 <Grid item md={5}>
                     <strong>Enable Group Syncing</strong>
                     <p>
-                        Enables automatically syncing of users from the{' '}
+                        Enables automatically syncing of users from the {' '}
                         {ssoType}
                         provider when a user logs in.
                     </p>

--- a/website/docs/reference/sso.md
+++ b/website/docs/reference/sso.md
@@ -8,21 +8,17 @@ title: Single Sign-On
 
 :::
 
-Unleash Enterprise supports SAML 2.0, OpenID Connect and Google Authentication. In addition, Unleash supports username/password authentication out of the box.
+Unleash Enterprise supports SAML 2.0, OpenID Connect, and username/password authentication.
 
 ### Before you start
 
-In order to configure Single-Sign-On you will need to log in to the Unleash instance with a user that have "Admin" role. If you are self-hosting Unleash then a default user will be automatically created the first time you start unleash:
-
+In order to configure single sign-on you need Admin access to your Unleash instance. If you are self-hosting Unleash then a default user will be automatically created the first time you start Unleash:
 - username: `admin`
-- password: `unleash4all` _(or `admin` if you started with Unleash v3)._
+- password: `unleash4all` (or `admin` on Unleash v3 or less)
 
-## Guides
-
-Unleash enterprise supports multiple authentication providers.
-
+For detailed setup instructions for the different authentication providers, follow along with the respective guide:
 - [OpenID Connect with Okta](../how-to/how-to-add-sso-open-id-connect)
 - [SAML 2.0 with Okta](../how-to/how-to-add-sso-saml)
 - [SAML 2.0 with Keycloak](../how-to/how-to-add-sso-saml-keycloak)
 - [SAML 2.0 with Microsoft Entra ID](../how-to/how-to-add-sso-azure-saml)
-- [Google Authentication](../how-to/how-to-add-sso-google) (deprecated)
+- [Google Authentication](../how-to/how-to-add-sso-google) (deprecated) 

--- a/website/docs/reference/sso.md
+++ b/website/docs/reference/sso.md
@@ -2,21 +2,20 @@
 title: Single Sign-On
 ---
 
+
 :::note Availability
 
 **Plan**: [Enterprise](https://www.getunleash.io/pricing)
 
 :::
 
-Unleash Enterprise supports SAML 2.0, OpenID Connect, and username/password authentication.
+## Overview
 
-### Before you start
+Unleash provides Single Sign-On (SSO) support through SAML 2.0, OpenID Connect, and username/password authentication.
 
-In order to configure single sign-on you need Admin access to your Unleash instance. If you are self-hosting Unleash then a default user will be automatically created the first time you start Unleash:
-- username: `admin`
-- password: `unleash4all` (or `admin` on Unleash v3 or less)
+To configure SSO, navigate to **Admin > Single sign-on** in the Unleash Admin UI. Admin access is required.
 
-For detailed setup instructions for the different authentication providers, follow along with the respective guide:
+For step-by-step configuration instructions, refer to the following guides:
 - [OpenID Connect with Okta](../how-to/how-to-add-sso-open-id-connect)
 - [SAML 2.0 with Okta](../how-to/how-to-add-sso-saml)
 - [SAML 2.0 with Keycloak](../how-to/how-to-add-sso-saml-keycloak)

--- a/website/docs/reference/sso.md
+++ b/website/docs/reference/sso.md
@@ -11,7 +11,7 @@ title: Single Sign-On
 
 ## Overview
 
-Unleash provides Single Sign-On (SSO) support through SAML 2.0, OpenID Connect, and username/password authentication.
+Unleash provides single sign-on (SSO) support through SAML 2.0, OpenID Connect, and username/password authentication.
 
 To configure SSO, navigate to **Admin > Single sign-on** in the Unleash Admin UI. Admin access is required.
 

--- a/website/remote-content/edge-proxy.js
+++ b/website/remote-content/edge-proxy.js
@@ -28,10 +28,7 @@ const DOCS = mapObject(enrich)({
 });
 
 const getAdmonitions = (data) => {
-    const admonitions = {
-        'unleash-proxy': ``,
-        'unleash-edge': ``,
-    };
+    const admonitions = {};
 
     return [admonitions[data.slugName]];
 };

--- a/website/remote-content/edge-proxy.js
+++ b/website/remote-content/edge-proxy.js
@@ -29,11 +29,7 @@ const DOCS = mapObject(enrich)({
 
 const getAdmonitions = (data) => {
     const admonitions = {
-        'unleash-proxy': `:::tip
-
-Looking for how to run the Unleash proxy? Check out the [_how to run the Unleash proxy_ guide](../how-to/how-to-run-the-unleash-proxy.mdx)!
-
-:::`,
+        'unleash-proxy': ``,
         'unleash-edge': ``,
     };
 


### PR DESCRIPTION
This PR contains two small fixes:
1. [SSO Overview](https://unleash-docs-git-docs-misc-quick-fixes-unleash-team.vercel.app/reference/sso): remove Google Authentication from the list of supported providers in the intro, as it has been deprecated.
2. [Unleash Proxy generated docs](https://unleash-docs-git-docs-misc-quick-fixes-unleash-team.vercel.app/reference/unleash-proxy): remove injected admonition containing tips. Proxy is now in maintenance mode, and we don't want other admonitions to distract from that message