### PR TITLE
1-3060: remove features export import flag 

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleActions.test.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleActions.test.tsx
@@ -7,9 +7,7 @@ import { testServerRoute, testServerSetup } from 'utils/testServer';
 const server = testServerSetup();
 test('all options are drawn', async () => {
     testServerRoute(server, '/api/admin/ui-config', {
-        flags: {
-            featuresExportImport: true,
-        },
+        flags: {},
     });
 
     render(<FeatureToggleListActions onExportClick={() => {}} />);

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleActions.test.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleActions.test.tsx
@@ -6,9 +6,7 @@ import { testServerRoute, testServerSetup } from 'utils/testServer';
 
 const server = testServerSetup();
 test('all options are drawn', async () => {
-    testServerRoute(server, '/api/admin/ui-config', {
-        flags: {},
-    });
+    testServerRoute(server, '/api/admin/ui-config', {});
 
     render(<FeatureToggleListActions onExportClick={() => {}} />);
 

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleListActions.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleListActions.tsx
@@ -13,8 +13,6 @@ import {
 import Add from '@mui/icons-material/Add';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { Link } from 'react-router-dom';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { useUiFlag } from 'hooks/useUiFlag';
 import { CREATE_FEATURE } from 'component/providers/AccessProvider/permissions';
 import { PermissionHOC } from 'component/common/PermissionHOC/PermissionHOC';
 import { useCreateFeaturePath } from 'component/feature/CreateFeatureButton/useCreateFeaturePath';
@@ -40,7 +38,6 @@ export const FeatureToggleListActions: FC<IFeatureFlagListActions> = ({
 }: IFeatureFlagListActions) => {
     const { trackEvent } = usePlausibleTracker();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-    const featuresExportImport = useUiFlag('featuresExportImport');
     const createFeature = useCreateFeaturePath({
         query: '',
         project: 'default',
@@ -123,31 +120,24 @@ export const FeatureToggleListActions: FC<IFeatureFlagListActions> = ({
                             </MenuItem>
                         )}
                     </PermissionHOC>
-                    <ConditionallyRender
-                        condition={featuresExportImport}
-                        show={
-                            <MenuItem
-                                onClick={() => {
-                                    onExportClick();
-                                    handleClose();
-                                    trackEvent('search-feature-buttons', {
-                                        props: {
-                                            action: 'export',
-                                        },
-                                    });
-                                }}
-                            >
-                                <ListItemIcon>
-                                    <IosShare />
-                                </ListItemIcon>
-                                <ListItemText>
-                                    <Typography variant='body2'>
-                                        Export
-                                    </Typography>
-                                </ListItemText>
-                            </MenuItem>
-                        }
-                    />
+                    <MenuItem
+                        onClick={() => {
+                            onExportClick();
+                            handleClose();
+                            trackEvent('search-feature-buttons', {
+                                props: {
+                                    action: 'export',
+                                },
+                            });
+                        }}
+                    >
+                        <ListItemIcon>
+                            <IosShare />
+                        </ListItemIcon>
+                        <ListItemText>
+                            <Typography variant='body2'>Export</Typography>
+                        </ListItemText>
+                    </MenuItem>
                 </MenuList>
             </StyledPopover>
         </StyledActions>

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -339,16 +339,11 @@ export const FeatureToggleListTable: VFC = () => {
                     </Box>
                 }
             />
-            <ConditionallyRender
-                condition={Boolean(uiConfig?.flags?.featuresExportImport)}
-                show={
-                    <ExportDialog
-                        showExportDialog={showExportDialog}
-                        data={data}
-                        onClose={() => setShowExportDialog(false)}
-                        environments={enabledEnvironments}
-                    />
-                }
+            <ExportDialog
+                showExportDialog={showExportDialog}
+                data={data}
+                onClose={() => setShowExportDialog(false)}
+                environments={enabledEnvironments}
             />
         </PageContent>
     );

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -59,11 +59,11 @@ export const FlagCreationButton = ({
     skipNavigationOnComplete,
     onSuccess,
 }: IFlagCreationButtonProps) => {
+    const { loading } = useUiConfig();
     const [searchParams] = useSearchParams();
     const projectId = useRequiredPathParam('projectId');
     const showCreateDialog = Boolean(searchParams.get('create'));
     const [openCreateDialog, setOpenCreateDialog] = useState(showCreateDialog);
-    const { loading } = useUiConfig();
 
     return (
         <>
@@ -104,7 +104,6 @@ export const ProjectFeatureTogglesHeader: FC<
     const [showTitle, setShowTitle] = useState(true);
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-    const featuresExportImportFlag = useUiFlag('featuresExportImport');
     const [showExportDialog, setShowExportDialog] = useState(false);
     const { trackEvent } = usePlausibleTracker();
     const projectOverviewRefactorFeedback = useUiFlag(
@@ -168,48 +167,36 @@ export const ProjectFeatureTogglesHeader: FC<
                         />
                         {actions}
                         <PageHeader.Divider sx={{ marginLeft: 0 }} />
-                        <ConditionallyRender
-                            condition={featuresExportImportFlag}
-                            show={
-                                <>
-                                    <Tooltip
-                                        title='Export all project flags'
-                                        arrow
-                                    >
-                                        <IconButton
-                                            data-loading
-                                            onClick={() =>
-                                                setShowExportDialog(true)
-                                            }
-                                            sx={(theme) => ({
-                                                marginRight: theme.spacing(2),
-                                            })}
-                                        >
-                                            <IosShare />
-                                        </IconButton>
-                                    </Tooltip>
+                        <>
+                            <Tooltip title='Export all project flags' arrow>
+                                <IconButton
+                                    data-loading
+                                    onClick={() => setShowExportDialog(true)}
+                                    sx={(theme) => ({
+                                        marginRight: theme.spacing(2),
+                                    })}
+                                >
+                                    <IosShare />
+                                </IconButton>
+                            </Tooltip>
 
-                                    <ConditionallyRender
-                                        condition={!isLoading}
-                                        show={
-                                            <ExportDialog
-                                                showExportDialog={
-                                                    showExportDialog
-                                                }
-                                                project={projectId}
-                                                data={[]}
-                                                onClose={() =>
-                                                    setShowExportDialog(false)
-                                                }
-                                                environments={
-                                                    environmentsToExport || []
-                                                }
-                                            />
+                            <ConditionallyRender
+                                condition={!isLoading}
+                                show={
+                                    <ExportDialog
+                                        showExportDialog={showExportDialog}
+                                        project={projectId}
+                                        data={[]}
+                                        onClose={() =>
+                                            setShowExportDialog(false)
+                                        }
+                                        environments={
+                                            environmentsToExport || []
                                         }
                                     />
-                                </>
-                            }
-                        />
+                                }
+                            />
+                        </>
                         <ConditionallyRender
                             condition={
                                 projectOverviewRefactorFeedback &&

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -167,36 +167,30 @@ export const ProjectFeatureTogglesHeader: FC<
                         />
                         {actions}
                         <PageHeader.Divider sx={{ marginLeft: 0 }} />
-                        <>
-                            <Tooltip title='Export all project flags' arrow>
-                                <IconButton
-                                    data-loading
-                                    onClick={() => setShowExportDialog(true)}
-                                    sx={(theme) => ({
-                                        marginRight: theme.spacing(2),
-                                    })}
-                                >
-                                    <IosShare />
-                                </IconButton>
-                            </Tooltip>
+                        <Tooltip title='Export all project flags' arrow>
+                            <IconButton
+                                data-loading
+                                onClick={() => setShowExportDialog(true)}
+                                sx={(theme) => ({
+                                    marginRight: theme.spacing(2),
+                                })}
+                            >
+                                <IosShare />
+                            </IconButton>
+                        </Tooltip>
 
-                            <ConditionallyRender
-                                condition={!isLoading}
-                                show={
-                                    <ExportDialog
-                                        showExportDialog={showExportDialog}
-                                        project={projectId}
-                                        data={[]}
-                                        onClose={() =>
-                                            setShowExportDialog(false)
-                                        }
-                                        environments={
-                                            environmentsToExport || []
-                                        }
-                                    />
-                                }
-                            />
-                        </>
+                        <ConditionallyRender
+                            condition={!isLoading}
+                            show={
+                                <ExportDialog
+                                    showExportDialog={showExportDialog}
+                                    project={projectId}
+                                    data={[]}
+                                    onClose={() => setShowExportDialog(false)}
+                                    environments={environmentsToExport || []}
+                                />
+                            }
+                        />
                         <ConditionallyRender
                             condition={
                                 projectOverviewRefactorFeedback &&

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -302,10 +302,7 @@ export const Project = () => {
                         </StyledDiv>
                         <StyledDiv>
                             <ConditionallyRender
-                                condition={Boolean(
-                                    !simplifyProjectOverview &&
-                                        uiConfig?.flags?.featuresExportImport,
-                                )}
+                                condition={Boolean(!simplifyProjectOverview)}
                                 show={
                                     <PermissionIconButton
                                         permission={UPDATE_FEATURE}

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -56,7 +56,6 @@ export type UiFlags = {
     maintenanceMode?: boolean;
     messageBanner?: Variant;
     banner?: Variant;
-    featuresExportImport?: boolean;
     caseInsensitiveInOperators?: boolean;
     notifications?: boolean;
     personalAccessTokensKillSwitch?: boolean;

--- a/src/lib/features/export-import-toggles/export-import-controller.ts
+++ b/src/lib/features/export-import-toggles/export-import-controller.ts
@@ -22,7 +22,7 @@ import {
 } from '../../openapi';
 import type { IAuthRequest } from '../../routes/unleash-types';
 import { extractUsername } from '../../util';
-import { BadDataError, InvalidOperationError } from '../../error';
+import { BadDataError } from '../../error';
 import ApiUser from '../../types/api-user';
 
 class ExportImportController extends Controller {
@@ -116,7 +116,6 @@ class ExportImportController extends Controller {
         req: IAuthRequest<unknown, unknown, ExportQuerySchema, unknown>,
         res: Response,
     ): Promise<void> {
-        this.verifyExportImportEnabled();
         const query = req.body;
         const userName = extractUsername(req);
 
@@ -134,7 +133,6 @@ class ExportImportController extends Controller {
         req: IAuthRequest<unknown, unknown, ImportTogglesSchema, unknown>,
         res: Response,
     ): Promise<void> {
-        this.verifyExportImportEnabled();
         const dto = req.body;
         const { user } = req;
 
@@ -154,7 +152,6 @@ class ExportImportController extends Controller {
         req: IAuthRequest<unknown, unknown, ImportTogglesSchema, unknown>,
         res: Response,
     ): Promise<void> {
-        this.verifyExportImportEnabled();
         const { user, audit } = req;
 
         if (user instanceof ApiUser && user.type === 'admin') {
@@ -170,14 +167,6 @@ class ExportImportController extends Controller {
         );
 
         res.status(200).end();
-    }
-
-    private verifyExportImportEnabled() {
-        if (!this.config.flagResolver.isEnabled('featuresExportImport')) {
-            throw new InvalidOperationError(
-                'Feature export/import is not enabled',
-            );
-        }
     }
 }
 export default ExportImportController;

--- a/src/lib/features/export-import-toggles/export-import-permissions.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import-permissions.e2e.test.ts
@@ -249,9 +249,7 @@ beforeAll(async () => {
         db.stores,
         {
             experimental: {
-                flags: {
-                    featuresExportImport: true,
-                },
+                flags: {},
             },
         },
         db.rawDatabase,

--- a/src/lib/features/export-import-toggles/export-import.e2e.test.ts
+++ b/src/lib/features/export-import-toggles/export-import.e2e.test.ts
@@ -155,9 +155,7 @@ beforeAll(async () => {
         db.stores,
         {
             experimental: {
-                flags: {
-                    featuresExportImport: true,
-                },
+                flags: {},
             },
         },
         db.rawDatabase,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -13,7 +13,6 @@ export type IFlagKey =
     | 'responseTimeWithAppNameKillSwitch'
     | 'maintenanceMode'
     | 'messageBanner'
-    | 'featuresExportImport'
     | 'caseInsensitiveInOperators'
     | 'strictSchemaValidation'
     | 'personalAccessTokensKillSwitch'
@@ -96,10 +95,6 @@ const flags: IFlags = {
                 process.env.UNLEASH_EXPERIMENTAL_MESSAGE_BANNER_PAYLOAD ?? '',
         },
     },
-    featuresExportImport: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_FEATURES_EXPORT_IMPORT,
-        true,
-    ),
     caseInsensitiveInOperators: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CASE_INSENSITIVE_IN_OPERATORS,
         false,


### PR DESCRIPTION
This PR removes all references to the `featuresExportImport` flag.

The flag was introduced in [PR #3411](https://github.com/Unleash/unleash/pull/3411) on March 29th 2023, and the flag was archived on April 3rd. The flag has always defaulted to true.

I think it's safe to remove now.