### PR TITLE
fix: etag support RFC 9110 standard

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
@@ -98,7 +98,7 @@ test('should get 304 if asked for latest revision', async () => {
     const currentRevisionId = body.revisionId;
 
     await app.request
-        .set('If-None-Match', currentRevisionId)
+        .set('If-None-Match', `"${currentRevisionId}"`)
         .get('/api/client/delta')
         .expect(304);
 });
@@ -123,7 +123,7 @@ test('should return correct delta after feature created', async () => {
 
     const { body: deltaBody } = await app.request
         .get('/api/client/delta')
-        .set('If-None-Match', currentRevisionId)
+        .set('If-None-Match', `"${currentRevisionId}"`)
         .expect(200);
 
     expect(deltaBody).toMatchObject({
@@ -162,7 +162,7 @@ test('archived features should not be returned as updated', async () => {
 
     const { body: deltaBody } = await app.request
         .get('/api/client/delta')
-        .set('If-None-Match', currentRevisionId)
+        .set('If-None-Match', `"${currentRevisionId}"`)
         .expect(200);
 
     expect(deltaBody).toMatchObject({

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-controller.ts
@@ -85,7 +85,11 @@ export default class ClientFeatureToggleDeltaController extends Controller {
         const query = await this.resolveQuery(req);
         const etag = req.headers['if-none-match'];
 
-        const currentSdkRevisionId = etag ? Number.parseInt(etag) : undefined;
+        const sanitizedEtag = etag ? etag.replace(/^"(.*)"$/, '$1') : undefined;
+
+        const currentSdkRevisionId = sanitizedEtag
+            ? Number.parseInt(sanitizedEtag)
+            : undefined;
 
         const changedFeatures =
             await this.clientFeatureToggleService.getClientDelta(
@@ -107,7 +111,7 @@ export default class ClientFeatureToggleDeltaController extends Controller {
             return;
         }
 
-        res.setHeader('ETag', changedFeatures.revisionId.toString());
+        res.setHeader('ETag', `"${changedFeatures.revisionId}"`);
         this.openApiService.respondWithValidation(
             200,
             res,


### PR DESCRIPTION
ETag must be in double quotes based on standard. Fixing it.

```
If-None-Match: "<etag_value>"
