### PR TITLE
chore: make the milestone status a button

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStatus.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStatus.tsx
@@ -1,22 +1,35 @@
-import { Button, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
 import PauseCircleIcon from '@mui/icons-material/PauseCircle';
 import TripOriginIcon from '@mui/icons-material/TripOrigin';
 
 export type MilestoneStatus = 'not-started' | 'active' | 'paused' | 'completed';
 
-const StyledStatusButton = styled(Button, {
+const StyledStatusButton = styled('button', {
     shouldForwardProp: (prop) => prop !== 'status',
-})<{ status: MilestoneStatus }>(({ theme, status }) => ({
-    backgroundColor:
-        status === 'active' ? theme.palette.success.light : 'transparent',
-    '&&&': {
+})<{ status: MilestoneStatus; disabled?: boolean }>(
+    ({ theme, status, disabled }) => ({
+        display: 'flex',
+        alignItems: 'center',
+        border: 'none',
+        gap: theme.spacing(1),
+        padding: 0,
+        paddingRight: theme.spacing(1),
+        cursor: 'pointer',
+        backgroundColor:
+            status === 'active' ? theme.palette.success.light : 'transparent',
         '&:focus-visible': {
             outline: `2px solid ${theme.palette.primary.main}`,
         },
-        padding: theme.spacing(0, 0.5),
-        paddingRight: theme.spacing(1),
-        height: theme.spacing(3),
+        '&:hover': {
+            backgroundColor:
+                status === 'active'
+                    ? theme.palette.success.light
+                    : status === 'paused'
+                      ? 'transparent'
+                      : theme.palette.neutral.light,
+            textDecoration: 'none',
+        },
         fontSize: theme.fontSizes.smallerBody,
         lineHeight: theme.fontSizes.smallerBody,
         fontWeight: theme.fontWeight.medium,
@@ -43,8 +56,11 @@ const StyledStatusButton = styled(Button, {
             height: theme.spacing(3),
             width: theme.spacing(3),
         },
-    },
-}));
+        ...(disabled && {
+            pointerEvents: 'none',
+        }),
+    }),
+);
 
 interface IReleasePlanMilestoneStatusProps {
     status: MilestoneStatus;
@@ -83,8 +99,8 @@ export const ReleasePlanMilestoneStatus = ({
                 onStartMilestone();
             }}
             disabled={disabled}
-            startIcon={statusIcon}
         >
+            {statusIcon}
             {statusText}
         </StyledStatusButton>
     );


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3251/make-the-milestone-status-action-link-and-icon-a-proper-button-that

Makes the milestone status a button while trying to keep most of the original design intact.

![image](https://github.com/user-attachments/assets/677cb9df-8ae2-4244-8d07-6cd2bd1da5fe)
