### PR TITLE
chore: use union type for traffic search data

### DIFF
--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -30,16 +30,19 @@ const useNewOverageCostCalculation = (includedTraffic: number) => {
     const from = formatDate(startOfMonth(now));
     const to = formatDate(endOfMonth(now));
 
-    const { usage } = useTrafficSearch('daily', { from, to });
-
+    const { result } = useTrafficSearch('daily', { from, to });
     const overageCost = useMemo(() => {
-        const totalUsage = calculateTotalUsage(usage);
+        if (result.state !== 'success') {
+            return 0;
+        }
+
+        const totalUsage = calculateTotalUsage(result.usage);
         return calculateOverageCost(
             totalUsage,
             includedTraffic,
             BILLING_TRAFFIC_BUNDLE_PRICE,
         );
-    }, [includedTraffic, usage]);
+    }, [includedTraffic, JSON.stringify(result)]);
 
     return overageCost;
 };

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -36,7 +36,7 @@ const useNewOverageCostCalculation = (includedTraffic: number) => {
             return 0;
         }
 
-        const totalUsage = calculateTotalUsage(result.usage);
+        const totalUsage = calculateTotalUsage(result.data);
         return calculateOverageCost(
             totalUsage,
             includedTraffic,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -182,12 +182,12 @@ const useTrafficStats = (
     includedTraffic: number,
     chartDataSelection: ChartDataSelection,
 ) => {
-    const query = useTrafficSearch(
+    const { result } = useTrafficSearch(
         chartDataSelection.grouping,
         toDateRange(chartDataSelection, currentDate),
     );
     const results = useMemo(() => {
-        if (query.result.state !== 'success') {
+        if (result.state !== 'success') {
             return {
                 data: { datasets: [], labels: [] },
                 usageTotal: 0,
@@ -196,7 +196,7 @@ const useTrafficStats = (
                 requestSummaryUsage: 0,
             };
         }
-        const traffic = query.result.usage;
+        const traffic = result.data;
 
         const data = newToChartData(traffic);
         const usageTotal = calculateTotalUsage(traffic);

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -20,7 +20,10 @@ import {
 } from 'chart.js';
 
 import { Bar } from 'react-chartjs-2';
-import { useInstanceTrafficMetrics } from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
+import {
+    useInstanceTrafficMetrics,
+    useTrafficSearch,
+} from 'hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics';
 import type { Theme } from '@mui/material/styles/createTheme';
 import Grid from '@mui/material/Grid';
 import { NetworkTrafficUsagePlanSummary } from './NetworkTrafficUsagePlanSummary';
@@ -179,23 +182,22 @@ const useTrafficStats = (
     includedTraffic: number,
     chartDataSelection: ChartDataSelection,
 ) => {
-    const query = useInstanceTrafficMetrics2(
+    const query = useTrafficSearch(
         chartDataSelection.grouping,
         toDateRange(chartDataSelection, currentDate),
     );
-
-    if (query.result.state !== 'success') {
-        return {
-            data: { datasets: [], labels: [] },
-            usageTotal: 0,
-            overageCost: 0,
-            estimatedMonthlyCost: 0,
-            requestSummaryUsage: 0,
-        };
-    }
-    const traffic = query.result.usage;
-
     const results = useMemo(() => {
+        if (query.result.state !== 'success') {
+            return {
+                data: { datasets: [], labels: [] },
+                usageTotal: 0,
+                overageCost: 0,
+                estimatedMonthlyCost: 0,
+                requestSummaryUsage: 0,
+            };
+        }
+        const traffic = query.result.usage;
+
         const data = newToChartData(traffic);
         const usageTotal = calculateTotalUsage(traffic);
         const overageCost = calculateOverageCost(

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -226,7 +226,7 @@ const useTrafficStats = (
             requestSummaryUsage,
         };
     }, [
-        JSON.stringify(query.result),
+        JSON.stringify(result),
         includedTraffic,
         JSON.stringify(chartDataSelection),
     ]);

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -187,7 +187,7 @@ const useTrafficStats = (
 
     if (query.result.state !== 'success') {
         return {
-            data: newToChartData(undefined),
+            data: { datasets: [], labels: [] },
             usageTotal: 0,
             overageCost: 0,
             estimatedMonthlyCost: 0,

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -189,7 +189,7 @@ const useTrafficStats = (
     const results = useMemo(() => {
         if (result.state !== 'success') {
             return {
-                data: { datasets: [], labels: [] },
+                chartData: { datasets: [], labels: [] },
                 usageTotal: 0,
                 overageCost: 0,
                 estimatedMonthlyCost: 0,
@@ -198,7 +198,7 @@ const useTrafficStats = (
         }
         const traffic = result.data;
 
-        const data = newToChartData(traffic);
+        const chartData = newToChartData(traffic);
         const usageTotal = calculateTotalUsage(traffic);
         const overageCost = calculateOverageCost(
             usageTotal,
@@ -219,7 +219,7 @@ const useTrafficStats = (
                 : averageTrafficPreviousMonths(traffic);
 
         return {
-            data,
+            chartData,
             usageTotal,
             overageCost,
             estimatedMonthlyCost,
@@ -290,7 +290,7 @@ const NewNetworkTrafficUsage: FC = () => {
     }, [theme, chartDataSelection]);
 
     const {
-        data,
+        chartData,
         usageTotal,
         overageCost,
         estimatedMonthlyCost,
@@ -359,7 +359,7 @@ const NewNetworkTrafficUsage: FC = () => {
                             />
                         </TopRow>
                         <Bar
-                            data={data}
+                            data={chartData}
                             plugins={[customHighlightPlugin()]}
                             options={options}
                             aria-label={getChartLabel(chartDataSelection)}

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/average-traffic-previous-months.ts
@@ -5,7 +5,7 @@ export const averageTrafficPreviousMonths = (
     endpointData: string[],
     traffic: TrafficUsageDataSegmentedCombinedSchema,
 ) => {
-    if (!traffic || traffic.grouping === 'daily') {
+    if (traffic.grouping === 'daily') {
         return 0;
     }
 

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/chart-functions.test.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/chart-functions.test.ts
@@ -148,11 +148,4 @@ describe('toChartData', () => {
 
         expect(toChartData(input)).toMatchObject(expectedOutput);
     });
-
-    test('returns empty data if traffic is undefined', () => {
-        expect(toChartData(undefined)).toStrictEqual({
-            labels: [],
-            datasets: [],
-        });
-    });
 });

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/chart-functions.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/chart-functions.ts
@@ -12,12 +12,8 @@ import type { ChartDataSelection } from './chart-data-selection';
 export type ChartDatasetType = ChartDataset<'bar'>;
 
 export const toChartData = (
-    traffic?: TrafficUsageDataSegmentedCombinedSchema,
+    traffic: TrafficUsageDataSegmentedCombinedSchema,
 ): { datasets: ChartDatasetType[]; labels: string[] } => {
-    if (!traffic) {
-        return { labels: [], datasets: [] };
-    }
-
     const { newRecord, labels } = getLabelsAndRecords(traffic);
     const datasets = traffic.apiData
         .sort(

--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -61,7 +61,7 @@ export const useTrafficSearch = (
 
     return useMemo(() => {
         const result = data
-            ? { state: 'success' as const, usage: cleanTrafficData(data) }
+            ? { state: 'success' as const, data: cleanTrafficData(data) }
             : error
               ? { state: 'error' as const, error }
               : { state: 'loading' as const };

--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -38,13 +38,11 @@ export const useInstanceTrafficMetrics = (
 };
 
 export type InstanceTrafficMetricsResponse2 = {
-    usage: TrafficUsageDataSegmentedCombinedSchema;
-
     refetch: () => void;
-
-    loading: boolean;
-
-    error?: Error;
+    result:
+        | { state: 'success'; usage: TrafficUsageDataSegmentedCombinedSchema }
+        | { state: 'error'; error: Error }
+        | { state: 'loading' };
 };
 
 export const useInstanceTrafficMetrics2 = (
@@ -61,15 +59,17 @@ export const useInstanceTrafficMetrics2 = (
 
     const { data, error, mutate } = useSWR(formatApiPath(apiPath), fetcher);
 
-    return useMemo(
-        () => ({
-            usage: cleanTrafficData(data) as any,
-            loading: !error && !data,
+    return useMemo(() => {
+        const result = data
+            ? { state: 'success' as const, usage: cleanTrafficData(data) }
+            : error
+              ? { state: 'error' as const, error }
+              : { state: 'loading' as const };
+        return {
             refetch: () => mutate(),
-            error,
-        }),
-        [data, error, mutate],
-    );
+            result,
+        };
+    }, [data, error, mutate]);
 };
 
 const fetcher = (path: string) => {

--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -40,7 +40,7 @@ export const useInstanceTrafficMetrics = (
 export type InstanceTrafficMetricsResponse2 = {
     refetch: () => void;
     result:
-        | { state: 'success'; usage: TrafficUsageDataSegmentedCombinedSchema }
+        | { state: 'success'; data: TrafficUsageDataSegmentedCombinedSchema }
         | { state: 'error'; error: Error }
         | { state: 'loading' };
 };

--- a/frontend/src/utils/traffic-calculations.test.ts
+++ b/frontend/src/utils/traffic-calculations.test.ts
@@ -171,16 +171,6 @@ describe('traffic overage calculation', () => {
         expect(result2).toBe(result);
     });
 
-    it("doesn't die if traffic is undefined", () => {
-        expect(
-            calculateEstimatedMonthlyCost(
-                undefined,
-                500_000,
-                new Date('2024-05-15'),
-            ),
-        ).toBe(0);
-    });
-
     it('supports custom price and unit size', () => {
         const dataUsage = 54_000_000;
         const includedTraffic = 53_000_000;

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -128,9 +128,7 @@ export const calculateProjectedUsage = ({
 };
 
 export const calculateEstimatedMonthlyCost = (
-    trafficData:
-        | TrafficUsageDataSegmentedCombinedSchemaApiDataItem[]
-        | undefined,
+    trafficData: TrafficUsageDataSegmentedCombinedSchemaApiDataItem[],
     includedTraffic: number,
     currentDate: Date,
     trafficUnitCost = DEFAULT_TRAFFIC_DATA_UNIT_COST,

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -68,11 +68,8 @@ const dailyTrafficDataToCurrentUsage = (
 // Return the total number of requests for the selected month if showing daily
 // data, or the total for the most recent month if showing monthly data
 export const calculateTotalUsage = (
-    data?: TrafficUsageDataSegmentedCombinedSchema,
+    data: TrafficUsageDataSegmentedCombinedSchema,
 ): number => {
-    if (!data) {
-        return 0;
-    }
     const { grouping, apiData } = data;
     if (grouping === 'monthly') {
         const latestMonth = format(new Date(data.dateRange.to), 'yyyy-MM');

--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -21,12 +21,8 @@ export const METERED_TRAFFIC_ENDPOINTS = [
 ];
 
 export const cleanTrafficData = (
-    data?: TrafficUsageDataSegmentedCombinedSchema,
-): TrafficUsageDataSegmentedCombinedSchema | undefined => {
-    if (!data) {
-        return;
-    }
-
+    data: TrafficUsageDataSegmentedCombinedSchema,
+): TrafficUsageDataSegmentedCombinedSchema => {
     const { apiData, ...rest } = data;
     const cleanedApiData = apiData
         .filter((item) => METERED_TRAFFIC_ENDPOINTS.includes(item.apiPath))


### PR DESCRIPTION
Makes the data returned from the traffic search a union type to avoid
nasty object-is-undefined errors at runtime.

It requires more explicit handling, sure, but it means we don't need
to accept undefined.