### PR TITLE
chore: make Edge instance node width consistent

### DIFF
--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -15,6 +15,7 @@ import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { NetworkConnectedEdgeInstanceLatency } from './NetworkConnectedEdgeInstanceLatency';
 
 const StyledInstance = styled('div')(({ theme }) => ({
+    width: '100%',
     borderRadius: theme.shape.borderRadiusMedium,
     border: '1px solid',
     borderColor: theme.palette.secondary.border,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3295/make-edge-instance-nodes-width-consistent-in-the-connected-edges-view

When manually testing this feature I noticed that sometimes Edge instance nodes had different widths depending on their content.

This makes it so they stretch to the available space, making all instance nodes in a group (app-name) the same width.