### PR TITLE
fix: add legacy button styles

### DIFF
--- a/frontend/src/themes/theme.legacy.ts
+++ b/frontend/src/themes/theme.legacy.ts
@@ -31,7 +31,7 @@ export const theme = {
         fontWeightBold: '700',
         fontWeightMedium: '700',
         allVariants: { lineHeight: 1.4 },
-        button: { lineHeight: 1.75 },
+        button: { lineHeight: 1.75, fontSize: '16px' },
         h1: {
             fontSize: '1.5rem',
             lineHeight: 1.875,
@@ -322,6 +322,16 @@ export default createTheme({
                 a: {
                     color: theme.palette.links,
                 },
+            },
+        },
+
+        // Buttons
+        MuiButton: {
+            styleOverrides: {
+                root: ({ theme }) => ({
+                    borderRadius: '3px',
+                    textTransform: 'none',
+                }),
             },
         },
 


### PR DESCRIPTION
Adds the button styles that were removed from `app.css` into the
legacy theme file. These change very slightly when the flag is on, and
because the hardcoded `app.css` styles have been removed, we'll use
the legacy file as fallback.