### PR TITLE
feat: store memory footprints to grafana

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -173,12 +173,8 @@ export default class FeatureController extends Controller {
                 await this.clientFeatureToggleService.getActiveSegmentsForClient();
 
             try {
-                console.log(`storing features ${features.length}`);
                 const featuresSize = this.getCacheSizeInBytes(features);
                 const segmentsSize = this.getCacheSizeInBytes(segments);
-                console.log(
-                    `features storing ${featuresSize}, ${segmentsSize}`,
-                );
                 this.clientFeaturesCacheMap.set(
                     JSON.stringify(query),
                     featuresSize + segmentsSize,

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -90,7 +90,6 @@ export const calculateRequiredClientRevision = (
     const targetedRevisions = revisions.filter(
         (revision) => revision.revisionId > requiredRevisionId,
     );
-    console.log('targeted revisions', targetedRevisions);
     const projectFeatureRevisions = targetedRevisions.map((revision) =>
         filterRevisionByProject(revision, projects),
     );

--- a/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
+++ b/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
@@ -28,7 +28,7 @@ export const createClientFeatureToggleDelta = (
         eventStore,
         configurationRevisionService,
         flagResolver,
-        eventBus,
+        config,
     );
 
     return clientFeatureToggleDelta;

--- a/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
+++ b/src/lib/features/client-feature-toggles/delta/createClientFeatureToggleDelta.ts
@@ -28,6 +28,7 @@ export const createClientFeatureToggleDelta = (
         eventStore,
         configurationRevisionService,
         flagResolver,
+        eventBus,
     );
 
     return clientFeatureToggleDelta;

--- a/src/lib/features/client-feature-toggles/delta/revision-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/revision-delta.ts
@@ -12,7 +12,7 @@ export class RevisionDelta {
     private delta: Revision[];
     private maxLength: number;
 
-    constructor(data: Revision[] = [], maxLength: number = 100) {
+    constructor(data: Revision[] = [], maxLength: number = 20) {
         this.delta = data;
         this.maxLength = maxLength;
     }

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -16,6 +16,8 @@ const REQUEST_ORIGIN = 'request_origin' as const;
 const ADDON_EVENTS_HANDLED = 'addon-event-handled' as const;
 const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
 const CLIENT_METRICS_TAGS = 'client-api-tags';
+const CLIENT_FEATURES_MEMORY = 'client_features_memory';
+const CLIENT_DELTA_MEMORY = 'client_delta_memory';
 
 type MetricEvent =
     | typeof REQUEST_TIME
@@ -32,7 +34,9 @@ type MetricEvent =
     | typeof EXCEEDS_LIMIT
     | typeof REQUEST_ORIGIN
     | typeof CLIENT_METRICS_NAMEPREFIX
-    | typeof CLIENT_METRICS_TAGS;
+    | typeof CLIENT_METRICS_TAGS
+    | typeof CLIENT_FEATURES_MEMORY
+    | typeof CLIENT_DELTA_MEMORY;
 
 type RequestOriginEventPayload = {
     type: 'UI' | 'API';
@@ -82,6 +86,8 @@ export {
     ADDON_EVENTS_HANDLED,
     CLIENT_METRICS_NAMEPREFIX,
     CLIENT_METRICS_TAGS,
+    CLIENT_FEATURES_MEMORY,
+    CLIENT_DELTA_MEMORY,
     type MetricEvent,
     type MetricEventPayload,
     emitMetricEvent,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -624,6 +624,16 @@ export function registerPrometheusMetrics(
         help: 'Number of API tokens without a project',
     });
 
+    const clientFeaturesMemory = createGauge({
+        name: 'client_features_memory',
+        help: 'The amount of memory client features endpoint is using for caching',
+    });
+
+    const clientDeltaMemory = createGauge({
+        name: 'client_delta_memory',
+        help: 'The amount of memory client features delta endpoint is using for caching',
+    });
+
     const orphanedTokensActive = createGauge({
         name: 'orphaned_api_tokens_active',
         help: 'Number of API tokens without a project, last seen within 3 months',
@@ -750,6 +760,16 @@ export function registerPrometheusMetrics(
 
     eventBus.on(events.CLIENT_METRICS_TAGS, () => {
         tagsUsed.inc();
+    });
+
+    eventBus.on(events.CLIENT_FEATURES_MEMORY, (event: { memory: number }) => {
+        clientFeaturesMemory.reset();
+        clientFeaturesMemory.set(event.memory);
+    });
+
+    eventBus.on(events.CLIENT_DELTA_MEMORY, (event: { memory: number }) => {
+        clientDeltaMemory.reset();
+        clientDeltaMemory.set(event.memory);
     });
 
     events.onMetricEvent(


### PR DESCRIPTION
When there is new revision, we will start storing memory footprint for old client-api and the new delta-api.
We will be sending it as prometheus metrics.

The memory size will only be recalculated if revision changes, which does not happen very often.