### PR TITLE
feat: ability to communicate other license messages

### DIFF
--- a/frontend/src/component/banners/internalBanners/LicenseBanner.tsx
+++ b/frontend/src/component/banners/internalBanners/LicenseBanner.tsx
@@ -1,28 +1,45 @@
 import { Banner } from 'component/banners/Banner/Banner';
-import { useLicenseCheck } from 'hooks/api/getters/useLicense/useLicense';
+import {
+    useLicense,
+    useLicenseCheck,
+} from 'hooks/api/getters/useLicense/useLicense';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import type { BannerVariant } from 'interfaces/banner';
 
 export const LicenseBanner = () => {
     const { isEnterprise } = useUiConfig();
     const licenseInfo = useLicenseCheck();
+    const license = useLicense();
 
     // Only for enterprise
     if (
         isEnterprise() &&
         licenseInfo &&
-        !licenseInfo.isValid &&
         !licenseInfo.loading &&
         !licenseInfo.error
     ) {
-        const banner = {
-            message:
-                licenseInfo.message || 'You have an invalid Unleash license.',
-            variant: 'error' as BannerVariant,
-            sticky: true,
-        };
+        if (!licenseInfo.isValid) {
+            const banner = {
+                message:
+                    licenseInfo.message ||
+                    'You have an invalid Unleash license.',
+                variant: 'error' as BannerVariant,
+                sticky: true,
+            };
 
-        return <Banner key={banner.message} banner={banner} />;
+            return <Banner key={banner.message} banner={banner} />;
+        } else {
+            if (!license.loading && !license.error && licenseInfo.message) {
+                const banner = {
+                    message: licenseInfo.message,
+                    variant:
+                        licenseInfo.messageType ?? ('warning' as BannerVariant),
+                    sticky: true,
+                };
+                return <Banner key={banner.message} banner={banner} />;
+            }
+        }
     }
+
     return null;
 };

--- a/frontend/src/hooks/api/getters/useLicense/useLicense.ts
+++ b/frontend/src/hooks/api/getters/useLicense/useLicense.ts
@@ -2,10 +2,12 @@ import useSWR from 'swr';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
+import type { BannerVariant } from 'interfaces/banner';
 
 export interface LicenseInfo {
     isValid: boolean;
     message?: string;
+    messageType?: BannerVariant;
     loading: boolean;
     reCheckLicense: () => void;
     error?: Error;


### PR DESCRIPTION
## About the changes
This gives us the ability to communicate other license messages which are not errors. By default they'll be warning but I'm opening the possibility of using a backend-provided value to make them informative instead of warning.

The intention is to communicate things like:
- Your license is about to expire in x days.
- You are getting close to the maximum number of seats in your license
- etc