### PR TITLE
Fix: drag and drop reverts to previous position on drop

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneList.tsx
@@ -32,7 +32,11 @@ export const MilestoneList = ({
 }: IMilestoneListProps) => {
     const useNewMilestoneCard = useUiFlag('flagOverviewRedesign');
     const onMoveItem: OnMoveItem = useCallback(
-        async (dragIndex: number, dropIndex: number) => {
+        async (dragIndex: number, dropIndex: number, save?: boolean) => {
+            if (useNewMilestoneCard && save) {
+                return; // the user has let go, we should leave the current sort order as it is currently visually displayed
+            }
+
             if (dragIndex !== dropIndex) {
                 const oldMilestones = milestones || [];
                 const newMilestones = [...oldMilestones];


### PR DESCRIPTION
Fixes an issue where, when dragging large expanded milestone cards, the position would revert from the current visual state to the previous one when you drop the item.

