### PR TITLE
docs: fix background img dark mode opacity

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -249,6 +249,12 @@ main:after {
     content: "";
 }
 
+html[data-theme="dark"] {
+    main:after {
+        opacity: 0.06;
+    }
+}
+
 @media (min-width: 997px) {
     .show-when-collapsed {
         display: none;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3200/update-docs-bottom-left-background-image-in-dark-mode

The background mountain texture was a bit too striking visually. We should set an opacity of `0.06` in dark mode, the same as in Unleash dark mode.

### Before

![image](https://github.com/user-attachments/assets/30dc29ac-39e0-4f7c-92d9-6288b6f10d9a)

### After

![image](https://github.com/user-attachments/assets/ff6de0a0-7413-4356-a6c9-bbb927203c3e)
