### PR TITLE
fix: Use the right theme even if the payload is a variant.

### DIFF
--- a/frontend/src/component/feedback/FeedbackCES/__snapshots__/FeedbackCESForm.test.tsx.snap
+++ b/frontend/src/component/feedback/FeedbackCES/__snapshots__/FeedbackCESForm.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`FeedbackCESForm 1`] = `
           hidden=""
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-l6m2tn-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1ln3ri4-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"
             type="submit"

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`renders an empty list correctly 1`] = `
               />
               <button
                 aria-labelledby="useId-0"
-                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1xfu7h-MuiButtonBase-root-MuiButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1cn29am-MuiButtonBase-root-MuiButton-root"
                 disabled={false}
                 onBlur={[Function]}
                 onClick={[Function]}

--- a/frontend/src/hooks/useThemeMode.ts
+++ b/frontend/src/hooks/useThemeMode.ts
@@ -7,6 +7,7 @@ import legacyLightTheme from 'themes/theme.legacy';
 import legacyDarkTheme from 'themes/dark-theme.legacy';
 import type { Theme } from '@mui/material/styles/createTheme';
 import { useUiFlag } from './useUiFlag';
+import type { Variant } from 'utils/variants';
 
 interface IUseThemeModeOutput {
     resolveTheme: () => Theme;
@@ -22,10 +23,11 @@ export const useThemeMode = (): IUseThemeModeOutput => {
     let useNewTheme = false;
     if (typeof uiGlobalFontSizeEnabled === 'boolean') {
         useNewTheme = uiGlobalFontSizeEnabled;
-    } else if (typeof uiGlobalFontSizeEnabled === 'object') {
-        useNewTheme =
-            'name' in uiGlobalFontSizeEnabled &&
-            uiGlobalFontSizeEnabled.name !== 'disabled';
+    } else if (
+        typeof uiGlobalFontSizeEnabled === 'object' &&
+        'name' in uiGlobalFontSizeEnabled
+    ) {
+        useNewTheme = (uiGlobalFontSizeEnabled as Variant).name !== 'disabled';
     }
 
     const resolveTheme = () => {

--- a/frontend/src/hooks/useThemeMode.ts
+++ b/frontend/src/hooks/useThemeMode.ts
@@ -23,7 +23,9 @@ export const useThemeMode = (): IUseThemeModeOutput => {
     if (typeof uiGlobalFontSizeEnabled === 'boolean') {
         useNewTheme = uiGlobalFontSizeEnabled;
     } else if (typeof uiGlobalFontSizeEnabled === 'object') {
-        useNewTheme = uiGlobalFontSizeEnabled.name !== 'disabled';
+        useNewTheme =
+            'name' in uiGlobalFontSizeEnabled &&
+            uiGlobalFontSizeEnabled.name !== 'disabled';
     }
 
     const resolveTheme = () => {

--- a/frontend/src/hooks/useThemeMode.ts
+++ b/frontend/src/hooks/useThemeMode.ts
@@ -19,12 +19,19 @@ export const useThemeMode = (): IUseThemeModeOutput => {
     const key = 'unleash-theme';
     const uiGlobalFontSizeEnabled = useUiFlag('uiGlobalFontSize');
 
+    let useNewTheme = false;
+    if (typeof uiGlobalFontSizeEnabled === 'boolean') {
+        useNewTheme = uiGlobalFontSizeEnabled;
+    } else if (typeof uiGlobalFontSizeEnabled === 'object') {
+        useNewTheme = uiGlobalFontSizeEnabled.name !== 'disabled';
+    }
+
     const resolveTheme = () => {
         if (themeMode === 'light') {
-            return uiGlobalFontSizeEnabled ? lightTheme : legacyLightTheme;
+            return useNewTheme ? lightTheme : legacyLightTheme;
         }
 
-        return uiGlobalFontSizeEnabled ? darkTheme : legacyDarkTheme;
+        return useNewTheme ? darkTheme : legacyDarkTheme;
     };
 
     const onSetThemeMode = () => {

--- a/frontend/src/themes/dark-theme.legacy.ts
+++ b/frontend/src/themes/dark-theme.legacy.ts
@@ -39,7 +39,12 @@ const theme = {
         fontWeightBold: '700',
         fontWeightMedium: '700',
         allVariants: { lineHeight: 1.4 },
-        button: { lineHeight: 1.75, fontSize: '16px' },
+        button: {
+            lineHeight: 1.75,
+            '&&&': {
+                fontSize: '16px',
+            },
+        },
         h1: {
             fontSize: '1.5rem',
             lineHeight: 1.875,

--- a/frontend/src/themes/theme.legacy.ts
+++ b/frontend/src/themes/theme.legacy.ts
@@ -31,7 +31,12 @@ export const theme = {
         fontWeightBold: '700',
         fontWeightMedium: '700',
         allVariants: { lineHeight: 1.4 },
-        button: { lineHeight: 1.75, fontSize: '16px' },
+        button: {
+            lineHeight: 1.75,
+            '&&&': {
+                fontSize: '16px',
+            },
+        },
         h1: {
             fontSize: '1.5rem',
             lineHeight: 1.875,


### PR DESCRIPTION
Also, use extra css selectors to increase specificity so that this
takes precedence over the MUI themes.

I don't like that we need to do this weird selector thing, but hey, it
is what it is.