### PR TITLE
docs: Fixed diff syntax

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -179,6 +179,7 @@ const config: Config = {
                 'php',
                 'ruby',
                 'bash',
+                'diff',
             ],
         },
         languageTabs: [


### PR DESCRIPTION
The blocks with `diff` syntax didn't render correctly. This is a result of Docusaurus v3 [changing the included languages ](https://docusaurus.io/docs/migration/v3#prism-react-renderer-v20).