### PR TITLE
chore: make milestone_strategies.title nullable

### DIFF
--- a/src/migrations/20241127074206-milestone-strategy-title-nullable.js
+++ b/src/migrations/20241127074206-milestone-strategy-title-nullable.js
@@ -1,0 +1,12 @@
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE milestone_strategies ALTER COLUMN title DROP NOT NULL;
+        `,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    cb();
+};


### PR DESCRIPTION
Adds a migration that makes title property of milestone strategies nullable