### PR TITLE
Feat/refactor polling

### DIFF
--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -182,48 +182,37 @@ export class ClientFeatureToggleCache {
     }
 
     public async pollEvents() {
+        const keys = Object.keys(this.cache);
+
+        if (keys.length === 0) return;
         const latestRevision =
             await this.configurationRevisionService.getMaxRevisionId();
 
-        if (this.currentRevisionId === 0) {
-            await this.populateBaseCache(latestRevision);
-        } else {
-            const changeEvents = await this.eventStore.getRevisionRange(
-                this.currentRevisionId,
-                latestRevision,
-            );
+        const changeEvents = await this.eventStore.getRevisionRange(
+            this.currentRevisionId,
+            latestRevision,
+        );
 
-            const changedToggles = [
-                ...new Set(
-                    changeEvents
-                        .filter((event) => event.featureName)
-                        .map((event) => event.featureName!),
-                ),
-            ];
-            const newToggles = await this.getChangedToggles(
-                changedToggles,
-                latestRevision, // TODO: this should come back from the same query to not be out of sync
-            );
+        const changedToggles = [
+            ...new Set(
+                changeEvents
+                    .filter((event) => event.featureName)
+                    .map((event) => event.featureName!),
+            ),
+        ];
+        const newToggles = await this.getChangedToggles(
+            changedToggles,
+            latestRevision, // TODO: this should come back from the same query to not be out of sync
+        );
 
-            if (this.cache.development) {
-                this.cache.development.addRevision(newToggles);
-            }
+        // TODO: Discussion point. Should we filter events by environment and only add revisions in the cache
+        // for the environment that changed? If we do that we can also save CPU and memory, because we don't need
+        // to talk to the database if the cache is not initialized for that environment
+        for (const key of keys) {
+            this.cache[key].addRevision(newToggles);
         }
+
         this.currentRevisionId = latestRevision;
-    }
-
-    private async populateBaseCache(latestRevisionId: number) {
-        const features = await this.getClientFeatures({
-            environment: 'development',
-        });
-        if (this.cache.development) {
-            this.cache.development.addRevision({
-                updated: features as any, //impressionData is not on the type but should be
-                removed: [],
-                revisionId: latestRevisionId,
-            });
-        }
-        console.log(`Populated base cache with ${features.length} features`);
     }
 
     async getChangedToggles(

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -177,11 +177,11 @@ export class ClientFeatureToggleCache {
 
     private async onUpdateRevisionEvent() {
         if (this.flagResolver.isEnabled('deltaApi')) {
-            await this.pollEvents();
+            await this.listenToRevisionChange();
         }
     }
 
-    public async pollEvents() {
+    public async listenToRevisionChange() {
         const keys = Object.keys(this.cache);
 
         if (keys.length === 0) return;


### PR DESCRIPTION
This PR refactors the method that listens on revision changes:
- Now supports all environments
- Removed unnecessary populate cache method

# Discussion point

In the listen method, should we implement logic to look into which environments the events touched? By doing this we would: 
- Reduce cache size
- Save some memory/CPU if the environment is not initialized in the cache, because we could skip the DB calls.