### PR TITLE
chore: fix traffic data timezone visualization issue with getUTCDate

### DIFF
--- a/frontend/src/hooks/useTrafficData.ts
+++ b/frontend/src/hooks/useTrafficData.ts
@@ -132,7 +132,7 @@ const toChartData = (
 
             for (const dayKey in item.days) {
                 const day = item.days[dayKey];
-                const dayNum = new Date(Date.parse(day.day)).getDate();
+                const dayNum = new Date(Date.parse(day.day)).getUTCDate();
                 daysRec[`d${dayNum}`] = day.trafficTypes[0].count;
             }
             const epInfo = endpointsInfo[item.apiPath];


### PR DESCRIPTION
Dates are hard. For a lot of timezones new Date(Date.parse('2025-01-01T00:00:00.000Z')).getDate() could be returned as 31 and not 1

By using getUTCDate instead we now adjust accordingly and return the right day number.