### PR TITLE
feat: limit user filter options

### DIFF
--- a/frontend/src/component/admin/groups/GroupForm/GroupFormUsersSelect/GroupFormUsersSelect.tsx
+++ b/frontend/src/component/admin/groups/GroupForm/GroupFormUsersSelect/GroupFormUsersSelect.tsx
@@ -125,12 +125,14 @@ export const GroupFormUsersSelect: VFC<IGroupFormUsersSelectProps> = ({
                     renderOption(props, option as UserOption, selected)
                 }
                 filterOptions={(options, { inputValue }) =>
-                    options.filter(
-                        ({ name, username, email }) =>
-                            caseInsensitiveSearch(inputValue, email) ||
-                            caseInsensitiveSearch(inputValue, name) ||
-                            caseInsensitiveSearch(inputValue, username),
-                    )
+                    options
+                        .filter(
+                            ({ name, username, email }) =>
+                                caseInsensitiveSearch(inputValue, email) ||
+                                caseInsensitiveSearch(inputValue, name) ||
+                                caseInsensitiveSearch(inputValue, username),
+                        )
+                        .slice(0, 100)
                 }
                 isOptionEqualToValue={(option, value) => option.id === value.id}
                 getOptionLabel={(option: UserOption) =>

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -414,34 +414,37 @@ export const ProjectAccessAssign = ({
                                     }
                                 }}
                                 filterOptions={(options, { inputValue }) =>
-                                    options.filter((option: IAccessOption) => {
-                                        if (
-                                            option.type === ENTITY_TYPE.USER ||
-                                            option.type ===
-                                                ENTITY_TYPE.SERVICE_ACCOUNT
-                                        ) {
-                                            const optionUser =
-                                                option.entity as IUser;
-                                            return (
-                                                caseInsensitiveSearch(
-                                                    inputValue,
-                                                    optionUser.email,
-                                                ) ||
-                                                caseInsensitiveSearch(
-                                                    inputValue,
-                                                    optionUser.name,
-                                                ) ||
-                                                caseInsensitiveSearch(
-                                                    inputValue,
-                                                    optionUser.username,
-                                                )
+                                    options
+                                        .filter((option: IAccessOption) => {
+                                            if (
+                                                option.type ===
+                                                    ENTITY_TYPE.USER ||
+                                                option.type ===
+                                                    ENTITY_TYPE.SERVICE_ACCOUNT
+                                            ) {
+                                                const optionUser =
+                                                    option.entity as IUser;
+                                                return (
+                                                    caseInsensitiveSearch(
+                                                        inputValue,
+                                                        optionUser.email,
+                                                    ) ||
+                                                    caseInsensitiveSearch(
+                                                        inputValue,
+                                                        optionUser.name,
+                                                    ) ||
+                                                    caseInsensitiveSearch(
+                                                        inputValue,
+                                                        optionUser.username,
+                                                    )
+                                                );
+                                            }
+                                            return caseInsensitiveSearch(
+                                                inputValue,
+                                                option.entity.name,
                                             );
-                                        }
-                                        return caseInsensitiveSearch(
-                                            inputValue,
-                                            option.entity.name,
-                                        );
-                                    })
+                                        })
+                                        .slice(0, 100)
                                 }
                                 isOptionEqualToValue={(option, value) =>
                                     option.type === value.type &&


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

2 dropdowns in project users and group users have filtering limit. It means that we only render at most 100 items. When a user starts typing autocomplete text it searches across all users. Only the final render list is limited. It makes rendering of large user lists possible.
<img width="737" alt="Screenshot 2025-01-31 at 09 56 29" src="https://github.com/user-attachments/assets/a3e5d4e8-dd2e-42ec-aff7-3438374c08e7" />

In the following PR we'll start adding virtualization.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
