### PR TITLE
fix: initialize cache when we get the first request

### DIFF
--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -139,13 +139,12 @@ export class ClientFeatureToggleCache {
         const hasCache = this.cache[environment] !== undefined;
 
         if (!hasCache) {
-            this.initEnvironmentCache(environment);
+            await this.initEnvironmentCache(environment);
         }
 
         // Should get the latest state if revision does not exist or if sdkRevision is not present
         // We should be able to do this without going to the database by merging revisions from the cache with
         // the base case
-
         const firstTimeCalling = !sdkRevisionId;
         if (
             firstTimeCalling ||
@@ -217,7 +216,6 @@ export class ClientFeatureToggleCache {
         const features = await this.getClientFeatures({
             environment: 'development',
         });
-
         if (this.cache.development) {
             this.cache.development.addRevision({
                 updated: features as any, //impressionData is not on the type but should be

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -259,7 +259,7 @@ export class ClientFeatureToggleCache {
             environment,
         });
 
-        this.latestRevision =
+        this.currentRevisionId =
             await this.configurationRevisionService.getMaxRevisionId();
 
         const cache = new RevisionCache([


### PR DESCRIPTION
This PR changes the caching functionality so that we initialize the cache when we receive the first request instead of frontloading the caches.