### PR TITLE
feat: backend for retrieving tag colors

### DIFF
--- a/src/lib/db/feature-tag-store.ts
+++ b/src/lib/db/feature-tag-store.ts
@@ -102,11 +102,18 @@ class FeatureTagStore implements IFeatureTagStore {
         const stopTimer = this.timer('getAllForFeature');
         if (await this.featureExists(featureName)) {
             const rows = await this.db
-                .select(COLUMNS)
+                .select([...COLUMNS, 'tag_types.color as color'])
                 .from<FeatureTagTable>(TABLE)
+                .leftJoin('tag_types', 'tag_types.name', 'feature_tag.tag_type')
                 .where({ feature_name: featureName });
+
             stopTimer();
-            return rows.map(this.featureTagRowToTag);
+
+            return rows.map((row) => ({
+                type: row.tag_type,
+                value: row.tag_value,
+                color: row.color,
+            }));
         } else {
             throw new NotFoundError(
                 `Could not find feature with name ${featureName}`,

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -134,6 +134,7 @@ class FeatureSearchStore implements IFeatureSearchStore {
                     'environments.sort_order as environment_sort_order',
                     'ft.tag_value as tag_value',
                     'ft.tag_type as tag_type',
+                    'tag_types.color as tag_type_color',
                     'segments.name as segment_name',
                     'users.id as user_id',
                     'users.name as user_name',
@@ -207,6 +208,7 @@ class FeatureSearchStore implements IFeatureSearchStore {
                         'ft.feature_name',
                         'features.name',
                     )
+                    .leftJoin('tag_types', 'tag_types.name', 'ft.tag_type')
                     .leftJoin(
                         'feature_strategies',
                         'feature_strategies.feature_name',
@@ -548,6 +550,7 @@ class FeatureSearchStore implements IFeatureSearchStore {
         return {
             value: r.tag_value,
             type: r.tag_type,
+            color: r.tag_type_color,
         };
     }
 

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1252,3 +1252,39 @@ test('should return archived when query param set', async () => {
         ],
     });
 });
+
+test('should return tags with color information from tag type', async () => {
+    await app.createFeature('my_feature_a');
+
+    await app.request
+        .put('/api/admin/tag-types/simple')
+        .send({
+            name: 'simple',
+            description: 'Simple tag type',
+            icon: 'tag',
+            color: '#FF0000',
+        })
+        .expect(200);
+
+    await app.addTag('my_feature_a', {
+        type: 'simple',
+        value: 'my_tag',
+    });
+
+    const { body } = await searchFeatures({});
+
+    expect(body).toMatchObject({
+        features: [
+            {
+                name: 'my_feature_a',
+                tags: [
+                    {
+                        type: 'simple',
+                        value: 'my_tag',
+                        color: '#FF0000',
+                    },
+                ],
+            },
+        ],
+    });
+});

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1260,8 +1260,6 @@ test('should return tags with color information from tag type', async () => {
         .put('/api/admin/tag-types/simple')
         .send({
             name: 'simple',
-            description: 'Simple tag type',
-            icon: 'tag',
             color: '#FF0000',
         })
         .expect(200);

--- a/src/lib/openapi/spec/deprecated-project-overview-schema.ts
+++ b/src/lib/openapi/spec/deprecated-project-overview-schema.ts
@@ -13,6 +13,7 @@ import { projectEnvironmentSchema } from './project-environment-schema';
 import { createStrategyVariantSchema } from './create-strategy-variant-schema';
 import { strategyVariantSchema } from './strategy-variant-schema';
 import { createFeatureNamingPatternSchema } from './create-feature-naming-pattern-schema';
+import { tagSchema } from './tag-schema';
 
 export const deprecatedProjectOverviewSchema = {
     $id: '#/components/schemas/deprecatedProjectOverviewSchema',
@@ -144,6 +145,7 @@ export const deprecatedProjectOverviewSchema = {
             variantSchema,
             projectStatsSchema,
             createFeatureNamingPatternSchema,
+            tagSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/health-overview-schema.ts
+++ b/src/lib/openapi/spec/health-overview-schema.ts
@@ -13,6 +13,7 @@ import { projectEnvironmentSchema } from './project-environment-schema';
 import { createStrategyVariantSchema } from './create-strategy-variant-schema';
 import { strategyVariantSchema } from './strategy-variant-schema';
 import { createFeatureNamingPatternSchema } from './create-feature-naming-pattern-schema';
+import { tagSchema } from './tag-schema';
 
 export const healthOverviewSchema = {
     $id: '#/components/schemas/healthOverviewSchema',
@@ -138,6 +139,7 @@ export const healthOverviewSchema = {
             variantSchema,
             projectStatsSchema,
             createFeatureNamingPatternSchema,
+            tagSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/tag-schema.ts
+++ b/src/lib/openapi/spec/tag-schema.ts
@@ -24,6 +24,13 @@ export const tagSchema = {
                 'The [type](https://docs.getunleash.io/reference/feature-toggles#tags) of the tag',
             example: 'simple',
         },
+        color: {
+            type: 'string',
+            description: 'The hexadecimal color code for the tag type.',
+            example: '#FFFFFF',
+            pattern: '^#[0-9A-Fa-f]{6}$',
+            nullable: true,
+        },
     },
     components: {},
 } as const;

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -353,6 +353,7 @@ export interface IFeatureToggleDeltaQuery extends IFeatureToggleQuery {
 export interface ITag {
     value: string;
     type: string;
+    color?: string | null;
 }
 
 export interface IAddonParameterDefinition {

--- a/src/test/e2e/api/admin/tags.e2e.test.ts
+++ b/src/test/e2e/api/admin/tags.e2e.test.ts
@@ -226,9 +226,10 @@ test('backward compatibility: the API should return invalid tag names if they ex
 
 test('should include tag color information when getting feature tags', async () => {
     const featureName = 'test.feature.with.color';
+    const tagType = 'simple';
     const tag = {
         value: 'TeamRed',
-        type: 'simple',
+        type: tagType,
     };
 
     await app.request.post('/api/admin/projects/default/features').send({
@@ -239,11 +240,9 @@ test('should include tag color information when getting feature tags', async () 
     });
 
     await app.request
-        .put('/api/admin/tag-types/simple')
+        .put(`/api/admin/tag-types/${tagType}`)
         .send({
-            name: 'simple',
-            description: 'Simple tag type',
-            icon: 'tag',
+            name: tagType,
             color: '#FF0000',
         })
         .expect(200);

--- a/src/test/e2e/stores/feature-tag-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-tag-store.e2e.test.ts
@@ -45,7 +45,7 @@ test('should tag feature', async () => {
         createdByUserId: TESTUSERID,
     });
     expect(featureTags).toHaveLength(1);
-    expect(featureTags[0]).toStrictEqual(tag);
+    expect(featureTags[0]).toStrictEqual({ ...tag, color: '#FFFFFF' });
     expect(featureTag!.featureName).toBe(featureName);
     expect(featureTag!.tagValue).toBe(tag.value);
 });

--- a/src/test/e2e/stores/feature-tag-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-tag-store.e2e.test.ts
@@ -13,6 +13,7 @@ let featureToggleStore: IFeatureToggleStore;
 const featureName = 'test-tag';
 const tag = { type: 'simple', value: 'test' };
 const TESTUSERID = 3333;
+const DEFAULT_TAG_COLOR = '#FFFFFF';
 
 beforeAll(async () => {
     db = await dbInit('feature_tag_store_serial', getLogger);
@@ -45,7 +46,7 @@ test('should tag feature', async () => {
         createdByUserId: TESTUSERID,
     });
     expect(featureTags).toHaveLength(1);
-    expect(featureTags[0]).toStrictEqual({ ...tag, color: '#FFFFFF' });
+    expect(featureTags[0]).toStrictEqual({ ...tag, color: DEFAULT_TAG_COLOR });
     expect(featureTag!.featureName).toBe(featureName);
     expect(featureTag!.tagValue).toBe(tag.value);
 });


### PR DESCRIPTION
# Add tag color support to feature tags

## Description
This PR adds support for including tag color information when retrieving feature tags. The color information is propagated from the tag type to the feature tags, allowing the UI to display tags with their associated colors.

## Changes
1. **Schema Updates**
   - Updated `tag-schema.ts` to include color information in the tag schema
   - Added tagSchema to schemas already using tagSchema but lacking the component import

2. **Store Updates**
   - Modified `FeatureTagStore` to join with the `tag_types` table when retrieving feature tags and retrieve color
   - Updated `getAllTagsForFeature` method to include color information from tag types

3. **Test Updates**
   - Added new test case in `tags.e2e.test.ts` to verify color information propagation
   - Added new test case in  `feature.search.e2e.test.ts` to verify color information propagation

## Related
This change enables the UI to display tags with their associated colors, improving the visual organization and categorization of features.