### PR TITLE
feat(1-3379): add stale badge to the new header

### DIFF
--- a/frontend/src/component/common/FeatureStatusChip/FeatureStatusChip.tsx
+++ b/frontend/src/component/common/FeatureStatusChip/FeatureStatusChip.tsx
@@ -3,11 +3,13 @@ import { Badge } from 'component/common/Badge/Badge';
 interface IStatusChip {
     stale: boolean;
     showActive?: boolean;
+    withLeftMargin?: boolean;
 }
 
 export const FeatureStatusChip = ({
     stale,
     showActive = true,
+    withLeftMargin = true,
 }: IStatusChip) => {
     if (!stale && !showActive) {
         return null;
@@ -19,7 +21,7 @@ export const FeatureStatusChip = ({
     const value = stale ? 'Stale' : 'Active';
 
     return (
-        <div data-loading style={{ marginLeft: '8px' }}>
+        <div data-loading style={{ marginLeft: withLeftMargin ? '8px' : 0 }}>
             <Badge color={stale ? 'error' : 'success'} title={title}>
                 {value}
             </Badge>

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -51,11 +51,15 @@ const NewStyledHeader = styled('div')(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.divider}`,
 }));
 
-const LowerHeaderRow = styled('div')(({ theme }) => ({
+const UpperHeaderRow = styled('div')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'row wrap',
-    justifyContent: 'space-between',
     columnGap: theme.spacing(4),
+    alignItems: 'center',
+}));
+
+const LowerHeaderRow = styled(UpperHeaderRow)(({ theme }) => ({
+    justifyContent: 'space-between',
 }));
 
 const HeaderActions = styled('div')(({ theme }) => ({
@@ -259,7 +263,15 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
         <>
             {flagOverviewRedesign ? (
                 <NewStyledHeader>
-                    <Typography variant='h1'>{feature.name}</Typography>
+                    <UpperHeaderRow>
+                        <Typography variant='h1'>{feature.name}</Typography>
+                        {feature.stale ? (
+                            <FeatureStatusChip
+                                withLeftMargin={false}
+                                stale={true}
+                            />
+                        ) : null}
+                    </UpperHeaderRow>
                     <LowerHeaderRow>
                         <Tabs
                             value={activeTab.path}


### PR DESCRIPTION
Without this, there's no way to tell if a flag is stale or not on the flag page, so we're adding it back in. However, we'll only show the badge if it's stale, not if it's an active flag.

To make the badge line up properly when it wraps, I also added a way to opt out of the hard-coded left margin in the badge.