### PR TITLE
fix: make the chip in the playground project selector small

### DIFF
--- a/frontend/src/component/common/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/component/common/ProjectSelect/ProjectSelect.tsx
@@ -133,6 +133,7 @@ export const ProjectSelect: VFC<IProjectSelectProps> = forwardRef(
                             {value.slice(0, limitTags).map((option, index) => (
                                 <Chip
                                     {...getTagProps({ index })}
+                                    size='small'
                                     key={index}
                                     label={option.label}
                                 />


### PR DESCRIPTION
This makes it the same size as the env selector, fixing a slight
visual misalignment.

Doing a reference check, I can't find any other uses of this selector,
so I'm making the changes directly.

Before:
![image](https://github.com/user-attachments/assets/a9847dc7-8237-46bd-8d5b-7149a5682a59)

After:
![image](https://github.com/user-attachments/assets/a78d71ed-3391-4f72-9c8f-64f926a821cf)
