### PR TITLE
fix: remove archived features from delta

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -53,12 +53,12 @@ const applyRevision = (first: Revision, last: Revision): Revision => {
         ]),
     );
 
-    for (const feature of last.removed) {
-        updatedMap.delete(feature.name);
-    }
-
     for (const feature of last.updated) {
         removedMap.delete(feature.name);
+    }
+
+    for (const feature of last.removed) {
+        updatedMap.delete(feature.name);
     }
 
     return {


### PR DESCRIPTION
Revisions are added to the delta every second.

This means that in a single revision, you can disable an event, remove a dependency, and archive it simultaneously. These actions are usually performed together since archiving an event will inherently disable it, remove its dependencies, and so on.

Currently, we observe these events happening within the same revision. However, since we were checking `.updated` last, the event was always removed from the `removedMap`.

Now, by checking `.removed` last, the archive action will properly propagate to the revision.