### PR TITLE
fix: add some missing button labels on the project page

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -99,6 +99,8 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         checkAccess(CREATE_FEATURE_STRATEGY, environment),
     );
 
+    const label = `Copy to environment${enabled ? '' : ' (Access denied)'}`;
+
     return (
         <div>
             <ChangeRequestDialogue
@@ -115,15 +117,12 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                     />
                 }
             />
-            <Tooltip
-                title={`Copy to environment${
-                    enabled ? '' : ' (Access denied)'
-                }`}
-            >
+            <Tooltip title={label}>
                 <div>
                     <IconButton
                         size='large'
                         id={`copy-strategy-icon-menu-${strategy.id}`}
+                        aria-label={label}
                         aria-controls={open ? 'basic-menu' : undefined}
                         aria-haspopup='true'
                         aria-expanded={open ? 'true' : undefined}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelEnvironmentSwitches/FeatureOverviewSidePanelEnvironmentSwitch/FeatureOverviewSidePanelEnvironmentHider.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelEnvironmentSwitches/FeatureOverviewSidePanelEnvironmentSwitch/FeatureOverviewSidePanelEnvironmentHider.tsx
@@ -32,13 +32,16 @@ export const FeatureOverviewSidePanelEnvironmentHider = ({
         setHiddenEnvironments(environment.name);
     };
 
+    const isHidden = hiddenEnvironments.has(environment.name);
+
     return (
         <StyledVisibilityToggle
             onClick={toggleHiddenEnvironments}
-            visibilityOff={hiddenEnvironments.has(environment.name)}
+            visibilityOff={isHidden}
+            aria-label={`${isHidden ? 'Show' : 'Hide'} environment "${environment.name}"`}
         >
             <ConditionallyRender
-                condition={hiddenEnvironments.has(environment.name)}
+                condition={isHidden}
                 show={<VisibilityOff />}
                 elseShow={<Visibility />}
             />


### PR DESCRIPTION
Adds aria-labels to the env visibility toggle button and the "copy
env" button.