### PR TITLE
chore: use a local image of unleash enterprise for testing FE

### DIFF
--- a/.github/docker-compose.test.yml
+++ b/.github/docker-compose.test.yml
@@ -1,0 +1,56 @@
+# This docker compose setup configures:
+# - the Unleash server instance + the necessary backing Postgres database
+# - the Unleash proxy
+#
+# To learn more about all the parts of Unleash, visit
+# https://docs.getunleash.io
+#
+# NOTE: please do not use this configuration for production setups.
+# Unleash does not take responsibility for any data leaks or other
+# problems that may arise as a result.
+#
+# This is intended to be used for demo, development, and learning
+# purposes only.
+
+services:
+  # The Unleash server contains the Unleash configuration and
+  # communicates with server-side SDKs and the Unleash Proxy
+  unleash:
+    image: 726824350591.dkr.ecr.eu-central-1.amazonaws.com/unleash-enterprise:latest
+    pull_policy: "always"
+    ports:
+      - "4242:4242"
+    environment:
+      DATABASE_URL: "postgres://postgres:unleash@db/unleash"
+      DATABASE_SSL: "false"
+      UNLEASH_LICENSE: "${FRONTEND_TEST_LICENSE}"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1
+      interval: 1s
+      timeout: 1m
+      retries: 5
+      start_period: 15s
+  db:
+    expose:
+      - "5432"
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "unleash"
+      # trust incoming connections blindly (DON'T DO THIS IN PRODUCTION!)
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "pg_isready",
+          "--username=postgres",
+          "--host=127.0.0.1",
+          "--port=5432",
+        ]
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s

--- a/.github/docker-compose.test.yml
+++ b/.github/docker-compose.test.yml
@@ -1,6 +1,5 @@
 # This docker compose setup configures:
-# - the Unleash server instance + the necessary backing Postgres database
-# - the Unleash proxy
+# - the Unleash enterprise server instance + the necessary backing Postgres database
 #
 # To learn more about all the parts of Unleash, visit
 # https://docs.getunleash.io

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -4,20 +4,8 @@ on:
     # paths:
     #   - 'frontend/**'
 jobs:
-  get-token:
-    runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.get-token.outputs.token }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get Token
-        id: get-token
-        run: |
-          echo "token=$(curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }})" >> $GITHUB_OUTPUT
-
   e2e:
     runs-on: ubuntu-latest
-    needs: get-token
     strategy:
       matrix:
         test:
@@ -35,8 +23,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Start Unleash test instance
         run: |
-          echo ${{ needs.get-token.outputs.token }} | docker login --username AWS --password-stdin 726824350591.dkr.ecr.eu-central-1.amazonaws.com
-          docker compose up -f .github/docker-compose.test.yml -d --wait -t 90
+          curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }} | docker login --username AWS --password-stdin 726824350591.dkr.ecr.eu-central-1.amazonaws.com
+          docker compose -f .github/docker-compose.test.yml up -d --wait -t 90
         env:
           FRONTEND_TEST_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}
       - name: Run Cypress

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -18,33 +18,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: get-token
-    services:
-      db:
-        image: postgres
-        env:
-          POSTGRES_USER: unleash_user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: unleash_test
-          POSTGRES_INITDB_ARGS: "--no-sync"
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      unleashEnterprise:
-        image: 726824350591.dkr.ecr.eu-central-1.amazonaws.com/unleash-enterprise:latest
-        credentials:
-          username: AWS
-          password: ${{ needs.get-token.outputs.token }}
-        env:
-          DATABASE_URL: "postgres://postgres:unleash@localhost/unleash"
-          UNLEASH_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}
-        options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1" 
-          --health-interval 10s 
-          --health-timeout 5s 
-          --health-retries 5
-
-
     strategy:
       matrix:
         test:
@@ -60,6 +33,12 @@ jobs:
           echo "$GITHUB_CONTEXT"
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Start Unleash test instance
+        run: |
+          echo ${{ needs.get-token.outputs.token }} | docker login --username AWS --password-stdin 726824350591.dkr.ecr.eu-central-1.amazonaws.com
+          docker compose up -f .github/docker-compose.test.yml -d --wait -t 90
+        env:
+          FRONTEND_TEST_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}
       - name: Run Cypress
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -1,9 +1,33 @@
 name: e2e:frontend
-on: [deployment_status]
+on:
+  pull_request:
+    # paths:
+    #   - 'frontend/**'
 jobs:
   e2e:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && contains(github.event.deployment_status.target_url, 'unleash-monorepo-frontend')
     runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres
+        env:
+          POSTGRES_USER: unleash_user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: unleash_test
+          POSTGRES_INITDB_ARGS: "--no-sync"
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      unleashEnterprise:
+        image: 726824350591.dkr.ecr.eu-central-1.amazonaws.com/unleash-enterprise:latest
+        credentials:
+          username: AWS
+          password: ${{ secrets.ECR_ENTERPRISE_TOKEN }}
+        env:
+          DATABASE_URL: "postgres://postgres:unleash@localhost/unleash"
+          UNLEASH_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}
+
+
     strategy:
       matrix:
         test:

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -4,8 +4,20 @@ on:
     # paths:
     #   - 'frontend/**'
 jobs:
+  get-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.get-token.outputs.token }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Token
+        id: get-token
+        run: |
+          echo "::set-output name=token::$(curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }})"
+
   e2e:
     runs-on: ubuntu-latest
+    needs: get-token
     services:
       db:
         image: postgres
@@ -22,7 +34,7 @@ jobs:
         image: 726824350591.dkr.ecr.eu-central-1.amazonaws.com/unleash-enterprise:latest
         credentials:
           username: AWS
-          password: ${{ secrets.ECR_ENTERPRISE_TOKEN }}
+          password: ${{ needs.get-token.outputs.token }}
         env:
           DATABASE_URL: "postgres://postgres:unleash@localhost/unleash"
           UNLEASH_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Get Token
         id: get-token
         run: |
-          echo "::set-output name=token::$(curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }})"
+          echo "token=$(curl https://app.unleash-hosted.com/docker-login/token/${{ secrets.ECR_ENTERPRISE_TOKEN }})" >> $GITHUB_OUTPUT
 
   e2e:
     runs-on: ubuntu-latest
@@ -60,6 +60,6 @@ jobs:
         with:
           working-directory: frontend
           env: AUTH_USER=admin,AUTH_PASSWORD=unleash4all
-          config: baseUrl=${{ github.event.deployment_status.target_url }}
+          config: baseUrl=http://localhost:4242
           spec: cypress/integration/${{ matrix.test }}
           install-command: yarn --immutable

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -38,6 +38,11 @@ jobs:
         env:
           DATABASE_URL: "postgres://postgres:unleash@localhost/unleash"
           UNLEASH_LICENSE: ${{ secrets.FRONTEND_TEST_LICENSE }}
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:4242/health || exit 1" 
+          --health-interval 10s 
+          --health-timeout 5s 
+          --health-retries 5
 
 
     strategy:


### PR DESCRIPTION
This removes the need of running a heroku instance with enterprise to run frontend tests. We can also get rid of vercel deployments of the frontend for PRs (ofc we'd be loosing the preview if we do this)

It relies on the free enterprise docker image to spin up a clean Unleash instance on each frontend spec test.

It also seems to speed up tests, I guess because we don't have to wait for vercel deployment queue:
![image](https://github.com/user-attachments/assets/60a2aef1-9a5a-442d-b241-8c5c145c679e)


Compared with other recent PRs:
![image](https://github.com/user-attachments/assets/9a7498aa-26e6-48a4-aba0-c67e5380ced4)

Unrelated to this PR but something is making the features spec tests very slow since Cypress upgrade: https://github.com/Unleash/unleash/actions/runs/13784760762/job/38550079932#step:4:138
