### PR TITLE
chore: finish up disabled strategies

### DIFF
--- a/frontend/src/component/common/ConstraintsList/ConstraintsList.tsx
+++ b/frontend/src/component/common/ConstraintsList/ConstraintsList.tsx
@@ -33,6 +33,10 @@ const StyledAnd = styled('div')(({ theme }) => ({
     background: theme.palette.background.application,
     borderRadius: theme.shape.borderRadiusLarge,
     zIndex: theme.zIndex.fab,
+    '.strategy-disabled &': {
+        color: theme.palette.text.secondary,
+        filter: 'contrast(107%)',
+    },
 }));
 
 export const ConstraintsList: FC<{ children: ReactNode }> = ({ children }) => {

--- a/frontend/src/component/common/ConstraintsList/ConstraintsList.tsx
+++ b/frontend/src/component/common/ConstraintsList/ConstraintsList.tsx
@@ -33,10 +33,6 @@ const StyledAnd = styled('div')(({ theme }) => ({
     background: theme.palette.background.application,
     borderRadius: theme.shape.borderRadiusLarge,
     zIndex: theme.zIndex.fab,
-    '.strategy-disabled &': {
-        color: theme.palette.text.secondary,
-        filter: 'contrast(107%)',
-    },
 }));
 
 export const ConstraintsList: FC<{ children: ReactNode }> = ({ children }) => {

--- a/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
+++ b/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
@@ -1,4 +1,4 @@
-import { Chip, type ChipProps, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import type { FC, ReactNode } from 'react';
 
 type StrategyItemProps = {
@@ -34,20 +34,21 @@ const StyledType = styled('span')(({ theme }) => ({
     width: theme.spacing(10),
 }));
 
-const StyledValuesGroup = styled('div')(({ theme }) => ({
+const StyledValuesGroup = styled('ul')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
+    listStyle: 'none',
+    padding: 0,
 }));
 
-const StyledValue = styled(({ ...props }: ChipProps) => (
-    <Chip size='small' {...props} />
-))(({ theme }) => ({
-    padding: theme.spacing(0.5),
-    background: theme.palette.background.elevation1,
+const StyledValue = styled('li')(({ theme }) => ({
     '.strategy-disabled &': {
         filter: 'grayscale(1)',
         color: theme.palette.text.secondary,
+    },
+    ':not(&:last-of-type)::after': {
+        content: '", "',
     },
 }));
 
@@ -66,7 +67,9 @@ export const StrategyEvaluationItem: FC<StrategyItemProps> = ({
             {values && values?.length > 0 ? (
                 <StyledValuesGroup>
                     {values?.map((value, index) => (
-                        <StyledValue key={`${value}#${index}`} label={value} />
+                        <StyledValue key={`${value}#${index}`}>
+                            {value}
+                        </StyledValue>
                     ))}
                 </StyledValuesGroup>
             ) : null}

--- a/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
+++ b/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material';
+import { disabledStrategyClassName } from 'component/common/StrategyItemContainer/disabled-strategy-utils';
 import type { FC, ReactNode } from 'react';
 
 type StrategyItemProps = {
@@ -19,7 +20,7 @@ const StyledContent = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
     flexWrap: 'wrap',
     alignItems: 'center',
-    '.strategy-disabled &': {
+    [`.${disabledStrategyClassName} &`]: {
         filter: 'grayscale(1)',
         color: theme.palette.text.secondary,
     },
@@ -43,7 +44,7 @@ const StyledValuesGroup = styled('ul')(({ theme }) => ({
 }));
 
 const StyledValue = styled('li')(({ theme }) => ({
-    '.strategy-disabled &': {
+    [`.${disabledStrategyClassName} &`]: {
         filter: 'grayscale(1)',
         color: theme.palette.text.secondary,
     },

--- a/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
+++ b/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
@@ -19,6 +19,10 @@ const StyledContent = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
     flexWrap: 'wrap',
     alignItems: 'center',
+    '.strategy-disabled &': {
+        filter: 'grayscale(1)',
+        color: theme.palette.text.secondary,
+    },
 }));
 
 const StyledType = styled('span')(({ theme }) => ({

--- a/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
+++ b/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
@@ -37,6 +37,7 @@ const StyledType = styled('span')(({ theme }) => ({
 
 const StyledValuesGroup = styled('ul')(({ theme }) => ({
     display: 'flex',
+    flexFlow: 'row wrap',
     alignItems: 'center',
     gap: theme.spacing(0.5),
     listStyle: 'none',

--- a/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
+++ b/frontend/src/component/common/ConstraintsList/StrategyEvaluationItem/StrategyEvaluationItem.tsx
@@ -45,6 +45,10 @@ const StyledValue = styled(({ ...props }: ChipProps) => (
 ))(({ theme }) => ({
     padding: theme.spacing(0.5),
     background: theme.palette.background.elevation1,
+    '.strategy-disabled &': {
+        filter: 'grayscale(1)',
+        color: theme.palette.text.secondary,
+    },
 }));
 
 /**

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -8,6 +8,7 @@ import type { PlaygroundStrategySchema } from 'openapi';
 import { Badge } from '../Badge/Badge';
 import { Link } from 'react-router-dom';
 import { Truncator } from '../Truncator/Truncator';
+import { disabledStrategyClassName } from './disabled-strategy-utils';
 
 type StrategyItemContainerProps = {
     strategyHeaderLevel?: 1 | 2 | 3 | 4 | 5 | 6;
@@ -87,7 +88,10 @@ export const StrategyItemContainer: FC<StrategyItemContainerProps> = ({
             : ({ children }) => <> {children} </>;
 
     return (
-        <Box sx={{ position: 'relative' }}>
+        <Box
+            className={strategy.disabled ? disabledStrategyClassName : ''}
+            sx={{ position: 'relative' }}
+        >
             <StyledContainer style={style} className={className}>
                 <StyledHeader disabled={Boolean(strategy?.disabled)}>
                     {onDragStart ? (

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -136,9 +136,6 @@ export const StrategyItemContainer: FC<StrategyItemContainerProps> = ({
                             </StyledHeaderContainer>
                         </StrategyHeaderLink>
 
-                        {strategy.disabled ? (
-                            <Badge color='disabled'>Disabled</Badge>
-                        ) : null}
                         {headerItemsLeft}
                     </StyledHeaderInner>
                     <Box
@@ -148,6 +145,9 @@ export const StrategyItemContainer: FC<StrategyItemContainerProps> = ({
                             alignItems: 'center',
                         }}
                     >
+                        {strategy.disabled ? (
+                            <Badge color='warning'>Strategy disabled</Badge>
+                        ) : null}
                         {headerItemsRight}
                     </Box>
                 </StyledHeader>

--- a/frontend/src/component/common/StrategyItemContainer/disabled-strategy-utils.ts
+++ b/frontend/src/component/common/StrategyItemContainer/disabled-strategy-utils.ts
@@ -1,0 +1,2 @@
+export const disabledStrategyClassName =
+    'disabled-strategy-55d37c31-ca3f-4c19-bf86-9158824899bf';

--- a/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
+++ b/frontend/src/component/common/StrategySeparator/StrategySeparator.tsx
@@ -13,6 +13,10 @@ const Chip = styled('div')(({ theme }) => ({
     left: theme.spacing(4),
 }));
 
-export const StrategySeparator = () => {
-    return <Chip role='separator'>OR</Chip>;
+export const StrategySeparator = ({ className }: { className?: string }) => {
+    return (
+        <Chip role='separator' className={className}>
+            OR
+        </Chip>
+    );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -22,6 +22,7 @@ import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePla
 import { ReleasePlan } from '../../../ReleasePlan/ReleasePlan';
 import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 import { ProjectEnvironmentStrategyDraggableItem } from './StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem';
+import { disabledStrategyClassName } from 'component/common/StrategyItemContainer/disabled-strategy-utils';
 
 interface IEnvironmentAccordionBodyProps {
     isDisabled: boolean;
@@ -78,7 +79,7 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
 }));
 
 const StyledStrategySeparator = styled(StrategySeparator)(({ theme }) => ({
-    '&:has(+ .strategy-disabled), &:has(+ ol>li:first-of-type>.strategy-disabled)':
+    [`&:has(+ *:not(ol) .${disabledStrategyClassName}), &:has(+ ol > li:first-of-type .${disabledStrategyClassName})`]:
         {
             filter: 'grayscale(1)',
         },
@@ -253,9 +254,6 @@ export const EnvironmentAccordionBody = ({
                         {index > 0 ? <StyledStrategySeparator /> : null}
 
                         <ProjectEnvironmentStrategyDraggableItem
-                            className={
-                                strategy.disabled ? 'strategy-disabled' : ''
-                            }
                             strategy={strategy}
                             index={index}
                             environmentName={featureEnvironment.name}
@@ -281,9 +279,6 @@ export const EnvironmentAccordionBody = ({
                             {index > 0 ? <StyledStrategySeparator /> : null}
 
                             <ProjectEnvironmentStrategyDraggableItem
-                                className={
-                                    strategy.disabled ? 'strategy-disabled' : ''
-                                }
                                 strategy={strategy}
                                 index={index + pageIndex * pageSize}
                                 environmentName={featureEnvironment.name}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -77,6 +77,13 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
     marginInline: theme.spacing(2), // should consider finding a variable here
 }));
 
+const StyledStrategySeparator = styled(StrategySeparator)(({ theme }) => ({
+    '&:has(+ .strategy-disabled), &:has(+ ol>li:first-of-type>.strategy-disabled)':
+        {
+            filter: 'grayscale(1)',
+        },
+}));
+
 export const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
@@ -243,9 +250,12 @@ export const EnvironmentAccordionBody = ({
             <StyledContentList>
                 {strategies.map((strategy, index) => (
                     <StyledListItem key={strategy.id}>
-                        {index > 0 ? <StrategySeparator /> : null}
+                        {index > 0 ? <StyledStrategySeparator /> : null}
 
                         <ProjectEnvironmentStrategyDraggableItem
+                            className={
+                                strategy.disabled ? 'strategy-disabled' : ''
+                            }
                             strategy={strategy}
                             index={index}
                             environmentName={featureEnvironment.name}
@@ -268,9 +278,12 @@ export const EnvironmentAccordionBody = ({
                 <StyledContentList>
                     {page.map((strategy, index) => (
                         <StyledListItem key={strategy.id}>
-                            {index > 0 ? <StrategySeparator /> : null}
+                            {index > 0 ? <StyledStrategySeparator /> : null}
 
                             <ProjectEnvironmentStrategyDraggableItem
+                                className={
+                                    strategy.disabled ? 'strategy-disabled' : ''
+                                }
                                 strategy={strategy}
                                 index={index + pageIndex * pageSize}
                                 environmentName={featureEnvironment.name}
@@ -303,7 +316,7 @@ export const EnvironmentAccordionBody = ({
                         ))}
                         {strategies.length > 0 ? (
                             <li>
-                                <StrategySeparator />
+                                <StyledStrategySeparator />
                                 {strategyList}
                             </li>
                         ) : null}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -17,6 +17,7 @@ import { UPDATE_FEATURE_STRATEGY } from '@server/types/permissions';
 import { StrategyDraggableItem } from './StrategyDraggableItem';
 
 type ProjectEnvironmentStrategyDraggableItemProps = {
+    className?: string;
     strategy: IFeatureStrategy;
     environmentName: string;
     index: number;
@@ -36,6 +37,7 @@ type ProjectEnvironmentStrategyDraggableItemProps = {
 const onDragNoOp = () => () => {};
 
 export const ProjectEnvironmentStrategyDraggableItem = ({
+    className,
     strategy,
     index,
     environmentName,
@@ -74,6 +76,7 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
 
     return (
         <Box
+            className={className}
             key={strategy.id}
             ref={ref}
             onDragOver={onDragOver(ref, index)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import { styled } from '@mui/material';
 import type { FeatureStrategySchema } from 'openapi';
 import type { IFeatureStrategyPayload } from 'interfaces/strategy';
 import { useUiFlag } from 'hooks/useUiFlag';
@@ -12,12 +11,6 @@ import { useStrategyParameters } from './hooks/useStrategyParameters';
 import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
 import { SegmentItem } from 'component/common/SegmentItem/SegmentItem';
 import { ConstraintsList } from 'component/common/ConstraintsList/ConstraintsList';
-
-const FilterContainer = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'grayscale',
-})<{ grayscale: boolean }>(({ grayscale }) =>
-    grayscale ? { filter: 'grayscale(1)', opacity: 0.67 } : {},
-);
 
 type StrategyExecutionProps = {
     strategy: IFeatureStrategyPayload | FeatureStrategySchema;
@@ -52,19 +45,17 @@ export const StrategyExecution: FC<StrategyExecutionProps> = ({
     }
 
     return (
-        <FilterContainer grayscale={strategy.disabled === true}>
-            <ConstraintsList>
-                {strategySegments?.map((segment) => (
-                    <SegmentItem segment={segment} key={segment.id} />
-                ))}
-                {constraints?.map((constraint, index) => (
-                    <ConstraintItem
-                        key={`${objectId(constraint)}-${index}`}
-                        {...constraint}
-                    />
-                ))}
-                {isCustomStrategy ? customStrategyItems : strategyParameters}
-            </ConstraintsList>
-        </FilterContainer>
+        <ConstraintsList>
+            {strategySegments?.map((segment) => (
+                <SegmentItem segment={segment} key={segment.id} />
+            ))}
+            {constraints?.map((constraint, index) => (
+                <ConstraintItem
+                    key={`${objectId(constraint)}-${index}`}
+                    {...constraint}
+                />
+            ))}
+            {isCustomStrategy ? customStrategyItems : strategyParameters}
+        </ConstraintsList>
     );
 };


### PR DESCRIPTION
Aligns the design of disabled strategies with the sketches. Most notable changes:
- makes the disabled badge warning yellow
- greys out the preceding "or" separator
- makes the segment "preview" button *not* grey (because it's still interactable)

As a bonus: uses a list for the constraint value lists instead of a div and updates the design to match the sketches (no chips). 

![image](https://github.com/user-attachments/assets/1b3ddfa0-b0e8-4856-ae01-26e507590a4f)

With strat variants:
![image](https://github.com/user-attachments/assets/dc143fbf-256b-4e96-872b-a6aa84df2111)


Bonus fix: 
Lets the constraint value list wrap so that we avoid this kind of blowout:
![image](https://github.com/user-attachments/assets/4c0977ac-f8a4-41cc-8fb7-194e8b09c0a3)

Instead: 
![image](https://github.com/user-attachments/assets/a68ed4cf-c68c-43a1-9d6c-b90e85a0841f)


