### PR TITLE
chore: filter out milestone strategies in features_view

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -535,12 +535,13 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 return a.sortOrder - b.sortOrder;
             });
             featureToggle.environments = featureToggle.environments.map((e) => {
-                e.strategies = e.strategies.sort(
-                    (a, b) => a.sortOrder - b.sortOrder,
-                );
                 if (e.strategies && e.strategies.length === 0) {
                     e.enabled = false;
                 }
+                e.strategies = e.strategies
+                    .filter(({ milestoneId }) => !milestoneId)
+                    .map(({ milestoneId, ...strategy }) => strategy)
+                    .sort((a, b) => a.sortOrder - b.sortOrder);
                 return e;
             });
 
@@ -860,6 +861,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             id: r.strategy_id,
             title: r.strategy_title,
             disabled: r.strategy_disabled || false,
+            milestoneId: r.strategy_milestone_id,
         };
         if (!includeId) {
             delete strategy.id;

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -535,13 +535,9 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 return a.sortOrder - b.sortOrder;
             });
             featureToggle.environments = featureToggle.environments.map((e) => {
-                if (e.strategies && e.strategies.length === 0) {
-                    e.enabled = false;
-                }
-                e.strategies = e.strategies
-                    .filter(({ milestoneId }) => !milestoneId)
-                    .map(({ milestoneId, ...strategy }) => strategy)
-                    .sort((a, b) => a.sortOrder - b.sortOrder);
+                e.strategies = e.strategies.sort(
+                    (a, b) => a.sortOrder - b.sortOrder,
+                );
                 return e;
             });
 
@@ -861,7 +857,6 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             id: r.strategy_id,
             title: r.strategy_title,
             disabled: r.strategy_disabled || false,
-            milestoneId: r.strategy_milestone_id,
         };
         if (!includeId) {
             delete strategy.id;

--- a/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
+++ b/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
@@ -39,13 +39,15 @@ exports.up = function (db, callback) {
           FROM
               features
                   LEFT JOIN feature_environments ON feature_environments.feature_name = features.name
-                  LEFT JOIN feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
+                  LEFT JOIN (
+                      SELECT *
+                      FROM feature_strategies
+                      WHERE milestone_id IS NULL
+                  ) AS feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
                   and feature_strategies.environment = feature_environments.environment
                   LEFT JOIN environments ON feature_environments.environment = environments.name
                   LEFT JOIN feature_strategy_segment as fss ON fss.feature_strategy_id = feature_strategies.id
-                  LEFT JOIN users ON users.id = features.created_by_user_id
-          WHERE
-              feature_strategies.milestone_id IS NULL;
+                  LEFT JOIN users ON users.id = features.created_by_user_id;
         `,
         callback,
     );

--- a/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
+++ b/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
@@ -32,7 +32,6 @@ exports.up = function (db, callback) {
               feature_strategies.title as strategy_title,
               feature_strategies.disabled as strategy_disabled,
               feature_strategies.variants as strategy_variants,
-              feature_strategies.milestone_id as strategy_milestone_id,
               users.id as user_id,
               users.name as user_name,
               users.username as user_username,
@@ -40,7 +39,11 @@ exports.up = function (db, callback) {
           FROM
               features
                   LEFT JOIN feature_environments ON feature_environments.feature_name = features.name
-                  LEFT JOIN feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
+                  LEFT JOIN (
+                      SELECT *
+                      FROM feature_strategies
+                      WHERE milestone_id IS NULL
+                  ) AS feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
                   and feature_strategies.environment = feature_environments.environment
                   LEFT JOIN environments ON feature_environments.environment = environments.name
                   LEFT JOIN feature_strategy_segment as fss ON fss.feature_strategy_id = feature_strategies.id

--- a/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
+++ b/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
@@ -32,6 +32,7 @@ exports.up = function (db, callback) {
               feature_strategies.title as strategy_title,
               feature_strategies.disabled as strategy_disabled,
               feature_strategies.variants as strategy_variants,
+              feature_strategies.milestone_id as strategy_milestone_id,
               users.id as user_id,
               users.name as user_name,
               users.username as user_username,
@@ -39,11 +40,7 @@ exports.up = function (db, callback) {
           FROM
               features
                   LEFT JOIN feature_environments ON feature_environments.feature_name = features.name
-                  LEFT JOIN (
-                      SELECT *
-                      FROM feature_strategies
-                      WHERE milestone_id IS NULL
-                  ) AS feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
+                  LEFT JOIN feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
                   and feature_strategies.environment = feature_environments.environment
                   LEFT JOIN environments ON feature_environments.environment = environments.name
                   LEFT JOIN feature_strategy_segment as fss ON fss.feature_strategy_id = feature_strategies.id

--- a/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
+++ b/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
@@ -1,0 +1,101 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+          DROP VIEW features_view;
+
+          CREATE VIEW features_view AS
+          SELECT
+              features.name as name,
+              features.description as description,
+              features.type as type,
+              features.project as project,
+              features.stale as stale,
+              features.impression_data as impression_data,
+              features.created_at as created_at,
+              features.archived_at as archived_at,
+              features.last_seen_at as last_seen_at,
+              feature_environments.last_seen_at as env_last_seen_at,
+              feature_environments.enabled as enabled,
+              feature_environments.environment as environment,
+              feature_environments.variants as variants,
+              environments.name as environment_name,
+              environments.type as environment_type,
+              environments.sort_order as environment_sort_order,
+              feature_strategies.id as strategy_id,
+              feature_strategies.strategy_name as strategy_name,
+              feature_strategies.parameters as parameters,
+              feature_strategies.constraints as constraints,
+              feature_strategies.sort_order as sort_order,
+              fss.segment_id as segments,
+              feature_strategies.title as strategy_title,
+              feature_strategies.disabled as strategy_disabled,
+              feature_strategies.variants as strategy_variants,
+              users.id as user_id,
+              users.name as user_name,
+              users.username as user_username,
+              users.email as user_email
+          FROM
+              features
+                  LEFT JOIN feature_environments ON feature_environments.feature_name = features.name
+                  LEFT JOIN feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
+                  and feature_strategies.environment = feature_environments.environment
+                  LEFT JOIN environments ON feature_environments.environment = environments.name
+                  LEFT JOIN feature_strategy_segment as fss ON fss.feature_strategy_id = feature_strategies.id
+                  LEFT JOIN users ON users.id = features.created_by_user_id
+          WHERE
+              feature_strategies.milestone_id IS NULL;
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+          DROP VIEW features_view;
+
+          CREATE VIEW features_view AS
+          SELECT
+              features.name as name,
+              features.description as description,
+              features.type as type,
+              features.project as project,
+              features.stale as stale,
+              features.impression_data as impression_data,
+              features.created_at as created_at,
+              features.archived_at as archived_at,
+              features.last_seen_at as last_seen_at,
+              feature_environments.last_seen_at as env_last_seen_at,
+              feature_environments.enabled as enabled,
+              feature_environments.environment as environment,
+              feature_environments.variants as variants,
+              environments.name as environment_name,
+              environments.type as environment_type,
+              environments.sort_order as environment_sort_order,
+              feature_strategies.id as strategy_id,
+              feature_strategies.strategy_name as strategy_name,
+              feature_strategies.parameters as parameters,
+              feature_strategies.constraints as constraints,
+              feature_strategies.sort_order as sort_order,
+              fss.segment_id as segments,
+              feature_strategies.title as strategy_title,
+              feature_strategies.disabled as strategy_disabled,
+              feature_strategies.variants as strategy_variants,
+              users.id as user_id,
+              users.name as user_name,
+              users.username as user_username,
+              users.email as user_email
+          FROM
+              features
+                  LEFT JOIN feature_environments ON feature_environments.feature_name = features.name
+                  LEFT JOIN feature_strategies ON feature_strategies.feature_name = feature_environments.feature_name
+                  and feature_strategies.environment = feature_environments.environment
+                  LEFT JOIN environments ON feature_environments.environment = environments.name
+                  LEFT JOIN feature_strategy_segment as fss ON fss.feature_strategy_id = feature_strategies.id
+                  LEFT JOIN users ON users.id = features.created_by_user_id;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3033/filter-out-release-plan-milestone-strategies-from-admin-feature

Filters out milestone strategies from our `features_view`.

This felt like the most elegant way to address this, since it seems we only rely on this view to fetch the feature strategies in the admin UI.


### No more milestone strategies showing up on our UI when we have a running milestone

![image](https://github.com/user-attachments/assets/02bac5a5-7ddb-4bde-b487-8b6bca0923b5)

### However they're still part of the client features response

```json
{
	"name": "r-plan",
	"type": "release",
	"enabled": false,
	"project": "default",
	"stale": false,
	"strategies": [
		{
			"name": "flexibleRollout",
			"constraints": [
				{
					"values": [
						"Portugal"
					],
					"inverted": false,
					"operator": "IN",
					"contextName": "country",
					"caseInsensitive": false
				},
				{
					"values": [
						"Portugal",
						"Norway"
					],
					"inverted": false,
					"operator": "IN",
					"contextName": "country",
					"caseInsensitive": false
				}
			],
			"parameters": {
				"groupId": "newOverview",
				"rollout": "100",
				"stickiness": "default"
			},
			"variants": [
				{
					"name": "A",
					"weight": 500,
					"stickiness": "default",
					"weightType": "variable"
				},
				{
					"name": "B",
					"weight": 500,
					"stickiness": "default",
					"weightType": "variable"
				}
			]
		},
		{
			"name": "flexibleRollout",
			"constraints": [],
			"parameters": {
				"groupId": "much_feature",
				"rollout": "25",
				"stickiness": "default"
			},
			"variants": []
		},
		{
			"name": "flexibleRollout",
			"constraints": [],
			"parameters": {
				"groupId": "r-plan",
				"rollout": "100",
				"stickiness": "default"
			},
			"variants": []
		}
	],
	"variants": [],
	"description": null,
	"impressionData": false
},
```