### PR TITLE
refactor: add functions to estimate monthly usage from data directly

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -47,7 +47,6 @@ import {
     calculateEstimatedMonthlyCost,
 } from 'utils/traffic-calculations';
 import { currentDate, currentMonth } from './dates';
-import { endpointsInfo } from './endpoint-info';
 import { type ChartDataSelection, toDateRange } from './chart-data-selection';
 import {
     type ChartDatasetType,
@@ -301,7 +300,6 @@ const NewNetworkTrafficUsage: FC = () => {
                                         chartDataSelection.grouping === 'daily'
                                             ? usageTotal
                                             : averageTrafficPreviousMonths(
-                                                  Object.keys(endpointsInfo),
                                                   traffic.usage,
                                               )
                                     }

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -248,7 +248,7 @@ const NewNetworkTrafficUsage: FC = () => {
     );
 
     const estimatedMonthlyCost = calculateEstimatedMonthlyCost(
-        traffic.usage.apiData,
+        traffic.usage?.apiData,
         includedTraffic,
         currentDate,
         BILLING_TRAFFIC_BUNDLE_PRICE,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -28,7 +28,10 @@ import type { Theme } from '@mui/material/styles/createTheme';
 import Grid from '@mui/material/Grid';
 import { NetworkTrafficUsagePlanSummary } from './NetworkTrafficUsagePlanSummary';
 import annotationPlugin from 'chartjs-plugin-annotation';
-import { useTrafficDataEstimation } from 'hooks/useTrafficData';
+import {
+    useTrafficDataEstimation,
+    calculateEstimatedMonthlyCost as deprecatedCalculateEstimatedMonthlyCost,
+} from 'hooks/useTrafficData';
 import { customHighlightPlugin } from 'component/common/Chart/customHighlightPlugin';
 import { formatTickValue } from 'component/common/Chart/formatTickValue';
 import { useTrafficLimit } from './hooks/useTrafficLimit';
@@ -245,10 +248,7 @@ const NewNetworkTrafficUsage: FC = () => {
     );
 
     const estimatedMonthlyCost = calculateEstimatedMonthlyCost(
-        chartDataSelection.grouping === 'daily'
-            ? chartDataSelection.month
-            : currentMonth,
-        data.datasets,
+        traffic.usage.apiData,
         includedTraffic,
         currentDate,
         BILLING_TRAFFIC_BUNDLE_PRICE,
@@ -428,7 +428,7 @@ const OldNetworkTrafficUsage: FC = () => {
                 setOverageCost(calculatedOverageCost);
 
                 setEstimatedMonthlyCost(
-                    calculateEstimatedMonthlyCost(
+                    deprecatedCalculateEstimatedMonthlyCost(
                         period,
                         data.datasets,
                         includedTraffic,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
@@ -2,7 +2,6 @@ import { differenceInCalendarMonths, format } from 'date-fns';
 import type { TrafficUsageDataSegmentedCombinedSchema } from 'openapi';
 
 export const averageTrafficPreviousMonths = (
-    endpointData: string[],
     traffic: TrafficUsageDataSegmentedCombinedSchema,
 ) => {
     if (!traffic || traffic.grouping === 'daily') {
@@ -19,7 +18,6 @@ export const averageTrafficPreviousMonths = (
     const currentMonth = format(new Date(), 'yyyy-MM');
 
     const totalTraffic = traffic.apiData
-        .filter((endpoint) => endpointData.includes(endpoint.apiPath))
         .map((endpoint) =>
             endpoint.dataPoints
                 .filter(({ period }) => period !== currentMonth)

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
@@ -1,5 +1,6 @@
-import { differenceInCalendarMonths, format } from 'date-fns';
+import { differenceInCalendarMonths } from 'date-fns';
 import type { TrafficUsageDataSegmentedCombinedSchema } from 'openapi';
+import { currentMonth } from './dates';
 
 export const averageTrafficPreviousMonths = (
     traffic: TrafficUsageDataSegmentedCombinedSchema,
@@ -14,8 +15,6 @@ export const averageTrafficPreviousMonths = (
             new Date(traffic.dateRange.from),
         ),
     );
-
-    const currentMonth = format(new Date(), 'yyyy-MM');
 
     const totalTraffic = traffic.apiData
         .map((endpoint) =>

--- a/frontend/src/utils/traffic-calculations.test.ts
+++ b/frontend/src/utils/traffic-calculations.test.ts
@@ -1,8 +1,8 @@
 import { format, getDaysInMonth } from 'date-fns';
 import {
-    calculateEstimatedMonthlyCost2,
+    calculateEstimatedMonthlyCost,
     calculateOverageCost,
-    calculateProjectedUsage2,
+    calculateProjectedUsage,
     cleanTrafficData,
 } from './traffic-calculations';
 import { toSelectablePeriod } from '../component/admin/network/NetworkTrafficUsage/selectable-periods';
@@ -11,8 +11,8 @@ import type {
     TrafficUsageDataSegmentedCombinedSchemaApiDataItem,
 } from 'openapi';
 import {
-    calculateEstimatedMonthlyCost,
-    calculateProjectedUsage,
+    calculateEstimatedMonthlyCost as deprecatedCalculateEstimatedMonthlyCost,
+    calculateProjectedUsage as deprecatedCalculateProjectedUsage,
 } from 'hooks/useTrafficData';
 
 const testData4Days = [
@@ -96,7 +96,7 @@ describe('traffic overage calculation', () => {
         const period = toSelectablePeriod(now);
         const testNow = new Date(now.getFullYear(), now.getMonth(), 4);
         const includedTraffic = 53_000_000;
-        const result = calculateEstimatedMonthlyCost(
+        const result = deprecatedCalculateEstimatedMonthlyCost(
             period.key,
             testData4Days,
             includedTraffic,
@@ -105,7 +105,7 @@ describe('traffic overage calculation', () => {
         expect(result).toBe(0);
 
         const rawData = trafficData4Days(now);
-        const result2 = calculateEstimatedMonthlyCost2(
+        const result2 = calculateEstimatedMonthlyCost(
             rawData,
             includedTraffic,
             testNow,
@@ -122,7 +122,7 @@ describe('traffic overage calculation', () => {
         const period = toSelectablePeriod(now);
         const testNow = new Date(now.getFullYear(), now.getMonth(), 5);
         const includedTraffic = 53_000_000;
-        const result = calculateEstimatedMonthlyCost(
+        const result = deprecatedCalculateEstimatedMonthlyCost(
             period.key,
             testData,
             includedTraffic,
@@ -134,7 +134,7 @@ describe('traffic overage calculation', () => {
         rawData[0].dataPoints.push(dataPoint(now)(5, 23_000_000));
         rawData[1].dataPoints.push(dataPoint(now)(5, 23_000_000));
         rawData[2].dataPoints.push(dataPoint(now)(5, 23_000_000));
-        const result2 = calculateEstimatedMonthlyCost2(
+        const result2 = calculateEstimatedMonthlyCost(
             rawData,
             includedTraffic,
             testNow,
@@ -150,7 +150,7 @@ describe('traffic overage calculation', () => {
         // Testing April 5th of 2024 (30 days)
         const now = new Date(2024, 3, 5);
         const period = toSelectablePeriod(now);
-        const result = calculateProjectedUsage(
+        const result = deprecatedCalculateProjectedUsage(
             now.getDate(),
             testData,
             period.dayCount,
@@ -162,7 +162,7 @@ describe('traffic overage calculation', () => {
         rawData[0].dataPoints.push(dataPoint(now)(5, 22_500_000));
         rawData[1].dataPoints.push(dataPoint(now)(5, 22_500_000));
         rawData[2].dataPoints.push(dataPoint(now)(5, 22_500_000));
-        const result2 = calculateProjectedUsage2({
+        const result2 = calculateProjectedUsage({
             dayOfMonth: now.getDate(),
             daysInMonth: period.dayCount,
             trafficData: rawData,
@@ -193,7 +193,7 @@ describe('traffic overage calculation', () => {
         const includedTraffic = 53_000_000;
         const trafficUnitSize = 500_000;
         const trafficUnitCost = 10;
-        const result = calculateEstimatedMonthlyCost(
+        const result = deprecatedCalculateEstimatedMonthlyCost(
             period.key,
             testData,
             includedTraffic,
@@ -212,7 +212,7 @@ describe('traffic overage calculation', () => {
         rawData[0].dataPoints.push(dataPoint(now)(5, 22_500_000));
         rawData[1].dataPoints.push(dataPoint(now)(5, 22_500_000));
         rawData[2].dataPoints.push(dataPoint(now)(5, 22_500_000));
-        const result2 = calculateEstimatedMonthlyCost2(
+        const result2 = calculateEstimatedMonthlyCost(
             rawData,
             includedTraffic,
             testNow,

--- a/frontend/src/utils/traffic-calculations.test.ts
+++ b/frontend/src/utils/traffic-calculations.test.ts
@@ -1,9 +1,7 @@
 import { format, getDaysInMonth } from 'date-fns';
 import {
-    calculateEstimatedMonthlyCost,
     calculateEstimatedMonthlyCost2,
     calculateOverageCost,
-    calculateProjectedUsage,
     calculateProjectedUsage2,
     cleanTrafficData,
 } from './traffic-calculations';
@@ -12,6 +10,10 @@ import type {
     TrafficUsageDataSegmentedCombinedSchema,
     TrafficUsageDataSegmentedCombinedSchemaApiDataItem,
 } from 'openapi';
+import {
+    calculateEstimatedMonthlyCost,
+    calculateProjectedUsage,
+} from 'hooks/useTrafficData';
 
 const testData4Days = [
     {

--- a/frontend/src/utils/traffic-calculations.test.ts
+++ b/frontend/src/utils/traffic-calculations.test.ts
@@ -170,6 +170,16 @@ describe('traffic overage calculation', () => {
         expect(result2).toBe(result);
     });
 
+    it("doesn't die if traffic is undefined", () => {
+        expect(
+            calculateEstimatedMonthlyCost(
+                undefined,
+                500_000,
+                new Date('2024-05-15'),
+            ),
+        ).toBe(0);
+    });
+
     it('supports custom price and unit size', () => {
         const dataUsage = 54_000_000;
         const includedTraffic = 53_000_000;

--- a/frontend/src/utils/traffic-calculations.test.ts
+++ b/frontend/src/utils/traffic-calculations.test.ts
@@ -38,7 +38,7 @@ const dataPoint = (month: Date) => (day: number, count: number) => {
     const monthPrefix = format(month, 'yyyy-MM');
 
     return {
-        period: `${monthPrefix}-${day}`,
+        period: `${monthPrefix}-${day.toString().padStart(2, '0')}`,
         trafficTypes: [{ count, group: 'successful-requests' }],
     };
 };

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -134,12 +134,17 @@ export const calculateProjectedUsage = ({
 };
 
 export const calculateEstimatedMonthlyCost = (
-    trafficData: TrafficUsageDataSegmentedCombinedSchemaApiDataItem[],
+    trafficData:
+        | TrafficUsageDataSegmentedCombinedSchemaApiDataItem[]
+        | undefined,
     includedTraffic: number,
     currentDate: Date,
     trafficUnitCost = DEFAULT_TRAFFIC_DATA_UNIT_COST,
     trafficUnitSize = DEFAULT_TRAFFIC_DATA_UNIT_SIZE,
 ) => {
+    if (!trafficData) {
+        return 0;
+    }
     const dayOfMonth = currentDate.getDate();
     const daysInMonth = getDaysInMonth(currentDate);
 

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -106,7 +106,7 @@ export const calculateOverageCost = (
         : 0;
 };
 
-export const calculateProjectedUsage2 = ({
+export const calculateProjectedUsage = ({
     dayOfMonth,
     daysInMonth,
     trafficData,
@@ -133,7 +133,7 @@ export const calculateProjectedUsage2 = ({
     return (dataUsage / (dayOfMonth - 1)) * daysInMonth;
 };
 
-export const calculateEstimatedMonthlyCost2 = (
+export const calculateEstimatedMonthlyCost = (
     trafficData: TrafficUsageDataSegmentedCombinedSchemaApiDataItem[],
     includedTraffic: number,
     currentDate: Date,
@@ -143,7 +143,7 @@ export const calculateEstimatedMonthlyCost2 = (
     const dayOfMonth = currentDate.getDate();
     const daysInMonth = getDaysInMonth(currentDate);
 
-    const projectedUsage = calculateProjectedUsage2({
+    const projectedUsage = calculateProjectedUsage({
         dayOfMonth,
         daysInMonth,
         trafficData,

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -2,15 +2,11 @@ import type {
     TrafficUsageDataSegmentedCombinedSchema,
     TrafficUsageDataSegmentedCombinedSchemaApiDataItem,
 } from 'openapi';
-import {
-    currentMonth,
-    daysInCurrentMonth,
-} from '../component/admin/network/NetworkTrafficUsage/dates';
-import type { ChartDatasetType } from '../component/admin/network/NetworkTrafficUsage/chart-functions';
+import { currentMonth } from '../component/admin/network/NetworkTrafficUsage/dates';
 import { getDaysInMonth } from 'date-fns';
 
-const DEFAULT_TRAFFIC_DATA_UNIT_COST = 5;
-const DEFAULT_TRAFFIC_DATA_UNIT_SIZE = 1_000_000;
+export const DEFAULT_TRAFFIC_DATA_UNIT_COST = 5;
+export const DEFAULT_TRAFFIC_DATA_UNIT_SIZE = 1_000_000;
 
 export const TRAFFIC_MEASUREMENT_START_DATE = new Date('2024-05-01');
 
@@ -108,70 +104,6 @@ export const calculateOverageCost = (
     return overage > 0
         ? calculateTrafficDataCost(overage, trafficUnitCost, trafficUnitSize)
         : 0;
-};
-
-export const calculateProjectedUsage = (
-    today: number,
-    trafficData: ChartDatasetType[],
-    daysInPeriod: number,
-) => {
-    if (today < 5) {
-        return 0;
-    }
-
-    const spliceToYesterday = today - 1;
-    const trafficDataUpToYesterday = trafficData.map((item) => {
-        return {
-            ...item,
-            data: item.data.slice(0, spliceToYesterday),
-        };
-    });
-
-    const toTrafficUsageSum = (trafficData: ChartDatasetType[]): number => {
-        const data = trafficData.reduce(
-            (acc: number, current: ChartDatasetType) => {
-                return (
-                    acc +
-                    current.data.reduce(
-                        (acc_inner, current_inner) => acc_inner + current_inner,
-                        0,
-                    )
-                );
-            },
-            0,
-        );
-        return data;
-    };
-
-    const dataUsage = toTrafficUsageSum(trafficDataUpToYesterday);
-    return (dataUsage / spliceToYesterday) * daysInPeriod;
-};
-
-export const calculateEstimatedMonthlyCost = (
-    period: string,
-    trafficData: ChartDatasetType[],
-    includedTraffic: number,
-    currentDate: Date,
-    trafficUnitCost = DEFAULT_TRAFFIC_DATA_UNIT_COST,
-    trafficUnitSize = DEFAULT_TRAFFIC_DATA_UNIT_SIZE,
-) => {
-    if (period !== currentMonth) {
-        return 0;
-    }
-
-    const today = currentDate.getDate();
-    const projectedUsage = calculateProjectedUsage(
-        today,
-        trafficData,
-        daysInCurrentMonth,
-    );
-
-    return calculateOverageCost(
-        projectedUsage,
-        includedTraffic,
-        trafficUnitCost,
-        trafficUnitSize,
-    );
 };
 
 export const calculateProjectedUsage2 = ({

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -188,10 +188,12 @@ export const calculateProjectedUsage2 = ({
     }
 
     const trafficDataUpToYesterday = trafficData.map((item) => {
-        item.dataPoints = item.dataPoints.filter((point) => {
-            Number(point.period.slice(-2)) < dayOfMonth;
-        });
-        return item;
+        return {
+            ...item,
+            dataPoints: item.dataPoints.filter(
+                (point) => Number(point.period.slice(-2)) < dayOfMonth,
+            ),
+        };
     });
 
     const dataUsage = dailyTrafficDataToCurrentUsage(trafficDataUpToYesterday);


### PR DESCRIPTION
Adds new monthly estimation functions that operate on raw usage data instead of chart data. This brings those methods in line with the rest of the traffic calculation functions that we have in that file and means we can remove other external dependencies. 

 This is somewhat inspired by #9218, but not directly linked.