### PR TITLE
chore: remove references to admin token kill switch

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -4,20 +4,17 @@ import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironmen
 import type { IApiTokenCreate } from 'hooks/api/actions/useApiTokensApi/useApiTokensApi';
 import { TokenType } from 'interfaces/token';
 import {
-    ADMIN,
     CREATE_FRONTEND_API_TOKEN,
     CREATE_CLIENT_API_TOKEN,
     CREATE_PROJECT_API_TOKEN,
 } from '@server/types/permissions';
 import { useHasRootAccess } from 'hooks/useHasAccess';
 import type { SelectOption } from './TokenTypeSelector/TokenTypeSelector';
-import { useUiFlag } from '../../../../hooks/useUiFlag';
 
 export type ApiTokenFormErrorType = 'username' | 'projects';
 export const useApiTokenForm = (project?: string) => {
     const { environments } = useEnvironments();
     const { uiConfig } = useUiConfig();
-    const adminTokenKillSwitch = useUiFlag('adminTokenKillSwitch');
     const initialEnvironment = environments?.find((e) => e.enabled)?.name;
 
     const hasCreateTokenPermission = useHasRootAccess(CREATE_CLIENT_API_TOKEN);
@@ -36,20 +33,11 @@ export const useApiTokenForm = (project?: string) => {
         },
     ];
 
-    const hasAdminAccess = useHasRootAccess(ADMIN);
     const hasCreateFrontendAccess = useHasRootAccess(CREATE_FRONTEND_API_TOKEN);
     const hasCreateFrontendTokenAccess = useHasRootAccess(
         CREATE_PROJECT_API_TOKEN,
         project,
     );
-    if (!project && !adminTokenKillSwitch) {
-        apiTokenTypes.push({
-            key: TokenType.ADMIN,
-            label: TokenType.ADMIN,
-            title: 'Full access for managing Unleash',
-            enabled: hasAdminAccess,
-        });
-    }
 
     if (uiConfig.flags.embedProxyFrontend) {
         apiTokenTypes.splice(1, 0, {

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -71,7 +71,6 @@ export type UiFlags = {
     automatedActions?: boolean;
     celebrateUnleash?: boolean;
     enableLicense?: boolean;
-    adminTokenKillSwitch?: boolean;
     feedbackComments?: Variant;
     showInactiveUsers?: boolean;
     feedbackPosting?: boolean;


### PR DESCRIPTION
This feature has been removed