### PR TITLE
feat: add use template button to strategies selector on flag config pane

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -10,6 +10,7 @@ interface IFeatureStrategyMenuCardsProps {
     projectId: string;
     featureId: string;
     environmentId: string;
+    onlyReleasePlans: boolean;
     onAddReleasePlan: (template: IReleasePlanTemplate) => void;
 }
 
@@ -22,10 +23,12 @@ export const FeatureStrategyMenuCards = ({
     projectId,
     featureId,
     environmentId,
+    onlyReleasePlans,
     onAddReleasePlan,
 }: IFeatureStrategyMenuCardsProps) => {
     const { strategies } = useStrategies();
     const { templates } = useReleasePlanTemplates();
+    const allStrategies = !onlyReleasePlans;
 
     const preDefinedStrategies = strategies.filter(
         (strategy) => !strategy.deprecated && !strategy.editable,
@@ -43,20 +46,22 @@ export const FeatureStrategyMenuCards = ({
     };
     return (
         <List dense>
-            <>
-                <StyledTypography color='textSecondary'>
-                    Default strategy for {environmentId} environment
-                </StyledTypography>
-                <ListItem key={defaultStrategy.name}>
-                    <FeatureStrategyMenuCard
-                        projectId={projectId}
-                        featureId={featureId}
-                        environmentId={environmentId}
-                        strategy={defaultStrategy}
-                        defaultStrategy={true}
-                    />
-                </ListItem>
-            </>
+            {allStrategies ? (
+                <>
+                    <StyledTypography color='textSecondary'>
+                        Default strategy for {environmentId} environment
+                    </StyledTypography>
+                    <ListItem key={defaultStrategy.name}>
+                        <FeatureStrategyMenuCard
+                            projectId={projectId}
+                            featureId={featureId}
+                            environmentId={environmentId}
+                            strategy={defaultStrategy}
+                            defaultStrategy={true}
+                        />
+                    </ListItem>
+                </>
+            ) : null}
             <ConditionallyRender
                 condition={templates.length > 0}
                 show={
@@ -75,39 +80,43 @@ export const FeatureStrategyMenuCards = ({
                     </>
                 }
             />
-            <StyledTypography color='textSecondary'>
-                Predefined strategy types
-            </StyledTypography>
-            {preDefinedStrategies.map((strategy) => (
-                <ListItem key={strategy.name}>
-                    <FeatureStrategyMenuCard
-                        projectId={projectId}
-                        featureId={featureId}
-                        environmentId={environmentId}
-                        strategy={strategy}
+            {allStrategies ? (
+                <>
+                    <StyledTypography color='textSecondary'>
+                        Predefined strategy types
+                    </StyledTypography>
+                    {preDefinedStrategies.map((strategy) => (
+                        <ListItem key={strategy.name}>
+                            <FeatureStrategyMenuCard
+                                projectId={projectId}
+                                featureId={featureId}
+                                environmentId={environmentId}
+                                strategy={strategy}
+                            />
+                        </ListItem>
+                    ))}
+                    <ConditionallyRender
+                        condition={customStrategies.length > 0}
+                        show={
+                            <>
+                                <StyledTypography color='textSecondary'>
+                                    Custom strategies
+                                </StyledTypography>
+                                {customStrategies.map((strategy) => (
+                                    <ListItem key={strategy.name}>
+                                        <FeatureStrategyMenuCard
+                                            projectId={projectId}
+                                            featureId={featureId}
+                                            environmentId={environmentId}
+                                            strategy={strategy}
+                                        />
+                                    </ListItem>
+                                ))}
+                            </>
+                        }
                     />
-                </ListItem>
-            ))}
-            <ConditionallyRender
-                condition={customStrategies.length > 0}
-                show={
-                    <>
-                        <StyledTypography color='textSecondary'>
-                            Custom strategies
-                        </StyledTypography>
-                        {customStrategies.map((strategy) => (
-                            <ListItem key={strategy.name}>
-                                <FeatureStrategyMenuCard
-                                    projectId={projectId}
-                                    featureId={featureId}
-                                    environmentId={environmentId}
-                                    strategy={strategy}
-                                />
-                            </ListItem>
-                        ))}
-                    </>
-                }
-            />
+                </>
+            ) : null}
         </List>
     );
 };


### PR DESCRIPTION
Adds a new button to the strategy options on the toggle config pane to be able to add a release plan directly

![image](https://github.com/user-attachments/assets/b0685a8f-0a91-4f75-aacf-83eabc61f5f3)

When clicked this just renders the usual popup but with only the release plans populated.

![image](https://github.com/user-attachments/assets/545455e6-ce6a-4c47-a230-ea172eecd904)
