### PR TITLE
fix: Only show accrued traffic charges and estimated overages for the current month

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -57,6 +57,7 @@ const NetworkTrafficUsage: FC = () => {
 
     const showOverageCalculations =
         chartDataSelection.grouping === 'daily' &&
+        chartDataSelection.month === currentMonth &&
         includedTraffic > 0 &&
         usageTotal - includedTraffic > 0 &&
         estimateTrafficDataCost;


### PR DESCRIPTION
For past months, customers can refer to their invoices instead. Hiding it when the selection is not the current month avoids weird things such as estimation errors due to to a month not having finished (vs what it actually *was* when it finished), potential changes in traffic package pricing, etc.
