### PR TITLE
chore: improve UX in the Edge observability latency table

### DIFF
--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -146,7 +146,7 @@ export const NetworkConnectedEdgeInstance = ({
     const memory = getMemory(instance);
     const archWarning = cpuPercentage === 'No usage' &&
         memory === 'No usage' && (
-            <p>Resource metrics are only available when running on Linux</p>
+            <p>Resource metrics are only available when running on Linux.</p>
         );
 
     return (
@@ -216,7 +216,7 @@ export const NetworkConnectedEdgeInstance = ({
                                     <>
                                         <p>
                                             CPU average usage since instance
-                                            started
+                                            started.
                                         </p>
                                         {archWarning}
                                     </>
@@ -232,7 +232,7 @@ export const NetworkConnectedEdgeInstance = ({
                             <HelpIcon
                                 tooltip={
                                     <>
-                                        <p>Current memory usage</p>
+                                        <p>Current memory usage.</p>
                                         {archWarning}
                                     </>
                                 }

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstance.tsx
@@ -170,8 +170,16 @@ export const NetworkConnectedEdgeInstance = ({
                         <span>{instance.instanceId}</span>
                     </StyledDetailRow>
                     <StyledDetailRow>
-                        <strong>Upstream</strong>
+                        <strong>Upstream server</strong>
                         <span>{instance.connectedVia || 'Unleash'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Region</strong>
+                        <span>{instance.region || 'Unknown'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Version</strong>
+                        <span>{instance.edgeVersion}</span>
                     </StyledDetailRow>
                     <StyledDetailRow>
                         <strong>Status</strong>
@@ -194,18 +202,6 @@ export const NetworkConnectedEdgeInstance = ({
                     <StyledDetailRow>
                         <strong>Last report</strong>
                         <span>{lastReport}</span>
-                    </StyledDetailRow>
-                    <StyledDetailRow>
-                        <strong>App name</strong>
-                        <span>{instance.appName}</span>
-                    </StyledDetailRow>
-                    <StyledDetailRow>
-                        <strong>Region</strong>
-                        <span>{instance.region || 'Unknown'}</span>
-                    </StyledDetailRow>
-                    <StyledDetailRow>
-                        <strong>Version</strong>
-                        <span>{instance.edgeVersion}</span>
                     </StyledDetailRow>
                     <StyledDetailRow>
                         <strong>CPU</strong>

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
@@ -20,11 +20,9 @@ const StyledTable = styled('table')(({ theme }) => ({
 const StyledSectionHeader = styled('tr')(({ theme }) => ({
     fontWeight: theme.fontWeight.bold,
     '&&& > td': {
-        textAlign: 'center',
         paddingTop: theme.spacing(1),
         '& > div': {
             display: 'flex',
-            justifyContent: 'center',
             alignItems: 'center',
         },
     },

--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdgeInstanceLatency.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import type { ConnectedEdge } from 'interfaces/connectedEdge';
 
 const StyledTable = styled('table')(({ theme }) => ({
@@ -10,17 +11,22 @@ const StyledTable = styled('table')(({ theme }) => ({
     },
     '& tr': {
         textAlign: 'right',
-        '& > th:first-of-type,td:first-of-type': {
+        '& > th:first-of-type, td:first-of-type': {
             textAlign: 'left',
         },
     },
 }));
 
-const StyledUpstreamSection = styled('tr')(({ theme }) => ({
+const StyledSectionHeader = styled('tr')(({ theme }) => ({
     fontWeight: theme.fontWeight.bold,
-    borderBottom: `1px solid ${theme.palette.text.primary}`,
-    '& > td:first-of-type': {
+    '&&& > td': {
+        textAlign: 'center',
         paddingTop: theme.spacing(1),
+        '& > div': {
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+        },
     },
 }));
 
@@ -41,19 +47,19 @@ export const NetworkConnectedEdgeInstanceLatency = ({
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>Client Features</td>
-                    <td>{instance.clientFeaturesAverageLatencyMs}</td>
-                    <td>{instance.clientFeaturesP99LatencyMs}</td>
-                </tr>
-                <tr>
-                    <td>Frontend</td>
-                    <td>{instance.frontendApiAverageLatencyMs}</td>
-                    <td>{instance.frontendApiP99LatencyMs}</td>
-                </tr>
-                <StyledUpstreamSection>
-                    <td colSpan={3}>Upstream</td>
-                </StyledUpstreamSection>
+                <StyledSectionHeader>
+                    <td colSpan={3}>
+                        <div>
+                            Upstream{' '}
+                            <HelpIcon
+                                tooltip={
+                                    'Latency measured for requests sent from this Edge instance to the configured upstream, i.e. Unleash or another Edge instance.'
+                                }
+                                size='16px'
+                            />
+                        </div>
+                    </td>
+                </StyledSectionHeader>
                 <tr>
                     <td>Client Features</td>
                     <td>{instance.upstreamFeaturesAverageLatencyMs}</td>
@@ -68,6 +74,29 @@ export const NetworkConnectedEdgeInstanceLatency = ({
                     <td>Edge</td>
                     <td>{instance.upstreamEdgeAverageLatencyMs}</td>
                     <td>{instance.upstreamEdgeP99LatencyMs}</td>
+                </tr>
+                <StyledSectionHeader>
+                    <td colSpan={3}>
+                        <div>
+                            Downstream{' '}
+                            <HelpIcon
+                                tooltip={
+                                    'Latency measured when serving requests from clients, i.e. SDKs or other Edge instances.'
+                                }
+                                size='16px'
+                            />
+                        </div>
+                    </td>
+                </StyledSectionHeader>
+                <tr>
+                    <td>Client Features</td>
+                    <td>{instance.clientFeaturesAverageLatencyMs}</td>
+                    <td>{instance.clientFeaturesP99LatencyMs}</td>
+                </tr>
+                <tr>
+                    <td>Frontend</td>
+                    <td>{instance.frontendApiAverageLatencyMs}</td>
+                    <td>{instance.frontendApiP99LatencyMs}</td>
                 </tr>
             </tbody>
         </StyledTable>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3298/make-latency-table-clearer

Improves UX of the Edge observability latency table.

![image](https://github.com/user-attachments/assets/c8b36bdf-7bb5-4646-8176-41b8de70fa30)