### PR TITLE
fix: legal values styling in segments

### DIFF
--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/LegalValueLabel/LegalValueLabel.styles.ts
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/LegalValueLabel/LegalValueLabel.styles.ts
@@ -4,6 +4,13 @@ export const useStyles = makeStyles()((theme) => ({
     container: {
         display: 'inline-block',
         wordBreak: 'break-word',
+        padding: theme.spacing(0.5, 1),
+        background: theme.palette.background.paper,
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: theme.shape.borderRadius,
+        '&:hover': {
+            border: `1px solid ${theme.palette.primary.main}`,
+        },
     },
     value: {
         lineHeight: 1.33,

--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { Alert, Checkbox } from '@mui/material';
+import { Alert, Checkbox, styled } from '@mui/material';
 import { useThemeStyles } from 'themes/themeStyles';
 import { ConstraintValueSearch } from 'component/common/ConstraintAccordion/ConstraintValueSearch/ConstraintValueSearch';
 import { ConstraintFormHeader } from '../ConstraintFormHeader/ConstraintFormHeader';
@@ -48,6 +48,17 @@ export const getIllegalValues = (
 
     return constraintValues.filter((value) => deletedValuesSet.has(value));
 };
+
+const StyledValuesContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+    padding: theme.spacing(2),
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusMedium,
+    maxHeight: '378px',
+    overflow: 'auto',
+}));
 
 export const RestrictiveLegalValues = ({
     data,
@@ -134,23 +145,25 @@ export const RestrictiveLegalValues = ({
                     />
                 }
             />
-            {filteredValues.map((match) => (
-                <LegalValueLabel
-                    key={match.value}
-                    legal={match}
-                    control={
-                        <Checkbox
-                            checked={Boolean(valuesMap[match.value])}
-                            onChange={() => onChange(match.value)}
-                            name={match.value}
-                            color='primary'
-                            disabled={deletedLegalValues
-                                .map(({ value }) => value)
-                                .includes(match.value)}
-                        />
-                    }
-                />
-            ))}
+            <StyledValuesContainer>
+                {filteredValues.map((match) => (
+                    <LegalValueLabel
+                        key={match.value}
+                        legal={match}
+                        control={
+                            <Checkbox
+                                checked={Boolean(valuesMap[match.value])}
+                                onChange={() => onChange(match.value)}
+                                name={match.value}
+                                color='primary'
+                                disabled={deletedLegalValues
+                                    .map(({ value }) => value)
+                                    .includes(match.value)}
+                            />
+                        }
+                    />
+                ))}
+            </StyledValuesContainer>
 
             <ConditionallyRender
                 condition={Boolean(error)}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Fixing styling of legal values in segments. 

Before
<img width="905" alt="Screenshot 2024-12-30 at 15 15 38" src="https://github.com/user-attachments/assets/36790100-105c-48dc-8325-bb6cab8b72ec" />

After
<img width="909" alt="Screenshot 2024-12-30 at 15 15 17" src="https://github.com/user-attachments/assets/70317925-2cbb-48ec-8e39-37cc581004d0" />

The styles are copied from a similar component we use in strategies.

The best long term solution would be using the same constraint accordion we have in strategies. Currently we use new accordion for strategies and old one for the segments. Now sure why the migration wasn't finished when we updates strategies. @FredrikOseberg do you know?

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
