### PR TITLE
feat(1-3260): store support for data traffic from a range

### DIFF
--- a/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
@@ -1,9 +1,15 @@
 import type {
     IStatTrafficUsageKey,
     IStatTrafficUsage,
+    IStatMonthlyTrafficUsage,
 } from './traffic-data-usage-store-type';
 import type { ITrafficDataUsageStore } from '../../types';
-import { isSameMonth, parse } from 'date-fns';
+import {
+    differenceInCalendarMonths,
+    format,
+    isSameMonth,
+    parse,
+} from 'date-fns';
 
 export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
     private trafficData: IStatTrafficUsage[] = [];
@@ -49,5 +55,38 @@ export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
         return this.trafficData.filter((data) =>
             isSameMonth(data.day, periodDate),
         );
+    }
+
+    async getTrafficDataForMonthRange(
+        monthsBack: number,
+    ): Promise<IStatMonthlyTrafficUsage[]> {
+        const now = new Date();
+
+        const data: { [key: string]: IStatMonthlyTrafficUsage } =
+            this.trafficData
+                .filter(
+                    (entry) =>
+                        differenceInCalendarMonths(now, entry.day) <=
+                        monthsBack,
+                )
+                .reduce((acc, entry) => {
+                    const month = format(entry.day, 'yyyy-MM');
+                    const key = `${month}-${entry.trafficGroup}-${entry.statusCodeSeries}`;
+
+                    if (acc[key]) {
+                        acc[key].count += entry.count;
+                    } else {
+                        acc[key] = {
+                            month,
+                            trafficGroup: entry.trafficGroup,
+                            statusCodeSeries: entry.statusCodeSeries,
+                            count: entry.count,
+                        };
+                    }
+
+                    return acc;
+                }, {});
+
+        return Object.values(data);
     }
 }

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
@@ -7,6 +7,13 @@ export type IStatTrafficUsage = {
     count: number;
 };
 
+export type IStatMonthlyTrafficUsage = {
+    month: Date;
+    trafficGroup: string;
+    statusCodeSeries: number;
+    count: number;
+};
+
 export interface IStatTrafficUsageKey {
     day: Date;
     trafficGroup: string;
@@ -17,4 +24,7 @@ export interface ITrafficDataUsageStore
     extends Store<IStatTrafficUsage, IStatTrafficUsageKey> {
     upsert(trafficDataUsage: IStatTrafficUsage): Promise<void>;
     getTrafficDataUsageForPeriod(period: string): Promise<IStatTrafficUsage[]>;
+    getTrafficDataForMonthRange(
+        monthsBack: number,
+    ): Promise<IStatMonthlyTrafficUsage[]>;
 }

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
@@ -8,7 +8,7 @@ export type IStatTrafficUsage = {
 };
 
 export type IStatMonthlyTrafficUsage = {
-    month: Date;
+    month: string;
     trafficGroup: string;
     statusCodeSeries: number;
     count: number;

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -204,7 +204,7 @@ test('can query for monthly aggregation of data for a specified range', async ()
 
     // fill in with data for the last 13 months
     for (let i = 0; i <= 12; i++) {
-        const month = subMonths(now, i).getMonth();
+        const then = subMonths(now, i);
         let monthAggregateA = 0;
         let monthAggregateB = 0;
         for (let day = 1; day <= 5; day++) {
@@ -213,14 +213,14 @@ test('can query for monthly aggregation of data for a specified range', async ()
             monthAggregateA += dayValue;
             monthAggregateB += dayValueB;
             const dataA = {
-                day: new Date(2024, month, day),
+                day: new Date(then.getFullYear(), then.getMonth(), day),
                 trafficGroup: 'groupA',
                 statusCodeSeries: 200,
                 count: dayValue,
             };
             await trafficDataUsageStore.upsert(dataA);
             const dataB = {
-                day: new Date(2024, month, day),
+                day: new Date(then.getFullYear(), then.getMonth(), day),
                 trafficGroup: 'groupB',
                 statusCodeSeries: 200,
                 count: dayValueB,
@@ -233,14 +233,12 @@ test('can query for monthly aggregation of data for a specified range', async ()
         });
     }
 
-    console.log(expectedValues);
-
     for (const monthsBack of [3, 6, 12]) {
         const result =
             await trafficDataUsageStore.getTrafficDataForMonthRange(monthsBack);
 
         // should have the current month and the preceding n months
-        expect(result.length).toBe(monthsBack + 1);
+        expect(result.length).toBe((monthsBack + 1) * 2);
 
         for (const entry of result) {
             const index = differenceInCalendarMonths(

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -237,7 +237,7 @@ test('can query for monthly aggregation of data for a specified range', async ()
         const result =
             await trafficDataUsageStore.getTrafficDataForMonthRange(monthsBack);
 
-        // should have the current month and the preceding n months
+        // should have the current month and the preceding n months (one entry per group)
         expect(result.length).toBe((monthsBack + 1) * 2);
 
         for (const entry of result) {

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -245,10 +245,14 @@ test('can query for monthly aggregation of data for a specified range', async ()
                 now,
                 new Date(entry.month),
             );
+            const expectedCount = expectedValues[index];
 
-            const expected = expectedValues[index];
-
-            expect(entry.count).toBe(expected[entry.trafficGroup]);
+            expect(entry).toMatchObject({
+                statusCodeSeries: 200,
+                trafficGroup: expect.stringMatching(/group(A|B)/),
+                month: expect.stringMatching(/\d{4}-\d{2}/),
+                count: expectedCount[entry.trafficGroup],
+            });
         }
     }
 });

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -20,6 +20,10 @@ afterAll(async () => {
     await db.destroy();
 });
 
+beforeEach(async () => {
+    await trafficDataUsageStore.deleteAll();
+});
+
 test('upsert stores new entries', async () => {
     const data = {
         day: new Date(),
@@ -62,7 +66,6 @@ test('upsert upserts', async () => {
 });
 
 test('getAll returns all', async () => {
-    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',
@@ -83,7 +86,6 @@ test('getAll returns all', async () => {
 });
 
 test('delete deletes the specified item', async () => {
-    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',
@@ -110,7 +112,6 @@ test('delete deletes the specified item', async () => {
 });
 
 test('can query for specific items', async () => {
-    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(),
         trafficGroup: 'default3',
@@ -154,7 +155,6 @@ test('can query for specific items', async () => {
 });
 
 test('can query for data from specific periods', async () => {
-    await trafficDataUsageStore.deleteAll();
     const data1 = {
         day: new Date(2024, 2, 12),
         trafficGroup: 'default-period-query',

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -246,13 +246,7 @@ test('can query for monthly aggregation of data for a specified range', async ()
                 new Date(entry.month),
             );
             const expectedCount = expectedValues[index];
-
-            expect(entry).toMatchObject({
-                statusCodeSeries: 200,
-                trafficGroup: expect.stringMatching(/group(A|B)/),
-                month: expect.stringMatching(/\d{4}-\d{2}/),
-                count: expectedCount[entry.trafficGroup],
-            });
+            expect(entry.count).toBe(expectedCount[entry.trafficGroup]);
         }
     }
 });

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.test.ts
@@ -195,3 +195,45 @@ test('can query for data from specific periods', async () => {
     expect(traffic_period_usage_older.length).toBe(1);
     expect(traffic_period_usage_older[0].count).toBe(12);
 });
+
+test('can query for monthly aggregation of data for a specified range', async () => {
+    const data1 = {
+        day: new Date(2024, 2, 12),
+        trafficGroup: 'default-period-query',
+        statusCodeSeries: 200,
+        count: 1,
+    };
+    const data2 = {
+        day: new Date(2024, 2, 13),
+        trafficGroup: 'default-period-query',
+        statusCodeSeries: 200,
+        count: 3,
+    };
+    const data3 = {
+        day: new Date(2024, 1, 12),
+        trafficGroup: 'default-period-query',
+        statusCodeSeries: 200,
+        count: 2,
+    };
+    const data4 = {
+        day: new Date(2023, 9, 6),
+        trafficGroup: 'default-period-query',
+        statusCodeSeries: 200,
+        count: 12,
+    };
+    await trafficDataUsageStore.upsert(data1);
+    await trafficDataUsageStore.upsert(data2);
+    await trafficDataUsageStore.upsert(data3);
+    await trafficDataUsageStore.upsert(data4);
+
+    const traffic_period_usage =
+        await trafficDataUsageStore.getTrafficDataUsageForPeriod('2024-03');
+    expect(traffic_period_usage).toBeDefined();
+    expect(traffic_period_usage.length).toBe(2);
+
+    const traffic_period_usage_older =
+        await trafficDataUsageStore.getTrafficDataUsageForPeriod('2023-10');
+    expect(traffic_period_usage_older).toBeDefined();
+    expect(traffic_period_usage_older.length).toBe(1);
+    expect(traffic_period_usage_older[0].count).toBe(12);
+});

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
@@ -1,6 +1,7 @@
 import type { Db } from '../../db/db';
 import type { Logger, LogProvider } from '../../logger';
 import type {
+    IStatMonthlyTrafficUsage,
     IStatTrafficUsage,
     IStatTrafficUsageKey,
     ITrafficDataUsageStore,
@@ -96,5 +97,11 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
             [period],
         );
         return rows.map(mapRow);
+    }
+
+    async getTrafficDataForMonthRange(
+        monthsBack: number,
+    ): Promise<IStatMonthlyTrafficUsage[]> {
+        return [];
     }
 }


### PR DESCRIPTION
Add support for querying the traffic data usage store for the aggregated data for an arbitrary number of months back.

Adds a new `getTrafficDataForMonthRange(monthsBack: number)` method to the store that aggregates data on a monthly basis by status code and traffic group. Returns a new type with month data instead of day data. 