### PR TITLE
docs: align table of contents with content

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -275,6 +275,10 @@ main .theme-doc-breadcrumbs {
     line-height: 22px;
 }
 
+.table-of-contents {
+    margin-top: 70px;
+}
+
 .table-of-contents:before {
     content: "Table of Contents";
     display: inline-flex;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3191/align-table-of-contents-with-content

Vertically aligns the table of contents with the content, by adding some margin top.

![image](https://github.com/user-attachments/assets/3d6e84c0-cb87-4b2c-a722-38d5e97fdd54)
