### PR TITLE
test: fix feature e2e test by checking flag name in a td instead of url

### DIFF
--- a/frontend/cypress/integration/feature/feature.spec.ts
+++ b/frontend/cypress/integration/feature/feature.spec.ts
@@ -53,7 +53,7 @@ describe('feature', () => {
 
     it('can create a feature flag', () => {
         cy.createFeature_UI(featureToggleName, true, projectName);
-        cy.url().should('include', featureToggleName);
+        cy.contains('td', featureToggleName).should('exist');
     });
 
     it('gives an error if a toggle exists with the same name', () => {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3028/fix-create-feature-flag-e2e-test

Fixes our failing [create feature e2e test](https://github.com/Unleash/unleash/actions/runs/12027120576/job/33527490303?pr=8843).

We were looking for the feature flag name in the URL, not the DOM. Previously, whenever we created a new feature flag, this would automatically redirect us to that flag's page. This is no longer the case if you use the "Create flag" button you see in the onboarding header, which is the one the test is now using.

I agree it makes sense not to redirect in this case, but the test should be adapted accordingly, and instead look for the feature flag name in the table.