### PR TITLE
chore(unl-204): make toasts smaller

### DIFF
--- a/frontend/src/component/common/CheckmarkBadge/CheckMarkBadge.tsx
+++ b/frontend/src/component/common/CheckmarkBadge/CheckMarkBadge.tsx
@@ -1,46 +1,16 @@
-import Check from '@mui/icons-material/Check';
-import Close from '@mui/icons-material/Close';
-import { styled } from '@mui/material';
+import Check from '@mui/icons-material/CheckCircle';
+import Cancel from '@mui/icons-material/Cancel';
 
 interface ICheckMarkBadgeProps {
     className: string;
     type?: string;
 }
 
-const StyledBatch = styled('div')(({ theme }) => ({
-    backgroundColor: theme.palette.background.alternative,
-    width: '75px',
-    height: '75px',
-    borderRadius: '50px',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    [theme.breakpoints.down('sm')]: {
-        width: '50px',
-        height: '50px',
-    },
-}));
-
-const StyledClose = styled(Close)(({ theme }) => ({
-    color: theme.palette.common.white,
-    width: '35px',
-    height: '35px',
-}));
-const StyledCheck = styled(Check)(({ theme }) => ({
-    color: theme.palette.common.white,
-    width: '35px',
-    height: '35px',
-}));
-
-const CheckMarkBadge = ({ type, className }: ICheckMarkBadgeProps) => {
-    return (
-        <StyledBatch className={className}>
-            {type === 'error' ? (
-                <StyledClose titleAccess='Error' />
-            ) : (
-                <StyledCheck />
-            )}
-        </StyledBatch>
+const CheckMarkBadge = ({ type }: ICheckMarkBadgeProps) => {
+    return type === 'error' ? (
+        <Cancel color='primary' titleAccess='Error' />
+    ) : (
+        <Check color='primary' />
     );
 };
 

--- a/frontend/src/component/common/ToastRenderer/Toast/Toast.styles.ts
+++ b/frontend/src/component/common/ToastRenderer/Toast/Toast.styles.ts
@@ -8,7 +8,7 @@ export const useStyles = makeStyles()((theme) => ({
         zIndex: 500,
         margin: '0 0.8rem',
         borderRadius: theme.shape.borderRadiusMedium,
-        padding: theme.spacing(0.5),
+        padding: theme.spacing(1),
         paddingInlineStart: theme.spacing(2),
     },
     innerContainer: {
@@ -17,19 +17,11 @@ export const useStyles = makeStyles()((theme) => ({
     starting: {
         opacity: 0,
     },
-    headerContainer: {
-        display: 'flex',
-        alignItems: 'center',
-    },
     confettiContainer: {
         position: 'relative',
         maxWidth: '600px',
         margin: '0 auto',
         display: 'flex',
-    },
-    textContainer: {
-        marginLeft: '1rem',
-        wordBreak: 'break-word',
     },
     headerStyles: {
         fontSize: theme.typography.body1.fontSize,

--- a/frontend/src/component/common/ToastRenderer/Toast/Toast.styles.ts
+++ b/frontend/src/component/common/ToastRenderer/Toast/Toast.styles.ts
@@ -3,12 +3,13 @@ import { makeStyles } from 'tss-react/mui';
 export const useStyles = makeStyles()((theme) => ({
     container: {
         maxWidth: '450px',
-        background: theme.palette.background.paper,
+        background: theme.palette.background.paper, // todo: add new background colors here
         boxShadow: theme.boxShadows.popup,
         zIndex: 500,
         margin: '0 0.8rem',
-        borderRadius: '12.5px',
-        padding: '2rem',
+        borderRadius: theme.shape.borderRadiusMedium,
+        padding: theme.spacing(0.5),
+        paddingInlineStart: theme.spacing(2),
     },
     innerContainer: {
         position: 'relative',
@@ -31,27 +32,30 @@ export const useStyles = makeStyles()((theme) => ({
         wordBreak: 'break-word',
     },
     headerStyles: {
+        fontSize: theme.typography.body1.fontSize,
         fontWeight: 'normal',
         margin: 0,
-        marginBottom: '0.5rem',
     },
     createdContainer: {
         display: 'flex',
         alignItems: 'center',
-        flexDirection: 'column',
+        flexDirection: 'row',
+        whiteSpace: 'nowrap',
+        gap: theme.spacing(1),
     },
     anim: {
         animation: `$drop 10s 3s`,
     },
     checkMark: {
-        width: '65px',
-        height: '65px',
+        marginInlineStart: theme.spacing(1),
     },
     buttonStyle: {
-        position: 'absolute',
-        top: '-33px',
-        right: '-33px',
+        color: theme.palette.text.primary, // set icon color here
+        svg: {
+            fontSize: '1em',
+        },
     },
+
     '@keyframes drop': {
         '0%': {
             opacity: '0%',

--- a/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
+++ b/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
@@ -4,12 +4,10 @@ import { useContext } from 'react';
 import { IconButton, Tooltip } from '@mui/material';
 import CheckMarkBadge from 'component/common/CheckmarkBadge/CheckMarkBadge';
 import UIContext from 'contexts/UIContext';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import Close from '@mui/icons-material/Close';
 import type { IToast } from 'interfaces/toast';
-import { TOAST_TEXT } from 'utils/testIds';
 
-const Toast = ({ title, text, type, confetti }: IToast) => {
+const Toast = ({ title, type, confetti }: IToast) => {
     const { setToast } = useContext(UIContext);
 
     const { classes: styles } = useStyles();
@@ -61,29 +59,18 @@ const Toast = ({ title, text, type, confetti }: IToast) => {
                 <div className={styles.confettiContainer}>
                     {confetti && renderConfetti()}
                     <div className={styles.createdContainer}>
-                        <div className={styles.headerContainer}>
-                            <div>
-                                <CheckMarkBadge
-                                    type={type}
-                                    className={styles.checkMark}
-                                />
-                            </div>
-                            <div className={styles.textContainer}>
-                                <h3 className={styles.headerStyles}>{title}</h3>
+                        <CheckMarkBadge
+                            type={type}
+                            className={styles.checkMark}
+                        />
 
-                                <ConditionallyRender
-                                    condition={Boolean(text)}
-                                    show={
-                                        <p data-testid={TOAST_TEXT}>{text}</p>
-                                    }
-                                />
-                            </div>
-                        </div>
+                        <h3 className={styles.headerStyles}>{title}</h3>
+
                         <Tooltip title='Close' arrow>
                             <IconButton
                                 onClick={hide}
                                 className={styles.buttonStyle}
-                                size='large'
+                                size='small'
                             >
                                 <Close />
                             </IconButton>

--- a/frontend/src/component/common/ToastRenderer/ToastRenderer.tsx
+++ b/frontend/src/component/common/ToastRenderer/ToastRenderer.tsx
@@ -36,7 +36,7 @@ const ToastRenderer = () => {
                 right: 0,
                 left: 0,
                 margin: '0 auto',
-                maxWidth: '450px',
+                width: 'min-content',
             },
             enter: fadeInBottomEnter,
             leave: fadeInBottomLeave,


### PR DESCRIPTION
This PR makes toasts smaller and less intrusive, and gives them a new color scheme.

Changes include:
- new color scheme
- no description, only title
- new padding


I'll remove the description prop in a separate PR and remove code references to it. 