### PR TITLE
fix: solve 31 day month issue by using trafficUnitSize and not constant 1_000_000

### DIFF
--- a/frontend/src/utils/traffic-calculations.ts
+++ b/frontend/src/utils/traffic-calculations.ts
@@ -94,7 +94,8 @@ export const calculateOverageCost = (
     }
 
     const overage =
-        Math.floor((dataUsage - includedTraffic) / 1_000_000) * 1_000_000;
+        Math.floor((dataUsage - includedTraffic) / trafficUnitSize) *
+        trafficUnitSize;
     return overage > 0
         ? calculateTrafficDataCost(overage, trafficUnitCost, trafficUnitSize)
         : 0;


### PR DESCRIPTION
Fixes an issue with `estimates based on custom price and unit size` test failing every month that has 31 days.
We were not respecting the custom unit sizes when calculating overage