### PR TITLE
chore: tests are timing out

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "jest": {
     "automock": false,
     "maxWorkers": 4,
-    "testTimeout": 10000,
+    "testTimeout": 20000,
     "globalSetup": "./scripts/jest-setup.js",
     "transform": {
       "^.+\\.tsx?$": [


### PR DESCRIPTION
## About the changes
I figured that many of our tests are timing out and we can solve this by increasing test timeout.

This is a signal that either our tests became slower or that our query performance got worse. On the first point it might be due to having more migrations than before and requiring more time.  The second point is harder to validate but something to keep an eye on