### PR TITLE
fix: check for enterprise in the create/edit templates UI

### DIFF
--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -10,11 +10,19 @@ import { useNavigate } from 'react-router-dom';
 import { useReleasePlanTemplates } from 'hooks/api/getters/useReleasePlanTemplates/useReleasePlanTemplates';
 import { EmptyTemplatesListMessage } from './EmptyTemplatesListMessage';
 import { ReleasePlanTemplateList } from './ReleasePlanTemplateList';
+import { useUiFlag } from 'hooks/useUiFlag';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 export const ReleaseManagement = () => {
     usePageTitle('Release management');
     const navigate = useNavigate();
     const data = useReleasePlanTemplates();
+
+    const { isEnterprise } = useUiConfig();
+    const releasePlansEnabled = useUiFlag('releasePlans');
+    if (!releasePlansEnabled || !isEnterprise()) {
+        return null;
+    }
 
     return (
         <>

--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -20,7 +20,7 @@ export const ReleaseManagement = () => {
 
     const { isEnterprise } = useUiConfig();
     const releasePlansEnabled = useUiFlag('releasePlans');
-    if (!releasePlansEnabled || !isEnterprise()) {
+    if (!releasePlansEnabled) {
         return null;
     }
 
@@ -40,7 +40,7 @@ export const ReleaseManagement = () => {
                                 }}
                                 maxWidth='700px'
                                 permission={CREATE_RELEASE_TEMPLATE}
-                                disabled={false}
+                                disabled={!isEnterprise()}
                             >
                                 New template
                             </ResponsiveButton>

--- a/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/CreateReleasePlanTemplate.tsx
@@ -24,7 +24,7 @@ const StyledCancelButton = styled(Button)(({ theme }) => ({
 }));
 
 export const CreateReleasePlanTemplate = () => {
-    const { uiConfig } = useUiConfig();
+    const { uiConfig, isEnterprise } = useUiConfig();
     const releasePlansEnabled = useUiFlag('releasePlans');
     const { setToastApiError, setToastData } = useToast();
     const navigate = useNavigate();
@@ -75,7 +75,7 @@ export const CreateReleasePlanTemplate = () => {
     --header 'Content-Type: application/json' \\
     --data-raw '${JSON.stringify(getTemplatePayload(), undefined, 2)}'`;
 
-    if (!releasePlansEnabled) {
+    if (!releasePlansEnabled || !isEnterprise()) {
         return null;
     }
 

--- a/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
@@ -24,7 +24,7 @@ const StyledCancelButton = styled(Button)(({ theme }) => ({
 }));
 
 export const EditReleasePlanTemplate = () => {
-    const { uiConfig } = useUiConfig();
+    const { uiConfig, isEnterprise } = useUiConfig();
     const releasePlansEnabled = useUiFlag('releasePlans');
     const templateId = useRequiredPathParam('templateId');
     const { template, loading, error, refetch } =
@@ -82,7 +82,7 @@ export const EditReleasePlanTemplate = () => {
     --header 'Content-Type: application/json' \\
     --data-raw '${JSON.stringify(getTemplatePayload(), undefined, 2)}'`;
 
-    if (!releasePlansEnabled) {
+    if (!releasePlansEnabled || !isEnterprise()) {
         return null;
     }
 


### PR DESCRIPTION
Hiding with enterprise tag in routes wasn't enough anymore as we're showing those to Pro with upgrade messages. This temporarily disables the UI completely.

Before
![Skjermbilde 2024-12-16 kl  11 26 36](https://github.com/user-attachments/assets/5c9fd1ff-d6b3-4f0d-bfcd-5d201c06c532)

After
![image](https://github.com/user-attachments/assets/d00a5db8-c1dd-4bd3-ba84-759aee88c786)

Also disables the create screen if you know the direct url:
![Skjermbilde 2024-12-16 kl  14 49 48](https://github.com/user-attachments/assets/cc361666-a6d7-4ed7-b429-c6b3c7199c40)
