### PR TITLE
chore: drag to reorder release plan template milestones

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -9,19 +9,22 @@ import {
     AccordionSummary,
     AccordionDetails,
     IconButton,
+    FormHelperText,
 } from '@mui/material';
 import Delete from '@mui/icons-material/DeleteOutlined';
 import type {
     IReleasePlanMilestonePayload,
     IReleasePlanMilestoneStrategy,
 } from 'interfaces/releasePlans';
-import { type DragEventHandler, type RefObject, useState } from 'react';
+import { type DragEventHandler, type RefObject, useRef, useState } from 'react';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { MilestoneCardName } from './MilestoneCardName';
 import { MilestoneStrategyMenuCards } from './MilestoneStrategyMenu/MilestoneStrategyMenuCards';
 import { MilestoneStrategyDraggableItem } from './MilestoneStrategyDraggableItem';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { ReleasePlanTemplateAddStrategyForm } from '../../MilestoneStrategy/ReleasePlanTemplateAddStrategyForm';
+import DragIndicator from '@mui/icons-material/DragIndicator';
+import { type MoveListItem, useDragItem } from 'hooks/useDragItem';
 
 const StyledMilestoneCard = styled(Card, {
     shouldForwardProp: (prop) => prop !== 'hasError',
@@ -110,13 +113,25 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
     color: theme.palette.primary.main,
 }));
 
-interface IMilestoneCardProps {
+const StyledDragIcon = styled(IconButton)(({ theme }) => ({
+    padding: 0,
+    cursor: 'grab',
+    transition: 'color 0.2s ease-in-out',
+    marginRight: theme.spacing(1),
+    '& > svg': {
+        color: 'action.active',
+    },
+}));
+
+export interface IMilestoneCardProps {
     milestone: IReleasePlanMilestonePayload;
     milestoneChanged: (milestone: IReleasePlanMilestonePayload) => void;
     errors: { [key: string]: string };
     clearErrors: () => void;
     removable: boolean;
     onDeleteMilestone: () => void;
+    index: number;
+    moveListItem: MoveListItem;
 }
 
 export const MilestoneCard = ({
@@ -126,6 +141,8 @@ export const MilestoneCard = ({
     clearErrors,
     removable,
     onDeleteMilestone,
+    index,
+    moveListItem,
 }: IMilestoneCardProps) => {
     const [anchor, setAnchor] = useState<Element>();
     const [dragItem, setDragItem] = useState<{
@@ -140,6 +157,20 @@ export const MilestoneCard = ({
     const popoverId = isPopoverOpen
         ? 'MilestoneStrategyMenuPopover'
         : undefined;
+
+    const dragHandleRef = useRef(null);
+
+    const dragItemRef = useDragItem<HTMLTableRowElement>(
+        index,
+        moveListItem,
+        dragHandleRef,
+    );
+
+    const dragHandle = (
+        <StyledDragIcon ref={dragHandleRef} disableRipple size='small'>
+            <DragIndicator titleAccess='Drag to reorder' />
+        </StyledDragIcon>
+    );
 
     const onClose = () => {
         setAnchor(undefined);
@@ -217,7 +248,7 @@ export const MilestoneCard = ({
         setAddUpdateStrategyOpen(true);
     };
 
-    const onDragOver =
+    const onStrategyDragOver =
         (targetId: string) =>
         (
             ref: RefObject<HTMLDivElement>,
@@ -253,7 +284,7 @@ export const MilestoneCard = ({
             }
         };
 
-    const onDragStartRef =
+    const onStrategyDragStartRef =
         (
             ref: RefObject<HTMLDivElement>,
             index: number,
@@ -275,7 +306,7 @@ export const MilestoneCard = ({
                 event.dataTransfer.setDragImage(ref.current, 20, 20);
             }
         };
-    const onDragEnd = () => {
+    const onStrategyDragEnd = () => {
         setDragItem(null);
         onReOrderStrategies();
     };
@@ -313,10 +344,12 @@ export const MilestoneCard = ({
                         Boolean(errors?.[milestone.id]) ||
                         Boolean(errors?.[`${milestone.id}_name`])
                     }
+                    ref={dragItemRef}
                 >
                     <StyledMilestoneCardBody>
                         <Grid container>
                             <StyledGridItem item xs={6} md={6}>
+                                {dragHandle}
                                 <MilestoneCardName
                                     milestone={milestone}
                                     errors={errors}
@@ -368,6 +401,10 @@ export const MilestoneCard = ({
                     </StyledMilestoneCardBody>
                 </StyledMilestoneCard>
 
+                <FormHelperText error={Boolean(errors?.[milestone.id])}>
+                    {errors?.[milestone.id]}
+                </FormHelperText>
+
                 <SidebarModal
                     label='Add strategy to template milestone'
                     onClose={() => {
@@ -398,7 +435,9 @@ export const MilestoneCard = ({
             >
                 <StyledAccordionSummary
                     expandIcon={<ExpandMore titleAccess='Toggle' />}
+                    ref={dragItemRef}
                 >
+                    {dragHandle}
                     <MilestoneCardName
                         milestone={milestone}
                         errors={errors}
@@ -411,9 +450,9 @@ export const MilestoneCard = ({
                         <div key={strg.id}>
                             <MilestoneStrategyDraggableItem
                                 index={index}
-                                onDragEnd={onDragEnd}
-                                onDragStartRef={onDragStartRef}
-                                onDragOver={onDragOver(strg.id)}
+                                onDragEnd={onStrategyDragEnd}
+                                onDragStartRef={onStrategyDragStartRef}
+                                onDragOver={onStrategyDragOver(strg.id)}
                                 onDeleteClick={() =>
                                     milestoneStrategyDeleted(strg.id)
                                 }
@@ -462,6 +501,10 @@ export const MilestoneCard = ({
                     </StyledAccordionFooter>
                 </StyledAccordionDetails>
             </StyledAccordion>
+
+            <FormHelperText error={Boolean(errors?.[milestone.id])}>
+                {errors?.[milestone.id]}
+            </FormHelperText>
 
             <SidebarModal
                 label='Add strategy to template milestone'

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
@@ -1,8 +1,10 @@
 import type { IReleasePlanMilestonePayload } from 'interfaces/releasePlans';
-import { MilestoneCard } from './MilestoneCard/MilestoneCard';
-import { styled, Button, FormHelperText } from '@mui/material';
+import { styled, Button } from '@mui/material';
 import Add from '@mui/icons-material/Add';
 import { v4 as uuidv4 } from 'uuid';
+import { useCallback } from 'react';
+import type { MoveListItem } from 'hooks/useDragItem';
+import { MilestoneCard } from './MilestoneCard/MilestoneCard';
 
 interface IMilestoneListProps {
     milestones: IReleasePlanMilestonePayload[];
@@ -26,6 +28,22 @@ export const MilestoneList = ({
     clearErrors,
     milestoneChanged,
 }: IMilestoneListProps) => {
+    const moveListItem: MoveListItem = useCallback(
+        async (dragIndex: number, dropIndex: number) => {
+            const oldMilestones = milestones || [];
+            const newMilestones = [...oldMilestones];
+            const movedMilestone = newMilestones.splice(dragIndex, 1)[0];
+            newMilestones.splice(dropIndex, 0, movedMilestone);
+
+            newMilestones.forEach((milestone, index) => {
+                milestone.sortOrder = index;
+            });
+
+            setMilestones(newMilestones);
+        },
+        [milestones],
+    );
+
     const onDeleteMilestone = (milestoneId: string) => () => {
         setMilestones((prev) =>
             prev
@@ -36,22 +54,18 @@ export const MilestoneList = ({
 
     return (
         <>
-            {milestones.map((milestone) => (
-                <>
-                    <MilestoneCard
-                        key={milestone.id}
-                        milestone={milestone}
-                        milestoneChanged={milestoneChanged}
-                        errors={errors}
-                        clearErrors={clearErrors}
-                        removable={milestones.length > 1}
-                        onDeleteMilestone={onDeleteMilestone(milestone.id)}
-                    />
-
-                    <FormHelperText error={Boolean(errors?.[milestone.id])}>
-                        {errors?.[milestone.id]}
-                    </FormHelperText>
-                </>
+            {milestones.map((milestone, index) => (
+                <MilestoneCard
+                    key={milestone.id}
+                    index={index}
+                    moveListItem={moveListItem}
+                    milestone={milestone}
+                    milestoneChanged={milestoneChanged}
+                    errors={errors}
+                    clearErrors={clearErrors}
+                    removable={milestones.length > 1}
+                    onDeleteMilestone={onDeleteMilestone(milestone.id)}
+                />
             ))}
             <StyledAddMilestoneButton
                 variant='text'


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2821/drag-to-reorder-template-milestones

This PR introduces reordering release plan template milestones by dragging and dropping them.

Was a bit undecided on the approach, but it seems like using an old `useDragItem` hook we have is pretty elegant and behaves as expected.

I suggest reviewers try it out themselves.

![image](https://github.com/user-attachments/assets/3e433f70-53f8-4860-a704-60361f3b0ed7)