### PR TITLE
chore(1-3293): add new query for daily data that uses  date ranges

### DIFF
--- a/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
@@ -6,9 +6,11 @@ import type {
 import type { ITrafficDataUsageStore } from '../../types';
 import {
     differenceInCalendarMonths,
+    endOfDay,
     format,
     isSameMonth,
     parse,
+    startOfDay,
 } from 'date-fns';
 
 export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
@@ -90,22 +92,26 @@ export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
         return Object.values(data);
     }
 
-    async getDailyTrafficDataForPeriod(
+    async getDailyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]> {
         return this.trafficData.filter(
-            (data) => data.day >= from && data.day <= to,
+            (data) => data.day >= startOfDay(from) && data.day <= endOfDay(to),
         );
     }
 
-    async getMonthlyTrafficDataForPeriod(
+    async getMonthlyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]> {
         const data: { [key: string]: IStatMonthlyTrafficUsage } =
             this.trafficData
-                .filter((entry) => entry.day >= from && entry.day <= to)
+                .filter(
+                    (data) =>
+                        data.day >= startOfDay(from) &&
+                        data.day <= endOfDay(to),
+                )
                 .reduce((acc, entry) => {
                     const month = format(entry.day, 'yyyy-MM');
                     const key = `${month}-${entry.trafficGroup}-${entry.statusCodeSeries}`;

--- a/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
@@ -89,4 +89,41 @@ export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
 
         return Object.values(data);
     }
+
+    async getDailyTrafficDataForPeriod(
+        from: Date,
+        to: Date,
+    ): Promise<IStatTrafficUsage[]> {
+        return this.trafficData.filter(
+            (data) => data.day >= from && data.day <= to,
+        );
+    }
+
+    async getMonthlyTrafficDataForPeriod(
+        from: Date,
+        to: Date,
+    ): Promise<IStatMonthlyTrafficUsage[]> {
+        const data: { [key: string]: IStatMonthlyTrafficUsage } =
+            this.trafficData
+                .filter((entry) => entry.day >= from && entry.day <= to)
+                .reduce((acc, entry) => {
+                    const month = format(entry.day, 'yyyy-MM');
+                    const key = `${month}-${entry.trafficGroup}-${entry.statusCodeSeries}`;
+
+                    if (acc[key]) {
+                        acc[key].count += entry.count;
+                    } else {
+                        acc[key] = {
+                            month,
+                            trafficGroup: entry.trafficGroup,
+                            statusCodeSeries: entry.statusCodeSeries,
+                            count: entry.count,
+                        };
+                    }
+
+                    return acc;
+                }, {});
+
+        return Object.values(data);
+    }
 }

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
@@ -27,4 +27,12 @@ export interface ITrafficDataUsageStore
     getTrafficDataForMonthRange(
         monthsBack: number,
     ): Promise<IStatMonthlyTrafficUsage[]>;
+    getDailyTrafficDataForPeriod(
+        from: Date,
+        to: Date,
+    ): Promise<IStatTrafficUsage[]>;
+    getMonthlyTrafficDataForPeriod(
+        from: Date,
+        to: Date,
+    ): Promise<IStatMonthlyTrafficUsage[]>;
 }

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
@@ -27,11 +27,11 @@ export interface ITrafficDataUsageStore
     getTrafficDataForMonthRange(
         monthsBack: number,
     ): Promise<IStatMonthlyTrafficUsage[]>;
-    getDailyTrafficDataForPeriod(
+    getDailyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]>;
-    getMonthlyTrafficDataForPeriod(
+    getMonthlyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]>;

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
@@ -96,7 +96,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
             });
     }
 
-    async getDailyTrafficDataForPeriod(
+    async getDailyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]> {
@@ -107,7 +107,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         return rows.map(mapRow);
     }
 
-    async getMonthlyTrafficDataForPeriod(
+    async getMonthlyTrafficUsageDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]> {
@@ -143,7 +143,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         period: string,
     ): Promise<IStatTrafficUsage[]> {
         const month = new Date(period);
-        return this.getDailyTrafficDataForPeriod(
+        return this.getDailyTrafficUsageDataForPeriod(
             startOfMonth(month),
             endOfMonth(month),
         );
@@ -155,6 +155,6 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
     ): Promise<IStatMonthlyTrafficUsage[]> {
         const to = endOfMonth(new Date());
         const from = startOfMonth(subMonths(to, monthsBack));
-        return this.getMonthlyTrafficDataForPeriod(from, to);
+        return this.getMonthlyTrafficUsageDataForPeriod(from, to);
     }
 }

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
@@ -96,7 +96,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
             });
     }
 
-    async getDailyTrafficDataUsageForPeriod(
+    async getDailyTrafficDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]> {
@@ -107,7 +107,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         return rows.map(mapRow);
     }
 
-    async getMonthlyTrafficDataUsageForPeriod(
+    async getMonthlyTrafficDataForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]> {
@@ -143,7 +143,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         period: string,
     ): Promise<IStatTrafficUsage[]> {
         const month = new Date(period);
-        return this.getDailyTrafficDataUsageForPeriod(
+        return this.getDailyTrafficDataForPeriod(
             startOfMonth(month),
             endOfMonth(month),
         );
@@ -155,6 +155,6 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
     ): Promise<IStatMonthlyTrafficUsage[]> {
         const to = endOfMonth(new Date());
         const from = startOfMonth(subMonths(to, monthsBack));
-        return this.getMonthlyTrafficDataUsageForPeriod(from, to);
+        return this.getMonthlyTrafficDataForPeriod(from, to);
     }
 }


### PR DESCRIPTION
Add new methods to the store behind data usage metrics that accept date ranges instead of a single month. The old data collection methods re-route to the new ones instead, so the new methods are tested implicitly.

Also deprecates the new endpoint that's not in use anywhere except in an unused service method in Enterprise yet.

## Discussion point:

Should the new methods accept `from` and `to` as dates? Or as strings? If they're strings, there's a chance the parsing can go wrong, so dates feel safer to me.

There's *one* instance of a place where call the old daily data method (in `src/lib/features/instance-stats/instance-stats-service.ts`). Should we update that to use the new method? Should we keep the old one and have both?