### PR TITLE
chore: fix smaller broken UI things in release templates

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/EditReleasePlanTemplate.tsx
@@ -29,7 +29,7 @@ export const EditReleasePlanTemplate = () => {
     const templateId = useRequiredPathParam('templateId');
     const { template, loading, error, refetch } =
         useReleasePlanTemplate(templateId);
-    usePageTitle(`Edit template: ${template.name}`);
+    usePageTitle(`Edit release template`);
     const navigate = useNavigate();
     const { setToastApiError, setToastData } = useToast();
     const { updateReleasePlanTemplate } = useReleasePlanTemplatesApi();
@@ -96,7 +96,7 @@ export const EditReleasePlanTemplate = () => {
             setMilestones={setMilestones}
             errors={errors}
             clearErrors={clearErrors}
-            formTitle={`Edit template ${template.name}`}
+            formTitle={`Edit release template`}
             formatApiCode={formatApiCode}
             handleSubmit={handleSubmit}
             loading={loading}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -256,7 +256,7 @@ export const MilestoneCard = ({
             >
                 <StyledMilestoneCardBody>
                     <Grid container>
-                        <StyledGridItem item xs={8} md={9}>
+                        <StyledGridItem item xs={6} md={6}>
                             <MilestoneCardName
                                 milestone={milestone}
                                 errors={errors}
@@ -264,7 +264,7 @@ export const MilestoneCard = ({
                                 milestoneNameChanged={milestoneNameChanged}
                             />
                         </StyledGridItem>
-                        <StyledMilestoneActionGrid item xs={4} md={3}>
+                        <StyledMilestoneActionGrid item xs={6} md={6}>
                             <Button
                                 variant='outlined'
                                 color='primary'

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
@@ -25,6 +25,11 @@ import { MilestoneStrategyTitle } from './MilestoneStrategyTitle';
 import { MilestoneStrategyConstraints } from './MilestoneStrategyConstraints';
 import { MilestoneStrategyVariants } from './MilestoneStrategyVariants';
 import { MilestoneStrategyType } from './MilestoneStrategyType';
+import {
+    featureStrategyDocsLink,
+    featureStrategyDocsLinkLabel,
+    featureStrategyHelp,
+} from 'component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit';
 
 const StyledCancelButton = styled(Button)(({ theme }) => ({
     marginLeft: theme.spacing(3),
@@ -236,7 +241,9 @@ export const ReleasePlanTemplateAddStrategyForm = ({
     return (
         <FormTemplate
             modal
-            description='Add a strategy to your release plan template.'
+            description={featureStrategyHelp}
+            documentationLink={featureStrategyDocsLink}
+            documentationLinkLabel={featureStrategyDocsLinkLabel}
         >
             <StyledHeaderBox>
                 <StyledTitle>
@@ -316,6 +323,8 @@ export const ReleasePlanTemplateAddStrategyForm = ({
                         <StyledTargetingHeader>
                             Segmentation and constraints allow you to set
                             filters on your strategies, so that they will only
+                            be evaluated for users and applications that match
+                            the specified preconditions.
                             <MilestoneStrategySegment
                                 segments={segments}
                                 setSegments={setSegments}
@@ -328,8 +337,6 @@ export const ReleasePlanTemplateAddStrategyForm = ({
                                 strategy={currentStrategy}
                                 setStrategy={setCurrentStrategy}
                             />
-                            be evaluated for users and applications that match
-                            the specified preconditions.
                         </StyledTargetingHeader>
                     </>
                 )}


### PR DESCRIPTION
- Add strategy button doesn't break up in narrower UIs
- Added description + docs link to add/edit strategy
- Fixed broken up text in segmentation/constraints UI