### PR TITLE
fix: hydration event should update with every event

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
@@ -169,6 +169,7 @@ describe('RevisionCache', () => {
 
         const hydrationEvent = deltaCache.getHydrationEvent();
         expect(hydrationEvent.features).toHaveLength(2);
+        expect(hydrationEvent.eventId).toEqual(7);
         expect(hydrationEvent.features).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ name: 'my-feature-flag' }),

--- a/src/lib/features/client-feature-toggles/delta/delta-cache.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.ts
@@ -92,6 +92,7 @@ export class DeltaCache {
                     break;
                 }
             }
+            this.hydrationEvent.eventId = appliedEvent.eventId;
         }
     }
 }


### PR DESCRIPTION
We were not updating hydration event id. This fixes it.