### PR TITLE
chore: default event log span 1 year

### DIFF
--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -10,7 +10,7 @@ import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
 import type { SearchEventsParams } from 'openapi';
 import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
-import { format, subMonths } from 'date-fns';
+import { format, subYears } from 'date-fns';
 
 type Log =
     | { type: 'global' }
@@ -62,7 +62,7 @@ export const useEventLogSearch = (
         limit: withDefault(NumberParam, DEFAULT_PAGE_SIZE),
         query: StringParam,
         from: withDefault(FilterItemParam, {
-            values: [format(subMonths(new Date(), 1), 'yyyy-MM-dd')],
+            values: [format(subYears(new Date(), 1), 'yyyy-MM-dd')],
             operator: 'IS',
         }),
         to: withDefault(FilterItemParam, {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Default event log date range span is a 1 year moving window. Yesterday I set it to a month but it seems too short of a time period.

<img width="1143" alt="Screenshot 2024-12-18 at 14 59 48" src="https://github.com/user-attachments/assets/88d41a87-0dbe-479e-ad7b-9d87c4368728" />


<img width="730" alt="Screenshot 2024-12-18 at 15 00 06" src="https://github.com/user-attachments/assets/99c349d0-3715-47ef-ba82-98f94bf60613" />

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
