### PR TITLE
chore: move strategy UI into milestonecard and open milestone when adding strategy to it

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
@@ -1,7 +1,4 @@
-import type {
-    IReleasePlanMilestonePayload,
-    IReleasePlanMilestoneStrategy,
-} from 'interfaces/releasePlans';
+import type { IReleasePlanMilestonePayload } from 'interfaces/releasePlans';
 import { MilestoneCard } from './MilestoneCard/MilestoneCard';
 import { styled, Button, FormHelperText } from '@mui/material';
 import Add from '@mui/icons-material/Add';
@@ -12,11 +9,6 @@ interface IMilestoneListProps {
     setMilestones: React.Dispatch<
         React.SetStateAction<IReleasePlanMilestonePayload[]>
     >;
-    openAddStrategyForm: (
-        milestoneId: string,
-        strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>,
-        editing: boolean,
-    ) => void;
     errors: { [key: string]: string };
     clearErrors: () => void;
     milestoneChanged: (milestone: IReleasePlanMilestonePayload) => void;
@@ -30,7 +22,6 @@ const StyledAddMilestoneButton = styled(Button)(({ theme }) => ({
 export const MilestoneList = ({
     milestones,
     setMilestones,
-    openAddStrategyForm,
     errors,
     clearErrors,
     milestoneChanged,
@@ -51,7 +42,6 @@ export const MilestoneList = ({
                         key={milestone.id}
                         milestone={milestone}
                         milestoneChanged={milestoneChanged}
-                        showAddStrategyDialog={openAddStrategyForm}
                         errors={errors}
                         clearErrors={clearErrors}
                         removable={milestones.length > 1}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
@@ -124,18 +124,15 @@ const StyledDividerContent = styled(Box)(({ theme }) => ({
 }));
 
 interface IReleasePlanTemplateAddStrategyFormProps {
-    milestoneId: string | undefined;
     onCancel: () => void;
     strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>;
     onAddUpdateStrategy: (
-        milestoneId: string,
         strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>,
     ) => void;
     editMode: boolean;
 }
 
 export const ReleasePlanTemplateAddStrategyForm = ({
-    milestoneId,
     onCancel,
     strategy,
     onAddUpdateStrategy,
@@ -231,11 +228,7 @@ export const ReleasePlanTemplateAddStrategyForm = ({
     };
 
     const AddUpdateMilestoneStrategy = () => {
-        if (!milestoneId) {
-            return;
-        }
-
-        onAddUpdateStrategy(milestoneId, currentStrategy);
+        onAddUpdateStrategy(currentStrategy);
     };
 
     return (

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
@@ -1,15 +1,9 @@
 import Input from 'component/common/Input/Input';
 import { styled, useTheme } from '@mui/material';
-import type {
-    IReleasePlanMilestonePayload,
-    IReleasePlanMilestoneStrategy,
-} from 'interfaces/releasePlans';
+import type { IReleasePlanMilestonePayload } from 'interfaces/releasePlans';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
-import { useState } from 'react';
 import { TemplateFormDescription } from './TemplateFormDescription';
 import { MilestoneList } from './MilestoneList/MilestoneList';
-import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
-import { ReleasePlanTemplateAddStrategyForm } from './MilestoneStrategy/ReleasePlanTemplateAddStrategyForm';
 
 const StyledInput = styled(Input)(({ theme }) => ({
     width: '100%',
@@ -61,77 +55,7 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
     handleSubmit,
     children,
 }) => {
-    const [addUpdateStrategyOpen, setAddUpdateStrategyOpen] = useState(false);
-    const [activeMilestoneId, setActiveMilestoneId] = useState<
-        string | undefined
-    >();
-    const [strategyModeEdit, setStrategyModeEdit] = useState(false);
-    const [strategy, setStrategy] = useState<
-        Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>
-    >({
-        name: 'flexibleRollout',
-        parameters: { rollout: '50' },
-        constraints: [],
-        title: '',
-        id: 'temp',
-    });
-
     const theme = useTheme();
-    const openAddUpdateStrategyForm = (
-        milestoneId: string,
-        strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>,
-        editing: boolean,
-    ) => {
-        setStrategyModeEdit(editing);
-        setActiveMilestoneId(milestoneId);
-        setStrategy(strategy);
-        setAddUpdateStrategyOpen(true);
-    };
-
-    const addUpdateStrategy = (
-        milestoneId: string,
-        strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>,
-    ) => {
-        const milestone = milestones.find((m) => m.id === milestoneId);
-        const existingStrategy = milestone?.strategies?.find(
-            (strat) => strat.id === strategy.id,
-        );
-        if (!milestone) {
-            return;
-        }
-        if (existingStrategy) {
-            milestoneStrategyChanged(milestone, strategy);
-        } else {
-            setMilestones((prev) =>
-                prev.map((milestone, i) =>
-                    milestone.id === milestoneId
-                        ? {
-                              ...milestone,
-                              strategies: [
-                                  ...(milestone.strategies || []),
-                                  {
-                                      ...strategy,
-                                      strategyName: strategy.strategyName,
-                                      sortOrder:
-                                          milestone.strategies?.length || 0,
-                                  },
-                              ],
-                          }
-                        : milestone,
-                ),
-            );
-        }
-        setAddUpdateStrategyOpen(false);
-        setStrategyModeEdit(false);
-        setActiveMilestoneId(undefined);
-        setStrategy({
-            name: 'flexibleRollout',
-            parameters: { rollout: '50' },
-            constraints: [],
-            title: '',
-            id: 'temp',
-        });
-    };
 
     const milestoneChanged = (milestone: IReleasePlanMilestonePayload) => {
         setMilestones((prev) =>
@@ -139,21 +63,6 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                 mstone.id === milestone.id ? { ...milestone } : mstone,
             ),
         );
-    };
-
-    const milestoneStrategyChanged = (
-        milestone: IReleasePlanMilestonePayload,
-        strategy: Omit<IReleasePlanMilestoneStrategy, 'milestoneId'>,
-    ) => {
-        const strategies = milestone.strategies || [];
-        milestoneChanged({
-            ...milestone,
-            strategies: [
-                ...strategies.map((strat) =>
-                    strat.id === strategy.id ? strategy : strat,
-                ),
-            ],
-        });
     };
 
     return (
@@ -203,33 +112,12 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                 <MilestoneList
                     milestones={milestones}
                     setMilestones={setMilestones}
-                    openAddStrategyForm={openAddUpdateStrategyForm}
                     errors={errors}
                     clearErrors={clearErrors}
                     milestoneChanged={milestoneChanged}
                 />
 
                 {children}
-
-                <SidebarModal
-                    label='Add strategy to template milestone'
-                    onClose={() => {
-                        setAddUpdateStrategyOpen(false);
-                        setStrategyModeEdit(false);
-                    }}
-                    open={addUpdateStrategyOpen}
-                >
-                    <ReleasePlanTemplateAddStrategyForm
-                        milestoneId={activeMilestoneId}
-                        strategy={strategy}
-                        onAddUpdateStrategy={addUpdateStrategy}
-                        onCancel={() => {
-                            setAddUpdateStrategyOpen(false);
-                            setStrategyModeEdit(false);
-                        }}
-                        editMode={strategyModeEdit}
-                    />
-                </SidebarModal>
             </StyledForm>
         </FormTemplate>
     );


### PR DESCRIPTION
Refactor that moves strategy form into milestone card component, and tracks milestone expanded state so we can open it when adding strategies to it