### PR TITLE
fix: feature-dependencies-removed event should not be created always

### DIFF
--- a/src/lib/features/dependent-features/dependent.features.e2e.test.ts
+++ b/src/lib/features/dependent-features/dependent.features.e2e.test.ts
@@ -175,7 +175,7 @@ test('should add and delete feature dependencies', async () => {
     await app.createFeature(child2);
 
     const { body: options } = await getPossibleParentFeatures(child);
-    expect(options).toStrictEqual([child2, parent]);
+    expect(options).toMatchObject([parent, child2].sort());
 
     // save explicit enabled and variants
     await addFeatureDependency(child, {


### PR DESCRIPTION
Currently, every time you archived feature, it created feature-dependencies-removed event.

This PR adds a check to only create events for those features that have dependency.