### PR TITLE
fix: return undefined from delta if no events

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -201,6 +201,10 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 namePrefix,
             );
 
+            if (events.length === 0) {
+                return undefined;
+            }
+
             const response: ClientFeaturesDeltaSchema = {
                 events: events.map((event) => {
                     if (event.type === 'feature-removed') {


### PR DESCRIPTION
Nameprefix can remove events from result, so we should send 304 in that case.