### PR TITLE
chore: remove deprecated method from project-service

### DIFF
--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -934,7 +934,7 @@ test('should add admin users to the project', async () => {
     await isProjectUser(adminUsers[2].id, project.id, true);
 });
 
-test('add user should fail if user already have access', async () => {
+test('add user do nothing if user already has access', async () => {
     const project = {
         id: 'add-users-twice',
         name: 'New project',
@@ -958,18 +958,18 @@ test('add user should fail if user already have access', async () => {
         [projectMember1.id],
         auditUser,
     );
-    await expect(
-        async () =>
-            await projectService.addAccess(
-                project.id,
-                [memberRole.id],
-                [], // no groups
-                [projectMember1.id],
-                auditUser,
-            ),
-    ).rejects.toThrow(
-        new Error('User already has access to project=add-users-twice'),
+    const access = await projectService.getAccessToProject(project.id);
+    expect(access.users).toHaveLength(2);
+
+    await projectService.addAccess(
+        project.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id],
+        auditUser,
     );
+    const accessAfter = await projectService.getAccessToProject(project.id);
+    expect(accessAfter.users).toHaveLength(2);
 });
 
 test('should remove user from the project', async () => {
@@ -1460,9 +1460,9 @@ test('should change a users role in the project', async () => {
 
     await projectService.addAccess(
         project.id,
-        [projectUser.id],
-        [], // no groups
         [member.id],
+        [], // no groups
+        [projectUser.id],
         auditUser,
     );
     const { users } = await projectService.getAccessToProject(project.id);
@@ -2331,7 +2331,7 @@ test('should get correct amount of project members for current and past window',
 
     const result = await projectService.getStatusUpdates(project.id);
     expect(result.updates.projectMembersAddedCurrentWindow).toBe(6); // 5 members + 1 owner
-    expect(result.updates.projectActivityCurrentWindow).toBe(6);
+    expect(result.updates.projectActivityCurrentWindow).toBe(2);
     expect(result.updates.projectActivityPastWindow).toBe(0);
 });
 

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -476,16 +476,11 @@ test('should add a member user to the project', async () => {
 
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        memberRole.id,
-        projectMember1.id,
-        auditUser,
-    );
-    await projectService.addUser(
-        project.id,
-        memberRole.id,
-        projectMember2.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id, projectMember2.id],
         auditUser,
     );
 
@@ -917,16 +912,11 @@ test('should add admin users to the project', async () => {
 
     const ownerRole = await stores.roleStore.getRoleByName(RoleName.OWNER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        ownerRole.id,
-        projectAdmin1.id,
-        auditUser,
-    );
-    await projectService.addUser(
-        project.id,
-        ownerRole.id,
-        projectAdmin2.id,
+        [ownerRole.id],
+        [], // no groups
+        [projectAdmin1.id, projectAdmin2.id],
         auditUser,
     );
 
@@ -961,20 +951,22 @@ test('add user should fail if user already have access', async () => {
 
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        memberRole.id,
-        projectMember1.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id],
         auditUser,
     );
-
-    await expect(async () =>
-        projectService.addUser(
-            project.id,
-            memberRole.id,
-            projectMember1.id,
-            auditUser,
-        ),
+    await expect(
+        async () =>
+            await projectService.addAccess(
+                project.id,
+                [memberRole.id],
+                [], // no groups
+                [projectMember1.id],
+                auditUser,
+            ),
     ).rejects.toThrow(
         new Error('User already has access to project=add-users-twice'),
     );
@@ -997,10 +989,11 @@ test('should remove user from the project', async () => {
 
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        memberRole.id,
-        projectMember1.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id],
         auditUser,
     );
     await projectService.removeUser(
@@ -1360,10 +1353,11 @@ test('should add a user to the project with a custom role', async () => {
         SYSTEM_USER_AUDIT,
     );
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        customRole.id,
-        projectMember1.id,
+        [customRole.id],
+        [], // no groups
+        [projectMember1.id],
         auditUser,
     );
 
@@ -1414,16 +1408,11 @@ test('should delete role entries when deleting project', async () => {
         SYSTEM_USER_AUDIT,
     );
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        customRole.id,
-        user1.id,
-        auditUser,
-    );
-    await projectService.addUser(
-        project.id,
-        customRole.id,
-        user2.id,
+        [customRole.id],
+        [], // no groups
+        [user1.id, user2.id],
         auditUser,
     );
 
@@ -1469,10 +1458,11 @@ test('should change a users role in the project', async () => {
     );
     const member = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        member.id,
-        projectUser.id,
+        [projectUser.id],
+        [], // no groups
+        [member.id],
         auditUser,
     );
     const { users } = await projectService.getAccessToProject(project.id);
@@ -1487,13 +1477,13 @@ test('should change a users role in the project', async () => {
         projectUser.id,
         auditUser,
     );
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        customRole.id,
-        projectUser.id,
+        [customRole.id],
+        [], // no groups
+        [projectUser.id],
         auditUser,
     );
-
     const { users: updatedUsers } = await projectService.getAccessToProject(
         project.id,
     );
@@ -1522,10 +1512,11 @@ test('should update role for user on project', async () => {
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
     const ownerRole = await stores.roleStore.getRoleByName(RoleName.OWNER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        memberRole.id,
-        projectMember1.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id],
         auditUser,
     );
     await projectService.changeRole(
@@ -1566,10 +1557,11 @@ test('should able to assign role without existing members', async () => {
 
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        memberRole.id,
-        projectMember1.id,
+        [memberRole.id],
+        [], // no groups
+        [projectMember1.id],
         auditUser,
     );
     await projectService.changeRole(
@@ -1680,10 +1672,11 @@ describe('ensure project has at least one owner', () => {
             RoleName.MEMBER,
         );
 
-        await projectService.addUser(
+        await projectService.addAccess(
             project.id,
-            memberRole.id,
-            projectMember1.id,
+            [memberRole.id],
+            [], // no groups
+            [projectMember1.id],
             auditUser,
         );
 
@@ -2328,15 +2321,12 @@ test('should get correct amount of project members for current and past window',
     );
     const memberRole = await stores.roleStore.getRoleByName(RoleName.MEMBER);
 
-    await Promise.all(
-        createdUsers.map((createdUser) =>
-            projectService.addUser(
-                project.id,
-                memberRole.id,
-                createdUser.id,
-                auditUser,
-            ),
-        ),
+    await projectService.addAccess(
+        project.id,
+        [memberRole.id],
+        [], // no groups
+        createdUsers.map((u) => u.id),
+        auditUser,
     );
 
     const result = await projectService.getStatusUpdates(project.id);

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -48,7 +48,6 @@ import {
     ProjectGroupUpdateRoleEvent,
     ProjectRevivedEvent,
     ProjectUpdatedEvent,
-    ProjectUserAddedEvent,
     ProjectUserRemovedEvent,
     ProjectUserUpdateRoleEvent,
     RoleName,
@@ -653,47 +652,6 @@ export default class ProjectService {
     // RBAC methods
     async getAccessToProject(projectId: string): Promise<AccessWithRoles> {
         return this.accessService.getProjectRoleAccess(projectId);
-    }
-
-    /**
-     * @deprecated see addAccess instead.
-     */
-    async addUser(
-        projectId: string,
-        roleId: number,
-        userId: number,
-        auditUser: IAuditUser,
-    ): Promise<void> {
-        const { roles, users } =
-            await this.accessService.getProjectRoleAccess(projectId);
-        const user = await this.accountStore.get(userId);
-
-        const role = roles.find((r) => r.id === roleId);
-        if (!role) {
-            throw new NotFoundError(
-                `Could not find roleId=${roleId} on project=${projectId}`,
-            );
-        }
-
-        const alreadyHasAccess = users.some((u) => u.id === userId);
-        if (alreadyHasAccess) {
-            throw new Error(`User already has access to project=${projectId}`);
-        }
-
-        await this.accessService.addUserToRole(userId, role.id, projectId);
-
-        await this.eventService.storeEvent(
-            new ProjectUserAddedEvent({
-                project: projectId,
-                auditUser,
-                data: {
-                    roleId,
-                    userId,
-                    roleName: role.name,
-                    email: user.email,
-                },
-            }),
-        );
     }
 
     /**

--- a/src/test/e2e/services/access-service.e2e.test.ts
+++ b/src/test/e2e/services/access-service.e2e.test.ts
@@ -684,10 +684,11 @@ test('Should be denied access to delete a role that is in use', async () => {
         },
     ]);
 
-    await projectService.addUser(
+    await projectService.addAccess(
         project.id,
-        customRole.id,
-        projectMember.id,
+        [customRole.id],
+        [], // no groups
+        [projectMember.id],
         SYSTEM_USER_AUDIT,
     );
 


### PR DESCRIPTION
Depends on https://github.com/bricks-software/unleash-enterprise/pull/137

This method has been deprecated and has an alternative. Migrating to that alternative