### PR TITLE
chore: changes the panel title to "Event timeline"

### DIFF
--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -198,7 +198,7 @@ export const PersonalDashboard = () => {
                     >
                         <AccordionSummaryText>
                             <AccordionSummaryHeader>
-                                Timeline of events
+                                Event timeline
                             </AccordionSummaryHeader>
                             <AccordionSummarySubtitle>
                                 Overview of recent activities across all


### PR DESCRIPTION
Keeps it consistent with the previous title for this component and
with what it's known as in the docs.