### PR TITLE
fix: access overview fallback to email

### DIFF
--- a/frontend/src/component/admin/users/AccessOverview/AccessOverview.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/AccessOverview.tsx
@@ -153,7 +153,7 @@ export const AccessOverview = () => {
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Access overview for ${user.name ?? user.username}`}
+                    title={`Access overview for ${user.name || user.email || user.username}`}
                     actions={
                         <ConditionallyRender
                             condition={!isSmallScreen}

--- a/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
+++ b/frontend/src/component/user/Profile/ProfileTab/ProfileTab.tsx
@@ -131,7 +131,7 @@ export const ProfileTab = ({ user }: IProfileTabProps) => {
                 <StyledAvatar user={user} />
                 <StyledInfo>
                     <StyledInfoName>
-                        {user.name || user.username}
+                        {user.name || user.email || user.username}
                     </StyledInfoName>
                     <Typography variant='body1'>{user.email}</Typography>
                 </StyledInfo>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3430/fix-undefined-in-access-overview-when-user-name-is-unavailable

Adds a fallback to email in case the name is not available.

Also switches the priority of the fallbacks to be consistent with other places in our codebase (email > username) and uses `||` instead of `??` because falsy values don't provide much informational value anyways.

![image](https://github.com/user-attachments/assets/2726247c-b7ba-4ed8-8589-f56fff63d031)
