### PR TITLE
chore: adjust env dropdown

### DIFF
--- a/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
+++ b/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
@@ -1,24 +1,18 @@
-import { styled, useTheme } from '@mui/material';
+import { styled } from '@mui/material';
 
 interface IStrategySeparatorProps {
     text: 'AND' | 'OR';
 }
 
-const StyledAnd = styled('div')(({ theme }) => ({
+const StyledOr = styled('div')(({ theme }) => ({
     padding: theme.spacing(0.75, 1),
-    color: theme.palette.text.primary,
     fontSize: theme.fontSizes.smallerBody,
-    backgroundColor: theme.palette.background.elevation2,
     position: 'absolute',
     zIndex: theme.zIndex.fab,
     top: 0,
-    left: theme.spacing(2),
     transform: 'translateY(-50%)',
     lineHeight: 1,
     borderRadius: theme.shape.borderRadiusLarge,
-}));
-
-const StyledOr = styled(StyledAnd)(({ theme }) => ({
     fontWeight: 'bold',
     backgroundColor: theme.palette.background.alternative,
     color: theme.palette.primary.contrastText,
@@ -26,12 +20,5 @@ const StyledOr = styled(StyledAnd)(({ theme }) => ({
 }));
 
 export const StrategySeparator = ({ text }: IStrategySeparatorProps) => {
-    const theme = useTheme();
-    return text === 'AND' ? (
-        <StyledAnd>{text}</StyledAnd>
-    ) : (
-        <>
-            <StyledOr>{text}</StyledOr>
-        </>
-    );
+    return <StyledOr>{text}</StyledOr>;
 };

--- a/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
+++ b/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
@@ -1,4 +1,4 @@
-import { Box, styled, useTheme } from '@mui/material';
+import { styled, useTheme } from '@mui/material';
 
 interface IStrategySeparatorProps {
     text: 'AND' | 'OR';
@@ -11,7 +11,7 @@ const StyledAnd = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.elevation2,
     position: 'absolute',
     zIndex: theme.zIndex.fab,
-    top: '50%',
+    top: 0,
     left: theme.spacing(2),
     transform: 'translateY(-50%)',
     lineHeight: 1,
@@ -27,21 +27,11 @@ const StyledOr = styled(StyledAnd)(({ theme }) => ({
 
 export const StrategySeparator = ({ text }: IStrategySeparatorProps) => {
     const theme = useTheme();
-    return (
-        <Box
-            sx={{
-                height: theme.spacing(text === 'AND' ? 1 : 1.5),
-                position: 'relative',
-            }}
-            aria-hidden={true}
-        >
-            {text === 'AND' ? (
-                <StyledAnd>{text}</StyledAnd>
-            ) : (
-                <>
-                    <StyledOr>{text}</StyledOr>
-                </>
-            )}
-        </Box>
+    return text === 'AND' ? (
+        <StyledAnd>{text}</StyledAnd>
+    ) : (
+        <>
+            <StyledOr>{text}</StyledOr>
+        </>
     );
 };

--- a/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
+++ b/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
@@ -25,15 +25,6 @@ const StyledOr = styled(StyledAnd)(({ theme }) => ({
     left: theme.spacing(4),
 }));
 
-const StyledSeparator = styled('hr')(({ theme }) => ({
-    border: 0,
-    borderTop: `1px solid ${theme.palette.divider}`,
-    margin: 0,
-    position: 'absolute',
-    top: '50%',
-    width: '100%',
-}));
-
 export const StrategySeparator = ({ text }: IStrategySeparatorProps) => {
     const theme = useTheme();
     return (
@@ -48,7 +39,6 @@ export const StrategySeparator = ({ text }: IStrategySeparatorProps) => {
                 <StyledAnd>{text}</StyledAnd>
             ) : (
                 <>
-                    <StyledSeparator />
                     <StyledOr>{text}</StyledOr>
                 </>
             )}

--- a/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
+++ b/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
@@ -1,10 +1,6 @@
 import { styled } from '@mui/material';
 
-interface IStrategySeparatorProps {
-    text: 'AND' | 'OR';
-}
-
-const StyledOr = styled('div')(({ theme }) => ({
+const Chip = styled('div')(({ theme }) => ({
     padding: theme.spacing(0.75, 1),
     fontSize: theme.fontSizes.smallerBody,
     position: 'absolute',
@@ -19,6 +15,6 @@ const StyledOr = styled('div')(({ theme }) => ({
     left: theme.spacing(4),
 }));
 
-export const StrategySeparator = ({ text }: IStrategySeparatorProps) => {
-    return <StyledOr>{text}</StyledOr>;
+export const StrategySeparator = () => {
+    return <Chip>OR</Chip>;
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -20,7 +20,7 @@ import type { IFeatureStrategy } from 'interfaces/strategy';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
-import { StrategyDraggableItem as NewStrategyDraggableItem } from './StrategyDraggableItem/StrategyDraggableItem';
+import { StrategyDraggableItem } from './StrategyDraggableItem/StrategyDraggableItem';
 import { ReleasePlan } from '../../../ReleasePlan/ReleasePlan';
 import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 
@@ -252,7 +252,7 @@ export const EnvironmentAccordionBody = ({
                                             <StrategySeparator text='OR' />
                                         ) : null}
 
-                                        <NewStrategyDraggableItem
+                                        <StrategyDraggableItem
                                             strategy={strategy}
                                             index={index}
                                             environmentName={
@@ -287,7 +287,7 @@ export const EnvironmentAccordionBody = ({
                                                 <StrategySeparator text='OR' />
                                             ) : null}
 
-                                            <NewStrategyDraggableItem
+                                            <StrategyDraggableItem
                                                 strategy={strategy}
                                                 index={
                                                     index + pageIndex * pageSize

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -57,6 +57,7 @@ const StyledReleasePlanList = styled(StyledStrategyList)(({ theme }) => ({
 const StyledListItem = styled('li')(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.divider}`,
     background: 'inherit',
+    paddingBottom: theme.spacing(2.5),
 }));
 
 const PaginatedStrategyContainer = styled('div')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -275,7 +275,7 @@ export const EnvironmentAccordionBody = ({
                                 </StyledStrategyList>
                             ) : (
                                 <PaginatedStrategyContainer>
-                                    <Alert severity='error'>
+                                    <Alert severity='warning'>
                                         We noticed you're using a high number of
                                         activation strategies. To ensure a more
                                         targeted approach, consider leveraging

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -21,7 +21,6 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
 import { StrategyDraggableItem as NewStrategyDraggableItem } from './StrategyDraggableItem/StrategyDraggableItem';
-import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 import { ReleasePlan } from '../../../ReleasePlan/ReleasePlan';
 
 interface IEnvironmentAccordionBodyProps {
@@ -36,13 +35,13 @@ const StyledAccordionBodyInnerContainer = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledStrategyList = styled('ol')({
+const StyledContentList = styled('ol')({
     listStyle: 'none',
     padding: 0,
     margin: 0,
 });
 
-const StyledReleasePlanList = styled(StyledStrategyList)(({ theme }) => ({
+const StyledReleasePlanList = styled(StyledContentList)(({ theme }) => ({
     background: theme.palette.background.elevation2,
 }));
 
@@ -53,9 +52,7 @@ const StyledListItem = styled('li')(({ theme }) => ({
     paddingBlock: theme.spacing(2.5),
 }));
 
-const StrategyContainer = styled('div')(({ theme }) => ({
-    position: 'relative',
-}));
+const StrategyContainer = styled('div')(({ theme }) => ({}));
 
 const PaginatedStrategyContainer = styled('div')(({ theme }) => ({
     paddingTop: theme.spacing(2.5),
@@ -234,97 +231,81 @@ export const EnvironmentAccordionBody = ({
         <div>
             <StyledAccordionBodyInnerContainer>
                 {releasePlans.length > 0 || strategies.length > 0 ? (
-                    <>
-                        <StyledReleasePlanList>
-                            {releasePlans.map((plan) => (
-                                <StyledListItem key={plan.id}>
-                                    <ReleasePlan
-                                        plan={plan}
-                                        environmentIsDisabled={isDisabled}
-                                    />
-                                </StyledListItem>
-                            ))}
-                        </StyledReleasePlanList>
-                        <StrategyContainer>
-                            {releasePlans.length > 0 &&
-                            strategies.length > 0 ? (
-                                <StrategySeparator text='OR' />
-                            ) : null}
-                            {strategies.length < 50 ||
-                            !manyStrategiesPagination ? (
-                                <StyledStrategyList>
-                                    {strategies.map((strategy, index) => (
+                    <StyledReleasePlanList>
+                        {releasePlans.map((plan) => (
+                            <StyledListItem key={plan.id}>
+                                <ReleasePlan
+                                    plan={plan}
+                                    environmentIsDisabled={isDisabled}
+                                />
+                            </StyledListItem>
+                        ))}
+                        {strategies.length < 50 || !manyStrategiesPagination ? (
+                            <StyledContentList>
+                                {strategies.map((strategy, index) => (
+                                    <StyledListItem key={strategy.id}>
+                                        <NewStrategyDraggableItem
+                                            strategy={strategy}
+                                            index={index}
+                                            environmentName={
+                                                featureEnvironment.name
+                                            }
+                                            otherEnvironments={
+                                                otherEnvironments
+                                            }
+                                            isDragging={
+                                                dragItem?.id === strategy.id
+                                            }
+                                            onDragStartRef={onDragStartRef}
+                                            onDragOver={onDragOver(strategy.id)}
+                                            onDragEnd={onDragEnd}
+                                        />
+                                    </StyledListItem>
+                                ))}
+                            </StyledContentList>
+                        ) : (
+                            <PaginatedStrategyContainer>
+                                <StyledAlert severity='warning'>
+                                    We noticed you're using a high number of
+                                    activation strategies. To ensure a more
+                                    targeted approach, consider leveraging
+                                    constraints or segments.
+                                </StyledAlert>
+                                <StyledContentList>
+                                    {page.map((strategy, index) => (
                                         <StyledListItem key={strategy.id}>
                                             <NewStrategyDraggableItem
                                                 strategy={strategy}
-                                                index={index}
+                                                index={
+                                                    index + pageIndex * pageSize
+                                                }
                                                 environmentName={
                                                     featureEnvironment.name
                                                 }
                                                 otherEnvironments={
                                                     otherEnvironments
                                                 }
-                                                isDragging={
-                                                    dragItem?.id === strategy.id
+                                                isDragging={false}
+                                                onDragStartRef={
+                                                    (() => {}) as any
                                                 }
-                                                onDragStartRef={onDragStartRef}
-                                                onDragOver={onDragOver(
-                                                    strategy.id,
-                                                )}
-                                                onDragEnd={onDragEnd}
+                                                onDragOver={(() => {}) as any}
+                                                onDragEnd={(() => {}) as any}
                                             />
                                         </StyledListItem>
                                     ))}
-                                </StyledStrategyList>
-                            ) : (
-                                <PaginatedStrategyContainer>
-                                    <StyledAlert severity='warning'>
-                                        We noticed you're using a high number of
-                                        activation strategies. To ensure a more
-                                        targeted approach, consider leveraging
-                                        constraints or segments.
-                                    </StyledAlert>
-                                    <StyledStrategyList>
-                                        {page.map((strategy, index) => (
-                                            <StyledListItem key={strategy.id}>
-                                                <NewStrategyDraggableItem
-                                                    strategy={strategy}
-                                                    index={
-                                                        index +
-                                                        pageIndex * pageSize
-                                                    }
-                                                    environmentName={
-                                                        featureEnvironment.name
-                                                    }
-                                                    otherEnvironments={
-                                                        otherEnvironments
-                                                    }
-                                                    isDragging={false}
-                                                    onDragStartRef={
-                                                        (() => {}) as any
-                                                    }
-                                                    onDragOver={
-                                                        (() => {}) as any
-                                                    }
-                                                    onDragEnd={
-                                                        (() => {}) as any
-                                                    }
-                                                />
-                                            </StyledListItem>
-                                        ))}
-                                    </StyledStrategyList>
-                                    <Pagination
-                                        count={pages.length}
-                                        shape='rounded'
-                                        page={pageIndex + 1}
-                                        onChange={(_, page) =>
-                                            setPageIndex(page - 1)
-                                        }
-                                    />
-                                </PaginatedStrategyContainer>
-                            )}
-                        </StrategyContainer>
-                    </>
+                                </StyledContentList>
+                                <Pagination
+                                    count={pages.length}
+                                    shape='rounded'
+                                    page={pageIndex + 1}
+                                    onChange={(_, page) =>
+                                        setPageIndex(page - 1)
+                                    }
+                                />
+                            </PaginatedStrategyContainer>
+                        )}
+                    </StyledReleasePlanList>
                 ) : (
                     <FeatureStrategyEmpty
                         projectId={projectId}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -55,7 +55,7 @@ const StyledReleasePlanList = styled(StyledStrategyList)(({ theme }) => ({
 }));
 
 const StyledListItem = styled('li')(({ theme }) => ({
-    borderBottom: `1px solid ${theme.palette.background.elevation2}`,
+    borderBottom: `1px solid ${theme.palette.divider}`,
     background: 'inherit',
 }));
 
@@ -235,12 +235,12 @@ export const EnvironmentAccordionBody = ({
                         <>
                             <StyledReleasePlanList>
                                 {releasePlans.map((plan) => (
-                                    <li key={plan.id}>
+                                    <StyledListItem key={plan.id}>
                                         <ReleasePlan
                                             plan={plan}
                                             environmentIsDisabled={isDisabled}
                                         />
-                                    </li>
+                                    </StyledListItem>
                                 ))}
                             </StyledReleasePlanList>
                             {releasePlans.length > 0 &&

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -9,7 +9,6 @@ import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFe
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useToast from 'hooks/useToast';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { StrategyDraggableItem } from './StrategyDraggableItem/LegacyStrategyDraggableItem';
 import type { IFeatureEnvironment } from 'interfaces/featureToggle';
 import { FeatureStrategyEmpty } from 'component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
@@ -285,7 +284,7 @@ export const EnvironmentAccordionBody = ({
                                     <StyledStrategyList>
                                         {page.map((strategy, index) => (
                                             <StyledListItem key={strategy.id}>
-                                                <StrategyDraggableItem
+                                                <NewStrategyDraggableItem
                                                     strategy={strategy}
                                                     index={
                                                         index +

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -65,6 +65,10 @@ const PaginatedStrategyContainer = styled('div')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
+const StyledAlert = styled(Alert)(({ theme }) => ({
+    marginInline: theme.spacing(2), // should consider finding a variable here
+}));
+
 export const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
@@ -275,12 +279,12 @@ export const EnvironmentAccordionBody = ({
                                 </StyledStrategyList>
                             ) : (
                                 <PaginatedStrategyContainer>
-                                    <Alert severity='warning'>
+                                    <StyledAlert severity='warning'>
                                         We noticed you're using a high number of
                                         activation strategies. To ensure a more
                                         targeted approach, consider leveraging
                                         constraints or segments.
-                                    </Alert>
+                                    </StyledAlert>
                                     <StyledStrategyList>
                                         {page.map((strategy, index) => (
                                             <StyledListItem key={strategy.id}>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -70,6 +70,11 @@ const StyledReleasePlanList = styled(StyledStrategyList)(({ theme }) => ({
     background: theme.palette.background.elevation2,
 }));
 
+const StyledListItem = styled('li')(({ theme }) => ({
+    borderBottom: `1px solid ${theme.palette.background.elevation2}`,
+    background: 'inherit',
+}));
+
 export const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
@@ -260,7 +265,7 @@ export const EnvironmentAccordionBody = ({
                                 show={
                                     <StyledStrategyList>
                                         {strategies.map((strategy, index) => (
-                                            <li key={strategy.id}>
+                                            <StyledListItem key={strategy.id}>
                                                 <NewStrategyDraggableItem
                                                     strategy={strategy}
                                                     index={index}
@@ -282,7 +287,7 @@ export const EnvironmentAccordionBody = ({
                                                     )}
                                                     onDragEnd={onDragEnd}
                                                 />
-                                            </li>
+                                            </StyledListItem>
                                         ))}
                                     </StyledStrategyList>
                                 }
@@ -298,7 +303,9 @@ export const EnvironmentAccordionBody = ({
                                         <br />
                                         <StyledStrategyList>
                                             {page.map((strategy, index) => (
-                                                <li key={strategy.id}>
+                                                <StyledListItem
+                                                    key={strategy.id}
+                                                >
                                                     <StrategyDraggableItem
                                                         strategy={strategy}
                                                         index={
@@ -322,7 +329,7 @@ export const EnvironmentAccordionBody = ({
                                                             (() => {}) as any
                                                         }
                                                     />
-                                                </li>
+                                                </StyledListItem>
                                             ))}
                                         </StyledStrategyList>
                                         <br />

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -75,6 +75,12 @@ const StyledListItem = styled('li')(({ theme }) => ({
     background: 'inherit',
 }));
 
+const PaginatedStrategyContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    gap: theme.spacing(2),
+}));
+
 export const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
@@ -292,7 +298,7 @@ export const EnvironmentAccordionBody = ({
                                     </StyledStrategyList>
                                 }
                                 elseShow={
-                                    <>
+                                    <PaginatedStrategyContainer>
                                         <Alert severity='error'>
                                             We noticed you're using a high
                                             number of activation strategies. To
@@ -300,7 +306,6 @@ export const EnvironmentAccordionBody = ({
                                             consider leveraging constraints or
                                             segments.
                                         </Alert>
-                                        <br />
                                         <StyledStrategyList>
                                             {page.map((strategy, index) => (
                                                 <StyledListItem
@@ -332,7 +337,6 @@ export const EnvironmentAccordionBody = ({
                                                 </StyledListItem>
                                             ))}
                                         </StyledStrategyList>
-                                        <br />
                                         <Pagination
                                             count={pages.length}
                                             shape='rounded'
@@ -341,7 +345,7 @@ export const EnvironmentAccordionBody = ({
                                                 setPageIndex(page - 1)
                                             }
                                         />
-                                    </>
+                                    </PaginatedStrategyContainer>
                                 }
                             />
                         </>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -22,7 +22,6 @@ import type { IFeatureStrategy } from 'interfaces/strategy';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
-import { Badge } from 'component/common/Badge/Badge';
 import { StrategyDraggableItem as NewStrategyDraggableItem } from './StrategyDraggableItem/StrategyDraggableItem';
 import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 import { ReleasePlan } from '../../../ReleasePlan/ReleasePlan';
@@ -43,21 +42,6 @@ const StyledAccordionBodyInnerContainer = styled('div')(({ theme }) => ({
     [theme.breakpoints.down(400)]: {
         padding: theme.spacing(1),
     },
-}));
-
-const StyledBadge = styled(Badge)(({ theme }) => ({
-    backgroundColor: theme.palette.primary.light,
-    border: 'none',
-    padding: theme.spacing(0.75, 1.5),
-    borderRadius: theme.shape.borderRadiusLarge,
-    color: theme.palette.common.white,
-}));
-
-const AdditionalStrategiesDiv = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: theme.spacing(2),
 }));
 
 const StyledStrategyList = styled('ol')({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -263,91 +263,79 @@ export const EnvironmentAccordionBody = ({
                             strategies.length > 0 ? (
                                 <StrategySeparator text='OR' />
                             ) : null}
-                            <ConditionallyRender
-                                condition={
-                                    strategies.length < 50 ||
-                                    !manyStrategiesPagination
-                                }
-                                show={
+                            {strategies.length < 50 ||
+                            !manyStrategiesPagination ? (
+                                <StyledStrategyList>
+                                    {strategies.map((strategy, index) => (
+                                        <StyledListItem key={strategy.id}>
+                                            <NewStrategyDraggableItem
+                                                strategy={strategy}
+                                                index={index}
+                                                environmentName={
+                                                    featureEnvironment.name
+                                                }
+                                                otherEnvironments={
+                                                    otherEnvironments
+                                                }
+                                                isDragging={
+                                                    dragItem?.id === strategy.id
+                                                }
+                                                onDragStartRef={onDragStartRef}
+                                                onDragOver={onDragOver(
+                                                    strategy.id,
+                                                )}
+                                                onDragEnd={onDragEnd}
+                                            />
+                                        </StyledListItem>
+                                    ))}
+                                </StyledStrategyList>
+                            ) : (
+                                <PaginatedStrategyContainer>
+                                    <Alert severity='error'>
+                                        We noticed you're using a high number of
+                                        activation strategies. To ensure a more
+                                        targeted approach, consider leveraging
+                                        constraints or segments.
+                                    </Alert>
                                     <StyledStrategyList>
-                                        {strategies.map((strategy, index) => (
+                                        {page.map((strategy, index) => (
                                             <StyledListItem key={strategy.id}>
-                                                <NewStrategyDraggableItem
+                                                <StrategyDraggableItem
                                                     strategy={strategy}
-                                                    index={index}
+                                                    index={
+                                                        index +
+                                                        pageIndex * pageSize
+                                                    }
                                                     environmentName={
                                                         featureEnvironment.name
                                                     }
                                                     otherEnvironments={
                                                         otherEnvironments
                                                     }
-                                                    isDragging={
-                                                        dragItem?.id ===
-                                                        strategy.id
-                                                    }
+                                                    isDragging={false}
                                                     onDragStartRef={
-                                                        onDragStartRef
+                                                        (() => {}) as any
                                                     }
-                                                    onDragOver={onDragOver(
-                                                        strategy.id,
-                                                    )}
-                                                    onDragEnd={onDragEnd}
+                                                    onDragOver={
+                                                        (() => {}) as any
+                                                    }
+                                                    onDragEnd={
+                                                        (() => {}) as any
+                                                    }
                                                 />
                                             </StyledListItem>
                                         ))}
                                     </StyledStrategyList>
-                                }
-                                elseShow={
-                                    <PaginatedStrategyContainer>
-                                        <Alert severity='error'>
-                                            We noticed you're using a high
-                                            number of activation strategies. To
-                                            ensure a more targeted approach,
-                                            consider leveraging constraints or
-                                            segments.
-                                        </Alert>
-                                        <StyledStrategyList>
-                                            {page.map((strategy, index) => (
-                                                <StyledListItem
-                                                    key={strategy.id}
-                                                >
-                                                    <StrategyDraggableItem
-                                                        strategy={strategy}
-                                                        index={
-                                                            index +
-                                                            pageIndex * pageSize
-                                                        }
-                                                        environmentName={
-                                                            featureEnvironment.name
-                                                        }
-                                                        otherEnvironments={
-                                                            otherEnvironments
-                                                        }
-                                                        isDragging={false}
-                                                        onDragStartRef={
-                                                            (() => {}) as any
-                                                        }
-                                                        onDragOver={
-                                                            (() => {}) as any
-                                                        }
-                                                        onDragEnd={
-                                                            (() => {}) as any
-                                                        }
-                                                    />
-                                                </StyledListItem>
-                                            ))}
-                                        </StyledStrategyList>
-                                        <Pagination
-                                            count={pages.length}
-                                            shape='rounded'
-                                            page={pageIndex + 1}
-                                            onChange={(_, page) =>
-                                                setPageIndex(page - 1)
-                                            }
-                                        />
-                                    </PaginatedStrategyContainer>
-                                }
-                            />
+                                    <Pagination
+                                        count={pages.length}
+                                        shape='rounded'
+                                        page={pageIndex + 1}
+                                        onChange={(_, page) =>
+                                            setPageIndex(page - 1)
+                                        }
+                                    />
+                                </PaginatedStrategyContainer>
+                            )}
                         </>
                     }
                     elseShow={

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -249,7 +249,7 @@ export const EnvironmentAccordionBody = ({
                                     <StyledListItem key={strategy.id}>
                                         {index > 0 ||
                                         releasePlans.length > 0 ? (
-                                            <StrategySeparator text='OR' />
+                                            <StrategySeparator />
                                         ) : null}
 
                                         <StrategyDraggableItem
@@ -284,7 +284,7 @@ export const EnvironmentAccordionBody = ({
                                         <StyledListItem key={strategy.id}>
                                             {index > 0 ||
                                             releasePlans.length > 0 ? (
-                                                <StrategySeparator text='OR' />
+                                                <StrategySeparator />
                                             ) : null}
 
                                             <StrategyDraggableItem

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -8,7 +8,6 @@ import { Alert, Pagination, styled } from '@mui/material';
 import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useToast from 'hooks/useToast';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { IFeatureEnvironment } from 'interfaces/featureToggle';
 import { FeatureStrategyEmpty } from 'component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
@@ -234,115 +233,105 @@ export const EnvironmentAccordionBody = ({
     return (
         <div>
             <StyledAccordionBodyInnerContainer>
-                <ConditionallyRender
-                    condition={releasePlans.length > 0 || strategies.length > 0}
-                    show={
-                        <>
-                            <StyledReleasePlanList>
-                                {releasePlans.map((plan) => (
-                                    <StyledListItem key={plan.id}>
-                                        <ReleasePlan
-                                            plan={plan}
-                                            environmentIsDisabled={isDisabled}
-                                        />
-                                    </StyledListItem>
-                                ))}
-                            </StyledReleasePlanList>
-                            <StrategyContainer>
-                                {releasePlans.length > 0 &&
-                                strategies.length > 0 ? (
-                                    <StrategySeparator text='OR' />
-                                ) : null}
-                                {strategies.length < 50 ||
-                                !manyStrategiesPagination ? (
+                {releasePlans.length > 0 || strategies.length > 0 ? (
+                    <>
+                        <StyledReleasePlanList>
+                            {releasePlans.map((plan) => (
+                                <StyledListItem key={plan.id}>
+                                    <ReleasePlan
+                                        plan={plan}
+                                        environmentIsDisabled={isDisabled}
+                                    />
+                                </StyledListItem>
+                            ))}
+                        </StyledReleasePlanList>
+                        <StrategyContainer>
+                            {releasePlans.length > 0 &&
+                            strategies.length > 0 ? (
+                                <StrategySeparator text='OR' />
+                            ) : null}
+                            {strategies.length < 50 ||
+                            !manyStrategiesPagination ? (
+                                <StyledStrategyList>
+                                    {strategies.map((strategy, index) => (
+                                        <StyledListItem key={strategy.id}>
+                                            <NewStrategyDraggableItem
+                                                strategy={strategy}
+                                                index={index}
+                                                environmentName={
+                                                    featureEnvironment.name
+                                                }
+                                                otherEnvironments={
+                                                    otherEnvironments
+                                                }
+                                                isDragging={
+                                                    dragItem?.id === strategy.id
+                                                }
+                                                onDragStartRef={onDragStartRef}
+                                                onDragOver={onDragOver(
+                                                    strategy.id,
+                                                )}
+                                                onDragEnd={onDragEnd}
+                                            />
+                                        </StyledListItem>
+                                    ))}
+                                </StyledStrategyList>
+                            ) : (
+                                <PaginatedStrategyContainer>
+                                    <StyledAlert severity='warning'>
+                                        We noticed you're using a high number of
+                                        activation strategies. To ensure a more
+                                        targeted approach, consider leveraging
+                                        constraints or segments.
+                                    </StyledAlert>
                                     <StyledStrategyList>
-                                        {strategies.map((strategy, index) => (
+                                        {page.map((strategy, index) => (
                                             <StyledListItem key={strategy.id}>
                                                 <NewStrategyDraggableItem
                                                     strategy={strategy}
-                                                    index={index}
+                                                    index={
+                                                        index +
+                                                        pageIndex * pageSize
+                                                    }
                                                     environmentName={
                                                         featureEnvironment.name
                                                     }
                                                     otherEnvironments={
                                                         otherEnvironments
                                                     }
-                                                    isDragging={
-                                                        dragItem?.id ===
-                                                        strategy.id
-                                                    }
+                                                    isDragging={false}
                                                     onDragStartRef={
-                                                        onDragStartRef
+                                                        (() => {}) as any
                                                     }
-                                                    onDragOver={onDragOver(
-                                                        strategy.id,
-                                                    )}
-                                                    onDragEnd={onDragEnd}
+                                                    onDragOver={
+                                                        (() => {}) as any
+                                                    }
+                                                    onDragEnd={
+                                                        (() => {}) as any
+                                                    }
                                                 />
                                             </StyledListItem>
                                         ))}
                                     </StyledStrategyList>
-                                ) : (
-                                    <PaginatedStrategyContainer>
-                                        <StyledAlert severity='warning'>
-                                            We noticed you're using a high
-                                            number of activation strategies. To
-                                            ensure a more targeted approach,
-                                            consider leveraging constraints or
-                                            segments.
-                                        </StyledAlert>
-                                        <StyledStrategyList>
-                                            {page.map((strategy, index) => (
-                                                <StyledListItem
-                                                    key={strategy.id}
-                                                >
-                                                    <NewStrategyDraggableItem
-                                                        strategy={strategy}
-                                                        index={
-                                                            index +
-                                                            pageIndex * pageSize
-                                                        }
-                                                        environmentName={
-                                                            featureEnvironment.name
-                                                        }
-                                                        otherEnvironments={
-                                                            otherEnvironments
-                                                        }
-                                                        isDragging={false}
-                                                        onDragStartRef={
-                                                            (() => {}) as any
-                                                        }
-                                                        onDragOver={
-                                                            (() => {}) as any
-                                                        }
-                                                        onDragEnd={
-                                                            (() => {}) as any
-                                                        }
-                                                    />
-                                                </StyledListItem>
-                                            ))}
-                                        </StyledStrategyList>
-                                        <Pagination
-                                            count={pages.length}
-                                            shape='rounded'
-                                            page={pageIndex + 1}
-                                            onChange={(_, page) =>
-                                                setPageIndex(page - 1)
-                                            }
-                                        />
-                                    </PaginatedStrategyContainer>
-                                )}
-                            </StrategyContainer>
-                        </>
-                    }
-                    elseShow={
-                        <FeatureStrategyEmpty
-                            projectId={projectId}
-                            featureId={featureId}
-                            environmentId={featureEnvironment.name}
-                        />
-                    }
-                />
+                                    <Pagination
+                                        count={pages.length}
+                                        shape='rounded'
+                                        page={pageIndex + 1}
+                                        onChange={(_, page) =>
+                                            setPageIndex(page - 1)
+                                        }
+                                    />
+                                </PaginatedStrategyContainer>
+                            )}
+                        </StrategyContainer>
+                    </>
+                ) : (
+                    <FeatureStrategyEmpty
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={featureEnvironment.name}
+                    />
+                )}
             </StyledAccordionBodyInnerContainer>
         </div>
     );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -31,12 +31,6 @@ interface IEnvironmentAccordionBodyProps {
     otherEnvironments?: IFeatureEnvironment['name'][];
 }
 
-const StyledAccordionBody = styled('div')(({ theme }) => ({
-    width: '100%',
-    position: 'relative',
-    paddingBottom: theme.spacing(2),
-}));
-
 const StyledAccordionBodyInnerContainer = styled('div')(({ theme }) => ({
     [theme.breakpoints.down(400)]: {
         padding: theme.spacing(1),
@@ -56,10 +50,17 @@ const StyledReleasePlanList = styled(StyledStrategyList)(({ theme }) => ({
 const StyledListItem = styled('li')(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.divider}`,
     background: 'inherit',
-    paddingBottom: theme.spacing(2.5),
+    position: 'relative',
+    paddingBlock: theme.spacing(2.5),
+}));
+
+const StrategyContainer = styled('div')(({ theme }) => ({
+    position: 'relative',
 }));
 
 const PaginatedStrategyContainer = styled('div')(({ theme }) => ({
+    paddingTop: theme.spacing(2.5),
+    position: 'relative',
     display: 'flex',
     flexFlow: 'column nowrap',
     gap: theme.spacing(2),
@@ -231,7 +232,7 @@ export const EnvironmentAccordionBody = ({
     };
 
     return (
-        <StyledAccordionBody>
+        <div>
             <StyledAccordionBodyInnerContainer>
                 <ConditionallyRender
                     condition={releasePlans.length > 0 || strategies.length > 0}
@@ -247,83 +248,91 @@ export const EnvironmentAccordionBody = ({
                                     </StyledListItem>
                                 ))}
                             </StyledReleasePlanList>
-                            {releasePlans.length > 0 &&
-                            strategies.length > 0 ? (
-                                <StrategySeparator text='OR' />
-                            ) : null}
-                            {strategies.length < 50 ||
-                            !manyStrategiesPagination ? (
-                                <StyledStrategyList>
-                                    {strategies.map((strategy, index) => (
-                                        <StyledListItem key={strategy.id}>
-                                            <NewStrategyDraggableItem
-                                                strategy={strategy}
-                                                index={index}
-                                                environmentName={
-                                                    featureEnvironment.name
-                                                }
-                                                otherEnvironments={
-                                                    otherEnvironments
-                                                }
-                                                isDragging={
-                                                    dragItem?.id === strategy.id
-                                                }
-                                                onDragStartRef={onDragStartRef}
-                                                onDragOver={onDragOver(
-                                                    strategy.id,
-                                                )}
-                                                onDragEnd={onDragEnd}
-                                            />
-                                        </StyledListItem>
-                                    ))}
-                                </StyledStrategyList>
-                            ) : (
-                                <PaginatedStrategyContainer>
-                                    <StyledAlert severity='warning'>
-                                        We noticed you're using a high number of
-                                        activation strategies. To ensure a more
-                                        targeted approach, consider leveraging
-                                        constraints or segments.
-                                    </StyledAlert>
+                            <StrategyContainer>
+                                {releasePlans.length > 0 &&
+                                strategies.length > 0 ? (
+                                    <StrategySeparator text='OR' />
+                                ) : null}
+                                {strategies.length < 50 ||
+                                !manyStrategiesPagination ? (
                                     <StyledStrategyList>
-                                        {page.map((strategy, index) => (
+                                        {strategies.map((strategy, index) => (
                                             <StyledListItem key={strategy.id}>
                                                 <NewStrategyDraggableItem
                                                     strategy={strategy}
-                                                    index={
-                                                        index +
-                                                        pageIndex * pageSize
-                                                    }
+                                                    index={index}
                                                     environmentName={
                                                         featureEnvironment.name
                                                     }
                                                     otherEnvironments={
                                                         otherEnvironments
                                                     }
-                                                    isDragging={false}
+                                                    isDragging={
+                                                        dragItem?.id ===
+                                                        strategy.id
+                                                    }
                                                     onDragStartRef={
-                                                        (() => {}) as any
+                                                        onDragStartRef
                                                     }
-                                                    onDragOver={
-                                                        (() => {}) as any
-                                                    }
-                                                    onDragEnd={
-                                                        (() => {}) as any
-                                                    }
+                                                    onDragOver={onDragOver(
+                                                        strategy.id,
+                                                    )}
+                                                    onDragEnd={onDragEnd}
                                                 />
                                             </StyledListItem>
                                         ))}
                                     </StyledStrategyList>
-                                    <Pagination
-                                        count={pages.length}
-                                        shape='rounded'
-                                        page={pageIndex + 1}
-                                        onChange={(_, page) =>
-                                            setPageIndex(page - 1)
-                                        }
-                                    />
-                                </PaginatedStrategyContainer>
-                            )}
+                                ) : (
+                                    <PaginatedStrategyContainer>
+                                        <StyledAlert severity='warning'>
+                                            We noticed you're using a high
+                                            number of activation strategies. To
+                                            ensure a more targeted approach,
+                                            consider leveraging constraints or
+                                            segments.
+                                        </StyledAlert>
+                                        <StyledStrategyList>
+                                            {page.map((strategy, index) => (
+                                                <StyledListItem
+                                                    key={strategy.id}
+                                                >
+                                                    <NewStrategyDraggableItem
+                                                        strategy={strategy}
+                                                        index={
+                                                            index +
+                                                            pageIndex * pageSize
+                                                        }
+                                                        environmentName={
+                                                            featureEnvironment.name
+                                                        }
+                                                        otherEnvironments={
+                                                            otherEnvironments
+                                                        }
+                                                        isDragging={false}
+                                                        onDragStartRef={
+                                                            (() => {}) as any
+                                                        }
+                                                        onDragOver={
+                                                            (() => {}) as any
+                                                        }
+                                                        onDragEnd={
+                                                            (() => {}) as any
+                                                        }
+                                                    />
+                                                </StyledListItem>
+                                            ))}
+                                        </StyledStrategyList>
+                                        <Pagination
+                                            count={pages.length}
+                                            shape='rounded'
+                                            page={pageIndex + 1}
+                                            onChange={(_, page) =>
+                                                setPageIndex(page - 1)
+                                            }
+                                        />
+                                    </PaginatedStrategyContainer>
+                                )}
+                            </StrategyContainer>
                         </>
                     }
                     elseShow={
@@ -335,6 +344,6 @@ export const EnvironmentAccordionBody = ({
                     }
                 />
             </StyledAccordionBodyInnerContainer>
-        </StyledAccordionBody>
+        </div>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -22,6 +22,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
 import { StrategyDraggableItem as NewStrategyDraggableItem } from './StrategyDraggableItem/StrategyDraggableItem';
 import { ReleasePlan } from '../../../ReleasePlan/ReleasePlan';
+import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 
 interface IEnvironmentAccordionBodyProps {
     isDisabled: boolean;
@@ -41,18 +42,20 @@ const StyledContentList = styled('ol')({
     margin: 0,
 });
 
-const StyledReleasePlanList = styled(StyledContentList)(({ theme }) => ({
-    background: theme.palette.background.elevation2,
-}));
-
-const StyledListItem = styled('li')(({ theme }) => ({
+const StyledListItem = styled('li', {
+    shouldForwardProp: (prop) => prop !== 'type',
+})<{ type?: 'release plan' | 'strategy' }>(({ theme, type }) => ({
     borderBottom: `1px solid ${theme.palette.divider}`,
-    background: 'inherit',
+    background:
+        type === 'release plan'
+            ? theme.palette.background.elevation2
+            : theme.palette.background.elevation1,
     position: 'relative',
     paddingBlock: theme.spacing(2.5),
+    '&:first-of-type': {
+        paddingTop: theme.spacing(1),
+    },
 }));
-
-const StrategyContainer = styled('div')(({ theme }) => ({}));
 
 const PaginatedStrategyContainer = styled('div')(({ theme }) => ({
     paddingTop: theme.spacing(2.5),
@@ -231,9 +234,9 @@ export const EnvironmentAccordionBody = ({
         <div>
             <StyledAccordionBodyInnerContainer>
                 {releasePlans.length > 0 || strategies.length > 0 ? (
-                    <StyledReleasePlanList>
+                    <StyledContentList>
                         {releasePlans.map((plan) => (
-                            <StyledListItem key={plan.id}>
+                            <StyledListItem type='release plan' key={plan.id}>
                                 <ReleasePlan
                                     plan={plan}
                                     environmentIsDisabled={isDisabled}
@@ -244,6 +247,11 @@ export const EnvironmentAccordionBody = ({
                             <StyledContentList>
                                 {strategies.map((strategy, index) => (
                                     <StyledListItem key={strategy.id}>
+                                        {index > 0 ||
+                                        releasePlans.length > 0 ? (
+                                            <StrategySeparator text='OR' />
+                                        ) : null}
+
                                         <NewStrategyDraggableItem
                                             strategy={strategy}
                                             index={index}
@@ -274,6 +282,11 @@ export const EnvironmentAccordionBody = ({
                                 <StyledContentList>
                                     {page.map((strategy, index) => (
                                         <StyledListItem key={strategy.id}>
+                                            {index > 0 ||
+                                            releasePlans.length > 0 ? (
+                                                <StrategySeparator text='OR' />
+                                            ) : null}
+
                                             <NewStrategyDraggableItem
                                                 strategy={strategy}
                                                 index={
@@ -305,7 +318,7 @@ export const EnvironmentAccordionBody = ({
                                 />
                             </PaginatedStrategyContainer>
                         )}
-                    </StyledReleasePlanList>
+                    </StyledContentList>
                 ) : (
                     <FeatureStrategyEmpty
                         projectId={projectId}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -15,7 +15,6 @@ import {
     type ScheduledChangeRequestViewModel,
     useScheduledChangeRequestsWithStrategy,
 } from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
-import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 import { StrategyItem } from './StrategyItem/StrategyItem';
 
 interface IStrategyDraggableItemProps {
@@ -65,11 +64,6 @@ export const StrategyDraggableItem = ({
             onDragOver={onDragOver(ref, index)}
             sx={{ opacity: isDragging ? '0.5' : '1' }}
         >
-            <ConditionallyRender
-                condition={index > 0}
-                show={<StrategySeparator text='OR' />}
-            />
-
             <StrategyItem
                 strategy={strategy}
                 environmentId={environmentName}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -15,8 +15,8 @@ import {
     type ScheduledChangeRequestViewModel,
     useScheduledChangeRequestsWithStrategy,
 } from 'hooks/api/getters/useScheduledChangeRequestsWithStrategy/useScheduledChangeRequestsWithStrategy';
-import { StrategySeparator as NewStrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
-import { StrategyItem as NewStrategyItem } from './StrategyItem/StrategyItem';
+import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
+import { StrategyItem } from './StrategyItem/StrategyItem';
 
 interface IStrategyDraggableItemProps {
     strategy: IFeatureStrategy;
@@ -67,10 +67,10 @@ export const StrategyDraggableItem = ({
         >
             <ConditionallyRender
                 condition={index > 0}
-                show={<NewStrategySeparator text='OR' />}
+                show={<StrategySeparator text='OR' />}
             />
 
-            <NewStrategyItem
+            <StrategyItem
                 strategy={strategy}
                 environmentId={environmentName}
                 otherEnvironments={otherEnvironments}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -46,7 +46,6 @@ const StyledAccordionFooter = styled('footer')(({ theme }) => ({
     flexDirection: 'column',
     alignItems: 'flex-end',
     gap: theme.spacing(2),
-    borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
 const StyledEnvironmentAccordionContainer = styled('div')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -68,7 +68,6 @@ const StyledHeaderDescription = styled('p')(({ theme }) => ({
 const StyledBody = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
-    marginTop: theme.spacing(3),
 }));
 
 const StyledConnection = styled('div')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -28,10 +28,11 @@ const StyledContainer = styled('div', {
     shouldForwardProp: (prop) => prop !== 'readonly',
 })<{ readonly?: boolean }>(({ theme, readonly }) => ({
     padding: theme.spacing(2),
-    '& + &': {
-        marginTop: theme.spacing(2),
-    },
+    paddingTop: theme.spacing(0),
     background: 'inherit',
+    display: 'flex',
+    flexFlow: 'column',
+    gap: theme.spacing(1),
 }));
 
 const StyledHeader = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Adjusts styling of the env dropdown now that we have both release plans and strategies.

Key points:
- simplifies strategy separator, removes inherent height. Also: extracts it from the draggable component (it has no business knowing whether to add that or not)
- Puts release plans and strategies in the same list so that it becomes:
```markdown
- Release plan
  - strategy 1
  - strategy 2
- (OR) Strategy A
- (OR) Strategy B
```
- Adjusts some padding around to make it line up properly
- Swaps a couple conditional renders for ternaries


Rendered:
![image](https://github.com/user-attachments/assets/d6d5cd56-572f-419e-90ed-6449a63fdc96)

## Still todo:

Handle cases where you have >50 strats and we show the warning etc. It's a little trickier because of how it interacts with release plans, so I wanna leave that for later.

I'm also unsure about how we handle spacing today. All the little items have their own different spacing and I'm not sure it won't get out of sync, but I'm also not sure how else to handle it. We should look at it later.