### PR TITLE
fix: do not initialize cache when flag is off

### DIFF
--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -3,6 +3,7 @@ import type {
     IFeatureToggleClient,
     IFeatureToggleClientStore,
     IFeatureToggleQuery,
+    IFlagResolver,
 } from '../../../types';
 import type { FeatureConfigurationClient } from '../../feature-toggle/types/feature-toggle-strategies-store-type';
 import type ConfigurationRevisionService from '../../feature-toggle/configuration-revision-service';
@@ -99,19 +100,23 @@ export class ClientFeatureToggleCache {
 
     private interval: NodeJS.Timer;
 
+    private flagResolver: IFlagResolver;
+
     private configurationRevisionService: ConfigurationRevisionService;
 
     constructor(
         clientFeatureToggleStore: IFeatureToggleClientStore,
         eventStore: IEventStore,
         configurationRevisionService: ConfigurationRevisionService,
+        flagResolver: IFlagResolver,
     ) {
         this.eventStore = eventStore;
         this.configurationRevisionService = configurationRevisionService;
         this.clientFeatureToggleStore = clientFeatureToggleStore;
+        this.flagResolver = flagResolver;
         this.onUpdateRevisionEvent = this.onUpdateRevisionEvent.bind(this);
 
-        this.initCache();
+        // this.initCache(); TODO: we dont want to initialize cache on startup, but ondemand?
         this.configurationRevisionService.on(
             UPDATE_REVISION,
             this.onUpdateRevisionEvent,
@@ -158,7 +163,9 @@ export class ClientFeatureToggleCache {
     }
 
     private async onUpdateRevisionEvent() {
-        await this.pollEvents();
+        if (this.flagResolver.isEnabled('deltaApi')) {
+            await this.pollEvents();
+        }
     }
 
     public async pollEvents() {

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -116,7 +116,7 @@ export class ClientFeatureToggleCache {
         this.flagResolver = flagResolver;
         this.onUpdateRevisionEvent = this.onUpdateRevisionEvent.bind(this);
 
-        // this.initCache(); TODO: we dont want to initialize cache on startup, but ondemand?
+        // this.initCache(); TODO: we dont want to initialize cache on startup, but ondemand in future?
         this.configurationRevisionService.on(
             UPDATE_REVISION,
             this.onUpdateRevisionEvent,

--- a/src/lib/features/client-feature-toggles/cache/createClientFeatureToggleCache.ts
+++ b/src/lib/features/client-feature-toggles/cache/createClientFeatureToggleCache.ts
@@ -27,6 +27,7 @@ export const createClientFeatureToggleCache = (
         featureToggleClientStore,
         eventStore,
         configurationRevisionService,
+        flagResolver,
     );
 
     return clientFeatureToggleCache;


### PR DESCRIPTION
This feature is still in early alpha. We do not want to populate any cache on startup. We might not want to do it ever. 