### PR TITLE
fix: specify colors for buttons

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -72,6 +72,7 @@ const Wrapper = styled('article')(({ theme }) => ({
         fontSize: theme.typography.body1.fontSize,
         padding: theme.spacing(0.5),
         borderRadius: theme.shape.borderRadius,
+        color: theme.palette.text.primary,
 
         '&.selected': {
             backgroundColor: theme.palette.secondary.light,
@@ -79,6 +80,7 @@ const Wrapper = styled('article')(({ theme }) => ({
     },
     'button:disabled': {
         cursor: 'default',
+        color: theme.palette.text.disabled,
     },
 }));
 


### PR DESCRIPTION
Fixes an issue where the buttons would be illegible in dark mode
because we don't set the color explicitly. It just happened to work in
light mode.