### PR TITLE
chore: make grid group cards have a consistent height

### DIFF
--- a/frontend/src/component/admin/groups/GroupsList/GroupsList.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupsList.tsx
@@ -23,6 +23,7 @@ const StyledGridContainer = styled('div')(({ theme }) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
     gap: theme.spacing(2),
+    gridAutoRows: '1fr',
 }));
 
 type PageQueryType = Partial<Record<'search', string>>;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3114/group-cards-should-have-a-consistent-height-in-their-grid

Makes the group cards height consistent in the grid.

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/27c2dbd4-4a72-419b-bbad-39a4309e5c30" />