### PR TITLE
chore: release template card min height

### DIFF
--- a/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateList.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateList.tsx
@@ -1,6 +1,10 @@
-import { Grid } from '@mui/material';
+import { Grid, styled } from '@mui/material';
 import { ReleasePlanTemplateCard } from './ReleasePlanTemplateCard/ReleasePlanTemplateCard';
 import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
+
+const StyledGridItem = styled(Grid)({
+    minHeight: '180px',
+});
 
 interface ITemplateList {
     templates: IReleasePlanTemplate[];
@@ -12,9 +16,9 @@ export const ReleasePlanTemplateList: React.FC<ITemplateList> = ({
     return (
         <>
             {templates.map((template) => (
-                <Grid key={template.id} item xs={6} md={4}>
+                <StyledGridItem key={template.id} item xs={6} md={4}>
                     <ReleasePlanTemplateCard template={template} />
-                </Grid>
+                </StyledGridItem>
             ))}
         </>
     );


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3328/release-template-cards-should-have-a-consistent-minimum-height

Sets a consistent min height in our release template cards.

![image](https://github.com/user-attachments/assets/4e1f1994-6044-4df0-9019-abe76ffc9a37)