### PR TITLE
feat: view diff in edit segment CR

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { VFC, FC, ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 import { Box, styled, Typography } from '@mui/material';
 import type {
     ChangeRequestState,
@@ -52,12 +52,15 @@ const SegmentContainer = styled(Box, {
     borderRadius: `0 0 ${theme.shape.borderRadiusLarge}px ${theme.shape.borderRadiusLarge}px`,
 }));
 
-export const SegmentChangeDetails: VFC<{
+export const SegmentChangeDetails: FC<{
     actions?: ReactNode;
     change: IChangeRequestUpdateSegment | IChangeRequestDeleteSegment;
     changeRequestState: ChangeRequestState;
 }> = ({ actions, change, changeRequestState }) => {
     const { segment: currentSegment } = useSegment(change.payload.id);
+    const snapshotSegment = change.payload.snapshot;
+    const referenceSegment =
+        changeRequestState === 'Applied' ? snapshotSegment : currentSegment;
 
     return (
         <SegmentContainer conflict={change.conflict}>
@@ -97,7 +100,7 @@ export const SegmentChangeDetails: VFC<{
                             <SegmentTooltipLink change={change}>
                                 <SegmentDiff
                                     change={change}
-                                    currentSegment={currentSegment}
+                                    currentSegment={referenceSegment}
                                 />
                             </SegmentTooltipLink>
                         </ChangeItemInfo>

--- a/frontend/src/component/changeRequest/ChangeRequest/SegmentTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/SegmentTooltipLink.tsx
@@ -35,7 +35,7 @@ export const SegmentDiff: FC<{
             <EventDiff
                 entry={{
                     preData: omit(currentSegment, ['createdAt', 'createdBy']),
-                    data: changeRequestSegment,
+                    data: omit(changeRequestSegment, ['snapshot']),
                 }}
             />
         </StyledCodeSection>
@@ -56,9 +56,15 @@ const StyledContainer: FC<{ children?: React.ReactNode }> = styled('div')(
     }),
 );
 
+const ViewDiff = styled('span')(({ theme }) => ({
+    color: theme.palette.primary.main,
+    marginLeft: theme.spacing(1),
+}));
+
 const Truncated = styled('div')(() => ({
     ...textTruncated,
     maxWidth: 500,
+    display: 'flex',
 }));
 
 export const SegmentTooltipLink: FC<IStrategyTooltipLinkProps> = ({
@@ -67,6 +73,10 @@ export const SegmentTooltipLink: FC<IStrategyTooltipLinkProps> = ({
 }) => (
     <StyledContainer>
         <Truncated>
+            <NameWithChangeInfo
+                previousName={change.name}
+                newName={change.payload.name}
+            />
             <TooltipLink
                 tooltip={children}
                 tooltipProps={{
@@ -74,10 +84,7 @@ export const SegmentTooltipLink: FC<IStrategyTooltipLinkProps> = ({
                     maxHeight: 600,
                 }}
             >
-                <NameWithChangeInfo
-                    previousName={change.name}
-                    newName={change.payload.name}
-                />
+                <ViewDiff>View Diff</ViewDiff>
             </TooltipLink>
         </Truncated>
     </StyledContainer>

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -196,6 +196,7 @@ export interface IChangeRequestDeleteSegment {
     payload: {
         id: number;
         name: string;
+        snapshot?: ISegment;
     };
 }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<img width="598" alt="Screenshot 2024-11-27 at 16 42 59" src="https://github.com/user-attachments/assets/8d14d604-9964-4488-a002-3607752dce79">

Changes:
* edit segment has the same View Diff as edit strategy
* removing snapshot from diff comparison. Segment snapshots broke diffs

Next PRs:
* take update segment snapshots on apply change request similarly to update strategy 
* add tests for this UI component
* consider removing delete segment CR visualization since we can only remove unused segments so CRs never take part in segments removal

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
