### PR TITLE
feat: deleted feature names should come from event

### DIFF
--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.test.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.test.ts
@@ -51,7 +51,12 @@ test('revision that adds, removes then adds again does not end up with the remov
         {
             revisionId: 2,
             updated: [],
-            removed: ['some-toggle'],
+            removed: [
+                {
+                    name: 'some-toggle',
+                    project: 'default',
+                },
+            ],
         },
         {
             revisionId: 3,
@@ -76,7 +81,12 @@ test('revision that removes, adds then removes again does not end up with the re
         {
             revisionId: 1,
             updated: [],
-            removed: ['some-toggle'],
+            removed: [
+                {
+                    name: 'some-toggle',
+                    project: 'default',
+                },
+            ],
         },
         {
             revisionId: 2,
@@ -86,7 +96,12 @@ test('revision that removes, adds then removes again does not end up with the re
         {
             revisionId: 3,
             updated: [],
-            removed: ['some-toggle'],
+            removed: [
+                {
+                    name: 'some-toggle',
+                    project: 'default',
+                },
+            ],
         },
     ];
 
@@ -97,7 +112,12 @@ test('revision that removes, adds then removes again does not end up with the re
     expect(revisions).toEqual({
         revisionId: 3,
         updated: [],
-        removed: ['some-toggle'],
+        removed: [
+            {
+                name: 'some-toggle',
+                project: 'default',
+            },
+        ],
     });
 });
 
@@ -131,6 +151,31 @@ test('revision equal to the base case returns only later revisions ', () => {
     expect(revisions).toEqual({
         revisionId: 3,
         updated: [mockAdd({ name: 'feature4' }), mockAdd({ name: 'feature5' })],
+        removed: [],
+    });
+});
+
+test('project filter removes features not in project', () => {
+    const revisionList = [
+        {
+            revisionId: 1,
+            updated: [mockAdd({ name: 'feature1', project: 'project1' })],
+            removed: [],
+        },
+        {
+            revisionId: 2,
+            updated: [mockAdd({ name: 'feature2', project: 'project2' })],
+            removed: [],
+        },
+    ];
+
+    const revisions = calculateRequiredClientRevision(revisionList, 0, [
+        'project1',
+    ]);
+
+    expect(revisions).toEqual({
+        revisionId: 2,
+        updated: [mockAdd({ name: 'feature1', project: 'project1' })],
         removed: [],
     });
 });

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.test.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.test.ts
@@ -51,12 +51,7 @@ test('revision that adds, removes then adds again does not end up with the remov
         {
             revisionId: 2,
             updated: [],
-            removed: [
-                {
-                    name: 'some-toggle',
-                    project: 'default',
-                },
-            ],
+            removed: ['some-toggle'],
         },
         {
             revisionId: 3,
@@ -81,12 +76,7 @@ test('revision that removes, adds then removes again does not end up with the re
         {
             revisionId: 1,
             updated: [],
-            removed: [
-                {
-                    name: 'some-toggle',
-                    project: 'default',
-                },
-            ],
+            removed: ['some-toggle'],
         },
         {
             revisionId: 2,
@@ -96,12 +86,7 @@ test('revision that removes, adds then removes again does not end up with the re
         {
             revisionId: 3,
             updated: [],
-            removed: [
-                {
-                    name: 'some-toggle',
-                    project: 'default',
-                },
-            ],
+            removed: ['some-toggle'],
         },
     ];
 
@@ -112,12 +97,7 @@ test('revision that removes, adds then removes again does not end up with the re
     expect(revisions).toEqual({
         revisionId: 3,
         updated: [],
-        removed: [
-            {
-                name: 'some-toggle',
-                project: 'default',
-            },
-        ],
+        removed: ['some-toggle'],
     });
 });
 
@@ -151,31 +131,6 @@ test('revision equal to the base case returns only later revisions ', () => {
     expect(revisions).toEqual({
         revisionId: 3,
         updated: [mockAdd({ name: 'feature4' }), mockAdd({ name: 'feature5' })],
-        removed: [],
-    });
-});
-
-test('project filter removes features not in project', () => {
-    const revisionList = [
-        {
-            revisionId: 1,
-            updated: [mockAdd({ name: 'feature1', project: 'project1' })],
-            removed: [],
-        },
-        {
-            revisionId: 2,
-            updated: [mockAdd({ name: 'feature2', project: 'project2' })],
-            removed: [],
-        },
-    ];
-
-    const revisions = calculateRequiredClientRevision(revisionList, 0, [
-        'project1',
-    ]);
-
-    expect(revisions).toEqual({
-        revisionId: 2,
-        updated: [mockAdd({ name: 'feature1', project: 'project1' })],
         removed: [],
     });
 });

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -208,8 +208,12 @@ export class ClientFeatureToggleCache {
         ];
 
         const removed = changeEvents
+            .filter((event) => event.featureName && event.project)
             .filter((event) => event.type === 'feature-deleted')
-            .map((event) => event.featureName!);
+            .map((event) => ({
+                name: event.featureName!,
+                project: event.project!,
+            }));
 
         // TODO: we might want to only update the environments that had events changed for performance
         for (const environment of keys) {

--- a/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
+++ b/src/lib/features/client-feature-toggles/cache/client-feature-toggle-cache.ts
@@ -73,11 +73,8 @@ export const calculateRequiredClientRevision = (
         (revision) => revision.revisionId > requiredRevisionId,
     );
     console.log('targeted revisions', targetedRevisions);
-    const projectFeatureRevisions = targetedRevisions.map((revision) =>
-        filterRevisionByProject(revision, projects),
-    );
 
-    return projectFeatureRevisions.reduce(applyRevision);
+    return targetedRevisions.reduce(applyRevision);
 };
 
 export class ClientFeatureToggleCache {

--- a/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
@@ -10,7 +10,7 @@ import type { Logger } from '../../logger';
 
 import type { FeatureConfigurationClient } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import type {
-    ClientFeatureChange,
+    RevisionCacheEntry,
     ClientFeatureToggleCache,
 } from './cache/client-feature-toggle-cache';
 
@@ -43,15 +43,10 @@ export class ClientFeatureToggleService {
 
     async getClientDelta(
         revisionId: number | undefined,
-        projects: string[],
-        environment: string,
-    ): Promise<ClientFeatureChange | undefined> {
+        query: IFeatureToggleQuery,
+    ): Promise<RevisionCacheEntry | undefined> {
         if (this.clientFeatureToggleCache !== null) {
-            return this.clientFeatureToggleCache.getDelta(
-                revisionId,
-                environment,
-                projects,
-            );
+            return this.clientFeatureToggleCache.getDelta(revisionId, query);
         } else {
             throw new Error(
                 'Calling the partial updates but the cache is not initialized',


### PR DESCRIPTION
This is still raw and experimental.
We started to pull deleted features from event payload.
Now we put full query towards read model.

Co-Author:  @FredrikOseberg 