### PR TITLE
chore: improve group projects tooltip behavior

### DIFF
--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCard.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCard.tsx
@@ -116,10 +116,12 @@ const StyledProjectsTooltip = styled(Box)(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),
+    maxWidth: theme.spacing(25),
 }));
 
 const StyledProjectBadge = styled(Badge)({
     cursor: 'pointer',
+    overflowWrap: 'anywhere',
 });
 
 interface IGroupCardProps {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3111/improve-group-card-projects-tooltip

Slight improvement to the group card projects tooltip.

This handles very long project names a little bit better by allowing them to break into new lines.

![image](https://github.com/user-attachments/assets/8f30e729-7877-463b-8e1e-d05934396827)
