### PR TITLE
fix: now hydration event is being returned if revision does not exist in cache

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -173,7 +173,6 @@ export class ClientFeatureToggleDelta {
             return Promise.resolve(response);
         } else {
             const environmentEvents = delta.getEvents();
-            // TODO: check if the rev exists in cache, if not return hydration
             const events = filterEventsByQuery(
                 environmentEvents,
                 requiredRevisionId,
@@ -305,7 +304,6 @@ export class ClientFeatureToggleDelta {
     }
 
     private async initEnvironmentDelta(environment: string) {
-        // Todo: replace with method that gets all features for an environment
         const baseFeatures = await this.getClientFeatures({
             environment,
         });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -154,8 +154,12 @@ export class ClientFeatureToggleDelta {
         if (requiredRevisionId >= this.currentRevisionId) {
             return undefined;
         }
-        if (requiredRevisionId === 0) {
-            const hydrationEvent = this.delta[environment].getHydrationEvent();
+        const delta = this.delta[environment];
+        if (
+            requiredRevisionId === 0 ||
+            delta.isMissingRevision(requiredRevisionId)
+        ) {
+            const hydrationEvent = delta.getHydrationEvent();
             const filteredEvent = filterHydrationEventByQuery(
                 hydrationEvent,
                 projects,
@@ -168,7 +172,8 @@ export class ClientFeatureToggleDelta {
 
             return Promise.resolve(response);
         } else {
-            const environmentEvents = this.delta[environment].getEvents();
+            const environmentEvents = delta.getEvents();
+            // TODO: check if the rev exists in cache, if not return hydration
             const events = filterEventsByQuery(
                 environmentEvents,
                 requiredRevisionId,
@@ -299,7 +304,7 @@ export class ClientFeatureToggleDelta {
         });
     }
 
-    public async initEnvironmentDelta(environment: string) {
+    private async initEnvironmentDelta(environment: string) {
         // Todo: replace with method that gets all features for an environment
         const baseFeatures = await this.getClientFeatures({
             environment,

--- a/src/lib/features/client-feature-toggles/delta/delta-cache.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.ts
@@ -12,6 +12,22 @@ export class DeltaCache {
     constructor(hydrationEvent: DeltaHydrationEvent, maxLength: number = 20) {
         this.hydrationEvent = hydrationEvent;
         this.maxLength = maxLength;
+
+        this.addBaseEventFromHydration(hydrationEvent);
+    }
+
+    private addBaseEventFromHydration(
+        hydrationEvent: DeltaHydrationEvent,
+    ): void {
+        const lastFeature =
+            hydrationEvent.features[hydrationEvent.features.length - 1];
+        this.addEvents([
+            {
+                eventId: hydrationEvent.eventId,
+                type: 'feature-updated',
+                feature: lastFeature,
+            },
+        ]);
     }
 
     public addEvents(events: DeltaEvent[]): void {
@@ -25,6 +41,10 @@ export class DeltaCache {
 
     public getEvents(): DeltaEvent[] {
         return this.events;
+    }
+
+    public isMissingRevision(revisionId: number): boolean {
+        return !this.events.some((event) => event.eventId === revisionId);
     }
 
     public getHydrationEvent(): DeltaHydrationEvent {


### PR DESCRIPTION
Now when customer is coming with revision ID that does not exist in cache, we return hydration.