### PR TITLE
chore: remove legacy feature type

### DIFF
--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -125,12 +125,6 @@ export interface FeatureToggleView extends FeatureToggleWithEnvironment {
     collaborators?: { users: Collaborator[] };
 }
 
-// @deprecated
-export interface FeatureToggleLegacy extends FeatureToggle {
-    strategies: IStrategyConfig[];
-    enabled: boolean;
-}
-
 export interface IEnvironmentDetail extends IEnvironmentBase {
     strategies: IStrategyConfig[];
     variants: IVariant[];


### PR DESCRIPTION
This has been deprecated 4 years ago and is not used