### PR TITLE
docs: enviroment->environment

### DIFF
--- a/website/docs/reference/api/legacy/unleash/admin/features-v2.mdx
+++ b/website/docs/reference/api/legacy/unleash/admin/features-v2.mdx
@@ -709,7 +709,7 @@ Content-Type: application/json; charset=utf-8
 
 This API documentation is no longer maintained. You should use the [OpenAPI docs for this endpoint](/docs/reference/api/unleash/overwrite-feature-variants.api.mdx) instead.
 
-This endpoint affects all environments at once. If you only want to update a single environment, use the [operation for updating variants per enviroment](/docs/reference/api/unleash/overwrite-feature-variants-on-environments.api.mdx) instead.
+This endpoint affects all environments at once. If you only want to update a single environment, use the [operation for updating variants per environment](/docs/reference/api/unleash/overwrite-feature-variants-on-environments.api.mdx) instead.
 
 :::
 


### PR DESCRIPTION
Fixes a typo so we get a new hash