### PR TITLE
chore: improve the accordion summary looks

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -71,8 +71,13 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
 const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
     boxShadow: 'none',
     padding: theme.spacing(1.5, 2),
+    borderRadius: theme.shape.borderRadiusMedium,
     [theme.breakpoints.down(400)]: {
         padding: theme.spacing(1, 2),
+    },
+    '&.Mui-focusVisible': {
+        backgroundColor: theme.palette.background.paper,
+        padding: theme.spacing(0.5, 2, 0.3, 2),
     },
 }));
 

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCardName.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCardName.tsx
@@ -57,6 +57,10 @@ export const MilestoneCardName = ({
                             setEditMode(false);
                         }
                     }}
+                    onClick={(ev) => {
+                        ev.preventDefault();
+                        ev.stopPropagation();
+                    }}
                 />
             )}
             {!editMode && (


### PR DESCRIPTION
Removes the darker background when the milestone name input is present and focused.
Clicking inside the milestone name input doesn't trigger the accordion.
Sizing tweaks to prevent content jumping around when editing milestone name