### PR TITLE
fix: Change to use database environment variables in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:coverage:jest": "NODE_ENV=test PORT=4243 jest --silent --ci --json --coverage --testLocationInResults --outputFile=\"report.json\" --forceExit --testTimeout=10000",
     "test:updateSnapshot": "NODE_ENV=test PORT=4243 jest --updateSnapshot --testTimeout=10000",
     "seed:setup": "ts-node --compilerOptions '{\"strictNullChecks\": false}' src/test/e2e/seed/segment.seed.ts",
-    "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
+    "seed:serve": "DATABASE_NAME=unleash_test DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",
     "heroku-postbuild": "cd frontend && yarn && yarn build",
     "prepack": "./scripts/prepack.sh",

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -2,6 +2,7 @@ import { start } from './lib/server-impl';
 import { createConfig } from './lib/create-config';
 import { LogLevel } from './lib/logger';
 import { ApiTokenType } from './lib/types/models/api-token';
+import { parseEnvVarNumber, parseEnvVarBoolean } from './lib/util';
 
 process.nextTick(async () => {
     try {
@@ -10,15 +11,23 @@ process.nextTick(async () => {
                 db: process.env.DATABASE_URL
                     ? undefined
                     : {
-                          user: 'unleash_user',
-                          password: 'password',
-                          host: 'localhost',
-                          port: 5432,
-                          database:
-                              process.env.UNLEASH_DATABASE_NAME || 'unleash',
-                          schema: process.env.UNLEASH_DATABASE_SCHEMA,
+                          user: process.env.DATABASE_USERNAME || 'unleash_user',
+                          password: process.env.DATABASE_PASSWORD || 'password',
+                          host: process.env.DATABASE_HOST || 'localhost',
+                          port: parseEnvVarNumber(
+                              process.env.DATABASE_PORT,
+                              5432,
+                          ),
+                          database: process.env.DATBASE_NAME || 'unleash',
+                          schema: process.env.DATABASE_SCHEMA,
                           ssl: false,
-                          applicationName: 'unleash',
+                          applicationName:
+                              process.env.DATABASE_APPLICATION_NAME ||
+                              'unleash',
+                          disableMigration: parseEnvVarBoolean(
+                              process.env.DATABASE_DISABLE_MIGRATION,
+                              false,
+                          ),
                       },
                 server: {
                     enableRequestLogger: true,

--- a/website/docs/contributing/backend/overview.md
+++ b/website/docs/contributing/backend/overview.md
@@ -50,6 +50,21 @@ export DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash
 export TEST_DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash_test
 ```
 
+However, you cal also use your pre-defined database with env vars:
+
+```
+export DATABASE_USERNAME=YOUR-DATBASE-USERNAME
+export DATABASE_PASSWORD=YOUR-DATABASE-PASSWORD
+export DATABASE_HOST=YOUR-DATABASE-HOST
+export DATABASE_PORT=YOUR-DATABASE-PORT
+export DATABASE_NAME=YOUR-DATABASE-NAME
+export DATABASE_SCHEMA=YOUR-DATABASE-SCHEMA
+export DATABASE_APPLICATION_NAME=YOUR-DATABASE-APPLICATION_NAME
+export DATABASE_DISABLE_MIGRATION=YOUR-DATABASE-DISABLE_MIGRATION
+```
+
+You can check what each option means on [Database configuration](../../using-unleash/deploy/configuring-unleash.mdx#database-configuration)
+
 ## PostgreSQL with docker {#postgresql-with-docker}
 
 If you don't want to install PostgreSQL locally, you can spin up an Docker instance. We have created a script to ease this process: `scripts/docker-postgres.sh`


### PR DESCRIPTION
## About the changes

- Change to use database environment variables such as `DATABASE_HOST` when running dev mode
- Change contributing backend overview document to describe how to use pre-defined database with environment variables

## Discussion points

In some cases, users want to use their pre-defined database in dev mode and now they only can use `DATABASE_URL`. However, it is more efficient to help them use separated options such as `DATABASE_HOST` and `DATABASE_PORT`.