### PR TITLE
feat: render markdown in toats

### DIFF
--- a/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
+++ b/frontend/src/component/common/ToastRenderer/Toast/Toast.tsx
@@ -6,6 +6,7 @@ import CheckMarkBadge from 'component/common/CheckmarkBadge/CheckMarkBadge';
 import UIContext from 'contexts/UIContext';
 import Close from '@mui/icons-material/Close';
 import type { IToast } from 'interfaces/toast';
+import { Markdown } from 'component/common/Markdown/Markdown';
 
 const Toast = ({ text, type }: IToast) => {
     const { setToast } = useContext(UIContext);
@@ -20,7 +21,9 @@ const Toast = ({ text, type }: IToast) => {
         <div className={classnames(styles.container, 'dropdown-outline')}>
             <CheckMarkBadge type={type} className={styles.checkMark} />
 
-            <h3 className={styles.headerStyles}>{text}</h3>
+            <h3 className={styles.headerStyles}>
+                <Markdown>{text}</Markdown>
+            </h3>
 
             <Tooltip title='Close' arrow>
                 <IconButton


### PR DESCRIPTION
## About the changes
Toasts sometimes render messages that are in markdown format. This changes how we display them from 
![image](https://github.com/user-attachments/assets/61930d1d-b54c-49a0-b982-af1484cd2981)
to this:
![Screenshot from 2025-02-04 15-23-36](https://github.com/user-attachments/assets/a569345c-abf5-4d9d-9cf6-4c94701689c7)
