### PR TITLE
chore(1-3333): add new pnps reset

### DIFF
--- a/src/migrations/20250205132446-reset-pnps-feedback.js
+++ b/src/migrations/20250205132446-reset-pnps-feedback.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.up = function (db, callback) {
+    db.runSql(
+        `
+       DELETE FROM user_feedback WHERE feedback_id = 'pnps' AND given < NOW() - INTERVAL '6 months';
+        `,
+        callback(),
+    );
+};
+
+exports.down = function (db, callback) {
+    callback();
+};


### PR DESCRIPTION
This migration resets the pNPS survey results older than 6 months, so that the survey appears again for users who have already completed it.