### PR TITLE
fix: make traffic usage test more robust by using this month's actual numbers

### DIFF
--- a/frontend/src/hooks/useTrafficData.test.ts
+++ b/frontend/src/hooks/useTrafficData.test.ts
@@ -139,6 +139,6 @@ describe('traffic overage calculation', () => {
         const overage = totalExpectedUsage - includedTraffic;
         const overageUnits = Math.floor(overage / trafficUnitSize);
         const total = overageUnits * trafficUnitCost;
-        expect(result).toBeGreaterThanOrEqual(total);
+        expect(result).toBe(total);
     });
 });

--- a/frontend/src/hooks/useTrafficData.test.ts
+++ b/frontend/src/hooks/useTrafficData.test.ts
@@ -1,3 +1,4 @@
+import { getDaysInMonth } from 'date-fns';
 import {
     toSelectablePeriod,
     calculateOverageCost,
@@ -122,18 +123,22 @@ describe('traffic overage calculation', () => {
         const now = new Date();
         const period = toSelectablePeriod(now);
         const testNow = new Date(now.getFullYear(), now.getMonth(), 5);
+        const includedTraffic = 53_000_000;
+        const trafficUnitSize = 500_000;
+        const trafficUnitCost = 10;
         const result = calculateEstimatedMonthlyCost(
             period.key,
             testData,
-            53_000_000,
+            includedTraffic,
             testNow,
-            10,
-            500_000,
+            trafficUnitCost,
+            trafficUnitSize,
         );
-        // 22_500_000 * 3 * 30 = 2_025_000_000 total usage
-        // 2_025_000_000 - 53_000_000 = 1_972_000_000 overage
-        // 1_972_000_000 / 500_000 = 3_944 overage units
-        // 3_944 * 10 = 39_440
-        expect(result).toBeGreaterThanOrEqual(39_440);
+
+        const totalExpectedUsage = 22_500_000 * 3 * getDaysInMonth(now);
+        const overage = totalExpectedUsage - includedTraffic;
+        const overageUnits = Math.floor(overage / trafficUnitSize);
+        const total = overageUnits * trafficUnitCost;
+        expect(result).toBeGreaterThanOrEqual(total);
     });
 });


### PR DESCRIPTION
The test was breaking because it assumed a month would have at least
30 days.

Because the test relies on the current month, this isn't necessarily true.

Further, there's parts of the code that relies on "impure" state via
the "current date" (which will change based on when you run it), so
setting a specific month in the test won't work.

As such, this test makes the calculation explicit and uses the number
of days in the current month.