### PR TITLE
chore: feature release plans other strategies indicator

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -52,6 +52,13 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
     color: theme.palette.common.white,
 }));
 
+const AdditionalStrategiesDiv = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: theme.spacing(2),
+}));
+
 const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
@@ -245,9 +252,14 @@ const EnvironmentAccordionBody = ({
                                     strategies.length > 0
                                 }
                                 show={
-                                    <SectionSeparator>
-                                        <StyledBadge>OR</StyledBadge>
-                                    </SectionSeparator>
+                                    <>
+                                        <SectionSeparator>
+                                            <StyledBadge>OR</StyledBadge>
+                                        </SectionSeparator>
+                                        <AdditionalStrategiesDiv>
+                                            Additional strategies
+                                        </AdditionalStrategiesDiv>
+                                    </>
                                 }
                             />
                             <ConditionallyRender


### PR DESCRIPTION
Adds a text in the environment strategy separator between release plans and normal strategies that reads "Additional strategies" 


![image](https://github.com/user-attachments/assets/39e1ab2e-05d6-4afb-a0cb-e410dbe6ef19)
