### PR TITLE
chore: remove deprecated getAdmin from client features store

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
@@ -31,12 +31,6 @@ export interface IGetAllFeatures {
     userId?: number;
 }
 
-export interface IGetAdminFeatures {
-    featureQuery?: IFeatureToggleQuery;
-    archived?: boolean;
-    userId?: number;
-}
-
 export default class FeatureToggleClientStore
     implements IFeatureToggleClientStore
 {
@@ -367,19 +361,6 @@ export default class FeatureToggleClientStore
             featureQuery,
             archived: false,
             requestType: 'playground',
-        });
-    }
-
-    async getAdmin({
-        featureQuery,
-        userId,
-        archived,
-    }: IGetAdminFeatures): Promise<IFeatureToggleClient[]> {
-        return this.getAll({
-            featureQuery,
-            archived: Boolean(archived),
-            requestType: 'admin',
-            userId,
         });
     }
 }

--- a/src/lib/features/client-feature-toggles/fakes/fake-client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/fakes/fake-client-feature-toggle-store.ts
@@ -4,7 +4,6 @@ import type {
     IFeatureToggleQuery,
 } from '../../../types/model';
 import type { IFeatureToggleClientStore } from '../types/client-feature-toggle-store-type';
-import type { IGetAdminFeatures } from '../client-feature-toggle-store';
 
 export default class FakeClientFeatureToggleStore
     implements IFeatureToggleClientStore
@@ -16,7 +15,7 @@ export default class FakeClientFeatureToggleStore
         archived: boolean = false,
     ): Promise<IFeatureToggleClient[]> {
         const rows = this.featureToggles.filter((toggle) => {
-            if (featureQuery.namePrefix) {
+            if (featureQuery?.namePrefix) {
                 if (featureQuery.project) {
                     return (
                         toggle.name.startsWith(featureQuery.namePrefix) &&
@@ -27,7 +26,7 @@ export default class FakeClientFeatureToggleStore
                 }
                 return toggle.name.startsWith(featureQuery.namePrefix);
             }
-            if (featureQuery.project) {
+            if (featureQuery?.project) {
                 return featureQuery.project.some((project) =>
                     project.includes(toggle.project),
                 );
@@ -71,13 +70,6 @@ export default class FakeClientFeatureToggleStore
                 id: `strategy#${index}`,
             })),
         }));
-    }
-
-    async getAdmin({
-        featureQuery: query,
-        archived,
-    }: IGetAdminFeatures): Promise<IFeatureToggleClient[]> {
-        return this.getFeatures(query, archived);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/src/lib/features/client-feature-toggles/types/client-feature-toggle-store-type.ts
+++ b/src/lib/features/client-feature-toggles/types/client-feature-toggle-store-type.ts
@@ -2,7 +2,6 @@ import type {
     IFeatureToggleClient,
     IFeatureToggleQuery,
 } from '../../../types/model';
-import type { IGetAdminFeatures } from '../client-feature-toggle-store';
 
 export interface IFeatureToggleClientStore {
     getClient(
@@ -16,7 +15,4 @@ export interface IFeatureToggleClientStore {
     getPlayground(
         featureQuery: Partial<IFeatureToggleQuery>,
     ): Promise<IFeatureToggleClient[]>;
-
-    // @Deprecated
-    getAdmin(params: IGetAdminFeatures): Promise<IFeatureToggleClient[]>;
 }


### PR DESCRIPTION
This method has been deprecated 2 years ago and is not used