### PR TITLE
chore: consolidate release plan flags

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -71,13 +71,10 @@ export const FeatureStrategyMenu = ({
         usePendingChangeRequests(projectId);
     const { refetch } = useReleasePlans(projectId, featureId, environmentId);
     const { addReleasePlanToFeature } = useReleasePlansApi();
-    const releasePlanChangeRequestsEnabled = useUiFlag(
-        'releasePlanChangeRequests',
-    );
+    const releasePlansEnabled = useUiFlag('releasePlans');
 
     const crProtected =
-        releasePlanChangeRequestsEnabled &&
-        isChangeRequestConfigured(environmentId);
+        releasePlansEnabled && isChangeRequestConfigured(environmentId);
 
     const onClose = () => {
         setAnchor(undefined);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/LegacyReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/LegacyReleasePlan.tsx
@@ -119,9 +119,7 @@ export const ReleasePlan = ({
     const { refetch: refetchChangeRequests } =
         usePendingChangeRequests(projectId);
 
-    const releasePlanChangeRequestsEnabled = useUiFlag(
-        'releasePlanChangeRequests',
-    );
+    const releasePlansEnabled = useUiFlag('releasePlans');
 
     const onAddRemovePlanChangesConfirm = async () => {
         await addChange(projectId, environment, {
@@ -163,10 +161,7 @@ export const ReleasePlan = ({
     };
 
     const confirmRemoveReleasePlan = () => {
-        if (
-            releasePlanChangeRequestsEnabled &&
-            isChangeRequestConfigured(environment)
-        ) {
+        if (releasePlansEnabled && isChangeRequestConfigured(environment)) {
             setChangeRequestDialogRemoveOpen(true);
         } else {
             setRemoveOpen(true);
@@ -201,10 +196,7 @@ export const ReleasePlan = ({
     };
 
     const onStartMilestone = async (milestone: IReleasePlanMilestone) => {
-        if (
-            releasePlanChangeRequestsEnabled &&
-            isChangeRequestConfigured(environment)
-        ) {
+        if (releasePlansEnabled && isChangeRequestConfigured(environment)) {
             setMilestoneForChangeRequestDialog(milestone);
             setChangeRequestDialogStartMilestoneOpen(true);
         } else {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -122,9 +122,7 @@ export const ReleasePlan = ({
     const { refetch: refetchChangeRequests } =
         usePendingChangeRequests(projectId);
 
-    const releasePlanChangeRequestsEnabled = useUiFlag(
-        'releasePlanChangeRequests',
-    );
+    const releasePlansEnabled = useUiFlag('releasePlans');
 
     const onAddRemovePlanChangesConfirm = async () => {
         await addChange(projectId, environment, {
@@ -166,10 +164,7 @@ export const ReleasePlan = ({
     };
 
     const confirmRemoveReleasePlan = () => {
-        if (
-            releasePlanChangeRequestsEnabled &&
-            isChangeRequestConfigured(environment)
-        ) {
+        if (releasePlansEnabled && isChangeRequestConfigured(environment)) {
             setChangeRequestDialogRemoveOpen(true);
         } else {
             setRemoveOpen(true);
@@ -204,10 +199,7 @@ export const ReleasePlan = ({
     };
 
     const onStartMilestone = async (milestone: IReleasePlanMilestone) => {
-        if (
-            releasePlanChangeRequestsEnabled &&
-            isChangeRequestConfigured(environment)
-        ) {
+        if (releasePlansEnabled && isChangeRequestConfigured(environment)) {
             setMilestoneForChangeRequestDialog(milestone);
             setChangeRequestDialogStartMilestoneOpen(true);
         } else {

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -84,7 +84,6 @@ export type UiFlags = {
     enableLegacyVariants?: boolean;
     flagCreator?: boolean;
     releasePlans?: boolean;
-    releasePlanChangeRequests?: boolean;
     'enterprise-payg'?: boolean;
     productivityReportEmail?: boolean;
     showUserDeviceCount?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -50,7 +50,6 @@ export type IFlagKey =
     | 'originMiddlewareRequestLogging'
     | 'webhookDomainLogging'
     | 'releasePlans'
-    | 'releasePlanChangeRequests'
     | 'productivityReportEmail'
     | 'productivityReportUnsubscribers'
     | 'enterprise-payg'
@@ -252,10 +251,6 @@ const flags: IFlags = {
     ),
     releasePlans: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_RELEASE_PLANS,
-        false,
-    ),
-    releasePlanChangeRequests: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_RELEASE_PLAN_CHANGE_REQUESTS,
         false,
     ),
     productivityReportEmail: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -50,7 +50,6 @@ process.nextTick(async () => {
                         originMiddlewareRequestLogging: true,
                         webhookDomainLogging: true,
                         releasePlans: false,
-                        releasePlanChangeRequests: false,
                         showUserDeviceCount: true,
                         flagOverviewRedesign: true,
                         deltaApi: true,


### PR DESCRIPTION
Removes the `releasePlanChangeRequests` flag and swaps existing references to it to the `releasePlans` flag instead