### PR TITLE
fix: use strategyName instead of name property for component to load

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategyType.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategyType.tsx
@@ -24,7 +24,7 @@ export const MilestoneStrategyType = ({
         return null;
     }
 
-    switch (strategy.name) {
+    switch (strategy.strategyName) {
         case 'default':
             return <DefaultStrategy strategyDefinition={strategyDefinition} />;
         case 'flexibleRollout':


### PR DESCRIPTION
resolves which component to load based on strategyName instead of name, as the former is always present

![Skjermbilde 2024-12-16 kl  08 38 49](https://github.com/user-attachments/assets/e5b38d75-f219-4fc1-8d27-91ff24b7af80)

after switch

![Skjermbilde 2024-12-16 kl  08 39 11](https://github.com/user-attachments/assets/6fac6872-f14a-4d33-a33e-b52306af742c)
