### PR TITLE
fix: Killwitch to block usage-metrics from non-exiting flag-names

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -67,7 +67,6 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
-    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -67,6 +67,7 @@ exports[`should create default config 1`] = `
     "_events": {},
     "_eventsCount": 0,
     "_maxListeners": undefined,
+    Symbol(shapeMode): false,
     Symbol(kCapture): false,
   },
   "feedbackUriPath": undefined,

--- a/src/lib/features/metrics/client-metrics/client-metrics-store-v2-type.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-store-v2-type.ts
@@ -48,4 +48,5 @@ export interface IClientMetricsStoreV2
         variantCount: number;
     }>;
     aggregateDailyMetrics(): Promise<void>;
+    getFeatureFlagNames(): Promise<string[]>;
 }

--- a/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
@@ -155,6 +155,7 @@ export class ClientMetricsStoreV2 implements IClientMetricsStoreV2 {
         throw new NotFoundError(`Could not find metric`);
     }
 
+    //TODO: Consider moving this to a specific feature store
     async getFeatureFlagNames(): Promise<string[]> {
         return this.db(FEATURES_TABLE).distinct('name').pluck('name');
     }

--- a/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
@@ -33,7 +33,7 @@ const DAILY_TABLE = 'client_metrics_env_daily';
 const HOURLY_TABLE_VARIANTS = 'client_metrics_env_variants';
 const DAILY_TABLE_VARIANTS = 'client_metrics_env_variants_daily';
 
-const FEATUREs_TABLE = 'features';
+const FEATURES_TABLE = 'features';
 
 const fromRow = (row: ClientMetricsEnvTable) => ({
     featureName: row.feature_name,
@@ -156,7 +156,7 @@ export class ClientMetricsStoreV2 implements IClientMetricsStoreV2 {
     }
 
     async getFeatureFlagNames(): Promise<string[]> {
-        return this.db(FEATUREs_TABLE).distinct('name').pluck('name');
+        return this.db(FEATURES_TABLE).distinct('name').pluck('name');
     }
 
     async getAll(query: Object = {}): Promise<IClientMetricsEnv[]> {

--- a/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-store-v2.ts
@@ -33,6 +33,8 @@ const DAILY_TABLE = 'client_metrics_env_daily';
 const HOURLY_TABLE_VARIANTS = 'client_metrics_env_variants';
 const DAILY_TABLE_VARIANTS = 'client_metrics_env_variants_daily';
 
+const FEATUREs_TABLE = 'features';
+
 const fromRow = (row: ClientMetricsEnvTable) => ({
     featureName: row.feature_name,
     appName: row.app_name,
@@ -151,6 +153,10 @@ export class ClientMetricsStoreV2 implements IClientMetricsStoreV2 {
             return fromRow(row);
         }
         throw new NotFoundError(`Could not find metric`);
+    }
+
+    async getFeatureFlagNames(): Promise<string[]> {
+        return this.db(FEATUREs_TABLE).distinct('name').pluck('name');
     }
 
     async getAll(query: Object = {}): Promise<IClientMetricsEnv[]> {

--- a/src/lib/features/metrics/client-metrics/fake-client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/fake-client-metrics-store-v2.ts
@@ -17,6 +17,11 @@ export default class FakeClientMetricsStoreV2
         super();
         this.setMaxListeners(0);
     }
+
+    getFeatureFlagNames(): Promise<string[]> {
+        throw new Error('Method not implemented.');
+    }
+
     getSeenTogglesForApp(
         appName: string,
         hoursBack?: number,

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -129,11 +129,9 @@ export default class ClientMetricsServiceV2 {
                 return this.filterValidToggleNames(existingNames);
             } catch (e) {
                 this.logger.error(e);
-                return this.filterValidToggleNames(toggleNames);
             }
-        } else {
-            return this.filterValidToggleNames(toggleNames);
         }
+        return this.filterValidToggleNames(toggleNames);
     }
 
     async filterValidToggleNames(toggleNames: string[]): Promise<string[]> {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -23,6 +23,7 @@ export type IFlagKey =
     | 'disableNotifications'
     | 'advancedPlayground'
     | 'filterInvalidClientMetrics'
+    | 'filterExistingFlagNames'
     | 'disableMetrics'
     | 'signals'
     | 'automatedActions'
@@ -126,6 +127,10 @@ const flags: IFlags = {
         false,
     ),
     filterInvalidClientMetrics: parseEnvVarBoolean(
+        process.env.FILTER_INVALID_CLIENT_METRICS,
+        false,
+    ),
+    filterExistingFlagNames: parseEnvVarBoolean(
         process.env.FILTER_INVALID_CLIENT_METRICS,
         false,
     ),

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,6 +58,7 @@ process.nextTick(async () => {
                         uniqueSdkTracking: true,
                         frontendHeaderRedesign: true,
                         dataUsageMultiMonthView: true,
+                        filterExistingFlagNames: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Adds a killswitch called "filterExistingFlagNames". When enabled it will filter out reported SDK metrics and remove all reported metrics for names that does not match an exiting feature flag in Unleash. 

This have proven critical in the rare case of an SDK that start sending random flag-names back to unleash, and thus filling up the database. At some point the database will start slowing down due to the noisy data. 

In order to not resolve the flagNames all the time we have added a small cache (10s) for feature flag names. This gives a small delay (10s) from flag is created until we start allow metrics for the flag when kill-switch is enabled. We should probably listen to the event-stream and use that invalidate the cache when a flag is created. 