### PR TITLE
fix(1-3247): remove explicit "in project" text from change request event text

### DIFF
--- a/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
+++ b/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Should format specialised text for events when a scheduled change reque
 exports[`Should format specialised text for events when change request is scheduled 1`] = `
 {
   "label": "Change request scheduled",
-  "text": "*user@company.com* scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* to be applied at  in project *my-other-project*",
+  "text": "*user@company.com* scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* to be applied at ",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;
@@ -203,7 +203,7 @@ exports[`Should format specialised text for events when rollout percentage chang
 exports[`Should format specialised text for events when scheduled change request fails  1`] = `
 {
   "label": "Scheduled change request failed",
-  "text": "*Failed* to apply the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com* in project *my-other-project*.",
+  "text": "*Failed* to apply the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;
@@ -211,7 +211,7 @@ exports[`Should format specialised text for events when scheduled change request
 exports[`Should format specialised text for events when scheduled change request succeeds  1`] = `
 {
   "label": "Scheduled change request applied successfully",
-  "text": "*Successfully* applied the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com* in project *my-other-project*.",
+  "text": "*Successfully* applied the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;

--- a/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
+++ b/src/lib/addons/__snapshots__/feature-event-formatter-md.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Should format specialised text for events when a scheduled change reque
 exports[`Should format specialised text for events when change request is scheduled 1`] = `
 {
   "label": "Change request scheduled",
-  "text": "*user@company.com* scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* to be applied at ",
+  "text": "*user@company.com* scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* to be applied at 2024-06-01T10:03:11.549Z.",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;
@@ -203,7 +203,7 @@ exports[`Should format specialised text for events when rollout percentage chang
 exports[`Should format specialised text for events when scheduled change request fails  1`] = `
 {
   "label": "Scheduled change request failed",
-  "text": "*Failed* to apply the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*",
+  "text": "*Failed* to apply the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*.",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;
@@ -211,7 +211,7 @@ exports[`Should format specialised text for events when scheduled change request
 exports[`Should format specialised text for events when scheduled change request succeeds  1`] = `
 {
   "label": "Scheduled change request applied successfully",
-  "text": "*Successfully* applied the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*",
+  "text": "*Successfully* applied the scheduled change request *[#1](unleashUrl/projects/my-other-project/change-requests/1)* for feature flag *[new-feature](unleashUrl/projects/my-other-project/features/new-feature)* in the *production* environment in project *[my-other-project](unleashUrl/projects/my-other-project)* by *user@company.com*.",
   "url": "unleashUrl/projects/my-other-project/change-requests/1",
 }
 `;

--- a/src/lib/addons/feature-event-formatter-md-events.ts
+++ b/src/lib/addons/feature-event-formatter-md-events.ts
@@ -152,17 +152,17 @@ export const EVENT_MAP: Record<string, IEventData> = {
     },
     [CHANGE_REQUEST_SCHEDULED]: {
         label: 'Change request scheduled',
-        action: '{{b}}{{user}}{{b}} scheduled change request {{changeRequest}} to be applied at {{event.data.scheduledDate}} in project {{b}}{{event.project}}{{b}}',
+        action: '{{b}}{{user}}{{b}} scheduled change request {{changeRequest}} to be applied at {{event.data.scheduledDate}}',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULED_APPLICATION_SUCCESS]: {
         label: 'Scheduled change request applied successfully',
-        action: '{{b}}Successfully{{b}} applied the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}} in project {{b}}{{event.project}}{{b}}.',
+        action: '{{b}}Successfully{{b}} applied the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULED_APPLICATION_FAILURE]: {
         label: 'Scheduled change request failed',
-        action: '{{b}}Failed{{b}} to apply the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}} in project {{b}}{{event.project}}{{b}}.',
+        action: '{{b}}Failed{{b}} to apply the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULE_SUSPENDED]: {

--- a/src/lib/addons/feature-event-formatter-md-events.ts
+++ b/src/lib/addons/feature-event-formatter-md-events.ts
@@ -152,17 +152,17 @@ export const EVENT_MAP: Record<string, IEventData> = {
     },
     [CHANGE_REQUEST_SCHEDULED]: {
         label: 'Change request scheduled',
-        action: '{{b}}{{user}}{{b}} scheduled change request {{changeRequest}} to be applied at {{event.data.scheduledDate}}',
+        action: '{{b}}{{user}}{{b}} scheduled change request {{changeRequest}} to be applied at {{event.data.scheduledDate}}.',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULED_APPLICATION_SUCCESS]: {
         label: 'Scheduled change request applied successfully',
-        action: '{{b}}Successfully{{b}} applied the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}',
+        action: '{{b}}Successfully{{b}} applied the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}.',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULED_APPLICATION_FAILURE]: {
         label: 'Scheduled change request failed',
-        action: '{{b}}Failed{{b}} to apply the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}',
+        action: '{{b}}Failed{{b}} to apply the scheduled change request {{changeRequest}} by {{b}}{{user}}{{b}}.',
         path: '/projects/{{event.project}}/change-requests/{{event.data.changeRequestId}}',
     },
     [CHANGE_REQUEST_SCHEDULE_SUSPENDED]: {

--- a/src/lib/addons/feature-event-formatter-md.test.ts
+++ b/src/lib/addons/feature-event-formatter-md.test.ts
@@ -510,6 +510,7 @@ const testCases: [string, IEvent][] = [
             createdByUserId: SYSTEM_USER_ID,
             data: {
                 changeRequestId: 1,
+                scheduledDate: '2024-06-01T10:03:11.549Z',
             },
             preData: {},
             tags: [],


### PR DESCRIPTION
We got an event for a scheduled application success today that looked a little something like this:

> Successfully applied the scheduled change request #1168 in the production environment in project eg by gaston in project eg.

Notice that we're stating the project twice (once with a link (removed here) and once without).

This PR removes the redundancy in CR events:


The project is already included in the `changeRequest` variable, which
is populated in `src/lib/addons/feature-event-formatter-md.ts` by
the `generateChangeRequestLink` function.

The (current) definition is:

```typescript
    generateChangeRequestLink(event: IEvent): string | undefined {
        const { preData, data, project, environment } = event;
        const changeRequestId =
            data?.changeRequestId || preData?.changeRequestId;
        if (project && changeRequestId) {
            const url = `${this.unleashUrl}/projects/${project}/change-requests/${changeRequestId}`;
            const text = `#${changeRequestId}`;
            const featureLink = this.generateFeatureLink(event);
            const featureText = featureLink
                ? ` for feature flag ${this.bold(featureLink)}`
                : '';
            const environmentText = environment
                ? ` in the ${this.bold(environment)} environment`
                : '';
            const projectLink = this.generateProjectLink(event);
            const projectText = project
                ? ` in project ${this.bold(projectLink)}`
                : '';
            if (this.linkStyle === LinkStyle.SLACK) {
                return `${this.bold(`<${url}|${text}>`)}${featureText}${environmentText}${projectText}`;
            } else {
                return `${this.bold(`[${text}](${url})`)}${featureText}${environmentText}${projectText}`;
            }
        }
    }
```

Which includes links, env, and project info already.