### PR TITLE
chore: mark SSO as an Enterprise only feature

### DIFF
--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -58,7 +58,7 @@ export const adminRoutes: INavigationMenuItem[] = [
     {
         path: '/admin/auth',
         title: 'Single sign-on',
-        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        menu: { adminSettings: true, mode: ['enterprise'] },
         group: 'access',
     },
     {

--- a/frontend/src/component/admin/auth/AuthSettings.tsx
+++ b/frontend/src/component/admin/auth/AuthSettings.tsx
@@ -1,6 +1,5 @@
 import { Tab, Tabs } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { OidcAuth } from './OidcAuth/OidcAuth';
 import { SamlAuth } from './SamlAuth/SamlAuth';
@@ -45,58 +44,51 @@ export const AuthSettings = () => {
     const [activeTab, setActiveTab] = useState(0);
     usePageTitle(`Single sign-on: ${tabs[activeTab].label}`);
 
+    if (!isEnterprise()) {
+        return <PremiumFeature feature='sso' page />;
+    }
+
     return (
         <div>
             <PermissionGuard permissions={[ADMIN, UPDATE_AUTH_CONFIGURATION]}>
                 <PageContent
                     withTabs
                     header={
-                        <ConditionallyRender
-                            condition={isEnterprise()}
-                            show={
-                                <Tabs
-                                    value={activeTab}
-                                    onChange={(_, tabId) => {
-                                        setActiveTab(tabId);
+                        <Tabs
+                            value={activeTab}
+                            onChange={(_, tabId) => {
+                                setActiveTab(tabId);
+                            }}
+                            indicatorColor='primary'
+                            textColor='primary'
+                        >
+                            {tabs.map((tab, index) => (
+                                <Tab
+                                    key={`${tab.label}_${index}`}
+                                    label={tab.label}
+                                    id={`tab-${index}`}
+                                    aria-controls={`tabpanel-${index}`}
+                                    sx={{
+                                        minWidth: {
+                                            lg: 160,
+                                        },
                                     }}
-                                    indicatorColor='primary'
-                                    textColor='primary'
-                                >
-                                    {tabs.map((tab, index) => (
-                                        <Tab
-                                            key={`${tab.label}_${index}`}
-                                            label={tab.label}
-                                            id={`tab-${index}`}
-                                            aria-controls={`tabpanel-${index}`}
-                                            sx={{
-                                                minWidth: {
-                                                    lg: 160,
-                                                },
-                                            }}
-                                        />
-                                    ))}
-                                </Tabs>
-                            }
-                        />
+                                />
+                            ))}
+                        </Tabs>
                     }
                 >
-                    <ConditionallyRender
-                        condition={isEnterprise()}
-                        show={
-                            <div>
-                                {tabs.map((tab, index) => (
-                                    <TabPanel
-                                        key={index}
-                                        value={activeTab}
-                                        index={index}
-                                    >
-                                        {tab.component}
-                                    </TabPanel>
-                                ))}
-                            </div>
-                        }
-                        elseShow={<PremiumFeature feature='sso' />}
-                    />
+                    <div>
+                        {tabs.map((tab, index) => (
+                            <TabPanel
+                                key={index}
+                                value={activeTab}
+                                index={index}
+                            >
+                                {tab.component}
+                            </TabPanel>
+                        ))}
+                    </div>
                 </PageContent>
             </PermissionGuard>
         </div>

--- a/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
+++ b/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
@@ -89,7 +89,7 @@ const PremiumFeatures = {
         label: 'User groups',
     },
     sso: {
-        plan: FeaturePlan.PRO,
+        plan: FeaturePlan.ENTERPRISE,
         url: 'https://docs.getunleash.io/reference/rbac#user-group-sso-integration',
         label: 'Single Sign-On',
     },


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3124/mark-sso-as-an-enterprise-only-feature

For all intents and purposes, SSO seems to have always been an Enterprise only feature. It just wasn't very clear previously.

See: https://github.com/Unleash/unleash/pull/9045/files#r1899635618

![image](https://github.com/user-attachments/assets/7ffed499-83d6-4dc2-ae11-6b0d930a82d1)