### PR TITLE
docs: update React Native / Expo community SDK entry

### DIFF
--- a/website/docs/reference/sdks/index.mdx
+++ b/website/docs/reference/sdks/index.mdx
@@ -127,7 +127,7 @@ Here's some of the fantastic work our community has done to make Unleash work in
 -   NestJS - Node.js ([pmb0/nestjs-unleash](https://github.com/pmb0/nestjs-unleash))
 -   PHP ([minds/unleash-client-php](https://gitlab.com/minds/unleash-client-php))
 -   PHP - Symfony ([Stogon/unleash-bundle](https://github.com/Stogon/unleash-bundle))
--   React Native / Expo ([nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native))
+-   React Native / Expo ([nunogois/unleash-react-native](https://github.com/nunogois/unleash-react-native))
 -   Solid ([nunogois/proxy-client-solid](https://github.com/nunogois/proxy-client-solid))
 -   _...your implementation for your favorite language._
 


### PR DESCRIPTION
Updates our React Native / Expo community SDK entry from the deprecated **[@nunogois/proxy-client-react-native](https://github.com/nunogois/proxy-client-react-native)** to the new **[@nunogois/unleash-react-native](https://github.com/nunogois/unleash-react-native)**.