### PR TITLE
fix: ignore segment order in diff calculation

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
@@ -333,3 +333,38 @@ test('Adding strategy always diffs against undefined strategy', async () => {
     await screen.findByText('Setting strategy variants to:');
     await screen.findByText('change_variant');
 });
+
+test('Segments order does not matter for diff calculation', async () => {
+    render(
+        <Routes>
+            <Route
+                path='/projects/:projectId'
+                element={
+                    <StrategyChange
+                        featureName={feature}
+                        environmentName={environmentName}
+                        projectId={projectId}
+                        changeRequestState='Applied'
+                        change={{
+                            action: 'updateStrategy',
+                            id: 1,
+                            payload: {
+                                ...strategy,
+                                segments: [3, 2, 1],
+                                snapshot: {
+                                    ...strategy,
+                                    segments: [1, 2, 3],
+                                },
+                            },
+                        }}
+                    />
+                }
+            />
+        </Routes>,
+        { route: `/projects/${projectId}` },
+    );
+
+    const viewDiff = await screen.findByText('View Diff');
+    await userEvent.hover(viewDiff);
+    await screen.findByText('(no changes)');
+});

--- a/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/StrategyTooltipLink/StrategyTooltipLink.tsx
@@ -28,6 +28,18 @@ const StyledCodeSection = styled('div')(({ theme }) => ({
     },
 }));
 
+const sortSegments = <T extends { segments?: number[] }>(
+    item?: T,
+): T | undefined => {
+    if (!item || !item.segments) {
+        return item;
+    }
+    return {
+        ...item,
+        segments: [...item.segments].sort((a, b) => a - b),
+    };
+};
+
 export const StrategyDiff: FC<{
     change:
         | IChangeRequestAddStrategy
@@ -38,12 +50,15 @@ export const StrategyDiff: FC<{
     const changeRequestStrategy =
         change.action === 'deleteStrategy' ? undefined : change.payload;
 
+    const sortedCurrentStrategy = sortSegments(currentStrategy);
+    const sortedChangeRequestStrategy = sortSegments(changeRequestStrategy);
+
     return (
         <StyledCodeSection>
             <EventDiff
                 entry={{
-                    preData: omit(currentStrategy, 'sortOrder'),
-                    data: omit(changeRequestStrategy, 'snapshot'),
+                    preData: omit(sortedCurrentStrategy, 'sortOrder'),
+                    data: omit(sortedChangeRequestStrategy, 'snapshot'),
                 }}
             />
         </StyledCodeSection>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Backend does not guarantee segment order (segments are more like a set than a list) so very often in diff calculation we get those results even when no segments changed in the CR
<img width="501" alt="Screenshot 2024-11-28 at 15 19 16" src="https://github.com/user-attachments/assets/7ebd38f3-7fcf-4241-b0b3-03daf63f1169">

After this fix we get info about no changes since we always sort segments before diffing
<img width="557" alt="Screenshot 2024-11-28 at 15 17 32" src="https://github.com/user-attachments/assets/d7762c03-75d8-4871-bad5-6cc5d6df3139">

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
