### PR TITLE
fix: stop changing null to empty string when reading empty title

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -858,7 +858,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             segments: [],
             sortOrder: r.sort_order,
             id: r.strategy_id,
-            title: r.strategy_title || '',
+            title: r.strategy_title,
             disabled: r.strategy_disabled || false,
         };
         if (!includeId) {

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -444,6 +444,33 @@ test('Cloning a feature flag also clones segments correctly', async () => {
     ).toHaveLength(1);
 });
 
+test('Should not convert null title to empty string', async () => {
+    const featureName = 'FeatureNoTitle';
+    await service.createFeatureToggle(
+        'default',
+        {
+            name: featureName,
+        },
+        TEST_AUDIT_USER,
+    );
+    const config: Omit<FeatureStrategySchema, 'id'> = {
+        name: 'default',
+        constraints: [],
+        parameters: {},
+    };
+    await service.createStrategy(
+        config,
+        { projectId: 'default', featureName, environment: DEFAULT_ENV },
+        TEST_AUDIT_USER,
+    );
+
+    const feature = await service.getFeature({
+        featureName: featureName,
+    });
+
+    expect(feature.environments[0].strategies[0].title).toBe(null);
+});
+
 test('If change requests are enabled, cannot change variants without going via CR', async () => {
     const featureName = 'feature-with-variants-per-env-and-cr';
     await service.createFeatureToggle(


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When you don't specify title on strategy create you get null stored in a DB.

However when reading it back for edit you get:
<img width="260" alt="Screenshot 2024-11-28 at 11 09 14" src="https://github.com/user-attachments/assets/6fe1a4d7-0d75-4d6f-a820-13222e2b2c2d">
This is confusing since null got changed to empty string.

It also affects change request diffs:
<img width="175" alt="Screenshot 2024-11-28 at 10 48 05" src="https://github.com/user-attachments/assets/bccb51b8-5c41-44b8-a1dd-732cb2911b29">
I haven't changed the title but diff shows null to "" change

After this change when you edit strategy you get:
<img width="246" alt="Screenshot 2024-11-28 at 11 50 59" src="https://github.com/user-attachments/assets/036835c1-0840-4fde-b7bb-faf333e410ab">

I was also considering turning nulls into removed fields in the read strategy response but current solution seems to be ok.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
