### PR TITLE
fix: only drag handle is draggable, allow you to select text in the header

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -188,7 +188,7 @@ export const MilestoneCard = ({
 
     const dragHandle = (
         <DragButton type='button'>
-            <DraggableContent>
+            <DraggableContent ref={dragItemRef}>
                 <DragIndicator aria-hidden />
                 <ScreenReaderOnly>Drag to reorder</ScreenReaderOnly>
             </DraggableContent>
@@ -363,7 +363,7 @@ export const MilestoneCard = ({
     if (!milestone.strategies || milestone.strategies.length === 0) {
         return (
             <>
-                <DraggableCardContainer ref={dragItemRef}>
+                <DraggableCardContainer>
                     {dragHandle}
                     <StyledMilestoneCard
                         hasError={


### PR DESCRIPTION
Previously, the entire card was draggable, which meant that you couldn't select text inside the card or inside the milestone title when editing. This makes it so that only the drag handle is draggable.