### PR TITLE
feat: Unique connection tracking

### DIFF
--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -130,7 +130,7 @@ test('should collect metrics for requests', async () => {
 
     const metrics = await prometheusRegister.metrics();
     expect(metrics).toMatch(
-        /http_request_duration_milliseconds\{quantile="0\.99",path="somePath",method="GET",status="200",appName="undefined"\}.*1337/,
+        /http_request_duration_milliseconds\{quantile="0\.99",path="somePath",method="GET",status="200",appName="undefined",connectionId="undefined"\}.*1337/,
     );
 });
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -124,7 +124,7 @@ export function registerPrometheusMetrics(
     const requestDuration = createSummary({
         name: 'http_request_duration_milliseconds',
         help: 'App response time',
-        labelNames: ['path', 'method', 'status', 'appName'],
+        labelNames: ['path', 'method', 'status', 'appName', 'connectionId'],
         percentiles: [0.1, 0.5, 0.9, 0.95, 0.99],
         maxAgeSeconds: 600,
         ageBuckets: 5,
@@ -700,13 +700,14 @@ export function registerPrometheusMetrics(
 
     eventBus.on(
         events.REQUEST_TIME,
-        ({ path, method, time, statusCode, appName }) => {
+        ({ path, method, time, statusCode, appName, connectionId }) => {
             requestDuration
                 .labels({
                     path,
                     method,
                     status: statusCode,
                     appName,
+                    connectionId,
                 })
                 .observe(time);
         },

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -55,12 +55,17 @@ export function responseTimeMetrics(
         // when pathname is undefined use a fallback
         pathname = pathname ?? collapse(req.path);
         let appName: string | undefined;
+        let connectionId: string | undefined;
         if (
             !flagResolver.isEnabled('responseTimeWithAppNameKillSwitch') &&
             (instanceStatsService.getAppCountSnapshot('7d') ??
                 appNameReportingThreshold) < appNameReportingThreshold
         ) {
+            // TODO: upgrade to x-unleash-appname
             appName = req.headers['unleash-appname'] ?? req.query.appName;
+            if (flagResolver.isEnabled('uniqueSdkTracking')) {
+                connectionId = req.headers['x-unleash-connection-id'];
+            }
         }
 
         const timingInfo = {
@@ -69,6 +74,7 @@ export function responseTimeMetrics(
             statusCode,
             time,
             appName,
+            connectionId,
         };
         if (!res.locals.responseTimeEmitted) {
             res.locals.responseTimeEmitted = true;

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -62,7 +62,10 @@ export function responseTimeMetrics(
                 appNameReportingThreshold) < appNameReportingThreshold
         ) {
             // TODO: upgrade to x-unleash-appname
-            appName = req.headers['unleash-appname'] ?? req.query.appName;
+            appName =
+                req.headers['x-unleash-appname'] ??
+                req.headers['unleash-appname'] ??
+                req.query.appName;
             if (flagResolver.isEnabled('uniqueSdkTracking')) {
                 connectionId = req.headers['x-unleash-connection-id'];
             }

--- a/src/lib/middleware/response-time-metrics.ts
+++ b/src/lib/middleware/response-time-metrics.ts
@@ -61,7 +61,6 @@ export function responseTimeMetrics(
             (instanceStatsService.getAppCountSnapshot('7d') ??
                 appNameReportingThreshold) < appNameReportingThreshold
         ) {
-            // TODO: upgrade to x-unleash-appname
             appName =
                 req.headers['x-unleash-appname'] ??
                 req.headers['unleash-appname'] ??

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -61,7 +61,8 @@ export type IFlagKey =
     | 'streaming'
     | 'etagVariant'
     | 'oidcRedirect'
-    | 'deltaApi';
+    | 'deltaApi'
+    | 'uniqueSdkTracking';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -288,6 +289,10 @@ const flags: IFlags = {
     ),
     deltaApi: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_DELTA_API,
+        false,
+    ),
+    uniqueSdkTracking: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_UNIQUE_SDK_TRACKING,
         false,
     ),
 };


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Enhancing request timing metrics with connection id (think instance id but guaranteed to be unique and handled internally by us). 

Details:
* I checked how appName was added in the first place: https://github.com/Unleash/unleash/pull/2117. Same tradeoffs apply here
* connection id is implemented here: https://github.com/Unleash/unleash-client-node/pull/690
* This is behind a flag to opt-into tracking and also it can be disabled with the killswitch for appName
* We have a new `x-unleash-appname` header that replaces `unleash-appname` but not all SDKs use it so we check both with preference given to the x-header
* I'm not using a new `x-unleash-sdk` header here to keep the metrics data as small as possible for now with the ability to track unique clients

Important:
* connection id has higher cardinality than the app name. We have as many unique connection ids as client pods AND frontend api instances (that's why I want this to be opt-in only for the time of debugging)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
