### PR TITLE
fix: don't check license in OSS

### DIFF
--- a/frontend/src/hooks/api/getters/useLicense/useLicense.ts
+++ b/frontend/src/hooks/api/getters/useLicense/useLicense.ts
@@ -1,4 +1,3 @@
-import useSWR from 'swr';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useEnterpriseSWR } from '../useEnterpriseSWR/useEnterpriseSWR';
@@ -51,7 +50,8 @@ export const useLicenseCheck = (): LicenseInfo => {
 };
 
 export const useLicense = (): License => {
-    const { data, error, mutate } = useSWR(
+    const { data, error, mutate } = useEnterpriseSWR(
+        undefined,
         formatApiPath(`api/admin/license`),
         fetcher,
     );


### PR DESCRIPTION
The license check API call was giving me 404s in the console of the
OSS version of Unleash.

This changes the `useLicense` hook to use `useEnterpriseSWR` instead
of `useSWR` to avoid making the API call in the OSS version. This is
consistent with the `useLicenseCheck` hook in the same file.