### PR TITLE
chore: deprecate `envAccordion` colors; update non-legacy components

### DIFF
--- a/frontend/src/component/common/Card/Card.tsx
+++ b/frontend/src/component/common/Card/Card.tsx
@@ -66,7 +66,7 @@ const StyledCardBodyContent = styled(Box)(({ theme }) => ({
 const StyledCardFooter = styled(Box)(({ theme }) => ({
     padding: theme.spacing(0, 2),
     display: 'flex',
-    background: theme.palette.envAccordion.expanded,
+    background: theme.palette.background.elevation1,
     boxShadow: theme.boxShadows.accordionFooter,
     alignItems: 'center',
     justifyContent: 'space-between',

--- a/frontend/src/component/project/ProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
+++ b/frontend/src/component/project/ProjectCard/ProjectCardFooter/ProjectCardFooter.tsx
@@ -19,7 +19,7 @@ const StyledFooter = styled(Box)<{ disabled: boolean }>(
         display: 'flex',
         background: disabled
             ? theme.palette.background.paper
-            : theme.palette.envAccordion.expanded,
+            : theme.palette.background.elevation1,
         boxShadow: theme.boxShadows.accordionFooter,
         alignItems: 'center',
         justifyContent: 'space-between',

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -253,7 +253,7 @@ const theme = {
 
         /**
          * For Environment Accordion.
-         * @deprecated You're probably looking for `elevation1` instead.
+         * @deprecated Use `elevation1` for `disabled` and `elevation2` for `expanded` instead.
          * remove with the flagOverviewRedesign flag
          */
         envAccordion: {

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -253,6 +253,8 @@ const theme = {
 
         /**
          * For Environment Accordion.
+         * @deprecated You're probably looking for `elevation1` instead.
+         * remove with the flagOverviewRedesign flag
          */
         envAccordion: {
             disabled: colors.grey[100],


### PR DESCRIPTION
Deprecates the `envAccordion` colors (`expanded` and `disabled`) and updates the components that I do not expect to be deprecated as part of the strategy facelift project to use `elevation1` instead.

The difference is very slight. envAccordion.expanded:
![image](https://github.com/user-attachments/assets/affaa000-11a7-45af-ac1e-1454281615d8)

Elevation 1:
![image](https://github.com/user-attachments/assets/6baa7219-7a6b-4e5d-bd55-1da9e284e7ed)
