### PR TITLE
fix:  correct name order -> traffic usage data -> traffic data usage

### DIFF
--- a/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/fake-traffic-data-usage-store.ts
@@ -92,7 +92,7 @@ export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
         return Object.values(data);
     }
 
-    async getDailyTrafficUsageDataForPeriod(
+    async getDailyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]> {
@@ -101,7 +101,7 @@ export class FakeTrafficDataUsageStore implements ITrafficDataUsageStore {
         );
     }
 
-    async getMonthlyTrafficUsageDataForPeriod(
+    async getMonthlyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]> {

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store-type.ts
@@ -27,11 +27,11 @@ export interface ITrafficDataUsageStore
     getTrafficDataForMonthRange(
         monthsBack: number,
     ): Promise<IStatMonthlyTrafficUsage[]>;
-    getDailyTrafficUsageDataForPeriod(
+    getDailyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]>;
-    getMonthlyTrafficUsageDataForPeriod(
+    getMonthlyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]>;

--- a/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
+++ b/src/lib/features/traffic-data-usage/traffic-data-usage-store.ts
@@ -96,7 +96,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
             });
     }
 
-    async getDailyTrafficUsageDataForPeriod(
+    async getDailyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatTrafficUsage[]> {
@@ -107,7 +107,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         return rows.map(mapRow);
     }
 
-    async getMonthlyTrafficUsageDataForPeriod(
+    async getMonthlyTrafficDataUsageForPeriod(
         from: Date,
         to: Date,
     ): Promise<IStatMonthlyTrafficUsage[]> {
@@ -143,7 +143,7 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
         period: string,
     ): Promise<IStatTrafficUsage[]> {
         const month = new Date(period);
-        return this.getDailyTrafficUsageDataForPeriod(
+        return this.getDailyTrafficDataUsageForPeriod(
             startOfMonth(month),
             endOfMonth(month),
         );
@@ -155,6 +155,6 @@ export class TrafficDataUsageStore implements ITrafficDataUsageStore {
     ): Promise<IStatMonthlyTrafficUsage[]> {
         const to = endOfMonth(new Date());
         const from = startOfMonth(subMonths(to, monthsBack));
-        return this.getMonthlyTrafficUsageDataForPeriod(from, to);
+        return this.getMonthlyTrafficDataUsageForPeriod(from, to);
     }
 }


### PR DESCRIPTION
Correcting a slight oversight from when we created the new methods. This brings the name in line with the other store methods.