### PR TITLE
fix: tabs not growing to fill all available space

### DIFF
--- a/frontend/src/component/project/Project/Project.styles.ts
+++ b/frontend/src/component/project/Project/Project.styles.ts
@@ -74,13 +74,13 @@ export const StyledTabContainer = styled('div')(({ theme }) => ({
 export const StyledTab = styled(Tab)(({ theme }) => ({
     textTransform: 'none',
     fontSize: theme.fontSizes.bodySize,
-    flexGrow: 1,
     flexBasis: 0,
     [theme.breakpoints.down('md')]: {
         paddingLeft: theme.spacing(1),
         paddingRight: theme.spacing(1),
+        minWidth: 170
     },
     [theme.breakpoints.up('md')]: {
-        minWidth: 160,
+        minWidth: 170,
     },
 }));

--- a/frontend/src/component/project/Project/Project.styles.ts
+++ b/frontend/src/component/project/Project/Project.styles.ts
@@ -78,7 +78,7 @@ export const StyledTab = styled(Tab)(({ theme }) => ({
     [theme.breakpoints.down('md')]: {
         paddingLeft: theme.spacing(1),
         paddingRight: theme.spacing(1),
-        minWidth: 170
+        minWidth: 170,
     },
     [theme.breakpoints.up('md')]: {
         minWidth: 170,

--- a/frontend/src/component/project/Project/Project.tsx
+++ b/frontend/src/component/project/Project/Project.tsx
@@ -76,7 +76,10 @@ interface ITab {
 const StyledCounterBadge = styled(CounterBadge)(({ theme }) => ({
     '.MuiBadge-badge': {
         backgroundColor: theme.palette.background.alternative,
-        right: '2px',
+        right: '-4px',
+    },
+    [theme.breakpoints.down('md')]: {
+        right: '6px',
     },
     flex: 'auto',
     justifyContent: 'center',


### PR DESCRIPTION
Fix an issue where tabs would fill out all available space, now it's left aligned: 

<img width="1696" alt="Skjermbilde 2025-01-28 kl  13 40 56" src="https://github.com/user-attachments/assets/311a39a0-cf0a-45e2-a6f8-141d1bfd9b24" />

Previously:

<img width="1656" alt="Skjermbilde 2025-01-28 kl  13 41 32" src="https://github.com/user-attachments/assets/985f8a26-ca35-4b6e-8d16-f634d601c743" />
