### PR TITLE
fix(1-3375):   Fix unintended scroll on dashboard

### DIFF
--- a/frontend/src/component/personalDashboard/MyFlags.tsx
+++ b/frontend/src/component/personalDashboard/MyFlags.tsx
@@ -40,9 +40,10 @@ const FlagListItem: FC<{
     useEffect(() => {
         if (activeFlagRef.current) {
             activeFlagRef.current.scrollIntoView({
-                block: 'nearest',
+                block: 'start',
                 inline: 'start',
             });
+            window.scrollTo({ top: 0 });
         }
     }, []);
     const IconComponent = getFeatureTypeIcons(flag.type);

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -88,9 +88,10 @@ const ProjectListItem: FC<{
     useEffect(() => {
         if (activeProjectRef.current) {
             activeProjectRef.current.scrollIntoView({
-                block: 'nearest',
+                block: 'start',
                 inline: 'start',
             });
+            window.scrollTo({ top: 0 });
         }
     }, []);
 


### PR DESCRIPTION
Fixes a bug where the dashboard would scroll you down from the top of
the page on load if your window was too short too see both the
selected flag and the selected project.

This solves it by immediately scrolling to the top of the page after
scrolling your selected element into view. Because this hook only runs
on page load, it shouldn't be safe. (At least I couldn't make this
misbehave with manual testing).

It also changes the list scroll behavior to scroll your selected item
to the top of the list instead of to the bottom (effectively). During
testing, that seems like a better solution to me.

## Background (or why do we auto-scroll here?)

The dashboard's flag and projects panels stores your last selection,
so that when you return to the page you'll be shown what you were
looking at last. This is especially useful if you have a lot of flags
but you're focusing on one in particular.

However, if you **do** have a lot of flags, then it's also quite
likely that your selection will be "below the fold" of the panel, and
you won't see your selected flag/project immediately in the
list (without scrolling).

It seemed like a nice UI affordance to automatically bring your
selected item into view (especially because without it, there's no way
to see what flag/project) you're looking at, so I added the
[`scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) hook.

What I didn't realize, however, is that it scrolls all scrollable
ancestor containers, which means that if your screen is too short,
it'll scroll you down the page.

From my reading of the docs and some local testing, I don't think
there is a way to limit the scrolling to only the nearest ancestor, so
the easiest way to ensure that we're always at the top seemed to be to
just scroll to the immediately after.