### PR TITLE
feat: make env selector filterable

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -1,13 +1,5 @@
 import { Popover, styled } from '@mui/material';
 
-export const StyledDropdown = styled('div')(({ theme }) => ({
-    paddingInline: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1),
-    maxHeight: '70vh',
-}));
-
 export const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
         borderRadius: `${theme.shape.borderRadiusMedium}px`,

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -1,16 +1,4 @@
-import { Popover, styled } from '@mui/material';
-
-export const StyledPopover = styled(Popover)(({ theme }) => ({
-    '& .MuiPaper-root': {
-        borderRadius: `${theme.shape.borderRadiusMedium}px`,
-        paddingInline: 0,
-        paddingTop: theme.spacing(1.5),
-        display: 'flex',
-        flexDirection: 'column',
-        gap: theme.spacing(1),
-        maxHeight: '70vh',
-    },
-}));
+import { styled } from '@mui/material';
 
 export const ButtonLabel = styled('span', {
     shouldForwardProp: (prop) => prop !== 'labelWidth',

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -1,7 +1,8 @@
 import { Popover, styled } from '@mui/material';
 
 export const StyledDropdown = styled('div')(({ theme }) => ({
-    padding: theme.spacing(2),
+    paddingInline: 0,
+    paddingTop: theme.spacing(1.5),
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -12,6 +12,12 @@ export const StyledDropdown = styled('div')(({ theme }) => ({
 export const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
+        paddingInline: 0,
+        paddingTop: theme.spacing(1.5),
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing(1),
+        maxHeight: '70vh',
     },
 }));
 

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles.tsx
@@ -2,7 +2,6 @@ import { Popover, styled } from '@mui/material';
 
 export const StyledDropdown = styled('div')(({ theme }) => ({
     paddingInline: 0,
-    paddingTop: theme.spacing(1.5),
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
@@ -93,6 +93,7 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
                     vertical: 'top',
                     horizontal: 'left',
                 }}
+                aria-describedby={descriptionId}
             >
                 <ScreenReaderOnly>
                     <p id={descriptionId}>{description}</p>

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
@@ -2,7 +2,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { type FC, type ReactNode, useRef, type PropsWithChildren } from 'react';
 import { Box, Button } from '@mui/material';
 import {
-    StyledDropdown,
     StyledPopover,
     ButtonLabel,
     StyledTooltipContent,
@@ -98,9 +97,7 @@ export const ConfigButton: FC<PropsWithChildren<ConfigButtonProps>> = ({
                 <ScreenReaderOnly>
                     <p id={descriptionId}>{description}</p>
                 </ScreenReaderOnly>
-                <StyledDropdown aria-describedby={descriptionId}>
-                    {children}
-                </StyledDropdown>
+                {children}
             </StyledPopover>
         </>
     );

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/ConfigButton.tsx
@@ -1,13 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import { type FC, type ReactNode, useRef, type PropsWithChildren } from 'react';
 import { Box, Button } from '@mui/material';
-import {
-    StyledPopover,
-    ButtonLabel,
-    StyledTooltipContent,
-} from './ConfigButton.styles';
+import { ButtonLabel, StyledTooltipContent } from './ConfigButton.styles';
 import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
 import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
+import { StyledPopover } from './shared.styles';
 
 export type ConfigButtonProps = {
     button: {

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.styles.tsx
@@ -1,8 +1,10 @@
 import { Checkbox, ListItem, styled } from '@mui/material';
 
 export const StyledListItem = styled(ListItem)(({ theme }) => ({
-    paddingLeft: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    paddingBlock: theme.spacing(1),
     cursor: 'pointer',
+
     '&:hover, &:focus': {
         backgroundColor: theme.palette.action.hover,
         outline: 'none',

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
@@ -1,4 +1,4 @@
-import { TextField, styled } from '@mui/material';
+import { Popover, TextField, type Theme, styled } from '@mui/material';
 
 const visuallyHiddenStyles = {
     border: 0,
@@ -12,12 +12,27 @@ const visuallyHiddenStyles = {
     whiteSpace: 'nowrap',
 };
 
+const padding = (theme: Theme) => theme.spacing(1.5);
+
+export const StyledPopover = styled(Popover)(({ theme }) => ({
+    '& .MuiPaper-root': {
+        borderRadius: `${theme.shape.borderRadiusMedium}px`,
+        paddingInline: 0,
+        paddingTop: padding(theme),
+        display: 'flex',
+        flexDirection: 'column',
+
+        gap: theme.spacing(1),
+        maxHeight: '70vh',
+    },
+}));
+
 export const StyledDropdownSearch = styled(TextField, {
     shouldForwardProp: (prop) => prop !== 'hideLabel',
 })<{ hideLabel?: boolean }>(({ theme, hideLabel }) => ({
-    padding: theme.spacing(0, 1.5),
+    paddingInline: padding(theme),
     '& .MuiInputBase-root': {
-        padding: theme.spacing(0, 1.5),
+        paddingInline: padding(theme),
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
     },
     '& .MuiInputBase-input': {

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
@@ -1,4 +1,4 @@
-import { Popover, TextField, type Theme, styled } from '@mui/material';
+import { Popover, TextField, styled } from '@mui/material';
 
 const visuallyHiddenStyles = {
     border: 0,
@@ -12,13 +12,13 @@ const visuallyHiddenStyles = {
     whiteSpace: 'nowrap',
 };
 
-const padding = (theme: Theme) => theme.spacing(1.5);
+const dropdownPadding = 1.5;
 
 export const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
         paddingInline: 0,
-        paddingTop: padding(theme),
+        paddingTop: theme.spacing(dropdownPadding),
         display: 'flex',
         flexDirection: 'column',
 
@@ -30,9 +30,9 @@ export const StyledPopover = styled(Popover)(({ theme }) => ({
 export const StyledDropdownSearch = styled(TextField, {
     shouldForwardProp: (prop) => prop !== 'hideLabel',
 })<{ hideLabel?: boolean }>(({ theme, hideLabel }) => ({
-    paddingInline: padding(theme),
+    paddingInline: theme.spacing(dropdownPadding),
     '& .MuiInputBase-root': {
-        paddingInline: padding(theme),
+        paddingInline: theme.spacing(1.5),
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
     },
     '& .MuiInputBase-input': {

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
@@ -15,6 +15,7 @@ const visuallyHiddenStyles = {
 export const StyledDropdownSearch = styled(TextField, {
     shouldForwardProp: (prop) => prop !== 'hideLabel',
 })<{ hideLabel?: boolean }>(({ theme, hideLabel }) => ({
+    padding: theme.spacing(0, 1.5),
     '& .MuiInputBase-root': {
         padding: theme.spacing(0, 1.5),
         borderRadius: `${theme.shape.borderRadiusMedium}px`,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -1,5 +1,5 @@
 import { Button, Popover, styled } from '@mui/material';
-import { useMemo, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -41,19 +41,12 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
         setAnchorEl(null);
     };
 
-    const allEnvironments = useMemo(
-        () => environments.map((environment) => environment.name),
-        [JSON.stringify(environments)],
-    );
+    const allEnvironments = environments.map((environment) => environment.name);
 
-    const selectedOptions = useMemo(
-        () =>
-            new Set(
-                allEnvironments.filter(
-                    (environment) => !hiddenEnvironments.includes(environment),
-                ),
-            ),
-        [environments, hiddenEnvironments],
+    const selectedOptions = new Set(
+        allEnvironments.filter(
+            (environment) => !hiddenEnvironments.includes(environment),
+        ),
     );
 
     const handleToggle = (value: string) => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -43,7 +43,7 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
 
     const allEnvironments = useMemo(
         () => environments.map((environment) => environment.name),
-        [environments],
+        [JSON.stringify(environments)],
     );
 
     const selectedOptions = useMemo(

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -1,8 +1,9 @@
-import { Button, Checkbox, Menu, MenuItem, styled } from '@mui/material';
-import { useState, type FC } from 'react';
+import { Button, Popover, styled } from '@mui/material';
+import { useMemo, useState, type FC } from 'react';
 
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { DropdownList } from 'component/common/DialogFormTemplate/ConfigButtons/DropdownList';
 
 type EnvironmentVisibilityMenuProps = {
     environments: Array<{ name: string }>;
@@ -19,6 +20,13 @@ const StyledContainer = styled('div')(({ theme }) => ({
     paddingTop: theme.spacing(4),
 }));
 
+export const StyledPopover = styled(Popover)(({ theme }) => ({
+    '& .MuiPaper-root': {
+        borderRadius: `${theme.shape.borderRadiusMedium}px`,
+        paddingTop: theme.spacing(2),
+    },
+}));
+
 export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
     environments,
     hiddenEnvironments,
@@ -33,6 +41,25 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
         setAnchorEl(null);
     };
 
+    const allEnvironments = useMemo(
+        () => environments.map((environment) => environment.name),
+        [environments],
+    );
+
+    const selectedOptions = useMemo(
+        () =>
+            new Set(
+                allEnvironments.filter(
+                    (environment) => !hiddenEnvironments.includes(environment),
+                ),
+            ),
+        [environments, hiddenEnvironments],
+    );
+
+    const handleToggle = (value: string) => {
+        onChange(value);
+    };
+
     return (
         <StyledContainer>
             <Button
@@ -40,30 +67,43 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
                 endIcon={isOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                 variant='outlined'
                 id={buttonId}
-                aria-controls={isOpen ? menuId : undefined}
+                aria-controls={menuId}
                 aria-haspopup='true'
                 aria-expanded={isOpen ? 'true' : undefined}
                 data-loading
             >
                 Hide/show environments
             </Button>
-            <Menu
+
+            <StyledPopover
                 id={menuId}
+                open={Boolean(anchorEl)}
                 anchorEl={anchorEl}
-                open={isOpen}
                 onClose={handleClose}
-                MenuListProps={{ 'aria-labelledby': buttonId }}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
             >
-                {environments.map(({ name }) => (
-                    <MenuItem key={name} onClick={() => onChange(name)}>
-                        <Checkbox
-                            onChange={() => onChange(name)}
-                            checked={!hiddenEnvironments?.includes(name)}
-                        />
-                        {name}
-                    </MenuItem>
-                ))}
-            </Menu>
+                <DropdownList
+                    multiselect={{
+                        selectedOptions,
+                    }}
+                    onChange={handleToggle}
+                    options={allEnvironments.map((env) => ({
+                        label: env,
+                        value: env,
+                    }))}
+                    search={{
+                        label: '',
+                        placeholder: 'Select environment',
+                    }}
+                />
+            </StyledPopover>
         </StyledContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -92,8 +92,8 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
                         value: env,
                     }))}
                     search={{
-                        label: '',
-                        placeholder: 'Select environment',
+                        label: 'Filter environments',
+                        placeholder: 'Filter environments',
                     }}
                 />
             </StyledPopover>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -4,10 +4,7 @@ import { useState, type FC } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { DropdownList } from 'component/common/DialogFormTemplate/ConfigButtons/DropdownList';
-import {
-    StyledDropdown,
-    StyledPopover,
-} from 'component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles';
+import { StyledPopover } from 'component/common/DialogFormTemplate/ConfigButtons/shared.styles';
 
 type EnvironmentVisibilityMenuProps = {
     environments: Array<{ name: string }>;
@@ -79,22 +76,20 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
                     horizontal: 'left',
                 }}
             >
-                <StyledDropdown>
-                    <DropdownList
-                        multiselect={{
-                            selectedOptions,
-                        }}
-                        onChange={handleToggle}
-                        options={allEnvironments.map((env) => ({
-                            label: env,
-                            value: env,
-                        }))}
-                        search={{
-                            label: 'Filter environments',
-                            placeholder: 'Filter environments',
-                        }}
-                    />
-                </StyledDropdown>
+                <DropdownList
+                    multiselect={{
+                        selectedOptions,
+                    }}
+                    onChange={handleToggle}
+                    options={allEnvironments.map((env) => ({
+                        label: env,
+                        value: env,
+                    }))}
+                    search={{
+                        label: 'Filter environments',
+                        placeholder: 'Filter environments',
+                    }}
+                />
             </StyledPopover>
         </StyledContainer>
     );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -24,6 +24,9 @@ export const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
         paddingTop: theme.spacing(2),
+        rowGap: theme.spacing(1.5),
+        display: 'flex',
+        flexFlow: 'column',
     },
 }));
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -1,10 +1,13 @@
-import { Button, Popover, styled } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import { useState, type FC } from 'react';
 
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { DropdownList } from 'component/common/DialogFormTemplate/ConfigButtons/DropdownList';
-import { StyledDropdown } from 'component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles';
+import {
+    StyledDropdown,
+    StyledPopover,
+} from 'component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles';
 
 type EnvironmentVisibilityMenuProps = {
     environments: Array<{ name: string }>;
@@ -19,12 +22,6 @@ const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     justifyContent: 'center',
     paddingTop: theme.spacing(4),
-}));
-
-export const StyledPopover = styled(Popover)(({ theme }) => ({
-    '& .MuiPaper-root': {
-        borderRadius: `${theme.shape.borderRadiusMedium}px`,
-    },
 }));
 
 export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/EnvironmentVisibilityMenu/EnvironmentVisibilityMenu.tsx
@@ -4,6 +4,7 @@ import { useState, type FC } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { DropdownList } from 'component/common/DialogFormTemplate/ConfigButtons/DropdownList';
+import { StyledDropdown } from 'component/common/DialogFormTemplate/ConfigButtons/ConfigButton.styles';
 
 type EnvironmentVisibilityMenuProps = {
     environments: Array<{ name: string }>;
@@ -23,10 +24,6 @@ const StyledContainer = styled('div')(({ theme }) => ({
 export const StyledPopover = styled(Popover)(({ theme }) => ({
     '& .MuiPaper-root': {
         borderRadius: `${theme.shape.borderRadiusMedium}px`,
-        paddingTop: theme.spacing(2),
-        rowGap: theme.spacing(1.5),
-        display: 'flex',
-        flexFlow: 'column',
     },
 }));
 
@@ -85,20 +82,22 @@ export const EnvironmentVisibilityMenu: FC<EnvironmentVisibilityMenuProps> = ({
                     horizontal: 'left',
                 }}
             >
-                <DropdownList
-                    multiselect={{
-                        selectedOptions,
-                    }}
-                    onChange={handleToggle}
-                    options={allEnvironments.map((env) => ({
-                        label: env,
-                        value: env,
-                    }))}
-                    search={{
-                        label: 'Filter environments',
-                        placeholder: 'Filter environments',
-                    }}
-                />
+                <StyledDropdown>
+                    <DropdownList
+                        multiselect={{
+                            selectedOptions,
+                        }}
+                        onChange={handleToggle}
+                        options={allEnvironments.map((env) => ({
+                            label: env,
+                            value: env,
+                        }))}
+                        search={{
+                            label: 'Filter environments',
+                            placeholder: 'Filter environments',
+                        }}
+                    />
+                </StyledDropdown>
             </StyledPopover>
         </StyledContainer>
     );


### PR DESCRIPTION
Makes the env selector on the flag page act the same way as the env selector on the new project page or any of the filterable buttons in the new project/flag dialogs. 

Also slightly changes the styles of the existing dropdown lists to bring them in line with the new env selector (more padding, full-width highlights).

Selector:

![image](https://github.com/user-attachments/assets/83875aa3-f9d1-4763-b8eb-75f7dc493b13)


Project/flag creation:
Before:
![image](https://github.com/user-attachments/assets/97926ec8-64a0-4d08-900b-0acd5709ef92)


After:

![image](https://github.com/user-attachments/assets/2616615f-3382-4183-a048-5ea4defc8fb2)

## Technical notes

I was a little unsure how best to share the padding/spacing styles between the search field and popover at first (as was requested by UX). The easiest way (and most compliant with how we do it today) was to define the spacing in a variable and move the relevant components into the same file.

However, I actually think that using a CSS variable (e.g. `--popover-spacing`) would be "better" here, but we don't really use them much, so I've left that out for now. That said, if you agree, I'd be more than happy to use that instead 🙋🏼 