### PR TITLE
feat: add prom metrics

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -219,11 +219,11 @@ export default class FeatureController extends Controller {
         }
 
         if (namePrefix) {
-            this.eventBus.emit(CLIENT_METRICS_NAMEPREFIX, { namePrefix });
+            this.eventBus.emit(CLIENT_METRICS_NAMEPREFIX);
         }
 
         if (tag) {
-            this.eventBus.emit(CLIENT_METRICS_TAGS, { tag });
+            this.eventBus.emit(CLIENT_METRICS_TAGS);
         }
 
         const tagQuery = this.paramToArray(tag);

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -1,4 +1,5 @@
 import type EventEmitter from 'events';
+import { CLIENT_METRICS } from './internals';
 
 const REQUEST_TIME = 'request_time';
 const DB_TIME = 'db_time';
@@ -14,6 +15,8 @@ const USER_LOGIN = 'user-login' as const;
 const EXCEEDS_LIMIT = 'exceeds-limit' as const;
 const REQUEST_ORIGIN = 'request_origin' as const;
 const ADDON_EVENTS_HANDLED = 'addon-event-handled' as const;
+const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
+const CLIENT_METRICS_TAGS = 'client-api-tags';
 
 type MetricEvent =
     | typeof REQUEST_TIME
@@ -28,7 +31,9 @@ type MetricEvent =
     | typeof STAGE_ENTERED
     | typeof USER_LOGIN
     | typeof EXCEEDS_LIMIT
-    | typeof REQUEST_ORIGIN;
+    | typeof REQUEST_ORIGIN
+    | typeof CLIENT_METRICS_NAMEPREFIX
+    | typeof CLIENT_METRICS_TAGS;
 
 type RequestOriginEventPayload = {
     type: 'UI' | 'API';
@@ -76,6 +81,8 @@ export {
     EXCEEDS_LIMIT,
     REQUEST_ORIGIN,
     ADDON_EVENTS_HANDLED,
+    CLIENT_METRICS_NAMEPREFIX,
+    CLIENT_METRICS_TAGS,
     type MetricEvent,
     type MetricEventPayload,
     emitMetricEvent,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -504,6 +504,16 @@ export function registerPrometheusMetrics(
         })
         .set(config.rateLimiting.callSignalEndpointMaxPerSecond * 60);
 
+    const namePrefixUsed = createCounter({
+        name: 'nameprefix_count',
+        help: 'Count of nameprefix usage in client api',
+    });
+
+    const tagsUsed = createCounter({
+        name: 'tags_count',
+        help: 'Count of tags usage in client api',
+    });
+
     const featureCreatedByMigration = createCounter({
         name: 'feature_created_by_migration_count',
         help: 'Feature createdBy migration count',
@@ -732,6 +742,14 @@ export function registerPrometheusMetrics(
 
     eventBus.on(events.PROXY_FEATURES_FOR_TOKEN_TIME, ({ duration }) => {
         mapFeaturesForClientDuration.observe(duration);
+    });
+
+    eventBus.on(events.CLIENT_METRICS_NAMEPREFIX, () => {
+        namePrefixUsed.inc();
+    });
+
+    eventBus.on(events.CLIENT_METRICS_TAGS, () => {
+        tagsUsed.inc();
     });
 
     events.onMetricEvent(


### PR DESCRIPTION
This PR adds prometheus metrics that allows us to see whether or not tags and namePrefix is used at all in our cloud offering.