### PR TITLE
fix: Concurrency issue when creating a user by using database error

### DIFF
--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -253,11 +253,6 @@ class UserService {
                 );
             }
 
-            const exists = await this.store.hasUser({ username, email });
-            if (exists) {
-                throw new BadDataError('User already exists');
-            }
-
             const user = await this.store.insert({
                 username,
                 email,

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -162,6 +162,22 @@ test('should not be allowed to create existing user', async () => {
     ).rejects.toThrow(Error);
 });
 
+test('should not be allowed to create existing user in a concurrency situation', async () => {
+    const username = 'test';
+    const calls = [
+        userService.createUser(
+            { username, rootRole: adminRole.id },
+            TEST_AUDIT_USER,
+        ),
+        userService.createUser(
+            { username, rootRole: adminRole.id },
+            TEST_AUDIT_USER,
+        ),
+    ];
+
+    await expect(Promise.all(calls)).rejects.toThrow('User already exists');
+});
+
 test('should create user with password', async () => {
     const recordedEvents: Array<{ loginOrder: number }> = [];
     eventBus.on(USER_LOGIN, (data) => {

--- a/src/test/e2e/services/user-service.e2e.test.ts
+++ b/src/test/e2e/services/user-service.e2e.test.ts
@@ -159,7 +159,7 @@ test('should not be allowed to create existing user', async () => {
             { username: 'test', rootRole: adminRole.id },
             TEST_AUDIT_USER,
         ),
-    ).rejects.toThrow(Error);
+    ).rejects.toThrow('User already exists');
 });
 
 test('should not be allowed to create existing user in a concurrency situation', async () => {


### PR DESCRIPTION
## About the changes

### Context

I got `500 Internal Server Error` when trying to create a new user like the image below because the user service layer has a concurrency issue. 

<img width="1040" alt="1. Concurrency Issue" src="https://github.com/user-attachments/assets/6966a8d2-b893-4380-ae44-52bdce90cf35">

The previous validation, using `hasUser` method, can't guarantee to check existing users properly in a concurrent situation because `SELECT` transaction can't retrieve uncommitted data, which refers a read committed isolation. You can simply understand this concurrency issue with the image below.

<img width="980" alt="2. Concurrency Issue Diagram" src="https://github.com/user-attachments/assets/a5fe4bf4-5075-4bbb-abd1-ddc3003fd6c1">

Therefore, I add `catch` statement to handle the an unique violation error from database because it is thrown by `INSERT` transaction, and add a test case to ensure resolving the concurrency issue. The test will be failed like the image below if it doesn't handle the concurrency situation.

<img width="1510" alt="3. Failed Test" src="https://github.com/user-attachments/assets/e3adf498-bb88-4389-ba56-376559d5d807">


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

I removed `hasUser` method on `createUser` method because it is unnecessary. It is only used on `upsert` method and test codes. I think it is enough to check an existing user by the unique violation.