### PR TITLE
fix: can't sort on undefined sdks

### DIFF
--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -412,7 +412,7 @@ export default class ClientApplicationsStore
             return acc;
         }, []);
         environments.forEach((env) => {
-            env.sdks.sort();
+            env.sdks?.sort();
         });
 
         return {


### PR DESCRIPTION
## About the changes
According to some logs, sdks can be undefined:
```
TypeError: Cannot read properties of null (reading 'sort')\n    at /unleash/node_modules/unleash-server/dist/lib/db/client-applications-store.js:330:22\n 
```