### PR TITLE
chore: Use 20.18.1 instead of 20.14 as our node base image

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 20.14.0-alpine ]
+        version: [ 20.18.1-alpine ]
     steps:
       - name: Checkout tag v${{ inputs.version }}
         if: ${{ inputs.version != '' }}


### PR DESCRIPTION
We already have 20.18.1 set as the default in our Dockerfile, but we override it with an arg from the workflow, so this brings the workflow up to date with what we use as our default.