### PR TITLE
feat: grouping of project level roles in autocomplete

### DIFF
--- a/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.test.tsx
+++ b/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.test.tsx
@@ -15,9 +15,16 @@ test('Display grouped project roles with names and descriptions', async () => {
                 },
                 {
                     id: 1,
-                    name: 'My Custom Role',
+                    name: 'B Custom Role',
                     project: null,
-                    description: 'Custom role description',
+                    description: 'Custom role description A',
+                    type: 'custom',
+                },
+                {
+                    id: 2,
+                    name: 'A Custom Role',
+                    project: null,
+                    description: 'Custom role description B',
                     type: 'custom',
                 },
             ]}
@@ -34,6 +41,13 @@ test('Display grouped project roles with names and descriptions', async () => {
     expect(screen.getByText('Owner')).toBeInTheDocument();
     expect(screen.getByText('Owner description')).toBeInTheDocument();
     expect(screen.getByText('Custom project roles')).toBeInTheDocument();
-    expect(screen.getByText('My Custom Role')).toBeInTheDocument();
-    expect(screen.getByText('Custom role description')).toBeInTheDocument();
+    const customRoleA = screen.getByText('A Custom Role');
+    const customRoleB = screen.getByText('B Custom Role');
+    expect(customRoleA).toBeInTheDocument();
+    expect(customRoleB).toBeInTheDocument();
+    expect(customRoleA.compareDocumentPosition(customRoleB)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.getByText('Custom role description A')).toBeInTheDocument();
+    expect(screen.getByText('Custom role description B')).toBeInTheDocument();
 });

--- a/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.test.tsx
+++ b/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.test.tsx
@@ -1,0 +1,39 @@
+import { render } from 'utils/testRenderer';
+import { MultipleRoleSelect } from './MultipleRoleSelect';
+import { fireEvent, screen } from '@testing-library/react';
+
+test('Display grouped project roles with names and descriptions', async () => {
+    render(
+        <MultipleRoleSelect
+            roles={[
+                {
+                    id: 0,
+                    name: 'Owner',
+                    project: null,
+                    description: 'Owner description',
+                    type: 'project',
+                },
+                {
+                    id: 1,
+                    name: 'My Custom Role',
+                    project: null,
+                    description: 'Custom role description',
+                    type: 'custom',
+                },
+            ]}
+            value={[]}
+            setValue={() => {}}
+        />,
+    );
+
+    const multiselect = await screen.findByLabelText('Role');
+
+    fireEvent.click(multiselect);
+
+    expect(screen.getByText('Predefined project roles')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Owner description')).toBeInTheDocument();
+    expect(screen.getByText('Custom project roles')).toBeInTheDocument();
+    expect(screen.getByText('My Custom Role')).toBeInTheDocument();
+    expect(screen.getByText('Custom role description')).toBeInTheDocument();
+});

--- a/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.tsx
+++ b/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.tsx
@@ -3,8 +3,8 @@ import {
     type AutocompleteProps,
     type AutocompleteRenderOptionState,
     Checkbox,
-    TextField,
     styled,
+    TextField,
 } from '@mui/material';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
@@ -13,6 +13,7 @@ import { RoleDescription } from '../RoleDescription/RoleDescription';
 import { ConditionallyRender } from '../ConditionallyRender/ConditionallyRender';
 
 const StyledRoleOption = styled('div')(({ theme }) => ({
+    paddingTop: theme.spacing(0.75),
     display: 'flex',
     flexDirection: 'column',
     '& > span:last-of-type': {
@@ -29,6 +30,25 @@ interface IMultipleRoleSelectProps
     required?: boolean;
 }
 
+function sortItems<T extends { name: string; type: string }>(items: T[]): T[] {
+    return items.sort((a, b) => {
+        if (a.type !== b.type) {
+            return a.type === 'project' ? -1 : 1;
+        }
+
+        if (a.type === 'custom') {
+            return a.name.localeCompare(b.name);
+        }
+
+        return 0;
+    });
+}
+
+const StyledListItem = styled('li')(({ theme }) => ({
+    display: 'flex',
+    gap: theme.spacing(0.5),
+}));
+
 export const MultipleRoleSelect = ({
     roles,
     value,
@@ -41,30 +61,48 @@ export const MultipleRoleSelect = ({
         option: IRole,
         state: AutocompleteRenderOptionState,
     ) => (
-        <li {...props}>
+        <StyledListItem {...props} key={option.id}>
             <Checkbox
                 icon={<CheckBoxOutlineBlankIcon fontSize='small' />}
                 checkedIcon={<CheckBoxIcon fontSize='small' />}
-                style={{ marginRight: 8 }}
                 checked={state.selected}
             />
             <StyledRoleOption>
                 <span>{option.name}</span>
                 <span>{option.description}</span>
             </StyledRoleOption>
-        </li>
+        </StyledListItem>
     );
+
+    const sortedRoles = sortItems(roles);
 
     return (
         <>
             <Autocomplete
+                slotProps={{
+                    paper: {
+                        sx: {
+                            '& .MuiAutocomplete-listbox': {
+                                '& .MuiAutocomplete-option': {
+                                    paddingLeft: (theme) => theme.spacing(0.5),
+                                    alignItems: 'flex-start',
+                                },
+                            },
+                        },
+                    },
+                }}
                 multiple
                 disableCloseOnSelect
                 openOnFocus
                 size='small'
                 value={value}
+                groupBy={(option) => {
+                    return option.type === 'project'
+                        ? 'Predefined project roles'
+                        : 'Custom project roles';
+                }}
                 onChange={(_, roles) => setValue(roles)}
-                options={roles}
+                options={sortedRoles}
                 renderOption={renderRoleOption}
                 getOptionLabel={(option) => option.name}
                 renderInput={(params) => (


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

<img width="451" alt="Screenshot 2024-12-30 at 17 01 31" src="https://github.com/user-attachments/assets/9f1eb0fd-8a6c-449b-b052-7caecfa635d0" />

Details:
* project roles and custom roles are grouped
* project roles (Owner,Member) always go first
* custom project roles are sorted alphabetically
* checkbox is aligned with top of the text

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
