### PR TITLE
chore: make playground code editor height dynamic

### DIFF
--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -97,6 +97,9 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
         [setContext],
     );
 
+    // (placeholder line count * font size * line height) + padding
+    const codeInputHeight = `calc(6 * ${theme.typography.body1.fontSize} * ${theme.typography.body1.lineHeight}) + 8px`;
+
     return (
         <Box sx={{ width: '100%' }}>
             <StyledEditorHeader>
@@ -119,7 +122,7 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
             </StyledEditorHeader>
             <CodeMirror
                 value={context}
-                height='150px'
+                height={codeInputHeight}
                 theme={themeMode === 'dark' ? duotoneDark : duotoneLight}
                 extensions={[json()]}
                 onChange={onCodeFieldChange}


### PR DESCRIPTION
The playground code editor had a fixed height of `150px`. This works
well with the current font size, but if we're changing it, we'll end
up with too much height compared to the font size.

So instead, let's calculate the font size based on the current font
size.