### PR TITLE
fix: Change Open API validation middleware to specify and use path parameters

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -193,10 +193,6 @@ export default async function getApp(
     // Setup API routes
     app.use(`${baseUriPath}/`, new IndexRouter(config, services, db).router);
 
-    if (services.openApiService) {
-        services.openApiService.useErrorHandler(app);
-    }
-
     if (process.env.NODE_ENV !== 'production') {
         app.use(errorHandler());
     } else {

--- a/src/lib/routes/controller.ts
+++ b/src/lib/routes/controller.ts
@@ -65,7 +65,7 @@ const checkPrivateProjectPermissions = () => async (req, res, next) => {
     return res.status(404).end();
 };
 
-const checkOpenAPIValidationError = async (err, req, res, next) => {
+const openAPIValidationMiddleware = async (err, req, res, next) => {
     if (err?.status && err.validationErrors) {
         const apiError = fromOpenApiValidationErrors(req, err.validationErrors);
 
@@ -126,7 +126,7 @@ export default class Controller {
             this.useRouteErrorHandler(options.handler.bind(this)),
         );
 
-        this.app.use(options.path, checkOpenAPIValidationError);
+        this.app.use(options.path, openAPIValidationMiddleware);
     }
 
     get(

--- a/src/lib/routes/controller.ts
+++ b/src/lib/routes/controller.ts
@@ -65,7 +65,7 @@ const checkPrivateProjectPermissions = () => async (req, res, next) => {
     return res.status(404).end();
 };
 
-const checkOpenAPIValidationError = () => async (err, req, res, next) => {
+const checkOpenAPIValidationError = async (err, req, res, next) => {
     if (err?.status && err.validationErrors) {
         const apiError = fromOpenApiValidationErrors(req, err.validationErrors);
 
@@ -126,7 +126,7 @@ export default class Controller {
             this.useRouteErrorHandler(options.handler.bind(this)),
         );
 
-        this.app.use(options.path, checkOpenAPIValidationError());
+        this.app.use(options.path, checkOpenAPIValidationError);
     }
 
     get(

--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -11,7 +11,6 @@ import type { ApiOperation } from '../openapi/util/api-operation';
 import type { Logger } from '../logger';
 import { validateSchema } from '../openapi/validate';
 import type { IFlagResolver } from '../types';
-import { fromOpenApiValidationErrors } from '../error/bad-data-error';
 
 export class OpenApiService {
     private readonly config: IUnleashConfig;
@@ -57,21 +56,6 @@ export class OpenApiService {
     ): void {
         Object.entries(schemas).forEach(([name, schema]) => {
             this.api.schema(name, removeJsonSchemaProps(schema));
-        });
-    }
-
-    useErrorHandler(app: Express): void {
-        app.use((err, req, res, next) => {
-            if (err?.status && err.validationErrors) {
-                const apiError = fromOpenApiValidationErrors(
-                    req,
-                    err.validationErrors,
-                );
-
-                res.status(apiError.statusCode).json(apiError);
-            } else {
-                next(err);
-            }
         });
     }
 


### PR DESCRIPTION
## About the changes

### Context

I removed `idNumberMiddleware` and changed to use Open API validation process to validate path parameters in #8734 .

However, Express can't parse path parameters if they don't exist in the path, which is the first argument of the method such as `use`, hence it is impossible to parse them by using `useErrorHandler` method like the one below.

```TypeScript
    useErrorHandler(app: Express): void {
        // We need to pass a specific parameter such as `/:segmentId` as the first argument of the `use` method.
        // ex. `app.use('/:segmentId/, (err, req, res, next) => { ... }`
        app.use((err, req, res, next) => {
            if (err?.status && err.validationErrors) {
                const apiError = fromOpenApiValidationErrors(
                    req,
                    err.validationErrors,
                );

                res.status(apiError.statusCode).json(apiError);
            } else {
                next(err);
            }
        });
    }

```

Nevertheless, we can't pass the specific path parameter to `useErrorHandler` because it is defined on the top level, `app.ts` file. Consequently, we need to handle it on the controller level, `/routs/controller.ts`,  like the one below.

```TypeScript
// Open API validation handler the same as inner logic of `useErrorHandler` method.
const checkOpenAPIValidationError = () => async (err, req, res, next) => {
    if (err?.status && err.validationErrors) {
        const apiError = fromOpenApiValidationErrors(req, err.validationErrors);

        res.status(apiError.statusCode).json(apiError);
    } else {
        next(err);
    }
};

export default class Controller {

    route(options: IRouteOptions): void {
        this.app[options.method](
            options.path,
            storeRequestedRoute,
            checkPermission(options.permission),
            checkPrivateProjectPermissions(),
            this.useContentTypeMiddleware(options),
            this.useRouteErrorHandler(options.handler.bind(this)),
        );

        // Add OpenAPI validation handler with specified path parameter, `options.path`, and now Express can handle them.
        this.app.use(options.path, checkOpenAPIValidationError());
    }
}
```

I moved Open API validation handler to the controller layer to reuse on all services such as project and segments, and also removed unnecessary middleware at the top level, `app.ts`, and method, `useErrorHandler` in `openapi-service.ts`.

### Important files

#### Before

<img width="1510" alt="1  Before" src="https://github.com/user-attachments/assets/96ac245d-92ac-469e-a097-c6c0b78d0def">

Express cant' parse the path parameter because it doesn't be specified on the `use` method. Therefore, it returns `undefined` as an error message.

#### After

<img width="1510" alt="2  After" src="https://github.com/user-attachments/assets/501dae6c-fef5-4e77-94c3-128a9f7210da">

Express can parse the path parameter because I change to specify it on the controller layer. Accordingly, it returns `test`.

## Discussion points

- I think we don't need to add tests about this change because there are already some tests of the `fromOpenApiValidatoinError`.
