### PR TITLE
fix: return if empty array

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -226,11 +226,6 @@ export class ClientFeatureToggleDelta {
             latestRevision,
         );
 
-        this.logger.info(
-            'Change events',
-            JSON.stringify(changeEvents, null, 2),
-        );
-
         const featuresUpdated = [
             ...new Set(
                 changeEvents
@@ -257,19 +252,12 @@ export class ClientFeatureToggleDelta {
             )
             .map((event) => event.data.id);
 
-        this.logger.info(
-            'Segments updated',
-            JSON.stringify(segmentsUpdated, null, 2),
-        );
-
         const segmentsRemoved = changeEvents
             .filter((event) => event.type === 'segment-deleted')
             .map((event) => event.preData.id);
 
         const segments =
             await this.segmentReadModel.getAllForClientIds(segmentsUpdated);
-
-        this.logger.info('segments', JSON.stringify(segments, null, 2));
 
         const segmentsUpdatedEvents: DeltaEvent[] = segments.map((segment) => ({
             eventId: latestRevision,

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -152,11 +152,6 @@ export class ClientFeatureToggleDelta {
             await this.initEnvironmentDelta(environment);
         }
 
-        this.logger.info(
-            'Delta Cache',
-            JSON.stringify(this.delta[environment].getEvents(), null, 2),
-        );
-
         if (requiredRevisionId >= this.currentRevisionId) {
             return undefined;
         }

--- a/src/lib/features/segment/fake-segment-read-model.ts
+++ b/src/lib/features/segment/fake-segment-read-model.ts
@@ -23,7 +23,7 @@ export class FakeSegmentReadModel implements ISegmentReadModel {
         return [];
     }
 
-    async getAllForClient(ids?: number[]): Promise<IClientSegment[]> {
+    async getAllForClientIds(ids?: number[]): Promise<IClientSegment[]> {
         return [];
     }
 }

--- a/src/lib/features/segment/segment-read-model-type.ts
+++ b/src/lib/features/segment/segment-read-model-type.ts
@@ -9,5 +9,5 @@ export interface ISegmentReadModel {
     getAllFeatureStrategySegments(): Promise<IFeatureStrategySegment[]>;
     getActive(): Promise<ISegment[]>;
     getActiveForClient(): Promise<IClientSegment[]>;
-    getAllForClient(ids?: number[]): Promise<IClientSegment[]>;
+    getAllForClientIds(ids?: number[]): Promise<IClientSegment[]>;
 }

--- a/src/lib/features/segment/segment-read-model.ts
+++ b/src/lib/features/segment/segment-read-model.ts
@@ -110,7 +110,11 @@ export class SegmentReadModel implements ISegmentReadModel {
         }));
     }
 
-    async getAllForClient(ids?: number[]): Promise<IClientSegment[]> {
+    async getAllForClientIds(ids?: number[]): Promise<IClientSegment[]> {
+        if (!ids || ids.length === 0) {
+            return [];
+        }
+
         const fullSegments = await this.getAll(ids);
 
         return fullSegments.map((segments) => ({


### PR DESCRIPTION
Fixes an issue where segment-updated event would be added to cache even though there were no correlated events. Tests needs to be added in Enterprise.