### PR TITLE
chore: await so change requests banner shows up after adding release plans changes

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -84,7 +84,7 @@ export const FeatureStrategyMenu = ({
     };
 
     const addReleasePlanToChangeRequest = async () => {
-        addChange(projectId, environmentId, {
+        await addChange(projectId, environmentId, {
             feature: featureId,
             action: 'addReleasePlan',
             payload: {
@@ -92,7 +92,7 @@ export const FeatureStrategyMenu = ({
             },
         });
 
-        refetchChangeRequests();
+        await refetchChangeRequests();
 
         setToastData({
             type: 'success',

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -124,7 +124,7 @@ export const ReleasePlan = ({
     );
 
     const onAddRemovePlanChangesConfirm = async () => {
-        addChange(projectId, environment, {
+        await addChange(projectId, environment, {
             feature: featureName,
             action: 'deleteReleasePlan',
             payload: {
@@ -132,7 +132,7 @@ export const ReleasePlan = ({
             },
         });
 
-        refetchChangeRequests();
+        await refetchChangeRequests();
 
         setToastData({
             type: 'success',
@@ -143,7 +143,7 @@ export const ReleasePlan = ({
     };
 
     const onAddStartMilestoneChangesConfirm = async () => {
-        addChange(projectId, environment, {
+        await addChange(projectId, environment, {
             feature: featureName,
             action: 'startMilestone',
             payload: {
@@ -152,7 +152,7 @@ export const ReleasePlan = ({
             },
         });
 
-        refetchChangeRequests();
+        await refetchChangeRequests();
 
         setToastData({
             type: 'success',


### PR DESCRIPTION
Await adding changes and refetching change requests so that the banner can show up immediately after adding release plan changes