### PR TITLE
feat: allow SCIM user deletion

### DIFF
--- a/frontend/src/component/admin/auth/ScimSettings/ScimDeleteUsersDialog.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimDeleteUsersDialog.tsx
@@ -24,7 +24,7 @@ export const ScimDeleteEntityDialog = ({
         open={open}
         primaryButtonText={`Delete SCIM ${entityType}`}
         secondaryButtonText='Cancel'
-        title={`Really Delete All SCIM ${entityType}?`}
+        title={`Do you really want to delete ALL SCIM ${entityType}?`}
         onClose={closeDialog}
         onClick={removeUser}
     >

--- a/frontend/src/component/admin/auth/ScimSettings/ScimDeleteUsersDialog.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimDeleteUsersDialog.tsx
@@ -1,0 +1,36 @@
+import { Alert, styled, Typography } from '@mui/material';
+import { Dialogue } from 'component/common/Dialogue/Dialogue';
+
+const StyledAlert = styled(Alert)(({ theme }) => ({
+    marginBottom: theme.spacing(3),
+}));
+
+export type EntityType = 'Users' | 'Groups';
+
+interface IScimDeleteUsersProps {
+    open: boolean;
+    entityType: EntityType;
+    closeDialog: () => void;
+    deleteEntities: () => void;
+}
+
+export const ScimDeleteEntityDialog = ({
+    open,
+    closeDialog,
+    deleteEntities: removeUser,
+    entityType,
+}: IScimDeleteUsersProps) => (
+    <Dialogue
+        open={open}
+        primaryButtonText={`Delete SCIM ${entityType}`}
+        secondaryButtonText='Cancel'
+        title={`Really Delete All SCIM ${entityType}?`}
+        onClose={closeDialog}
+        onClick={removeUser}
+    >
+        <Typography variant='body1'>
+            This will delete all {entityType.toLocaleLowerCase()} created or
+            managed by SCIM.
+        </Typography>
+    </Dialogue>
+);

--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -200,7 +200,7 @@ export const ScimSettings = () => {
                     </Grid>
                     <Grid item md={10.5} mb={2}>
                         <StyledTitleDiv>
-                            <strong>Clear SCIM Groups</strong>
+                            <strong>Delete SCIM Groups</strong>
                         </StyledTitleDiv>
                         <p>
                             This will remove all SCIM groups from the Unleash

--- a/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
+++ b/frontend/src/component/admin/auth/ScimSettings/ScimSettings.tsx
@@ -11,6 +11,7 @@ import { useScimSettingsApi } from 'hooks/api/actions/useScimSettingsApi/useScim
 import { useScimSettings } from 'hooks/api/getters/useScimSettings/useScimSettings';
 import { ScimDeleteEntityDialog } from './ScimDeleteUsersDialog';
 import useAdminUsersApi from 'hooks/api/actions/useAdminUsersApi/useAdminUsersApi';
+import { useGroupApi } from 'hooks/api/actions/useGroupApi/useGroupApi';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(3),
@@ -32,6 +33,7 @@ export const ScimSettings = () => {
     const [tokenDialog, setTokenDialog] = useState(false);
     const { settings, refetch } = useScimSettings();
     const { deleteScimUsers } = useAdminUsersApi();
+    const { deleteScimGroups } = useGroupApi();
     const [enabled, setEnabled] = useState(settings.enabled ?? true);
 
     useEffect(() => {
@@ -46,7 +48,17 @@ export const ScimSettings = () => {
     };
 
     const onDeleteScimGroups = async () => {
-        setDeleteGroupsDialog(true);
+        try {
+            await deleteScimGroups();
+            setToastData({
+                text: 'Scim Groups have been deleted',
+                type: 'success',
+            });
+            setDeleteGroupsDialog(false);
+            refetch();
+        } catch (error: unknown) {
+            setToastApiError(formatUnknownError(error));
+        }
     };
 
     const onDeleteScimUsers = async () => {
@@ -203,7 +215,9 @@ export const ScimSettings = () => {
                             variant='outlined'
                             color='error'
                             disabled={loading}
-                            onClick={onDeleteScimGroups}
+                            onClick={() => {
+                                setDeleteGroupsDialog(true);
+                            }}
                         >
                             Delete Groups
                         </Button>
@@ -226,14 +240,14 @@ export const ScimSettings = () => {
                     closeDialog={() => setDeleteUsersDialog(false)}
                     deleteEntities={onDeleteScimUsers}
                     entityType='Users'
-                ></ScimDeleteEntityDialog>
+                />
 
                 <ScimDeleteEntityDialog
                     open={deleteGroupsDialog}
                     closeDialog={() => setDeleteGroupsDialog(false)}
                     deleteEntities={onDeleteScimGroups}
                     entityType='Groups'
-                ></ScimDeleteEntityDialog>
+                />
             </StyledContainer>
         </>
     );

--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -270,11 +270,8 @@ export const Group: VFC = () => {
                                     onClick={() => setRemoveOpen(true)}
                                     permission={ADMIN}
                                     tooltipProps={{
-                                        title: isScimGroup
-                                            ? scimGroupTooltip
-                                            : 'Delete group',
+                                        title: 'Delete group',
                                     }}
-                                    disabled={isScimGroup}
                                 >
                                     <Delete />
                                 </PermissionIconButton>

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions.tsx
@@ -125,7 +125,6 @@ export const GroupCardActions: FC<IGroupCardActions> = ({
                             onRemove();
                             handleClose();
                         }}
-                        disabled={isScimGroup}
                     >
                         <ListItemIcon>
                             <Delete />

--- a/frontend/src/component/admin/users/UsersList/DeleteUser/DeleteUser.tsx
+++ b/frontend/src/component/admin/users/UsersList/DeleteUser/DeleteUser.tsx
@@ -77,6 +77,9 @@ const DeleteUser = ({
                           })`
                         : ''}
                     ?
+                    {user.scimId
+                        ? ' This user is currently managed by SCIM and may be re-added by your SCIM provider.'
+                        : ''}
                 </Typography>
             </div>
         </Dialogue>

--- a/frontend/src/component/admin/users/UsersList/UsersActionsCell/UsersActionsCell.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersActionsCell/UsersActionsCell.tsx
@@ -91,9 +91,8 @@ export const UsersActionsCell: VFC<IUsersActionsCellProps> = ({
                 onClick={onDelete}
                 permission={ADMIN}
                 tooltipProps={{
-                    title: isScimUser ? scimTooltip : 'Remove user',
+                    title: 'Remove user',
                 }}
-                disabled={isScimUser}
             >
                 <Delete />
             </PermissionIconButton>

--- a/frontend/src/hooks/api/actions/useAdminUsersApi/useAdminUsersApi.ts
+++ b/frontend/src/hooks/api/actions/useAdminUsersApi/useAdminUsersApi.ts
@@ -94,6 +94,19 @@ const useAdminUsersApi = () => {
         return makeRequest(req.caller, req.id);
     };
 
+    const deleteScimUsers = async () => {
+        const requestId = 'deleteScimUsers';
+        const req = createRequest(
+            'api/admin/user-admin/scim-users',
+            {
+                method: 'DELETE',
+            },
+            requestId,
+        );
+
+        return makeRequest(req.caller, req.id);
+    };
+
     return {
         addUser,
         updateUser,
@@ -101,6 +114,7 @@ const useAdminUsersApi = () => {
         changePassword,
         validatePassword,
         resetPassword,
+        deleteScimUsers,
         userApiErrors: errors,
         userLoading: loading,
     };

--- a/frontend/src/hooks/api/actions/useGroupApi/useGroupApi.ts
+++ b/frontend/src/hooks/api/actions/useGroupApi/useGroupApi.ts
@@ -46,10 +46,20 @@ export const useGroupApi = () => {
         await makeRequest(req.caller, req.id);
     };
 
+    const deleteScimGroups = async () => {
+        const path = `api/admin/groups/scim-groups`;
+        const req = createRequest(path, {
+            method: 'DELETE',
+        });
+
+        await makeRequest(req.caller, req.id);
+    };
+
     return {
         createGroup,
         updateGroup,
         removeGroup,
+        deleteScimGroups,
         errors,
         loading,
     };

--- a/src/lib/db/group-store.ts
+++ b/src/lib/db/group-store.ts
@@ -354,4 +354,8 @@ export default class GroupStore implements IGroupStore {
         const { present } = result.rows[0];
         return present;
     }
+
+    async deleteScimGroups(): Promise<void> {
+        await this.db(T.GROUPS).whereNotNull('scim_id').del();
+    }
 }

--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -272,6 +272,10 @@ class UserStore implements IUserStore {
         await this.activeUsers().del();
     }
 
+    async deleteScimUsers(): Promise<void> {
+        await this.db(TABLE).whereNotNull('scim_id').del();
+    }
+
     async count(): Promise<number> {
         return this.activeUsers()
             .count('*')

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -674,8 +674,6 @@ export default class UserAdminController extends Controller {
         const { user, params } = req;
         const { id } = params;
 
-        await this.throwIfScimUser({ id });
-
         await this.userService.deleteUser(+id, req.audit);
         res.status(200).send();
     }

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -413,6 +413,26 @@ export default class UserAdminController extends Controller {
 
         this.route({
             method: 'delete',
+            path: '/scim-users',
+            acceptAnyContentType: true,
+            handler: this.deleteScimUsers,
+            permission: ADMIN,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Users'],
+                    operationId: 'deleteScimUsers',
+                    summary: 'Delete all SCIM users',
+                    description: 'Deletes all users managed by SCIM',
+                    responses: {
+                        200: emptyResponse,
+                        ...getStandardResponses(401, 403),
+                    },
+                }),
+            ],
+        });
+
+        this.route({
+            method: 'delete',
             path: '/:id',
             acceptAnyContentType: true,
             handler: this.deleteUser,
@@ -437,26 +457,6 @@ export default class UserAdminController extends Controller {
                     responses: {
                         200: emptyResponse,
                         ...getStandardResponses(401, 403, 404),
-                    },
-                }),
-            ],
-        });
-
-        //add a method to delete all scim users
-        this.route({
-            method: 'delete',
-            path: '/scim-users',
-            handler: this.deleteScimUsers,
-            permission: ADMIN,
-            middleware: [
-                openApiService.validPath({
-                    tags: ['Users'],
-                    operationId: 'deleteScimUsers',
-                    summary: 'Delete all SCIM users',
-                    description: 'Deletes all users managed by SCIM',
-                    responses: {
-                        200: emptyResponse,
-                        ...getStandardResponses(401, 403),
                     },
                 }),
             ],

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -441,6 +441,26 @@ export default class UserAdminController extends Controller {
                 }),
             ],
         });
+
+        //add a method to delete all scim users
+        this.route({
+            method: 'delete',
+            path: '/scim-users',
+            handler: this.deleteScimUsers,
+            permission: ADMIN,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Users'],
+                    operationId: 'deleteScimUsers',
+                    summary: 'Delete all SCIM users',
+                    description: 'Deletes all users managed by SCIM',
+                    responses: {
+                        200: emptyResponse,
+                        ...getStandardResponses(401, 403),
+                    },
+                }),
+            ],
+        });
     }
 
     async resetUserPassword(
@@ -765,5 +785,11 @@ export default class UserAdminController extends Controller {
             Boolean(scimId) ||
             Boolean((await this.userService.getUser(id)).scimId)
         );
+    }
+
+    async deleteScimUsers(req: IAuthRequest, res: Response): Promise<void> {
+        const { audit } = req;
+        await this.userService.deleteScimUsers(audit);
+        res.status(200).send();
     }
 }

--- a/src/lib/services/group-service.ts
+++ b/src/lib/services/group-service.ts
@@ -21,6 +21,7 @@ import {
     GROUP_CREATED,
     GroupUserAdded,
     GroupUserRemoved,
+    ScimGroupsDeleted,
     type IBaseEvent,
 } from '../types/events';
 import NameExistsError from '../error/name-exists-error';
@@ -308,6 +309,16 @@ export class GroupService {
 
             await this.eventService.storeEvents(events);
         }
+    }
+
+    async deleteScimGroups(auditUser: IAuditUser): Promise<void> {
+        await this.groupStore.deleteScimGroups();
+        await this.eventService.storeEvent(
+            new ScimGroupsDeleted({
+                data: null,
+                auditUser,
+            }),
+        );
     }
 
     private mapGroupWithUsers(

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -24,6 +24,7 @@ import type SessionService from './session-service';
 import type { IUnleashStores } from '../types/stores';
 import PasswordUndefinedError from '../error/password-undefined';
 import {
+    ScimUsersDeleted,
     UserCreatedEvent,
     UserDeletedEvent,
     UserUpdatedEvent,
@@ -393,6 +394,17 @@ class UserService {
         await this.eventService.storeEvent(
             new UserDeletedEvent({
                 deletedUser: user,
+                auditUser,
+            }),
+        );
+    }
+
+    async deleteScimUsers(auditUser: IAuditUser): Promise<void> {
+        await this.store.deleteScimUsers();
+
+        await this.eventService.storeEvent(
+            new ScimUsersDeleted({
+                data: null,
                 auditUser,
             }),
         );

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -217,6 +217,8 @@ export const RELEASE_PLAN_MILESTONE_STARTED =
     'release-plan-milestone-started' as const;
 
 export const USER_PREFERENCE_UPDATED = 'user-preference-updated' as const;
+export const SCIM_USERS_DELETED = 'scim-users-deleted' as const;
+export const SCIM_GROUPS_DELETED = 'scim-groups-deleted' as const;
 
 export const IEventTypes = [
     APPLICATION_CREATED,
@@ -372,6 +374,8 @@ export const IEventTypes = [
     RELEASE_PLAN_REMOVED,
     RELEASE_PLAN_MILESTONE_STARTED,
     USER_PREFERENCE_UPDATED,
+    SCIM_USERS_DELETED,
+    SCIM_GROUPS_DELETED,
 ] as const;
 export type IEventType = (typeof IEventTypes)[number];
 
@@ -1605,6 +1609,30 @@ export class UserDeletedEvent extends BaseEvent {
     }) {
         super(USER_DELETED, eventData.auditUser);
         this.preData = mapUserToData(eventData.deletedUser);
+    }
+}
+
+export class ScimUsersDeleted extends BaseEvent {
+    readonly data: any;
+
+    constructor(eventData: {
+        data: any;
+        auditUser: IAuditUser;
+    }) {
+        super(SCIM_USERS_DELETED, eventData.auditUser);
+        this.data = eventData.data;
+    }
+}
+
+export class ScimGroupsDeleted extends BaseEvent {
+    readonly data: any;
+
+    constructor(eventData: {
+        data: any;
+        auditUser: IAuditUser;
+    }) {
+        super(SCIM_GROUPS_DELETED, eventData.auditUser);
+        this.data = eventData.data;
     }
 }
 

--- a/src/lib/types/stores/group-store.ts
+++ b/src/lib/types/stores/group-store.ts
@@ -66,4 +66,6 @@ export interface IGroupStore extends Store<IGroup, number> {
     create(group: IStoreGroup): Promise<IGroup>;
 
     count(): Promise<number>;
+
+    deleteScimGroups(): Promise<void>;
 }

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -40,4 +40,5 @@ export interface IUserStore extends Store<IUser, number> {
     count(): Promise<number>;
     countRecentlyDeleted(): Promise<number>;
     countServiceAccounts(): Promise<number>;
+    deleteScimUsers(): Promise<void>;
 }

--- a/src/test/fixtures/fake-group-store.ts
+++ b/src/test/fixtures/fake-group-store.ts
@@ -125,4 +125,8 @@ export default class FakeGroupStore implements IGroupStore {
     hasProjectRole(groupId: number): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
+
+    deleteScimGroups(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
 }

--- a/src/test/fixtures/fake-user-store.ts
+++ b/src/test/fixtures/fake-user-store.ts
@@ -159,6 +159,10 @@ class UserStoreMock implements IUserStore {
         return Promise.resolve(undefined);
     }
 
+    deleteScimUsers(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
     upsert(user: ICreateUser): Promise<IUser> {
         this.data.splice(this.data.findIndex((u) => u.email === user.email));
         const userToReturn = {


### PR DESCRIPTION
# Summary 

Adds a way to remove SCIM entities if you're an admin

## Frontend Changes

Groups and users can now be deleted if they originate from SCIM, the usual deletion buttons have just been re-enabled.

The UI for SCIM setup itself has been given two new buttons, one each for nuking all SCIM groups and users. This requires a [companion PR](https://github.com/bricks-software/unleash-enterprise/pull/35) on enterprise to work correctly. I've opted specifically to add these buttons to the SCIM setup interface because this is more a SCIM problem that a group/user problem from a user perspective and because this really shouldn't be part of the standard manage groups/users flow,

## Backend Changes

Group/user deletion code no longer rejects calls if the group/user is a SCIM entity.

A method for deleting all users has been added to the user-service. This is specifically not added to the SCIM code because that code is for handling callers from the outside world wanting to work against the SCIM protocol. 

## Discussion

This has added two new events for bulk deletion. Those events do not do a pre-data/post data check, which means they show up in the event log as just "ScimGroupsDeleted". I'm not convinced this is the correct choice because audit logs should show a full record of what happened. That being said, this is very much an escape hatch for SCIM if something goes wrong and I'm worried about dropping a 70K entity change into the event log, both from a UI sanity perspective and from a melt-the-database perspective
