### PR TITLE
feat: allow command bar navigation to wrap around

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -257,9 +257,18 @@ export const CommandBar = () => {
             const { allCommandBarLinks, selectedIndex } = itemsAndIndex;
 
             const newIndex = selectedIndex + 1;
-            if (newIndex >= allCommandBarLinks.length) return;
-
-            (allCommandBarLinks[newIndex] as HTMLElement).focus();
+            if (newIndex >= allCommandBarLinks.length) {
+                const element = searchInputRef.current;
+                if (element) {
+                    element.focus();
+                    element.setSelectionRange(
+                        element.value.length,
+                        element.value.length,
+                    );
+                }
+            } else {
+                (allCommandBarLinks[newIndex] as HTMLElement).focus();
+            }
         },
     );
     useKeyboardShortcut(
@@ -273,10 +282,11 @@ export const CommandBar = () => {
             const { allCommandBarLinks, selectedIndex } = itemsAndIndex;
 
             const newIndex = selectedIndex - 1;
+            console.log(newIndex, allCommandBarLinks);
 
             if (newIndex >= 0) {
                 (allCommandBarLinks[newIndex] as HTMLElement).focus();
-            } else {
+            } else if (newIndex === -1) {
                 const element = searchInputRef.current;
                 if (element) {
                     element.focus();
@@ -285,6 +295,12 @@ export const CommandBar = () => {
                         element.value.length,
                     );
                 }
+            } else if (newIndex === -2) {
+                (
+                    allCommandBarLinks[
+                        allCommandBarLinks.length - 1
+                    ] as HTMLElement
+                ).focus();
             }
         },
     );

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -282,7 +282,6 @@ export const CommandBar = () => {
             const { allCommandBarLinks, selectedIndex } = itemsAndIndex;
 
             const newIndex = selectedIndex - 1;
-            console.log(newIndex, allCommandBarLinks);
 
             if (newIndex >= 0) {
                 (allCommandBarLinks[newIndex] as HTMLElement).focus();


### PR DESCRIPTION
Lets you navigate to the top of the list when you're at the bottom,
and vice versa.

Arrow down at the end of the list takes you to the search field and
arrow up from the search field takes you to the end of the list.