### PR TITLE
chore: clear scim fields when deleting user + migration for existing cases

### DIFF
--- a/src/lib/db/user-store.ts
+++ b/src/lib/db/user-store.ts
@@ -197,6 +197,8 @@ class UserStore implements IUserStore {
                 deleted_at: new Date(),
                 email: null,
                 username: null,
+                scim_id: null,
+                scim_external_id: null,
                 name: this.db.raw('name || ?', '(Deleted)'),
             });
     }

--- a/src/migrations/20250205072305-clean-scim-id-from-deleted-users.js
+++ b/src/migrations/20250205072305-clean-scim-id-from-deleted-users.js
@@ -1,0 +1,14 @@
+exports.up = (db, cb) => {
+    db.runSql(`
+        UPDATE users
+        SET
+            scim_id = NULL,
+            scim_external_id = NULL
+        WHERE deleted_at IS NOT NULL AND scim_id IS NOT NULL;
+    `, cb);
+
+  };
+
+  exports.down = (db, cb) => {
+    cb();
+  };


### PR DESCRIPTION
users.scim_id is unique and will cause collision errors when reinserted.

PR adds a migration that clears scim_id and scim_external_id fields on deleted users, and clears scim_id and scim_external_id when deleting users through user store