### PR TITLE
feat: ability to upsert single legal values

### DIFF
--- a/src/lib/features/context/context.test.ts
+++ b/src/lib/features/context/context.test.ts
@@ -156,7 +156,7 @@ test('should add and update a single context field with new legal values', async
 
     // non existent context
     await request
-        .put(`${base}/api/admin/context/doesntexist/legalValues`)
+        .post(`${base}/api/admin/context/doesntexist/legalValues`)
         .send({
             value: 'local',
             description: 'Local environment',
@@ -166,7 +166,7 @@ test('should add and update a single context field with new legal values', async
 
     // invalid schema
     await request
-        .put(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legalValues`)
         .send({
             valueInvalid: 'invalid schema',
             description: 'Local environment',
@@ -176,7 +176,7 @@ test('should add and update a single context field with new legal values', async
 
     // add a new context field legal value
     await request
-        .put(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legalValues`)
         .send({
             value: 'newvalue',
             description: 'new description',
@@ -186,7 +186,7 @@ test('should add and update a single context field with new legal values', async
 
     // update existing context field legal value description
     await request
-        .put(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legalValues`)
         .send({
             value: 'newvalue',
             description: 'updated description',

--- a/src/lib/features/context/context.test.ts
+++ b/src/lib/features/context/context.test.ts
@@ -151,6 +151,59 @@ test('should update a context field with new legal values', () => {
         .expect(200);
 });
 
+test('should add and update a single context field with new legal values', async () => {
+    expect.assertions(1);
+
+    // non existent context
+    await request
+        .put(`${base}/api/admin/context/doesntexist/legalValues`)
+        .send({
+            value: 'local',
+            description: 'Local environment',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(404);
+
+    // invalid schema
+    await request
+        .put(`${base}/api/admin/context/environment/legalValues`)
+        .send({
+            valueInvalid: 'invalid schema',
+            description: 'Local environment',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(400);
+
+    // add a new context field legal value
+    await request
+        .put(`${base}/api/admin/context/environment/legalValues`)
+        .send({
+            value: 'newvalue',
+            description: 'new description',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(200);
+
+    // update existing context field legal value description
+    await request
+        .put(`${base}/api/admin/context/environment/legalValues`)
+        .send({
+            value: 'newvalue',
+            description: 'updated description',
+        })
+        .set('Content-Type', 'application/json')
+        .expect(200);
+
+    const { body } = await request.get(`${base}/api/admin/context/environment`);
+
+    expect(body).toMatchObject({
+        name: 'environment',
+        legalValues: [
+            { value: 'newvalue', description: 'updated description' },
+        ],
+    });
+});
+
 test('should not delete a unknown context field', () => {
     expect.assertions(0);
 

--- a/src/lib/features/context/context.test.ts
+++ b/src/lib/features/context/context.test.ts
@@ -166,7 +166,7 @@ test('should add and update a single context field with new legal values', async
 
     // invalid schema
     await request
-        .post(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legal-values`)
         .send({
             valueInvalid: 'invalid schema',
             description: 'Local environment',
@@ -176,7 +176,7 @@ test('should add and update a single context field with new legal values', async
 
     // add a new context field legal value
     await request
-        .post(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legal-values`)
         .send({
             value: 'newvalue',
             description: 'new description',
@@ -186,7 +186,7 @@ test('should add and update a single context field with new legal values', async
 
     // update existing context field legal value description
     await request
-        .post(`${base}/api/admin/context/environment/legalValues`)
+        .post(`${base}/api/admin/context/environment/legal-values`)
         .send({
             value: 'newvalue',
             description: 'updated description',

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -177,10 +177,9 @@ export class ContextController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
-                    summary:
-                        'Add or update a single legal value to the context field',
-                    description: `Endpoint that allows adding or updating a custom context field legal value. If the legal value already exists, it will be updated with the new description`,
-                    operationId: 'addContextFieldLegalValue',
+                    summary: 'Add or update legal value for the context field',
+                    description: `Endpoint that allows adding or updating a single custom context field legal value. If the legal value already exists, it will be updated with the new description`,
+                    operationId: 'updateContextFieldLegalValue',
                     requestBody: createRequestSchema('legalValueSchema'),
                     responses: {
                         200: emptyResponse,

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -170,7 +170,7 @@ export class ContextController extends Controller {
         });
 
         this.route({
-            method: 'put',
+            method: 'post',
             path: '/:contextField/legalValues',
             handler: this.updateContextFieldLegalValue,
             permission: UPDATE_CONTEXT_FIELD,

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -171,7 +171,7 @@ export class ContextController extends Controller {
 
         this.route({
             method: 'post',
-            path: '/:contextField/legalValues',
+            path: '/:contextField/legal-values',
             handler: this.updateContextFieldLegalValue,
             permission: UPDATE_CONTEXT_FIELD,
             middleware: [

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -39,6 +39,7 @@ import {
 import type { UpdateContextFieldSchema } from '../../openapi/spec/update-context-field-schema';
 import type { CreateContextFieldSchema } from '../../openapi/spec/create-context-field-schema';
 import { extractUserIdFromUser } from '../../util';
+import type { LegalValueSchema } from '../../openapi';
 
 interface ContextParam {
     contextField: string;
@@ -169,6 +170,26 @@ export class ContextController extends Controller {
         });
 
         this.route({
+            method: 'put',
+            path: '/:contextField/legalValues',
+            handler: this.updateContextFieldLegalValue,
+            permission: UPDATE_CONTEXT_FIELD,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Context'],
+                    summary:
+                        'Add or update a single legal value to the context field',
+                    description: `Endpoint that allows adding or updating a custom context field legal value. If the legal value already exists, it will be updated with the new description`,
+                    operationId: 'addContextFieldLegalValue',
+                    requestBody: createRequestSchema('legalValueSchema'),
+                    responses: {
+                        200: emptyResponse,
+                    },
+                }),
+            ],
+        });
+
+        this.route({
             method: 'delete',
             path: '/:contextField',
             handler: this.deleteContextField,
@@ -266,6 +287,20 @@ export class ContextController extends Controller {
 
         await this.contextService.updateContextField(
             { ...contextField, name },
+            req.audit,
+        );
+        res.status(200).end();
+    }
+
+    async updateContextFieldLegalValue(
+        req: IAuthRequest<ContextParam, void, LegalValueSchema>,
+        res: Response,
+    ): Promise<void> {
+        const name = req.params.contextField;
+        const legalValue = req.body;
+
+        await this.contextService.updateContextFieldLegalValue(
+            { name, legalValue },
             req.audit,
         );
         res.status(200).end();

--- a/src/lib/services/context-schema.ts
+++ b/src/lib/services/context-schema.ts
@@ -3,7 +3,7 @@ import { nameType } from '../routes/util';
 
 export const nameSchema = joi.object().keys({ name: nameType });
 
-const legalValueSchema = joi.object().keys({
+export const legalValueSchema = joi.object().keys({
     value: joi.string().min(1).max(100).required(),
     description: joi.string().allow('').allow(null).optional(),
 });


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Ability to add/update a single legal value for the context. 

Important decisions:
* since it allows to add a new legal value or update description of a single legal value I decided to go for the PUT method since we know the identity of the legal value (context name + legal value name combination is unique).
* in the event log I'm using the same CONTEXT_FIELD_UPDATED event instead of creating a new event for single legal value updates 

Addresses: https://github.com/Unleash/unleash/issues/8934

Followup PRs:
* add delete single legal value capability
* wrap all context updates in transactions since they touch context and event log

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
