### PR TITLE
Chore/increase client api test coverage

### DIFF
--- a/src/lib/features/client-feature-toggles/tests/__snapshots__/client-feature-toggles.e2e.test.ts.snap
+++ b/src/lib/features/client-feature-toggles/tests/__snapshots__/client-feature-toggles.e2e.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should match snapshot from /api/client/features 1`] = `
+{
+  "features": [
+    {
+      "description": null,
+      "enabled": false,
+      "impressionData": false,
+      "name": "test1",
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "constraints": [],
+          "name": "flexibleRollout",
+          "parameters": {
+            "groupId": "test1",
+            "rollout": "100",
+            "stickiness": "default",
+          },
+          "variants": [],
+        },
+      ],
+      "type": "release",
+      "variants": [],
+    },
+    {
+      "description": null,
+      "enabled": false,
+      "impressionData": false,
+      "name": "test2",
+      "project": "default",
+      "stale": false,
+      "strategies": [
+        {
+          "constraints": [
+            {
+              "contextName": "userId",
+              "operator": "IN",
+              "values": [
+                "123",
+              ],
+            },
+          ],
+          "name": "default",
+          "parameters": {},
+          "variants": [],
+        },
+      ],
+      "type": "release",
+      "variants": [],
+    },
+  ],
+  "meta": {
+    "etag": ""61824cd0:11"",
+    "queryHash": "61824cd0",
+    "revisionId": 11,
+  },
+  "query": {
+    "environment": "default",
+    "inlineSegmentConstraints": true,
+  },
+  "version": 2,
+}
+`;


### PR DESCRIPTION
Added more tests around specific plans. Also added snapshot as per our conversation @gastonfournier, but I'm unsure how much value it will give because it seems that the tests should already catch this using respondWithValidation and the OpenAPI schema. The problem here is that empty array is a valid state, so there were no reason for the schema to break the tests.