### PR TITLE
refactor: don't use absolute positioning for drag handle

### DIFF
--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -94,26 +94,36 @@ const StyledFormContent = styled('div', {
         return !['disablePadding', 'compactPadding'].includes(prop.toString());
     },
 })<{ disablePadding?: boolean; compactPadding?: boolean }>(
-    ({ theme, disablePadding, compactPadding }) => ({
-        backgroundColor: theme.palette.background.paper,
-        display: 'flex',
-        flexDirection: 'column',
-        flexGrow: 1,
-        padding: disablePadding
+    ({ theme, disablePadding, compactPadding }) => {
+        const padding = disablePadding
             ? 0
             : compactPadding
               ? theme.spacing(4)
-              : theme.spacing(6),
-        [theme.breakpoints.down('lg')]: {
-            padding: disablePadding ? 0 : theme.spacing(4),
-        },
-        [theme.breakpoints.down(1100)]: {
-            width: '100%',
-        },
-        [theme.breakpoints.down(500)]: {
-            padding: disablePadding ? 0 : theme.spacing(4, 2),
-        },
-    }),
+              : theme.spacing(6);
+
+        const paddingLgDown = disablePadding ? 0 : theme.spacing(4);
+        const padding500Down = disablePadding ? 0 : theme.spacing(4, 2);
+
+        return {
+            '--form-content-padding': padding,
+            backgroundColor: theme.palette.background.paper,
+            display: 'flex',
+            flexDirection: 'column',
+            flexGrow: 1,
+            padding,
+            [theme.breakpoints.down('lg')]: {
+                padding: paddingLgDown,
+                '--form-content-padding': paddingLgDown,
+            },
+            [theme.breakpoints.down(1100)]: {
+                width: '100%',
+            },
+            [theme.breakpoints.down(500)]: {
+                padding: padding500Down,
+                '--form-content-padding': padding500Down,
+            },
+        };
+    },
 );
 
 const StyledFooter = styled('div')(({ theme }) => ({

--- a/frontend/src/component/common/FormTemplate/FormTemplate.tsx
+++ b/frontend/src/component/common/FormTemplate/FormTemplate.tsx
@@ -102,7 +102,8 @@ const StyledFormContent = styled('div', {
               : theme.spacing(6);
 
         const paddingLgDown = disablePadding ? 0 : theme.spacing(4);
-        const padding500Down = disablePadding ? 0 : theme.spacing(4, 2);
+        const padding500DownInline = disablePadding ? 0 : theme.spacing(2);
+        const padding500DownBlock = disablePadding ? 0 : theme.spacing(4);
 
         return {
             '--form-content-padding': padding,
@@ -119,8 +120,9 @@ const StyledFormContent = styled('div', {
                 width: '100%',
             },
             [theme.breakpoints.down(500)]: {
-                padding: padding500Down,
-                '--form-content-padding': padding500Down,
+                paddingInline: padding500DownInline,
+                paddingBlock: padding500DownBlock,
+                '--form-content-padding': padding500DownInline,
             },
         };
     },

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -436,6 +436,8 @@ export const MilestoneCard = ({
                                 titleAccess={`${expanded ? 'Hide' : 'Show'} milestone strategies`}
                             />
                         }
+                        id={`milestone-accordion-summary-${milestone.id}`}
+                        aria-controls={`milestone-accordion-details-${milestone.id}`}
                     >
                         <MilestoneCardName
                             milestone={milestone}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -31,16 +31,18 @@ import { StrategyDraggableItem } from 'component/feature/FeatureView/FeatureOver
 const leftPadding = 3;
 
 const DraggableCardContainer = styled('div')(({ theme }) => ({
-    '--left-offset': `calc(var(--form-content-padding, ${theme.spacing(4)}) * -1)`,
-    display: 'grid',
+    '--drag-column-width': `var(--form-content-padding, ${theme.spacing(4)})`,
+    '--left-offset': `calc(var(--drag-column-width) * -1)`,
     marginLeft: `var(--left-offset)`,
-    gridTemplateColumns: `var(--left-offset) 1fr`,
+    display: 'grid',
+    gridTemplateColumns: `var(--drag-column-width) 1fr`,
+    // display: 'flex',
+    // flexFlow: 'row nowrap',
 }));
 
 const StyledMilestoneCard = styled(Card, {
     shouldForwardProp: (prop) => prop !== 'hasError',
 })<{ hasError: boolean }>(({ theme, hasError }) => ({
-    marginTop: theme.spacing(2),
     position: 'relative',
     overflow: 'initial',
     display: 'flex',
@@ -68,7 +70,6 @@ const FlexContainer = styled('div')(({ theme }) => ({
 const StyledAddStrategyButton = styled(Button)(({ theme }) => ({}));
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
-    marginTop: theme.spacing(2),
     boxShadow: 'none',
     background: 'none',
     display: 'flex',
@@ -123,9 +124,7 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
 
 const StyledDragIcon = styled(IconButton)(({ theme }) => ({
     padding: 0,
-    position: 'absolute',
     cursor: 'grab',
-    left: theme.spacing(-4),
     transition: 'color 0.2s ease-in-out',
     '& > svg': {
         color: 'action.active',
@@ -349,14 +348,13 @@ export const MilestoneCard = ({
     if (!milestone.strategies || milestone.strategies.length === 0) {
         return (
             <>
-                <DraggableCardContainer>
+                <DraggableCardContainer ref={dragItemRef}>
                     {dragHandle}
                     <StyledMilestoneCard
                         hasError={
                             Boolean(errors?.[milestone.id]) ||
                             Boolean(errors?.[`${milestone.id}_name`])
                         }
-                        ref={dragItemRef}
                     >
                         <FlexContainer>
                             <MilestoneCardName
@@ -433,111 +431,115 @@ export const MilestoneCard = ({
 
     return (
         <>
-            <StyledAccordion
-                expanded={expanded}
-                onChange={(e, change) => setExpanded(change)}
-            >
-                <StyledAccordionSummary
-                    expandIcon={
-                        <ExpandMore
-                            titleAccess={`${expanded ? 'Hide' : 'Show'} milestone strategies`}
-                        />
-                    }
-                    ref={dragItemRef}
+            <DraggableCardContainer ref={dragItemRef}>
+                {dragHandle}
+                <StyledAccordion
+                    expanded={expanded}
+                    onChange={(e, change) => setExpanded(change)}
                 >
-                    {dragHandle}
-                    <MilestoneCardName
-                        milestone={milestone}
-                        errors={errors}
-                        clearErrors={clearErrors}
-                        milestoneNameChanged={milestoneNameChanged}
-                    />
-                </StyledAccordionSummary>
-                <StyledAccordionDetails>
-                    <StyledContentList>
-                        {milestone.strategies.map((strg, index) => (
-                            <StyledListItem key={strg.id}>
-                                {index > 0 ? <StrategySeparator /> : null}
-
-                                <StrategyDraggableItem
-                                    index={index}
-                                    onDragEnd={onStrategyDragEnd}
-                                    onDragStartRef={onStrategyDragStartRef}
-                                    onDragOver={onStrategyDragOver(strg.id)}
-                                    isDragging={dragItem?.id === strg.id}
-                                    strategy={{
-                                        ...strg,
-                                        name:
-                                            strg.name ||
-                                            strg.strategyName ||
-                                            '',
-                                    }}
-                                    headerItemsRight={
-                                        <>
-                                            <IconButton
-                                                title='Edit strategy'
-                                                onClick={() => {
-                                                    openAddUpdateStrategyForm(
-                                                        strg,
-                                                        true,
-                                                    );
-                                                }}
-                                            >
-                                                <Edit />
-                                            </IconButton>
-                                            <IconButton
-                                                title='Remove strategy'
-                                                onClick={() =>
-                                                    milestoneStrategyDeleted(
-                                                        strg.id,
-                                                    )
-                                                }
-                                            >
-                                                <Delete />
-                                            </IconButton>
-                                        </>
-                                    }
-                                />
-                            </StyledListItem>
-                        ))}
-                    </StyledContentList>
-                    <StyledAccordionFooter>
-                        <Button
-                            variant='text'
-                            color='primary'
-                            onClick={onDeleteMilestone}
-                            disabled={!removable}
-                        >
-                            <Delete /> Remove milestone
-                        </Button>
-                        <StyledAddStrategyButton
-                            variant='outlined'
-                            color='primary'
-                            onClick={(ev) => setAnchor(ev.currentTarget)}
-                        >
-                            Add strategy
-                        </StyledAddStrategyButton>
-                        <Popover
-                            id={popoverId}
-                            open={isPopoverOpen}
-                            anchorEl={anchor}
-                            onClose={onClose}
-                            onClick={onClose}
-                            PaperProps={{
-                                sx: (theme) => ({
-                                    paddingBottom: theme.spacing(1),
-                                }),
-                            }}
-                        >
-                            <MilestoneStrategyMenuCards
-                                openEditAddStrategy={(strategy) => {
-                                    openAddUpdateStrategyForm(strategy, false);
-                                }}
+                    <StyledAccordionSummary
+                        expandIcon={
+                            <ExpandMore
+                                titleAccess={`${expanded ? 'Hide' : 'Show'} milestone strategies`}
                             />
-                        </Popover>
-                    </StyledAccordionFooter>
-                </StyledAccordionDetails>
-            </StyledAccordion>
+                        }
+                    >
+                        <MilestoneCardName
+                            milestone={milestone}
+                            errors={errors}
+                            clearErrors={clearErrors}
+                            milestoneNameChanged={milestoneNameChanged}
+                        />
+                    </StyledAccordionSummary>
+                    <StyledAccordionDetails>
+                        <StyledContentList>
+                            {milestone.strategies.map((strg, index) => (
+                                <StyledListItem key={strg.id}>
+                                    {index > 0 ? <StrategySeparator /> : null}
+
+                                    <StrategyDraggableItem
+                                        index={index}
+                                        onDragEnd={onStrategyDragEnd}
+                                        onDragStartRef={onStrategyDragStartRef}
+                                        onDragOver={onStrategyDragOver(strg.id)}
+                                        isDragging={dragItem?.id === strg.id}
+                                        strategy={{
+                                            ...strg,
+                                            name:
+                                                strg.name ||
+                                                strg.strategyName ||
+                                                '',
+                                        }}
+                                        headerItemsRight={
+                                            <>
+                                                <IconButton
+                                                    title='Edit strategy'
+                                                    onClick={() => {
+                                                        openAddUpdateStrategyForm(
+                                                            strg,
+                                                            true,
+                                                        );
+                                                    }}
+                                                >
+                                                    <Edit />
+                                                </IconButton>
+                                                <IconButton
+                                                    title='Remove strategy'
+                                                    onClick={() =>
+                                                        milestoneStrategyDeleted(
+                                                            strg.id,
+                                                        )
+                                                    }
+                                                >
+                                                    <Delete />
+                                                </IconButton>
+                                            </>
+                                        }
+                                    />
+                                </StyledListItem>
+                            ))}
+                        </StyledContentList>
+                        <StyledAccordionFooter>
+                            <Button
+                                variant='text'
+                                color='primary'
+                                onClick={onDeleteMilestone}
+                                disabled={!removable}
+                            >
+                                <Delete /> Remove milestone
+                            </Button>
+                            <StyledAddStrategyButton
+                                variant='outlined'
+                                color='primary'
+                                onClick={(ev) => setAnchor(ev.currentTarget)}
+                            >
+                                Add strategy
+                            </StyledAddStrategyButton>
+                            <Popover
+                                id={popoverId}
+                                open={isPopoverOpen}
+                                anchorEl={anchor}
+                                onClose={onClose}
+                                onClick={onClose}
+                                PaperProps={{
+                                    sx: (theme) => ({
+                                        paddingBottom: theme.spacing(1),
+                                    }),
+                                }}
+                            >
+                                <MilestoneStrategyMenuCards
+                                    openEditAddStrategy={(strategy) => {
+                                        openAddUpdateStrategyForm(
+                                            strategy,
+                                            false,
+                                        );
+                                    }}
+                                />
+                            </Popover>
+                        </StyledAccordionFooter>
+                    </StyledAccordionDetails>
+                </StyledAccordion>
+            </DraggableCardContainer>
 
             <FormHelperText error={Boolean(errors?.[milestone.id])}>
                 {errors?.[milestone.id]}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -27,6 +27,7 @@ import { StrategySeparator } from 'component/common/StrategySeparator/StrategySe
 import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/DeleteOutlined';
 import { StrategyDraggableItem } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem';
+import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
 
 const leftPadding = 3;
 
@@ -82,6 +83,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     '&:before': {
         opacity: '0 !important',
     },
+    overflow: 'hidden',
 }));
 
 const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
@@ -91,6 +93,9 @@ const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusMedium,
     [theme.breakpoints.down(400)]: {
         padding: theme.spacing(1, 2),
+    },
+    '&:focus-visible': {
+        background: theme.palette.table.rowHover,
     },
 }));
 
@@ -107,7 +112,6 @@ const StyledAccordionFooter = styled('div')(({ theme }) => ({
     justifyContent: 'flex-end',
     gap: theme.spacing(3),
     backgroundColor: 'inherit',
-    borderRadius: theme.shape.borderRadiusMedium,
 }));
 
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
@@ -115,13 +119,25 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
     color: theme.palette.primary.main,
 }));
 
-const StyledDragIcon = styled(IconButton)(({ theme }) => ({
+const DragButton = styled('button')(({ theme }) => ({
     padding: 0,
     cursor: 'grab',
-    transition: 'color 0.2s ease-in-out',
-    '& > svg': {
-        color: 'action.active',
+    transition: 'background-color 0.2s ease-in-out',
+    backgroundColor: 'inherit',
+    border: 'none',
+    borderRadius: theme.shape.borderRadiusMedium,
+    color: theme.palette.text.secondary,
+    '&:hover, &:focus-visible': {
+        background: theme.palette.table.rowHover,
+        outline: 'none',
     },
+}));
+
+const DraggableContent = styled('span')(({ theme }) => ({
+    paddingTop: theme.spacing(2.5),
+    display: 'block',
+    height: '100%',
+    width: '100%',
 }));
 
 export interface IMilestoneCardProps {
@@ -168,9 +184,17 @@ export const MilestoneCard = ({
     );
 
     const dragHandle = (
-        <StyledDragIcon ref={dragHandleRef} disableRipple size='small'>
-            <DragIndicator titleAccess='Drag to reorder' />
-        </StyledDragIcon>
+        <DragButton
+            type='button'
+            onClick={() => {
+                console.log("draggin'");
+            }}
+        >
+            <DraggableContent ref={dragHandleRef}>
+                <DragIndicator aria-hidden />
+                <ScreenReaderOnly>Drag to reorder</ScreenReaderOnly>
+            </DraggableContent>
+        </DragButton>
     );
 
     const onClose = () => {

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -78,11 +78,10 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     [theme.breakpoints.down('sm')]: {
         justifyContent: 'center',
     },
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.background.paper,
     '&:before': {
         opacity: '0 !important',
     },
-    '&.Mui-expanded': { marginTop: `${theme.spacing(2)} !important` },
 }));
 
 const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
@@ -92,10 +91,6 @@ const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusMedium,
     [theme.breakpoints.down(400)]: {
         padding: theme.spacing(1, 2),
-    },
-    '&.Mui-focusVisible': {
-        backgroundColor: theme.palette.background.paper,
-        padding: theme.spacing(0.5, 2, 0.3, 2),
     },
 }));
 

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -36,8 +36,6 @@ const DraggableCardContainer = styled('div')(({ theme }) => ({
     marginLeft: `var(--left-offset)`,
     display: 'grid',
     gridTemplateColumns: `var(--drag-column-width) 1fr`,
-    // display: 'flex',
-    // flexFlow: 'row nowrap',
 }));
 
 const StyledMilestoneCard = styled(Card, {

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -33,8 +33,10 @@ const leftPadding = 3;
 
 const DraggableCardContainer = styled('div')(({ theme }) => ({
     marginTop: theme.spacing(2),
-    '--drag-column-width': `var(--form-content-padding, ${theme.spacing(4)})`,
-    '--left-offset': `calc(var(--drag-column-width) * -1)`,
+    '--left-padding': `var(--form-content-padding, ${theme.spacing(4)})`,
+    // for accessibility, never make button smaller than 32px
+    '--drag-column-width': `max(var(--left-padding), ${theme.spacing(4)})`,
+    '--left-offset': `calc(var(--left-padding) * -1)`,
     marginLeft: `var(--left-offset)`,
     display: 'grid',
     gridTemplateColumns: `var(--drag-column-width) 1fr`,
@@ -135,7 +137,7 @@ const DragButton = styled('button')(({ theme }) => ({
 }));
 
 const DraggableContent = styled('span')(({ theme }) => ({
-    paddingTop: theme.spacing(2.5),
+    paddingTop: theme.spacing(2.75),
     display: 'block',
     height: '100%',
     width: '100%',

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -82,7 +82,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
     [theme.breakpoints.down('sm')]: {
         justifyContent: 'center',
     },
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.default,
     '&:before': {
         opacity: '0 !important',
     },
@@ -98,7 +98,7 @@ const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
         padding: theme.spacing(1, 2),
     },
     '&:focus-visible': {
-        background: theme.palette.table.rowHover,
+        background: theme.palette.table.headerHover,
     },
 }));
 
@@ -131,7 +131,7 @@ const DragButton = styled('button')(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusMedium,
     color: theme.palette.text.secondary,
     '&:hover, &:focus-visible': {
-        background: theme.palette.table.rowHover,
+        background: theme.palette.table.headerHover,
         outline: 'none',
     },
 }));

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -32,6 +32,7 @@ import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReader
 const leftPadding = 3;
 
 const DraggableCardContainer = styled('div')(({ theme }) => ({
+    marginTop: theme.spacing(2),
     '--drag-column-width': `var(--form-content-padding, ${theme.spacing(4)})`,
     '--left-offset': `calc(var(--drag-column-width) * -1)`,
     marginLeft: `var(--left-offset)`,
@@ -184,13 +185,8 @@ export const MilestoneCard = ({
     );
 
     const dragHandle = (
-        <DragButton
-            type='button'
-            onClick={() => {
-                console.log("draggin'");
-            }}
-        >
-            <DraggableContent ref={dragHandleRef}>
+        <DragButton type='button'>
+            <DraggableContent>
                 <DragIndicator aria-hidden />
                 <ScreenReaderOnly>Drag to reorder</ScreenReaderOnly>
             </DraggableContent>

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -30,6 +30,13 @@ import { StrategyDraggableItem } from 'component/feature/FeatureView/FeatureOver
 
 const leftPadding = 3;
 
+const DraggableCardContainer = styled('div')(({ theme }) => ({
+    '--left-offset': `calc(var(--form-content-padding, ${theme.spacing(4)}) * -1)`,
+    display: 'grid',
+    marginLeft: `var(--left-offset)`,
+    gridTemplateColumns: `var(--left-offset) 1fr`,
+}));
+
 const StyledMilestoneCard = styled(Card, {
     shouldForwardProp: (prop) => prop !== 'hasError',
 })<{ hasError: boolean }>(({ theme, hasError }) => ({
@@ -342,64 +349,66 @@ export const MilestoneCard = ({
     if (!milestone.strategies || milestone.strategies.length === 0) {
         return (
             <>
-                <StyledMilestoneCard
-                    hasError={
-                        Boolean(errors?.[milestone.id]) ||
-                        Boolean(errors?.[`${milestone.id}_name`])
-                    }
-                    ref={dragItemRef}
-                >
+                <DraggableCardContainer>
                     {dragHandle}
-
-                    <FlexContainer>
-                        <MilestoneCardName
-                            milestone={milestone}
-                            errors={errors}
-                            clearErrors={clearErrors}
-                            milestoneNameChanged={milestoneNameChanged}
-                        />
-                    </FlexContainer>
-                    <FlexContainer>
-                        <Button
-                            variant='outlined'
-                            color='primary'
-                            onClick={(ev) => setAnchor(ev.currentTarget)}
-                        >
-                            Add strategy
-                        </Button>
-                        <StyledIconButton
-                            title='Remove milestone'
-                            onClick={onDeleteMilestone}
-                            disabled={!removable}
-                        >
-                            <Delete />
-                        </StyledIconButton>
-
-                        <Popover
-                            id={popoverId}
-                            open={isPopoverOpen}
-                            anchorEl={anchor}
-                            onClose={onClose}
-                            onClick={onClose}
-                            PaperProps={{
-                                sx: (theme) => ({
-                                    paddingBottom: theme.spacing(1),
-                                }),
-                            }}
-                        >
-                            <MilestoneStrategyMenuCards
-                                openEditAddStrategy={(strategy) => {
-                                    openAddUpdateStrategyForm(strategy, false);
-                                }}
+                    <StyledMilestoneCard
+                        hasError={
+                            Boolean(errors?.[milestone.id]) ||
+                            Boolean(errors?.[`${milestone.id}_name`])
+                        }
+                        ref={dragItemRef}
+                    >
+                        <FlexContainer>
+                            <MilestoneCardName
+                                milestone={milestone}
+                                errors={errors}
+                                clearErrors={clearErrors}
+                                milestoneNameChanged={milestoneNameChanged}
                             />
-                        </Popover>
-                    </FlexContainer>
-                </StyledMilestoneCard>
+                        </FlexContainer>
+                        <FlexContainer>
+                            <Button
+                                variant='outlined'
+                                color='primary'
+                                onClick={(ev) => setAnchor(ev.currentTarget)}
+                            >
+                                Add strategy
+                            </Button>
+                            <StyledIconButton
+                                title='Remove milestone'
+                                onClick={onDeleteMilestone}
+                                disabled={!removable}
+                            >
+                                <Delete />
+                            </StyledIconButton>
 
+                            <Popover
+                                id={popoverId}
+                                open={isPopoverOpen}
+                                anchorEl={anchor}
+                                onClose={onClose}
+                                onClick={onClose}
+                                PaperProps={{
+                                    sx: (theme) => ({
+                                        paddingBottom: theme.spacing(1),
+                                    }),
+                                }}
+                            >
+                                <MilestoneStrategyMenuCards
+                                    openEditAddStrategy={(strategy) => {
+                                        openAddUpdateStrategyForm(
+                                            strategy,
+                                            false,
+                                        );
+                                    }}
+                                />
+                            </Popover>
+                        </FlexContainer>
+                    </StyledMilestoneCard>
+                </DraggableCardContainer>
                 <FormHelperText error={Boolean(errors?.[milestone.id])}>
                     {errors?.[milestone.id]}
                 </FormHelperText>
-
                 <SidebarModal
                     label='Add strategy to template milestone'
                     onClose={() => {


### PR DESCRIPTION
Avoids absolutely positioning the drag handle by instead creating a two column grid where column 1 is the drag handle, column two is the milestone card. The grid has a negative margin based on the padding of the form container. I wanted to avoid modifying the form container component (because we use it in so many places), so I used css variables to store the information and hook into that further down the line.

Rendered:

Wide:

![image](https://github.com/user-attachments/assets/bb43b1b9-595b-475e-a59f-24ebf82df489)

Narrow:
![image](https://github.com/user-attachments/assets/344b9c6f-08e7-43ca-8a02-1b224ccdd2c8)

## Known bugs and limitations
The current drag implementation has some issues if you try to drag something over a large, expanded card. They'll trade places visually, but when you let go, the revert back to where they were. We can avoid that by modifying the onDrop function in the drag handler, but I don't want to do that before checking all the other places where we do drag and drop ([linear ticket](https://linear.app/unleash/issue/1-3458/drag-and-drop-is-a-little-finicky)).

I also want to get UX to sign off on this before making those changes.
