### PR TITLE
chore: remove unused newHostedAuthHandler flag

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -60,7 +60,6 @@ export type IFlagKey =
     | 'streaming'
     | 'etagVariant'
     | 'deltaApi'
-    | 'newHostedAuthHandler'
     | 'uniqueSdkTracking';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -280,10 +279,6 @@ const flags: IFlags = {
     },
     deltaApi: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_DELTA_API,
-        false,
-    ),
-    newHostedAuthHandler: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_NEW_HOSTED_AUTH_HANDLER,
         false,
     ),
     uniqueSdkTracking: parseEnvVarBoolean(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3106/clean-up-post-unified-auth-handler

Cleans up this flag that we never ended up using anyways.