### PR TITLE
chore: remove feature toggle kill switch for admin token UI

### DIFF
--- a/src/lib/routes/admin-api/api-token.test.ts
+++ b/src/lib/routes/admin-api/api-token.test.ts
@@ -6,17 +6,12 @@ import getApp from '../../app';
 import supertest from 'supertest';
 import { addDays } from 'date-fns';
 
-async function getSetup(adminTokenKillSwitchEnabled: boolean) {
+async function getSetup() {
     const base = `/random${Math.round(Math.random() * 1000)}`;
     const perms = permissions();
     const config = createTestConfig({
         preHook: perms.hook,
         server: { baseUriPath: base },
-        experimental: {
-            flags: {
-                adminTokenKillSwitch: adminTokenKillSwitchEnabled,
-            },
-        },
         //@ts-ignore - Just testing, so only need the isEnabled call here
     });
     const stores = createStores();
@@ -41,23 +36,8 @@ async function getSetup(adminTokenKillSwitchEnabled: boolean) {
 }
 
 describe('Admin token killswitch', () => {
-    test('If killswitch is off we can still create admin tokens', async () => {
-        const setup = await getSetup(false);
-        return setup.request
-            .post(`${setup.base}/api/admin/api-tokens`)
-            .set('Content-Type', 'application/json')
-            .send({
-                expiresAt: addDays(new Date(), 60),
-                type: 'ADMIN',
-                tokenName: 'Non killswitched',
-            })
-            .expect(201)
-            .expect((res) => {
-                expect(res.body.secret).toBeTruthy();
-            });
-    });
     test('If killswitch is on we will get an operation denied if we try to create an admin token', async () => {
-        const setup = await getSetup(true);
+        const setup = await getSetup();
         return setup.request
             .post(`${setup.base}/api/admin/api-tokens`)
             .set('Content-Type', 'application/json')
@@ -74,7 +54,7 @@ describe('Admin token killswitch', () => {
             });
     });
     test('If killswitch is on we can still create a client token', async () => {
-        const setup = await getSetup(true);
+        const setup = await getSetup();
         return setup.request
             .post(`${setup.base}/api/admin/api-tokens`)
             .set('Content-Type', 'application/json')
@@ -91,7 +71,7 @@ describe('Admin token killswitch', () => {
             });
     });
     test('If killswitch is on we can still create a frontend token', async () => {
-        const setup = await getSetup(true);
+        const setup = await getSetup();
         return setup.request
             .post(`${setup.base}/api/admin/api-tokens`)
             .set('Content-Type', 'application/json')

--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -306,10 +306,7 @@ export class ApiTokenController extends Controller {
         const permissionRequired = tokenTypeToCreatePermission(
             createToken.type,
         );
-        if (
-            createToken.type.toUpperCase() === 'ADMIN' &&
-            this.flagResolver.isEnabled('adminTokenKillSwitch')
-        ) {
+        if (createToken.type.toUpperCase() === 'ADMIN') {
             throw new OperationDeniedError(
                 `Admin tokens are disabled in this instance. Use a Service account or a PAT to access admin operations instead`,
             );

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -29,7 +29,6 @@ export type IFlagKey =
     | 'celebrateUnleash'
     | 'feedbackPosting'
     | 'extendedUsageMetrics'
-    | 'adminTokenKillSwitch'
     | 'feedbackComments'
     | 'showInactiveUsers'
     | 'killScheduledChangeRequestCache'
@@ -157,10 +156,6 @@ const flags: IFlags = {
     extendedUsageMetrics: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EXTENDED_USAGE_METRICS,
         false,
-    ),
-    adminTokenKillSwitch: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_ADMIN_TOKEN_KILL_SWITCH,
-        true,
     ),
     outdatedSdksBanner: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_OUTDATED_SDKS_BANNER,


### PR DESCRIPTION
## About the changes
This was released with 6.6 and now this flag is no longer needed. The default value is already set to true, so it's the same as removing it