### PR TITLE
fix: all users have a root role and warning if not

### DIFF
--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -457,8 +457,9 @@ export class AccessService {
     async getRootRoleForUser(userId: number): Promise<IRole> {
         const rootRole = await this.store.getRootRoleForUser(userId);
         if (!rootRole) {
-            const defaultRole = await this.getPredefinedRole(RoleName.VIEWER);
-            return defaultRole;
+            // this should never happen, but before breaking we want to know if it does.
+            this.logger.warn(`Could not find root role for user=${userId}.`);
+            return this.getPredefinedRole(RoleName.VIEWER);
         }
         return rootRole;
     }

--- a/src/migrations/20250320121200-all-users-have-a-root-role.js
+++ b/src/migrations/20250320121200-all-users-have-a-root-role.js
@@ -1,0 +1,19 @@
+exports.up = function (db, cb) {
+    // add root role Viewer (id 3) to all users who don't have a root role
+    db.runSql(
+        `INSERT INTO role_user(role_id, user_id, project) SELECT 3, u.id, 'default'
+FROM users u
+WHERE u.id > 0 AND u.deleted_at IS NULL AND NOT EXISTS (
+    SELECT 1
+    FROM role_user ru
+    JOIN roles r ON ru.role_id = r.id
+    WHERE ru.user_id = u.id
+      AND r.type IN ('root', 'root-custom')
+);`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    // No rollback
+};


### PR DESCRIPTION
## About the changes
SCIM provisioned users ended up without a root role. Unleash was assigning them the Viewer role by code but some queries using the db to resolve the role did not have the same logic leading to weird behaviors. 

This amends the situation by assigning the Viewer role to those users following the least privilege principle. 

Also adds a warning when assuming the Viewer role. That should never happen but we want to be confident before removing it.