### PR TITLE
chore(unl-204): remove uses of toast text and confetti

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenDocs/ApiTokenDocs.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenDocs/ApiTokenDocs.tsx
@@ -22,7 +22,7 @@ export const ApiTokenDocs = () => {
         copy(url);
         setToastData({
             type: 'success',
-            title: 'Copied to clipboard',
+            text: 'Copied to clipboard',
         });
     };
 

--- a/frontend/src/component/admin/apiToken/ConfirmToken/UserToken/UserToken.tsx
+++ b/frontend/src/component/admin/apiToken/ConfirmToken/UserToken/UserToken.tsx
@@ -14,12 +14,12 @@ export const UserToken = ({ token }: IUserTokenProps) => {
         if (copy(token)) {
             setToastData({
                 type: 'success',
-                title: 'Token copied to clipboard',
+                text: 'Token copied to clipboard',
             });
         } else
             setToastData({
                 type: 'error',
-                title: 'Could not copy token',
+                text: 'Could not copy token',
             });
     };
 

--- a/frontend/src/component/admin/auth/GoogleAuth/GoogleAuth.tsx
+++ b/frontend/src/component/admin/auth/GoogleAuth/GoogleAuth.tsx
@@ -59,7 +59,7 @@ export const GoogleAuth = () => {
         try {
             await updateSettings(removeEmptyStringFields(data));
             setToastData({
-                title: 'Settings stored',
+                text: 'Settings stored',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
+++ b/frontend/src/component/admin/auth/OidcAuth/OidcAuth.tsx
@@ -97,7 +97,7 @@ export const OidcAuth = () => {
         try {
             await updateSettings(removeEmptyStringFields(data));
             setToastData({
-                title: 'Settings stored',
+                text: 'Settings stored',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
+++ b/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
@@ -50,8 +50,7 @@ export const PasswordAuth = () => {
             await updateSettings(settings);
             refetch();
             setToastData({
-                title: 'Successfully saved',
-                text: 'Password authentication settings stored.',
+                text: 'Successfully saved',
                 autoHideDuration: 4000,
                 type: 'success',
                 show: true,

--- a/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
+++ b/frontend/src/component/admin/auth/PasswordAuth/PasswordAuth.tsx
@@ -50,7 +50,7 @@ export const PasswordAuth = () => {
             await updateSettings(settings);
             refetch();
             setToastData({
-                text: 'Successfully saved',
+                text: 'Password authentication settings stored',
                 autoHideDuration: 4000,
                 type: 'success',
                 show: true,

--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -88,7 +88,7 @@ export const SamlAuth = () => {
         try {
             await updateSettings(removeEmptyStringFields(data));
             setToastData({
-                title: 'Settings stored',
+                text: 'Settings stored',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -58,7 +58,7 @@ export const ScimSettings = () => {
             }
 
             setToastData({
-                title: 'Settings stored',
+                text: 'Settings stored',
                 type: 'success',
             });
             await refetch();

--- a/frontend/src/component/admin/banners/BannerModal/BannerModal.tsx
+++ b/frontend/src/component/admin/banners/BannerModal/BannerModal.tsx
@@ -101,7 +101,7 @@ export const BannerModal = ({ banner, open, setOpen }: IBannerModalProps) => {
                 await addBanner(payload);
             }
             setToastData({
-                title: `Banner ${editing ? 'updated' : 'added'} successfully`,
+                text: `Banner ${editing ? 'updated' : 'added'} successfully`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/admin/banners/BannersTable/BannersTable.tsx
+++ b/frontend/src/component/admin/banners/BannersTable/BannersTable.tsx
@@ -42,7 +42,7 @@ export const BannersTable = () => {
         try {
             await toggleBanner(banner.id, enabled);
             setToastData({
-                title: `"${banner.message}" has been ${
+                text: `"${banner.message}" has been ${
                     enabled ? 'enabled' : 'disabled'
                 }`,
                 type: 'success',
@@ -57,7 +57,7 @@ export const BannersTable = () => {
         try {
             await removeBanner(banner.id);
             setToastData({
-                title: `"${banner.message}" has been deleted`,
+                text: `"${banner.message}" has been deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/admin/cors/CorsForm.tsx
+++ b/frontend/src/component/admin/cors/CorsForm.tsx
@@ -25,7 +25,7 @@ export const CorsForm = ({ frontendApiOrigins }: ICorsFormProps) => {
             event.preventDefault();
             await setFrontendSettings(split);
             setValue(formatInputValue(split));
-            setToastData({ title: 'Settings saved', type: 'success' });
+            setToastData({ text: 'Settings saved', type: 'success' });
         } catch (error) {
             setToastApiError(formatUnknownError(error));
         }

--- a/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
+++ b/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
@@ -48,7 +48,7 @@ export const CreateGroup = () => {
             const group = await createGroup(payload);
             navigate(`/admin/groups/${group.id}`);
             setToastData({
-                title: 'Group created successfully',
+                text: 'Group created successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
+++ b/frontend/src/component/admin/groups/CreateGroup/CreateGroup.tsx
@@ -49,8 +49,6 @@ export const CreateGroup = () => {
             navigate(`/admin/groups/${group.id}`);
             setToastData({
                 title: 'Group created successfully',
-                text: 'Now you can start using your group.',
-                confetti: true,
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
+++ b/frontend/src/component/admin/groups/EditGroup/EditGroup.tsx
@@ -90,7 +90,7 @@ export const EditGroup = ({
             refetchGroups();
             navigate(GO_BACK);
             setToastData({
-                title: 'Group updated successfully',
+                text: 'Group updated successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/groups/Group/EditGroupUsers/EditGroupUsers.tsx
+++ b/frontend/src/component/admin/groups/Group/EditGroupUsers/EditGroupUsers.tsx
@@ -77,7 +77,7 @@ export const EditGroupUsers: FC<IEditGroupUsersProps> = ({
             refetchGroups();
             setOpen(false);
             setToastData({
-                title: 'Group users saved successfully',
+                text: 'Group users saved successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/groups/Group/RemoveGroupUser/RemoveGroupUser.tsx
+++ b/frontend/src/component/admin/groups/Group/RemoveGroupUser/RemoveGroupUser.tsx
@@ -38,7 +38,7 @@ export const RemoveGroupUser: FC<IRemoveGroupUserProps> = ({
             refetchGroup();
             setOpen(false);
             setToastData({
-                title: 'User removed from group successfully',
+                text: 'User removed from group successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/groups/RemoveGroup/RemoveGroup.tsx
+++ b/frontend/src/component/admin/groups/RemoveGroup/RemoveGroup.tsx
@@ -31,7 +31,7 @@ export const RemoveGroup: FC<IRemoveGroupProps> = ({
             setOpen(false);
             navigate('/admin/groups');
             setToastData({
-                title: 'Group removed successfully',
+                text: 'Group removed successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/license/License.tsx
+++ b/frontend/src/component/admin/license/License.tsx
@@ -58,7 +58,7 @@ export const License = () => {
         try {
             await updateLicenseKey(token);
             setToastData({
-                title: 'License key updated',
+                text: 'License key updated',
                 type: 'success',
             });
             refetchLicense();

--- a/frontend/src/component/admin/maintenance/MaintenanceToggle.tsx
+++ b/frontend/src/component/admin/maintenance/MaintenanceToggle.tsx
@@ -45,7 +45,7 @@ export const MaintenanceToggle = () => {
     const updateEnabled = async () => {
         setToastData({
             type: 'success',
-            title: `Maintenance mode has been successfully ${
+            text: `Maintenance mode has been successfully ${
                 enabled ? 'disabled' : 'enabled'
             }`,
         });

--- a/frontend/src/component/admin/roles/RoleModal/RoleModal.tsx
+++ b/frontend/src/component/admin/roles/RoleModal/RoleModal.tsx
@@ -96,7 +96,7 @@ export const RoleModal = ({
                 await addRole(payload);
             }
             setToastData({
-                title: `Role ${editing ? 'updated' : 'added'} successfully`,
+                text: `Role ${editing ? 'updated' : 'added'} successfully`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/admin/roles/RolesTable/RolesTable.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RolesTable.tsx
@@ -52,7 +52,7 @@ export const RolesTable = ({
         try {
             await removeRole(role.id);
             setToastData({
-                title: `${role.name} has been deleted`,
+                text: `${role.name} has been deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountModal.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountModal.tsx
@@ -196,7 +196,7 @@ export const ServiceAccountModal = ({
                 }
             }
             setToastData({
-                title: `Service account ${
+                text: `Service account ${
                     editing ? 'updated' : 'added'
                 } successfully`,
                 type: 'success',

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountTokens/ServiceAccountTokens.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountTokens/ServiceAccountTokens.tsx
@@ -127,7 +127,7 @@ export const ServiceAccountTokens = ({
             setNewToken(token);
             setTokenOpen(true);
             setToastData({
-                title: 'Token created successfully',
+                text: 'Token created successfully',
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -146,7 +146,7 @@ export const ServiceAccountTokens = ({
                 refetchTokens();
                 setDeleteOpen(false);
                 setToastData({
-                    title: 'Token deleted successfully',
+                    text: 'Token deleted successfully',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
@@ -48,7 +48,7 @@ export const ServiceAccountsTable = () => {
         try {
             await removeServiceAccount(serviceAccount.id);
             setToastData({
-                title: `${serviceAccount.name} has been deleted`,
+                text: `${serviceAccount.name} has been deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/admin/users/EditUser/EditUser.tsx
+++ b/frontend/src/component/admin/users/EditUser/EditUser.tsx
@@ -60,7 +60,7 @@ const EditUser = () => {
                 refetch();
                 navigate('/admin/users');
                 setToastData({
-                    title: 'User information updated',
+                    text: 'User information updated',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersList.tsx
+++ b/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersList.tsx
@@ -71,7 +71,7 @@ export const InactiveUsersList = () => {
         try {
             await deleteInactiveUsers(inactiveUsers.map((i) => i.id));
             setToastData({
-                title: `Inactive users has been deleted`,
+                text: `Inactive users has been deleted`,
                 type: 'success',
             });
             setShowDelInactiveDialog(false);
@@ -84,7 +84,7 @@ export const InactiveUsersList = () => {
         try {
             await removeUser(userId);
             setToastData({
-                title: `User has been deleted`,
+                text: `User has been deleted`,
                 type: 'success',
             });
             refetchInactiveUsers();

--- a/frontend/src/component/admin/users/LinkField/LinkField.tsx
+++ b/frontend/src/component/admin/users/LinkField/LinkField.tsx
@@ -51,7 +51,7 @@ export const LinkField: FC<ILinkFieldProps> = ({
     const setError = () =>
         setToastData({
             type: 'error',
-            title: errorTitle,
+            text: errorTitle,
         });
 
     const handleCopy = () => {
@@ -61,7 +61,7 @@ export const LinkField: FC<ILinkFieldProps> = ({
                 .then(() => {
                     setToastData({
                         type: 'success',
-                        title: successTitle,
+                        text: successTitle,
                     });
                     onCopy?.();
                 })

--- a/frontend/src/component/admin/users/UsersList/ChangePassword/ChangePassword.tsx
+++ b/frontend/src/component/admin/users/UsersList/ChangePassword/ChangePassword.tsx
@@ -62,8 +62,7 @@ const ChangePassword = ({
             setData({});
             closeDialog();
             setToastData({
-                title: 'Password changed successfully',
-                text: 'The user can now sign in using the new password.',
+                text: 'Password changed successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -112,7 +112,7 @@ const UsersList = () => {
         try {
             await removeUser(user.id);
             setToastData({
-                title: `${user.name} has been deleted`,
+                text: `${user.name} has been deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/application/Application.tsx
+++ b/frontend/src/component/application/Application.tsx
@@ -93,8 +93,7 @@ export const Application = () => {
         try {
             await deleteApplication(appName);
             setToastData({
-                title: 'Deleted Successfully',
-                text: 'Application deleted successfully',
+                text: 'Deleted Successfully',
                 type: 'success',
             });
             navigate('/applications');

--- a/frontend/src/component/application/ApplicationUpdate/ApplicationUpdate.tsx
+++ b/frontend/src/component/application/ApplicationUpdate/ApplicationUpdate.tsx
@@ -41,7 +41,6 @@ export const ApplicationUpdate = ({ application }: IApplicationUpdateProps) => {
             setToastData({
                 type: 'success',
                 title: 'Updated Successfully',
-                text: `${field} successfully updated`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/application/ApplicationUpdate/ApplicationUpdate.tsx
+++ b/frontend/src/component/application/ApplicationUpdate/ApplicationUpdate.tsx
@@ -40,7 +40,7 @@ export const ApplicationUpdate = ({ application }: IApplicationUpdateProps) => {
             refetchApplication();
             setToastData({
                 type: 'success',
-                title: 'Updated Successfully',
+                text: 'Updated Successfully',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/archive/ArchiveTable/ArchiveTable.test.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchiveTable.test.tsx
@@ -103,7 +103,7 @@ test('should show confirm dialog when reviving flag', async () => {
     });
     fireEvent.click(reviveFlagsButton);
 
-    await screen.findByText("And we're back!");
+    await screen.findByText('Feature flags revived');
 });
 
 test('should show confirm dialog when batch reviving flag', async () => {
@@ -134,7 +134,7 @@ test('should show confirm dialog when batch reviving flag', async () => {
     });
     fireEvent.click(reviveTogglesButton);
 
-    await screen.findByText("And we're back!");
+    await screen.findByText('Feature flags revived');
 });
 
 test('should show info box when disableAllEnvsOnRevive flag is on', async () => {

--- a/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureDeleteConfirm/ArchivedFeatureDeleteConfirm.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureDeleteConfirm/ArchivedFeatureDeleteConfirm.tsx
@@ -49,7 +49,7 @@ export const ArchivedFeatureDeleteConfirm = ({
             await refetch();
             setToastData({
                 type: 'success',
-                title: `Feature ${singularOrPluralFlags} deleted`,
+                text: `Feature ${singularOrPluralFlags} deleted`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureDeleteConfirm/ArchivedFeatureDeleteConfirm.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureDeleteConfirm/ArchivedFeatureDeleteConfirm.tsx
@@ -50,9 +50,6 @@ export const ArchivedFeatureDeleteConfirm = ({
             setToastData({
                 type: 'success',
                 title: `Feature ${singularOrPluralFlags} deleted`,
-                text: `You have successfully deleted the following feature ${singularOrPluralFlags}: ${deletedFeatures.join(
-                    ', ',
-                )}.`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
@@ -39,8 +39,7 @@ export const ArchivedFeatureReviveConfirm = ({
             await refetch();
             setToastData({
                 type: 'success',
-                title: "And we're back!",
-                text: 'The feature flags have been revived.',
+                title: 'The feature flags have been revived',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
@@ -39,7 +39,7 @@ export const ArchivedFeatureReviveConfirm = ({
             await refetch();
             setToastData({
                 type: 'success',
-                text: 'The feature flags have been revived',
+                text: 'Feature flags revived',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm.tsx
@@ -39,7 +39,7 @@ export const ArchivedFeatureReviveConfirm = ({
             await refetch();
             setToastData({
                 type: 'success',
-                title: 'The feature flags have been revived',
+                text: 'The feature flags have been revived',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -98,7 +98,7 @@ export const ChangeActions: FC<{
                 change.id,
             );
             setToastData({
-                title: 'Change discarded from change request draft.',
+                text: 'Change discarded from change request draft.',
                 type: 'success',
             });
             onRefetch?.();

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -125,7 +125,7 @@ export const EditChange = ({
             });
             onSubmit();
             setToastData({
-                title: 'Change updated',
+                text: 'Change updated',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -136,8 +136,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Changes applied',
+                title: 'Changes applied',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -159,8 +158,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Changes scheduled',
+                title: 'Changes scheduled',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -177,8 +175,7 @@ export const ChangeRequestOverview: FC = () => {
             await refetchChangeRequest();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Comment added',
+                title: 'Comment added',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -199,8 +196,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Changes cancelled',
+                title: 'Changes cancelled',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -221,8 +217,7 @@ export const ChangeRequestOverview: FC = () => {
 
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Changes rejected',
+                title: 'Changes rejected',
             });
             refetchChangeRequestOpen();
             refetchActionableChangeRequests();
@@ -244,8 +239,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchChangeRequestOpen();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Changes approved',
+                title: 'Changes approved',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -136,7 +136,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Changes applied',
+                text: 'Changes applied',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -158,7 +158,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Changes scheduled',
+                text: 'Changes scheduled',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -175,7 +175,7 @@ export const ChangeRequestOverview: FC = () => {
             await refetchChangeRequest();
             setToastData({
                 type: 'success',
-                title: 'Comment added',
+                text: 'Comment added',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -196,7 +196,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchActionableChangeRequests();
             setToastData({
                 type: 'success',
-                title: 'Changes cancelled',
+                text: 'Changes cancelled',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -217,7 +217,7 @@ export const ChangeRequestOverview: FC = () => {
 
             setToastData({
                 type: 'success',
-                title: 'Changes rejected',
+                text: 'Changes rejected',
             });
             refetchChangeRequestOpen();
             refetchActionableChangeRequests();
@@ -239,7 +239,7 @@ export const ChangeRequestOverview: FC = () => {
             refetchChangeRequestOpen();
             setToastData({
                 type: 'success',
-                title: 'Changes approved',
+                text: 'Changes approved',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/ChangeRequestTitle.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/ChangeRequestTitle.tsx
@@ -49,7 +49,7 @@ export const ChangeRequestTitle: FC<{
             );
             setToastData({
                 type: 'success',
-                title: 'Change request title updated!',
+                text: 'Change request title updated!',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/commandBar/CommandBarFeedback.tsx
+++ b/frontend/src/component/commandBar/CommandBarFeedback.tsx
@@ -44,7 +44,7 @@ export const CommandBarFeedback = ({ onSubmit }: ICommandBarFeedbackProps) => {
         });
         onSubmit();
         setToastData({
-            title: 'Feedback sent',
+            text: 'Feedback sent',
             type: 'success',
         });
     };

--- a/frontend/src/component/common/ApiTokenTable/CopyApiTokenButton/CopyApiTokenButton.tsx
+++ b/frontend/src/component/common/ApiTokenTable/CopyApiTokenButton/CopyApiTokenButton.tsx
@@ -23,7 +23,7 @@ export const CopyApiTokenButton = ({
         if (copy(value)) {
             setToastData({
                 type: 'success',
-                title: `Token copied to clipboard`,
+                text: `Token copied to clipboard`,
             });
 
             if (track && typeof track === 'function') {

--- a/frontend/src/component/common/ApiTokenTable/CopyApiTokenButton/CopyApiTokenButton.tsx
+++ b/frontend/src/component/common/ApiTokenTable/CopyApiTokenButton/CopyApiTokenButton.tsx
@@ -23,7 +23,7 @@ export const CopyApiTokenButton = ({
         if (copy(value)) {
             setToastData({
                 type: 'success',
-                text: `Token copied to clipboard`,
+                text: 'Token copied to clipboard',
             });
 
             if (track && typeof track === 'function') {

--- a/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
+++ b/frontend/src/component/common/ApiTokenTable/RemoveApiTokenButton/RemoveApiTokenButton.tsx
@@ -34,7 +34,7 @@ export const RemoveApiTokenButton = ({
 
             setToastData({
                 type: 'success',
-                title: 'API token removed',
+                text: 'API token removed',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -238,9 +238,6 @@ const useArchiveAction = ({
         );
         refetchChangeRequests();
         setToastData({
-            text: isBulkArchive
-                ? 'Your archive feature flags changes have been added to change request'
-                : 'Your archive feature flag change has been added to change request',
             type: 'success',
             title: isBulkArchive
                 ? 'Changes added to a draft'
@@ -251,18 +248,16 @@ const useArchiveAction = ({
     const archiveToggle = async () => {
         await archiveFeatureToggle(projectId, featureIds[0]);
         setToastData({
-            text: 'Your feature flag has been archived',
             type: 'success',
-            title: 'Feature archived',
+            title: 'Feature flag archived',
         });
     };
 
     const archiveToggles = async () => {
         await archiveFeatures(projectId, featureIds);
         setToastData({
-            text: 'Selected feature flags have been archived',
             type: 'success',
-            title: 'Features archived',
+            title: 'Feature flags archived',
         });
     };
 

--- a/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
+++ b/frontend/src/component/common/FeatureArchiveDialog/FeatureArchiveDialog.tsx
@@ -239,7 +239,7 @@ const useArchiveAction = ({
         refetchChangeRequests();
         setToastData({
             type: 'success',
-            title: isBulkArchive
+            text: isBulkArchive
                 ? 'Changes added to a draft'
                 : 'Change added to a draft',
         });
@@ -249,7 +249,7 @@ const useArchiveAction = ({
         await archiveFeatureToggle(projectId, featureIds[0]);
         setToastData({
             type: 'success',
-            title: 'Feature flag archived',
+            text: 'Feature flag archived',
         });
     };
 
@@ -257,7 +257,7 @@ const useArchiveAction = ({
         await archiveFeatures(projectId, featureIds);
         setToastData({
             type: 'success',
-            title: 'Feature flags archived',
+            text: 'Feature flags archived',
         });
     };
 

--- a/frontend/src/component/common/FeatureStaleDialog/FeatureStaleDialog.tsx
+++ b/frontend/src/component/common/FeatureStaleDialog/FeatureStaleDialog.tsx
@@ -50,12 +50,12 @@ export const FeatureStaleDialog = ({
         if (isStale) {
             setToastData({
                 type: 'success',
-                title: 'The flag is no longer marked as stale',
+                text: 'The flag is no longer marked as stale',
             });
         } else {
             setToastData({
                 type: 'success',
-                title: 'The flag has been marked as stale',
+                text: 'The flag has been marked as stale',
             });
         }
     };

--- a/frontend/src/component/common/FeatureStaleDialog/FeatureStaleDialog.tsx
+++ b/frontend/src/component/common/FeatureStaleDialog/FeatureStaleDialog.tsx
@@ -50,14 +50,12 @@ export const FeatureStaleDialog = ({
         if (isStale) {
             setToastData({
                 type: 'success',
-                title: "And we're back!",
-                text: 'The flag is no longer marked as stale.',
+                title: 'The flag is no longer marked as stale',
             });
         } else {
             setToastData({
                 type: 'success',
-                title: 'A job well done.',
-                text: 'The flag has been marked as stale.',
+                title: 'The flag has been marked as stale',
             });
         }
     };

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -260,7 +260,6 @@ const FormTemplate: React.FC<ICreateProps> = ({
             if (copy(formatApiCode())) {
                 setToastData({
                     title: 'Successfully copied the command',
-                    text: 'The command should now be automatically copied to your clipboard',
                     autoHideDuration: 6000,
                     type: 'success',
                     show: true,
@@ -268,7 +267,6 @@ const FormTemplate: React.FC<ICreateProps> = ({
             } else {
                 setToastData({
                     title: 'Could not copy the command',
-                    text: 'Sorry, but we could not copy the command.',
                     autoHideDuration: 6000,
                     type: 'error',
                     show: true,

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -259,14 +259,14 @@ const FormTemplate: React.FC<ICreateProps> = ({
         if (formatApiCode !== undefined) {
             if (copy(formatApiCode())) {
                 setToastData({
-                    title: 'Command copied',
+                    text: 'Command copied',
                     autoHideDuration: 6000,
                     type: 'success',
                     show: true,
                 });
             } else {
                 setToastData({
-                    title: 'Could not copy the command',
+                    text: 'Could not copy the command',
                     autoHideDuration: 6000,
                     type: 'error',
                     show: true,

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -259,7 +259,7 @@ const FormTemplate: React.FC<ICreateProps> = ({
         if (formatApiCode !== undefined) {
             if (copy(formatApiCode())) {
                 setToastData({
-                    title: 'Successfully copied the command',
+                    title: 'Command copied',
                     autoHideDuration: 6000,
                     type: 'success',
                     show: true,

--- a/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
+++ b/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
@@ -9,7 +9,7 @@ import Close from '@mui/icons-material/Close';
 import type { IToast } from 'interfaces/toast';
 import { TOAST_TEXT } from 'utils/testIds';
 
-const Toast = ({ title, text, type, confetti }: IToast) => {
+const Toast = ({ text: title, text, type, confetti }: IToast) => {
     const { setToast } = useContext(UIContext);
 
     const { classes: styles } = useStyles();

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -142,7 +142,7 @@ const ContextList: VFC = () => {
             refetchUnleashContext();
             setToastData({
                 type: 'success',
-                title: 'Context field deleted',
+                text: 'Context field deleted',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -142,8 +142,7 @@ const ContextList: VFC = () => {
             refetchUnleashContext();
             setToastData({
                 type: 'success',
-                title: 'Successfully deleted context',
-                text: 'Your context is now deleted',
+                title: 'Successfully deleted context field',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -142,7 +142,7 @@ const ContextList: VFC = () => {
             refetchUnleashContext();
             setToastData({
                 type: 'success',
-                title: 'Successfully deleted context field',
+                title: 'Context field deleted',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
+++ b/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
@@ -51,8 +51,7 @@ export const CreateUnleashContext = ({
                 await createContext(payload);
                 refetchUnleashContext();
                 setToastData({
-                    title: 'Context created',
-                    confetti: true,
+                    title: 'Context field created',
                     type: 'success',
                 });
                 onSubmit();

--- a/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
+++ b/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
@@ -51,7 +51,7 @@ export const CreateUnleashContext = ({
                 await createContext(payload);
                 refetchUnleashContext();
                 setToastData({
-                    title: 'Context field created',
+                    text: 'Context field created',
                     type: 'success',
                 });
                 onSubmit();

--- a/frontend/src/component/context/EditContext/EditContext.tsx
+++ b/frontend/src/component/context/EditContext/EditContext.tsx
@@ -63,7 +63,7 @@ export const EditContext = () => {
             refetch();
             navigate('/context');
             setToastData({
-                title: 'Context information updated',
+                text: 'Context information updated',
                 type: 'success',
             });
         } catch (e: unknown) {

--- a/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.tsx
+++ b/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.tsx
@@ -43,7 +43,7 @@ const CreateEnvironment = () => {
                 await createEnvironment(payload);
                 refetch();
                 setToastData({
-                    title: 'Environment created',
+                    text: 'Environment created',
                     type: 'success',
                 });
                 navigate('/environments');

--- a/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.tsx
+++ b/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.tsx
@@ -45,7 +45,6 @@ const CreateEnvironment = () => {
                 setToastData({
                     title: 'Environment created',
                     type: 'success',
-                    confetti: true,
                 });
                 navigate('/environments');
             } catch (error: unknown) {

--- a/frontend/src/component/environments/EditEnvironment/EditEnvironment.tsx
+++ b/frontend/src/component/environments/EditEnvironment/EditEnvironment.tsx
@@ -49,7 +49,7 @@ const EditEnvironment = () => {
             navigate('/environments');
             setToastData({
                 type: 'success',
-                title: 'Successfully updated environment.',
+                text: 'Successfully updated environment.',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
@@ -43,7 +43,7 @@ export const EnvironmentActionCell = ({
             refetchPermissions();
             setToastData({
                 type: 'success',
-                title: `Deleted environment '${environment.name}'`,
+                title: `Environment deleted`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -59,13 +59,13 @@ export const EnvironmentActionCell = ({
                 await toggleEnvironmentOff(environment.name);
                 setToastData({
                     type: 'success',
-                    title: 'Environment deprecated successfully',
+                    title: 'Environment deprecated',
                 });
             } else {
                 await toggleEnvironmentOn(environment.name);
                 setToastData({
                     type: 'success',
-                    title: 'Environment undeprecated successfully',
+                    title: 'Environment undeprecated',
                 });
             }
         } catch (error: unknown) {

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
@@ -43,7 +43,7 @@ export const EnvironmentActionCell = ({
             refetchPermissions();
             setToastData({
                 type: 'success',
-                title: `Environment deleted`,
+                text: `Environment deleted`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -59,13 +59,13 @@ export const EnvironmentActionCell = ({
                 await toggleEnvironmentOff(environment.name);
                 setToastData({
                     type: 'success',
-                    title: 'Environment deprecated',
+                    text: 'Environment deprecated',
                 });
             } else {
                 await toggleEnvironmentOn(environment.name);
                 setToastData({
                     type: 'success',
-                    title: 'Environment undeprecated',
+                    text: 'Environment undeprecated',
                 });
             }
         } catch (error: unknown) {
@@ -88,7 +88,7 @@ export const EnvironmentActionCell = ({
                     } else {
                         setToastData({
                             type: 'error',
-                            title: `Environment limit (${environmentLimit}) reached`,
+                            text: `Environment limit (${environmentLimit}) reached`,
                         });
                     }
                 }}

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentActionCell.tsx
@@ -43,8 +43,7 @@ export const EnvironmentActionCell = ({
             refetchPermissions();
             setToastData({
                 type: 'success',
-                title: 'Environment deleted',
-                text: `You have successfully deleted the ${environment.name} environment.`,
+                title: `Deleted environment '${environment.name}'`,
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -89,8 +88,7 @@ export const EnvironmentActionCell = ({
                     } else {
                         setToastData({
                             type: 'error',
-                            title: 'Environment limit reached',
-                            text: `You have reached the maximum number of environments (${environmentLimit}). Please reach out if you need more.`,
+                            title: `Environment limit (${environmentLimit}) reached`,
                         });
                     }
                 }}

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -184,7 +184,7 @@ export const EnvironmentCloneModal = ({
                 newToken(token);
             }
             setToastData({
-                text: 'Environment successfully cloned!',
+                text: 'Environment cloned',
                 type: 'success',
             });
             refetchEnvironments();

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -184,7 +184,7 @@ export const EnvironmentCloneModal = ({
                 newToken(token);
             }
             setToastData({
-                title: 'Environment successfully cloned!',
+                text: 'Environment successfully cloned!',
                 type: 'success',
             });
             refetchEnvironments();

--- a/frontend/src/component/feature/Dependencies/useManageDependency.ts
+++ b/frontend/src/component/feature/Dependencies/useManageDependency.ts
@@ -64,7 +64,7 @@ export const useManageDependency = (
         void refetchChangeRequests();
         setToastData({
             type: 'success',
-            title: 'Change added to draft',
+            text: 'Change added to draft',
         });
     };
 
@@ -91,7 +91,7 @@ export const useManageDependency = (
                         eventType: 'dependency removed',
                     },
                 });
-                setToastData({ title: 'Dependency removed', type: 'success' });
+                setToastData({ text: 'Dependency removed', type: 'success' });
             } else {
                 await addDependency(featureId, {
                     feature: parent,
@@ -106,7 +106,7 @@ export const useManageDependency = (
                         eventType: 'dependency added',
                     },
                 });
-                setToastData({ title: 'Dependency added', type: 'success' });
+                setToastData({ text: 'Dependency added', type: 'success' });
             }
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/feature/Dependencies/useManageDependency.ts
+++ b/frontend/src/component/feature/Dependencies/useManageDependency.ts
@@ -63,12 +63,8 @@ export const useManageDependency = (
         }
         void refetchChangeRequests();
         setToastData({
-            text:
-                actionType === 'addDependency'
-                    ? `${featureId} will depend on ${parent}`
-                    : `${featureId} dependency will be removed`,
             type: 'success',
-            title: 'Change added to a draft',
+            title: 'Change added to draft',
         });
     };
 

--- a/frontend/src/component/feature/EditFeature/EditFeature.tsx
+++ b/frontend/src/component/feature/EditFeature/EditFeature.tsx
@@ -54,7 +54,7 @@ const EditFeature = () => {
             await patchFeatureFlag(project, featureId, patch);
             navigate(`/projects/${project}/features/${name}`);
             setToastData({
-                text: 'Flag updated successfully',
+                text: 'Flag updated',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/feature/EditFeature/EditFeature.tsx
+++ b/frontend/src/component/feature/EditFeature/EditFeature.tsx
@@ -54,7 +54,7 @@ const EditFeature = () => {
             await patchFeatureFlag(project, featureId, patch);
             navigate(`/projects/${project}/features/${name}`);
             setToastData({
-                title: 'Flag updated successfully',
+                text: 'Flag updated successfully',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -152,7 +152,6 @@ export const FeatureStrategyCreate = () => {
         setToastData({
             title: 'Strategy created',
             type: 'success',
-            confetti: true,
         });
     };
 
@@ -166,7 +165,6 @@ export const FeatureStrategyCreate = () => {
         setToastData({
             title: 'Strategy added to draft',
             type: 'success',
-            confetti: true,
         });
         refetchChangeRequests();
     };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -150,7 +150,7 @@ export const FeatureStrategyCreate = () => {
         );
 
         setToastData({
-            title: 'Strategy created',
+            text: 'Strategy created',
             type: 'success',
         });
     };
@@ -163,7 +163,7 @@ export const FeatureStrategyCreate = () => {
         });
         // FIXME: segments in change requests
         setToastData({
-            title: 'Strategy added to draft',
+            text: 'Strategy added to draft',
             type: 'success',
         });
         refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -211,7 +211,6 @@ export const FeatureStrategyEdit = () => {
         setToastData({
             title: 'Strategy updated',
             type: 'success',
-            confetti: true,
         });
     };
 
@@ -225,7 +224,6 @@ export const FeatureStrategyEdit = () => {
         setToastData({
             title: 'Change added to draft',
             type: 'success',
-            confetti: true,
         });
         refetchChangeRequests();
     };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -209,7 +209,7 @@ export const FeatureStrategyEdit = () => {
 
         await refetchSavedStrategySegments();
         setToastData({
-            title: 'Strategy updated',
+            text: 'Strategy updated',
             type: 'success',
         });
     };
@@ -222,7 +222,7 @@ export const FeatureStrategyEdit = () => {
         });
         // FIXME: segments in change requests
         setToastData({
-            title: 'Change added to draft',
+            text: 'Change added to draft',
             type: 'success',
         });
         refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
@@ -78,10 +78,7 @@ export const FeatureStrategyEmpty = ({
         refetchFeatureImmutable();
 
         setToastData({
-            title: multiple ? 'Strategies created' : 'Strategy created',
-            text: multiple
-                ? 'Successfully copied from another environment'
-                : 'Successfully created strategy',
+            text: multiple ? 'Strategies created' : 'Strategy created',
             type: 'success',
         });
     };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
@@ -75,7 +75,7 @@ export const FeatureReleasePlanCard = ({
             );
             setToastData({
                 type: 'success',
-                title: 'Release plan added',
+                text: 'Release plan added',
             });
             refetch();
         } catch (error: unknown) {

--- a/frontend/src/component/feature/FeatureToggleList/BulkDisableDialog.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/BulkDisableDialog.tsx
@@ -73,9 +73,8 @@ export const BulkDisableDialog = ({
                 );
                 refetchChangeRequests();
                 setToastData({
-                    text: 'Your disabled feature flags changes have been added to change request',
                     type: 'success',
-                    title: 'Changes added to a draft',
+                    title: 'Changes added to draft',
                 });
             } else {
                 await bulkToggleFeaturesEnvironmentOff(
@@ -84,9 +83,8 @@ export const BulkDisableDialog = ({
                     selected,
                 );
                 setToastData({
-                    text: 'Your feature flags have been disabled',
                     type: 'success',
-                    title: 'Features disabled',
+                    title: 'Feature flags disabled',
                 });
             }
             onClose();

--- a/frontend/src/component/feature/FeatureToggleList/BulkDisableDialog.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/BulkDisableDialog.tsx
@@ -74,7 +74,7 @@ export const BulkDisableDialog = ({
                 refetchChangeRequests();
                 setToastData({
                     type: 'success',
-                    title: 'Changes added to draft',
+                    text: 'Changes added to draft',
                 });
             } else {
                 await bulkToggleFeaturesEnvironmentOff(
@@ -84,7 +84,7 @@ export const BulkDisableDialog = ({
                 );
                 setToastData({
                     type: 'success',
-                    title: 'Feature flags disabled',
+                    text: 'Feature flags disabled',
                 });
             }
             onClose();

--- a/frontend/src/component/feature/FeatureToggleList/BulkEnableDialog.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/BulkEnableDialog.tsx
@@ -74,7 +74,7 @@ export const BulkEnableDialog = ({
                 refetchChangeRequests();
                 setToastData({
                     type: 'success',
-                    title: 'Changes added to draft',
+                    text: 'Changes added to draft',
                 });
             } else {
                 await bulkToggleFeaturesEnvironmentOn(
@@ -84,7 +84,7 @@ export const BulkEnableDialog = ({
                 );
                 setToastData({
                     type: 'success',
-                    title: 'Feature flags enabled',
+                    text: 'Feature flags enabled',
                 });
             }
 

--- a/frontend/src/component/feature/FeatureToggleList/BulkEnableDialog.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/BulkEnableDialog.tsx
@@ -73,9 +73,8 @@ export const BulkEnableDialog = ({
                 );
                 refetchChangeRequests();
                 setToastData({
-                    text: 'Your enable feature flags changes have been added to change request',
                     type: 'success',
-                    title: 'Changes added to a draft',
+                    title: 'Changes added to draft',
                 });
             } else {
                 await bulkToggleFeaturesEnvironmentOn(
@@ -84,9 +83,8 @@ export const BulkEnableDialog = ({
                     selected,
                 );
                 setToastData({
-                    text: 'Your feature flags have been enabled',
                     type: 'success',
-                    title: 'Features enabled',
+                    title: 'Feature flags enabled',
                 });
             }
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -111,7 +111,7 @@ const EnvironmentAccordionBody = ({
             );
             refetchFeature();
             setToastData({
-                title: 'Order of strategies updated',
+                text: 'Order of strategies updated',
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -129,7 +129,7 @@ const EnvironmentAccordionBody = ({
         });
 
         setToastData({
-            title: 'Strategy execution order added to draft',
+            text: 'Strategy execution order added to draft',
             type: 'success',
         });
         refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -131,7 +131,6 @@ const EnvironmentAccordionBody = ({
         setToastData({
             title: 'Strategy execution order added to draft',
             type: 'success',
-            confetti: true,
         });
         refetchChangeRequests();
     };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -86,8 +86,7 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
             refetchFeature();
             refetchFeatureImmutable();
             setToastData({
-                title: `Strategy created`,
-                text: `Successfully copied a strategy to ${targetEnvironment}`,
+                title: `Strategy copied to ${targetEnvironment}`,
                 type: 'success',
             });
         } catch (error) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -86,7 +86,7 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
             refetchFeature();
             refetchFeatureImmutable();
             setToastData({
-                title: `Strategy copied to ${targetEnvironment}`,
+                text: `Strategy copied to ${targetEnvironment}`,
                 type: 'success',
             });
         } catch (error) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DialogStrategyRemove.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DialogStrategyRemove.tsx
@@ -194,7 +194,7 @@ const useOnRemove = ({
                 strategyId,
             );
             setToastData({
-                title: 'Strategy deleted',
+                text: 'Strategy deleted',
                 type: 'success',
             });
             refetchFeature();
@@ -227,7 +227,7 @@ const useOnSuggestRemove = ({
                 },
             });
             setToastData({
-                title: 'Changes added to the draft!',
+                text: 'Changes added to the draft!',
                 type: 'success',
             });
             await refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DialogStrategyRemove.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DialogStrategyRemove.tsx
@@ -227,7 +227,7 @@ const useOnSuggestRemove = ({
                 },
             });
             setToastData({
-                text: 'Changes added to the draft!',
+                text: 'Changes added to draft',
                 type: 'success',
             });
             await refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useEnableDisable.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useEnableDisable.ts
@@ -24,7 +24,7 @@ export const useEnableDisable = ({
                 !enabled,
             );
             setToastData({
-                title: `Strategy ${enabled ? 'enabled' : 'disabled'}`,
+                text: `Strategy ${enabled ? 'enabled' : 'disabled'}`,
                 type: 'success',
             });
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useSuggestEnableDisable.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useSuggestEnableDisable.ts
@@ -25,7 +25,7 @@ export const useSuggestEnableDisable = ({
                 },
             });
             setToastData({
-                text: 'Changes added to the draft!',
+                text: 'Changes added to draft',
                 type: 'success',
             });
             await refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useSuggestEnableDisable.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/MenuStrategyRemove/DisableEnableStrategyDialog/hooks/useSuggestEnableDisable.ts
@@ -25,7 +25,7 @@ export const useSuggestEnableDisable = ({
                 },
             });
             setToastData({
-                title: 'Changes added to the draft!',
+                text: 'Changes added to the draft!',
                 type: 'success',
             });
             await refetchChangeRequests();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/DependencyRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/DependencyRow.tsx
@@ -69,9 +69,8 @@ const useDeleteDependency = (project: string, featureId: string) => {
                     },
                 });
                 setToastData({
-                    text: `${featureId} dependency will be removed`,
                     type: 'success',
-                    title: 'Change added to a draft',
+                    title: 'Change added to draft',
                 });
                 await refetchChangeRequests();
             } else {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/DependencyRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/DependencyRow.tsx
@@ -70,7 +70,7 @@ const useDeleteDependency = (project: string, featureId: string) => {
                 });
                 setToastData({
                     type: 'success',
-                    title: 'Change added to draft',
+                    text: 'Change added to draft',
                 });
                 await refetchChangeRequests();
             } else {
@@ -80,7 +80,7 @@ const useDeleteDependency = (project: string, featureId: string) => {
                         eventType: 'dependency removed',
                     },
                 });
-                setToastData({ title: 'Dependency removed', type: 'success' });
+                setToastData({ text: 'Dependency removed', type: 'success' });
                 await refetchFeature();
             }
         } catch (error) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.test.tsx
@@ -255,7 +255,7 @@ test('delete dependency with change request', async () => {
     const deleteButton = await screen.findByText('Delete');
     fireEvent.click(deleteButton);
 
-    await screen.findByText('Change added to a draft');
+    await screen.findByText('Change added to draft');
 });
 
 test('edit dependency', async () => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/OldDependencyRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/OldDependencyRow.tsx
@@ -60,9 +60,8 @@ const useDeleteDependency = (project: string, featureId: string) => {
                     },
                 });
                 setToastData({
-                    text: `${featureId} dependency will be removed`,
                     type: 'success',
-                    title: 'Change added to a draft',
+                    text: 'Change added to draft',
                 });
                 await refetchChangeRequests();
             } else {
@@ -72,7 +71,7 @@ const useDeleteDependency = (project: string, featureId: string) => {
                         eventType: 'dependency removed',
                     },
                 });
-                setToastData({ title: 'Dependency removed', type: 'success' });
+                setToastData({ text: 'Dependency removed', type: 'success' });
                 await refetchFeature();
             }
         } catch (error) {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
@@ -92,8 +92,7 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
             refetch();
             setToastData({
                 type: 'success',
-                title: 'Tag removed',
-                text: 'Successfully removed tag',
+                text: 'Tag removed',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelTags/FeatureOverviewSidePanelTags.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelTags/FeatureOverviewSidePanelTags.tsx
@@ -71,8 +71,7 @@ export const FeatureOverviewSidePanelTags = ({
             refetch();
             setToastData({
                 type: 'success',
-                title: 'Tag deleted',
-                text: 'Successfully deleted tag',
+                text: 'Tag deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
@@ -135,7 +135,7 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
         } catch (error: unknown) {
             setToastData({
                 type: 'error',
-                text: `Failed to add tag`,
+                text: 'Failed to add tag',
             });
         }
     };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
@@ -135,7 +135,7 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
         } catch (error: unknown) {
             setToastData({
                 type: 'error',
-                title: `Failed to add tag`,
+                text: `Failed to add tag`,
             });
         }
     };
@@ -175,7 +175,7 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
             differenceCount > 0 &&
                 setToastData({
                     type: 'success',
-                    title: `Updated tag${added.length > 1 ? 's' : ''} to flag`,
+                    text: `Updated tag${added.length > 1 ? 's' : ''} to flag`,
                 });
         }
         setDifferenceCount(0);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
@@ -10,7 +10,6 @@ import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import useFeatureApi from 'hooks/api/actions/useFeatureApi/useFeatureApi';
 import useFeatureTags from 'hooks/api/getters/useFeatureTags/useFeatureTags';
 import useToast from 'hooks/useToast';
-import { formatUnknownError } from 'utils/formatUnknownError';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import type { ITag, ITagType } from 'interfaces/tags';
 import { type TagOption, TagsInput } from './TagsInput';
@@ -134,12 +133,9 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
             });
             await refetch();
         } catch (error: unknown) {
-            const message = formatUnknownError(error);
             setToastData({
                 type: 'error',
                 title: `Failed to add tag`,
-                text: message,
-                confetti: false,
             });
         }
     };
@@ -180,8 +176,6 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
                 setToastData({
                     type: 'success',
                     title: `Updated tag${added.length > 1 ? 's' : ''} to flag`,
-                    text: getToastText(added.length, removed.length),
-                    confetti: true,
                 });
         }
         setDifferenceCount(0);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/NewFeatureOverviewEnvironment/FeatureOverviewEnvironmentBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/NewFeatureOverviewEnvironment/FeatureOverviewEnvironmentBody.tsx
@@ -120,7 +120,7 @@ export const FeatureOverviewEnvironmentBody = ({
             );
             refetchFeature();
             setToastData({
-                title: 'Order of strategies updated',
+                text: 'Order of strategies updated',
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -138,9 +138,8 @@ export const FeatureOverviewEnvironmentBody = ({
         });
 
         setToastData({
-            title: 'Strategy execution order added to draft',
+            text: 'Strategy execution order added to draft',
             type: 'success',
-            confetti: true,
         });
         refetchChangeRequests();
     };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -101,7 +101,7 @@ export const ReleasePlan = ({
                 id,
             );
             setToastData({
-                title: `Release plan "${name}" has been removed from ${featureName} in ${environment}`,
+                text: `Release plan "${name}" has been removed from ${featureName} in ${environment}`,
                 type: 'success',
             });
             refetch();
@@ -121,7 +121,7 @@ export const ReleasePlan = ({
                 milestone.id,
             );
             setToastData({
-                title: `Milestone "${milestone.name}" has started`,
+                text: `Milestone "${milestone.name}" has started`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/feature/FeatureView/FeatureSettings/FeatureSettingsProject/FeatureSettingsProject.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureSettings/FeatureSettingsProject/FeatureSettingsProject.tsx
@@ -34,7 +34,7 @@ const FeatureSettingsProject = () => {
             if (project) {
                 await changeFeatureProject(projectId, featureId, project);
                 refetchFeature();
-                setToastData({ title: 'Project changed', type: 'success' });
+                setToastData({ text: 'Project changed', type: 'success' });
                 setShowConfirmDialog(false);
                 navigate(
                     `/projects/${project}/features/${featureId}/settings`,

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/FeatureEnvironmentVariants.tsx
@@ -117,7 +117,7 @@ export const FeatureEnvironmentVariants = () => {
             if (error) {
                 setToastData({
                     type: 'error',
-                    title: error,
+                    text: error,
                 });
                 return;
             }
@@ -183,7 +183,7 @@ export const FeatureEnvironmentVariants = () => {
                 pushTitle && draftTitle ? '. ' : ''
             }${draftTitle}`;
             setToastData({
-                title,
+                text: title,
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -202,7 +202,7 @@ export const FeatureEnvironmentVariants = () => {
                 await updateVariants(selectedEnvironment, updatedVariants);
                 setModalOpen(false);
                 setToastData({
-                    title: selectedEnvironment.crEnabled
+                    text: selectedEnvironment.crEnabled
                         ? `Variant changes added to draft`
                         : 'Variants updated successfully',
                     type: 'success',
@@ -221,7 +221,7 @@ export const FeatureEnvironmentVariants = () => {
             const variants = fromEnvironment.variants ?? [];
             await updateVariants(toEnvironment, variants);
             setToastData({
-                title: toEnvironment.crEnabled
+                text: toEnvironment.crEnabled
                     ? 'Variants copy added to draft'
                     : 'Variants copied successfully',
                 type: 'success',

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -224,7 +224,7 @@ export const FeatureView = () => {
         } catch (error: unknown) {
             setToastData({
                 type: 'error',
-                title: 'Could not copy feature name',
+                text: 'Could not copy feature name',
             });
         }
     };

--- a/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.tsx
@@ -82,7 +82,7 @@ export const FeatureTypeForm: VFC<FeatureTypeFormProps> = ({
             await updateFeatureTypeLifetime(featureType.id, value);
             refetch();
             setToastData({
-                title: 'Feature type updated',
+                text: 'Feature type updated',
                 type: 'success',
             });
             navigate('/feature-toggle-type');

--- a/frontend/src/component/feedback/FeedbackCES/FeedbackCESForm.tsx
+++ b/frontend/src/component/feedback/FeedbackCES/FeedbackCESForm.tsx
@@ -77,8 +77,7 @@ export const FeedbackCESForm = ({ state, onClose }: IFeedbackCESFormProps) => {
             await sendFeedbackInput(form);
             setToastData({
                 type: 'success',
-                title: 'Feedback sent. Thank you!',
-                confetti: true,
+                text: 'Feedback sent. Thank you!',
             });
             onClose();
         } finally {

--- a/frontend/src/component/feedbackNew/FeedbackComponent.tsx
+++ b/frontend/src/component/feedbackNew/FeedbackComponent.tsx
@@ -260,7 +260,7 @@ export const FeedbackComponent = ({
         }
 
         setToastData({
-            title: toastTitle,
+            text: toastTitle,
             type: toastType,
         });
         closeFeedback();

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationDelete/IntegrationDelete.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationDelete/IntegrationDelete.tsx
@@ -33,8 +33,7 @@ export const IntegrationDelete: VFC<IIntegrationDeleteProps> = ({ id }) => {
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Deleted addon successfully',
+                title: 'Integration deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationDelete/IntegrationDelete.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationDelete/IntegrationDelete.tsx
@@ -33,7 +33,7 @@ export const IntegrationDelete: VFC<IIntegrationDeleteProps> = ({ id }) => {
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: 'Integration deleted',
+                text: 'Integration deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
@@ -251,15 +251,14 @@ export const IntegrationForm: FC<IntegrationFormProps> = ({
                 navigate('/integrations');
                 setToastData({
                     type: 'success',
-                    title: 'Integration updated successfully',
+                    text: 'Integration updated successfully',
                 });
             } else {
                 await createAddon(formValues as Omit<AddonSchema, 'id'>);
                 navigate('/integrations');
                 setToastData({
                     type: 'success',
-                    confetti: true,
-                    title: 'Integration created successfully',
+                    text: 'Integration created successfully',
                 });
             }
         } catch (error) {

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
@@ -251,14 +251,14 @@ export const IntegrationForm: FC<IntegrationFormProps> = ({
                 navigate('/integrations');
                 setToastData({
                     type: 'success',
-                    text: 'Integration updated successfully',
+                    text: 'Integration updated',
                 });
             } else {
                 await createAddon(formValues as Omit<AddonSchema, 'id'>);
                 navigate('/integrations');
                 setToastData({
                     type: 'success',
-                    text: 'Integration created successfully',
+                    text: 'Integration created',
                 });
             }
         } catch (error) {

--- a/frontend/src/component/integrations/IntegrationList/IntegrationCard/IntegrationCardMenu/IntegrationCardMenu.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationCard/IntegrationCardMenu/IntegrationCardMenu.tsx
@@ -76,7 +76,7 @@ export const IntegrationCardMenu: VFC<IIntegrationCardMenuProps> = ({
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: !addon.enabled
+                text: !addon.enabled
                     ? 'Integration enabled'
                     : 'Integration disabled',
             });
@@ -91,7 +91,7 @@ export const IntegrationCardMenu: VFC<IIntegrationCardMenuProps> = ({
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: 'Integration deleted',
+                text: 'Integration deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/integrations/IntegrationList/IntegrationCard/IntegrationCardMenu/IntegrationCardMenu.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationCard/IntegrationCardMenu/IntegrationCardMenu.tsx
@@ -76,10 +76,9 @@ export const IntegrationCardMenu: VFC<IIntegrationCardMenuProps> = ({
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: !addon.enabled
-                    ? 'Integration is now enabled'
-                    : 'Integration is now disabled',
+                title: !addon.enabled
+                    ? 'Integration enabled'
+                    : 'Integration disabled',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));
@@ -92,8 +91,7 @@ export const IntegrationCardMenu: VFC<IIntegrationCardMenuProps> = ({
             refetchAddons();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Integration has been deleted',
+                title: 'Integration deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/onboarding/dialog/CodeRenderer.tsx
+++ b/frontend/src/component/onboarding/dialog/CodeRenderer.tsx
@@ -62,7 +62,7 @@ const CopyBlock: FC<{ title: string; code: string }> = ({ title, code }) => {
         copy(data);
         setToastData({
             type: 'success',
-            title: 'Copied to clipboard',
+            text: 'Copied to clipboard',
         });
     };
     const { setToastData } = useToast();

--- a/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlayground.tsx
@@ -150,7 +150,7 @@ export const AdvancedPlayground: FC<{
         } catch (error) {
             setToastData({
                 type: 'error',
-                title: `Failed to parse URL parameters: ${formatUnknownError(
+                text: `Failed to parse URL parameters: ${formatUnknownError(
                     error,
                 )}`,
             });
@@ -233,14 +233,12 @@ export const AdvancedPlayground: FC<{
             } else if (error instanceof SyntaxError) {
                 setToastData({
                     type: 'error',
-                    title: `Error parsing context: ${formatUnknownError(
-                        error,
-                    )}`,
+                    text: `Error parsing context: ${formatUnknownError(error)}`,
                 });
             } else {
                 setToastData({
                     type: 'error',
-                    title: formatUnknownError(error),
+                    text: formatUnknownError(error),
                 });
             }
         }

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -112,7 +112,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
         } catch (error) {
             setToastData({
                 type: 'error',
-                title: `Error parsing context: ${formatUnknownError(error)}`,
+                text: `Error parsing context: ${formatUnknownError(error)}`,
             });
         }
     };

--- a/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
@@ -31,7 +31,6 @@ export const ArchiveProjectDialogue = ({
             setToastData({
                 title: 'Archived project',
                 type: 'success',
-                text: 'Successfully archived project',
             });
             onSuccess?.();
         } catch (ex: unknown) {

--- a/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
@@ -29,7 +29,7 @@ export const ArchiveProjectDialogue = ({
             await archiveProject(project);
             refetchProjectOverview();
             setToastData({
-                title: 'Archived project',
+                title: 'Project archived',
                 type: 'success',
             });
             onSuccess?.();

--- a/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/ArchiveProject/ArchiveProjectDialogue.tsx
@@ -29,7 +29,7 @@ export const ArchiveProjectDialogue = ({
             await archiveProject(project);
             refetchProjectOverview();
             setToastData({
-                title: 'Project archived',
+                text: 'Project archived',
                 type: 'success',
             });
             onSuccess?.();

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -178,7 +178,7 @@ export const CreateProjectDialog = ({
                 refetchUser();
                 navigate(`/projects/${createdProject.id}`);
                 setToastData({
-                    title: 'Project created',
+                    text: 'Project created',
                     type: 'success',
                 });
 

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -179,8 +179,6 @@ export const CreateProjectDialog = ({
                 navigate(`/projects/${createdProject.id}`);
                 setToastData({
                     title: 'Project created',
-                    text: 'Now you can add flags to this project',
-                    confetti: true,
                     type: 'success',
                 });
 

--- a/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
@@ -43,7 +43,7 @@ export const DeleteProjectDialogue = ({
             refetchProjects();
             refetchProjectArchive();
             setToastData({
-                title: 'Deleted project',
+                title: 'Project deleted',
                 type: 'success',
             });
             onSuccess?.();

--- a/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
@@ -45,7 +45,6 @@ export const DeleteProjectDialogue = ({
             setToastData({
                 title: 'Deleted project',
                 type: 'success',
-                text: 'Successfully deleted project',
             });
             onSuccess?.();
         } catch (ex: unknown) {

--- a/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
+++ b/frontend/src/component/project/Project/DeleteProject/DeleteProjectDialogue.tsx
@@ -43,7 +43,7 @@ export const DeleteProjectDialogue = ({
             refetchProjects();
             refetchProjectArchive();
             setToastData({
-                title: 'Project deleted',
+                text: 'Project deleted',
                 type: 'success',
             });
             onSuccess?.();

--- a/frontend/src/component/project/Project/Import/configure/ConfigurationStage.tsx
+++ b/frontend/src/component/project/Project/Import/configure/ConfigurationStage.tsx
@@ -89,14 +89,14 @@ export const ImportArea: FC<{
                         setActiveTab('code');
                         setToastData({
                             type: 'success',
-                            title: 'File uploaded',
+                            text: 'File uploaded',
                         });
                     }}
                     onError={(error) => {
                         setImportPayload('');
                         setToastData({
                             type: 'error',
-                            title: error,
+                            text: error,
                         });
                     }}
                     onDragStatusChange={setDragActive}

--- a/frontend/src/component/project/Project/Import/import/ImportStage.tsx
+++ b/frontend/src/component/project/Project/Import/import/ImportStage.tsx
@@ -80,7 +80,7 @@ export const ImportStage: FC<{
             .catch((error) => {
                 setToastData({
                     type: 'error',
-                    title: formatUnknownError(error),
+                    text: formatUnknownError(error),
                 });
             });
     }, []);

--- a/frontend/src/component/project/Project/Import/validate/ValidationStage.tsx
+++ b/frontend/src/component/project/Project/Import/validate/ValidationStage.tsx
@@ -124,7 +124,7 @@ export const ValidationStage: FC<{
                 setValidJSON(false);
                 setToastData({
                     type: 'error',
-                    title: formatUnknownError(error),
+                    text: formatUnknownError(error),
                 });
             });
     }, []);

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -165,8 +165,6 @@ const CreateFeatureDialogContent = ({
                 }
                 setToastData({
                     title: 'Flag created successfully',
-                    text: 'Now you can start using your flag.',
-                    confetti: true,
                     type: 'success',
                 });
                 onClose();

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -164,7 +164,7 @@ const CreateFeatureDialogContent = ({
                     navigate(`/projects/${project}/features/${name}`);
                 }
                 setToastData({
-                    title: 'Flag created successfully',
+                    text: 'Flag created successfully',
                     type: 'success',
                 });
                 onClose();

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -235,7 +235,7 @@ export const Project = () => {
             const text = created ? 'Project created' : 'Project updated';
             setToastData({
                 type: 'success',
-                text: text,
+                text,
             });
         }
         /* eslint-disable-next-line */

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -235,7 +235,7 @@ export const Project = () => {
             const text = created ? 'Project created' : 'Project updated';
             setToastData({
                 type: 'success',
-                title: text,
+                text: text,
             });
         }
         /* eslint-disable-next-line */

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -81,7 +81,7 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
         } catch (error: unknown) {
             setToastData({
                 type: 'error',
-                title: 'Could not copy feature name',
+                text: 'Could not copy feature name',
             });
         }
     };

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -170,7 +170,7 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
 
                     setToastData({
                         type: 'success',
-                        title: `Enabled in ${config.environmentName}`,
+                        text: `Enabled in ${config.environmentName}`,
                     });
                     config.onSuccess?.();
                 } catch (error: unknown) {
@@ -192,7 +192,7 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     );
                     setToastData({
                         type: 'success',
-                        title: `Disabled in ${config.environmentName}`,
+                        text: `Disabled in ${config.environmentName}`,
                     });
                     config.onSuccess?.();
                 } catch (error: unknown) {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -171,7 +171,6 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     setToastData({
                         type: 'success',
                         title: `Enabled in ${config.environmentName}`,
-                        text: `${config.featureId} is now available in ${config.environmentName} based on its defined strategies.`,
                     });
                     config.onSuccess?.();
                 } catch (error: unknown) {
@@ -194,7 +193,6 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                     setToastData({
                         type: 'success',
                         title: `Disabled in ${config.environmentName}`,
-                        text: `${config.featureId} is unavailable in ${config.environmentName} and its strategies will no longer have any effect.`,
                     });
                     config.onSuccess?.();
                 } catch (error: unknown) {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -63,20 +63,8 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         const payload = { features, tags: { addedTags, removedTags } };
         try {
             await bulkUpdateTags(payload, projectId);
-            const added = addedTags.length
-                ? `Added tags: ${addedTags
-                      .map(({ type, value }) => `${type}:${value}`)
-                      .join(', ')}.`
-                : '';
-            const removed = removedTags.length
-                ? `Removed tags: ${removedTags
-                      .map(({ type, value }) => `${type}:${value}`)
-                      .join(', ')}.`
-                : '';
-
             setToastData({
                 title: 'Tags updated',
-                text: `${features.length} feature flags updated. ${added} ${removed}`,
                 type: 'success',
                 autoHideDuration: 12000,
             });

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -64,7 +64,7 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         try {
             await bulkUpdateTags(payload, projectId);
             setToastData({
-                title: 'Tags updated',
+                text: 'Tags updated',
                 type: 'success',
                 autoHideDuration: 12000,
             });

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -62,9 +62,12 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         const features = data.map(({ name }) => name);
         const payload = { features, tags: { addedTags, removedTags } };
         try {
+            console.log(addedTags, removedTags, features);
             const toastText = [
-                addedTags.length > 0 && `added ${addedTags.length} tags`,
-                removedTags.length > 0 && `removed ${removedTags.length} tags`,
+                addedTags.length > 0 &&
+                    `added ${addedTags.length} tag${addedTags.length > 1 ? 's' : ''}`,
+                removedTags.length > 0 &&
+                    `removed ${removedTags.length} tag${removedTags.length > 1 ? 's' : ''}`,
             ]
                 .filter(Boolean)
                 .join(' and ');

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -62,9 +62,16 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         const features = data.map(({ name }) => name);
         const payload = { features, tags: { addedTags, removedTags } };
         try {
+            const toastText = [
+                addedTags.length > 0 && `added ${addedTags.length} tags`,
+                removedTags.length > 0 && `removed ${removedTags.length} tags`,
+            ]
+                .filter(Boolean)
+                .join(' and ');
+
             await bulkUpdateTags(payload, projectId);
             setToastData({
-                text: 'Tags updated',
+                text: toastText,
                 type: 'success',
                 autoHideDuration: 12000,
             });

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
@@ -58,7 +58,7 @@ export const MoreActions: VFC<IMoreActionsProps> = ({
             await staleFeatures(projectId, selectedIds);
             onChange?.();
             setToastData({
-                title: 'Feature flags marked as stale',
+                text: 'Feature flags marked as stale',
                 type: 'success',
             });
             trackEvent('batch_operations', {
@@ -77,7 +77,7 @@ export const MoreActions: VFC<IMoreActionsProps> = ({
             await staleFeatures(projectId, selectedIds, false);
             onChange?.();
             setToastData({
-                title: 'Feature flags unmarked as stale',
+                text: 'Feature flags unmarked as stale',
                 type: 'success',
             });
             trackEvent('batch_operations', {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
@@ -58,8 +58,7 @@ export const MoreActions: VFC<IMoreActionsProps> = ({
             await staleFeatures(projectId, selectedIds);
             onChange?.();
             setToastData({
-                title: 'State updated',
-                text: 'Feature flags marked as stale',
+                title: 'Feature flags marked as stale',
                 type: 'success',
             });
             trackEvent('batch_operations', {
@@ -78,8 +77,7 @@ export const MoreActions: VFC<IMoreActionsProps> = ({
             await staleFeatures(projectId, selectedIds, false);
             onChange?.();
             setToastData({
-                title: 'State updated',
-                text: 'Feature flags unmarked as stale',
+                title: 'Feature flags unmarked as stale',
                 type: 'success',
             });
             trackEvent('batch_operations', {

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -96,7 +96,7 @@ export const ChangeRequestTable: VFC = () => {
             );
             setToastData({
                 type: 'success',
-                title: 'Change request status updated',
+                text: 'Change request status updated',
             });
             await refetchChangeRequestConfig();
         } catch (error) {

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -97,7 +97,6 @@ export const ChangeRequestTable: VFC = () => {
             setToastData({
                 type: 'success',
                 title: 'Updated change request status',
-                text: 'Successfully updated change request status.',
             });
             await refetchChangeRequestConfig();
         } catch (error) {

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -96,7 +96,7 @@ export const ChangeRequestTable: VFC = () => {
             );
             setToastData({
                 type: 'success',
-                title: 'Updated change request status',
+                title: 'Change request status updated',
             });
             await refetchChangeRequestConfig();
         } catch (error) {

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsModal.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsModal.tsx
@@ -159,7 +159,7 @@ export const ProjectActionsModal = ({
                 await addActionSet(payload);
             }
             setToastData({
-                title: `action ${editing ? 'updated' : 'added'} successfully`,
+                text: `action ${editing ? 'updated' : 'added'} successfully`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
@@ -57,7 +57,7 @@ export const ProjectActionsTable = ({
         try {
             await toggleActionSet(action.id, enabled);
             setToastData({
-                title: `"${action.name}" has been ${
+                text: `"${action.name}" has been ${
                     enabled ? 'enabled' : 'disabled'
                 }`,
                 type: 'success',
@@ -72,7 +72,7 @@ export const ProjectActionsTable = ({
         try {
             await removeActionSet(action.id);
             setToastData({
-                title: `"${action.name}" has been deleted`,
+                text: `"${action.name}" has been deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -107,7 +107,7 @@ const EditDefaultStrategy = () => {
         refetchSavedStrategySegments();
         refetchProjectOverview();
         setToastData({
-            title: 'Default Strategy updated',
+            text: 'Default Strategy updated',
             type: 'success',
         });
     };

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/EditDefaultStrategy.tsx
@@ -109,7 +109,6 @@ const EditDefaultStrategy = () => {
         setToastData({
             title: 'Default Strategy updated',
             type: 'success',
-            confetti: true,
         });
     };
 

--- a/frontend/src/component/project/Project/ProjectSettings/Settings/EditProject/UpdateEnterpriseSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/Settings/EditProject/UpdateEnterpriseSettings.tsx
@@ -125,7 +125,7 @@ export const UpdateEnterpriseSettings = ({
             await editProjectSettings(id, payload);
             refetch();
             setToastData({
-                title: 'Project information updated',
+                text: 'Project information updated',
                 type: 'success',
             });
             trackPattern(featureNamingPattern);

--- a/frontend/src/component/project/Project/ProjectSettings/Settings/EditProject/UpdateProject.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/Settings/EditProject/UpdateProject.tsx
@@ -94,7 +94,7 @@ export const UpdateProject = ({ project }: IUpdateProject) => {
                 await editProject(id, payload);
                 refetch();
                 setToastData({
-                    title: 'Project information updated',
+                    text: 'Project information updated',
                     type: 'success',
                 });
                 if (projectStickiness !== DEFAULT_PROJECT_STICKINESS) {

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -233,7 +233,7 @@ export const ProjectAccessAssign = ({
             refetchProjectAccess();
             navigate(GO_BACK);
             setToastData({
-                title: `${selectedOptions.length} ${
+                text: `${selectedOptions.length} ${
                     selectedOptions.length === 1 ? 'access' : 'accesses'
                 } ${!edit ? 'assigned' : 'edited'} successfully`,
                 type: 'success',

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
@@ -382,14 +382,14 @@ export const ProjectAccessTable: VFC = () => {
             refetchProjectAccess();
             setToastData({
                 type: 'success',
-                title: `${
+                text: `${
                     name || `The ${entityType}`
                 } has been removed from project`,
             });
         } catch (err: any) {
             setToastData({
                 type: 'error',
-                title:
+                text:
                     err.message ||
                     `Server problems when removing ${entityType}.`,
             });

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -111,8 +111,7 @@ const ProjectEnvironmentList = () => {
                 return;
             }
             setToastData({
-                title: 'One environment must be visible',
-                text: 'You must always have at least one visible environment per project',
+                title: 'At least one environment must be visible',
                 type: 'error',
             });
         } else {
@@ -121,7 +120,6 @@ const ProjectEnvironmentList = () => {
                 refetch();
                 setToastData({
                     title: 'Environment set as visible',
-                    text: 'Environment successfully set as visible.',
                     type: 'success',
                 });
             } catch (error) {
@@ -139,8 +137,7 @@ const ProjectEnvironmentList = () => {
                 );
                 refetch();
                 setToastData({
-                    title: 'Environment set as hidden',
-                    text: 'Environment successfully set as hidden.',
+                    title: 'Environment hidden',
                     type: 'success',
                 });
             } catch (e) {

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -111,7 +111,7 @@ const ProjectEnvironmentList = () => {
                 return;
             }
             setToastData({
-                text: 'At least one environment must be visible',
+                text: 'At least one environment must be visible in the project',
                 type: 'error',
             });
         } else {

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -111,7 +111,7 @@ const ProjectEnvironmentList = () => {
                 return;
             }
             setToastData({
-                title: 'At least one environment must be visible',
+                text: 'At least one environment must be visible',
                 type: 'error',
             });
         } else {
@@ -119,7 +119,7 @@ const ProjectEnvironmentList = () => {
                 await addEnvironmentToProject(projectId, env.name);
                 refetch();
                 setToastData({
-                    title: 'Environment set as visible',
+                    text: 'Environment set as visible',
                     type: 'success',
                 });
             } catch (error) {
@@ -137,7 +137,7 @@ const ProjectEnvironmentList = () => {
                 );
                 refetch();
                 setToastData({
-                    title: 'Environment hidden',
+                    text: 'Environment hidden',
                     type: 'success',
                 });
             } catch (e) {

--- a/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
+++ b/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
@@ -39,7 +39,7 @@ export const ReviveProjectDialog = ({
             refetchProjectArchive();
             navigate(`/projects/${id}`);
             setToastData({
-                title: 'Revived project',
+                title: 'Project revived',
                 type: 'success',
             });
         } catch (ex: unknown) {

--- a/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
+++ b/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
@@ -39,7 +39,7 @@ export const ReviveProjectDialog = ({
             refetchProjectArchive();
             navigate(`/projects/${id}`);
             setToastData({
-                title: 'Project revived',
+                text: 'Project revived',
                 type: 'success',
             });
         } catch (ex: unknown) {

--- a/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
+++ b/frontend/src/component/project/ProjectList/ReviveProjectDialog/ReviveProjectDialog.tsx
@@ -39,9 +39,8 @@ export const ReviveProjectDialog = ({
             refetchProjectArchive();
             navigate(`/projects/${id}`);
             setToastData({
-                title: 'Revive project',
+                title: 'Revived project',
                 type: 'success',
-                text: 'Successfully revived project',
             });
         } catch (ex: unknown) {
             setToastApiError(formatUnknownError(ex));

--- a/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCardMenu.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCardMenu.tsx
@@ -30,8 +30,7 @@ export const ReleasePlanTemplateCardMenu = ({
             refetch();
             setToastData({
                 type: 'success',
-                title: 'Success',
-                text: 'Release plan template deleted',
+                title: 'Release plan template deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCardMenu.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCardMenu.tsx
@@ -30,7 +30,7 @@ export const ReleasePlanTemplateCardMenu = ({
             refetch();
             setToastData({
                 type: 'success',
-                title: 'Release plan template deleted',
+                text: 'Release plan template deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
@@ -59,7 +59,7 @@ export const CreateReleasePlanTemplate = () => {
                 scrollToTop();
                 setToastData({
                     type: 'success',
-                    title: 'Release plan template created',
+                    text: 'Release plan template created',
                 });
                 navigate('/release-management');
             } catch (error: unknown) {

--- a/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
@@ -66,7 +66,7 @@ export const EditReleasePlanTemplate = () => {
                 await refetch();
                 setToastData({
                     type: 'success',
-                    title: 'Release plan template updated',
+                    text: 'Release plan template updated',
                 });
                 navigate('/release-management');
             } catch (error: unknown) {

--- a/frontend/src/component/segments/CreateSegment/CreateSegment.tsx
+++ b/frontend/src/component/segments/CreateSegment/CreateSegment.tsx
@@ -76,8 +76,7 @@ export const CreateSegment = ({ modal }: ICreateSegmentProps) => {
                 navigate('/segments/');
             }
             setToastData({
-                title: 'Segment created',
-                confetti: true,
+                text: 'Segment created',
                 type: 'success',
             });
             showFeedbackCES({

--- a/frontend/src/component/segments/EditSegment/EditSegment.tsx
+++ b/frontend/src/component/segments/EditSegment/EditSegment.tsx
@@ -101,7 +101,7 @@ export const EditSegment = ({ modal }: IEditSegmentProps) => {
                     navigate('/segments/');
                 }
                 setToastData({
-                    title: `Segment ${
+                    text: `Segment ${
                         changeRequestEnv ? 'change added to draft' : 'updated'
                     }`,
                     type: 'success',

--- a/frontend/src/component/segments/RemoveSegmentButton/RemoveSegmentButton.tsx
+++ b/frontend/src/component/segments/RemoveSegmentButton/RemoveSegmentButton.tsx
@@ -32,7 +32,7 @@ export const RemoveSegmentButton = ({ segment }: IRemoveSegmentButtonProps) => {
             await refetchSegments();
             setToastData({
                 type: 'success',
-                title: 'Successfully deleted segment',
+                text: 'Successfully deleted segment',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/segments/RemoveSegmentButton/RemoveSegmentButton.tsx
+++ b/frontend/src/component/segments/RemoveSegmentButton/RemoveSegmentButton.tsx
@@ -32,7 +32,7 @@ export const RemoveSegmentButton = ({ segment }: IRemoveSegmentButtonProps) => {
             await refetchSegments();
             setToastData({
                 type: 'success',
-                text: 'Successfully deleted segment',
+                text: 'Segment deleted',
             });
         } catch (error: unknown) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsFormURL.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsFormURL.tsx
@@ -47,7 +47,7 @@ export const SignalEndpointsFormURL = ({
         copy(url);
         setToastData({
             type: 'success',
-            title: 'Copied to clipboard',
+            text: 'Copied to clipboard',
         });
     };
 

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
@@ -115,7 +115,7 @@ export const SignalEndpointsTokens = ({
             setNewToken(token);
             setTokenOpen(true);
             setToastData({
-                title: 'Token created successfully',
+                text: 'Token created successfully',
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -134,7 +134,7 @@ export const SignalEndpointsTokens = ({
                 refetchTokens();
                 setDeleteOpen(false);
                 setToastData({
-                    title: 'Token deleted successfully',
+                    text: 'Token deleted successfully',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
@@ -115,7 +115,7 @@ export const SignalEndpointsTokens = ({
             setNewToken(token);
             setTokenOpen(true);
             setToastData({
-                text: 'Token created successfully',
+                text: 'Token created',
                 type: 'success',
             });
         } catch (error: unknown) {
@@ -134,7 +134,7 @@ export const SignalEndpointsTokens = ({
                 refetchTokens();
                 setDeleteOpen(false);
                 setToastData({
-                    text: 'Token deleted successfully',
+                    text: 'Token deleted',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsModal.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsModal.tsx
@@ -132,7 +132,7 @@ export const SignalEndpointsModal = ({
                 }
             }
             setToastData({
-                title: `Signal endpoint ${
+                text: `Signal endpoint ${
                     editing ? 'updated' : 'added'
                 } successfully`,
                 type: 'success',

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsModal.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsModal.tsx
@@ -132,9 +132,7 @@ export const SignalEndpointsModal = ({
                 }
             }
             setToastData({
-                text: `Signal endpoint ${
-                    editing ? 'updated' : 'added'
-                } successfully`,
+                text: `Signal endpoint ${editing ? 'updated' : 'added'}`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
+++ b/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
@@ -68,7 +68,7 @@ export const SignalEndpointsTable = () => {
         try {
             await toggleSignalEndpoint(id, enabled);
             setToastData({
-                title: `"${name}" has been ${enabled ? 'enabled' : 'disabled'}`,
+                text: `"${name}" has been ${enabled ? 'enabled' : 'disabled'}`,
                 type: 'success',
             });
             refetch();
@@ -81,7 +81,7 @@ export const SignalEndpointsTable = () => {
         try {
             await removeSignalEndpoint(id);
             setToastData({
-                title: `"${name}" has been deleted`,
+                text: `"${name}" has been deleted`,
                 type: 'success',
             });
             refetch();
@@ -181,7 +181,7 @@ export const SignalEndpointsTable = () => {
                             );
                             setToastData({
                                 type: 'success',
-                                title: 'Copied to clipboard',
+                                text: 'Copied to clipboard',
                             });
                         }}
                         onOpenSignals={() => {

--- a/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
+++ b/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
@@ -68,7 +68,7 @@ export const SignalEndpointsTable = () => {
         try {
             await toggleSignalEndpoint(id, enabled);
             setToastData({
-                text: `"${name}" has been ${enabled ? 'enabled' : 'disabled'}`,
+                text: `"${name}" ${enabled ? 'enabled' : 'disabled'}`,
                 type: 'success',
             });
             refetch();
@@ -81,7 +81,7 @@ export const SignalEndpointsTable = () => {
         try {
             await removeSignalEndpoint(id);
             setToastData({
-                text: `"${name}" has been deleted`,
+                text: `"${name}" deleted`,
                 type: 'success',
             });
             refetch();

--- a/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
+++ b/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
@@ -64,7 +64,7 @@ export const CreateStrategy = () => {
                 refetchStrategies();
                 navigate(`/strategies/${strategyName}`);
                 setToastData({
-                    title: 'Strategy created',
+                    text: 'Strategy created',
                     type: 'success',
                 });
             } catch (e: unknown) {

--- a/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
+++ b/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
@@ -65,8 +65,6 @@ export const CreateStrategy = () => {
                 navigate(`/strategies/${strategyName}`);
                 setToastData({
                     title: 'Strategy created',
-                    text: 'Successfully created strategy',
-                    confetti: true,
                     type: 'success',
                 });
             } catch (e: unknown) {

--- a/frontend/src/component/strategies/EditStrategy/EditStrategy.tsx
+++ b/frontend/src/component/strategies/EditStrategy/EditStrategy.tsx
@@ -50,7 +50,7 @@ export const EditStrategy = () => {
                 navigate(`/strategies/${strategyName}`);
                 setToastData({
                     type: 'success',
-                    title: 'Strategy updated',
+                    text: 'Strategy updated',
                 });
                 refetchStrategies();
             } catch (error: unknown) {

--- a/frontend/src/component/strategies/EditStrategy/EditStrategy.tsx
+++ b/frontend/src/component/strategies/EditStrategy/EditStrategy.tsx
@@ -50,8 +50,7 @@ export const EditStrategy = () => {
                 navigate(`/strategies/${strategyName}`);
                 setToastData({
                     type: 'success',
-                    title: 'Success',
-                    text: 'Successfully updated strategy',
+                    title: 'Strategy updated',
                 });
                 refetchStrategies();
             } catch (error: unknown) {

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -182,8 +182,7 @@ export const StrategiesList = () => {
                             refetchStrategies();
                             setToastData({
                                 type: 'success',
-                                title: 'Success',
-                                text: 'Strategy reactivated successfully',
+                                title: 'Strategy reactivated',
                             });
                         } catch (error: unknown) {
                             setToastApiError(formatUnknownError(error));
@@ -200,8 +199,7 @@ export const StrategiesList = () => {
                             refetchStrategies();
                             setToastData({
                                 type: 'success',
-                                title: 'Success',
-                                text: 'Strategy deprecated successfully',
+                                title: 'Strategy deprecated',
                             });
                         } catch (error: unknown) {
                             setToastApiError(formatUnknownError(error));
@@ -230,8 +228,7 @@ export const StrategiesList = () => {
                         refetchStrategies();
                         setToastData({
                             type: 'success',
-                            title: 'Success',
-                            text: 'Strategy deleted successfully',
+                            title: 'Strategy deleted',
                         });
                     } catch (error: unknown) {
                         setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -182,7 +182,7 @@ export const StrategiesList = () => {
                             refetchStrategies();
                             setToastData({
                                 type: 'success',
-                                title: 'Strategy reactivated',
+                                text: 'Strategy reactivated',
                             });
                         } catch (error: unknown) {
                             setToastApiError(formatUnknownError(error));
@@ -199,7 +199,7 @@ export const StrategiesList = () => {
                             refetchStrategies();
                             setToastData({
                                 type: 'success',
-                                title: 'Strategy deprecated',
+                                text: 'Strategy deprecated',
                             });
                         } catch (error: unknown) {
                             setToastApiError(formatUnknownError(error));
@@ -228,7 +228,7 @@ export const StrategiesList = () => {
                         refetchStrategies();
                         setToastData({
                             type: 'success',
-                            title: 'Strategy deleted',
+                            text: 'Strategy deleted',
                         });
                     } catch (error: unknown) {
                         setToastApiError(formatUnknownError(error));

--- a/frontend/src/component/tags/CreateTagType/CreateTagType.tsx
+++ b/frontend/src/component/tags/CreateTagType/CreateTagType.tsx
@@ -37,7 +37,6 @@ const CreateTagType = () => {
                 navigate('/tag-types');
                 setToastData({
                     title: 'Tag type created',
-                    confetti: true,
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/tags/CreateTagType/CreateTagType.tsx
+++ b/frontend/src/component/tags/CreateTagType/CreateTagType.tsx
@@ -36,7 +36,7 @@ const CreateTagType = () => {
                 await createTag(payload);
                 navigate('/tag-types');
                 setToastData({
-                    title: 'Tag type created',
+                    text: 'Tag type created',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/tags/EditTagType/EditTagType.tsx
+++ b/frontend/src/component/tags/EditTagType/EditTagType.tsx
@@ -37,7 +37,7 @@ const EditTagType = () => {
             await updateTagType(tagName, payload);
             navigate('/tag-types');
             setToastData({
-                title: 'Tag type updated',
+                text: 'Tag type updated',
                 type: 'success',
             });
         } catch (error: unknown) {

--- a/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
+++ b/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
@@ -178,7 +178,7 @@ export const TagTypeList = () => {
                 setToastData({
                     type: 'success',
                     show: true,
-                    title: 'Successfully deleted tag type.',
+                    text: 'Successfully deleted tag type.',
                 });
             }
         } catch (error) {

--- a/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
+++ b/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
@@ -178,7 +178,7 @@ export const TagTypeList = () => {
                 setToastData({
                     type: 'success',
                     show: true,
-                    text: 'Successfully deleted tag type.',
+                    text: 'Tag type deleted',
                 });
             }
         } catch (error) {

--- a/frontend/src/component/user/HostedAuth.tsx
+++ b/frontend/src/component/user/HostedAuth.tsx
@@ -80,7 +80,6 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
                 setToastData({
                     type: 'success',
                     title: 'Maximum Session Limit Reached',
-                    text: `You can have up to ${data.activeSessions} active sessions at a time. To enhance your account security, we’ve ended ${data.deletedSessions} session(s) on other browsers.`,
                 });
             }
             refetchUser();

--- a/frontend/src/component/user/HostedAuth.tsx
+++ b/frontend/src/component/user/HostedAuth.tsx
@@ -79,7 +79,7 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
             if (data.deletedSessions && data.activeSessions) {
                 setToastData({
                     type: 'success',
-                    title: 'Maximum Session Limit Reached',
+                    text: 'Maximum Session Limit Reached',
                 });
             }
             refetchUser();

--- a/frontend/src/component/user/HostedAuth.tsx
+++ b/frontend/src/component/user/HostedAuth.tsx
@@ -79,7 +79,7 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
             if (data.deletedSessions && data.activeSessions) {
                 setToastData({
                     type: 'success',
-                    text: 'Maximum Session Limit Reached',
+                    text: `Maximum session limit of ${data.activeSessions} reached`,
                 });
             }
             refetchUser();

--- a/frontend/src/component/user/PasswordAuth.test.tsx
+++ b/frontend/src/component/user/PasswordAuth.test.tsx
@@ -46,7 +46,7 @@ test('should show deleted stale sessions info for Password Auth', async () => {
 
     button.click();
 
-    await screen.findByText('Maximum Session Limit Reached');
+    await screen.findByText('Maximum session limit of 3 reached');
 });
 
 test('should show deleted stale sessions info for Hosted Auth', async () => {
@@ -72,5 +72,5 @@ test('should show deleted stale sessions info for Hosted Auth', async () => {
 
     button.click();
 
-    await screen.findByText('Maximum Session Limit Reached');
+    await screen.findByText('Maximum session limit of 3 reached');
 });

--- a/frontend/src/component/user/PasswordAuth.tsx
+++ b/frontend/src/component/user/PasswordAuth.tsx
@@ -79,7 +79,6 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
                 setToastData({
                     type: 'success',
                     title: 'Maximum Session Limit Reached',
-                    text: `You can have up to ${data.activeSessions} active sessions at a time. To enhance your account security, we’ve ended ${data.deletedSessions} session(s) on other browsers.`,
                 });
             }
 

--- a/frontend/src/component/user/PasswordAuth.tsx
+++ b/frontend/src/component/user/PasswordAuth.tsx
@@ -78,7 +78,7 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
             if (data.deletedSessions && data.activeSessions) {
                 setToastData({
                     type: 'success',
-                    title: 'Maximum Session Limit Reached',
+                    text: 'Maximum Session Limit Reached',
                 });
             }
 

--- a/frontend/src/component/user/PasswordAuth.tsx
+++ b/frontend/src/component/user/PasswordAuth.tsx
@@ -78,7 +78,7 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
             if (data.deletedSessions && data.activeSessions) {
                 setToastData({
                     type: 'success',
-                    text: 'Maximum Session Limit Reached',
+                    text: `Maximum session limit of ${data.activeSessions} reached`,
                 });
             }
 

--- a/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
+++ b/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
@@ -62,7 +62,7 @@ export const PasswordTab = () => {
                     oldPassword,
                 });
                 setToastData({
-                    text: 'Password changed successfully',
+                    text: 'Password changed',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
+++ b/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
@@ -62,7 +62,7 @@ export const PasswordTab = () => {
                     oldPassword,
                 });
                 setToastData({
-                    title: 'Password changed successfully',
+                    text: 'Password changed successfully',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
+++ b/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
@@ -63,7 +63,6 @@ export const PasswordTab = () => {
                 });
                 setToastData({
                     title: 'Password changed successfully',
-                    text: 'Now you can sign in using your new password.',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
@@ -29,7 +29,7 @@ export const DeletePersonalAPIToken: FC<IDeletePersonalAPITokenProps> = ({
                 refetchTokens();
                 setOpen(false);
                 setToastData({
-                    title: 'Token deleted successfully',
+                    text: 'Token deleted successfully',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/DeletePersonalAPIToken/DeletePersonalAPIToken.tsx
@@ -29,7 +29,7 @@ export const DeletePersonalAPIToken: FC<IDeletePersonalAPITokenProps> = ({
                 refetchTokens();
                 setOpen(false);
                 setToastData({
-                    text: 'Token deleted successfully',
+                    text: 'Token deleted',
                     type: 'success',
                 });
             } catch (error: unknown) {

--- a/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.test.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.test.tsx
@@ -100,6 +100,6 @@ test('handle error', async () => {
 
     checkbox.click();
 
-    await screen.findByText('Something went wrong');
+    await screen.findByText('user error');
     expect(changed).toBe(true);
 });

--- a/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProductivityEmailSubscription.tsx
@@ -28,7 +28,7 @@ export const ProductivityEmailSubscription: FC<{
                                 if (status === 'subscribed') {
                                     await unsubscribe('productivity-report');
                                     setToastData({
-                                        title: 'Unsubscribed from productivity report',
+                                        text: 'Unsubscribed from productivity report',
                                         type: 'success',
                                     });
                                     trackEvent('productivity-report', {
@@ -39,7 +39,7 @@ export const ProductivityEmailSubscription: FC<{
                                 } else {
                                     await subscribe('productivity-report');
                                     setToastData({
-                                        title: 'Subscribed to productivity report',
+                                        text: 'Subscribed to productivity report',
                                         type: 'success',
                                     });
                                     trackEvent('productivity-report', {

--- a/frontend/src/contexts/UIContext.ts
+++ b/frontend/src/contexts/UIContext.ts
@@ -15,7 +15,7 @@ export type themeMode = 'light' | 'dark';
 export const createEmptyToast = (): IToast => {
     return {
         type: 'success',
-        title: '',
+        text: '',
         components: [],
         show: false,
         persist: false,

--- a/frontend/src/contexts/UIContext.ts
+++ b/frontend/src/contexts/UIContext.ts
@@ -16,7 +16,6 @@ export const createEmptyToast = (): IToast => {
     return {
         type: 'success',
         title: '',
-        text: '',
         components: [],
         show: false,
         persist: false,

--- a/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
+++ b/frontend/src/hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi.ts
@@ -24,7 +24,7 @@ export const useFavoriteFeaturesApi = () => {
                 await makeLightRequest(req.caller, req.id);
 
                 setToastData({
-                    title: 'Feature flag added to favorites',
+                    text: 'Feature flag added to favorites',
                     type: 'success',
                 });
                 trackEvent('favorite', {
@@ -52,7 +52,7 @@ export const useFavoriteFeaturesApi = () => {
                 await makeLightRequest(req.caller, req.id);
 
                 setToastData({
-                    title: 'Feature flag removed from favorites',
+                    text: 'Feature flag removed from favorites',
                     type: 'success',
                 });
                 trackEvent('favorite', {

--- a/frontend/src/hooks/api/actions/useFavoriteProjectsApi/useFavoriteProjectsApi.ts
+++ b/frontend/src/hooks/api/actions/useFavoriteProjectsApi/useFavoriteProjectsApi.ts
@@ -24,7 +24,7 @@ export const useFavoriteProjectsApi = () => {
                 await makeLightRequest(req.caller, req.id);
 
                 setToastData({
-                    title: 'Project added to favorites',
+                    text: 'Project added to favorites',
                     type: 'success',
                 });
                 trackEvent('favorite', {
@@ -52,7 +52,7 @@ export const useFavoriteProjectsApi = () => {
                 await makeLightRequest(req.caller, req.id);
 
                 setToastData({
-                    title: 'Project removed from favorites',
+                    text: 'Project removed from favorites',
                     type: 'success',
                 });
                 trackEvent('favorite', {

--- a/frontend/src/hooks/useChangeRequestAddStrategy.ts
+++ b/frontend/src/hooks/useChangeRequestAddStrategy.ts
@@ -78,7 +78,7 @@ export const useChangeRequestAddStrategy = (
             setChangeRequestDialogDetails({ isOpen: false });
             setToastData({
                 type: 'success',
-                text: 'Changes added to the draft!',
+                text: 'Changes added to draft',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));
@@ -105,7 +105,7 @@ export const useChangeRequestAddStrategy = (
             setChangeRequestDialogDetails({ isOpen: false });
             setToastData({
                 type: 'success',
-                text: 'Changes added to the draft!',
+                text: 'Changes added to draft',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/hooks/useChangeRequestAddStrategy.ts
+++ b/frontend/src/hooks/useChangeRequestAddStrategy.ts
@@ -78,7 +78,7 @@ export const useChangeRequestAddStrategy = (
             setChangeRequestDialogDetails({ isOpen: false });
             setToastData({
                 type: 'success',
-                title: 'Changes added to the draft!',
+                text: 'Changes added to the draft!',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));
@@ -105,7 +105,7 @@ export const useChangeRequestAddStrategy = (
             setChangeRequestDialogDetails({ isOpen: false });
             setToastData({
                 type: 'success',
-                title: 'Changes added to the draft!',
+                text: 'Changes added to the draft!',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/hooks/useChangeRequestToggle.ts
+++ b/frontend/src/hooks/useChangeRequestToggle.ts
@@ -62,7 +62,7 @@ export const useChangeRequestToggle = (project: string) => {
             }));
             setToastData({
                 type: 'success',
-                title: 'Changes added to the draft!',
+                text: 'Changes added to the draft!',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/hooks/useChangeRequestToggle.ts
+++ b/frontend/src/hooks/useChangeRequestToggle.ts
@@ -62,7 +62,7 @@ export const useChangeRequestToggle = (project: string) => {
             }));
             setToastData({
                 type: 'success',
-                text: 'Changes added to the draft!',
+                text: 'Changes added to draft',
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -14,7 +14,7 @@ const useToast = () => {
     const setToastApiError = useCallback(
         (text: string, overrides?: IToast) => {
             setToast({
-                title: text || 'Something went wrong.',
+                text: text || 'Something went wrong.',
                 type: 'error',
                 show: true,
                 autoHideDuration: 12000,

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -14,8 +14,7 @@ const useToast = () => {
     const setToastApiError = useCallback(
         (text: string, overrides?: IToast) => {
             setToast({
-                title: 'Something went wrong',
-                text,
+                title: text,
                 type: 'error',
                 show: true,
                 autoHideDuration: 12000,

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -14,7 +14,7 @@ const useToast = () => {
     const setToastApiError = useCallback(
         (text: string, overrides?: IToast) => {
             setToast({
-                title: text,
+                title: text || 'Something went wrong.',
                 type: 'error',
                 show: true,
                 autoHideDuration: 12000,

--- a/frontend/src/interfaces/toast.ts
+++ b/frontend/src/interfaces/toast.ts
@@ -1,10 +1,8 @@
 export interface IToast {
     type: 'success' | 'error';
     title: string;
-    text?: string;
     components?: JSX.Element[];
     show?: boolean;
     persist?: boolean;
-    confetti?: boolean;
     autoHideDuration?: number;
 }

--- a/frontend/src/interfaces/toast.ts
+++ b/frontend/src/interfaces/toast.ts
@@ -1,6 +1,6 @@
 export interface IToast {
     type: 'success' | 'error';
-    title: string;
+    text: string;
     components?: JSX.Element[];
     show?: boolean;
     persist?: boolean;


### PR DESCRIPTION
As of PR #8935, we no longer support both text and title, and confetti has been removed.

This PR:
- removes `confetti` from the toast interface
- merges `text` and `title` into `text` and updates its uses across the codebase.
- readjusts the text where necessary.