### PR TITLE
chore: release plan changes in change request view

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -14,6 +14,7 @@ import { EnvironmentStrategyExecutionOrder } from './EnvironmentStrategyExecutio
 import { ArchiveFeatureChange } from './ArchiveFeatureChange';
 import { DependencyChange } from './DependencyChange';
 import { Link } from 'react-router-dom';
+import { ReleasePlanChange } from './ReleasePlanChange';
 
 const StyledSingleChangeBox = styled(Box, {
     shouldForwardProp: (prop: string) => !prop.startsWith('$'),
@@ -190,6 +191,18 @@ export const FeatureChange: FC<{
                         environment={changeRequest.environment}
                         change={change}
                         actions={actions}
+                    />
+                )}
+                {(change.action === 'addReleasePlan' ||
+                    change.action === 'deleteReleasePlan' ||
+                    change.action === 'startMilestone') && (
+                    <ReleasePlanChange
+                        actions={actions}
+                        change={change}
+                        featureName={feature.name}
+                        environmentName={changeRequest.environment}
+                        projectId={changeRequest.project}
+                        changeRequestState={changeRequest.state}
                     />
                 )}
             </ChangeInnerBox>

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -1,0 +1,267 @@
+import type React from 'react';
+import type { FC, ReactNode } from 'react';
+import { Box, styled, Typography } from '@mui/material';
+import type {
+    ChangeRequestState,
+    IChangeRequestAddReleasePlan,
+    IChangeRequestDeleteReleasePlan,
+    IChangeRequestStartMilestone,
+} from 'component/changeRequest/changeRequest.types';
+import { useReleasePlanTemplate } from 'hooks/api/getters/useReleasePlanTemplates/useReleasePlanTemplate';
+import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
+import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
+import EventDiff from 'component/events/EventDiff/EventDiff';
+import { ReleasePlan } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan';
+
+export const ChangeItemWrapper = styled(Box)({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+});
+
+const ChangeItemCreateEditDeleteWrapper = styled(Box)(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'auto auto',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+    width: '100%',
+}));
+
+const ChangeItemInfo: FC<{ children?: React.ReactNode }> = styled(Box)(
+    ({ theme }) => ({
+        display: 'flex',
+        gap: theme.spacing(1),
+    }),
+);
+
+const ViewDiff = styled('span')(({ theme }) => ({
+    color: theme.palette.primary.main,
+    marginLeft: theme.spacing(1),
+}));
+
+const StyledCodeSection = styled('div')(({ theme }) => ({
+    overflowX: 'auto',
+    '& code': {
+        wordWrap: 'break-word',
+        whiteSpace: 'pre-wrap',
+        fontFamily: 'monospace',
+        lineHeight: 1.5,
+        fontSize: theme.fontSizes.smallBody,
+    },
+}));
+
+const DeleteReleasePlan: FC<{
+    change: IChangeRequestDeleteReleasePlan;
+    environmentName: string;
+    featureName: string;
+    projectId: string;
+    changeRequestState: ChangeRequestState;
+    actions?: ReactNode;
+}> = ({
+    change,
+    environmentName,
+    featureName,
+    projectId,
+    changeRequestState,
+    actions,
+}) => {
+    const { releasePlans } = useReleasePlans(
+        projectId,
+        featureName,
+        environmentName,
+    );
+    const currentReleasePlan = releasePlans[0];
+
+    const releasePlan =
+        changeRequestState === 'Applied' && change.payload.snapshot
+            ? change.payload.snapshot
+            : currentReleasePlan;
+
+    return (
+        <>
+            <ChangeItemCreateEditDeleteWrapper>
+                <ChangeItemInfo>
+                    <Typography
+                        sx={(theme) => ({
+                            color: theme.palette.error.main,
+                        })}
+                    >
+                        - Deleting release plan:
+                    </Typography>
+                    <Typography>{releasePlan.name}</Typography>
+                </ChangeItemInfo>
+                <div>{actions}</div>
+            </ChangeItemCreateEditDeleteWrapper>
+            <ReleasePlan plan={releasePlan} readonly />
+        </>
+    );
+};
+
+const StartMilestone: FC<{
+    change: IChangeRequestStartMilestone;
+    environmentName: string;
+    featureName: string;
+    projectId: string;
+    changeRequestState: ChangeRequestState;
+    actions?: ReactNode;
+}> = ({
+    change,
+    environmentName,
+    featureName,
+    projectId,
+    changeRequestState,
+    actions,
+}) => {
+    const { releasePlans } = useReleasePlans(
+        projectId,
+        featureName,
+        environmentName,
+    );
+    const currentReleasePlan = releasePlans[0];
+
+    const releasePlan =
+        changeRequestState === 'Applied' && change.payload.snapshot
+            ? change.payload.snapshot
+            : currentReleasePlan;
+
+    const previousMilestone = releasePlan.milestones.find(
+        (milestone) => milestone.id === releasePlan.activeMilestoneId,
+    );
+
+    const newMilestone = releasePlan.milestones.find(
+        (milestone) => milestone.id === change.payload.milestoneId,
+    );
+
+    return (
+        <>
+            <ChangeItemCreateEditDeleteWrapper>
+                <ChangeItemInfo>
+                    <Typography color='success.dark'>
+                        + Start milestone:
+                    </Typography>
+                    <Typography>{newMilestone?.name}</Typography>
+                    <TooltipLink
+                        tooltip={
+                            <StyledCodeSection>
+                                <EventDiff
+                                    entry={{
+                                        preData: previousMilestone,
+                                        data: newMilestone,
+                                    }}
+                                />
+                            </StyledCodeSection>
+                        }
+                        tooltipProps={{
+                            maxWidth: 500,
+                            maxHeight: 600,
+                        }}
+                    >
+                        <ViewDiff>View Diff</ViewDiff>
+                    </TooltipLink>
+                </ChangeItemInfo>
+                <div>{actions}</div>
+            </ChangeItemCreateEditDeleteWrapper>
+        </>
+    );
+};
+
+const AddReleasePlan: FC<{
+    change: IChangeRequestAddReleasePlan;
+    environmentName: string;
+    featureName: string;
+    actions?: ReactNode;
+}> = ({ change, environmentName, featureName, actions }) => {
+    const { template } = useReleasePlanTemplate(change.payload.templateId);
+
+    const tentativeReleasePlan = {
+        ...template,
+        environment: environmentName,
+        featureName,
+        milestones: template.milestones.map((milestone) => ({
+            ...milestone,
+            releasePlanDefinitionId: template.id,
+            strategies: (milestone.strategies || []).map((strategy) => ({
+                ...strategy,
+                parameters: {
+                    ...strategy.parameters,
+                    ...(strategy.parameters.groupId && {
+                        groupId: String(strategy.parameters.groupId).replaceAll(
+                            '{{featureName}}',
+                            featureName,
+                        ),
+                    }),
+                },
+                milestoneId: milestone.id,
+            })),
+        })),
+    };
+
+    return (
+        <>
+            <ChangeItemCreateEditDeleteWrapper>
+                <ChangeItemInfo>
+                    <Typography color='success.dark'>
+                        + Adding release plan:
+                    </Typography>
+                    <Typography>{template.name}</Typography>
+                </ChangeItemInfo>
+                <div>{actions}</div>
+            </ChangeItemCreateEditDeleteWrapper>
+            <ReleasePlan plan={tentativeReleasePlan} readonly />
+        </>
+    );
+};
+
+export const ReleasePlanChange: FC<{
+    actions?: ReactNode;
+    change:
+        | IChangeRequestAddReleasePlan
+        | IChangeRequestDeleteReleasePlan
+        | IChangeRequestStartMilestone;
+    environmentName: string;
+    featureName: string;
+    projectId: string;
+    changeRequestState: ChangeRequestState;
+}> = ({
+    actions,
+    change,
+    featureName,
+    environmentName,
+    projectId,
+    changeRequestState,
+}) => {
+    return (
+        <>
+            {change.action === 'addReleasePlan' && (
+                <AddReleasePlan
+                    change={change}
+                    environmentName={environmentName}
+                    featureName={featureName}
+                    actions={actions}
+                />
+            )}
+            {change.action === 'deleteReleasePlan' && (
+                <DeleteReleasePlan
+                    change={change}
+                    environmentName={environmentName}
+                    featureName={featureName}
+                    projectId={projectId}
+                    changeRequestState={changeRequestState}
+                    actions={actions}
+                />
+            )}
+            {change.action === 'startMilestone' && (
+                <StartMilestone
+                    change={change}
+                    environmentName={environmentName}
+                    featureName={featureName}
+                    projectId={projectId}
+                    changeRequestState={changeRequestState}
+                    actions={actions}
+                />
+            )}
+        </>
+    );
+};

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -12,6 +12,7 @@ import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePla
 import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
 import EventDiff from 'component/events/EventDiff/EventDiff';
 import { ReleasePlan } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan';
+import { ReleasePlanMilestone } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone';
 
 export const ChangeItemWrapper = styled(Box)({
     display: 'flex',
@@ -79,6 +80,8 @@ const DeleteReleasePlan: FC<{
             ? change.payload.snapshot
             : currentReleasePlan;
 
+    if (!releasePlan) return;
+
     return (
         <>
             <ChangeItemCreateEditDeleteWrapper>
@@ -126,6 +129,8 @@ const StartMilestone: FC<{
             ? change.payload.snapshot
             : currentReleasePlan;
 
+    if (!releasePlan) return;
+
     const previousMilestone = releasePlan.milestones.find(
         (milestone) => milestone.id === releasePlan.activeMilestoneId,
     );
@@ -134,6 +139,8 @@ const StartMilestone: FC<{
         (milestone) => milestone.id === change.payload.milestoneId,
     );
 
+    if (!newMilestone) return;
+
     return (
         <>
             <ChangeItemCreateEditDeleteWrapper>
@@ -141,7 +148,7 @@ const StartMilestone: FC<{
                     <Typography color='success.dark'>
                         + Start milestone:
                     </Typography>
-                    <Typography>{newMilestone?.name}</Typography>
+                    <Typography>{newMilestone.name}</Typography>
                     <TooltipLink
                         tooltip={
                             <StyledCodeSection>
@@ -163,6 +170,7 @@ const StartMilestone: FC<{
                 </ChangeItemInfo>
                 <div>{actions}</div>
             </ChangeItemCreateEditDeleteWrapper>
+            <ReleasePlanMilestone readonly milestone={newMilestone} />
         </>
     );
 };
@@ -174,6 +182,8 @@ const AddReleasePlan: FC<{
     actions?: ReactNode;
 }> = ({ change, environmentName, featureName, actions }) => {
     const { template } = useReleasePlanTemplate(change.payload.templateId);
+
+    if (!template) return;
 
     const tentativeReleasePlan = {
         ...template,

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -3,6 +3,7 @@ import type { ISegment } from 'interfaces/segment';
 import type { IFeatureStrategy } from '../../interfaces/strategy';
 import type { IUser } from '../../interfaces/user';
 import type { SetStrategySortOrderSchema } from '../../openapi';
+import type { IReleasePlan } from 'interfaces/releasePlans';
 
 type BaseChangeRequest = {
     id: number;
@@ -126,7 +127,10 @@ type ChangeRequestPayload =
     | IChangeRequestDeleteSegment
     | SetStrategySortOrderSchema
     | IChangeRequestArchiveFeature
-    | ChangeRequestAddDependency;
+    | ChangeRequestAddDependency
+    | ChangeRequestAddReleasePlan
+    | ChangeRequestDeleteReleasePlan
+    | ChangeRequestStartMilestone;
 
 export interface IChangeRequestAddStrategy extends IChangeRequestChangeBase {
     action: 'addStrategy';
@@ -165,6 +169,22 @@ export interface IChangeRequestAddDependency extends IChangeRequestChangeBase {
 export interface IChangeRequestDeleteDependency
     extends IChangeRequestChangeBase {
     action: 'deleteDependency';
+}
+
+export interface IChangeRequestAddReleasePlan extends IChangeRequestChangeBase {
+    action: 'addReleasePlan';
+    payload: ChangeRequestAddReleasePlan;
+}
+
+export interface IChangeRequestDeleteReleasePlan
+    extends IChangeRequestChangeBase {
+    action: 'deleteReleasePlan';
+    payload: ChangeRequestDeleteReleasePlan;
+}
+
+export interface IChangeRequestStartMilestone extends IChangeRequestChangeBase {
+    action: 'startMilestone';
+    payload: ChangeRequestStartMilestone;
 }
 
 export interface IChangeRequestReorderStrategy
@@ -211,7 +231,10 @@ export type IFeatureChange =
     | IChangeRequestReorderStrategy
     | IChangeRequestArchiveFeature
     | IChangeRequestAddDependency
-    | IChangeRequestDeleteDependency;
+    | IChangeRequestDeleteDependency
+    | IChangeRequestAddReleasePlan
+    | IChangeRequestDeleteReleasePlan
+    | IChangeRequestStartMilestone;
 
 export type ISegmentChange =
     | IChangeRequestUpdateSegment
@@ -228,6 +251,20 @@ type ChangeRequestAddDependency = {
     feature: string;
     enabled: boolean;
     variants?: string[];
+};
+
+type ChangeRequestAddReleasePlan = {
+    templateId: string;
+};
+
+type ChangeRequestDeleteReleasePlan = {
+    planId: string;
+    snapshot?: IReleasePlan;
+};
+
+type ChangeRequestStartMilestone = {
+    milestoneId: string;
+    snapshot?: IReleasePlan;
 };
 
 export type ChangeRequestAddStrategy = Pick<
@@ -264,4 +301,7 @@ export type ChangeRequestAction =
     | 'deleteSegment'
     | 'archiveFeature'
     | 'addDependency'
-    | 'deleteDependency';
+    | 'deleteDependency'
+    | 'addReleasePlan'
+    | 'deleteReleasePlan'
+    | 'startMilestone';

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -16,13 +16,17 @@ import { ReleasePlanRemoveDialog } from './ReleasePlanRemoveDialog';
 import { ReleasePlanMilestone } from './ReleasePlanMilestone/ReleasePlanMilestone';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
-const StyledContainer = styled('div')(({ theme }) => ({
+const StyledContainer = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'readonly',
+})<{ readonly?: boolean }>(({ theme, readonly }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusMedium,
     '& + &': {
         marginTop: theme.spacing(2),
     },
-    background: theme.palette.background.paper,
+    background: readonly
+        ? theme.palette.background.elevation1
+        : theme.palette.background.paper,
 }));
 
 const StyledHeader = styled('div')(({ theme }) => ({
@@ -66,12 +70,14 @@ const StyledConnection = styled('div')(({ theme }) => ({
 
 interface IReleasePlanProps {
     plan: IReleasePlan;
-    environmentIsDisabled: boolean;
+    environmentIsDisabled?: boolean;
+    readonly?: boolean;
 }
 
 export const ReleasePlan = ({
     plan,
     environmentIsDisabled,
+    readonly,
 }: IReleasePlanProps) => {
     const {
         id,
@@ -134,7 +140,7 @@ export const ReleasePlan = ({
     );
 
     return (
-        <StyledContainer>
+        <StyledContainer readonly={readonly}>
             <StyledHeader>
                 <StyledHeaderTitleContainer>
                     <StyledHeaderTitleLabel>
@@ -145,22 +151,25 @@ export const ReleasePlan = ({
                         {description}
                     </StyledHeaderDescription>
                 </StyledHeaderTitleContainer>
-                <PermissionIconButton
-                    onClick={() => setRemoveOpen(true)}
-                    permission={DELETE_FEATURE_STRATEGY}
-                    environmentId={environment}
-                    projectId={projectId}
-                    tooltipProps={{
-                        title: 'Remove release plan',
-                    }}
-                >
-                    <Delete />
-                </PermissionIconButton>
+                {!readonly && (
+                    <PermissionIconButton
+                        onClick={() => setRemoveOpen(true)}
+                        permission={DELETE_FEATURE_STRATEGY}
+                        environmentId={environment}
+                        projectId={projectId}
+                        tooltipProps={{
+                            title: 'Remove release plan',
+                        }}
+                    >
+                        <Delete />
+                    </PermissionIconButton>
+                )}
             </StyledHeader>
             <StyledBody>
                 {milestones.map((milestone, index) => (
                     <div key={milestone.id}>
                         <ReleasePlanMilestone
+                            readonly={readonly}
                             milestone={milestone}
                             status={
                                 milestone.id === activeMilestoneId

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -56,26 +56,12 @@ const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
     borderBottomRightRadius: theme.shape.borderRadiusLarge,
 }));
 
-interface IBaseReleasePlanMilestoneProps {
+interface IReleasePlanMilestoneProps {
     milestone: IReleasePlanMilestone;
     status?: MilestoneStatus;
+    onStartMilestone?: (milestone: IReleasePlanMilestone) => void;
+    readonly?: boolean;
 }
-
-interface IEditableReleasePlanMilestoneProps
-    extends IBaseReleasePlanMilestoneProps {
-    readonly?: false;
-    onStartMilestone: (milestone: IReleasePlanMilestone) => void;
-}
-
-interface IReadonlyReleasePlanMilestoneProps
-    extends IBaseReleasePlanMilestoneProps {
-    readonly: true;
-    onStartMilestone?: never;
-}
-
-type IReleasePlanMilestoneProps =
-    | IEditableReleasePlanMilestoneProps
-    | IReadonlyReleasePlanMilestoneProps;
 
 export const ReleasePlanMilestone = ({
     milestone,
@@ -91,7 +77,7 @@ export const ReleasePlanMilestone = ({
                 <StyledAccordionSummary>
                     <StyledTitleContainer>
                         <StyledTitle>{milestone.name}</StyledTitle>
-                        {!readonly && (
+                        {!readonly && onStartMilestone && (
                             <ReleasePlanMilestoneStatus
                                 status={status}
                                 onStartMilestone={() =>
@@ -114,7 +100,7 @@ export const ReleasePlanMilestone = ({
             <StyledAccordionSummary expandIcon={<ExpandMore />}>
                 <StyledTitleContainer>
                     <StyledTitle>{milestone.name}</StyledTitle>
-                    {!readonly && (
+                    {!readonly && onStartMilestone && (
                         <ReleasePlanMilestoneStatus
                             status={status}
                             onStartMilestone={() => onStartMilestone(milestone)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -56,16 +56,30 @@ const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
     borderBottomRightRadius: theme.shape.borderRadiusLarge,
 }));
 
-interface IReleasePlanMilestoneProps {
+interface IBaseReleasePlanMilestoneProps {
     milestone: IReleasePlanMilestone;
-    status: MilestoneStatus;
-    onStartMilestone: (milestone: IReleasePlanMilestone) => void;
-    readonly?: boolean;
+    status?: MilestoneStatus;
 }
+
+interface IEditableReleasePlanMilestoneProps
+    extends IBaseReleasePlanMilestoneProps {
+    readonly?: false;
+    onStartMilestone: (milestone: IReleasePlanMilestone) => void;
+}
+
+interface IReadonlyReleasePlanMilestoneProps
+    extends IBaseReleasePlanMilestoneProps {
+    readonly: true;
+    onStartMilestone?: never;
+}
+
+type IReleasePlanMilestoneProps =
+    | IEditableReleasePlanMilestoneProps
+    | IReadonlyReleasePlanMilestoneProps;
 
 export const ReleasePlanMilestone = ({
     milestone,
-    status,
+    status = 'not-started',
     onStartMilestone,
     readonly,
 }: IReleasePlanMilestoneProps) => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -60,12 +60,14 @@ interface IReleasePlanMilestoneProps {
     milestone: IReleasePlanMilestone;
     status: MilestoneStatus;
     onStartMilestone: (milestone: IReleasePlanMilestone) => void;
+    readonly?: boolean;
 }
 
 export const ReleasePlanMilestone = ({
     milestone,
     status,
     onStartMilestone,
+    readonly,
 }: IReleasePlanMilestoneProps) => {
     const [expanded, setExpanded] = useState(false);
 
@@ -75,10 +77,14 @@ export const ReleasePlanMilestone = ({
                 <StyledAccordionSummary>
                     <StyledTitleContainer>
                         <StyledTitle>{milestone.name}</StyledTitle>
-                        <ReleasePlanMilestoneStatus
-                            status={status}
-                            onStartMilestone={() => onStartMilestone(milestone)}
-                        />
+                        {!readonly && (
+                            <ReleasePlanMilestoneStatus
+                                status={status}
+                                onStartMilestone={() =>
+                                    onStartMilestone(milestone)
+                                }
+                            />
+                        )}
                     </StyledTitleContainer>
                     <StyledSecondaryLabel>No strategies</StyledSecondaryLabel>
                 </StyledAccordionSummary>
@@ -94,10 +100,12 @@ export const ReleasePlanMilestone = ({
             <StyledAccordionSummary expandIcon={<ExpandMore />}>
                 <StyledTitleContainer>
                     <StyledTitle>{milestone.name}</StyledTitle>
-                    <ReleasePlanMilestoneStatus
-                        status={status}
-                        onStartMilestone={() => onStartMilestone(milestone)}
-                    />
+                    {!readonly && (
+                        <ReleasePlanMilestoneStatus
+                            status={status}
+                            onStartMilestone={() => onStartMilestone(milestone)}
+                        />
+                    )}
                 </StyledTitleContainer>
                 <StyledSecondaryLabel>
                     {milestone.strategies.length === 1


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3169/add-release-plan-ui-representation-in-change-request-ui

Adds visual representations for release plan change requests.

### Add release plan

![image](https://github.com/user-attachments/assets/8511c6a3-c83e-4eee-aa18-9affe4a9ac1d)

### Remove release plan

![image](https://github.com/user-attachments/assets/ed13f9ac-140c-40c9-a1a2-3c066c89c09a)

### Start milestone

![image](https://github.com/user-attachments/assets/ac8e5408-e877-470c-a98b-295b41444bfa)

![image](https://github.com/user-attachments/assets/abf19a55-89df-4dd8-8738-9dfcd63949b7)