### PR TITLE
fix: delta do not return archived as changed

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-service.ts
@@ -9,10 +9,8 @@ import type {
 import type { Logger } from '../../logger';
 
 import type { FeatureConfigurationClient } from '../feature-toggle/types/feature-toggle-strategies-store-type';
-import type {
-    RevisionDeltaEntry,
-    ClientFeatureToggleDelta,
-} from './delta/client-feature-toggle-delta';
+import type { ClientFeatureToggleDelta } from './delta/client-feature-toggle-delta';
+import type { ClientFeaturesDeltaSchema } from '../../openapi';
 
 export class ClientFeatureToggleService {
     private logger: Logger;
@@ -44,7 +42,7 @@ export class ClientFeatureToggleService {
     async getClientDelta(
         revisionId: number | undefined,
         query: IFeatureToggleQuery,
-    ): Promise<RevisionDeltaEntry | undefined> {
+    ): Promise<ClientFeaturesDeltaSchema | undefined> {
         if (this.clientFeatureToggleDelta !== null) {
             return this.clientFeatureToggleDelta.getDelta(revisionId, query);
         } else {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
@@ -17,8 +17,10 @@ import type { OpenApiService } from '../../../services/openapi-service';
 import { NONE } from '../../../types/permissions';
 import { createResponseSchema } from '../../../openapi/util/create-response-schema';
 import type { ClientFeatureToggleService } from '../client-feature-toggle-service';
-import type { RevisionDeltaEntry } from './client-feature-toggle-delta';
-import { clientFeaturesDeltaSchema } from '../../../openapi';
+import {
+    type ClientFeaturesDeltaSchema,
+    clientFeaturesDeltaSchema,
+} from '../../../openapi';
 import type { QueryOverride } from '../client-feature-toggle.controller';
 
 export default class ClientFeatureToggleDeltaController extends Controller {
@@ -75,7 +77,7 @@ export default class ClientFeatureToggleDeltaController extends Controller {
 
     async getDelta(
         req: IAuthRequest,
-        res: Response<RevisionDeltaEntry>,
+        res: Response<ClientFeaturesDeltaSchema>,
     ): Promise<void> {
         if (!this.flagResolver.isEnabled('deltaApi')) {
             throw new NotFoundError();

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model-type.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model-type.ts
@@ -4,7 +4,7 @@ import type { FeatureConfigurationClient } from '../../feature-toggle/types/feat
 export interface FeatureConfigurationDeltaClient
     extends FeatureConfigurationClient {
     description: string;
-    impressionData: false;
+    impressionData: boolean;
 }
 
 export interface IClientFeatureToggleDeltaReadModel {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -75,10 +75,13 @@ const filterRevisionByProject = (
         (feature) =>
             projects.includes('*') || projects.includes(feature.project),
     );
-    const removed = revision.removed.filter(
-        (feature) =>
-            projects.includes('*') || projects.includes(feature.project),
-    );
+    const removed = revision.removed
+        .filter(
+            (feature) =>
+                projects.includes('*') || projects.includes(feature.project),
+        )
+        .map((feature) => feature.name);
+
     return { ...revision, updated, removed };
 };
 
@@ -197,6 +200,9 @@ export class ClientFeatureToggleDelta {
         }
     }
 
+    /**
+     * This is used in client-feature-delta-api.e2e.test.ts, do not remove
+     */
     public resetDelta() {
         this.delta = {};
     }
@@ -217,7 +223,7 @@ export class ClientFeatureToggleDelta {
             ...new Set(
                 changeEvents
                     .filter((event) => event.featureName)
-                    .filter((event) => event.type !== 'feature-archived')
+                    // .filter((event) => event.type !== 'feature-archived')
                     .map((event) => event.featureName!),
             ),
         ];

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -223,7 +223,7 @@ export class ClientFeatureToggleDelta {
             ...new Set(
                 changeEvents
                     .filter((event) => event.featureName)
-                    // .filter((event) => event.type !== 'feature-archived')
+                    .filter((event) => event.type !== 'feature-archived')
                     .map((event) => event.featureName!),
             ),
         ];

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -217,6 +217,7 @@ export class ClientFeatureToggleDelta {
             ...new Set(
                 changeEvents
                     .filter((event) => event.featureName)
+                    .filter((event) => event.type !== 'feature-archived')
                     .map((event) => event.featureName!),
             ),
         ];

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -17,6 +17,7 @@ import type {
 import { CLIENT_DELTA_MEMORY } from '../../../metric-events';
 import type EventEmitter from 'events';
 import type { Logger } from '../../../logger';
+import type { ClientFeaturesDeltaSchema } from '../../../openapi';
 
 type DeletedFeature = {
     name: string;
@@ -75,12 +76,10 @@ const filterRevisionByProject = (
         (feature) =>
             projects.includes('*') || projects.includes(feature.project),
     );
-    const removed = revision.removed
-        .filter(
-            (feature) =>
-                projects.includes('*') || projects.includes(feature.project),
-        )
-        .map((feature) => feature.name);
+    const removed = revision.removed.filter(
+        (feature) =>
+            projects.includes('*') || projects.includes(feature.project),
+    );
 
     return { ...revision, updated, removed };
 };
@@ -156,7 +155,7 @@ export class ClientFeatureToggleDelta {
     async getDelta(
         sdkRevisionId: number | undefined,
         query: IFeatureToggleQuery,
-    ): Promise<RevisionDeltaEntry | undefined> {
+    ): Promise<ClientFeaturesDeltaSchema | undefined> {
         const projects = query.project ? query.project : ['*'];
         const environment = query.environment ? query.environment : 'default';
         // TODO: filter by tags, what is namePrefix? anything else?
@@ -184,9 +183,10 @@ export class ClientFeatureToggleDelta {
             projects,
         );
 
-        const revisionResponse = {
+        const revisionResponse: ClientFeaturesDeltaSchema = {
             ...compressedRevision,
             segments: this.segments,
+            removed: compressedRevision.removed.map((feature) => feature.name),
         };
 
         return Promise.resolve(revisionResponse);

--- a/src/lib/openapi/spec/client-features-delta-schema.test.ts
+++ b/src/lib/openapi/spec/client-features-delta-schema.test.ts
@@ -1,0 +1,27 @@
+import { validateSchema } from '../validate';
+import type { ClientFeaturesDeltaSchema } from './client-features-delta-schema';
+
+test('clientFeaturesDeltaSchema all fields', () => {
+    const data: ClientFeaturesDeltaSchema = {
+        revisionId: 6,
+        updated: [
+            {
+                impressionData: false,
+                enabled: false,
+                name: 'base_feature',
+                description: null,
+                project: 'default',
+                stale: false,
+                type: 'release',
+                variants: [],
+                strategies: [],
+            },
+        ],
+        removed: [],
+        segments: [],
+    };
+
+    expect(
+        validateSchema('#/components/schemas/clientFeaturesDeltaSchema', data),
+    ).toBeUndefined();
+});

--- a/src/lib/openapi/spec/client-features-query-schema.test.ts
+++ b/src/lib/openapi/spec/client-features-query-schema.test.ts
@@ -1,27 +1,24 @@
 import { validateSchema } from '../validate';
-import type { ClientFeaturesDeltaSchema } from './client-features-delta-schema';
+import type { ClientFeaturesQuerySchema } from './client-features-query-schema';
 
-test('clientFeaturesDeltaSchema all fields', () => {
-    const data: ClientFeaturesDeltaSchema = {
-        revisionId: 6,
-        updated: [
-            {
-                impressionData: false,
-                enabled: false,
-                name: 'base_feature',
-                description: null,
-                project: 'default',
-                stale: false,
-                type: 'release',
-                variants: [],
-                strategies: [],
-            },
-        ],
-        removed: [],
-        segments: [],
+test('clientFeatureQuerySchema empty', () => {
+    const data: ClientFeaturesQuerySchema = {};
+
+    expect(
+        validateSchema('#/components/schemas/clientFeaturesQuerySchema', data),
+    ).toBeUndefined();
+});
+
+test('clientFeatureQuerySchema all fields', () => {
+    const data: ClientFeaturesQuerySchema = {
+        tag: [['some-tag', 'some-other-tag']],
+        project: ['default'],
+        namePrefix: 'some-prefix',
+        environment: 'some-env',
+        inlineSegmentConstraints: true,
     };
 
     expect(
-        validateSchema('#/components/schemas/clientFeaturesDeltaSchema', data),
+        validateSchema('#/components/schemas/clientFeaturesQuerySchema', data),
     ).toBeUndefined();
 });

--- a/src/lib/openapi/spec/client-features-query-schema.test.ts
+++ b/src/lib/openapi/spec/client-features-query-schema.test.ts
@@ -1,24 +1,27 @@
 import { validateSchema } from '../validate';
-import type { ClientFeaturesQuerySchema } from './client-features-query-schema';
+import type { ClientFeaturesDeltaSchema } from './client-features-delta-schema';
 
-test('clientFeatureQuerySchema empty', () => {
-    const data: ClientFeaturesQuerySchema = {};
-
-    expect(
-        validateSchema('#/components/schemas/clientFeaturesQuerySchema', data),
-    ).toBeUndefined();
-});
-
-test('clientFeatureQuerySchema all fields', () => {
-    const data: ClientFeaturesQuerySchema = {
-        tag: [['some-tag', 'some-other-tag']],
-        project: ['default'],
-        namePrefix: 'some-prefix',
-        environment: 'some-env',
-        inlineSegmentConstraints: true,
+test('clientFeaturesDeltaSchema all fields', () => {
+    const data: ClientFeaturesDeltaSchema = {
+        revisionId: 6,
+        updated: [
+            {
+                impressionData: false,
+                enabled: false,
+                name: 'base_feature',
+                description: null,
+                project: 'default',
+                stale: false,
+                type: 'release',
+                variants: [],
+                strategies: [],
+            },
+        ],
+        removed: [],
+        segments: [],
     };
 
     expect(
-        validateSchema('#/components/schemas/clientFeaturesQuerySchema', data),
+        validateSchema('#/components/schemas/clientFeaturesDeltaSchema', data),
     ).toBeUndefined();
 });


### PR DESCRIPTION
Our delta API was returning archived feature as updated. Now making sure we do not put `archived-feature `event into `updated` event array.
Also stop returning removed as complex object.