### PR TITLE
chore: make remove release plan warning conditional on env. enabled

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -185,6 +185,7 @@ export const ReleasePlan = ({
                 open={removeOpen}
                 setOpen={setRemoveOpen}
                 onConfirm={onRemoveConfirm}
+                environmentActive={!environmentIsDisabled}
             />
         </StyledContainer>
     );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanRemoveDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanRemoveDialog.tsx
@@ -8,6 +8,7 @@ interface IReleasePlanRemoveDialogProps {
     open: boolean;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
     onConfirm: () => void;
+    environmentActive: boolean;
 }
 
 export const ReleasePlanRemoveDialog = ({
@@ -15,6 +16,7 @@ export const ReleasePlanRemoveDialog = ({
     open,
     setOpen,
     onConfirm,
+    environmentActive,
 }: IReleasePlanRemoveDialogProps) => (
     <Dialogue
         title='Remove release plan?'
@@ -25,7 +27,7 @@ export const ReleasePlanRemoveDialog = ({
         onClose={() => setOpen(false)}
     >
         <ConditionallyRender
-            condition={Boolean(plan.activeMilestoneId)}
+            condition={Boolean(plan.activeMilestoneId) && environmentActive}
             show={
                 <Alert severity='error' sx={{ mb: 2 }}>
                     This release plan currently has one active milestone.


### PR DESCRIPTION
Only shows the active milestone warning in the delete release plan dialog if the feature environment is enabled

![Skjermbilde 2025-01-15 kl  15 15 11](https://github.com/user-attachments/assets/ca8117a0-ab94-41a7-a047-55d9f775b597)
![Skjermbilde 2025-01-15 kl  15 15 00](https://github.com/user-attachments/assets/2f38a738-422c-4eaa-b7e8-a82bd51f32b8)
