### PR TITLE
fix: use bucket stop as timestamp for metrics bucket

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -210,7 +210,7 @@ export default class ClientMetricsServiceV2 {
                     featureName: name,
                     appName: value.appName,
                     environment: value.environment ?? 'default',
-                    timestamp: value.bucket.start, //we might need to approximate between start/stop...
+                    timestamp: value.bucket.stop, //we might need to approximate between start/stop...
                     yes: value.bucket.toggles[name].yes ?? 0,
                     no: value.bucket.toggles[name].no ?? 0,
                     variants: value.bucket.toggles[name].variants,


### PR DESCRIPTION
This fixes a problem where the yggdrasil-engine does not send the correct value for bucket.start. In practice clients sends metrics every 60s and it does not matter if we use start or the stop timestamp to resolve the nearest full hour.
