### PR TITLE
Fix features table migrations in 20220603081324-add-archive-at-to-fea…

### DIFF
--- a/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
+++ b/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
@@ -13,7 +13,7 @@ exports.up = function (db, callback) {
                           AND e.created_at =
                               (SELECT Max(created_at) date
                                FROM   events
-                               WHERE  type = 'feature-archived'
+                               WHERE  e.type = 'feature-archived'
                                       AND e.feature_name = f.NAME)) res
         WHERE  res.NAME = f.NAME;
         UPDATE features

--- a/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
+++ b/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
@@ -13,8 +13,9 @@ exports.up = function (db, callback) {
                           AND e.created_at =
                               (SELECT Max(created_at) date
                                FROM   events
-                               WHERE  e.type = 'feature-archived'
-                                      AND e.feature_name = f.NAME)) res
+                               WHERE  type = 'feature-archived'
+                                      AND feature_name = f.NAME
+                                      AND f.archived = 't')) res
         WHERE  res.NAME = f.NAME;
         UPDATE features
         SET    archived_at = Now()


### PR DESCRIPTION
Changes to migration file - 20220603081324-add-archive-at-to-feature-toggle.js

1. Fixes the migration script where features table is updated with archived_at column with the latest date instead of taking the date from the events table. 
2. Also it fails for the latest toggle which was archived and then revived but after migration it updates the toggle as archived toggle.
3. Also because of the buggy reference to the outer join's events table `e` its taking a huge time to run the migration.

This PR fixes all the above issues.

## About the changes

We have faced an issue during migration of unleash-server from 4.8.2 to 6.6.0 where one of our toggle which was archived and unarchived once before migration and that was the latest toggle in terms of the archived date, but after the migration was ran it was in archived status. 

Upon further debugging and running the SQL command in the features table migration file we noticed that we should not be referencing the outer join's events table `e` for the  feature_name check and additionally we should add the features table's archived toggle check instead.

### Important files

The change in only in this file.

[20220603081324-add-archive-at-to-feature-toggle.js](https://github.com/Unleash/unleash/pull/9518/files#diff-b91c299b96edc46ca3a1963bf54966aa777c9fa107f3bd8b45f5fb54dc57460e)

## Discussion points

Let me know if any further details is required.
