### PR TITLE
fix: remove deleted event from being update event

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -225,6 +225,7 @@ export class ClientFeatureToggleDelta {
                 changeEvents
                     .filter((event) => event.featureName)
                     .filter((event) => event.type !== 'feature-archived')
+                    .filter((event) => event.type !== 'feature-deleted')
                     .map((event) => event.featureName!),
             ),
         ];


### PR DESCRIPTION
The feature was getting into updated array due to feature-deleted event.