### PR TITLE
fix(1-3374): access e2e test

### DIFF
--- a/frontend/cypress/integration/projects/access.spec.ts
+++ b/frontend/cypress/integration/projects/access.spec.ts
@@ -126,8 +126,8 @@ describe('project-access', () => {
 
         cy.get(`[data-testid='${PA_ASSIGN_CREATE_ID}']`).click();
         cy.wait('@editAccess');
-        cy.get("td span:contains('Owner')").should('have.length', 2);
-        cy.get("td span:contains('Member')").should('have.length', 1);
+        cy.get("td a span:contains('Owner')").should('have.length', 2);
+        cy.get("td a span:contains('Member')").should('have.length', 1);
     });
 
     it('can edit role to multiple roles', () => {
@@ -145,8 +145,8 @@ describe('project-access', () => {
 
         cy.get(`[data-testid='${PA_ASSIGN_CREATE_ID}']`).click();
         cy.wait('@editAccess');
-        cy.get("td span:contains('Owner')").should('have.length', 2);
-        cy.get("td span:contains('2 roles')").should('have.length', 1);
+        cy.get("td a span:contains('Owner')").should('have.length', 2);
+        cy.get("td a span:contains('2 roles')").should('have.length', 1);
     });
 
     it('can remove access', () => {


### PR DESCRIPTION
## About the changes
Fix e2e test, failing because of subtle table syntax change. Nested `span`s are counted twice in Cypress `:contains`
![image](https://github.com/user-attachments/assets/6fab343a-ad67-457e-b35a-26fed5b83bfd)
