### PR TITLE
chore: fix missing primary routes for commandbar

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -126,7 +126,11 @@ export const CommandBar = () => {
     const [value, setValue] = useState<string>('');
     const { routes } = useRoutes();
     const allRoutes: Record<string, IPageRouteInfo> = {};
-    for (const route of [...routes.mainNavRoutes, ...routes.adminRoutes]) {
+    for (const route of [
+        ...routes.mainNavRoutes,
+        ...routes.adminRoutes,
+        ...routes.primaryRoutes,
+    ]) {
         allRoutes[route.path] = {
             path: route.path,
             route: route.route,

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/useRoutes.ts
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/useRoutes.ts
@@ -1,5 +1,5 @@
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { getNavRoutes } from 'component/menu/routes';
+import { getNavRoutes, getPrimaryRoutes } from 'component/menu/routes';
 import { useAdminRoutes } from 'component/admin/useAdminRoutes';
 import { filterByConfig, mapRouteLink } from 'component/common/util';
 
@@ -7,12 +7,16 @@ export const useRoutes = () => {
     const { uiConfig } = useUiConfig();
     const routes = getNavRoutes();
     const adminRoutes = useAdminRoutes();
+    const primaryRoutes = getPrimaryRoutes();
 
     const filteredMainRoutes = {
         mainNavRoutes: routes
             .filter(filterByConfig(uiConfig))
             .map(mapRouteLink),
         adminRoutes,
+        primaryRoutes: primaryRoutes
+            .filter(filterByConfig(uiConfig))
+            .map(mapRouteLink),
     };
 
     return { routes: filteredMainRoutes };

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -12,7 +12,9 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
-    "menu": {},
+    "menu": {
+      "primary": true,
+    },
     "path": "/personal",
     "title": "Dashboard",
     "type": "protected",
@@ -90,7 +92,9 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
-    "menu": {},
+    "menu": {
+      "primary": true,
+    },
     "path": "/projects",
     "title": "Projects",
     "type": "protected",
@@ -104,7 +108,9 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
-    "menu": {},
+    "menu": {
+      "primary": true,
+    },
     "path": "/search",
     "title": "Search",
     "type": "protected",
@@ -119,7 +125,9 @@ exports[`returns all baseRoutes 1`] = `
       },
     },
     "hidden": false,
-    "menu": {},
+    "menu": {
+      "primary": true,
+    },
     "path": "/playground",
     "title": "Playground",
     "type": "protected",
@@ -127,7 +135,9 @@ exports[`returns all baseRoutes 1`] = `
   {
     "component": [Function],
     "enterprise": true,
-    "menu": {},
+    "menu": {
+      "primary": true,
+    },
     "path": "/insights",
     "title": "Insights",
     "type": "protected",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -68,7 +68,7 @@ export const routes: IRoute[] = [
         title: 'Dashboard',
         component: PersonalDashboard,
         type: 'protected',
-        menu: {},
+        menu: { primary: true },
     },
 
     // Project
@@ -127,7 +127,7 @@ export const routes: IRoute[] = [
         title: 'Projects',
         component: ProjectList,
         type: 'protected',
-        menu: {},
+        menu: { primary: true },
     },
     {
         path: '/projects-archive',
@@ -143,7 +143,7 @@ export const routes: IRoute[] = [
         title: 'Search',
         component: FeatureToggleListTable,
         type: 'protected',
-        menu: {},
+        menu: { primary: true },
     },
 
     // Playground
@@ -153,7 +153,7 @@ export const routes: IRoute[] = [
         component: LazyPlayground,
         hidden: false,
         type: 'protected',
-        menu: {},
+        menu: { primary: true },
     },
 
     // Insights
@@ -162,7 +162,7 @@ export const routes: IRoute[] = [
         title: 'Insights',
         component: Insights,
         type: 'protected',
-        menu: {},
+        menu: { primary: true },
         enterprise: true,
     },
 
@@ -535,4 +535,7 @@ const getCondensedRoutes = (routes: IRoute[]): INavigationMenuItem[] => {
 export const baseRoutes = routes.filter((route) => !route.hidden);
 export const getNavRoutes = () => {
     return getCondensedRoutes(baseRoutes.filter((route) => route.menu.main));
+};
+export const getPrimaryRoutes = () => {
+    return getCondensedRoutes(baseRoutes.filter((route) => route.menu.primary));
 };

--- a/frontend/src/interfaces/route.ts
+++ b/frontend/src/interfaces/route.ts
@@ -30,6 +30,7 @@ export interface INavigationMenuItem {
 
 interface IRouteMenu {
     main?: boolean;
+    primary?: boolean;
     adminSettings?: boolean;
     mode?: Array<'pro' | 'enterprise'>;
     billing?: boolean;


### PR DESCRIPTION
Cleaning up mobile routes also removed the primary routes (what we call them in navigation sidebar) to be unresolvable, resulting in:
![image](https://github.com/user-attachments/assets/c437a9fe-ac7e-4b95-b6d2-5629173727e3)


This PR fixes this by adding a menu property "primary?: boolean", and some code mapping matching items into a route collection for command bar. The collection should be reusable for menu-rendering in the future if we choose to
![image](https://github.com/user-attachments/assets/cd1d892c-ad86-4ded-9d8b-8810c342123a)
