### PR TITLE
refactor: period selector component

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -14,7 +14,7 @@ const BaseButton = styled('button', {
 })<{ selected?: boolean }>(({ theme, selected }) => ({
     cursor: 'pointer',
     border: 'none',
-    backgroundColor: selected ? theme.palette.secondary.light : 'none',
+    backgroundColor: selected ? theme.palette.secondary.light : 'inherit',
     fontSize: theme.typography.body1.fontSize,
     padding: theme.spacing(0.5),
     borderRadius: theme.shape.borderRadius,
@@ -24,15 +24,15 @@ const BaseButton = styled('button', {
     ':focus': {
         outline: `2px solid ${theme.palette.primary.main}`,
     },
+    ':hover:not(:disabled)': {
+        backgroundColor: theme.palette.action.hover,
+    },
 }));
 
 const GridButton = styled(BaseButton)(({ theme }) => ({
     ':disabled': {
         cursor: 'default',
         color: theme.palette.text.disabled,
-    },
-    ':hover:not(:disabled)': {
-        backgroundColor: theme.palette.action.hover,
     },
 }));
 
@@ -68,30 +68,6 @@ const Wrapper = styled('article')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'column',
     gap: theme.spacing(2),
-    button: {
-        cursor: 'pointer',
-        border: 'none',
-        background: 'none',
-        fontSize: theme.typography.body1.fontSize,
-        padding: theme.spacing(0.5),
-        borderRadius: theme.shape.borderRadius,
-        color: theme.palette.text.primary,
-        transition: 'background-color 0.2s ease',
-
-        '&.selected': {
-            backgroundColor: theme.palette.secondary.light,
-        },
-    },
-    'button:disabled': {
-        cursor: 'default',
-        color: theme.palette.text.disabled,
-    },
-    'button:hover:not(:disabled)': {
-        backgroundColor: theme.palette.action.hover,
-    },
-    'button:focus': {
-        outline: `2px solid ${theme.palette.primary.main}`,
-    },
 }));
 
 const MonthSelector = styled('article')(({ theme }) => ({
@@ -140,14 +116,6 @@ const RangeList = styled('ul')(({ theme }) => ({
     width: '100%',
     li: {
         width: '100%',
-    },
-
-    button: {
-        width: '100%',
-        paddingBlock: theme.spacing(1),
-        textAlign: 'left',
-        borderRadius: 0,
-        paddingInline: dropdownInlinePadding(theme),
     },
 }));
 

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -71,7 +71,6 @@ const Wrapper = styled('article')(({ theme }) => ({
 }));
 
 const MonthSelector = styled('article')(({ theme }) => ({
-    border: 'none',
     paddingInline: dropdownInlinePadding(theme),
     hgroup: {
         h3: {
@@ -93,7 +92,6 @@ const MonthGrid = styled('ul')(({ theme }) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(4, 1fr)',
     rowGap: theme.spacing(1),
-    columnGap: theme.spacing(2),
 }));
 
 const RangeSelector = styled('article')(({ theme }) => ({

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -21,7 +21,7 @@ const BaseButton = styled('button', {
     color: theme.palette.text.primary,
     transition: 'background-color 0.2s ease',
 
-    ':focus': {
+    ':focus-visible': {
         outline: `2px solid ${theme.palette.primary.main}`,
     },
     ':hover:not(:disabled)': {

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -9,6 +9,59 @@ import { selectablePeriods } from './selectable-periods';
 const dropdownWidth = '15rem';
 const dropdownInlinePadding = (theme: Theme) => theme.spacing(3);
 
+const BaseButton = styled('button', {
+    shouldForwardProp: (prop) => prop !== 'selected',
+})<{ selected?: boolean }>(({ theme, selected }) => ({
+    cursor: 'pointer',
+    border: 'none',
+    backgroundColor: selected ? theme.palette.secondary.light : 'none',
+    fontSize: theme.typography.body1.fontSize,
+    padding: theme.spacing(0.5),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.text.primary,
+    transition: 'background-color 0.2s ease',
+
+    ':focus': {
+        outline: `2px solid ${theme.palette.primary.main}`,
+    },
+}));
+
+const GridButton = styled(BaseButton)(({ theme }) => ({
+    ':disabled': {
+        cursor: 'default',
+        color: theme.palette.text.disabled,
+    },
+    ':hover:not(:disabled)': {
+        backgroundColor: theme.palette.action.hover,
+    },
+}));
+
+const RangeButton = styled(BaseButton)(({ theme }) => ({
+    width: '100%',
+    paddingBlock: theme.spacing(1),
+    textAlign: 'left',
+    borderRadius: 0,
+    paddingInline: dropdownInlinePadding(theme),
+}));
+
+const SelectorDropdownButton = styled(Button)(({ theme }) => ({
+    whiteSpace: 'nowrap',
+    width: dropdownWidth,
+    justifyContent: 'space-between',
+    fontWeight: 'normal',
+    color: theme.palette.text.primary,
+    borderColor: theme.palette.divider,
+    ':focus-within': {
+        borderColor: theme.palette.primary.main,
+    },
+    ':hover': {
+        borderColor: theme.palette.text.disabled,
+        backgroundColor: 'inherit',
+    },
+
+    transition: 'border-color 0.1s ease',
+}));
+
 const Wrapper = styled('article')(({ theme }) => ({
     width: dropdownWidth,
     paddingBlock: theme.spacing(2),
@@ -136,31 +189,14 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
 
     return (
         <Box ref={ref}>
-            <Button
+            <SelectorDropdownButton
                 endIcon={open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
-                sx={(theme) => ({
-                    whiteSpace: 'nowrap',
-                    width: dropdownWidth,
-                    justifyContent: 'space-between',
-                    fontWeight: 'normal',
-                    color: theme.palette.text.primary,
-                    borderColor: theme.palette.divider,
-                    ':focus-within': {
-                        borderColor: theme.palette.primary.main,
-                    },
-                    ':hover': {
-                        borderColor: theme.palette.text.disabled,
-                        backgroundColor: 'inherit',
-                    },
-
-                    transition: 'border-color 0.1s ease',
-                })}
                 variant='outlined'
                 disableRipple
                 onClick={() => setOpen(true)}
             >
                 {buttonText}
-            </Button>
+            </SelectorDropdownButton>
             <StyledPopover
                 open={open}
                 anchorEl={ref.current}
@@ -183,15 +219,12 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                         <MonthGrid>
                             {selectablePeriods.map((period, index) => (
                                 <li key={period.label}>
-                                    <button
-                                        className={
+                                    <GridButton
+                                        selected={
                                             selectedPeriod.grouping ===
                                                 'daily' &&
                                             period.key === selectedPeriod.month
-                                                ? 'selected'
-                                                : ''
                                         }
-                                        type='button'
                                         disabled={!period.selectable}
                                         onClick={() => {
                                             selectPeriod({
@@ -201,7 +234,7 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                                         }}
                                     >
                                         {period.shortLabel}
-                                    </button>
+                                    </GridButton>
                                 </li>
                             ))}
                         </MonthGrid>
@@ -212,14 +245,12 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                         <RangeList>
                             {rangeOptions.map((option) => (
                                 <li key={option.label}>
-                                    <button
-                                        className={
+                                    <RangeButton
+                                        selected={
                                             selectedPeriod.grouping ===
                                                 'monthly' &&
                                             option.value ===
                                                 selectedPeriod.monthsBack
-                                                ? 'selected'
-                                                : ''
                                         }
                                         type='button'
                                         onClick={() => {
@@ -230,7 +261,7 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                                         }}
                                     >
                                         Last {option.value} months
-                                    </button>
+                                    </RangeButton>
                                 </li>
                             ))}
                         </RangeList>

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/PeriodSelector.tsx
@@ -72,17 +72,16 @@ const Wrapper = styled('article')(({ theme }) => ({
 
 const MonthSelector = styled('article')(({ theme }) => ({
     paddingInline: dropdownInlinePadding(theme),
-    hgroup: {
-        h3: {
-            margin: 0,
-            fontSize: theme.typography.h3.fontSize,
-        },
-        p: {
-            color: theme.palette.text.secondary,
-            fontSize: theme.typography.body2.fontSize,
-        },
+}));
 
-        marginBottom: theme.spacing(1),
+const MonthSelectorHeaderGroup = styled('hgroup')(({ theme }) => ({
+    h3: {
+        margin: 0,
+        fontSize: theme.typography.h3.fontSize,
+    },
+    p: {
+        color: theme.palette.text.secondary,
+        fontSize: theme.typography.body2.fontSize,
     },
 }));
 
@@ -98,13 +97,15 @@ const RangeSelector = styled('article')(({ theme }) => ({
     display: 'flex',
     width: '100%',
     flexFlow: 'column',
-    gap: theme.spacing(0),
-    h4: {
-        paddingInline: dropdownInlinePadding(theme),
-        fontSize: theme.typography.body2.fontSize,
-        margin: 0,
-        color: theme.palette.text.secondary,
-    },
+    gap: theme.spacing(0.5),
+}));
+
+const RangeHeader = styled('p')(({ theme }) => ({
+    paddingInline: dropdownInlinePadding(theme),
+    fontSize: theme.typography.body2.fontSize,
+    margin: 0,
+    color: theme.palette.text.secondary,
+    fontWeight: 'bold',
 }));
 
 const RangeList = styled('ul')(({ theme }) => ({
@@ -178,10 +179,10 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
             >
                 <Wrapper>
                     <MonthSelector>
-                        <hgroup>
+                        <MonthSelectorHeaderGroup>
                             <h3>Select month</h3>
                             <p>Last 12 months</p>
-                        </hgroup>
+                        </MonthSelectorHeaderGroup>
                         <MonthGrid>
                             {selectablePeriods.map((period, index) => (
                                 <li key={period.label}>
@@ -206,7 +207,7 @@ export const PeriodSelector: FC<Props> = ({ selectedPeriod, setPeriod }) => {
                         </MonthGrid>
                     </MonthSelector>
                     <RangeSelector>
-                        <h4>Range</h4>
+                        <RangeHeader>Range</RangeHeader>
 
                         <RangeList>
                             {rangeOptions.map((option) => (


### PR DESCRIPTION
Refactors the period selector component now that the design / system is pretty much finished.

Main points are: change from using CSS selectors to using styled components; use props instead of classes. This is in keeping with the general Unleash approach.

There's two very slight visual changes here:
1. There is 4px of added space below the "range" "header" text.
2. The months in the grid are a little closer together and not as wide. This is because we remove the explicit column gap due to the grid having a set width. Previously the width was automatic, but because we want this to line up with the button, we need to set the width explicitly on both items. As such, with the padding, the grid was a little too wide, so there was too little padding on the right. This rectifies that.