### PR TITLE
feat: conditionally show groupId in StrategyExecution under rollout

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
@@ -105,60 +105,6 @@ export const StrategyExecution: FC<IStrategyExecutionProps> = ({
 
                     const badgeType = strategy.disabled ? 'neutral' : 'success';
 
-                    if (displayGroupId && parameters.groupId) {
-                        return (
-                            <StyledValueContainer
-                                sx={{
-                                    display: 'flex',
-                                    flexWrap: 'wrap',
-                                    alignItems: 'center',
-                                }}
-                            >
-                                <Box sx={{ mr: 2 }}>
-                                    <PercentageCircle
-                                        percentage={percentage}
-                                        size='2rem'
-                                        disabled={strategy.disabled}
-                                    />
-                                </Box>
-                                <div>
-                                    <Badge color={badgeType}>
-                                        {percentage}%
-                                    </Badge>{' '}
-                                    <span>of your base</span>{' '}
-                                    <span>
-                                        {explainStickiness ? (
-                                            <>
-                                                with{' '}
-                                                <strong>{stickiness}</strong>
-                                            </>
-                                        ) : (
-                                            ''
-                                        )}{' '}
-                                    </span>
-                                    <span>
-                                        {constraints.length > 0
-                                            ? 'who match constraints'
-                                            : ''}{' '}
-                                        is included.
-                                    </span>
-                                </div>
-                                <Box
-                                    sx={(theme) => ({
-                                        width: '100%',
-                                        mt: 1,
-                                        ml: 6,
-                                        color: theme.palette.info.contrastText,
-                                    })}
-                                >
-                                    <Badge color='info'>
-                                        GroupId: {parameters.groupId}
-                                    </Badge>
-                                </Box>
-                            </StyledValueContainer>
-                        );
-                    }
-
                     return (
                         <StyledValueContainer
                             sx={{ display: 'flex', alignItems: 'center' }}
@@ -189,6 +135,18 @@ export const StrategyExecution: FC<IStrategyExecutionProps> = ({
                                     is included.
                                 </span>
                             </div>
+                            {displayGroupId && parameters.groupId && (
+                                <Box
+                                    sx={(theme) => ({
+                                        ml: 1,
+                                        color: theme.palette.info.contrastText,
+                                    })}
+                                >
+                                    <Badge color='info'>
+                                        GroupId: {parameters.groupId}
+                                    </Badge>
+                                </Box>
+                            )}
                         </StyledValueContainer>
                     );
                 }

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
@@ -21,6 +21,7 @@ import { BuiltInStrategies } from 'utils/strategyNames';
 
 interface IStrategyExecutionProps {
     strategy: IFeatureStrategyPayload | CreateFeatureStrategySchema;
+    displayGroupId?: boolean;
 }
 
 const StyledContainer = styled(Box, {
@@ -77,6 +78,7 @@ const StyledValueSeparator = styled('span')(({ theme }) => ({
 
 export const StrategyExecution: FC<IStrategyExecutionProps> = ({
     strategy,
+    displayGroupId = false,
 }) => {
     const { parameters, constraints = [] } = strategy;
     const stickiness = parameters?.stickiness;
@@ -102,6 +104,60 @@ export const StrategyExecution: FC<IStrategyExecutionProps> = ({
                     const percentage = parseParameterNumber(parameters[key]);
 
                     const badgeType = strategy.disabled ? 'neutral' : 'success';
+
+                    if (displayGroupId && parameters.groupId) {
+                        return (
+                            <StyledValueContainer
+                                sx={{
+                                    display: 'flex',
+                                    flexWrap: 'wrap',
+                                    alignItems: 'center',
+                                }}
+                            >
+                                <Box sx={{ mr: 2 }}>
+                                    <PercentageCircle
+                                        percentage={percentage}
+                                        size='2rem'
+                                        disabled={strategy.disabled}
+                                    />
+                                </Box>
+                                <div>
+                                    <Badge color={badgeType}>
+                                        {percentage}%
+                                    </Badge>{' '}
+                                    <span>of your base</span>{' '}
+                                    <span>
+                                        {explainStickiness ? (
+                                            <>
+                                                with{' '}
+                                                <strong>{stickiness}</strong>
+                                            </>
+                                        ) : (
+                                            ''
+                                        )}{' '}
+                                    </span>
+                                    <span>
+                                        {constraints.length > 0
+                                            ? 'who match constraints'
+                                            : ''}{' '}
+                                        is included.
+                                    </span>
+                                </div>
+                                <Box
+                                    sx={(theme) => ({
+                                        width: '100%',
+                                        mt: 1,
+                                        ml: 6,
+                                        color: theme.palette.info.contrastText,
+                                    })}
+                                >
+                                    <Badge color='info'>
+                                        GroupId: {parameters.groupId}
+                                    </Badge>
+                                </Box>
+                            </StyledValueContainer>
+                        );
+                    }
 
                     return (
                         <StyledValueContainer

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategy.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategy.tsx
@@ -40,7 +40,7 @@ export const ReleasePlanMilestoneStrategy = ({
                 <Icon />
                 {`${formatStrategyName(String(strategy.strategyName))}${strategy.title ? `: ${strategy.title}` : ''}`}
             </StyledHeader>
-            <StrategyExecution strategy={strategy} displayGroupId={true} />
+            <StrategyExecution strategy={strategy} displayGroupId />
             {strategy.variants &&
                 strategy.variants.length > 0 &&
                 (strategy.disabled ? (

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategy.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategy.tsx
@@ -40,7 +40,7 @@ export const ReleasePlanMilestoneStrategy = ({
                 <Icon />
                 {`${formatStrategyName(String(strategy.strategyName))}${strategy.title ? `: ${strategy.title}` : ''}`}
             </StyledHeader>
-            <StrategyExecution strategy={strategy} />
+            <StrategyExecution strategy={strategy} displayGroupId={true} />
             {strategy.variants &&
                 strategy.variants.length > 0 &&
                 (strategy.disabled ? (


### PR DESCRIPTION
Adds a condition `displayGroupId` to StrategyExecution that toggles showing group id in the rollout section
Enables `displayGroupId` in the feature release plan strategy-view

![image](https://github.com/user-attachments/assets/39637832-bcce-4e4a-90fb-03649ce986b2)

![image](https://github.com/user-attachments/assets/3e7cc469-31b1-4b35-8712-11ac02e2d21f)
