### PR TITLE
chore(1-3423): adapt existing tests to new components

### DIFF
--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
@@ -4,6 +4,7 @@ import { StrategyItemContainer as LegacyStrategyItemContainer } from './LegacySt
 import type { IFeatureStrategy } from 'interfaces/strategy';
 import { StrategyItemContainer } from './StrategyItemContainer';
 
+// todo: remove this test along with the flag flagOverviewRedesign
 test('(deprecated) should render strategy name, custom title and description', async () => {
     const strategy: IFeatureStrategy = {
         id: 'irrelevant',

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.test.tsx
@@ -1,7 +1,29 @@
 import { screen } from '@testing-library/react';
 import { render } from 'utils/testRenderer';
-import { StrategyItemContainer } from './LegacyStrategyItemContainer';
+import { StrategyItemContainer as LegacyStrategyItemContainer } from './LegacyStrategyItemContainer';
 import type { IFeatureStrategy } from 'interfaces/strategy';
+import { StrategyItemContainer } from './StrategyItemContainer';
+
+test('(deprecated) should render strategy name, custom title and description', async () => {
+    const strategy: IFeatureStrategy = {
+        id: 'irrelevant',
+        name: 'strategy name',
+        title: 'custom title',
+        constraints: [],
+        parameters: {},
+    };
+
+    render(
+        <LegacyStrategyItemContainer
+            strategy={strategy}
+            description={'description'}
+        />,
+    );
+
+    expect(screen.getByText('strategy name')).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+    await screen.findByText('custom title'); // behind async flag
+});
 
 test('should render strategy name, custom title and description', async () => {
     const strategy: IFeatureStrategy = {


### PR DESCRIPTION
Adds tests for the new version of components that were moved to legacy files in https://github.com/Unleash/unleash/pull/9361 and where there were tests already.