### PR TITLE
fix: add a metric to track client registrations

### DIFF
--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -19,6 +19,7 @@ const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
 const CLIENT_METRICS_TAGS = 'client-api-tags';
 const CLIENT_FEATURES_MEMORY = 'client_features_memory';
 const CLIENT_DELTA_MEMORY = 'client_delta_memory';
+const CLIENT_REGISTERED = 'client_registered';
 
 type MetricEvent =
     | typeof REQUEST_TIME
@@ -91,6 +92,7 @@ export {
     CLIENT_METRICS_TAGS,
     CLIENT_FEATURES_MEMORY,
     CLIENT_DELTA_MEMORY,
+    CLIENT_REGISTERED,
     type MetricEvent,
     type MetricEventPayload,
     emitMetricEvent,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -169,6 +169,11 @@ export function registerPrometheusMetrics(
         help: 'Number of times a feature flag has been used',
         labelNames: ['toggle', 'active', 'appName'],
     });
+    const clientRegistrationTotal = createCounter({
+        name: 'client_registration_total',
+        help: 'Number of times a an application have registered',
+        labelNames: ['appName', 'environment'],
+    });
 
     dbMetrics.registerGaugeDbMetric({
         name: 'feature_toggles_total',
@@ -806,6 +811,9 @@ export function registerPrometheusMetrics(
     eventBus.on(events.CLIENT_DELTA_MEMORY, (event: { memory: number }) => {
         clientDeltaMemory.reset();
         clientDeltaMemory.set(event.memory);
+    });
+    eventBus.on(events.CLIENT_REGISTERED, ({ appName, environment }) => {
+        clientRegistrationTotal.labels({ appName, environment }).inc();
     });
 
     events.onMetricEvent(


### PR DESCRIPTION
Adding a counter to track every time a client registers with Unleash. 