### PR TITLE
chore: improve release plan events and add them to event timeline

### DIFF
--- a/frontend/src/component/events/EventTimeline/EventTimeline.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimeline.tsx
@@ -99,6 +99,9 @@ const RELEVANT_EVENT_TYPES: EventSchemaType[] = [
     'feature-strategy-remove',
     'feature-environment-enabled',
     'feature-environment-disabled',
+    'release-plan-added',
+    'release-plan-removed',
+    'release-plan-milestone-started',
 ];
 
 const toISODateString = (date: Date) => date.toISOString().split('T')[0];

--- a/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
+++ b/frontend/src/component/events/EventTimeline/EventTimelineEventGroup/EventTimelineEventCircle.tsx
@@ -59,7 +59,11 @@ const getEventIcon = ({ icon, type }: Pick<TimelineEvent, 'icon' | 'type'>) => {
     if (type === 'feature-environment-disabled') {
         return <ToggleOffIcon />;
     }
-    if (type.startsWith('strategy-') || type.startsWith('feature-strategy-')) {
+    if (
+        type.startsWith('strategy-') ||
+        type.startsWith('feature-strategy-') ||
+        type.startsWith('release-plan-')
+    ) {
         return (
             <ExtensionOutlinedIcon
                 sx={{ marginTop: '-2px', marginRight: '-2px' }}

--- a/src/lib/addons/feature-event-formatter-md-events.ts
+++ b/src/lib/addons/feature-event-formatter-md-events.ts
@@ -58,6 +58,9 @@ import {
     CHANGE_REQUEST_SCHEDULE_SUSPENDED,
     FEATURE_COMPLETED,
     PROJECT_ARCHIVED,
+    RELEASE_PLAN_ADDED,
+    RELEASE_PLAN_REMOVED,
+    RELEASE_PLAN_MILESTONE_STARTED,
 } from '../types';
 
 interface IEventData {
@@ -361,5 +364,20 @@ export const EVENT_MAP: Record<string, IEventData> = {
         label: 'User updated',
         action: '{{b}}{{user}}{{b}} updated user {{b}}{{event.preData.name}}{{b}}',
         path: '/admin/users',
+    },
+    [RELEASE_PLAN_ADDED]: {
+        label: 'Release plan added',
+        action: '{{b}}{{user}}{{b}} added release plan {{b}}{{event.data.name}}{{b}} to {{b}}{{feature}}{{b}} for the {{b}}{{event.environment}}{{b}} environment in project {{b}}{{project}}{{b}}',
+        path: '/projects/{{event.project}}/features/{{event.featureName}}',
+    },
+    [RELEASE_PLAN_REMOVED]: {
+        label: 'Release plan removed',
+        action: '{{b}}{{user}}{{b}} removed release plan {{b}}{{event.preData.name}}{{b}} from {{b}}{{feature}}{{b}} for the {{b}}{{event.environment}}{{b}} environment in project {{b}}{{project}}{{b}}',
+        path: '/projects/{{event.project}}/features/{{event.featureName}}',
+    },
+    [RELEASE_PLAN_MILESTONE_STARTED]: {
+        label: 'Release plan milestone started',
+        action: '{{b}}{{user}}{{b}} started milestone {{b}}{{event.data.milestoneName}}{{b}} in release plan {{b}}{{event.data.name}}{{b}} for {{b}}{{feature}}{{b}} for the {{b}}{{event.environment}}{{b}} environment in project {{b}}{{project}}{{b}}',
+        path: '/projects/{{event.project}}/features/{{event.featureName}}',
     },
 };

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -2067,36 +2067,63 @@ export class ReleasePlanTemplateDeletedEvent extends BaseEvent {
 }
 
 export class ReleasePlanAddedEvent extends BaseEvent {
+    readonly project: string;
+    readonly featureName: string;
+    readonly environment: string;
     readonly data: any;
     constructor(eventData: {
+        project: string;
+        featureName: string;
+        environment: string;
         data: any;
         auditUser: IAuditUser;
     }) {
         super(RELEASE_PLAN_ADDED, eventData.auditUser);
+        this.project = eventData.project;
+        this.featureName = eventData.featureName;
+        this.environment = eventData.environment;
         this.data = eventData.data;
     }
 }
 
 export class ReleasePlanRemovedEvent extends BaseEvent {
+    readonly project: string;
+    readonly featureName: string;
+    readonly environment: string;
     readonly preData: any;
     constructor(eventData: {
+        project: string;
+        featureName: string;
+        environment: string;
         preData: any;
         auditUser: IAuditUser;
     }) {
         super(RELEASE_PLAN_REMOVED, eventData.auditUser);
+        this.project = eventData.project;
+        this.featureName = eventData.featureName;
+        this.environment = eventData.environment;
         this.preData = eventData.preData;
     }
 }
 
 export class ReleasePlanMilestoneStartedEvent extends BaseEvent {
+    readonly project: string;
+    readonly featureName: string;
+    readonly environment: string;
     readonly preData: any;
     readonly data: any;
     constructor(eventData: {
+        project: string;
+        featureName: string;
+        environment: string;
         preData: any;
         data: any;
         auditUser: IAuditUser;
     }) {
         super(RELEASE_PLAN_MILESTONE_STARTED, eventData.auditUser);
+        this.project = eventData.project;
+        this.featureName = eventData.featureName;
+        this.environment = eventData.environment;
         this.preData = eventData.preData;
         this.data = eventData.data;
     }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3043/improve-release-plan-events-and-add-them-to-the-event-timeline

Improves release plan events and adds them to the event timeline.

This will break the events in Enterprise but that's okay, we can follow up with the Enterprise PR to fix them.

![image](https://github.com/user-attachments/assets/862818a5-d9bf-4006-beca-786fd6265759)