### PR TITLE
refactor(1-3429): makes the drag args optional, defaulting to noops

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -298,12 +298,6 @@ export const EnvironmentAccordionBody = ({
                                                 otherEnvironments={
                                                     otherEnvironments
                                                 }
-                                                isDragging={false}
-                                                onDragStartRef={
-                                                    (() => {}) as any
-                                                }
-                                                onDragOver={(() => {}) as any}
-                                                onDragEnd={(() => {}) as any}
                                             />
                                         </StyledListItem>
                                     ))}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -34,7 +34,7 @@ interface IStrategyDraggableItemProps {
     onDragEnd?: () => void;
 }
 
-const noop = () => () => {};
+const onDragNoOp = () => () => {};
 
 export const StrategyDraggableItem = ({
     strategy,
@@ -42,9 +42,9 @@ export const StrategyDraggableItem = ({
     environmentName,
     otherEnvironments,
     isDragging,
-    onDragStartRef = noop,
-    onDragOver = noop,
-    onDragEnd = noop,
+    onDragStartRef = onDragNoOp,
+    onDragOver = onDragNoOp,
+    onDragEnd = onDragNoOp,
 }: IStrategyDraggableItemProps) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -23,16 +23,18 @@ interface IStrategyDraggableItemProps {
     index: number;
     otherEnvironments?: IFeatureEnvironment['name'][];
     isDragging?: boolean;
-    onDragStartRef: (
+    onDragStartRef?: (
         ref: RefObject<HTMLDivElement>,
         index: number,
     ) => DragEventHandler<HTMLButtonElement>;
-    onDragOver: (
+    onDragOver?: (
         ref: RefObject<HTMLDivElement>,
         index: number,
     ) => DragEventHandler<HTMLDivElement>;
-    onDragEnd: () => void;
+    onDragEnd?: () => void;
 }
+
+const noop = () => () => {};
 
 export const StrategyDraggableItem = ({
     strategy,
@@ -40,9 +42,9 @@ export const StrategyDraggableItem = ({
     environmentName,
     otherEnvironments,
     isDragging,
-    onDragStartRef,
-    onDragOver,
-    onDragEnd,
+    onDragStartRef = noop,
+    onDragOver = noop,
+    onDragEnd = noop,
 }: IStrategyDraggableItemProps) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');


### PR DESCRIPTION
Removes the `() => {} as any` args from the StrategyDraggableItem invocation when you have paginated strats. Instead makes all the drag params optional. It defaults to a no op if not provided.

Also, the reason it had to be typed as `any` before is probably because it was missing a function. The correct empty param is `() => () => {}` 💁