### PR TITLE
fix: copy strategy is allowed to copy to self (duplicate)

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestPermissions.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestPermissions.test.tsx
@@ -278,7 +278,7 @@ const copyButtonsActiveInOtherEnv = async () => {
 
     // production
     const productionStrategyCopyButton = copyButtons[0];
-    expect(productionStrategyCopyButton).toBeDisabled();
+    expect(productionStrategyCopyButton).toBeEnabled();
 
     // custom env
     const customEnvStrategyCopyButton = copyButtons[1];

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -95,11 +95,11 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         onClose();
     };
 
-    const enabled = environments.some((environment) =>
+    const enabled = [...environments, environmentId].some((environment) =>
         checkAccess(CREATE_FEATURE_STRATEGY, environment),
     );
 
-    const label = `Copy to environment${enabled ? '' : ' (Access denied)'}`;
+    const label = `Copy to environment${enabled ? '' : ` (Access denied, missing ${CREATE_FEATURE_STRATEGY} permission)`}`;
 
     return (
         <div>


### PR DESCRIPTION
When checking for permissions we were checking if the user was allowed to copy to other environments but it can also copy to the same environment.

Before the change: 
![image](https://github.com/user-attachments/assets/3bb1b738-8a4b-4c1b-b45f-c48895454c0a)


After the change: 
![image](https://github.com/user-attachments/assets/869e0fed-b7da-436c-93b4-fc50b6830e45)
