### PR TITLE
chore: new user avatar tooltip

### DIFF
--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mui/material';
 import type { IUser } from 'interfaces/user';
 import { forwardRef } from 'react';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from '../HtmlTooltip/HtmlTooltip';
 
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
@@ -26,14 +25,10 @@ const StyledTooltip = styled(Box)(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
-const StyledTooltipAvatar = styled(Avatar)(({ theme }) => ({
+const StyledTooltipAvatar = styled(StyledAvatar)(({ theme }) => ({
     width: theme.spacing(5),
     height: theme.spacing(5),
-    margin: 'auto',
-    backgroundColor: theme.palette.secondary.light,
-    color: theme.palette.text.primary,
-    fontSize: theme.fontSizes.smallerBody,
-    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.fontSizes.smallBody,
 }));
 
 const StyledTooltipContent = styled(Box)({
@@ -109,29 +104,13 @@ export const UserAvatar = forwardRef<HTMLDivElement, IUserAvatarProps>(
                 alt={user?.name || user?.email || user?.username || 'Gravatar'}
                 src={src || user?.imageUrl}
             >
-                <ConditionallyRender
-                    condition={Boolean(fallback)}
-                    show={fallback}
-                    elseShow={children}
-                />
+                {fallback ? fallback : children}
             </StyledAvatar>
         );
 
         const tooltip = disableTooltip ? undefined : tooltipContent(user);
         if (tooltip) {
             const { main, secondary } = tooltip;
-
-            if (!src && !user?.imageUrl) {
-                return (
-                    <HtmlTooltip
-                        arrow
-                        describeChild
-                        title={<TooltipMainContent>{main}</TooltipMainContent>}
-                    >
-                        {Avatar}
-                    </HtmlTooltip>
-                );
-            }
 
             return (
                 <HtmlTooltip
@@ -140,37 +119,28 @@ export const UserAvatar = forwardRef<HTMLDivElement, IUserAvatarProps>(
                     maxWidth={400}
                     title={
                         <StyledTooltip>
-                            <ConditionallyRender
-                                condition={Boolean(src || user?.imageUrl)}
-                                show={
-                                    <StyledTooltipAvatar
-                                        src={src || user?.imageUrl}
-                                        alt={
-                                            user?.name ||
-                                            user?.email ||
-                                            user?.username ||
-                                            'Gravatar'
-                                        }
-                                    />
+                            <StyledTooltipAvatar
+                                src={src || user?.imageUrl}
+                                alt={
+                                    user?.name ||
+                                    user?.email ||
+                                    user?.username ||
+                                    'Gravatar'
                                 }
-                            />
+                            >
+                                {fallback ? fallback : children}
+                            </StyledTooltipAvatar>
                             <StyledTooltipContent>
-                                <ConditionallyRender
-                                    condition={Boolean(main)}
-                                    show={
-                                        <TooltipMainContent>
-                                            {main}
-                                        </TooltipMainContent>
-                                    }
-                                />
-                                <ConditionallyRender
-                                    condition={Boolean(secondary)}
-                                    show={
-                                        <TooltipSecondaryContent>
-                                            {secondary}
-                                        </TooltipSecondaryContent>
-                                    }
-                                />
+                                {main && (
+                                    <TooltipMainContent>
+                                        {main}
+                                    </TooltipMainContent>
+                                )}
+                                {secondary && (
+                                    <TooltipSecondaryContent>
+                                        {secondary}
+                                    </TooltipSecondaryContent>
+                                )}
                             </StyledTooltipContent>
                         </StyledTooltip>
                     }

--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -1,6 +1,7 @@
 import {
     Avatar,
     type AvatarProps,
+    Box,
     styled,
     type SxProps,
     type Theme,
@@ -9,6 +10,7 @@ import type { IUser } from 'interfaces/user';
 import { forwardRef } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { HtmlTooltip } from '../HtmlTooltip/HtmlTooltip';
+
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
     width: theme.spacing(3.5),
     height: theme.spacing(3.5),
@@ -18,6 +20,27 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
     fontWeight: theme.fontWeight.bold,
 }));
+
+const StyledTooltip = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    gap: theme.spacing(2),
+}));
+
+const StyledTooltipAvatar = styled(Avatar)(({ theme }) => ({
+    width: theme.spacing(5),
+    height: theme.spacing(5),
+    margin: 'auto',
+    backgroundColor: theme.palette.secondary.light,
+    color: theme.palette.text.primary,
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.fontWeight.bold,
+}));
+
+const StyledTooltipContent = styled(Box)({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+});
 
 export interface IUserAvatarProps extends AvatarProps {
     user?: Partial<
@@ -37,8 +60,8 @@ const tooltipContent = (
     }
 
     const [mainIdentifier, secondaryInfo] = [
-        user.email || user.username,
         user.name,
+        user.email || user.username,
     ];
 
     if (mainIdentifier) {
@@ -56,8 +79,10 @@ const TooltipSecondaryContent = styled('div')(({ theme }) => ({
     color: theme.palette.text.secondary,
     fontSize: theme.typography.body2.fontSize,
 }));
+
 const TooltipMainContent = styled('div')(({ theme }) => ({
     fontSize: theme.typography.body1.fontSize,
+    wordBreak: 'break-word',
 }));
 
 export const UserAvatar = forwardRef<HTMLDivElement, IUserAvatarProps>(
@@ -94,19 +119,60 @@ export const UserAvatar = forwardRef<HTMLDivElement, IUserAvatarProps>(
 
         const tooltip = disableTooltip ? undefined : tooltipContent(user);
         if (tooltip) {
+            const { main, secondary } = tooltip;
+
+            if (!src && !user?.imageUrl) {
+                return (
+                    <HtmlTooltip
+                        arrow
+                        describeChild
+                        title={<TooltipMainContent>{main}</TooltipMainContent>}
+                    >
+                        {Avatar}
+                    </HtmlTooltip>
+                );
+            }
+
             return (
                 <HtmlTooltip
                     arrow
                     describeChild
+                    maxWidth={400}
                     title={
-                        <>
-                            <TooltipSecondaryContent>
-                                {tooltip.secondary}
-                            </TooltipSecondaryContent>
-                            <TooltipMainContent>
-                                {tooltip.main}
-                            </TooltipMainContent>
-                        </>
+                        <StyledTooltip>
+                            <ConditionallyRender
+                                condition={Boolean(src || user?.imageUrl)}
+                                show={
+                                    <StyledTooltipAvatar
+                                        src={src || user?.imageUrl}
+                                        alt={
+                                            user?.name ||
+                                            user?.email ||
+                                            user?.username ||
+                                            'Gravatar'
+                                        }
+                                    />
+                                }
+                            />
+                            <StyledTooltipContent>
+                                <ConditionallyRender
+                                    condition={Boolean(main)}
+                                    show={
+                                        <TooltipMainContent>
+                                            {main}
+                                        </TooltipMainContent>
+                                    }
+                                />
+                                <ConditionallyRender
+                                    condition={Boolean(secondary)}
+                                    show={
+                                        <TooltipSecondaryContent>
+                                            {secondary}
+                                        </TooltipSecondaryContent>
+                                    }
+                                />
+                            </StyledTooltipContent>
+                        </StyledTooltip>
                     }
                 >
                     {Avatar}

--- a/frontend/src/component/common/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/component/common/UserAvatar/UserAvatar.tsx
@@ -82,7 +82,7 @@ const TooltipSecondaryContent = styled('div')(({ theme }) => ({
 
 const TooltipMainContent = styled('div')(({ theme }) => ({
     fontSize: theme.typography.body1.fontSize,
-    wordBreak: 'break-word',
+    overflowWrap: 'anywhere',
 }));
 
 export const UserAvatar = forwardRef<HTMLDivElement, IUserAvatarProps>(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3109/improve-avatar-tooltip

I noticed our current user avatar tooltip is a bit poor.

This PR tries to improve it a bit using only the data we already have available, without any drastic changes.

### Before

![image](https://github.com/user-attachments/assets/2eeb87ca-791a-422d-9e8b-27537b6f38ef)

### After

![image](https://github.com/user-attachments/assets/38bc1bb1-9187-4bf8-88ec-e57f4c95a0c8)

### Other examples after the changes

![image](https://github.com/user-attachments/assets/f25172aa-24aa-4c8c-8d46-65e2b61a33b9)

![image](https://github.com/user-attachments/assets/a420cafb-e690-4495-bf7f-b7b3d3ddf311)

![image](https://github.com/user-attachments/assets/66b2efa3-269e-4384-96a5-1b089333a9d1)

![image](https://github.com/user-attachments/assets/7c56dcf0-b6f1-4433-840a-e975baec6785)