### PR TITLE
feat(docs): Added ADR for logging levels

### DIFF
--- a/website/docs/contributing/ADRs/ADRs.md
+++ b/website/docs/contributing/ADRs/ADRs.md
@@ -15,6 +15,8 @@ These ADRs describe decisions that concern the entire codebase. They apply to ba
 
 * [Domain language](./overarching/domain-language.md)
 * [Separation of request and response schemas](./overarching/separation-request-response-schemas.md)
+* [Error Logging stack traces](./overarching/logging.md)
+* [Logging levels](./overarching/logging-levels.md)
 
 ## Back-end ADRs
 

--- a/website/docs/contributing/ADRs/overarching/logging-levels.md
+++ b/website/docs/contributing/ADRs/overarching/logging-levels.md
@@ -72,4 +72,4 @@ async markSeenAt(secrets: string[]): Promise<void> {
         }
     }
 ```
-Not being able to update lastSeen is not something we can anything about as on-calls, so this is also a good candidate for downgrading to warn
+Not being able to update lastSeen is not something we can do anything about as on-calls, so this is also a good candidate for downgrading to WARN.

--- a/website/docs/contributing/ADRs/overarching/logging-levels.md
+++ b/website/docs/contributing/ADRs/overarching/logging-levels.md
@@ -12,7 +12,7 @@ This ADR aims to solidify an understanding that levels are important to use corr
 
 ## Decision
 
-We should agree on the semantic information carried in each level, and which levels it is ok to ignore while scanning logs from running applications.
+We should agree on the semantic information carried in each level, and which levels are ok to ignore while scanning logs from running applications.
 
 Current suggestion
 

--- a/website/docs/contributing/ADRs/overarching/logging-levels.md
+++ b/website/docs/contributing/ADRs/overarching/logging-levels.md
@@ -1,0 +1,35 @@
+---
+title: "ADR: Logging levels"
+---
+## Date: 2025-03-20
+
+## Background
+
+Our log levels carry semantic information. 
+Log lines logged at the error level triggers SRE alerts if they exceed more than 1 per hour. Though we are pretty good at not excessively logging at ERROR, we do have cases where SRE alerts gets triggered, but by the time SRE can log on and check the deployment, everything is fine again. This means we never had an ERROR, we should have had a WARN message.
+
+This ADR aims to solidify an understanding that levels are important to use correctly to avoid mental load and on-call alerts for things we can't do anything about.
+
+## Decision
+
+We should agree on the semantic information carried in each level, and which levels it is ok to ignore while scanning logs from running applications.
+
+Current suggestion
+
+| Log level | Frequency in healthy application | Standard Availability                     | Configurable                |   
+|-----------|----------------------------------|-------------------------------------------|-----------------------------|
+| ERROR     | 0                                | All environments                          | NO                          |
+| WARN      | 1-10                             | All environments                          | NO                          |
+| INFO      | 10-100                           | Default deploy config sets LOG_LEVEL=info | YES                         |
+| DEBUG     | 100 - 1000                       | Local development                         | YES (specific deployments)  |
+| TRACE     | 1000 - 10000                     | NO                                        | YES (specific deployments)  |
+
+
+
+
+### Change
+
+Previously we might've logged an ERROR for a self-healable issue, this should change to WARN, and not be an ERROR.
+
+The only things that should be logged at ERROR are exceptional behaviour that we need to fix immediately, 
+everything else should be downgraded to WARN. In order to reduce WARN cardinality, this might mean that some messages at WARN today should be downgraded to INFO.


### PR DESCRIPTION
This PR starts an ADR for logging levels, and how to make your coworkers' days who are on-call less noisy.

This is my initial suggestion. Please feel free to help me with fleshing out both the table for what log levels means to you or if you disagree with what I've put as a background.

My impression is that we are pretty good at this, but we could be better, and having an ADR to lean on when pushing back on PR's log levels could help us. 

Thanks to @kwasniew for the push to start the ADR.

Examples: 
* https://github.com/Unleash/unleash/blob/038c10f6125c4cce200a0bf49f38c7bddada7093/src/lib/db/account-store.ts#L164-L173

And probably the storeFootprint method in our client-feature-toggle-delta
* https://github.com/Unleash/unleash/blob/038c10f6125c4cce200a0bf49f38c7bddada7093/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts#L363-L370


* https://github.com/bricks-software/unleash-enterprise/blob/293304a5d67231d584c3fa4c28589af23fb395e3/src/traffic-data/traffic-data-usage-service.ts#L69

