### PR TITLE
chore(1-3335): filters data coming from the API to remove data points we're not  interested in

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/endpoint-info.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/endpoint-info.ts
@@ -1,10 +1,14 @@
+import type { METERED_TRAFFIC_ENDPOINTS } from 'utils/traffic-calculations';
 export type EndpointInfo = {
     label: string;
     color: string;
     order: number;
 };
 
-export const endpointsInfo: Record<string, EndpointInfo> = {
+export const endpointsInfo: Record<
+    (typeof METERED_TRAFFIC_ENDPOINTS)[number],
+    EndpointInfo
+> = {
     '/api/admin': {
         label: 'Admin',
         color: '#6D66D9',

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/selectable-periods.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/selectable-periods.ts
@@ -1,5 +1,6 @@
 import { getDaysInMonth, subMonths } from 'date-fns';
 import { currentDate, formatMonth } from './dates';
+import { TRAFFIC_MEASUREMENT_START_DATE } from 'utils/traffic-calculations';
 
 export type Period = {
     key: string;
@@ -45,7 +46,11 @@ const generateSelectablePeriodsFromDate = (now: Date) => {
     ) {
         const date = subMonths(now, subtractMonthCount);
         selectablePeriods.push(
-            toSelectablePeriod(date, undefined, date >= new Date('2024-05')),
+            toSelectablePeriod(
+                date,
+                undefined,
+                date >= TRAFFIC_MEASUREMENT_START_DATE,
+            ),
         );
     }
     return selectablePeriods;

--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -6,6 +6,7 @@ import type {
     TrafficUsageDataSegmentedCombinedSchema,
     TrafficUsageDataSegmentedSchema,
 } from 'openapi';
+import { cleanTrafficData } from 'utils/traffic-calculations';
 
 export interface IInstanceTrafficMetricsResponse {
     usage: TrafficUsageDataSegmentedSchema;
@@ -62,7 +63,7 @@ export const useInstanceTrafficMetrics2 = (
 
     return useMemo(
         () => ({
-            usage: data,
+            usage: cleanTrafficData(data) as any,
             loading: !error && !data,
             refetch: () => mutate(),
             error,

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -7,14 +7,17 @@ import {
     daysInCurrentMonth,
 } from '../component/admin/network/NetworkTrafficUsage/dates';
 import type { ChartDatasetType } from '../component/admin/network/NetworkTrafficUsage/chart-functions';
-import { endpointsInfo } from 'component/admin/network/NetworkTrafficUsage/endpoint-info';
 
 const DEFAULT_TRAFFIC_DATA_UNIT_COST = 5;
 const DEFAULT_TRAFFIC_DATA_UNIT_SIZE = 1_000_000;
 
-// This is the first full month of data that we have on record for any of our
-// customers.
 export const TRAFFIC_MEASUREMENT_START_DATE = new Date('2024-05-01');
+
+export const METERED_TRAFFIC_ENDPOINTS = [
+    '/api/admin',
+    '/api/frontend',
+    '/api/client',
+];
 
 export const cleanTrafficData = (
     data?: TrafficUsageDataSegmentedCombinedSchema,
@@ -25,7 +28,7 @@ export const cleanTrafficData = (
 
     const { apiData, ...rest } = data;
     const cleanedApiData = apiData
-        .filter((item) => item.apiPath in endpointsInfo)
+        .filter((item) => METERED_TRAFFIC_ENDPOINTS.includes(item.apiPath))
         .map((item) => {
             item.dataPoints = item.dataPoints.filter(
                 ({ period }) =>
@@ -36,6 +39,7 @@ export const cleanTrafficData = (
     return { apiData: cleanedApiData, ...rest };
 };
 
+// todo: extract "currentMonth" into a function argument instead
 const monthlyTrafficDataToCurrentUsage = (
     apiData: TrafficUsageDataSegmentedCombinedSchemaApiDataItem[],
 ) => {

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -7,20 +7,33 @@ import {
     daysInCurrentMonth,
 } from '../component/admin/network/NetworkTrafficUsage/dates';
 import type { ChartDatasetType } from '../component/admin/network/NetworkTrafficUsage/chart-functions';
+import { endpointsInfo } from 'component/admin/network/NetworkTrafficUsage/endpoint-info';
 
 const DEFAULT_TRAFFIC_DATA_UNIT_COST = 5;
 const DEFAULT_TRAFFIC_DATA_UNIT_SIZE = 1_000_000;
 
-// todo: implement and test
-export const filterData = (
+// This is the first full month of data that we have on record for any of our
+// customers.
+export const TRAFFIC_MEASUREMENT_START_DATE = new Date('2024-05-01');
+
+export const cleanTrafficData = (
     data?: TrafficUsageDataSegmentedCombinedSchema,
 ): TrafficUsageDataSegmentedCombinedSchema | undefined => {
     if (!data) {
         return;
     }
-    // filter out endpoints not mentioned in endpointsInfo
-    // filter out any data from before May 2024
-    return data;
+
+    const { apiData, ...rest } = data;
+    const cleanedApiData = apiData
+        .filter((item) => item.apiPath in endpointsInfo)
+        .map((item) => {
+            item.dataPoints = item.dataPoints.filter(
+                ({ period }) =>
+                    new Date(period) >= TRAFFIC_MEASUREMENT_START_DATE,
+            );
+            return item;
+        });
+    return { apiData: cleanedApiData, ...rest };
 };
 
 const monthlyTrafficDataToCurrentUsage = (


### PR DESCRIPTION
Implements a function that cleans and filters incoming data from the
new traffic API.

Specifically, it:
- Removes `/edge` data points
- Removes any data from before may 2024, which is the first full month we have on record

Because all uses of the existing hook do this filtering themselves, I
have added the filtering at the hook level. This is to avoid
forgetting this filtering later. If we find out we need this data, we
can move the filtering.