### PR TITLE
chore: rebrand cache to delta

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
@@ -10,7 +10,7 @@ import type { Logger } from '../../logger';
 
 import type { FeatureConfigurationClient } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import type {
-    RevisionCacheEntry,
+    RevisionDeltaEntry,
     ClientFeatureToggleDelta,
 } from './delta/client-feature-toggle-delta';
 
@@ -21,7 +21,7 @@ export class ClientFeatureToggleService {
 
     private segmentReadModel: ISegmentReadModel;
 
-    private clientFeatureToggleCache: ClientFeatureToggleDelta | null = null;
+    private clientFeatureToggleDelta: ClientFeatureToggleDelta | null = null;
 
     constructor(
         {
@@ -33,7 +33,7 @@ export class ClientFeatureToggleService {
     ) {
         this.logger = getLogger('services/client-feature-toggle-service.ts');
         this.segmentReadModel = segmentReadModel;
-        this.clientFeatureToggleCache = clientFeatureToggleCache;
+        this.clientFeatureToggleDelta = clientFeatureToggleCache;
         this.clientFeatureToggleStore = clientFeatureToggleStore;
     }
 
@@ -44,9 +44,9 @@ export class ClientFeatureToggleService {
     async getClientDelta(
         revisionId: number | undefined,
         query: IFeatureToggleQuery,
-    ): Promise<RevisionCacheEntry | undefined> {
-        if (this.clientFeatureToggleCache !== null) {
-            return this.clientFeatureToggleCache.getDelta(revisionId, query);
+    ): Promise<RevisionDeltaEntry | undefined> {
+        if (this.clientFeatureToggleDelta !== null) {
+            return this.clientFeatureToggleDelta.getDelta(revisionId, query);
         } else {
             throw new Error(
                 'Calling the partial updates but the cache is not initialized',

--- a/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
@@ -11,8 +11,8 @@ import type { Logger } from '../../logger';
 import type { FeatureConfigurationClient } from '../feature-toggle/types/feature-toggle-strategies-store-type';
 import type {
     RevisionCacheEntry,
-    ClientFeatureToggleCache,
-} from './cache/client-feature-toggle-cache';
+    ClientFeatureToggleDelta,
+} from './delta/client-feature-toggle-delta';
 
 export class ClientFeatureToggleService {
     private logger: Logger;
@@ -21,14 +21,14 @@ export class ClientFeatureToggleService {
 
     private segmentReadModel: ISegmentReadModel;
 
-    private clientFeatureToggleCache: ClientFeatureToggleCache | null = null;
+    private clientFeatureToggleCache: ClientFeatureToggleDelta | null = null;
 
     constructor(
         {
             clientFeatureToggleStore,
         }: Pick<IUnleashStores, 'clientFeatureToggleStore'>,
         segmentReadModel: ISegmentReadModel,
-        clientFeatureToggleCache: ClientFeatureToggleCache | null,
+        clientFeatureToggleCache: ClientFeatureToggleDelta | null,
         { getLogger }: Pick<IUnleashConfig, 'getLogger' | 'flagResolver'>,
     ) {
         this.logger = getLogger('services/client-feature-toggle-service.ts');

--- a/src/lib/features/client-feature-toggles/createClientFeatureToggleService.ts
+++ b/src/lib/features/client-feature-toggles/createClientFeatureToggleService.ts
@@ -5,7 +5,7 @@ import FakeClientFeatureToggleStore from './fakes/fake-client-feature-toggle-sto
 import { ClientFeatureToggleService } from './client-feature-toggle-service';
 import { SegmentReadModel } from '../segment/segment-read-model';
 import { FakeSegmentReadModel } from '../segment/fake-segment-read-model';
-import { createClientFeatureToggleCache } from './cache/createClientFeatureToggleCache';
+import { createClientFeatureToggleDelta } from './delta/createClientFeatureToggleDelta';
 
 export const createClientFeatureToggleService = (
     db: Db,
@@ -22,7 +22,7 @@ export const createClientFeatureToggleService = (
 
     const segmentReadModel = new SegmentReadModel(db);
 
-    const clientFeatureToggleCache = createClientFeatureToggleCache(db, config);
+    const clientFeatureToggleCache = createClientFeatureToggleDelta(db, config);
 
     const clientFeatureToggleService = new ClientFeatureToggleService(
         {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
@@ -17,7 +17,7 @@ import type { OpenApiService } from '../../../services/openapi-service';
 import { NONE } from '../../../types/permissions';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
 import type { ClientFeatureToggleService } from '../client-feature-toggle-service';
-import type { RevisionCacheEntry } from './client-feature-toggle-cache';
+import type { RevisionDeltaEntry } from './client-feature-toggle-delta';
 import { clientFeaturesDeltaSchema } from '../../../openapi';
 import type { QueryOverride } from '../client-feature-toggle.controller';
 
@@ -142,7 +142,7 @@ export default class ClientFeatureToggleDeltaController extends Controller {
 
     async getDelta(
         req: IAuthRequest,
-        res: Response<RevisionCacheEntry>,
+        res: Response<RevisionDeltaEntry>,
     ): Promise<void> {
         if (!this.flagResolver.isEnabled('deltaApi')) {
             throw new NotFoundError();

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model-type.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model-type.ts
@@ -1,14 +1,14 @@
 import type { IFeatureToggleQuery } from '../../../types';
 import type { FeatureConfigurationClient } from '../../feature-toggle/types/feature-toggle-strategies-store-type';
 
-export interface FeatureConfigurationCacheClient
+export interface FeatureConfigurationDeltaClient
     extends FeatureConfigurationClient {
     description: string;
     impressionData: false;
 }
 
-export interface IClientFeatureToggleCacheReadModel {
+export interface IClientFeatureToggleDeltaReadModel {
     getAll(
         featureQuery: IFeatureToggleQuery,
-    ): Promise<FeatureConfigurationCacheClient[]>;
+    ): Promise<FeatureConfigurationDeltaClient[]>;
 }

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model.ts
@@ -5,21 +5,21 @@ import Raw = Knex.Raw;
 import type EventEmitter from 'events';
 import { ALL_PROJECTS, ensureStringValue, mapValues } from '../../../util';
 import type {
-    FeatureConfigurationCacheClient,
-    IClientFeatureToggleCacheReadModel,
-} from './client-feature-toggle-cache-read-model-type';
+    FeatureConfigurationDeltaClient,
+    IClientFeatureToggleDeltaReadModel,
+} from './client-feature-toggle-delta-read-model-type';
 import type { Db } from '../../../db/db';
 import {
     DB_TIME,
-    type IFeatureToggleCacheQuery,
+    type IFeatureToggleDeltaQuery,
     type IStrategyConfig,
     type PartialDeep,
 } from '../../../internals';
 import metricsHelper from '../../../util/metrics-helper';
 import FeatureToggleStore from '../../feature-toggle/feature-toggle-store';
 
-export default class ClientFeatureToggleCacheReadModel
-    implements IClientFeatureToggleCacheReadModel
+export default class ClientFeatureToggleDeltaReadModel
+    implements IClientFeatureToggleDeltaReadModel
 {
     private db: Db;
 
@@ -29,14 +29,14 @@ export default class ClientFeatureToggleCacheReadModel
         this.db = db;
         this.timer = (action: string) =>
             metricsHelper.wrapTimer(eventBus, DB_TIME, {
-                store: 'client-feature-toggle-cache-read-model',
+                store: 'client-feature-toggle-delta-read-model',
                 action,
             });
     }
 
     public async getAll(
-        featureQuery: IFeatureToggleCacheQuery,
-    ): Promise<FeatureConfigurationCacheClient[]> {
+        featureQuery: IFeatureToggleDeltaQuery,
+    ): Promise<FeatureConfigurationDeltaClient[]> {
         const environment = featureQuery.environment;
         const stopTimer = this.timer(`getAll`);
 
@@ -128,7 +128,7 @@ export default class ClientFeatureToggleCacheReadModel
         stopTimer();
 
         const featureToggles = rows.reduce((acc, r) => {
-            const feature: PartialDeep<FeatureConfigurationCacheClient> = acc[
+            const feature: PartialDeep<FeatureConfigurationDeltaClient> = acc[
                 r.name
             ] ?? {
                 strategies: [],
@@ -168,7 +168,7 @@ export default class ClientFeatureToggleCacheReadModel
             return acc;
         }, {});
 
-        const features: FeatureConfigurationCacheClient[] =
+        const features: FeatureConfigurationDeltaClient[] =
             Object.values(featureToggles);
 
         // strip away unwanted properties
@@ -193,7 +193,7 @@ export default class ClientFeatureToggleCacheReadModel
     }
 
     private addSegmentIdsToStrategy(
-        feature: PartialDeep<FeatureConfigurationCacheClient>,
+        feature: PartialDeep<FeatureConfigurationDeltaClient>,
         row: Record<string, any>,
     ) {
         const strategy = feature.strategies?.find(
@@ -222,7 +222,7 @@ export default class ClientFeatureToggleCacheReadModel
     }
 
     private isUnseenStrategyRow(
-        feature: PartialDeep<FeatureConfigurationCacheClient>,
+        feature: PartialDeep<FeatureConfigurationDeltaClient>,
         row: Record<string, any>,
     ): boolean {
         return (
@@ -232,7 +232,7 @@ export default class ClientFeatureToggleCacheReadModel
     }
 
     private addSegmentToStrategy(
-        feature: PartialDeep<FeatureConfigurationCacheClient>,
+        feature: PartialDeep<FeatureConfigurationDeltaClient>,
         row: Record<string, any>,
     ) {
         feature.strategies

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -1,4 +1,4 @@
-import { calculateRequiredClientRevision } from './client-feature-toggle-cache';
+import { calculateRequiredClientRevision } from './client-feature-toggle-delta';
 
 const mockAdd = (params): any => {
     const base = {

--- a/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
+++ b/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
@@ -1,30 +1,30 @@
-import { ClientFeatureToggleCache } from './client-feature-toggle-cache';
+import { ClientFeatureToggleDelta } from './client-feature-toggle-delta';
 import EventStore from '../../events/event-store';
 import ConfigurationRevisionService from '../../feature-toggle/configuration-revision-service';
 import type { IUnleashConfig } from '../../../types';
 import type { Db } from '../../../db/db';
-import ClientFeatureToggleCacheReadModel from './client-feature-toggle-cache-read-model';
+import ClientFeatureToggleDeltaReadModel from './client-feature-toggle-delta-read-model';
 
-export const createClientFeatureToggleCache = (
+export const createClientFeatureToggleDelta = (
     db: Db,
     config: IUnleashConfig,
-): ClientFeatureToggleCache => {
+): ClientFeatureToggleDelta => {
     const { getLogger, eventBus, flagResolver } = config;
 
     const eventStore = new EventStore(db, getLogger);
 
-    const clientFeatureToggleCacheReadModel =
-        new ClientFeatureToggleCacheReadModel(db, eventBus);
+    const clientFeatureToggleDeltaReadModel =
+        new ClientFeatureToggleDeltaReadModel(db, eventBus);
 
     const configurationRevisionService =
         ConfigurationRevisionService.getInstance({ eventStore }, config);
 
-    const clientFeatureToggleCache = new ClientFeatureToggleCache(
-        clientFeatureToggleCacheReadModel,
+    const clientFeatureToggleDelta = new ClientFeatureToggleDelta(
+        clientFeatureToggleDeltaReadModel,
         eventStore,
         configurationRevisionService,
         flagResolver,
     );
 
-    return clientFeatureToggleCache;
+    return clientFeatureToggleDelta;
 };

--- a/src/lib/features/client-feature-toggles/delta/revision-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/revision-delta.test.ts
@@ -1,5 +1,5 @@
-import { RevisionCache } from './revision-cache';
-import type { Revision } from './client-feature-toggle-cache';
+import { RevisionDelta } from './revision-delta';
+import type { Revision } from './client-feature-toggle-delta';
 
 describe('RevisionCache', () => {
     it('should create a new base when trying to add a new revision at the max limit', () => {
@@ -63,7 +63,7 @@ describe('RevisionCache', () => {
         ];
 
         const maxLength = 2;
-        const deltaCache = new RevisionCache(initialRevisions, maxLength);
+        const deltaCache = new RevisionDelta(initialRevisions, maxLength);
 
         // Add a new revision to trigger changeBase
         deltaCache.addRevision({

--- a/src/lib/features/client-feature-toggles/delta/revision-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/revision-delta.ts
@@ -1,4 +1,4 @@
-import type { Revision } from './client-feature-toggle-cache';
+import type { Revision } from './client-feature-toggle-delta';
 
 const mergeWithoutDuplicates = (arr1: any[], arr2: any[]) => {
     const map = new Map();
@@ -8,41 +8,41 @@ const mergeWithoutDuplicates = (arr1: any[], arr2: any[]) => {
     return Array.from(map.values());
 };
 
-export class RevisionCache {
-    private cache: Revision[];
+export class RevisionDelta {
+    private delta: Revision[];
     private maxLength: number;
 
     constructor(data: Revision[] = [], maxLength: number = 100) {
-        this.cache = data;
+        this.delta = data;
         this.maxLength = maxLength;
     }
 
     public addRevision(revision: Revision): void {
-        if (this.cache.length >= this.maxLength) {
+        if (this.delta.length >= this.maxLength) {
             this.changeBase();
         }
 
-        this.cache = [...this.cache, revision];
+        this.delta = [...this.delta, revision];
     }
 
     public getRevisions(): Revision[] {
-        return this.cache;
+        return this.delta;
     }
 
     public hasRevision(revisionId: number): boolean {
-        return this.cache.some(
+        return this.delta.some(
             (revision) => revision.revisionId === revisionId,
         );
     }
 
     private changeBase(): void {
-        if (!(this.cache.length >= 2)) return;
-        const base = this.cache[0];
-        const newBase = this.cache[1];
+        if (!(this.delta.length >= 2)) return;
+        const base = this.delta[0];
+        const newBase = this.delta[1];
 
         newBase.removed = mergeWithoutDuplicates(base.removed, newBase.removed);
         newBase.updated = mergeWithoutDuplicates(base.updated, newBase.updated);
 
-        this.cache = [newBase, ...this.cache.slice(2)];
+        this.delta = [newBase, ...this.delta.slice(2)];
     }
 }

--- a/src/lib/routes/client-api/index.ts
+++ b/src/lib/routes/client-api/index.ts
@@ -3,7 +3,7 @@ import FeatureController from '../../features/client-feature-toggles/client-feat
 import MetricsController from '../../features/metrics/instance/metrics';
 import RegisterController from '../../features/metrics/instance/register';
 import type { IUnleashConfig, IUnleashServices } from '../../types';
-import ClientFeatureToggleDeltaController from '../../features/client-feature-toggles/delta/client-feature-toggle-cache-controller';
+import ClientFeatureToggleDeltaController from '../../features/client-feature-toggles/delta/client-feature-toggle-delta-controller';
 
 export default class ClientApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {

--- a/src/lib/routes/client-api/index.ts
+++ b/src/lib/routes/client-api/index.ts
@@ -3,7 +3,7 @@ import FeatureController from '../../features/client-feature-toggles/client-feat
 import MetricsController from '../../features/metrics/instance/metrics';
 import RegisterController from '../../features/metrics/instance/register';
 import type { IUnleashConfig, IUnleashServices } from '../../types';
-import ClientFeatureToggleDeltaController from '../../features/client-feature-toggles/cache/client-feature-toggle-cache-controller';
+import ClientFeatureToggleDeltaController from '../../features/client-feature-toggles/delta/client-feature-toggle-cache-controller';
 
 export default class ClientApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -345,7 +345,7 @@ export interface IFeatureToggleQuery {
     inlineSegmentConstraints?: boolean;
 }
 
-export interface IFeatureToggleCacheQuery extends IFeatureToggleQuery {
+export interface IFeatureToggleDeltaQuery extends IFeatureToggleQuery {
     toggleNames?: string[];
     environment: string;
 }


### PR DESCRIPTION
The cache is too generic, we will be using delta from now on.