### PR TITLE
chore: visualize connected edges

### DIFF
--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -65,7 +65,6 @@ export const adminRoutes: INavigationMenuItem[] = [
         path: '/admin/network/*',
         title: 'Network',
         menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
-        configFlag: 'networkViewEnabled',
         group: 'instance',
     },
     {

--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -6,6 +6,9 @@ import { TabLink } from 'component/common/TabNav/TabLink';
 import { PageContent } from 'component/common/PageContent/PageContent';
 
 const NetworkOverview = lazy(() => import('./NetworkOverview/NetworkOverview'));
+const NetworkConnectedEdges = lazy(
+    () => import('./NetworkConnectedEdges/NetworkConnectedEdges'),
+);
 const NetworkTraffic = lazy(() => import('./NetworkTraffic/NetworkTraffic'));
 const NetworkTrafficUsage = lazy(
     () => import('./NetworkTrafficUsage/NetworkTrafficUsage'),
@@ -15,6 +18,10 @@ const tabs = [
     {
         label: 'Overview',
         path: '/admin/network',
+    },
+    {
+        label: 'Connected Edges',
+        path: '/admin/network/connected-edges',
     },
     {
         label: 'Traffic',
@@ -57,8 +64,12 @@ export const Network = () => {
                 }
             >
                 <Routes>
-                    <Route path='traffic' element={<NetworkTraffic />} />
                     <Route path='*' element={<NetworkOverview />} />
+                    <Route
+                        path='connected-edges'
+                        element={<NetworkConnectedEdges />}
+                    />
+                    <Route path='traffic' element={<NetworkTraffic />} />
                     <Route
                         path='data-usage'
                         element={<NetworkTrafficUsage />}

--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -71,13 +71,13 @@ export const Network = () => {
             >
                 <Routes>
                     <Route path='*' element={<NetworkOverview />} />
+                    <Route path='traffic' element={<NetworkTraffic />} />
                     {edgeObservabilityEnabled && (
                         <Route
                             path='connected-edges'
                             element={<NetworkConnectedEdges />}
                         />
                     )}
-                    <Route path='traffic' element={<NetworkTraffic />} />
                     <Route
                         path='data-usage'
                         element={<NetworkTrafficUsage />}

--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -4,6 +4,7 @@ import { Tab, Tabs } from '@mui/material';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { TabLink } from 'component/common/TabNav/TabLink';
 import { PageContent } from 'component/common/PageContent/PageContent';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const NetworkOverview = lazy(() => import('./NetworkOverview/NetworkOverview'));
 const NetworkConnectedEdges = lazy(
@@ -20,12 +21,12 @@ const tabs = [
         path: '/admin/network',
     },
     {
-        label: 'Connected Edges',
-        path: '/admin/network/connected-edges',
-    },
-    {
         label: 'Traffic',
         path: '/admin/network/traffic',
+    },
+    {
+        label: 'Connected Edges',
+        path: '/admin/network/connected-edges',
     },
     {
         label: 'Data Usage',
@@ -35,6 +36,11 @@ const tabs = [
 
 export const Network = () => {
     const { pathname } = useLocation();
+    const edgeObservabilityEnabled = useUiFlag('edgeObservability');
+
+    const filteredTabs = tabs.filter(
+        ({ label }) => label !== 'Connected Edges' || edgeObservabilityEnabled,
+    );
 
     return (
         <div>
@@ -48,7 +54,7 @@ export const Network = () => {
                         variant='scrollable'
                         allowScrollButtonsMobile
                     >
-                        {tabs.map(({ label, path }) => (
+                        {filteredTabs.map(({ label, path }) => (
                             <Tab
                                 key={label}
                                 value={path}
@@ -65,10 +71,12 @@ export const Network = () => {
             >
                 <Routes>
                     <Route path='*' element={<NetworkOverview />} />
-                    <Route
-                        path='connected-edges'
-                        element={<NetworkConnectedEdges />}
-                    />
+                    {edgeObservabilityEnabled && (
+                        <Route
+                            path='connected-edges'
+                            element={<NetworkConnectedEdges />}
+                        />
+                    )}
                     <Route path='traffic' element={<NetworkTraffic />} />
                     <Route
                         path='data-usage'

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -66,14 +66,15 @@ const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
-const StyledDetailRow = styled('div')({
+const StyledDetailRow = styled('div')(({ theme }) => ({
     display: 'flex',
     justifyContent: 'space-between',
+    gap: theme.spacing(2),
     '& > span': {
         display: 'flex',
         alignItems: 'center',
     },
-});
+}));
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
     padding: theme.spacing(0, 1),
@@ -159,7 +160,7 @@ export const NetworkConnectedEdgeInstance = ({
                     >
                         <CircleIcon />
                     </Tooltip>
-                    {instance.instanceId}
+                    {instance.id || instance.instanceId}
                 </StyledAccordionSummary>
                 <StyledAccordionDetails>
                     <StyledDetailRow>

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -97,7 +97,8 @@ const getCPUPercentage = ({
     reportedAt,
     cpuUsage,
 }: ConnectedEdge): string => {
-    if (!cpuUsage) return 'No usage';
+    const cpuUsageSeconds = Number(cpuUsage);
+    if (!cpuUsageSeconds) return 'No usage';
 
     const startedTimestamp = new Date(started).getTime();
     const reportedTimestamp = new Date(reportedAt).getTime();
@@ -105,7 +106,7 @@ const getCPUPercentage = ({
     const totalRuntimeSeconds = (reportedTimestamp - startedTimestamp) / 1000;
     if (totalRuntimeSeconds === 0) return 'No usage';
 
-    return `${((cpuUsage / totalRuntimeSeconds) * 100).toFixed(2)} %`;
+    return `${((cpuUsageSeconds / totalRuntimeSeconds) * 100).toFixed(2)} %`;
 };
 
 const getMemory = ({ memoryUsage }: ConnectedEdge): string => {

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -1,0 +1,247 @@
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+import CircleIcon from '@mui/icons-material/Circle';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import { formatDateYMDHMS } from 'utils/formatDate';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    styled,
+    Tooltip,
+} from '@mui/material';
+import { Badge } from 'component/common/Badge/Badge';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import { NetworkConnectedEdgeInstanceLatency } from './NetworkConnectedEdgeInstanceLatency';
+
+const StyledInstance = styled('div')(({ theme }) => ({
+    borderRadius: theme.shape.borderRadiusMedium,
+    border: '1px solid',
+    borderColor: theme.palette.secondary.border,
+    backgroundColor: theme.palette.secondary.light,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: 0,
+    zIndex: 1,
+    marginTop: theme.spacing(1),
+}));
+
+const StyledAccordion = styled(Accordion)({
+    background: 'transparent',
+    boxShadow: 'none',
+});
+
+const StyledAccordionSummary = styled(AccordionSummary, {
+    shouldForwardProp: (prop) => prop !== 'connectionStatus',
+})<{ connectionStatus: InstanceConnectionStatus }>(
+    ({ theme, connectionStatus }) => ({
+        fontSize: theme.fontSizes.smallBody,
+        padding: theme.spacing(1),
+        minHeight: theme.spacing(3),
+        '& .MuiAccordionSummary-content': {
+            alignItems: 'center',
+            gap: theme.spacing(1),
+            margin: 0,
+            '&.Mui-expanded': {
+                margin: 0,
+            },
+            '& svg': {
+                fontSize: theme.fontSizes.mainHeader,
+                color:
+                    connectionStatus === 'Stale'
+                        ? theme.palette.warning.main
+                        : connectionStatus === 'Disconnected'
+                          ? theme.palette.error.main
+                          : theme.palette.success.main,
+            },
+        },
+    }),
+);
+
+const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    fontSize: theme.fontSizes.smallerBody,
+    gap: theme.spacing(2),
+}));
+
+const StyledDetailRow = styled('div')({
+    display: 'flex',
+    justifyContent: 'space-between',
+    '& > span': {
+        display: 'flex',
+        alignItems: 'center',
+    },
+});
+
+const StyledBadge = styled(Badge)(({ theme }) => ({
+    padding: theme.spacing(0, 1),
+}));
+
+type InstanceConnectionStatus = 'Connected' | 'Stale' | 'Disconnected';
+
+interface INetworkConnectedEdgeInstanceProps {
+    instance: ConnectedEdge;
+}
+
+const getConnectionStatus = ({
+    reportedAt,
+}: ConnectedEdge): InstanceConnectionStatus => {
+    const reportedTime = new Date(reportedAt).getTime();
+    const reportedSecondsAgo = (Date.now() - reportedTime) / 1000;
+
+    if (reportedSecondsAgo > 360) return 'Disconnected';
+    if (reportedSecondsAgo > 180) return 'Stale';
+
+    return 'Connected';
+};
+
+const getCPUPercentage = ({
+    started,
+    reportedAt,
+    cpuUsage,
+}: ConnectedEdge): string => {
+    if (!cpuUsage) return 'No usage';
+
+    const startedTimestamp = new Date(started).getTime();
+    const reportedTimestamp = new Date(reportedAt).getTime();
+
+    const totalRuntimeSeconds = (reportedTimestamp - startedTimestamp) / 1000;
+    if (totalRuntimeSeconds === 0) return 'No usage';
+
+    return `${((cpuUsage / totalRuntimeSeconds) * 100).toFixed(2)} %`;
+};
+
+const getMemory = ({ memoryUsage }: ConnectedEdge): string => {
+    if (!memoryUsage) return 'No usage';
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let size = memoryUsage;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+    }
+
+    return `${size.toFixed(2)} ${units[unitIndex]}`;
+};
+
+export const NetworkConnectedEdgeInstance = ({
+    instance,
+}: INetworkConnectedEdgeInstanceProps) => {
+    const { locationSettings } = useLocationSettings();
+
+    const connectionStatus = getConnectionStatus(instance);
+    const start = formatDateYMDHMS(instance.started, locationSettings?.locale);
+    const lastReport = formatDateYMDHMS(
+        instance.reportedAt,
+        locationSettings?.locale,
+    );
+    const cpuPercentage = getCPUPercentage(instance);
+    const memory = getMemory(instance);
+    const archWarning = cpuPercentage === 'No usage' &&
+        memory === 'No usage' && (
+            <p>Resource metrics are only available when running on Linux</p>
+        );
+
+    return (
+        <StyledInstance>
+            <StyledAccordion>
+                <StyledAccordionSummary
+                    expandIcon={<ExpandMore />}
+                    connectionStatus={connectionStatus}
+                >
+                    <Tooltip
+                        arrow
+                        title={`${connectionStatus}. Last reported: ${lastReport}`}
+                    >
+                        <CircleIcon />
+                    </Tooltip>
+                    {instance.instanceId}
+                </StyledAccordionSummary>
+                <StyledAccordionDetails>
+                    <StyledDetailRow>
+                        <strong>ID</strong>
+                        <span>{instance.instanceId}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Upstream</strong>
+                        <span>{instance.connectedVia || 'Unleash'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Status</strong>
+                        <StyledBadge
+                            color={
+                                connectionStatus === 'Disconnected'
+                                    ? 'error'
+                                    : connectionStatus === 'Stale'
+                                      ? 'warning'
+                                      : 'success'
+                            }
+                        >
+                            {connectionStatus}
+                        </StyledBadge>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Start</strong>
+                        <span>{start}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Last report</strong>
+                        <span>{lastReport}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>App name</strong>
+                        <span>{instance.appName}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Region</strong>
+                        <span>{instance.region || 'Unknown'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Version</strong>
+                        <span>{instance.edgeVersion}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>CPU</strong>
+                        <span>
+                            {cpuPercentage}{' '}
+                            <HelpIcon
+                                tooltip={
+                                    <>
+                                        <p>
+                                            CPU average usage since instance
+                                            started
+                                        </p>
+                                        {archWarning}
+                                    </>
+                                }
+                                size='16px'
+                            />
+                        </span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Memory</strong>
+                        <span>
+                            {memory}{' '}
+                            <HelpIcon
+                                tooltip={
+                                    <>
+                                        <p>Current memory usage</p>
+                                        {archWarning}
+                                    </>
+                                }
+                                size='16px'
+                            />
+                        </span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <NetworkConnectedEdgeInstanceLatency />
+                    </StyledDetailRow>
+                </StyledAccordionDetails>
+            </StyledAccordion>
+        </StyledInstance>
+    );
+};

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -80,12 +80,6 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
     padding: theme.spacing(0, 1),
 }));
 
-type InstanceConnectionStatus = 'Connected' | 'Stale' | 'Disconnected';
-
-interface INetworkConnectedEdgeInstanceProps {
-    instance: ConnectedEdge;
-}
-
 const getConnectionStatus = ({
     reportedAt,
 }: ConnectedEdge): InstanceConnectionStatus => {
@@ -128,6 +122,12 @@ const getMemory = ({ memoryUsage }: ConnectedEdge): string => {
 
     return `${size.toFixed(2)} ${units[unitIndex]}`;
 };
+
+type InstanceConnectionStatus = 'Connected' | 'Stale' | 'Disconnected';
+
+interface INetworkConnectedEdgeInstanceProps {
+    instance: ConnectedEdge;
+}
 
 export const NetworkConnectedEdgeInstance = ({
     instance,
@@ -239,7 +239,13 @@ export const NetworkConnectedEdgeInstance = ({
                         </span>
                     </StyledDetailRow>
                     <StyledDetailRow>
-                        <NetworkConnectedEdgeInstanceLatency />
+                        <strong>Stream clients</strong>
+                        <span>{instance.connectedStreamingClients}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <NetworkConnectedEdgeInstanceLatency
+                            instance={instance}
+                        />
                     </StyledDetailRow>
                 </StyledAccordionDetails>
             </StyledAccordion>

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
@@ -1,23 +1,21 @@
-// TODO: Implement
-export const NetworkConnectedEdgeInstanceLatency = () => {
-    const latencyData = {
-        clientFeatures: { avg: 120, p99: 300 },
-        frontend: { avg: 100, p99: 250 },
-        upstream: {
-            'Client features': { avg: 130, p99: 320 },
-            Metrics: { avg: 90, p99: 200 },
-            Edge: { avg: 110, p99: 290 },
-        },
-    };
+import { styled } from '@mui/material';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
 
+const StyledTable = styled('table')(({ theme }) => ({
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: theme.fontSizes.smallerBody,
+}));
+
+interface INetworkConnectedEdgeInstanceLatencyProps {
+    instance: ConnectedEdge;
+}
+
+export const NetworkConnectedEdgeInstanceLatency = ({
+    instance,
+}: INetworkConnectedEdgeInstanceLatencyProps) => {
     return (
-        <table
-            style={{
-                width: '100%',
-                borderCollapse: 'collapse',
-                fontSize: '12px',
-            }}
-        >
+        <StyledTable>
             <thead>
                 <tr style={{ textAlign: 'left' }}>
                     <th
@@ -49,19 +47,19 @@ export const NetworkConnectedEdgeInstanceLatency = () => {
                 <tr>
                     <td style={{ padding: '4px' }}>Client Features</td>
                     <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {latencyData.clientFeatures.avg}
+                        {instance.clientFeaturesAverageLatencyMs}
                     </td>
                     <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {latencyData.clientFeatures.p99}
+                        {instance.clientFeaturesP99LatencyMs}
                     </td>
                 </tr>
                 <tr>
                     <td style={{ padding: '4px' }}>Frontend</td>
                     <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {latencyData.frontend.avg}
+                        {instance.frontendApiAverageLatencyMs}
                     </td>
                     <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {latencyData.frontend.p99}
+                        {instance.frontendApiP99LatencyMs}
                     </td>
                 </tr>
                 <tr>
@@ -72,18 +70,34 @@ export const NetworkConnectedEdgeInstanceLatency = () => {
                         Upstream
                     </td>
                 </tr>
-                {Object.entries(latencyData.upstream).map(([key, values]) => (
-                    <tr key={key}>
-                        <td style={{ padding: '4px 8px' }}>{key}</td>
-                        <td style={{ padding: '4px', textAlign: 'right' }}>
-                            {values.avg}
-                        </td>
-                        <td style={{ padding: '4px', textAlign: 'right' }}>
-                            {values.p99}
-                        </td>
-                    </tr>
-                ))}
+                <tr>
+                    <td style={{ padding: '4px 8px' }}>Client Features</td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamFeaturesAverageLatencyMs}
+                    </td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamFeaturesP99LatencyMs}
+                    </td>
+                </tr>
+                <tr>
+                    <td style={{ padding: '4px 8px' }}>Metrics</td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamMetricsAverageLatencyMs}
+                    </td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamMetricsP99LatencyMs}
+                    </td>
+                </tr>
+                <tr>
+                    <td style={{ padding: '4px 8px' }}>Edge</td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamEdgeAverageLatencyMs}
+                    </td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {instance.upstreamEdgeP99LatencyMs}
+                    </td>
+                </tr>
             </tbody>
-        </table>
+        </StyledTable>
     );
 };

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
@@ -5,6 +5,23 @@ const StyledTable = styled('table')(({ theme }) => ({
     width: '100%',
     borderCollapse: 'collapse',
     fontSize: theme.fontSizes.smallerBody,
+    '& > thead': {
+        borderBottom: `1px solid ${theme.palette.text.primary}`,
+    },
+    '& tr': {
+        textAlign: 'right',
+        '& > th:first-of-type,td:first-of-type': {
+            textAlign: 'left',
+        },
+    },
+}));
+
+const StyledUpstreamSection = styled('tr')(({ theme }) => ({
+    fontWeight: theme.fontWeight.bold,
+    borderBottom: `1px solid ${theme.palette.text.primary}`,
+    '& > td:first-of-type': {
+        paddingTop: theme.spacing(1),
+    },
 }));
 
 interface INetworkConnectedEdgeInstanceLatencyProps {
@@ -17,85 +34,40 @@ export const NetworkConnectedEdgeInstanceLatency = ({
     return (
         <StyledTable>
             <thead>
-                <tr style={{ textAlign: 'left' }}>
-                    <th
-                        style={{
-                            borderBottom: '1px solid #ccc',
-                        }}
-                    >
-                        Latency (ms)
-                    </th>
-                    <th
-                        style={{
-                            borderBottom: '1px solid #ccc',
-                            textAlign: 'right',
-                        }}
-                    >
-                        Avg
-                    </th>
-                    <th
-                        style={{
-                            borderBottom: '1px solid #ccc',
-                            textAlign: 'right',
-                        }}
-                    >
-                        p99
-                    </th>
+                <tr>
+                    <th>Latency (ms)</th>
+                    <th>Avg</th>
+                    <th>p99</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td style={{ padding: '4px' }}>Client Features</td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.clientFeaturesAverageLatencyMs}
-                    </td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.clientFeaturesP99LatencyMs}
-                    </td>
+                    <td>Client Features</td>
+                    <td>{instance.clientFeaturesAverageLatencyMs}</td>
+                    <td>{instance.clientFeaturesP99LatencyMs}</td>
                 </tr>
                 <tr>
-                    <td style={{ padding: '4px' }}>Frontend</td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.frontendApiAverageLatencyMs}
-                    </td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.frontendApiP99LatencyMs}
-                    </td>
+                    <td>Frontend</td>
+                    <td>{instance.frontendApiAverageLatencyMs}</td>
+                    <td>{instance.frontendApiP99LatencyMs}</td>
+                </tr>
+                <StyledUpstreamSection>
+                    <td colSpan={3}>Upstream</td>
+                </StyledUpstreamSection>
+                <tr>
+                    <td>Client Features</td>
+                    <td>{instance.upstreamFeaturesAverageLatencyMs}</td>
+                    <td>{instance.upstreamFeaturesP99LatencyMs}</td>
                 </tr>
                 <tr>
-                    <td
-                        colSpan={3}
-                        style={{ fontWeight: 'bold', paddingTop: '6px' }}
-                    >
-                        Upstream
-                    </td>
+                    <td>Metrics</td>
+                    <td>{instance.upstreamMetricsAverageLatencyMs}</td>
+                    <td>{instance.upstreamMetricsP99LatencyMs}</td>
                 </tr>
                 <tr>
-                    <td style={{ padding: '4px 8px' }}>Client Features</td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamFeaturesAverageLatencyMs}
-                    </td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamFeaturesP99LatencyMs}
-                    </td>
-                </tr>
-                <tr>
-                    <td style={{ padding: '4px 8px' }}>Metrics</td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamMetricsAverageLatencyMs}
-                    </td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamMetricsP99LatencyMs}
-                    </td>
-                </tr>
-                <tr>
-                    <td style={{ padding: '4px 8px' }}>Edge</td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamEdgeAverageLatencyMs}
-                    </td>
-                    <td style={{ padding: '4px', textAlign: 'right' }}>
-                        {instance.upstreamEdgeP99LatencyMs}
-                    </td>
+                    <td>Edge</td>
+                    <td>{instance.upstreamEdgeAverageLatencyMs}</td>
+                    <td>{instance.upstreamEdgeP99LatencyMs}</td>
                 </tr>
             </tbody>
         </StyledTable>

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
@@ -1,0 +1,89 @@
+// TODO: Implement
+export const NetworkConnectedEdgeInstanceLatency = () => {
+    const latencyData = {
+        clientFeatures: { avg: 120, p99: 300 },
+        frontend: { avg: 100, p99: 250 },
+        upstream: {
+            'Client features': { avg: 130, p99: 320 },
+            Metrics: { avg: 90, p99: 200 },
+            Edge: { avg: 110, p99: 290 },
+        },
+    };
+
+    return (
+        <table
+            style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontSize: '12px',
+            }}
+        >
+            <thead>
+                <tr style={{ textAlign: 'left' }}>
+                    <th
+                        style={{
+                            borderBottom: '1px solid #ccc',
+                        }}
+                    >
+                        Latency (ms)
+                    </th>
+                    <th
+                        style={{
+                            borderBottom: '1px solid #ccc',
+                            textAlign: 'right',
+                        }}
+                    >
+                        Avg
+                    </th>
+                    <th
+                        style={{
+                            borderBottom: '1px solid #ccc',
+                            textAlign: 'right',
+                        }}
+                    >
+                        p99
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td style={{ padding: '4px' }}>Client Features</td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {latencyData.clientFeatures.avg}
+                    </td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {latencyData.clientFeatures.p99}
+                    </td>
+                </tr>
+                <tr>
+                    <td style={{ padding: '4px' }}>Frontend</td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {latencyData.frontend.avg}
+                    </td>
+                    <td style={{ padding: '4px', textAlign: 'right' }}>
+                        {latencyData.frontend.p99}
+                    </td>
+                </tr>
+                <tr>
+                    <td
+                        colSpan={3}
+                        style={{ fontWeight: 'bold', paddingTop: '6px' }}
+                    >
+                        Upstream
+                    </td>
+                </tr>
+                {Object.entries(latencyData.upstream).map(([key, values]) => (
+                    <tr key={key}>
+                        <td style={{ padding: '4px 8px' }}>{key}</td>
+                        <td style={{ padding: '4px', textAlign: 'right' }}>
+                            {values.avg}
+                        </td>
+                        <td style={{ padding: '4px', textAlign: 'right' }}>
+                            {values.p99}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+};

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
@@ -1,0 +1,279 @@
+import { usePageTitle } from 'hooks/usePageTitle';
+import { ArcherContainer, ArcherElement } from 'react-archer';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Alert,
+    Typography,
+    styled,
+    useTheme,
+} from '@mui/material';
+import { unknownify } from 'utils/unknownify';
+import { useMemo } from 'react';
+import { ReactComponent as LogoIcon } from 'assets/icons/logoBg.svg';
+import { ReactComponent as LogoIconWhite } from 'assets/icons/logoWhiteBg.svg';
+import { ThemeMode } from 'component/common/ThemeMode/ThemeMode';
+import { useConnectedEdges } from 'hooks/api/getters/useConnectedEdges/useConnectedEdges';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+
+const UNLEASH = 'Unleash';
+
+const StyledUnleashLevel = styled('div')(({ theme }) => ({
+    marginBottom: theme.spacing(18),
+    display: 'flex',
+    justifyContent: 'center',
+}));
+
+const StyledEdgeLevel = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    gap: theme.spacing(4),
+    flexWrap: 'wrap',
+    marginTop: theme.spacing(2),
+}));
+
+const StyledElement = styled('div')(({ theme }) => ({
+    borderRadius: theme.shape.borderRadiusMedium,
+    border: '1px solid',
+    borderColor: theme.palette.secondary.border,
+    backgroundColor: theme.palette.secondary.light,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: theme.spacing(1.5),
+    zIndex: 1,
+    marginTop: theme.spacing(1),
+    '& > svg': {
+        width: theme.spacing(9),
+        height: theme.spacing(9),
+    },
+}));
+
+const StyledGroup = styled(StyledElement)(({ theme }) => ({
+    backgroundColor: 'transparent',
+}));
+
+const StyledElementHeader = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.fontWeight.bold,
+}));
+
+const StyledElementDescription = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallerBody,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledInstanceAccordion = styled(Accordion)(({ theme }) => ({
+    background: 'transparent',
+    boxShadow: 'none',
+}));
+
+type ConnectedEdgeInstance = ConnectedEdge & {
+    connectionStatus: InstanceConnectionStatus;
+};
+
+type AppNameGroup = {
+    appName: string;
+    instances: ConnectedEdgeInstance[];
+    groupTargets: Set<string>;
+    level: number;
+    levelComputed?: boolean;
+};
+
+type InstanceConnectionStatus = 'Connected' | 'Stale' | 'Disconnected';
+
+const getConnectionStatus = (
+    { reportedAt }: ConnectedEdge,
+    now: number,
+): InstanceConnectionStatus => {
+    const reportedTime = new Date(reportedAt).getTime();
+    const reportedSecondsAgo = (now - reportedTime) / 1000;
+
+    if (reportedSecondsAgo > 60) return 'Disconnected';
+    if (reportedSecondsAgo > 30) return 'Stale';
+
+    return 'Connected';
+};
+
+const computeLevel = (
+    appName: string,
+    groups: Map<string, AppNameGroup>,
+): number => {
+    const group = groups.get(appName);
+    if (!group) return 0;
+    if (group.levelComputed) return group.level;
+    let maxLevel = 0;
+    group.groupTargets.forEach((target) => {
+        if (target !== UNLEASH) {
+            const parentLevel = computeLevel(target, groups);
+            maxLevel = Math.max(maxLevel, parentLevel + 1);
+        }
+    });
+    group.level = maxLevel;
+    group.levelComputed = true;
+    return maxLevel;
+};
+
+const processGraph = (
+    connectedEdges: ConnectedEdge[],
+): Map<number, AppNameGroup[]> => {
+    const now = Date.now();
+    const groups = new Map<string, AppNameGroup>();
+
+    connectedEdges.forEach((edge) => {
+        const instance: ConnectedEdgeInstance = {
+            ...edge,
+            connectionStatus: getConnectionStatus(edge, now),
+        };
+        if (!groups.has(edge.appName)) {
+            groups.set(edge.appName, {
+                appName: edge.appName,
+                instances: [instance],
+                groupTargets: new Set<string>(),
+                level: 0,
+            });
+        } else {
+            groups.get(edge.appName)!.instances.push(instance);
+        }
+    });
+
+    const instanceToGroup = new Map<string, string>();
+    groups.forEach((group) => {
+        group.instances.forEach((instance) => {
+            instanceToGroup.set(instance.instanceId, group.appName);
+        });
+    });
+
+    groups.forEach((group, appName) => {
+        group.instances.forEach((instance) => {
+            const target = instance.connectedVia || UNLEASH;
+            if (target === UNLEASH) {
+                group.groupTargets.add(UNLEASH);
+            } else {
+                const targetGroup = instanceToGroup.get(target);
+                if (targetGroup && targetGroup !== appName) {
+                    group.groupTargets.add(targetGroup);
+                }
+            }
+        });
+    });
+
+    groups.forEach((_, appName) => {
+        computeLevel(appName, groups);
+    });
+
+    const groupsByLevel = new Map<number, AppNameGroup[]>();
+    groups.forEach((group) => {
+        const level = group.level;
+        if (!groupsByLevel.has(level)) {
+            groupsByLevel.set(level, []);
+        }
+        groupsByLevel.get(level)!.push(group);
+    });
+    return groupsByLevel;
+};
+
+export const NetworkConnectedEdges = () => {
+    usePageTitle('Network - Connected Edges');
+    const theme = useTheme();
+    const { connectedEdges } = useConnectedEdges();
+
+    const appNamesByLevel = useMemo(
+        () => processGraph(connectedEdges),
+        [connectedEdges],
+    );
+    const levels = [...appNamesByLevel.keys()].sort((a, b) => a - b);
+
+    if (appNamesByLevel.size === 0)
+        return <Alert severity='warning'>No data available.</Alert>;
+
+    return (
+        <ArcherContainer
+            strokeColor={theme.palette.text.primary}
+            endShape={{ arrow: { arrowLength: 4, arrowThickness: 4 } }}
+        >
+            <StyledUnleashLevel>
+                <ArcherElement id={UNLEASH}>
+                    <StyledElement>
+                        <ThemeMode
+                            darkmode={<LogoIconWhite />}
+                            lightmode={<LogoIcon />}
+                        />
+                        <Typography sx={{ marginTop: theme.spacing(1) }}>
+                            {UNLEASH}
+                        </Typography>
+                    </StyledElement>
+                </ArcherElement>
+            </StyledUnleashLevel>
+            {levels.map((level) => (
+                <StyledEdgeLevel key={level}>
+                    {appNamesByLevel
+                        .get(level)!
+                        .map(({ appName, groupTargets, instances }) => (
+                            <ArcherElement
+                                key={appName}
+                                id={appName}
+                                relations={Array.from(groupTargets).map(
+                                    (target) => ({
+                                        targetId: target,
+                                        targetAnchor: 'bottom',
+                                        sourceAnchor: 'top',
+                                        style: {
+                                            strokeColor:
+                                                theme.palette.secondary.border,
+                                        },
+                                    }),
+                                )}
+                            >
+                                <StyledGroup>
+                                    <StyledElementHeader>
+                                        {unknownify(appName)}
+                                    </StyledElementHeader>
+                                    <StyledElementDescription>
+                                        {instances.length} instance
+                                        {instances.length === 1 ? '' : 's'}
+                                    </StyledElementDescription>
+                                    {instances.map(
+                                        ({
+                                            instanceId,
+                                            edgeVersion,
+                                            connectedVia,
+                                        }) => (
+                                            <StyledElement key={instanceId}>
+                                                <StyledInstanceAccordion>
+                                                    <AccordionSummary>
+                                                        <StyledElementHeader>
+                                                            {instanceId}
+                                                        </StyledElementHeader>
+                                                    </AccordionSummary>
+                                                    <AccordionDetails>
+                                                        <p>
+                                                            Connected to:{' '}
+                                                            <strong>
+                                                                {connectedVia ||
+                                                                    UNLEASH}
+                                                            </strong>
+                                                        </p>
+                                                        <br />
+                                                        <p>
+                                                            (Edge {edgeVersion})
+                                                        </p>
+                                                        <p>
+                                                            Some more details
+                                                            here...
+                                                        </p>
+                                                    </AccordionDetails>
+                                                </StyledInstanceAccordion>
+                                            </StyledElement>
+                                        ),
+                                    )}
+                                </StyledGroup>
+                            </ArcherElement>
+                        ))}
+                </StyledEdgeLevel>
+            ))}
+        </ArcherContainer>
+    );
+};
+
+export default NetworkConnectedEdges;

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
@@ -26,10 +26,9 @@ const StyledEdgeLevel = styled('div')(({ theme }) => ({
     marginTop: theme.spacing(2),
 }));
 
-const StyledElement = styled('div')(({ theme }) => ({
+const StyledNode = styled('div')(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusMedium,
-    border: '1px solid',
-    borderColor: theme.palette.secondary.border,
+    border: `1px solid ${theme.palette.secondary.border}`,
     backgroundColor: theme.palette.secondary.light,
     display: 'flex',
     flexDirection: 'column',
@@ -43,15 +42,15 @@ const StyledElement = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledGroup = styled(StyledElement)({
+const StyledGroup = styled(StyledNode)({
     backgroundColor: 'transparent',
 });
 
-const StyledElementHeader = styled(Typography)(({ theme }) => ({
+const StyledNodeHeader = styled(Typography)(({ theme }) => ({
     fontWeight: theme.fontWeight.bold,
 }));
 
-const StyledElementDescription = styled(Typography)(({ theme }) => ({
+const StyledNodeDescription = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
     color: theme.palette.text.secondary,
 }));
@@ -61,96 +60,108 @@ type AppNameGroup = {
     instances: ConnectedEdge[];
     groupTargets: Set<string>;
     level: number;
-    levelComputed?: boolean;
 };
 
-const computeLevel = (
-    appName: string,
-    groups: Map<string, AppNameGroup>,
-): number => {
-    const group = groups.get(appName);
-    if (!group) return 0;
-    if (group.levelComputed) return group.level;
-    let maxLevel = 0;
-    group.groupTargets.forEach((target) => {
-        if (target !== UNLEASH) {
-            const parentLevel = computeLevel(target, groups);
-            maxLevel = Math.max(maxLevel, parentLevel + 1);
-        }
-    });
-    group.level = maxLevel;
-    group.levelComputed = true;
-    return maxLevel;
-};
-
-const processGraph = (
-    connectedEdges: ConnectedEdge[],
-): Map<number, AppNameGroup[]> => {
-    const groups = new Map<string, AppNameGroup>();
-    connectedEdges.forEach((edge) => {
+const createGroups = (edges: ConnectedEdge[]): Map<string, AppNameGroup> =>
+    edges.reduce((groups, edge) => {
         if (!groups.has(edge.appName)) {
             groups.set(edge.appName, {
                 appName: edge.appName,
-                instances: [edge],
-                groupTargets: new Set<string>(),
+                instances: [],
+                groupTargets: new Set(),
                 level: 0,
             });
-        } else {
-            groups.get(edge.appName)!.instances.push(edge);
         }
-    });
+        groups.get(edge.appName)!.instances.push(edge);
+        return groups;
+    }, new Map<string, AppNameGroup>());
 
-    const instanceToGroup = new Map<string, string>();
-    groups.forEach((group) => {
-        group.instances.forEach((instance) => {
-            instanceToGroup.set(instance.instanceId, group.appName);
-        });
-    });
+const computeGroupLevels = (
+    groups: Map<string, AppNameGroup>,
+): Map<number, AppNameGroup[]> => {
+    const memo = new Map<string, number>();
 
-    groups.forEach((group, appName) => {
-        group.instances.forEach((instance) => {
-            const target = instance.connectedVia || UNLEASH;
-            if (target === UNLEASH) {
-                group.groupTargets.add(UNLEASH);
-            } else {
-                const targetGroup = instanceToGroup.get(target);
-                if (targetGroup && targetGroup !== appName) {
-                    group.groupTargets.add(targetGroup);
+    const getLevel = (group: AppNameGroup): number => {
+        if (memo.has(group.appName)) return memo.get(group.appName)!;
+        let level = 0;
+        group.groupTargets.forEach((target) => {
+            if (target !== UNLEASH) {
+                const targetGroup = groups.get(target);
+                if (targetGroup) {
+                    level = Math.max(level, getLevel(targetGroup) + 1);
                 }
             }
         });
-    });
+        memo.set(group.appName, level);
+        return level;
+    };
 
-    groups.forEach((_, appName) => {
-        computeLevel(appName, groups);
-    });
-
-    const groupsByLevel = new Map<number, AppNameGroup[]>();
     groups.forEach((group) => {
-        const level = group.level;
-        if (!groupsByLevel.has(level)) {
-            groupsByLevel.set(level, []);
-        }
-        groupsByLevel.get(level)!.push(group);
+        group.level = getLevel(group);
     });
-    return groupsByLevel;
+
+    const levelsMap = new Map<number, AppNameGroup[]>();
+    groups.forEach((group) => {
+        const levelGroups = levelsMap.get(group.level) || [];
+        levelGroups.push(group);
+        levelsMap.set(group.level, levelGroups);
+    });
+    return levelsMap;
+};
+
+const processEdges = (edges: ConnectedEdge[]): Map<number, AppNameGroup[]> => {
+    const groups = createGroups(edges);
+    const instanceIdToId = new Map<string, string>();
+    const idToAppName = new Map<string, string>();
+
+    groups.forEach((group) => {
+        group.instances = group.instances
+            .sort((a, b) => a.instanceId.localeCompare(b.instanceId))
+            .map((instance, index) => {
+                const id = `${group.appName}-${index + 1}`;
+                instanceIdToId.set(instance.instanceId, id);
+                idToAppName.set(id, group.appName);
+                return { ...instance, id };
+            });
+    });
+
+    groups.forEach((group) => {
+        group.instances = group.instances.map((instance) => ({
+            ...instance,
+            connectedVia: instance.connectedVia
+                ? instanceIdToId.get(instance.connectedVia) ||
+                  instance.connectedVia
+                : UNLEASH,
+        }));
+        const targets = new Set<string>();
+        group.instances.forEach((instance) => {
+            if (!instance.connectedVia || instance.connectedVia === UNLEASH) {
+                targets.add(UNLEASH);
+            } else {
+                const targetApp = idToAppName.get(instance.connectedVia);
+                if (targetApp && targetApp !== group.appName) {
+                    targets.add(targetApp);
+                }
+            }
+        });
+        group.groupTargets = targets;
+    });
+
+    return computeGroupLevels(groups);
 };
 
 export const NetworkConnectedEdges = () => {
     usePageTitle('Network - Connected Edges');
     const theme = useTheme();
+    const { connectedEdges } = useConnectedEdges({ refreshInterval: 30_000 });
 
-    const { connectedEdges } = useConnectedEdges({
-        refreshInterval: 30 * 1000,
-    });
-
-    const appNamesByLevel = useMemo(
-        () => processGraph(connectedEdges),
+    const edgeLevels = useMemo(
+        () => processEdges(connectedEdges),
         [connectedEdges],
     );
-    const levels = [...appNamesByLevel.keys()].sort((a, b) => a - b);
+    const levels = Array.from(edgeLevels.keys()).sort((a, b) => a - b);
 
-    if (appNamesByLevel.size === 0)
+    if (edgeLevels.size === 0)
         return <Alert severity='warning'>No data available.</Alert>;
 
     return (
@@ -160,22 +171,20 @@ export const NetworkConnectedEdges = () => {
         >
             <StyledUnleashLevel>
                 <ArcherElement id={UNLEASH}>
-                    <StyledElement>
+                    <StyledNode>
                         <ThemeMode
                             darkmode={<LogoIconWhite />}
                             lightmode={<LogoIcon />}
                         />
-                        <Typography sx={{ marginTop: theme.spacing(1) }}>
-                            {UNLEASH}
-                        </Typography>
-                    </StyledElement>
+                        <Typography sx={{ mt: 1 }}>{UNLEASH}</Typography>
+                    </StyledNode>
                 </ArcherElement>
             </StyledUnleashLevel>
             {levels.map((level) => (
                 <StyledEdgeLevel key={level}>
-                    {appNamesByLevel
-                        .get(level)!
-                        .map(({ appName, groupTargets, instances }) => (
+                    {edgeLevels
+                        .get(level)
+                        ?.map(({ appName, groupTargets, instances }) => (
                             <ArcherElement
                                 key={appName}
                                 id={appName}
@@ -192,13 +201,13 @@ export const NetworkConnectedEdges = () => {
                                 )}
                             >
                                 <StyledGroup>
-                                    <StyledElementHeader>
+                                    <StyledNodeHeader>
                                         {unknownify(appName)}
-                                    </StyledElementHeader>
-                                    <StyledElementDescription>
+                                    </StyledNodeHeader>
+                                    <StyledNodeDescription>
                                         {instances.length} instance
-                                        {instances.length === 1 ? '' : 's'}
-                                    </StyledElementDescription>
+                                        {instances.length !== 1 && 's'}
+                                    </StyledNodeDescription>
                                     {instances.map((instance) => (
                                         <NetworkConnectedEdgeInstance
                                             key={instance.instanceId}

--- a/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
+++ b/frontend/src/component/admin/network/NetworkOverview/NetworkOverview.tsx
@@ -11,6 +11,7 @@ import type {
 import { ReactComponent as LogoIcon } from 'assets/icons/logoBg.svg';
 import { ReactComponent as LogoIconWhite } from 'assets/icons/logoWhiteBg.svg';
 import { ThemeMode } from 'component/common/ThemeMode/ThemeMode';
+import { NetworkPrometheusAPIWarning } from '../NetworkPrometheusAPIWarning';
 
 const StyleUnleashContainer = styled('div')(({ theme }) => ({
     marginBottom: theme.spacing(18),
@@ -122,7 +123,12 @@ export const NetworkOverview = () => {
     }, [metrics]);
 
     if (apps.length === 0) {
-        return <Alert severity='warning'>No data available.</Alert>;
+        return (
+            <Alert severity='warning'>
+                No data available.
+                <NetworkPrometheusAPIWarning />
+            </Alert>
+        );
     }
 
     return (

--- a/frontend/src/component/admin/network/NetworkPrometheusAPIWarning.tsx
+++ b/frontend/src/component/admin/network/NetworkPrometheusAPIWarning.tsx
@@ -1,0 +1,24 @@
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+
+export const NetworkPrometheusAPIWarning = () => {
+    const {
+        uiConfig: { networkViewEnabled },
+    } = useUiConfig();
+
+    if (networkViewEnabled) return null;
+
+    return (
+        <p>
+            This view requires the <strong>PROMETHEUS_API</strong> environment
+            variable to be set. Refer to our{' '}
+            <a
+                href='https://docs.getunleash.io/reference/network-view#data-source'
+                target='_blank'
+                rel='noreferrer'
+            >
+                documentation
+            </a>{' '}
+            for more information.
+        </p>
+    );
+};

--- a/frontend/src/component/admin/network/NetworkTraffic/NetworkTraffic.tsx
+++ b/frontend/src/component/admin/network/NetworkTraffic/NetworkTraffic.tsx
@@ -28,6 +28,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { usePageTitle } from 'hooks/usePageTitle';
 import { unknownify } from 'utils/unknownify';
 import type { Theme } from '@mui/material/styles/createTheme';
+import { NetworkPrometheusAPIWarning } from '../NetworkPrometheusAPIWarning';
 
 const pointStyles = ['circle', 'rect', 'rectRounded', 'rectRot', 'triangle'];
 
@@ -206,7 +207,12 @@ export const NetworkTraffic: VFC = () => {
     return (
         <ConditionallyRender
             condition={data.datasets.length === 0}
-            show={<Alert severity='warning'>No data available.</Alert>}
+            show={
+                <Alert severity='warning'>
+                    No data available.
+                    <NetworkPrometheusAPIWarning />
+                </Alert>
+            }
             elseShow={
                 <Box sx={{ display: 'grid', gap: 4 }}>
                     <div style={{ height: 400 }}>

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/__snapshots__/NavigationSidebar.test.tsx.snap
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/__snapshots__/NavigationSidebar.test.tsx.snap
@@ -79,6 +79,10 @@ exports[`order of items in navigation > menu for enterprise plan 1`] = `
     "text": "Single sign-on",
   },
   {
+    "icon": "HubOutlinedIcon",
+    "text": "Network",
+  },
+  {
     "icon": "BuildOutlinedIcon",
     "text": "Maintenance",
   },
@@ -255,6 +259,10 @@ exports[`order of items in navigation > menu for pro plan 1`] = `
   {
     "icon": "AssignmentOutlinedIcon",
     "text": "Single sign-on",
+  },
+  {
+    "icon": "HubOutlinedIcon",
+    "text": "Network",
   },
   {
     "icon": "BuildOutlinedIcon",

--- a/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
+++ b/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import useUiConfig from '../useUiConfig/useUiConfig';
+import { formatApiPath } from 'utils/formatPath';
+import handleErrorResponses from '../httpErrorResponseHandler';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+
+const DEFAULT_DATA: ConnectedEdge[] = [];
+
+export const useConnectedEdges = () => {
+    const { isEnterprise } = useUiConfig();
+
+    const { data, error, mutate } = useConditionalSWR<ConnectedEdge[]>(
+        isEnterprise(),
+        DEFAULT_DATA,
+        formatApiPath('api/admin/metrics/edges'),
+        fetcher,
+    );
+
+    return useMemo(
+        () => ({
+            connectedEdges: data ?? [],
+            loading: !error && !data,
+            refetch: () => mutate(),
+            error,
+        }),
+        [data, error, mutate],
+    );
+};
+
+const fetcher = (path: string) => {
+    return fetch(path)
+        .then(handleErrorResponses('Connected Edges'))
+        .then((res) => res.json());
+};

--- a/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
+++ b/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
@@ -4,10 +4,11 @@ import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 import type { ConnectedEdge } from 'interfaces/connectedEdge';
+import type { SWRConfiguration } from 'swr';
 
 const DEFAULT_DATA: ConnectedEdge[] = [];
 
-export const useConnectedEdges = () => {
+export const useConnectedEdges = (options?: SWRConfiguration) => {
     const { isEnterprise } = useUiConfig();
 
     const { data, error, mutate } = useConditionalSWR<ConnectedEdge[]>(
@@ -15,6 +16,7 @@ export const useConnectedEdges = () => {
         DEFAULT_DATA,
         formatApiPath('api/admin/metrics/edges'),
         fetcher,
+        options,
     );
 
     return useMemo(

--- a/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
+++ b/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
@@ -5,14 +5,16 @@ import handleErrorResponses from '../httpErrorResponseHandler';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
 import type { ConnectedEdge } from 'interfaces/connectedEdge';
 import type { SWRConfiguration } from 'swr';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const DEFAULT_DATA: ConnectedEdge[] = [];
 
 export const useConnectedEdges = (options?: SWRConfiguration) => {
     const { isEnterprise } = useUiConfig();
+    const edgeObservabilityEnabled = useUiFlag('edgeObservability');
 
     const { data, error, mutate } = useConditionalSWR<ConnectedEdge[]>(
-        isEnterprise(),
+        isEnterprise() && edgeObservabilityEnabled,
         DEFAULT_DATA,
         formatApiPath('api/admin/metrics/edges'),
         fetcher,

--- a/frontend/src/hooks/api/getters/useInstanceMetrics/useInstanceMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceMetrics/useInstanceMetrics.ts
@@ -1,8 +1,10 @@
-import useSWR, { type SWRConfiguration } from 'swr';
+import type { SWRConfiguration } from 'swr';
 import { useMemo } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler';
 import type { RequestsPerSecondSchema } from 'openapi';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR';
+import useUiConfig from '../useUiConfig/useUiConfig';
 
 export interface IInstanceMetricsResponse {
     metrics: RequestsPerSecondSchema;
@@ -17,7 +19,13 @@ export interface IInstanceMetricsResponse {
 export const useInstanceMetrics = (
     options: SWRConfiguration = {},
 ): IInstanceMetricsResponse => {
-    const { data, error, mutate } = useSWR(
+    const {
+        uiConfig: { networkViewEnabled },
+    } = useUiConfig();
+
+    const { data, error, mutate } = useConditionalSWR(
+        networkViewEnabled,
+        {},
         formatApiPath(`api/admin/metrics/rps`),
         fetcher,
         options,

--- a/frontend/src/interfaces/connectedEdge.ts
+++ b/frontend/src/interfaces/connectedEdge.ts
@@ -1,0 +1,10 @@
+export type ConnectedEdge = {
+    appName: string;
+    connectedStreamingClients: number;
+    edgeVersion: string;
+    instanceId: string;
+    region: string | null;
+    reportedAt: string;
+    start: string;
+    connectedVia?: string;
+};

--- a/frontend/src/interfaces/connectedEdge.ts
+++ b/frontend/src/interfaces/connectedEdge.ts
@@ -1,4 +1,5 @@
 export type ConnectedEdge = {
+    id?: string;
     appName: string;
     connectedStreamingClients: number;
     edgeVersion: string;

--- a/frontend/src/interfaces/connectedEdge.ts
+++ b/frontend/src/interfaces/connectedEdge.ts
@@ -5,6 +5,8 @@ export type ConnectedEdge = {
     instanceId: string;
     region: string | null;
     reportedAt: string;
-    start: string;
+    started: string;
     connectedVia?: string;
+    cpuUsage: number;
+    memoryUsage: number;
 };

--- a/frontend/src/interfaces/connectedEdge.ts
+++ b/frontend/src/interfaces/connectedEdge.ts
@@ -8,6 +8,16 @@ export type ConnectedEdge = {
     reportedAt: string;
     started: string;
     connectedVia?: string;
-    cpuUsage: number;
+    cpuUsage: string;
     memoryUsage: number;
+    clientFeaturesAverageLatencyMs: string;
+    clientFeaturesP99LatencyMs: string;
+    frontendApiAverageLatencyMs: string;
+    frontendApiP99LatencyMs: string;
+    upstreamFeaturesAverageLatencyMs: string;
+    upstreamFeaturesP99LatencyMs: string;
+    upstreamMetricsAverageLatencyMs: string;
+    upstreamMetricsP99LatencyMs: string;
+    upstreamEdgeAverageLatencyMs: string;
+    upstreamEdgeP99LatencyMs: string;
 };

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -95,6 +95,7 @@ export type UiFlags = {
     dataUsageMultiMonthView?: boolean;
     uiGlobalFontSize?: boolean;
     connectionCount?: boolean;
+    edgeObservability?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -101,7 +101,7 @@ export const uiConfigSchema = {
         },
         networkViewEnabled: {
             type: 'boolean',
-            description: 'Whether to enable the Unleash network view or not.',
+            description: 'Whether a Prometheus API is available.',
             example: true,
         },
         frontendApiOrigins: {

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -186,7 +186,7 @@ class ConfigController extends Controller {
             strategySegmentsLimit: this.config.resourceLimits.strategySegments,
             frontendApiOrigins: frontendSettings.frontendApiOrigins,
             versionInfo: await this.versionService.getVersionInfo(),
-            networkViewEnabled: this.config.prometheusApi !== undefined, // TODO: Should we free this up? Will there be a scenario where we want to show Edge data but we don't have Prometheus API configured here? YES
+            networkViewEnabled: this.config.prometheusApi !== undefined,
             resourceLimits: this.config.resourceLimits,
             disablePasswordAuth,
             maintenanceMode,

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -186,7 +186,7 @@ class ConfigController extends Controller {
             strategySegmentsLimit: this.config.resourceLimits.strategySegments,
             frontendApiOrigins: frontendSettings.frontendApiOrigins,
             versionInfo: await this.versionService.getVersionInfo(),
-            networkViewEnabled: this.config.prometheusApi !== undefined,
+            networkViewEnabled: this.config.prometheusApi !== undefined, // TODO: Should we free this up? Will there be a scenario where we want to show Edge data but we don't have Prometheus API configured here? YES
             resourceLimits: this.config.resourceLimits,
             disablePasswordAuth,
             maintenanceMode,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -67,7 +67,8 @@ export type IFlagKey =
     | 'dataUsageMultiMonthView'
     | 'uiGlobalFontSize'
     | 'connectionCount'
-    | 'teamsIntegrationChangeRequests';
+    | 'teamsIntegrationChangeRequests'
+    | 'edgeObservability';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -322,6 +323,10 @@ const flags: IFlags = {
     ),
     teamsIntegrationChangeRequests: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_TEAMS_INTEGRATION_CHANGE_REQUESTS,
+        false,
+    ),
+    edgeObservability: parseEnvVarBoolean(
+        process.env.EXPERIMENTAL_EDGE_OBSERVABILITY,
         false,
     ),
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3233/visualize-connected-edge-instances

Adds a new tab in the Network page to visualize connected Edges.

This is behind a `edgeObservability` flag.

Also opens up the Network page even if you don't have a Prometheus API configured. When accessing the tabs that require it to set, and it isn't, we show some extra information about this and redirect you to the respective section in our docs.

![image](https://github.com/user-attachments/assets/1689f785-7544-450b-8c33-159609fc0f7d)

![image](https://github.com/user-attachments/assets/a7a14805-0488-41d2-885f-5e11a8495127)

![image](https://github.com/user-attachments/assets/918cba87-5538-4600-a71f-1143b2e33e2a)