### PR TITLE
refactor: rename networkViewEnabled to prometheusAPIAvailable

### DIFF
--- a/frontend/src/component/admin/network/NetworkPrometheusAPIWarning.tsx
+++ b/frontend/src/component/admin/network/NetworkPrometheusAPIWarning.tsx
@@ -2,10 +2,10 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 export const NetworkPrometheusAPIWarning = () => {
     const {
-        uiConfig: { networkViewEnabled },
+        uiConfig: { prometheusAPIAvailable },
     } = useUiConfig();
 
-    if (networkViewEnabled) return null;
+    if (prometheusAPIAvailable) return null;
 
     return (
         <p>

--- a/frontend/src/hooks/api/getters/useInstanceMetrics/useInstanceMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceMetrics/useInstanceMetrics.ts
@@ -20,11 +20,11 @@ export const useInstanceMetrics = (
     options: SWRConfiguration = {},
 ): IInstanceMetricsResponse => {
     const {
-        uiConfig: { networkViewEnabled },
+        uiConfig: { prometheusAPIAvailable },
     } = useUiConfig();
 
     const { data, error, mutate } = useConditionalSWR(
-        networkViewEnabled,
+        prometheusAPIAvailable,
         {},
         formatApiPath(`api/admin/metrics/rps`),
         fetcher,

--- a/frontend/src/hooks/api/getters/useUiConfig/defaultValue.tsx
+++ b/frontend/src/hooks/api/getters/useUiConfig/defaultValue.tsx
@@ -27,7 +27,7 @@ export const defaultValue: IUiConfig = {
             title: 'Source code on GitHub',
         },
     ],
-    networkViewEnabled: false,
+    prometheusAPIAvailable: false,
     resourceLimits: {
         segmentValues: 1000,
         strategySegments: 5,

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -24,7 +24,7 @@ export interface IUiConfig {
     links: ILinks[];
     disablePasswordAuth?: boolean;
     emailEnabled?: boolean;
-    networkViewEnabled: boolean;
+    prometheusAPIAvailable: boolean;
     maintenanceMode?: boolean;
     toast?: IProclamationToast;
     segmentValuesLimit?: number;

--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -99,7 +99,7 @@ export const uiConfigSchema = {
                 ),
             },
         },
-        networkViewEnabled: {
+        prometheusAPIAvailable: {
             type: 'boolean',
             description: 'Whether a Prometheus API is available.',
             example: true,

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -186,7 +186,7 @@ class ConfigController extends Controller {
             strategySegmentsLimit: this.config.resourceLimits.strategySegments,
             frontendApiOrigins: frontendSettings.frontendApiOrigins,
             versionInfo: await this.versionService.getVersionInfo(),
-            networkViewEnabled: this.config.prometheusApi !== undefined,
+            prometheusAPIAvailable: this.config.prometheusApi !== undefined,
             resourceLimits: this.config.resourceLimits,
             disablePasswordAuth,
             maintenanceMode,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3290/rename-networkviewenabled-to-prometheusapiavailable

Follow-up to: https://github.com/Unleash/unleash/pull/9325

See: https://github.com/Unleash/unleash/pull/9325#discussion_r1960085303

Renames `networkViewEnabled` to `prometheusAPIAvailable`. This new name better reflects what it stands for.