### PR TITLE
feat: project field to feature removed event

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -205,9 +205,9 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 return undefined;
             }
 
-            return Promise.resolve({
+            return {
                 events,
-            });
+            };
         }
     }
 

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -205,17 +205,9 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 return undefined;
             }
 
-            const response: ClientFeaturesDeltaSchema = {
-                events: events.map((event) => {
-                    if (event.type === 'feature-removed') {
-                        const { project, ...rest } = event;
-                        return rest;
-                    }
-                    return event;
-                }),
-            };
-
-            return Promise.resolve(response);
+            return Promise.resolve({
+                events,
+            });
         }
     }
 

--- a/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.test.ts
@@ -131,13 +131,13 @@ describe('RevisionCache', () => {
             },
             {
                 eventId: 4,
-                type: 'feature-removed',
+                type: DELTA_EVENT_TYPES.FEATURE_REMOVED,
                 featureName: 'test-flag',
                 project: 'default',
             },
             {
                 eventId: 5,
-                type: 'segment-updated',
+                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
                 segment: {
                     id: 1,
                     name: 'update-segment-new',
@@ -146,12 +146,12 @@ describe('RevisionCache', () => {
             },
             {
                 eventId: 6,
-                type: 'segment-removed',
+                type: DELTA_EVENT_TYPES.SEGMENT_REMOVED,
                 segmentId: 2,
             },
             {
                 eventId: 7,
-                type: 'segment-updated',
+                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
                 segment: {
                     id: 3,
                     name: 'new-segment',

--- a/src/lib/openapi/spec/client-features-delta-schema.test.ts
+++ b/src/lib/openapi/spec/client-features-delta-schema.test.ts
@@ -8,6 +8,7 @@ test('clientFeaturesDeltaSchema all fields', () => {
                 eventId: 1,
                 type: 'feature-removed',
                 featureName: 'removed-event',
+                project: 'default',
             },
             {
                 eventId: 1,

--- a/src/lib/openapi/spec/client-features-delta-schema.ts
+++ b/src/lib/openapi/spec/client-features-delta-schema.ts
@@ -35,11 +35,12 @@ export const clientFeaturesDeltaSchema = {
                     },
                     {
                         type: 'object',
-                        required: ['eventId', 'type', 'featureName'],
+                        required: ['eventId', 'type', 'featureName', 'project'],
                         properties: {
                             eventId: { type: 'number' },
                             type: { type: 'string', enum: ['feature-removed'] },
                             featureName: { type: 'string' },
+                            project: { type: 'string' },
                         },
                     },
                     {


### PR DESCRIPTION
Start sending out project for feature deleted, as we need it for edge to keep exact copy.