### PR TITLE
chore: add button styles to dark mode too

### DIFF
--- a/frontend/src/themes/dark-theme.ts
+++ b/frontend/src/themes/dark-theme.ts
@@ -535,6 +535,8 @@ export const darkTheme = createTheme({
         MuiButton: {
             styleOverrides: {
                 root: ({ theme }) => ({
+                    borderRadius: theme.shape.borderRadius,
+                    textTransform: 'none',
                     '&:not(.Mui-disabled).MuiButton-containedPrimary': {
                         backgroundColor: theme.palette.background.alternative,
                         '&:hover': {


### PR DESCRIPTION
This adds the same button stylings to the dark theme as we did to the
light theme in #9275.