### PR TITLE
chore: rename to seats used

### DIFF
--- a/frontend/src/component/admin/users/UsersHeader/LicensedUsersSidebar.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/LicensedUsersSidebar.tsx
@@ -90,7 +90,7 @@ export const LicensedUsersSidebar = ({
         >
             <ModalContentContainer>
                 <HeaderRow>
-                    <ModalHeader>Licensed seats</ModalHeader>
+                    <ModalHeader>Seats used</ModalHeader>
                 </HeaderRow>
                 <WidgetContainer>
                     <Row>

--- a/frontend/src/hooks/useLicensedUsers.ts
+++ b/frontend/src/hooks/useLicensedUsers.ts
@@ -15,7 +15,7 @@ const placeholderData: LicensedUsersSchema = {
 export const useLicensedUsers = () => {
     const { data, refetch, loading, error } = useApiGetter<LicensedUsersSchema>(
         formatApiPath(path),
-        () => fetcher(formatApiPath(path), 'Licensed users'),
+        () => fetcher(formatApiPath(path), 'Seats used'),
     );
 
     return { data: data || placeholderData, refetch, loading, error };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -662,7 +662,7 @@ export function registerPrometheusMetrics(
 
     const licensedUsers = createGauge({
         name: 'licensed_users',
-        help: 'The number of licensed users.',
+        help: 'The number of seats used.',
     });
 
     const addonEventsHandledCounter = createCounter({


### PR DESCRIPTION
Instead of licensed users/used, we will use seats used.