### PR TITLE
fix(1-3377):  handle singular counts in project status lifecycle boxes

### DIFF
--- a/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectLifecycleSummary.tsx
@@ -167,10 +167,10 @@ export const ProjectLifecycleSummary = () => {
         );
     };
 
-    const totalArchivedStat = () => {
-        const count = data?.lifecycleSummary.archived.last30Days ?? 0;
-        return `${count} ${count === 1 ? 'flag' : 'flags'} archived`;
-    };
+    const archivedLast30DaysCount =
+        data?.lifecycleSummary.archived.last30Days ?? 0;
+    const totalArchivedText = `${archivedLast30DaysCount} ${archivedLast30DaysCount === 1 ? 'flag' : 'flags'} archived`;
+
     return (
         <LifecycleList ref={loadingRef}>
             <LifecycleBox tooltipText={lifecycleMessages.initial}>
@@ -264,7 +264,7 @@ export const ProjectLifecycleSummary = () => {
                 <Stats>
                     <dt>Last 30 days</dt>
                     <dd data-loading-project-lifecycle-summary>
-                        {totalArchivedStat()}
+                        {totalArchivedText}
                     </dd>
                 </Stats>
             </LifecycleBox>


### PR DESCRIPTION
If the average number of days in a stage is 1, use `1 day` instead of
`1 days`.

Likewise, if your total number of archived flags is 1, use `1 flag archived` instead of `1 flags archived`.

I grepped through the file, but couldn't find any other hardcoded instances of "flags" or "days", so I think this is everything.