### PR TITLE
feat(1-3281): wraps the new datepicker in a dropdown

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -165,9 +165,6 @@ const NewNetworkTrafficUsage: FC = () => {
         record,
         newPeriod,
         setNewPeriod,
-        selectablePeriods,
-        period,
-        setPeriod,
         toTrafficUsageSum,
         calculateOverageCost,
         calculateEstimatedMonthlyCost,
@@ -212,7 +209,6 @@ const NewNetworkTrafficUsage: FC = () => {
 
     const data = newToChartData(traffic.usage);
 
-    // these states can also be calculated without useEffect
     const [usageTotal, setUsageTotal] = useState<number>(0);
 
     const [overageCost, setOverageCost] = useState<number>(0);

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -291,7 +291,6 @@ const NewNetworkTrafficUsage: FC = () => {
                                 overageCost={overageCost}
                                 estimatedMonthlyCost={estimatedMonthlyCost}
                             />
-
                             <PeriodSelector
                                 selectedPeriod={newPeriod}
                                 setPeriod={setNewPeriod}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -296,18 +296,6 @@ const NewNetworkTrafficUsage: FC = () => {
                                 estimatedMonthlyCost={estimatedMonthlyCost}
                             />
 
-                            <Select
-                                id='dataperiod-select'
-                                name='dataperiod'
-                                options={selectablePeriods}
-                                value={period}
-                                onChange={(e) => setPeriod(e.target.value)}
-                                style={{
-                                    minWidth: '100%',
-                                    marginBottom: theme.spacing(2),
-                                }}
-                                formControlStyles={{ width: '100%' }}
-                            />
                             <PeriodSelector
                                 selectedPeriod={newPeriod}
                                 setPeriod={setNewPeriod}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -165,6 +165,9 @@ const NewNetworkTrafficUsage: FC = () => {
         record,
         newPeriod,
         setNewPeriod,
+        selectablePeriods,
+        period,
+        setPeriod,
         toTrafficUsageSum,
         calculateOverageCost,
         calculateEstimatedMonthlyCost,
@@ -209,6 +212,7 @@ const NewNetworkTrafficUsage: FC = () => {
 
     const data = newToChartData(traffic.usage);
 
+    // these states can also be calculated without useEffect
     const [usageTotal, setUsageTotal] = useState<number>(0);
 
     const [overageCost, setOverageCost] = useState<number>(0);
@@ -290,6 +294,19 @@ const NewNetworkTrafficUsage: FC = () => {
                                 includedTraffic={includedTraffic}
                                 overageCost={overageCost}
                                 estimatedMonthlyCost={estimatedMonthlyCost}
+                            />
+
+                            <Select
+                                id='dataperiod-select'
+                                name='dataperiod'
+                                options={selectablePeriods}
+                                value={period}
+                                onChange={(e) => setPeriod(e.target.value)}
+                                style={{
+                                    minWidth: '100%',
+                                    marginBottom: theme.spacing(2),
+                                }}
+                                formControlStyles={{ width: '100%' }}
                             />
                             <PeriodSelector
                                 selectedPeriod={newPeriod}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -66,8 +66,6 @@ const getSelectablePeriods = (): Period[] => {
 };
 
 const Wrapper = styled('article')(({ theme }) => ({
-    // borderRadius: theme.shape.borderRadiusLarge,
-    // border: `2px solid ${theme.palette.divider}`,
     width: dropdownWidth,
     paddingBlock: theme.spacing(2),
     display: 'flex',

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -1,12 +1,12 @@
-import { styled, Button, Popover, Box } from '@mui/material';
+import { styled, Button, Popover, Box, type Theme } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import type { ChartDataSelection } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
 import { useRef, useState, type FC } from 'react';
-import { useLocationSettings } from 'hooks/useLocationSettings';
 import { format } from 'date-fns';
 
 const dropdownWidth = '15rem';
+const dropdownInlinePadding = (theme: Theme) => theme.spacing(3);
 
 export type Period = {
     key: string;
@@ -69,7 +69,7 @@ const Wrapper = styled('article')(({ theme }) => ({
     // borderRadius: theme.shape.borderRadiusLarge,
     // border: `2px solid ${theme.palette.divider}`,
     width: dropdownWidth,
-    padding: theme.spacing(3),
+    paddingBlock: theme.spacing(2),
     display: 'flex',
     flexFlow: 'column',
     gap: theme.spacing(2),
@@ -91,7 +91,7 @@ const Wrapper = styled('article')(({ theme }) => ({
         cursor: 'default',
         color: theme.palette.text.disabled,
     },
-    'button:hover': {
+    'button:hover:not(:disabled)': {
         backgroundColor: theme.palette.action.hover,
     },
     'button:focus': {
@@ -101,6 +101,7 @@ const Wrapper = styled('article')(({ theme }) => ({
 
 const MonthSelector = styled('article')(({ theme }) => ({
     border: 'none',
+    paddingInline: dropdownInlinePadding(theme),
     hgroup: {
         h3: {
             margin: 0,
@@ -126,9 +127,11 @@ const MonthGrid = styled('ul')(({ theme }) => ({
 
 const RangeSelector = styled('article')(({ theme }) => ({
     display: 'flex',
+    width: '100%',
     flexFlow: 'column',
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(0),
     h4: {
+        paddingInline: dropdownInlinePadding(theme),
         fontSize: theme.typography.body2.fontSize,
         margin: 0,
         color: theme.palette.text.secondary,
@@ -137,13 +140,19 @@ const RangeSelector = styled('article')(({ theme }) => ({
 
 const RangeList = styled('ul')(({ theme }) => ({
     listStyle: 'none',
+    margin: 0,
     padding: 0,
-    'li + li': {
-        marginTop: theme.spacing(1),
+    width: '100%',
+    li: {
+        width: '100%',
     },
 
     button: {
-        marginLeft: `-${theme.spacing(0.5)}`,
+        width: '100%',
+        paddingBlock: theme.spacing(1),
+        textAlign: 'left',
+        borderRadius: 0,
+        paddingInline: dropdownInlinePadding(theme),
     },
 }));
 
@@ -161,7 +170,6 @@ const StyledPopover = styled(Popover)(({ theme }) => ({
 
 export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
     const selectablePeriods = getSelectablePeriods();
-    const { locationSettings } = useLocationSettings();
 
     const rangeOptions = [3, 6, 12].map((monthsBack) => ({
         value: monthsBack,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -94,6 +94,9 @@ const Wrapper = styled('article')(({ theme }) => ({
     'button:hover': {
         backgroundColor: theme.palette.action.hover,
     },
+    'button:focus': {
+        outline: `2px solid ${theme.palette.primary.main}`,
+    },
 }));
 
 const MonthSelector = styled('article')(({ theme }) => ({
@@ -144,16 +147,6 @@ const RangeList = styled('ul')(({ theme }) => ({
     },
 }));
 
-type Selection =
-    | {
-          type: 'month';
-          value: string;
-      }
-    | {
-          type: 'range';
-          monthsBack: number;
-      };
-
 type Props = {
     selectedPeriod: ChartDataSelection;
     setPeriod: (period: ChartDataSelection) => void;
@@ -161,9 +154,8 @@ type Props = {
 
 const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
-        // borderRadius: `${theme.shape.borderRadiusMedium}px`,
         borderRadius: theme.shape.borderRadiusLarge,
-        border: `2px solid ${theme.palette.divider}`,
+        border: `1px solid ${theme.palette.divider}`,
     },
 }));
 
@@ -205,6 +197,10 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                     fontWeight: 'normal',
                     color: theme.palette.text.primary,
                     borderColor: theme.palette.divider,
+                    borderWidth: '2px',
+                    ':focus-within': {
+                        borderColor: theme.palette.primary.main,
+                    },
                 })}
                 variant='outlined'
                 disableRipple

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -1,6 +1,8 @@
-import { styled } from '@mui/material';
+import { styled, Button, Popover, Box } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import type { ChartDataSelection } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
-import type { FC } from 'react';
+import { useRef, useState, type FC } from 'react';
 
 export type Period = {
     key: string;
@@ -58,6 +60,34 @@ const getSelectablePeriods = (): Period[] => {
     }
     return selectablePeriods;
 };
+
+// function SingleSelectConfigButton<T = string>({ onChange, ...props }) {
+//     const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>();
+//     const [recentlyClosed, setRecentlyClosed] = useState(false);
+
+//     const handleChange = (value: T) => {
+//         onChange(value);
+//         setAnchorEl(null);
+//         props.onClose?.();
+
+//         setRecentlyClosed(true);
+//         // this is a hack to prevent the button from being
+//         // auto-clicked after you select an item by pressing enter
+//         // in the search bar for single-select lists.
+//         setTimeout(() => setRecentlyClosed(false), 1);
+//     };
+
+//     return (
+//         <ConfigButton
+//             {...props}
+//             preventOpen={recentlyClosed}
+//             anchorEl={anchorEl}
+//             setAnchorEl={setAnchorEl}
+//         >
+//             <DropdownList<T> {...props} onChange={handleChange} />
+//         </ConfigButton>
+//     );
+// }
 
 const Wrapper = styled('article')(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusLarge,
@@ -152,6 +182,51 @@ type Props = {
     setPeriod: (period: ChartDataSelection) => void;
 };
 
+const StyledPopover = styled(Popover)(({ theme }) => ({
+    '& .MuiPaper-root': {
+        borderRadius: `${theme.shape.borderRadiusMedium}px`,
+    },
+}));
+
+const DropdownButton: FC<Props> = (props) => {
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+    return (
+        <Box ref={ref}>
+            <Button
+                endIcon={open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                sx={(theme) => ({
+                    width: '100%',
+                    justifyContent: 'space-between',
+                    fontWeight: 'normal',
+                    color: theme.palette.text.primary,
+                    borderColor: theme.palette.divider,
+                })}
+                variant='outlined'
+                disableRipple
+                onClick={() => setOpen(!open)}
+            >
+                Last 3 months
+            </Button>
+            <StyledPopover
+                open={open}
+                anchorEl={ref.current}
+                // onClose={handleClose}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+            >
+                PeriodSelecto
+            </StyledPopover>
+        </Box>
+    );
+};
+
 export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
     const selectablePeriods = getSelectablePeriods();
 
@@ -161,64 +236,68 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
     }));
 
     return (
-        <Wrapper>
-            <MonthSelector>
-                <hgroup>
-                    <h3>Select month</h3>
-                    <p>Last 12 months</p>
-                </hgroup>
-                <MonthGrid>
-                    {selectablePeriods.map((period, index) => (
-                        <li key={period.label}>
-                            <button
-                                className={
-                                    selectedPeriod.grouping === 'daily' &&
-                                    period.key === selectedPeriod.month
-                                        ? 'selected'
-                                        : ''
-                                }
-                                type='button'
-                                disabled={!period.selectable}
-                                onClick={() => {
-                                    setPeriod({
-                                        grouping: 'daily',
-                                        month: period.key,
-                                    });
-                                }}
-                            >
-                                {period.shortLabel}
-                            </button>
-                        </li>
-                    ))}
-                </MonthGrid>
-            </MonthSelector>
-            <RangeSelector>
-                <h4>Range</h4>
+        <div>
+            <DropdownButton />
+            <Wrapper>
+                <MonthSelector>
+                    <hgroup>
+                        <h3>Select month</h3>
+                        <p>Last 12 months</p>
+                    </hgroup>
+                    <MonthGrid>
+                        {selectablePeriods.map((period, index) => (
+                            <li key={period.label}>
+                                <button
+                                    className={
+                                        selectedPeriod.grouping === 'daily' &&
+                                        period.key === selectedPeriod.month
+                                            ? 'selected'
+                                            : ''
+                                    }
+                                    type='button'
+                                    disabled={!period.selectable}
+                                    onClick={() => {
+                                        setPeriod({
+                                            grouping: 'daily',
+                                            month: period.key,
+                                        });
+                                    }}
+                                >
+                                    {period.shortLabel}
+                                </button>
+                            </li>
+                        ))}
+                    </MonthGrid>
+                </MonthSelector>
+                <RangeSelector>
+                    <h4>Range</h4>
 
-                <RangeList>
-                    {rangeOptions.map((option) => (
-                        <li key={option.label}>
-                            <button
-                                className={
-                                    selectedPeriod.grouping === 'monthly' &&
-                                    option.value === selectedPeriod.monthsBack
-                                        ? 'selected'
-                                        : ''
-                                }
-                                type='button'
-                                onClick={() => {
-                                    setPeriod({
-                                        grouping: 'monthly',
-                                        monthsBack: option.value,
-                                    });
-                                }}
-                            >
-                                Last {option.value} months
-                            </button>
-                        </li>
-                    ))}
-                </RangeList>
-            </RangeSelector>
-        </Wrapper>
+                    <RangeList>
+                        {rangeOptions.map((option) => (
+                            <li key={option.label}>
+                                <button
+                                    className={
+                                        selectedPeriod.grouping === 'monthly' &&
+                                        option.value ===
+                                            selectedPeriod.monthsBack
+                                            ? 'selected'
+                                            : ''
+                                    }
+                                    type='button'
+                                    onClick={() => {
+                                        setPeriod({
+                                            grouping: 'monthly',
+                                            monthsBack: option.value,
+                                        });
+                                    }}
+                                >
+                                    Last {option.value} months
+                                </button>
+                            </li>
+                        ))}
+                    </RangeList>
+                </RangeSelector>
+            </Wrapper>{' '}
+        </div>
     );
 };

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -201,10 +201,13 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                     ':focus-within': {
                         borderColor: theme.palette.primary.main,
                     },
+                    ':hover': {
+                        borderWidth: '2px', // Prevent the border from changing width on hover
+                    },
                 })}
                 variant='outlined'
                 disableRipple
-                onClick={() => setOpen(!open)}
+                onClick={() => setOpen(true)}
             >
                 {buttonText}
             </Button>


### PR DESCRIPTION
Wraps the datepicker in a popover, making it function largely the same as a dropdown list.

The dropdown displays one of:
- "current month" if you've selected the current month
- "<month> <year>" (e.g. "December 2024") if you've selected a month that isn't the current month
- "Last n months" (e.g. "Last 3 months") if you have selected a range

Additionally, the range selections have been updated to span the whole row, aligning with the look of generic dropdown lists.

![image](https://github.com/user-attachments/assets/d356aec5-d51b-42fa-9591-60e2b5038a8e)

Like with the rest of this file (`PeriodSelector`), the code is rough and not according to Unleash standards. However, I'm prioritizing fast changes so UX can have a look before I clean up the code to switch to using styled components etc later. It's still behind a flag, so I'm not very worried about it.