### PR TITLE
chore: mark release management as an enterprise feature

### DIFF
--- a/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
+++ b/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
@@ -128,6 +128,11 @@ const PremiumFeatures = {
         url: 'https://docs.getunleash.io/reference/environments',
         label: 'Environments management',
     },
+    releaseManagement: {
+        plan: FeaturePlan.ENTERPRISE,
+        url: '',
+        label: 'Release management',
+    },
 };
 
 type PremiumFeatureType = keyof typeof PremiumFeatures;
@@ -255,14 +260,16 @@ export const PremiumFeature = ({
                                 </Button>
                             )}
 
-                            <Button
-                                href={url}
-                                target='_blank'
-                                rel='noreferrer'
-                                onClick={trackReadAbout}
-                            >
-                                Read about {label}
-                            </Button>
+                            {url && (
+                                <Button
+                                    href={url}
+                                    target='_blank'
+                                    rel='noreferrer'
+                                    onClick={trackReadAbout}
+                                >
+                                    Read about {label}
+                                </Button>
+                            )}
                         </StyledButtonContainer>
                     </>
                 }

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -266,7 +266,6 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
-    "enterprise": true,
     "flag": "releasePlans",
     "menu": {
       "advanced": true,

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -289,7 +289,6 @@ export const routes: IRoute[] = [
         type: 'protected',
         menu: { advanced: true, mode: ['enterprise'] },
         flag: 'releasePlans',
-        enterprise: true,
     },
     {
         path: '/release-management/create-template',

--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -12,6 +12,7 @@ import { EmptyTemplatesListMessage } from './EmptyTemplatesListMessage';
 import { ReleasePlanTemplateList } from './ReleasePlanTemplateList';
 import { useUiFlag } from 'hooks/useUiFlag';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 
 export const ReleaseManagement = () => {
     usePageTitle('Release management');
@@ -22,6 +23,10 @@ export const ReleaseManagement = () => {
     const releasePlansEnabled = useUiFlag('releasePlans');
     if (!releasePlansEnabled) {
         return null;
+    }
+
+    if (!isEnterprise()) {
+        return <PremiumFeature feature='releaseManagement' page />;
     }
 
     return (


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3093/sales-pitch-ui-for-release-management-to-show-non-enterprise-users

Marks Release Management as a premium Enterprise feature.

Once the `releasePlans` flag is enabled for everyone / removed, this is what non-Enterprise users will see:

![image](https://github.com/user-attachments/assets/7191fb09-976e-4e14-8e2f-6db114b5e2ca)
