### PR TITLE
feat: new flag header

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -5,6 +5,7 @@ import {
     Tab,
     Tabs,
     Tooltip,
+    Typography,
     useMediaQuery,
 } from '@mui/material';
 import Archive from '@mui/icons-material/Archive';
@@ -49,6 +50,24 @@ import useToast from 'hooks/useToast';
 import { useUiFlag } from 'hooks/useUiFlag';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
 import { Collaborators } from './Collaborators';
+
+const NewStyledHeader = styled('div')(({ theme }) => ({
+    backgroundColor: 'none',
+    marginBottom: theme.spacing(2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const LowerHeaderRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    justifyContent: 'space-between',
+    gap: theme.spacing(4),
+}));
+
+const HeaderActions = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+}));
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -139,6 +158,7 @@ const useLegacyVariants = (environments: IFeatureToggle['environments']) => {
 export const FeatureView = () => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
+    const flagOverviewRedesign = useUiFlag('flagOverviewRedesign');
     const { favorite, unfavorite } = useFavoriteFeaturesApi();
     const { refetchFeature } = useFeature(projectId, featureId);
     const { setToastData, setToastApiError } = useToast();
@@ -231,6 +251,89 @@ export const FeatureView = () => {
 
     return (
         <div ref={ref}>
+            {flagOverviewRedesign && (
+                <NewStyledHeader>
+                    <Typography variant='h1'>{feature.name}</Typography>
+                    <LowerHeaderRow>
+                        <Tabs
+                            value={activeTab.path}
+                            indicatorColor='primary'
+                            textColor='primary'
+                        >
+                            {tabData.map((tab) => (
+                                <StyledTabButton
+                                    key={tab.title}
+                                    label={tab.title}
+                                    value={tab.path}
+                                    onClick={() => navigate(tab.path)}
+                                    data-testid={`TAB-${tab.title}`}
+                                />
+                            ))}
+                        </Tabs>
+                        <HeaderActions>
+                            <FavoriteIconButton
+                                onClick={onFavorite}
+                                isFavorite={feature?.favorite}
+                            />
+                            <Tooltip
+                                title={
+                                    isFeatureNameCopied
+                                        ? 'Copied!'
+                                        : 'Copy name'
+                                }
+                                arrow
+                            >
+                                <IconButton
+                                    onClick={handleCopyToClipboard}
+                                    style={{ marginLeft: 8 }}
+                                >
+                                    {isFeatureNameCopied ? (
+                                        <Check style={{ fontSize: 16 }} />
+                                    ) : (
+                                        <FileCopy style={{ fontSize: 16 }} />
+                                    )}
+                                </IconButton>
+                            </Tooltip>
+
+                            <PermissionIconButton
+                                permission={CREATE_FEATURE}
+                                projectId={projectId}
+                                data-loading
+                                component={Link}
+                                to={`/projects/${projectId}/features/${featureId}/copy`}
+                                tooltipProps={{
+                                    title: 'Clone',
+                                }}
+                            >
+                                <LibraryAdd />
+                            </PermissionIconButton>
+
+                            <PermissionIconButton
+                                permission={DELETE_FEATURE}
+                                projectId={projectId}
+                                tooltipProps={{
+                                    title: 'Archive feature flag',
+                                }}
+                                data-loading
+                                onClick={() => setShowDelDialog(true)}
+                            >
+                                <Archive />
+                            </PermissionIconButton>
+                            <PermissionIconButton
+                                onClick={() => setOpenStaleDialog(true)}
+                                permission={UPDATE_FEATURE}
+                                projectId={projectId}
+                                tooltipProps={{
+                                    title: 'Toggle stale state',
+                                }}
+                                data-loading
+                            >
+                                <WatchLater />
+                            </PermissionIconButton>
+                        </HeaderActions>
+                    </LowerHeaderRow>
+                </NewStyledHeader>
+            )}
             <StyledHeader>
                 <StyledInnerContainer>
                     <StyledFlagInfoContainer>

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -89,11 +89,9 @@ const IconButtonWithTooltip: FC<
             arrow
             onClick={(e) => e.preventDefault()}
         >
-            <div>
-                <IconButton aria-label={label} onClick={onClick}>
-                    {children}
-                </IconButton>
-            </div>
+            <IconButton aria-label={label} onClick={onClick}>
+                {children}
+            </IconButton>
         </TooltipResolver>
     );
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -52,7 +52,7 @@ process.nextTick(async () => {
                         releasePlans: false,
                         releasePlanChangeRequests: false,
                         showUserDeviceCount: true,
-                        flagOverviewRedesign: false,
+                        flagOverviewRedesign: true,
                         granularAdminPermissions: true,
                         deltaApi: true,
                         uniqueSdkTracking: true,


### PR DESCRIPTION
Initial spike to add the new design for the flag header. This PR uses the flag and adds a new header if it's active.

As far as I can tell, all elements of the new header are present in this design.

![image](https://github.com/user-attachments/assets/811547cd-1149-4a58-8483-96563af9fc2f)

## Still to do in followup PRs

### Narrow windows

Handle narrow window widths. There is no handling of narrow windows here and the entire thing is set as nowrap, so it ends up with the actions hiding the tabs:
![image](https://github.com/user-attachments/assets/f236caff-dccb-4d8f-b37c-e3893b7487f9)

However, we also don't handle this very well today:
![image](https://github.com/user-attachments/assets/381925dd-e2d6-4ed8-87f4-2fa87d04cbca)

That said, I think now woud be a good time to handle this.


### Icon buttons with tooltips

Todays buttons for copying the flag, archiving it, etc, use `PermissionIconButton`. We want the same behavior, but without behavior checks. As far as I can tell, that's not a component we have today? (although I didn't look very hard). In this first instance, I've made a very simple version that's based on the permission icon button. Before we close off the header work, I'd like to make these two different button classes based of the same design. But I'd rather address it in a followup.
