### PR TITLE
fix: Use a proper dark theme for the activity graph

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
@@ -10,6 +10,9 @@ const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    'svg rect': {
+        stroke: '#0000 !important',
+    },
 }));
 
 type Output = { date: string; count: number; level: number };

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
@@ -3,6 +3,7 @@ import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectS
 import ActivityCalendar, { type ThemeInput } from 'react-activity-calendar';
 import type { ProjectActivitySchema } from '../../../../openapi';
 import { styled, Tooltip } from '@mui/material';
+import { useThemeMode } from 'hooks/useThemeMode';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -73,6 +74,7 @@ const transformData = (inputData: ProjectActivitySchema): Output[] => {
 export const ProjectActivity = () => {
     const projectId = useRequiredPathParam('projectId');
     const { data } = useProjectStatus(projectId);
+    const { themeMode } = useThemeMode();
 
     const explicitTheme: ThemeInput = {
         light: ['#f1f0fc', '#ceccfd', '#8982ff', '#6c65e5', '#615bc2'],
@@ -87,6 +89,7 @@ export const ProjectActivity = () => {
             {data.activityCountByDate.length > 0 ? (
                 <StyledContainer>
                     <ActivityCalendar
+                        colorScheme={themeMode}
                         theme={explicitTheme}
                         data={fullData}
                         maxLevel={4}

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
@@ -3,6 +3,7 @@ import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectS
 import ActivityCalendar, { type ThemeInput } from 'react-activity-calendar';
 import type { ProjectActivitySchema } from '../../../../openapi';
 import { styled, Tooltip } from '@mui/material';
+import theme from 'themes/theme';
 import { useThemeMode } from 'hooks/useThemeMode';
 
 const StyledContainer = styled('div')(({ theme }) => ({
@@ -78,7 +79,7 @@ export const ProjectActivity = () => {
 
     const explicitTheme: ThemeInput = {
         light: ['#f1f0fc', '#ceccfd', '#8982ff', '#6c65e5', '#615bc2'],
-        dark: ['#f1f0fc', '#ceccfd', '#8982ff', '#6c65e5', '#615bc2'],
+        dark: ['#302E42', theme.palette.background.alternative],
     };
 
     const levelledData = transformData(data.activityCountByDate);


### PR DESCRIPTION
This PR adds a proper dark theme for the activity graph. We previously used the exact same theme for both light and dark modes.

Before:
![image](https://github.com/user-attachments/assets/1f119dca-4a87-49e3-9f3e-13163bd060c2)


After (different chart):
![image](https://github.com/user-attachments/assets/798c320c-a1b4-4634-b72e-cdb0d7a2c4a4)


I'm also passing in the theme explicitly as the `colorScheme` property. Without that prop, the graph uses your system color scheme (according to the docs), which may not be the same as your Unleash theme color scheme.

A side effect of this, however, is that we're now getting small borders on the light theme dots. I haven't found a prop in the docs to control this, but I kinda like them.

Before:
![image](https://github.com/user-attachments/assets/04fca049-caf4-4df2-b354-42d7006d2186)

After (different chart):
![image](https://github.com/user-attachments/assets/5ad3392a-a31e-44c2-adbd-d006c6dac48f)
