### PR TITLE
chore(1-3342): extract into hook, use new endpoint if flag on

### DIFF
--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPAYG.tsx
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPAYG.tsx
@@ -11,11 +11,8 @@ import {
     BILLING_PAYG_USER_PRICE,
     BILLING_TRAFFIC_BUNDLE_PRICE,
 } from './BillingPlan';
-import { useTrafficDataEstimation } from 'hooks/useTrafficData';
-import { useInstanceTrafficMetrics } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
-import { useMemo } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { calculateOverageCost } from 'utils/traffic-calculations';
+import { useOverageCost } from './useOverageCost';
 
 const StyledInfoLabel = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.smallBody,
@@ -34,13 +31,6 @@ export const BillingDetailsPAYG = ({
     instanceStatus,
 }: IBillingDetailsPAYGProps) => {
     const { users, loading } = useUsers();
-    const {
-        currentPeriod,
-        toChartData,
-        toTrafficUsageSum,
-        endpointsInfo,
-        getDayLabels,
-    } = useTrafficDataEstimation();
 
     const eligibleUsers = users.filter((user) => user.email);
 
@@ -51,24 +41,7 @@ export const BillingDetailsPAYG = ({
     const usersCost = BILLING_PAYG_USER_PRICE * billableUsers;
 
     const includedTraffic = BILLING_INCLUDED_REQUESTS;
-    const traffic = useInstanceTrafficMetrics(currentPeriod.key);
-
-    const overageCost = useMemo(() => {
-        if (!includedTraffic) {
-            return 0;
-        }
-        const trafficData = toChartData(
-            getDayLabels(currentPeriod.dayCount),
-            traffic,
-            endpointsInfo,
-        );
-        const totalTraffic = toTrafficUsageSum(trafficData);
-        return calculateOverageCost(
-            totalTraffic,
-            includedTraffic,
-            BILLING_TRAFFIC_BUNDLE_PRICE,
-        );
-    }, [includedTraffic, traffic, currentPeriod, endpointsInfo]);
+    const overageCost = useOverageCost(includedTraffic);
 
     const totalCost = usersCost + overageCost;
 

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -1,0 +1,72 @@
+import { endOfMonth, format, startOfMonth } from 'date-fns';
+import { useTrafficSearch } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
+import { useMemo } from 'react';
+import {
+    calculateOverageCost,
+    calculateTotalUsage,
+} from 'utils/traffic-calculations';
+import { BILLING_TRAFFIC_BUNDLE_PRICE } from './BillingPlan';
+import { useUiFlag } from 'hooks/useUiFlag';
+
+export const useOverageCost = (includedTraffic: number) => {
+    if (useUiFlag('dataUsageMultiMonthView')) {
+        return useNewOverageCostCalculation(includedTraffic);
+    } else {
+        return useOldOverageCostCalculation(includedTraffic);
+    }
+};
+
+const useNewOverageCostCalculation = (includedTraffic: number) => {
+    if (!includedTraffic) {
+        return 0;
+    }
+
+    const now = new Date();
+    const formatDate = (date: Date) => format(date, 'yyyy-MM-dd');
+    const from = formatDate(startOfMonth(now));
+    const to = formatDate(endOfMonth(now));
+
+    const { usage } = useTrafficSearch('daily', { from, to });
+
+    const overageCost = useMemo(() => {
+        const totalUsage = calculateTotalUsage(usage);
+        return calculateOverageCost(
+            totalUsage,
+            includedTraffic,
+            BILLING_TRAFFIC_BUNDLE_PRICE,
+        );
+    }, [includedTraffic, usage]);
+
+    return overageCost;
+};
+
+const useOldOverageCostCalculation = (includedTraffic: number) => {
+    const {
+        currentPeriod,
+        toChartData,
+        toTrafficUsageSum,
+        endpointsInfo,
+        getDayLabels,
+    } = useTrafficDataEstimation();
+
+    const traffic = useInstanceTrafficMetrics(currentPeriod.key);
+
+    const overageCost = useMemo(() => {
+        if (!includedTraffic) {
+            return 0;
+        }
+        const trafficData = toChartData(
+            getDayLabels(currentPeriod.dayCount),
+            traffic,
+            endpointsInfo,
+        );
+        const totalTraffic = toTrafficUsageSum(trafficData);
+        return calculateOverageCost(
+            totalTraffic,
+            includedTraffic,
+            BILLING_TRAFFIC_BUNDLE_PRICE,
+        );
+    }, [includedTraffic, traffic, currentPeriod, endpointsInfo]);
+
+    return overageCost;
+};

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -1,5 +1,8 @@
 import { endOfMonth, format, startOfMonth } from 'date-fns';
-import { useTrafficSearch } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
+import {
+    useInstanceTrafficMetrics,
+    useTrafficSearch,
+} from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
 import { useMemo } from 'react';
 import {
     calculateOverageCost,
@@ -7,6 +10,7 @@ import {
 } from 'utils/traffic-calculations';
 import { BILLING_TRAFFIC_BUNDLE_PRICE } from './BillingPlan';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { useTrafficDataEstimation } from 'hooks/useTrafficData';
 
 export const useOverageCost = (includedTraffic: number) => {
     if (useUiFlag('dataUsageMultiMonthView')) {

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -22,7 +22,7 @@ import {
 import { Bar } from 'react-chartjs-2';
 import {
     useInstanceTrafficMetrics,
-    useInstanceTrafficMetrics2,
+    useTrafficSearch,
 } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
 import type { Theme } from '@mui/material/styles/createTheme';
 import Grid from '@mui/material/Grid';
@@ -231,7 +231,7 @@ const NewNetworkTrafficUsage: FC = () => {
         );
     }, [theme, chartDataSelection]);
 
-    const traffic = useInstanceTrafficMetrics2(
+    const traffic = useTrafficSearch(
         chartDataSelection.grouping,
         toDateRange(chartDataSelection, currentDate),
     );

--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -47,7 +47,7 @@ export type InstanceTrafficMetricsResponse2 = {
     error?: Error;
 };
 
-export const useInstanceTrafficMetrics2 = (
+export const useTrafficSearch = (
     grouping: 'monthly' | 'daily',
     {
         from,


### PR DESCRIPTION
Updates the existing BillingDetails pages (pro and payg) to use the new traffic search endpoint (and calculations) if the flag to do so is on. Otherwise, it falls back to using the existing method. 

I've extracted the overage calculation into a separate shared hook.