### PR TITLE
fix: ignore youtube embed from check links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -25,3 +25,5 @@ datadog.*/api/v1/events
 ddog.*/api/v1/events
 api.datadoghq.com
 myoidchost.azure.com
+
+www.youtube.com/embed/


### PR DESCRIPTION
It looks like it's not something we can validate

Closes #9519