### PR TITLE
chore: fix release template strategy padding and spacing

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
@@ -35,10 +35,17 @@ const StyledCancelButton = styled(Button)(({ theme }) => ({
     marginLeft: theme.spacing(3),
 }));
 
-const StyledButtonContainer = styled('div')(() => ({
+const StyledButtonContainer = styled('div')(({ theme }) => ({
     marginTop: 'auto',
     display: 'flex',
     justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+    paddingTop: theme.spacing(3),
+    paddingRight: theme.spacing(6),
+    paddingLeft: theme.spacing(6),
+    paddingBottom: theme.spacing(6),
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
 const StyledHeaderBox = styled(Box)(({ theme }) => ({
@@ -234,6 +241,7 @@ export const ReleasePlanTemplateAddStrategyForm = ({
     return (
         <FormTemplate
             modal
+            disablePadding
             description={featureStrategyHelp}
             documentationLink={featureStrategyDocsLink}
             documentationLinkLabel={featureStrategyDocsLinkLabel}


### PR DESCRIPTION
Fixes the weird padding issues and the low position of add/cancel buttons on the add/edit strategy dialog for release templates

Before:
![image](https://github.com/user-attachments/assets/3c77a889-9965-449a-b0db-7a4749a64190)


After:
![image](https://github.com/user-attachments/assets/d24b270e-ef3d-4867-b5b4-a600bd99f2e7)
