### PR TITLE
1-3163: align copy to seats used and change in -> over

### DIFF
--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersBox.tsx
@@ -84,7 +84,7 @@ export const LicensedUsersBox = () => {
             </TopRow>
 
             <StyledCaption>
-                <span>Seats used in the last 30 days</span>
+                <span>Seats used over the last 30 days</span>
                 <OpenSidebarButton />
             </StyledCaption>
         </Figure>

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersChart.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersChart.tsx
@@ -16,7 +16,7 @@ export const LicensedUsersChart: FC<ILicensedUsersChartProps> = ({
     const data = {
         datasets: [
             {
-                label: 'Licensed users',
+                label: 'Seats used',
                 data: licensedUsers,
                 borderColor: theme.palette.primary.main,
                 backgroundColor: theme.palette.primary.main,

--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersSidebar.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersSidebar.tsx
@@ -102,7 +102,7 @@ export const LicensedUsersSidebar = ({
                                     {data.seatCount}
                                 </Typography>
                                 <Typography variant='body2'>
-                                    Used seats last 30 days
+                                    Seats used over the last 30 days
                                 </Typography>
                             </LicenceBox>
                             <Alert severity='info'>


### PR DESCRIPTION
Changes "licensed users" to "seats used" as requested. Also slightly adjusts the copy a few other places.