### PR TITLE
fix: Add strategy and more strategies button are different heights

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -28,19 +28,18 @@ interface IFeatureStrategyMenuProps {
     disableReason?: string;
 }
 
-const StyledStrategyMenu = styled('div')({
+const StyledStrategyMenu = styled('div')(({ theme }) => ({
     flexShrink: 0,
-});
+    display: 'flex',
+    flexFlow: 'row',
+    gap: theme.spacing(1),
+}));
 
 const StyledAdditionalMenuButton = styled(PermissionButton)(({ theme }) => ({
-    paddingBlock: theme.spacing(0.25),
     minWidth: 0,
     width: theme.spacing(4.5),
-    alignItems: 'center',
-    justifyContent: 'center',
-    align: 'center',
-    flexDirection: 'column',
-    marginLeft: theme.spacing(1),
+    alignSelf: 'stretch',
+    paddingBlock: 0,
 }));
 
 export const FeatureStrategyMenu = ({
@@ -188,12 +187,7 @@ export const FeatureStrategyMenu = ({
                     title: disableReason ? disableReason : 'More strategies',
                 }}
             >
-                <MoreVert
-                    sx={(theme) => ({
-                        margin: theme.spacing(0.25, 0),
-                        fontSize: theme.typography.h2.fontSize,
-                    })}
-                />
+                <MoreVert />
             </StyledAdditionalMenuButton>
             <Popover
                 id={popoverId}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -179,7 +179,6 @@ export const FeatureStrategyMenu = ({
                 projectId={projectId}
                 environmentId={environmentId}
                 onClick={openMoreStrategies}
-                aria-labelledby={popoverId}
                 variant='outlined'
                 size={size}
                 hideLockIcon

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -33,6 +33,7 @@ const StyledStrategyMenu = styled('div')({
 });
 
 const StyledAdditionalMenuButton = styled(PermissionButton)(({ theme }) => ({
+    paddingBlock: theme.spacing(0.25),
     minWidth: 0,
     width: theme.spacing(4.5),
     alignItems: 'center',
@@ -188,7 +189,10 @@ export const FeatureStrategyMenu = ({
                 }}
             >
                 <MoreVert
-                    sx={(theme) => ({ margin: theme.spacing(0.25, 0) })}
+                    sx={(theme) => ({
+                        margin: theme.spacing(0.25, 0),
+                        fontSize: theme.typography.h2.fontSize,
+                    })}
                 />
             </StyledAdditionalMenuButton>
             <Popover

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -59,6 +59,7 @@ process.nextTick(async () => {
                         frontendHeaderRedesign: true,
                         dataUsageMultiMonthView: true,
                         filterExistingFlagNames: true,
+                        uiGlobalFontSize: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Fixes the height discrepancy between add strategy and more strategies buttons, both with and without the flag enabled.

The essence of the fix is to make the "more strategies" button's height dynamic and grow to match the height of the other button.

Before (flag enabled):

After (flag enabled):

Before (flag disabled):

After (flag disabled):