### PR TITLE
fix: add a hover color for buttons in the period selectors.

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -73,6 +73,7 @@ const Wrapper = styled('article')(({ theme }) => ({
         padding: theme.spacing(0.5),
         borderRadius: theme.shape.borderRadius,
         color: theme.palette.text.primary,
+        transition: 'background-color 0.2s ease',
 
         '&.selected': {
             backgroundColor: theme.palette.secondary.light,
@@ -81,6 +82,9 @@ const Wrapper = styled('article')(({ theme }) => ({
     'button:disabled': {
         cursor: 'default',
         color: theme.palette.text.disabled,
+    },
+    'button:hover': {
+        backgroundColor: theme.palette.action.hover,
     },
 }));
 


### PR DESCRIPTION
Adds the same hover color as for the sidebar. Also adds a transition animation.