### PR TITLE
chore(1-3316): update request info boxes to new design

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -290,7 +290,6 @@ const NewNetworkTrafficUsage: FC = () => {
                             overageCost > 0
                         }
                         show={
-                            // todo: we the text here should be modified based on the selection.
                             <Alert severity='warning' sx={{ mb: 4 }}>
                                 <BoldText>Heads up!</BoldText> You are currently
                                 consuming more requests than your plan includes
@@ -310,13 +309,6 @@ const NewNetworkTrafficUsage: FC = () => {
                     />
                     <StyledBox>
                         <NewHeader>
-                            {/* <NetworkTrafficUsagePlanSummary
-                                usageTotal={usageTotal}
-                                includedTraffic={includedTraffic}
-                                overageCost={overageCost}
-                                estimatedMonthlyCost={estimatedMonthlyCost}
-                            /> */}
-
                             <TrafficInfoBoxes>
                                 <RequestSummary
                                     period={newPeriod}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -282,7 +282,13 @@ const NewNetworkTrafficUsage: FC = () => {
             elseShow={
                 <>
                     <ConditionallyRender
-                        condition={includedTraffic > 0 && overageCost > 0}
+                        condition={
+                            (newPeriod.grouping === 'monthly' ||
+                                newPeriod.month ===
+                                    format(new Date(), 'yyyy-MM')) &&
+                            includedTraffic > 0 &&
+                            overageCost > 0
+                        }
                         show={
                             // todo: we the text here should be modified based on the selection.
                             <Alert severity='warning' sx={{ mb: 4 }}>
@@ -290,20 +296,14 @@ const NewNetworkTrafficUsage: FC = () => {
                                 consuming more requests than your plan includes
                                 and will be billed according to our terms.
                                 Please see{' '}
-                                <Link
-                                    component={RouterLink}
-                                    to='https://www.getunleash.io/pricing'
-                                >
+                                <RouterLink to='https://www.getunleash.io/pricing'>
                                     this page
-                                </Link>{' '}
+                                </RouterLink>{' '}
                                 for more information. In order to reduce your
                                 traffic consumption, you may configure an{' '}
-                                <Link
-                                    component={RouterLink}
-                                    to='https://docs.getunleash.io/reference/unleash-edge'
-                                >
+                                <RouterLink to='https://docs.getunleash.io/reference/unleash-edge'>
                                     Unleash Edge instance
-                                </Link>{' '}
+                                </RouterLink>{' '}
                                 in your own datacenter.
                             </Alert>
                         }

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -274,6 +274,15 @@ const NewNetworkTrafficUsage: FC = () => {
         .map((info) => info.label.toLowerCase())
         .toReversed();
     const requestTypes = `${otherLabels.toReversed().join(', ')}, and ${lastLabel}`;
+    const chartLabel =
+        newPeriod.grouping === 'daily'
+            ? `A bar chart showing daily traffic usage for ${new Date(
+                  newPeriod.month,
+              ).toLocaleDateString('en-US', {
+                  month: 'long',
+                  year: 'numeric',
+              })}. Each date shows ${requestTypes} requests.`
+            : `A bar chart showing monthly total traffic usage for the current month and the preceding ${newPeriod.monthsBack} months. Each month shows ${requestTypes} requests.`;
 
     return (
         <ConditionallyRender
@@ -346,16 +355,7 @@ const NewNetworkTrafficUsage: FC = () => {
                             data={data}
                             plugins={[customHighlightPlugin()]}
                             options={options}
-                            aria-label={
-                                newPeriod.grouping === 'daily'
-                                    ? `A bar chart showing daily traffic usage for ${new Date(
-                                          newPeriod.month,
-                                      ).toLocaleDateString('en-US', {
-                                          month: 'long',
-                                          year: 'numeric',
-                                      })}. Each date shows ${requestTypes} requests.`
-                                    : `A bar chart showing monthly total traffic usage for the current month and the preceding ${newPeriod.monthsBack} months. Each month shows ${requestTypes} requests.`
-                            }
+                            aria-label={chartLabel}
                         />
                     </StyledBox>
                 </>

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -205,7 +205,11 @@ const NewNetworkTrafficUsage: FC = () => {
                         },
                     );
                 } else {
-                    return new Date(tooltipItems[0].label).toLocaleDateString(
+                    const timestamp = Date.parse(tooltipItems[0].label);
+                    if (Number.isNaN(timestamp)) {
+                        return 'Current month to date';
+                    }
+                    return new Date(timestamp).toLocaleDateString(
                         locationSettings?.locale ?? 'en-US',
                         {
                             month: 'long',

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -40,10 +40,10 @@ import { BILLING_TRAFFIC_BUNDLE_PRICE } from 'component/admin/billing/BillingDas
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { PeriodSelector } from './PeriodSelector';
 import { useUiFlag } from 'hooks/useUiFlag';
-import { differenceInCalendarMonths, format } from 'date-fns';
+import { format } from 'date-fns';
 import { monthlyTrafficDataToCurrentUsage } from './monthly-traffic-data-to-current-usage';
 import { OverageInfo, RequestSummary } from './RequestSummary';
-import type { TrafficUsageDataSegmentedCombinedSchema } from 'openapi';
+import { averageTrafficPreviousMonths } from './average-traffic-previous-months';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     display: 'grid',
@@ -161,41 +161,8 @@ const TrafficInfoBoxes = styled('div')(({ theme }) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fit, minmax(200px, max-content))',
     flex: 1,
-
     gap: theme.spacing(2, 4),
 }));
-
-const averageTrafficPreviousMonths = (
-    endpointData: string[],
-    traffic: TrafficUsageDataSegmentedCombinedSchema,
-) => {
-    if (!traffic || traffic.grouping === 'daily') {
-        return 0;
-    }
-
-    const monthsToCount = Math.abs(
-        differenceInCalendarMonths(
-            new Date(traffic.dateRange.to),
-            new Date(traffic.dateRange.from),
-        ),
-    );
-
-    const currentMonth = format(new Date(), 'yyyy-MM');
-
-    const totalTraffic = traffic.apiData
-        .filter((endpoint) => endpointData.includes(endpoint.apiPath))
-        .map((endpoint) =>
-            endpoint.dataPoints
-                .filter(({ period }) => period !== currentMonth)
-                .reduce(
-                    (acc, current) => acc + current.trafficTypes[0].count,
-                    0,
-                ),
-        )
-        .reduce((total, next) => total + next, 0);
-
-    return Math.round(totalTraffic / monthsToCount);
-};
 
 const NewNetworkTrafficUsage: FC = () => {
     usePageTitle('Network - Data Usage');

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -158,14 +158,10 @@ const NewHeader = styled('div')(({ theme }) => ({
 }));
 
 const TrafficInfoBoxes = styled('div')(({ theme }) => ({
-    // display: 'flex',
-    // flexFlow: 'row wrap',
-    // justifyItems:
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(450px, max-content))',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(200px, max-content))',
     flex: 1,
 
-    // width: 'min-content',
     gap: theme.spacing(2, 4),
 }));
 

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -164,6 +164,10 @@ const TrafficInfoBoxes = styled('div')(({ theme }) => ({
     gap: theme.spacing(2, 4),
 }));
 
+const BoldText = styled('span')(({ theme }) => ({
+    fontWeight: 'bold',
+}));
+
 const NewNetworkTrafficUsage: FC = () => {
     usePageTitle('Network - Data Usage');
     const theme = useTheme();
@@ -278,13 +282,14 @@ const NewNetworkTrafficUsage: FC = () => {
             elseShow={
                 <>
                     <ConditionallyRender
-                        condition={true}
+                        condition={includedTraffic > 0 && overageCost > 0}
                         show={
                             // todo: we the text here should be modified based on the selection.
                             <Alert severity='warning' sx={{ mb: 4 }}>
-                                <b>Heads up!</b> You are currently consuming
-                                more requests than your plan includes and will
-                                be billed according to our terms. Please see{' '}
+                                <BoldText>Heads up!</BoldText> You are currently
+                                consuming more requests than your plan includes
+                                and will be billed according to our terms.
+                                Please see{' '}
                                 <Link
                                     component={RouterLink}
                                     to='https://www.getunleash.io/pricing'

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -320,7 +320,7 @@ const NewNetworkTrafficUsage: FC = () => {
                                                   traffic.usage,
                                               )
                                     }
-                                    includedTraffic={50}
+                                    includedTraffic={includedTraffic}
                                 />
                                 {newPeriod.grouping === 'daily' &&
                                     includedTraffic > 0 &&

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -168,6 +168,7 @@ const NewNetworkTrafficUsage: FC = () => {
         toTrafficUsageSum,
         calculateOverageCost,
         calculateEstimatedMonthlyCost,
+        endpointsInfo,
     } = useTrafficDataEstimation();
 
     const includedTraffic = useTrafficLimit();
@@ -248,6 +249,12 @@ const NewNetworkTrafficUsage: FC = () => {
         }
     }, [data]);
 
+    // todo: extract this (and also endpoints info)
+    const [lastLabel, ...otherLabels] = Object.values(endpointsInfo)
+        .map((info) => info.label.toLowerCase())
+        .toReversed();
+    const requestTypes = `${otherLabels.toReversed().join(', ')}, and ${lastLabel}`;
+
     return (
         <ConditionallyRender
             condition={isOss()}
@@ -300,7 +307,16 @@ const NewNetworkTrafficUsage: FC = () => {
                             data={data}
                             plugins={[customHighlightPlugin()]}
                             options={options}
-                            aria-label='An instance metrics line chart with two lines: requests per second for admin API and requests per second for client API' // todo: this isn't correct at all!
+                            aria-label={
+                                newPeriod.grouping === 'daily'
+                                    ? `A bar chart showing daily traffic usage for ${new Date(
+                                          newPeriod.month,
+                                      ).toLocaleDateString('en-US', {
+                                          month: 'long',
+                                          year: 'numeric',
+                                      })}. Each date shows ${requestTypes} requests.`
+                                    : `A bar chart showing monthly total traffic usage for the current month and the preceding ${newPeriod.monthsBack} months. Each month shows ${requestTypes} requests.`
+                            }
                         />
                     </StyledBox>
                 </>

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -322,11 +322,10 @@ const NewNetworkTrafficUsage: FC = () => {
                                     }
                                     includedTraffic={50}
                                 />
-                                {(newPeriod.grouping === 'daily' &&
+                                {newPeriod.grouping === 'daily' &&
                                     includedTraffic > 0 &&
                                     usageTotal - includedTraffic > 0 &&
-                                    estimateTrafficDataCost) ||
-                                    (true && (
+                                    estimateTrafficDataCost && (
                                         <OverageInfo
                                             overageCost={overageCost}
                                             overages={
@@ -336,7 +335,7 @@ const NewNetworkTrafficUsage: FC = () => {
                                                 estimatedMonthlyCost
                                             }
                                         />
-                                    ))}
+                                    )}
                             </TrafficInfoBoxes>
                             <PeriodSelector
                                 selectedPeriod={newPeriod}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsagePlanSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsagePlanSummary.tsx
@@ -95,7 +95,7 @@ export const NetworkTrafficUsagePlanSummary = ({
                             </RowContainer>
                         </StyledCardDescription>
                         <ConditionallyRender
-                            condition={true}
+                            condition={includedTraffic > 0}
                             show={
                                 <StyledCardDescription>
                                     <RowContainer>
@@ -112,7 +112,9 @@ export const NetworkTrafficUsagePlanSummary = ({
                 </StyledContainer>
             </StyledGrid>
             <ConditionallyRender
-                condition={true}
+                condition={
+                    estimateFlagEnabled && includedTraffic > 0 && overages > 0
+                }
                 show={
                     <StyledGrid item xs={5.5} md={5.5}>
                         <StyledContainer>
@@ -140,7 +142,7 @@ export const NetworkTrafficUsagePlanSummary = ({
                                         </StyledNumbersDiv>
                                     </RowContainer>
                                     <ConditionallyRender
-                                        condition={true}
+                                        condition={estimatedMonthlyCost > 0}
                                         show={
                                             <RowContainer>
                                                 Estimated traffic charges based

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsagePlanSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsagePlanSummary.tsx
@@ -95,7 +95,7 @@ export const NetworkTrafficUsagePlanSummary = ({
                             </RowContainer>
                         </StyledCardDescription>
                         <ConditionallyRender
-                            condition={includedTraffic > 0}
+                            condition={true}
                             show={
                                 <StyledCardDescription>
                                     <RowContainer>
@@ -112,9 +112,7 @@ export const NetworkTrafficUsagePlanSummary = ({
                 </StyledContainer>
             </StyledGrid>
             <ConditionallyRender
-                condition={
-                    estimateFlagEnabled && includedTraffic > 0 && overages > 0
-                }
+                condition={true}
                 show={
                     <StyledGrid item xs={5.5} md={5.5}>
                         <StyledContainer>
@@ -142,7 +140,7 @@ export const NetworkTrafficUsagePlanSummary = ({
                                         </StyledNumbersDiv>
                                     </RowContainer>
                                     <ConditionallyRender
-                                        condition={estimatedMonthlyCost > 0}
+                                        condition={true}
                                         show={
                                             <RowContainer>
                                                 Estimated traffic charges based

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
@@ -144,10 +144,9 @@ export const OverageInfo: FC<OverageProps> = ({
                         <Badge color='secondary'>{overageCost} USD</Badge>
                     </dd>
                 </Row>
-                {true && (
+                {estimatedMonthlyCost > 0 && (
                     <Row>
                         <dt>Estimated charges based on current usage</dt>
-
                         <dd>
                             <Badge color='secondary'>
                                 {estimatedMonthlyCost} USD

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
@@ -1,0 +1,161 @@
+import { Link, styled } from '@mui/material';
+import { Badge } from 'component/common/Badge/Badge';
+import { subMonths } from 'date-fns';
+import type { ChartDataSelection } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import type { FC } from 'react';
+
+type Props = {
+    period: ChartDataSelection;
+    usageTotal: number;
+    includedTraffic: number;
+};
+
+const Container = styled('article')(({ theme }) => ({
+    // flex: 'auto',
+    minWidth: 'min-content',
+    border: `2px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusLarge,
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+}));
+
+const Header = styled('h3')(({ theme }) => ({
+    margin: 0,
+    fontSize: theme.typography.body1.fontSize,
+    whiteSpace: 'nowrap',
+}));
+
+const List = styled('dl')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2.5),
+    padding: 0,
+    margin: 0,
+}));
+
+const Row = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row wrap',
+    // flexFlow: 'row ',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1, 3),
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+    whiteSpace: 'nowrap',
+
+    '& dd': {
+        margin: 0,
+        color: theme.palette.text.primary,
+    },
+}));
+
+const incomingRequestsText = (period: ChartDataSelection): string => {
+    const formatMonth = (date: Date) =>
+        date.toLocaleString('en-US', {
+            month: 'short',
+            year: 'numeric',
+        });
+
+    if (period.grouping === 'monthly') {
+        const currentMonth = new Date();
+        const fromMonth = subMonths(currentMonth, period.monthsBack);
+        const toMonth = subMonths(currentMonth, 1);
+        return `Average requests from ${formatMonth(fromMonth)} to ${formatMonth(toMonth)}`;
+    }
+
+    return `Incoming requests in ${formatMonth(new Date(period.month))}`;
+};
+
+export const RequestSummary: FC<Props> = ({
+    period,
+    usageTotal,
+    includedTraffic,
+}) => {
+    const { locationSettings } = useLocationSettings();
+
+    return (
+        <Container>
+            <Header>Number of requests to Unleash</Header>
+            <List>
+                <Row>
+                    <dt>{incomingRequestsText(period)}</dt>
+                    <dd>
+                        <Badge
+                            color={
+                                includedTraffic > 0
+                                    ? usageTotal <= includedTraffic
+                                        ? 'success'
+                                        : 'error'
+                                    : 'neutral'
+                            }
+                            tabIndex={-1}
+                        >
+                            {usageTotal.toLocaleString(
+                                locationSettings.locale ?? 'en-US',
+                            )}{' '}
+                            requests
+                        </Badge>
+                    </dd>
+                </Row>
+                {includedTraffic > 0 && (
+                    <Row>
+                        <dt>Included in your plan monthly</dt>
+                        <dd>
+                            {includedTraffic.toLocaleString('en-US')} requests
+                        </dd>
+                    </Row>
+                )}
+            </List>
+        </Container>
+    );
+};
+
+type OverageProps = {
+    overages: number;
+    overageCost: number;
+    estimatedMonthlyCost: number;
+};
+
+export const OverageInfo: FC<OverageProps> = ({
+    overages,
+    overageCost,
+    estimatedMonthlyCost,
+}) => {
+    return (
+        <Container>
+            <Header>Accrued traffic charges</Header>
+            <List>
+                <Row>
+                    <dt>
+                        Request overages this month (
+                        <Link href='https://www.getunleash.io/pricing'>
+                            pricing
+                        </Link>
+                        )
+                    </dt>
+                    <dd>{overages.toLocaleString()} requests</dd>
+                </Row>
+                <Row>
+                    <dt>Accrued traffic charges</dt>
+                    <dd>
+                        <Badge color='secondary'>{overageCost} USD</Badge>
+                    </dd>
+                </Row>
+                {true && (
+                    <Row>
+                        <dt>Estimated charges based on current usage</dt>
+
+                        <dd>
+                            <Badge color='secondary'>
+                                {estimatedMonthlyCost} USD
+                            </Badge>
+                        </dd>
+                    </Row>
+                )}
+            </List>
+        </Container>
+    );
+};

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
@@ -12,10 +12,7 @@ type Props = {
 };
 
 const Container = styled('article')(({ theme }) => ({
-    // flex: 'auto',
     minWidth: '200px',
-    // width: 'max-content',
-    // flexGrow: 1,
     border: `2px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(3),
@@ -44,7 +41,6 @@ const Row = styled('div')(({ theme }) => ({
     gap: theme.spacing(1, 3),
     fontSize: theme.typography.body2.fontSize,
     color: theme.palette.text.secondary,
-    // whiteSpace: 'nowrap',
 
     '& dd': {
         margin: 0,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
@@ -13,7 +13,9 @@ type Props = {
 
 const Container = styled('article')(({ theme }) => ({
     // flex: 'auto',
-    minWidth: 'min-content',
+    minWidth: '200px',
+    // width: 'max-content',
+    // flexGrow: 1,
     border: `2px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(3),
@@ -25,7 +27,6 @@ const Container = styled('article')(({ theme }) => ({
 const Header = styled('h3')(({ theme }) => ({
     margin: 0,
     fontSize: theme.typography.body1.fontSize,
-    whiteSpace: 'nowrap',
 }));
 
 const List = styled('dl')(({ theme }) => ({
@@ -39,12 +40,11 @@ const List = styled('dl')(({ theme }) => ({
 const Row = styled('div')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'row wrap',
-    // flexFlow: 'row ',
     justifyContent: 'space-between',
     gap: theme.spacing(1, 3),
     fontSize: theme.typography.body2.fontSize,
     color: theme.palette.text.secondary,
-    whiteSpace: 'nowrap',
+    // whiteSpace: 'nowrap',
 
     '& dd': {
         margin: 0,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
@@ -1,0 +1,34 @@
+import { differenceInCalendarMonths, format } from 'date-fns';
+import type { TrafficUsageDataSegmentedCombinedSchema } from 'openapi';
+
+export const averageTrafficPreviousMonths = (
+    endpointData: string[],
+    traffic: TrafficUsageDataSegmentedCombinedSchema,
+) => {
+    if (!traffic || traffic.grouping === 'daily') {
+        return 0;
+    }
+
+    const monthsToCount = Math.abs(
+        differenceInCalendarMonths(
+            new Date(traffic.dateRange.to),
+            new Date(traffic.dateRange.from),
+        ),
+    );
+
+    const currentMonth = format(new Date(), 'yyyy-MM');
+
+    const totalTraffic = traffic.apiData
+        .filter((endpoint) => endpointData.includes(endpoint.apiPath))
+        .map((endpoint) =>
+            endpoint.dataPoints
+                .filter(({ period }) => period !== currentMonth)
+                .reduce(
+                    (acc, current) => acc + current.trafficTypes[0].count,
+                    0,
+                ),
+        )
+        .reduce((total, next) => total + next, 0);
+
+    return Math.round(totalTraffic / monthsToCount);
+};

--- a/frontend/src/component/common/Badge/Badge.tsx
+++ b/frontend/src/component/common/Badge/Badge.tsx
@@ -29,6 +29,7 @@ interface IBadgeProps {
     children?: ReactNode;
     title?: string;
     onClick?: (event: React.SyntheticEvent) => void;
+    tabIndex?: number;
 }
 
 interface IBadgeIconProps {
@@ -96,13 +97,14 @@ export const Badge: FC<IBadgeProps> = forwardRef(
             className,
             sx,
             children,
+            tabIndex = 0,
             ...props
         }: IBadgeProps,
         ref: ForwardedRef<HTMLDivElement>,
     ) => (
         <StyledBadge
             as={as}
-            tabIndex={0}
+            tabIndex={tabIndex}
             color={color}
             icon={icon}
             className={className}

--- a/frontend/src/hooks/useTrafficData.ts
+++ b/frontend/src/hooks/useTrafficData.ts
@@ -172,7 +172,9 @@ const toMonthlyChartData = (
     );
 
     const labels = Array.from({ length: numMonths }).map((_, index) =>
-        formatMonth(addMonths(from, index)),
+        index === numMonths - 1
+            ? 'Current month'
+            : formatMonth(addMonths(from, index)),
     );
 
     return { datasets, labels };


### PR DESCRIPTION
Updates the existing number of requests and overage info boxes to the new design.

The existing versions of the boxes had some issues on narrower screens, so it was easier to just leave them as is and start from scratch.

The previous boxes on narrow screens:
![image](https://github.com/user-attachments/assets/f3efa00d-ac0d-41ed-82d8-11766e043cb5)


The current ones (from wide to narrower):
Wide
![image](https://github.com/user-attachments/assets/0a48c013-afcd-4652-9229-0fca19a83733)

Mid (the text should probably ideally wrap at the same time here, but I'm not sure how at the moment)
![image](https://github.com/user-attachments/assets/2ea3a672-80a6-4445-ae90-736c91c6e88e)

Narrow
![image](https://github.com/user-attachments/assets/03e3de0e-23c1-436a-8f6c-4c78cd4fdae7)

Extra narrow:
![image](https://github.com/user-attachments/assets/652c0c3b-71b1-4b2e-9e86-217f0c827aa6)



There's still some work we **could** do, but we should have UX have a look first. In particular, it's about how the text wraps in certain places etc, but I think it's good enough for now.

I'll come back with tests for the calculations and some refactoring and cleanup in a followup.