### PR TITLE
chore: rename release management to release templates

### DIFF
--- a/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
+++ b/frontend/src/component/common/PremiumFeature/PremiumFeature.tsx
@@ -131,7 +131,7 @@ const PremiumFeatures = {
     releaseManagement: {
         plan: FeaturePlan.ENTERPRISE,
         url: '',
-        label: 'Release management',
+        label: 'Release templates',
     },
 };
 

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash.tsx
@@ -164,7 +164,7 @@ export const NewInUnleash = ({
             ),
         },
         {
-            label: 'Release management',
+            label: 'Release templates',
             summary: 'Save time with release plans',
             icon: <StyledReleaseManagementIcon />,
             preview: <ReleaseManagementPreview />,

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`returns all baseRoutes 1`] = `
       ],
     },
     "path": "/release-management",
-    "title": "Release management",
+    "title": "Release templates",
     "type": "protected",
   },
   {

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -284,7 +284,7 @@ export const routes: IRoute[] = [
     // Release management/plans
     {
         path: '/release-management',
-        title: 'Release management',
+        title: 'Release templates',
         component: ReleaseManagement,
         type: 'protected',
         menu: { main: true, mode: ['enterprise'] },

--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -15,7 +15,7 @@ import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
 import { RELEASE_PLAN_TEMPLATE_CREATE } from '@server/types/permissions';
 
 export const ReleaseManagement = () => {
-    usePageTitle('Release management');
+    usePageTitle('Release templates');
     const navigate = useNavigate();
     const data = useReleasePlanTemplates();
 


### PR DESCRIPTION
renames release management to release templates:
- in the menu
- in the page title
- in the 'new in unleash'
- in the premium feature description