### PR TITLE
fix: make project ui query optimized

### DIFF
--- a/src/lib/features/project/project-read-model.test.ts
+++ b/src/lib/features/project/project-read-model.test.ts
@@ -46,6 +46,7 @@ afterAll(async () => {
 beforeEach(async () => {
     await projectStore.deleteAll();
     await flagStore.deleteAll();
+    await eventStore.deleteAll();
 });
 
 test("it doesn't count flags multiple times when they have multiple events associated with them", async () => {

--- a/src/migrations/20241211143944-events-index-project-feature-created.js
+++ b/src/migrations/20241211143944-events-index-project-feature-created.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+          CREATE INDEX idx_events_project_feature_created
+            ON events (project, feature_name, created_at DESC);
+        `,
+        callback,
+    );
+};
+
+exports.down = function (db, callback) {
+    db.runSql(
+        `
+           DROP INDEX idx_events_project_feature_created;
+        `,
+        callback,
+    );
+};


### PR DESCRIPTION
From 13 seconds to 0.1 seconds.

1. Joining 1 million events to projects/features is slow. **Solved by using CTE.**
2. Running grouping on 1 million rows is slow. **Solved by adding index.**