### PR TITLE
fix: frontend tests after Cypress upgrade

### DIFF
--- a/frontend/cypress/integration/projects/access.spec.ts
+++ b/frontend/cypress/integration/projects/access.spec.ts
@@ -150,7 +150,10 @@ describe('project-access', () => {
     });
 
     it('can remove access', () => {
-        cy.get(`[data-testid='${PA_REMOVE_BUTTON_ID}']`).first().click();
+        cy.get(`[data-testid='${PA_REMOVE_BUTTON_ID}']`)
+            .filter(':not(:disabled)')
+            .first()
+            .click();
 
         cy.intercept(
             'DELETE',

--- a/frontend/cypress/support/UI.ts
+++ b/frontend/cypress/support/UI.ts
@@ -165,7 +165,10 @@ export const addFlexibleRolloutStrategyToFeature_UI = (
         cy.get('[data-testid=ADD_CONSTRAINT_ID]').click();
         cy.get('[data-testid=DIALOGUE_CONFIRM_ID]').click();
     }
-    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`).first().click();
+    // this one needs to wait until the dropdown selector of stickiness is set, that's why waitForAnimations: true
+    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`)
+        .first()
+        .click({ waitForAnimations: true });
     return cy.wait('@addStrategyToFeature');
 };
 
@@ -213,7 +216,10 @@ export const updateFlexibleRolloutStrategy_UI = (
         },
     ).as('updateStrategy');
 
-    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`).first().click();
+    // this one needs to wait until the dropdown selector of stickiness is set, that's why waitForAnimations: true
+    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`)
+        .first()
+        .click({ waitForAnimations: true });
     return cy.wait('@updateStrategy');
 };
 
@@ -288,7 +294,10 @@ export const addUserIdStrategyToFeature_UI = (
         },
     ).as('addStrategyToFeature');
 
-    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`).first().click();
+    // this one needs to wait until the dropdown selector of stickiness is set, that's why waitForAnimations: true
+    cy.get(`[data-testid=STRATEGY_FORM_SUBMIT_ID]`)
+        .first()
+        .click({ waitForAnimations: true });
     return cy.wait('@addStrategyToFeature');
 };
 

--- a/frontend/cypress/support/UI.ts
+++ b/frontend/cypress/support/UI.ts
@@ -60,7 +60,7 @@ export const createFeature_UI = (
 
     cy.wait(5_000);
 
-    cy.get('[data-testid=NAVIGATE_TO_CREATE_FEATURE').click(uiOpts);
+    cy.get('[data-testid=NAVIGATE_TO_CREATE_FEATURE').first().click(uiOpts);
 
     cy.intercept('POST', `/api/admin/projects/${projectName}/features`).as(
         'createFeature',
@@ -72,10 +72,14 @@ export const createFeature_UI = (
     cy.get("[data-testid='FORM_DESCRIPTION_INPUT'] textarea")
         .first()
         .type('hello-world', uiOpts);
-    if (!shouldWait)
-        return cy.get("[data-testid='FORM_CREATE_BUTTON']").click(uiOpts);
-    else cy.get("[data-testid='FORM_CREATE_BUTTON']").click(uiOpts);
-    return cy.wait('@createFeature');
+    const clicked = cy
+        .get("[data-testid='FORM_CREATE_BUTTON']")
+        .first()
+        .click(uiOpts);
+    if (shouldWait) {
+        return cy.wait('@createFeature');
+    }
+    return clicked;
 };
 
 export const createProject_UI = (

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -68,3 +68,8 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
 
     return originalFn(url, options);
 });
+
+Cypress.Commands.overwrite('click', (originalFn, x, y, options = {}) => {
+    options.waitForAnimations = false;
+    return originalFn(x, y, options);
+});


### PR DESCRIPTION
The fix involved:

1. [Find the first button to click to create a feature flag](9b4500cded18e74fc66bbe7f555a70566694aef3) (there are 2)
2. [Find the button that's not disabled to remove access](fad627c6b3e1e3d244e58838602c90e086a25944)
3. [Don't wait for animations](5ce6ca59f5474745d2b96a09f7acf29b62202f0c) except in [this case](f4a7819ad1f134e61cc42f8d3e7e199b8a058f07)