### PR TITLE
Project collaboration mode docs: fix header levels

### DIFF
--- a/website/docs/reference/project-collaboration-mode.md
+++ b/website/docs/reference/project-collaboration-mode.md
@@ -8,7 +8,7 @@ title: Project Collaboration Mode
 
 :::
 
-# Overview
+## Overview
 
 Project collaboration modes allow you to manage project visibility and interaction levels, ensuring better control and collaboration within your organization.
 
@@ -16,17 +16,17 @@ The collaboration mode of a [project](./projects) defines who within your Unleas
 
 Unleash supports three collaboration modes: **open**, **protected**, and **private**. A user's [predefined root and project roles](./rbac#predefined-roles), as well as their [custom root roles](./rbac#custom-root-roles), determine what projects they can access.
 
-## Open collaboration mode
+### Open collaboration mode
 
 All users of your Unleash instance can view the project and submit change requests. This is the default collaboration mode.
 
 
-## Protected collaboration mode
+### Protected collaboration mode
 
 All users of your Unleash instance can view the project but only project Members and Admins can submit change requests.
 
 
-## Private collaboration mode
+### Private collaboration mode
 
 Only project Members, Admins, Editors, and users with [custom root roles](./rbac#custom-root-roles) can view the project. Viewers, who are not project Members, can't see the project in the project list. Only project Members and Admins can submit change requests. 
 
@@ -37,7 +37,7 @@ Only project Members, Admins, Editors, and users with [custom root roles](./rbac
 | Protected | All users                                                                                       | Project Members and Admins |
 | Private   | Project Members, Admins, Editors, and users with [custom root roles](rbac.md#custom-root-roles) | Project Members and Admins |
 
-# Set project collaboration mode
+## Set project collaboration mode
 
 To [create a new project](./projects#create-a-project) with a specific collaboration mode, do the following:
 1. In the Unleash Admin UI, go to **Projects** > **New project**.
@@ -45,21 +45,21 @@ To [create a new project](./projects#create-a-project) with a specific collabora
 3. Click **Open** to choose your collaboration mode.
 4. Click **Create project**.
 
-## Modify project collaboration mode
+### Modify project collaboration mode
 
 To modify the collaboration mode of an existing project, do the following:
 1. In the Unleash Admin UI, go to **Projects** and select the project you want to modify.
 2. Go to **Project settings > Enterprise settings** and use the **Project collaboration mode** list to update your collaboration mode.
 3. Click **Save changes**.
 
-### Change collaboration mode to protected
+#### Change collaboration mode to protected
 
 When you change the collaboration mode of an existing project to protected, all users who do not have sufficient permissions lose the ability to create new change requests. Existing change requests remain in place. Users with insufficient permissions can still cancel their change requests but can no longer update them.
 
-### Change collaboration mode to private
+#### Change collaboration mode to private
 
 When you change the collaboration mode of an existing project to private, all users who do not have [sufficient permissions](#private-collaboration-mode) lose access to the project, including their existing change requests.
 
-## Migrate existing projects
+### Migrate existing projects
 
 When upgrading Unleash to version `4.22.0` or later, all migrated projects get the open collaboration mode by default. See [Modify project collaboration mode](#modify-project-collaboration-mode) for instructions on changing the collaboration mode of an existing project.


### PR DESCRIPTION
This PR fixes header levels in the Project Collaboration doc. The page now renders the title and other headings as expected.

Preview link: https://unleash-docs-git-melinda-fix-project-collab-40917f-unleash-team.vercel.app/reference/project-collaboration-mode