### PR TITLE
chore: remove granularAdminPermissions flag

### DIFF
--- a/frontend/src/component/admin/cors/CorsForm.tsx
+++ b/frontend/src/component/admin/cors/CorsForm.tsx
@@ -7,29 +7,23 @@ import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useId } from 'hooks/useId';
 import { ADMIN, UPDATE_CORS } from '@server/types/permissions';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 interface ICorsFormProps {
     frontendApiOrigins: string[] | undefined;
 }
 
 export const CorsForm = ({ frontendApiOrigins }: ICorsFormProps) => {
-    const { setFrontendSettings, setCors } = useUiConfigApi();
+    const { setCors } = useUiConfigApi();
     const { setToastData, setToastApiError } = useToast();
     const [value, setValue] = useState(formatInputValue(frontendApiOrigins));
     const inputFieldId = useId();
     const helpTextId = useId();
-    const isGranularPermissionsEnabled = useUiFlag('granularAdminPermissions');
 
     const onSubmit = async (event: React.FormEvent) => {
         try {
             const split = parseInputValue(value);
             event.preventDefault();
-            if (isGranularPermissionsEnabled) {
-                await setCors(split);
-            } else {
-                await setFrontendSettings(split);
-            }
+            await setCors(split);
             setValue(formatInputValue(split));
             setToastData({ text: 'Settings saved', type: 'success' });
         } catch (error) {

--- a/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
+++ b/frontend/src/component/admin/roles/RoleForm/RolePermissionCategories/RolePermissionCategories.tsx
@@ -44,9 +44,6 @@ export const RolePermissionCategories = ({
     });
 
     const releasePlansEnabled = useUiFlag('releasePlans');
-    const granularAdminPermissionsEnabled = useUiFlag(
-        'granularAdminPermissions',
-    );
 
     const isProjectRole = PROJECT_ROLE_TYPES.includes(type);
 
@@ -89,12 +86,6 @@ export const RolePermissionCategories = ({
                         ({ label }) =>
                             releasePlansEnabled ||
                             label !== 'Release plan templates',
-                    )
-                    .filter(
-                        ({ label }) =>
-                            granularAdminPermissionsEnabled ||
-                            (label !== 'Instance maintenance' &&
-                                label !== 'Authentication'),
                     )
                     .map(({ label, type, permissions }) => (
                         <RolePermissionCategoryAccordion

--- a/frontend/src/hooks/api/actions/useUiConfigApi/useUiConfigApi.ts
+++ b/frontend/src/hooks/api/actions/useUiConfigApi/useUiConfigApi.ts
@@ -5,23 +5,6 @@ export const useUiConfigApi = () => {
         propagateErrors: true,
     });
 
-    /**
-     * @deprecated remove when `granularAdminPermissions` flag is removed
-     */
-    const setFrontendSettings = async (
-        frontendApiOrigins: string[],
-    ): Promise<void> => {
-        const payload = {
-            frontendSettings: { frontendApiOrigins },
-        };
-        const req = createRequest(
-            'api/admin/ui-config',
-            { method: 'POST', body: JSON.stringify(payload) },
-            'setFrontendSettings',
-        );
-        await makeRequest(req.caller, req.id);
-    };
-
     const setCors = async (frontendApiOrigins: string[]): Promise<void> => {
         const req = createRequest(
             'api/admin/ui-config/cors',
@@ -32,7 +15,6 @@ export const useUiConfigApi = () => {
     };
 
     return {
-        setFrontendSettings,
         setCors,
         loading,
         errors,

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -89,7 +89,6 @@ export type UiFlags = {
     productivityReportEmail?: boolean;
     showUserDeviceCount?: boolean;
     flagOverviewRedesign?: boolean;
-    granularAdminPermissions?: boolean;
     consumptionModel?: boolean;
     edgeObservability?: boolean;
 };

--- a/src/lib/routes/admin-api/config.test.ts
+++ b/src/lib/routes/admin-api/config.test.ts
@@ -19,11 +19,6 @@ const uiConfig = {
 async function getSetup() {
     const base = `/random${Math.round(Math.random() * 1000)}`;
     const config = createTestConfig({
-        experimental: {
-            flags: {
-                granularAdminPermissions: true,
-            },
-        },
         server: { baseUriPath: base },
         ui: uiConfig,
     });

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -100,7 +100,6 @@ class ConfigController extends Controller {
             ],
         });
 
-        // TODO: deprecate when removing `granularAdminPermissions` flag
         this.route({
             method: 'post',
             path: '',
@@ -115,6 +114,7 @@ class ConfigController extends Controller {
                     operationId: 'setUiConfig',
                     requestBody: createRequestSchema('setUiConfigSchema'),
                     responses: { 200: emptyResponse },
+                    deprecated: true,
                 }),
             ],
         });
@@ -222,14 +222,6 @@ class ConfigController extends Controller {
         req: IAuthRequest<void, void, SetCorsSchema>,
         res: Response<string>,
     ): Promise<void> {
-        const granularAdminPermissions = this.flagResolver.isEnabled(
-            'granularAdminPermissions',
-        );
-
-        if (!granularAdminPermissions) {
-            throw new NotFoundError();
-        }
-
         if (req.body.frontendApiOrigins) {
             await this.frontendApiService.setFrontendCorsSettings(
                 req.body.frontendApiOrigins,

--- a/src/lib/routes/admin-api/config.ts
+++ b/src/lib/routes/admin-api/config.ts
@@ -110,7 +110,7 @@ class ConfigController extends Controller {
                     tags: ['Admin UI'],
                     summary: 'Set UI configuration',
                     description:
-                        'Sets the UI configuration for this Unleash instance.',
+                        'Deprecated. Use `./cors` instead. Sets the UI configuration for this Unleash instance.',
                     operationId: 'setUiConfig',
                     requestBody: createRequestSchema('setUiConfigSchema'),
                     responses: { 200: emptyResponse },

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -57,7 +57,6 @@ export type IFlagKey =
     | 'flagOverviewRedesign'
     | 'showUserDeviceCount'
     | 'memorizeStats'
-    | 'granularAdminPermissions'
     | 'streaming'
     | 'etagVariant'
     | 'deltaApi'
@@ -275,10 +274,6 @@ const flags: IFlags = {
     ),
     flagOverviewRedesign: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FLAG_OVERVIEW_REDESIGN,
-        false,
-    ),
-    granularAdminPermissions: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_GRANULAR_ADMIN_PERMISSIONS,
         false,
     ),
     streaming: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -53,7 +53,6 @@ process.nextTick(async () => {
                         releasePlanChangeRequests: false,
                         showUserDeviceCount: true,
                         flagOverviewRedesign: true,
-                        granularAdminPermissions: true,
                         deltaApi: true,
                         uniqueSdkTracking: true,
                         filterExistingFlagNames: true,


### PR DESCRIPTION
- removed a flag
- deprecated `POST /admin/ui-config` endpoint in favor of `POST /admin/ui-config/cors`
