### PR TITLE
fix(1-3334): re-align the dropdown menu with the dropdown

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -155,6 +155,7 @@ const NewHeader = styled('div')(({ theme }) => ({
     flexFlow: 'row wrap',
     justifyContent: 'space-between',
     gap: theme.spacing(2, 4),
+    alignItems: 'start',
 }));
 
 const TrafficInfoBoxes = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Makes it so that the dropdown menu sits below the dropdown button,
rather than being offset to the end of the containing flexbox.

The issue was caused by the surrounding container being a flexbox.
This caused the popover anchor to grow to the full height of the box,
making the menu look offset.

By using `align-items: start`, we get around this.

Before
![image](https://github.com/user-attachments/assets/0f044627-05a3-4225-9a25-b20393c40158)


After:
![image](https://github.com/user-attachments/assets/9a6d1d7f-7f18-48d3-abdf-f4bb7c02ba68)
