### PR TITLE
feat: segment implementation in delta

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -41,7 +41,6 @@ import {
 } from '../../internals';
 import isEqual from 'lodash.isequal';
 import { diff } from 'json-diff';
-import type { DeltaHydrationEvent } from './delta/client-feature-toggle-delta-types';
 
 const version = 2;
 
@@ -192,9 +191,11 @@ export default class FeatureController extends Controller {
                 const sortedToggles = features.sort((a, b) =>
                     a.name.localeCompare(b.name),
                 );
+                const sortedSegments = segments.sort(
+                    (a, b) => Number(a.id) - Number(b.id),
+                );
                 if (delta?.events[0].type === 'hydration') {
-                    const hydrationEvent: DeltaHydrationEvent =
-                        delta?.events[0];
+                    const hydrationEvent = delta?.events[0];
                     const sortedNewToggles = hydrationEvent.features.sort(
                         (a, b) => a.name.localeCompare(b.name),
                     );
@@ -211,6 +212,24 @@ export default class FeatureController extends Controller {
                             }, new count ${hydrationEvent.features.length}, query ${JSON.stringify(query)},
                         diff ${JSON.stringify(
                             diff(sortedToggles, sortedNewToggles),
+                        )}`,
+                        );
+                    }
+                    const sortedNewSegments = hydrationEvent.segments.sort(
+                        (a, b) => Number(a.id) - Number(b.id),
+                    );
+                    if (
+                        !this.deepEqualIgnoreOrder(
+                            sortedToggles,
+                            sortedNewToggles,
+                        )
+                    ) {
+                        this.logger.warn(
+                            `old features and new features are different for segments. Old count ${
+                                segments.length
+                            }, new count ${hydrationEvent.segments.length}, query ${JSON.stringify(query)},
+                        diff ${JSON.stringify(
+                            diff(sortedSegments, sortedNewSegments),
                         )}`,
                         );
                     }

--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -215,24 +215,6 @@ export default class FeatureController extends Controller {
                         )}`,
                         );
                     }
-                    const sortedNewSegments = hydrationEvent.segments.sort(
-                        (a, b) => Number(a.id) - Number(b.id),
-                    );
-                    if (
-                        !this.deepEqualIgnoreOrder(
-                            sortedToggles,
-                            sortedNewToggles,
-                        )
-                    ) {
-                        this.logger.warn(
-                            `old features and new features are different for segments. Old count ${
-                                segments.length
-                            }, new count ${hydrationEvent.segments.length}, query ${JSON.stringify(query)},
-                        diff ${JSON.stringify(
-                            diff(sortedSegments, sortedNewSegments),
-                        )}`,
-                        );
-                    }
                 } else {
                     this.logger.warn(
                         `Delta diff should have only hydration event, query ${JSON.stringify(query)}`,

--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -191,9 +191,6 @@ export default class FeatureController extends Controller {
                 const sortedToggles = features.sort((a, b) =>
                     a.name.localeCompare(b.name),
                 );
-                const sortedSegments = segments.sort(
-                    (a, b) => Number(a.id) - Number(b.id),
-                );
                 if (delta?.events[0].type === 'hydration') {
                     const hydrationEvent = delta?.events[0];
                     const sortedNewToggles = hydrationEvent.features.sort(

--- a/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
@@ -217,6 +217,7 @@ test('should get segment updated and removed events', async () => {
     expect(body).toMatchObject({
         events: [
             {
+                type: DELTA_EVENT_TYPES.HYDRATION,
                 features: [
                     {
                         name: 'base_feature',

--- a/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-delta-api.e2e.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../test/e2e/helpers/test-helper';
 import getLogger from '../../../../test/fixtures/no-logger';
 import { DEFAULT_ENV } from '../../../util/constants';
+import { DELTA_EVENT_TYPES } from './client-feature-toggle-delta-types';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -121,7 +122,7 @@ test('should return correct delta after feature created', async () => {
     expect(body).toMatchObject({
         events: [
             {
-                type: 'hydration',
+                type: DELTA_EVENT_TYPES.HYDRATION,
                 features: [
                     {
                         name: 'base_feature',
@@ -134,8 +135,6 @@ test('should return correct delta after feature created', async () => {
     await app.createFeature('new_feature');
 
     await syncRevisions();
-    //@ts-ignore
-    await app.services.clientFeatureToggleService.clientFeatureToggleDelta.onUpdateRevisionEvent();
 
     const { body: deltaBody } = await app.request
         .get('/api/client/delta')
@@ -145,13 +144,7 @@ test('should return correct delta after feature created', async () => {
     expect(deltaBody).toMatchObject({
         events: [
             {
-                type: 'feature-updated',
-                feature: {
-                    name: 'new_feature',
-                },
-            },
-            {
-                type: 'feature-updated',
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
                 feature: {
                     name: 'new_feature',
                 },
@@ -161,7 +154,9 @@ test('should return correct delta after feature created', async () => {
 });
 
 const syncRevisions = async () => {
-    await app.services.configurationRevisionService.updateMaxRevisionId();
+    await app.services.configurationRevisionService.updateMaxRevisionId(false);
+    //@ts-ignore
+    await app.services.clientFeatureToggleService.clientFeatureToggleDelta.onUpdateRevisionEvent();
 };
 
 test('archived features should not be returned as updated', async () => {
@@ -187,7 +182,6 @@ test('archived features should not be returned as updated', async () => {
     await app.archiveFeature('base_feature');
     await syncRevisions();
     await app.createFeature('new_feature');
-
     await syncRevisions();
     await app.getProjectFeatures('new_feature'); // TODO: this is silly, but events syncing and tests do not work nicely. this is basically a setTimeout
 
@@ -199,14 +193,78 @@ test('archived features should not be returned as updated', async () => {
     expect(deltaBody).toMatchObject({
         events: [
             {
-                type: 'feature-removed',
+                type: DELTA_EVENT_TYPES.FEATURE_REMOVED,
                 featureName: 'base_feature',
             },
             {
-                type: 'feature-updated',
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
                 feature: {
                     name: 'new_feature',
                 },
+            },
+        ],
+    });
+});
+
+test('should get segment updated and removed events', async () => {
+    await app.createFeature('base_feature');
+    await syncRevisions();
+    const { body, headers } = await app.request
+        .get('/api/client/delta')
+        .expect(200);
+    const etag = headers.etag;
+
+    expect(body).toMatchObject({
+        events: [
+            {
+                features: [
+                    {
+                        name: 'base_feature',
+                    },
+                ],
+            },
+        ],
+    });
+
+    const { body: segmentBody } = await app.createSegment({
+        name: 'my_segment_a',
+        constraints: [],
+    });
+    // we need this, because revision service does not fire event for segment creation
+    await app.createFeature('not_important1');
+    await syncRevisions();
+    await app.updateSegment(segmentBody.id, {
+        name: 'a',
+        constraints: [],
+    });
+    await syncRevisions();
+    await app.deleteSegment(segmentBody.id);
+    // we need this, because revision service does not fire event for segment deletion
+    await app.createFeature('not_important2');
+    await syncRevisions();
+
+    const { body: deltaBody } = await app.request
+        .get('/api/client/delta')
+        .set('If-None-Match', etag)
+        .expect(200);
+
+    expect(deltaBody).toMatchObject({
+        events: [
+            {
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
+            },
+            {
+                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
+            },
+
+            {
+                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
+            },
+            {
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
+            },
+            {
+                type: DELTA_EVENT_TYPES.SEGMENT_REMOVED,
             },
         ],
     });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
@@ -5,6 +5,7 @@ export type DeltaHydrationEvent = {
     eventId: number;
     type: 'hydration';
     features: ClientFeatureSchema[];
+    segments: IClientSegment[];
 };
 
 export type DeltaEvent =
@@ -50,14 +51,11 @@ export const isDeltaFeatureRemovedEvent = (
     return event.type === DELTA_EVENT_TYPES.FEATURE_REMOVED;
 };
 
-export const isDeltaSegmentUpdatedEvent = (
+export const isDeltaSegmentEvent = (
     event: DeltaEvent,
 ): event is Extract<DeltaEvent, { type: 'segment-updated' }> => {
-    return event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED;
-};
-
-export const isDeltaSegmentRemovedEvent = (
-    event: DeltaEvent,
-): event is Extract<DeltaEvent, { type: 'segment-removed' }> => {
-    return event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED;
+    return (
+        event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED ||
+        event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED
+    );
 };

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -3,7 +3,10 @@ import {
     filterEventsByQuery,
     filterHydrationEventByQuery,
 } from './client-feature-toggle-delta';
-import type { DeltaHydrationEvent } from './client-feature-toggle-delta-types';
+import {
+    DELTA_EVENT_TYPES,
+    type DeltaHydrationEvent,
+} from './client-feature-toggle-delta-types';
 
 const mockAdd = (params): any => {
     const base = {
@@ -25,12 +28,12 @@ test('revision equal to the base case returns only later revisions ', () => {
     const revisionList: DeltaEvent[] = [
         {
             eventId: 2,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature4' }),
         },
         {
             eventId: 3,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature5' }),
         },
     ];
@@ -40,12 +43,12 @@ test('revision equal to the base case returns only later revisions ', () => {
     expect(revisions).toEqual([
         {
             eventId: 2,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature4' }),
         },
         {
             eventId: 3,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature5' }),
         },
     ]);
@@ -55,17 +58,17 @@ test('project filter removes features not in project and nameprefix', () => {
     const revisionList: DeltaEvent[] = [
         {
             eventId: 1,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature1', project: 'project1' }),
         },
         {
             eventId: 2,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'feature2', project: 'project2' }),
         },
         {
             eventId: 3,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'ffeature1', project: 'project1' }),
         },
     ];
@@ -75,7 +78,7 @@ test('project filter removes features not in project and nameprefix', () => {
     expect(revisions).toEqual([
         {
             eventId: 3,
-            type: 'feature-updated',
+            type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             feature: mockAdd({ name: 'ffeature1', project: 'project1' }),
         },
     ]);
@@ -85,7 +88,13 @@ test('project filter removes features not in project in hydration', () => {
     const revisionList: DeltaHydrationEvent = {
         eventId: 1,
         type: 'hydration',
-        segments: [],
+        segments: [
+            {
+                name: 'test',
+                constraints: [],
+                id: 1,
+            },
+        ],
         features: [
             mockAdd({ name: 'feature1', project: 'project1' }),
             mockAdd({ name: 'feature2', project: 'project2' }),
@@ -102,7 +111,13 @@ test('project filter removes features not in project in hydration', () => {
     expect(revisions).toEqual({
         eventId: 1,
         type: 'hydration',
-        segments: [],
+        segments: [
+            {
+                name: 'test',
+                constraints: [],
+                id: 1,
+            },
+        ],
         features: [mockAdd({ name: 'myfeature2', project: 'project2' })],
     });
 });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -85,6 +85,7 @@ test('project filter removes features not in project in hydration', () => {
     const revisionList: DeltaHydrationEvent = {
         eventId: 1,
         type: 'hydration',
+        segments: [],
         features: [
             mockAdd({ name: 'feature1', project: 'project1' }),
             mockAdd({ name: 'feature2', project: 'project2' }),
@@ -101,6 +102,7 @@ test('project filter removes features not in project in hydration', () => {
     expect(revisions).toEqual({
         eventId: 1,
         type: 'hydration',
+        segments: [],
         features: [mockAdd({ name: 'myfeature2', project: 'project2' })],
     });
 });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -304,7 +304,7 @@ export class ClientFeatureToggleDelta {
         const baseFeatures = await this.getClientFeatures({
             environment,
         });
-        const baseSegments = await this.segmentReadModel.getActiveForClient();
+        const baseSegments = await this.segmentReadModel.getAllForClient();
 
         this.currentRevisionId =
             await this.configurationRevisionService.getMaxRevisionId();

--- a/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
@@ -1,7 +1,8 @@
 import { DeltaCache } from './delta-cache';
-import type {
-    DeltaEvent,
-    DeltaHydrationEvent,
+import {
+    DELTA_EVENT_TYPES,
+    type DeltaEvent,
+    type DeltaHydrationEvent,
 } from './client-feature-toggle-delta-types';
 
 describe('RevisionCache', () => {
@@ -93,7 +94,7 @@ describe('RevisionCache', () => {
                     description: null,
                     impressionData: false,
                 },
-                type: 'feature-updated',
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
             },
         ];
 
@@ -105,7 +106,7 @@ describe('RevisionCache', () => {
         const addedEvents: DeltaEvent[] = [
             {
                 eventId: 3,
-                type: 'feature-updated',
+                type: DELTA_EVENT_TYPES.FEATURE_UPDATED,
                 feature: {
                     name: 'another-feature-flag',
                     type: 'release',

--- a/src/lib/features/client-feature-toggles/delta/delta-cache.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.ts
@@ -4,14 +4,6 @@ import {
     type DeltaHydrationEvent,
 } from './client-feature-toggle-delta-types';
 
-const mergeWithoutDuplicates = (arr1: any[], arr2: any[]) => {
-    const map = new Map();
-    arr1.concat(arr2).forEach((item) => {
-        map.set(item.name, item);
-    });
-    return Array.from(map.values());
-};
-
 export class DeltaCache {
     private events: DeltaEvent[] = [];
     private maxLength: number;
@@ -27,7 +19,7 @@ export class DeltaCache {
 
         this.updateHydrationEvent(events);
         while (this.events.length > this.maxLength) {
-            this.events.splice(1, 1);
+            this.events.shift();
         }
     }
 
@@ -62,15 +54,23 @@ export class DeltaCache {
                     break;
                 }
                 case DELTA_EVENT_TYPES.SEGMENT_UPDATED: {
-                    // TODO: segments do not exist in this scope, need to do it in different location
+                    const segmentToUpdate = this.hydrationEvent.segments.find(
+                        (segment) => segment.id === appliedEvent.segment.id,
+                    );
+                    if (segmentToUpdate) {
+                        Object.assign(segmentToUpdate, appliedEvent.segment);
+                    } else {
+                        this.hydrationEvent.segments.push(appliedEvent.segment);
+                    }
                     break;
                 }
                 case DELTA_EVENT_TYPES.SEGMENT_REMOVED: {
-                    // TODO: segments do not exist in this scope, need to do it in different location
+                    this.hydrationEvent.segments =
+                        this.hydrationEvent.segments.filter(
+                            (segment) => segment.id !== appliedEvent.segmentId,
+                        );
                     break;
                 }
-                default:
-                // TODO: something is seriously wrong
             }
         }
     }

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -4,6 +4,8 @@ import {
     type IBaseEvent,
     type IEvent,
     type IEventType,
+    SEGMENT_CREATED,
+    SEGMENT_DELETED,
     SEGMENT_UPDATED,
 } from '../../types/events';
 import type { Logger, LogProvider } from '../../logger';
@@ -214,6 +216,8 @@ class EventStore implements IEventStore {
                         SEGMENT_UPDATED,
                         FEATURE_IMPORT,
                         FEATURES_IMPORTED,
+                        SEGMENT_CREATED,
+                        SEGMENT_DELETED,
                     ]),
             )
             .orderBy('id', 'asc');

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -1,6 +1,5 @@
 import type { Logger } from '../../logger';
 import type {
-    IEvent,
     IEventStore,
     IFlagResolver,
     IUnleashConfig,
@@ -60,7 +59,7 @@ export default class ConfigurationRevisionService extends EventEmitter {
         }
     }
 
-    async updateMaxRevisionId(): Promise<number> {
+    async updateMaxRevisionId(emit: boolean = true): Promise<number> {
         if (this.flagResolver.isEnabled('disableUpdateMaxRevisionId')) {
             return 0;
         }
@@ -74,14 +73,12 @@ export default class ConfigurationRevisionService extends EventEmitter {
                 revisionId,
             );
             this.revisionId = revisionId;
-            this.emit(UPDATE_REVISION, revisionId);
+            if (emit) {
+                this.emit(UPDATE_REVISION, revisionId);
+            }
         }
 
         return this.revisionId;
-    }
-
-    async getRevisionRange(start: number, end: number): Promise<IEvent[]> {
-        return this.eventStore.getRevisionRange(start, end);
     }
 
     destroy(): void {

--- a/src/lib/features/segment/fake-segment-read-model.ts
+++ b/src/lib/features/segment/fake-segment-read-model.ts
@@ -7,8 +7,7 @@ import type { ISegmentReadModel } from './segment-read-model-type';
 
 export class FakeSegmentReadModel implements ISegmentReadModel {
     constructor(private segments: ISegment[] = []) {}
-
-    async getAll(): Promise<ISegment[]> {
+    async getAll(ids?: number[]): Promise<ISegment[]> {
         return this.segments;
     }
 
@@ -21,6 +20,10 @@ export class FakeSegmentReadModel implements ISegmentReadModel {
     }
 
     async getActiveForClient(): Promise<IClientSegment[]> {
+        return [];
+    }
+
+    async getAllForClient(ids?: number[]): Promise<IClientSegment[]> {
         return [];
     }
 }

--- a/src/lib/features/segment/segment-read-model-type.ts
+++ b/src/lib/features/segment/segment-read-model-type.ts
@@ -5,8 +5,9 @@ import type {
 } from '../../types';
 
 export interface ISegmentReadModel {
-    getAll(): Promise<ISegment[]>;
+    getAll(ids?: number[]): Promise<ISegment[]>;
     getAllFeatureStrategySegments(): Promise<IFeatureStrategySegment[]>;
     getActive(): Promise<ISegment[]>;
     getActiveForClient(): Promise<IClientSegment[]>;
+    getAllForClient(ids?: number[]): Promise<IClientSegment[]>;
 }

--- a/src/lib/features/segment/segment-read-model.ts
+++ b/src/lib/features/segment/segment-read-model.ts
@@ -61,11 +61,16 @@ export class SegmentReadModel implements ISegmentReadModel {
         };
     }
 
-    async getAll(): Promise<ISegment[]> {
-        const rows: ISegmentRow[] = await this.db
+    async getAll(ids?: number[]): Promise<ISegment[]> {
+        let query = this.db
             .select(this.prefixColumns())
             .from('segments')
             .orderBy('segments.name', 'asc');
+
+        if (ids && ids.length > 0) {
+            query = query.whereIn('id', ids);
+        }
+        const rows = await query;
 
         return rows.map(this.mapRow);
     }
@@ -82,7 +87,7 @@ export class SegmentReadModel implements ISegmentReadModel {
     }
 
     async getActive(): Promise<ISegment[]> {
-        const rows: ISegmentRow[] = await this.db
+        const query = this.db
             .distinct(this.prefixColumns())
             .from('segments')
             .orderBy('name', 'asc')
@@ -91,12 +96,22 @@ export class SegmentReadModel implements ISegmentReadModel {
                 'feature_strategy_segment.segment_id',
                 'segments.id',
             );
-
+        const rows: ISegmentRow[] = await query;
         return rows.map(this.mapRow);
     }
 
     async getActiveForClient(): Promise<IClientSegment[]> {
         const fullSegments = await this.getActive();
+
+        return fullSegments.map((segments) => ({
+            id: segments.id,
+            name: segments.name,
+            constraints: segments.constraints,
+        }));
+    }
+
+    async getAllForClient(ids?: number[]): Promise<IClientSegment[]> {
+        const fullSegments = await this.getAll(ids);
 
         return fullSegments.map((segments) => ({
             id: segments.id,

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -117,6 +117,15 @@ export interface IUnleashHttpAPI {
     getRecordedEvents(): supertest.Test;
 
     createSegment(postData: object, expectStatusCode?: number): supertest.Test;
+    deleteSegment(
+        segmentId: number,
+        expectedResponseCode?: number,
+    ): supertest.Test;
+    updateSegment(
+        segmentId: number,
+        postData: object,
+        expectStatusCode?: number,
+    ): supertest.Test;
 }
 
 function httpApis(
@@ -288,7 +297,25 @@ function httpApis(
                 .set('Content-Type', 'application/json')
                 .expect(expectedResponseCode);
         },
-
+        deleteSegment(
+            segmentId: number,
+            expectedResponseCode = 204,
+        ): supertest.Test {
+            return request
+                .delete(`/api/admin/segments/${segmentId}`)
+                .set('Content-Type', 'application/json')
+                .expect(expectedResponseCode);
+        },
+        updateSegment(
+            segmentId: number,
+            postData: object,
+            expectStatusCode = 204,
+        ): supertest.Test {
+            return request
+                .put(`/api/admin/segments/${segmentId}`)
+                .send(postData)
+                .expect(expectStatusCode);
+        },
         getRecordedEvents(
             project: string | null = null,
             expectedResponseCode: number = 200,


### PR DESCRIPTION
This is implementing the segments events for delta API. Previous version of delta API, we were just sending all of the segments. Now we will have `segment-updated` and `segment-removed `events coming to SDK.