### PR TITLE
feat:release templates strategy interaction improvements

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategyMenuCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategyMenuCard.tsx
@@ -34,6 +34,7 @@ const StyledName = styled(StringTruncator)(({ theme }) => ({
 
 const StyledCard = styled('div')(({ theme }) => ({
     display: 'grid',
+    cursor: 'pointer',
     gridTemplateColumns: '3rem 1fr',
     width: '20rem',
     padding: theme.spacing(2),

--- a/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategySegmentList.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/MilestoneStrategySegmentList.tsx
@@ -41,7 +41,6 @@ export const MilestoneStrategySegmentList = ({
     const lastSegmentIndex = segments.length - 1;
 
     if (segments.length === 0) {
-        console.log('segments.length === 0');
         return null;
     }
 

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm.tsx
@@ -195,6 +195,7 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                 <SidebarModal
                     label='Add strategy to template milestone'
                     onClose={() => {
+                        setAddUpdateStrategyOpen(false);
                         setStrategyModeEdit(false);
                     }}
                     open={addUpdateStrategyOpen}
@@ -205,6 +206,7 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                         onAddUpdateStrategy={addUpdateStrategy}
                         onCancel={() => {
                             setAddUpdateStrategyOpen(false);
+                            setStrategyModeEdit(false);
                         }}
                         editMode={strategyModeEdit}
                     />


### PR DESCRIPTION
Changes the mouse pointer when selecting a strategy to add to milestone
Closes strategy edit when pressing esc or clicking outside