### PR TITLE
feat: admin menu

### DIFF
--- a/frontend/src/component/admin/Admin.tsx
+++ b/frontend/src/component/admin/Admin.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import { ApiTokenPage } from './apiToken/ApiTokenPage/ApiTokenPage';
 import { CreateApiToken } from './apiToken/CreateApiToken/CreateApiToken';
 import { AuthSettings } from './auth/AuthSettings';
+import { OldAuthSettings } from './auth/OldAuthSettings';
 import { Billing } from './billing/Billing';
 import FlaggedBillingRedirect from './billing/FlaggedBillingRedirect/FlaggedBillingRedirect';
 import { CorsAdmin } from './cors';
@@ -47,7 +48,11 @@ export const Admin = () => {
                 <Route path='banners' element={<Banners />} />
                 <Route path='license' element={<License />} />
                 <Route path='cors' element={<CorsAdmin />} />
-                <Route path='auth' element={<AuthSettings />} />
+                {newAdminUIEnabled ? (
+                    <Route path='auth/*' element={<AuthSettings />} />
+                ) : (
+                    <Route path='auth' element={<OldAuthSettings />} />
+                )}
                 <Route
                     path='admin-invoices'
                     element={<FlaggedBillingRedirect />}

--- a/frontend/src/component/admin/AdminIndex.tsx
+++ b/frontend/src/component/admin/AdminIndex.tsx
@@ -1,7 +1,7 @@
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import type { VFC } from 'react';
-import { adminGroups } from './adminRoutes';
+import { adminGroups } from './oldAdminRoutes';
 import type { INavigationMenuItem } from 'interfaces/route';
 import { Box, Link, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';

--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -3,25 +3,24 @@ import type { INavigationMenuItem } from 'interfaces/route';
 export const adminGroups: Record<string, string> = {
     users: 'User administration',
     access: 'Access control',
+    sso: 'Single sign-on',
+    network: 'Network',
     instance: 'Instance configuration',
-    log: 'Logs',
-    other: 'Other',
 };
 
 export const adminRoutes: INavigationMenuItem[] = [
+    // Admin home
+    {
+        path: '/admin',
+        title: 'Admin home',
+        menu: {},
+    },
+
+    // Users
     {
         path: '/admin/users',
         title: 'Users',
         menu: { adminSettings: true },
-        group: 'users',
-    },
-    {
-        path: '/admin/service-accounts',
-        title: 'Service accounts',
-        menu: {
-            adminSettings: true,
-            mode: ['enterprise'],
-        },
         group: 'users',
     },
     {
@@ -34,14 +33,44 @@ export const adminRoutes: INavigationMenuItem[] = [
         group: 'users',
     },
     {
-        path: '/admin/roles/*',
-        title: 'Roles',
+        path: '/admin/roles',
+        title: 'Root roles',
         menu: {
             adminSettings: true,
             mode: ['enterprise'],
         },
         group: 'users',
     },
+    {
+        path: '/admin/roles/project-roles',
+        title: 'Project roles',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'users',
+    },
+    {
+        path: '/admin/logins',
+        title: 'Login history',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'users',
+    },
+
+    // Service accounts
+    {
+        path: '/admin/service-accounts',
+        title: 'Service accounts',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+    },
+
+    // Access control
     {
         path: '/admin/api',
         title: 'API access',
@@ -55,18 +84,73 @@ export const adminRoutes: INavigationMenuItem[] = [
         menu: { adminSettings: true },
         group: 'access',
     },
+
+    // Single sign-on/login
     {
         path: '/admin/auth',
-        title: 'Single sign-on',
+        title: 'Open ID Connect',
         menu: { adminSettings: true, mode: ['enterprise'] },
-        group: 'access',
+        group: 'sso',
     },
     {
-        path: '/admin/network/*',
-        title: 'Network',
-        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
-        group: 'instance',
+        path: '/admin/auth/saml',
+        title: 'SAML 2.0',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        group: 'sso',
     },
+    {
+        path: '/admin/auth/password',
+        title: 'Password login',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        group: 'sso',
+    },
+    {
+        path: '/admin/auth/google',
+        title: 'Google',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        flag: 'googleAuthEnabled',
+        group: 'sso',
+    },
+    {
+        path: '/admin/auth/scim',
+        title: 'SCIM',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        group: 'sso',
+    },
+
+    // Network
+    {
+        path: '/admin/network',
+        title: 'Overview',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'network',
+    },
+    {
+        path: '/admin/network/traffic',
+        title: 'Traffic',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'network',
+    },
+    {
+        path: '/admin/network/connected-edges',
+        title: 'Connected edges',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'network',
+    },
+    {
+        path: '/admin/network/backend-connections',
+        title: 'Backend connections',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'network',
+    },
+    {
+        path: '/admin/network/frontend-data-usage',
+        title: 'Frontend data usage',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'network',
+    },
+
+    // Instance configuration
     {
         path: '/admin/maintenance',
         title: 'Maintenance',
@@ -80,16 +164,16 @@ export const adminRoutes: INavigationMenuItem[] = [
         group: 'instance',
     },
     {
-        path: '/admin/instance',
-        title: 'Instance stats',
-        menu: { adminSettings: true },
-        group: 'instance',
-    },
-    {
         path: '/admin/license',
         title: 'License',
         menu: { adminSettings: true, mode: ['enterprise'] },
         flag: 'enableLicense',
+        group: 'instance',
+    },
+    {
+        path: '/admin/instance',
+        title: 'Instance stats',
+        menu: { adminSettings: true },
         group: 'instance',
     },
     {
@@ -98,25 +182,18 @@ export const adminRoutes: INavigationMenuItem[] = [
         menu: { adminSettings: true },
         group: 'instance',
     },
+
+    // Billing
     {
-        path: '/admin/admin-invoices',
+        path: '/admin/billing',
         title: 'Billing & invoices',
         menu: { adminSettings: true, billing: true },
-        group: 'instance',
     },
-    {
-        path: '/admin/logins',
-        title: 'Login history',
-        menu: {
-            adminSettings: true,
-            mode: ['enterprise'],
-        },
-        group: 'log',
-    },
+
+    // Event log
     {
         path: '/history',
         title: 'Event log',
         menu: { adminSettings: true },
-        group: 'log',
     },
 ];

--- a/frontend/src/component/admin/auth/AuthSettings.tsx
+++ b/frontend/src/component/admin/auth/AuthSettings.tsx
@@ -1,4 +1,4 @@
-import { Tab, Tabs } from '@mui/material';
+import {} from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { OidcAuth } from './OidcAuth/OidcAuth';
@@ -9,40 +9,42 @@ import { GoogleAuth } from './GoogleAuth/GoogleAuth';
 import { PermissionGuard } from 'component/common/PermissionGuard/PermissionGuard';
 import { ADMIN, UPDATE_AUTH_CONFIGURATION } from '@server/types/permissions';
 import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
-import { useState } from 'react';
-import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { usePageTitle } from 'hooks/usePageTitle';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 export const AuthSettings = () => {
-    const { uiConfig, isEnterprise } = useUiConfig();
+    const { isEnterprise } = useUiConfig();
+    const googleAuthEnabled = useUiFlag('googleAuthEnabled');
 
     const tabs = [
         {
-            label: 'OpenID Connect',
-            component: <OidcAuth />,
+            label: 'Single sign-on: OpenID Connect',
+            path: '/admin/auth',
         },
         {
-            label: 'SAML 2.0',
-            component: <SamlAuth />,
+            label: 'Single sign-on: SAML 2.0',
+            path: '/admin/auth/saml',
         },
         {
-            label: 'Password',
-            component: <PasswordAuth />,
+            label: 'Password login',
+            path: '/admin/auth/password',
         },
         {
-            label: 'Google',
-            component: <GoogleAuth />,
+            label: 'Single sign-on: Google',
+            path: '/admin/auth/google',
         },
         {
-            label: 'SCIM',
-            component: <ScimSettings />,
+            label: 'Single sign-on: SCIM',
+            path: '/admin/auth/scim',
         },
-    ].filter(
-        (item) => uiConfig.flags?.googleAuthEnabled || item.label !== 'Google',
-    );
+    ];
+    const { pathname } = useLocation();
+    const activeTab =
+        tabs.find((tab) => pathname === tab.path)?.label ||
+        'Single sign-on: OpenID Connect';
 
-    const [activeTab, setActiveTab] = useState(0);
-    usePageTitle(`Single sign-on: ${tabs[activeTab].label}`);
+    usePageTitle(activeTab);
 
     if (!isEnterprise()) {
         return <PremiumFeature feature='sso' page />;
@@ -51,44 +53,16 @@ export const AuthSettings = () => {
     return (
         <div>
             <PermissionGuard permissions={[ADMIN, UPDATE_AUTH_CONFIGURATION]}>
-                <PageContent
-                    withTabs
-                    header={
-                        <Tabs
-                            value={activeTab}
-                            onChange={(_, tabId) => {
-                                setActiveTab(tabId);
-                            }}
-                            indicatorColor='primary'
-                            textColor='primary'
-                        >
-                            {tabs.map((tab, index) => (
-                                <Tab
-                                    key={`${tab.label}_${index}`}
-                                    label={tab.label}
-                                    id={`tab-${index}`}
-                                    aria-controls={`tabpanel-${index}`}
-                                    sx={{
-                                        minWidth: {
-                                            lg: 160,
-                                        },
-                                    }}
-                                />
-                            ))}
-                        </Tabs>
-                    }
-                >
-                    <div>
-                        {tabs.map((tab, index) => (
-                            <TabPanel
-                                key={index}
-                                value={activeTab}
-                                index={index}
-                            >
-                                {tab.component}
-                            </TabPanel>
-                        ))}
-                    </div>
+                <PageContent header={activeTab}>
+                    <Routes>
+                        <Route path='/' element={<OidcAuth />} />
+                        <Route path='/saml' element={<SamlAuth />} />
+                        <Route path='/password' element={<PasswordAuth />} />
+                        {googleAuthEnabled && (
+                            <Route path='/google' element={<GoogleAuth />} />
+                        )}
+                        <Route path='/scim' element={<ScimSettings />} />
+                    </Routes>
                 </PageContent>
             </PermissionGuard>
         </div>

--- a/frontend/src/component/admin/auth/OldAuthSettings.tsx
+++ b/frontend/src/component/admin/auth/OldAuthSettings.tsx
@@ -1,0 +1,96 @@
+import { Tab, Tabs } from '@mui/material';
+import { PageContent } from 'component/common/PageContent/PageContent';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { OidcAuth } from './OidcAuth/OidcAuth';
+import { SamlAuth } from './SamlAuth/SamlAuth';
+import { ScimSettings } from './ScimSettings/ScimSettings';
+import { PasswordAuth } from './PasswordAuth/PasswordAuth';
+import { GoogleAuth } from './GoogleAuth/GoogleAuth';
+import { PermissionGuard } from 'component/common/PermissionGuard/PermissionGuard';
+import { ADMIN, UPDATE_AUTH_CONFIGURATION } from '@server/types/permissions';
+import { PremiumFeature } from 'component/common/PremiumFeature/PremiumFeature';
+import { useState } from 'react';
+import { TabPanel } from 'component/common/TabNav/TabPanel/TabPanel';
+import { usePageTitle } from 'hooks/usePageTitle';
+
+export const OldAuthSettings = () => {
+    const { uiConfig, isEnterprise } = useUiConfig();
+
+    const tabs = [
+        {
+            label: 'OpenID Connect',
+            component: <OidcAuth />,
+        },
+        {
+            label: 'SAML 2.0',
+            component: <SamlAuth />,
+        },
+        {
+            label: 'Password',
+            component: <PasswordAuth />,
+        },
+        {
+            label: 'Google',
+            component: <GoogleAuth />,
+        },
+        {
+            label: 'SCIM',
+            component: <ScimSettings />,
+        },
+    ].filter(
+        (item) => uiConfig.flags?.googleAuthEnabled || item.label !== 'Google',
+    );
+
+    const [activeTab, setActiveTab] = useState(0);
+    usePageTitle(`Single sign-on: ${tabs[activeTab].label}`);
+
+    if (!isEnterprise()) {
+        return <PremiumFeature feature='sso' page />;
+    }
+
+    return (
+        <div>
+            <PermissionGuard permissions={[ADMIN, UPDATE_AUTH_CONFIGURATION]}>
+                <PageContent
+                    withTabs
+                    header={
+                        <Tabs
+                            value={activeTab}
+                            onChange={(_, tabId) => {
+                                setActiveTab(tabId);
+                            }}
+                            indicatorColor='primary'
+                            textColor='primary'
+                        >
+                            {tabs.map((tab, index) => (
+                                <Tab
+                                    key={`${tab.label}_${index}`}
+                                    label={tab.label}
+                                    id={`tab-${index}`}
+                                    aria-controls={`tabpanel-${index}`}
+                                    sx={{
+                                        minWidth: {
+                                            lg: 160,
+                                        },
+                                    }}
+                                />
+                            ))}
+                        </Tabs>
+                    }
+                >
+                    <div>
+                        {tabs.map((tab, index) => (
+                            <TabPanel
+                                key={index}
+                                value={activeTab}
+                                index={index}
+                            >
+                                {tab.component}
+                            </TabPanel>
+                        ))}
+                    </div>
+                </PageContent>
+            </PermissionGuard>
+        </div>
+    );
+};

--- a/frontend/src/component/admin/oldAdminRoutes.ts
+++ b/frontend/src/component/admin/oldAdminRoutes.ts
@@ -1,0 +1,122 @@
+import type { INavigationMenuItem } from 'interfaces/route';
+
+export const adminGroups: Record<string, string> = {
+    users: 'User administration',
+    access: 'Access control',
+    instance: 'Instance configuration',
+    log: 'Logs',
+    other: 'Other',
+};
+
+export const adminRoutes: INavigationMenuItem[] = [
+    {
+        path: '/admin/users',
+        title: 'Users',
+        menu: { adminSettings: true },
+        group: 'users',
+    },
+    {
+        path: '/admin/service-accounts',
+        title: 'Service accounts',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'users',
+    },
+    {
+        path: '/admin/groups',
+        title: 'Groups',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'users',
+    },
+    {
+        path: '/admin/roles/*',
+        title: 'Roles',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'users',
+    },
+    {
+        path: '/admin/api',
+        title: 'API access',
+        menu: { adminSettings: true },
+        group: 'access',
+    },
+    {
+        path: '/admin/cors',
+        title: 'CORS origins',
+        flag: 'embedProxyFrontend',
+        menu: { adminSettings: true },
+        group: 'access',
+    },
+    {
+        path: '/admin/auth',
+        title: 'Single sign-on',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        group: 'access',
+    },
+    {
+        path: '/admin/network/*',
+        title: 'Network',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        group: 'instance',
+    },
+    {
+        path: '/admin/maintenance',
+        title: 'Maintenance',
+        menu: { adminSettings: true },
+        group: 'instance',
+    },
+    {
+        path: '/admin/banners',
+        title: 'Banners',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        group: 'instance',
+    },
+    {
+        path: '/admin/instance',
+        title: 'Instance stats',
+        menu: { adminSettings: true },
+        group: 'instance',
+    },
+    {
+        path: '/admin/license',
+        title: 'License',
+        menu: { adminSettings: true, mode: ['enterprise'] },
+        flag: 'enableLicense',
+        group: 'instance',
+    },
+    {
+        path: '/admin/instance-privacy',
+        title: 'Instance privacy',
+        menu: { adminSettings: true },
+        group: 'instance',
+    },
+    {
+        path: '/admin/admin-invoices',
+        title: 'Billing & invoices',
+        menu: { adminSettings: true, billing: true },
+        group: 'instance',
+    },
+    {
+        path: '/admin/logins',
+        title: 'Login history',
+        menu: {
+            adminSettings: true,
+            mode: ['enterprise'],
+        },
+        group: 'log',
+    },
+    {
+        path: '/history',
+        title: 'Event log',
+        menu: { adminSettings: true },
+        group: 'log',
+    },
+];

--- a/frontend/src/component/admin/useAdminRoutes.ts
+++ b/frontend/src/component/admin/useAdminRoutes.ts
@@ -1,5 +1,5 @@
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { adminRoutes } from './adminRoutes';
+import { adminRoutes } from './oldAdminRoutes';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
 import { filterAdminRoutes } from './filterAdminRoutes';
 import { filterByConfig, mapRouteLink } from 'component/common/util';

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
@@ -1,0 +1,166 @@
+import {
+    ListItem,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Typography,
+    styled,
+    Accordion,
+    AccordionSummary,
+    AccordionDetails,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import type { FC, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import type { Theme } from '@mui/material/styles/createTheme';
+
+const listItemButtonStyle = (theme: Theme) => ({
+    borderRadius: theme.spacing(0.5),
+    borderLeft: `${theme.spacing(0.5)} solid transparent`,
+    m: 0,
+    '&.Mui-selected': {
+        borderLeft: `${theme.spacing(0.5)} solid ${theme.palette.primary.main}`,
+    },
+    minHeight: '0px',
+    '.MuiAccordionSummary-content': { margin: 0 },
+    '&>.MuiAccordionSummary-content.MuiAccordionSummary-content': {
+        margin: '0',
+        alignItems: 'center',
+        padding: theme.spacing(0.5, 0),
+    },
+});
+
+const subListItemButtonStyle = (theme: Theme) => ({
+    paddingLeft: theme.spacing(4),
+    borderRadius: theme.spacing(0.5),
+    borderLeft: `${theme.spacing(0.5)} solid transparent`,
+    m: 0,
+    '&.Mui-selected': {
+        borderLeft: `${theme.spacing(0.5)} solid ${theme.palette.primary.main}`,
+    },
+});
+
+const CappedText = styled(Typography)({
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    width: '100%',
+});
+
+const StyledListItemIcon = styled(ListItemIcon)(({ theme }) => ({
+    minWidth: theme.spacing(4),
+    margin: theme.spacing(0.25, 0),
+}));
+
+const StyledListItemText = styled(ListItemText)(({ theme }) => ({
+    margin: 0,
+}));
+
+const StyledAccordion = styled(Accordion)(({ theme }) => ({
+    paddingTop: theme.spacing(0),
+}));
+
+const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
+    '&:hover': {
+        backgroundColor: theme.palette.action.hover,
+    },
+}));
+
+interface IMenuGroupProps {
+    title: string;
+    children: ReactNode;
+    icon: ReactNode;
+    activeIcon: ReactNode;
+    isActiveMenu: boolean;
+}
+
+export const MenuGroup = ({
+    title,
+    children,
+    icon,
+    activeIcon,
+    isActiveMenu,
+}: IMenuGroupProps) => {
+    return (
+        <StyledAccordion
+            disableGutters={true}
+            sx={{
+                boxShadow: 'none',
+                '&:before': {
+                    display: 'none',
+                },
+            }}
+        >
+            <StyledAccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls='configure-content'
+                id='configure-header'
+                sx={listItemButtonStyle}
+            >
+                <StyledListItemIcon>
+                    {isActiveMenu ? activeIcon : icon}
+                </StyledListItemIcon>
+                <StyledListItemText>
+                    <CappedText
+                        sx={{ fontWeight: isActiveMenu ? 'bold' : 'normal' }}
+                    >
+                        {title}
+                    </CappedText>
+                </StyledListItemText>
+            </StyledAccordionSummary>
+            <AccordionDetails sx={{ p: 0 }}>{children}</AccordionDetails>
+        </StyledAccordion>
+    );
+};
+
+export const AdminListItem: FC<{
+    href: string;
+    text: string;
+    badge?: ReactNode;
+    selected?: boolean;
+    children?: React.ReactNode;
+}> = ({ href, text, badge, selected, children }) => {
+    return (
+        <ListItem disablePadding>
+            <ListItemButton
+                dense={true}
+                component={Link}
+                to={href}
+                sx={listItemButtonStyle}
+                selected={selected}
+            >
+                <StyledListItemIcon>{children}</StyledListItemIcon>
+                <StyledListItemText>
+                    <CappedText>{text}</CappedText>
+                </StyledListItemText>
+                {badge}
+            </ListItemButton>
+        </ListItem>
+    );
+};
+
+export const AdminSubListItem: FC<{
+    href: string;
+    text: string;
+    badge?: ReactNode;
+    selected?: boolean;
+    children?: React.ReactNode;
+}> = ({ href, text, badge, selected, children }) => {
+    return (
+        <ListItem disablePadding>
+            <ListItemButton
+                dense={true}
+                component={Link}
+                to={href}
+                sx={subListItemButtonStyle}
+                selected={selected}
+            >
+                <StyledListItemIcon>{children}</StyledListItemIcon>
+                <StyledListItemText>
+                    <CappedText>{text}</CappedText>
+                </StyledListItemText>
+                {badge}
+            </ListItemButton>
+        </ListItem>
+    );
+};

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
@@ -119,7 +119,8 @@ export const AdminListItem: FC<{
     badge?: ReactNode;
     selected?: boolean;
     children?: React.ReactNode;
-}> = ({ href, text, badge, selected, children }) => {
+    onClick: () => void;
+}> = ({ href, text, badge, selected, children, onClick }) => {
     return (
         <ListItem disablePadding>
             <ListItemButton
@@ -128,6 +129,7 @@ export const AdminListItem: FC<{
                 to={href}
                 sx={listItemButtonStyle}
                 selected={selected}
+                onClick={onClick}
             >
                 <StyledListItemIcon>{children}</StyledListItemIcon>
                 <StyledListItemText>
@@ -145,7 +147,8 @@ export const AdminSubListItem: FC<{
     badge?: ReactNode;
     selected?: boolean;
     children?: React.ReactNode;
-}> = ({ href, text, badge, selected, children }) => {
+    onClick: () => void;
+}> = ({ href, text, badge, selected, children, onClick }) => {
     return (
         <ListItem disablePadding>
             <ListItemButton
@@ -154,6 +157,7 @@ export const AdminSubListItem: FC<{
                 to={href}
                 sx={subListItemButtonStyle}
                 selected={selected}
+                onClick={onClick}
             >
                 <StyledListItemIcon>{children}</StyledListItemIcon>
                 <StyledListItemText>

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -1,4 +1,13 @@
-import { Grid, styled, Paper, Typography, Button, List } from '@mui/material';
+import {
+    Grid,
+    styled,
+    Paper,
+    Typography,
+    Button,
+    List,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import { useUiFlag } from 'hooks/useUiFlag';
 import type { ReactNode } from 'react';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -106,10 +115,14 @@ interface IWrapIfAdminSubpageProps {
 
 export const WrapIfAdminSubpage = ({ children }: IWrapIfAdminSubpageProps) => {
     const newAdminUIEnabled = useUiFlag('adminNavUI');
-    const showOnlyAdminMenu =
-        newAdminUIEnabled && location.pathname.indexOf('/admin') === 0;
+    const theme = useTheme();
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
+    const showAdminMenu =
+        !isSmallScreen &&
+        newAdminUIEnabled &&
+        location.pathname.indexOf('/admin') === 0;
 
-    if (showOnlyAdminMenu) {
+    if (showAdminMenu) {
         return <AdminMenu>{children}</AdminMenu>;
     }
 
@@ -136,6 +149,8 @@ interface IAdminMenuProps {
 
 export const AdminMenu = ({ children }: IAdminMenuProps) => {
     const isActiveItem = (item: string) => location.pathname === item;
+    const theme = useTheme();
+    const isBreakpoint = useMediaQuery(theme.breakpoints.down(1350));
     const onClick = () => {
         scrollTo({
             top: 0,
@@ -280,7 +295,7 @@ export const AdminMenu = ({ children }: IAdminMenuProps) => {
                         </StyledMenuPaper>
                     </StickyContainer>
                 </Grid>
-                <Grid item md={9}>
+                <Grid item md={isBreakpoint ? true : 9}>
                     {children}
                 </Grid>
             </StyledAdminMainGrid>

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -185,78 +185,74 @@ export const AdminMenu = ({ children }: IAdminMenuProps) => {
     const items = Object.values(menuStructure);
 
     return (
-        <>
-            <StyledAdminMainGrid container spacing={1}>
-                <Grid item>
-                    <StickyContainer>
-                        <StyledMenuPaper>
-                            <SettingsHeader>Admin settings</SettingsHeader>
-                            <DashboardLink />
-                            <List>
-                                {items.map((item) => {
-                                    if (item.items) {
-                                        const isActiveMenu = item.items.find(
-                                            (itm) => isActiveItem(itm.href),
-                                        );
-                                        return (
-                                            <MenuGroup
-                                                title={item.text}
-                                                icon={
-                                                    <IconRenderer
-                                                        path={item.href}
-                                                        active={false}
-                                                    />
-                                                }
-                                                activeIcon={
-                                                    <IconRenderer
-                                                        path={item.href}
-                                                        active={true}
-                                                    />
-                                                }
-                                                isActiveMenu={Boolean(
-                                                    isActiveMenu,
-                                                )}
-                                                key={item.text}
-                                            >
-                                                {item.items.map((subItem) => (
-                                                    <AdminSubListItem
-                                                        href={subItem.href}
-                                                        text={subItem.text}
-                                                        selected={isActiveItem(
-                                                            subItem.href,
-                                                        )}
-                                                        onClick={onClick}
-                                                        key={subItem.href}
-                                                    >
-                                                        <StyledStopRoundedIcon />
-                                                    </AdminSubListItem>
-                                                ))}
-                                            </MenuGroup>
-                                        );
-                                    }
-                                    return (
-                                        <AdminListItem
-                                            href={item.href}
-                                            text={item.text}
-                                            selected={isActiveItem(item.href)}
-                                            onClick={onClick}
-                                            key={item.href}
-                                        >
-                                            <IconRenderer
-                                                path={item.href}
-                                                active={false}
-                                            />
-                                        </AdminListItem>
+        <StyledAdminMainGrid container spacing={1}>
+            <Grid item>
+                <StickyContainer>
+                    <StyledMenuPaper>
+                        <SettingsHeader>Admin settings</SettingsHeader>
+                        <DashboardLink />
+                        <List>
+                            {items.map((item) => {
+                                if (item.items) {
+                                    const isActiveMenu = item.items.find(
+                                        (itm) => isActiveItem(itm.href),
                                     );
-                                })}
-                            </List>
-                        </StyledMenuPaper>
-                    </StickyContainer>
-                </Grid>
-                <Grid item md={isBreakpoint ? true : 9}>
-                    {children}
-                </Grid>
-            </StyledAdminMainGrid>
-        </>
+                                    return (
+                                        <MenuGroup
+                                            title={item.text}
+                                            icon={
+                                                <IconRenderer
+                                                    path={item.href}
+                                                    active={false}
+                                                />
+                                            }
+                                            activeIcon={
+                                                <IconRenderer
+                                                    path={item.href}
+                                                    active={true}
+                                                />
+                                            }
+                                            isActiveMenu={Boolean(isActiveMenu)}
+                                            key={item.text}
+                                        >
+                                            {item.items.map((subItem) => (
+                                                <AdminSubListItem
+                                                    href={subItem.href}
+                                                    text={subItem.text}
+                                                    selected={isActiveItem(
+                                                        subItem.href,
+                                                    )}
+                                                    onClick={onClick}
+                                                    key={subItem.href}
+                                                >
+                                                    <StyledStopRoundedIcon />
+                                                </AdminSubListItem>
+                                            ))}
+                                        </MenuGroup>
+                                    );
+                                }
+                                return (
+                                    <AdminListItem
+                                        href={item.href}
+                                        text={item.text}
+                                        selected={isActiveItem(item.href)}
+                                        onClick={onClick}
+                                        key={item.href}
+                                    >
+                                        <IconRenderer
+                                            path={item.href}
+                                            active={false}
+                                        />
+                                    </AdminListItem>
+                                );
+                            })}
+                        </List>
+                    </StyledMenuPaper>
+                </StickyContainer>
+            </Grid>
+            <Grid item md={isBreakpoint ? true : 9}>
+                {children}
+            </Grid>
+        </StyledAdminMainGrid>
     );
 };

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -144,9 +144,9 @@ export const AdminMenu = ({ children }: IAdminMenuProps) => {
 
     const ssoItems = [
         { href: '/admin/auth', text: 'OpenID Connect' },
-        { href: '/admin/auth', text: 'SAML 2.0' },
-        { href: '/admin/auth', text: 'Password' },
-        { href: '/admin/auth', text: 'SCIM' },
+        { href: '/admin/auth/saml', text: 'SAML 2.0' },
+        { href: '/admin/auth/password', text: 'Password' },
+        { href: '/admin/auth/scim', text: 'SCIM' },
     ];
 
     const networkItems = [

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -13,6 +13,7 @@ import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import { AdminListItem, AdminSubListItem, MenuGroup } from './AdminListItem';
 import { useLocation } from 'react-router-dom';
+import { Sticky } from 'component/common/Sticky/Sticky';
 
 const StyledAdminMainGrid = styled(Grid)(({ theme }) => ({
     minWidth: 0, // this is a fix for overflowing flex
@@ -49,6 +50,14 @@ const StyledMenuPaper = styled(Paper)(({ theme }) => ({
     marginTop: theme.spacing(6.5),
     borderRadius: `${theme.shape.borderRadiusLarge}px`,
     boxShadow: 'none',
+}));
+
+const StickyContainer = styled(Sticky)(({ theme }) => ({
+    position: 'sticky',
+    top: 0,
+    zIndex: theme.zIndex.sticky,
+    background: theme.palette.background.application,
+    transition: 'padding 0.3s ease',
 }));
 
 const SettingsHeader = styled(Typography)(({ theme }) => ({
@@ -127,6 +136,12 @@ interface IAdminMenuProps {
 
 export const AdminMenu = ({ children }: IAdminMenuProps) => {
     const isActiveItem = (item: string) => location.pathname === item;
+    const onClick = () => {
+        scrollTo({
+            top: 0,
+            behavior: 'smooth',
+        });
+    };
     const location = useLocation();
 
     const userAdmItems = [
@@ -215,49 +230,55 @@ export const AdminMenu = ({ children }: IAdminMenuProps) => {
         <>
             <StyledAdminMainGrid container spacing={1}>
                 <Grid item>
-                    <StyledMenuPaper>
-                        <SettingsHeader>Admin settings</SettingsHeader>
-                        <DashboardLink />
-                        <List>
-                            {items.map((item) => {
-                                if (item.items) {
-                                    const isActiveMenu = item.items.find(
-                                        (itm) => isActiveItem(itm.href),
-                                    );
-                                    return (
-                                        <MenuGroup
-                                            title={item.text}
-                                            icon={item.icon}
-                                            activeIcon={item.activeIcon}
-                                            isActiveMenu={Boolean(isActiveMenu)}
-                                        >
-                                            {item.items.map((subItem) => (
-                                                <AdminSubListItem
-                                                    href={subItem.href}
-                                                    text={subItem.text}
-                                                    selected={isActiveItem(
-                                                        subItem.href,
-                                                    )}
-                                                >
-                                                    <StyledStopRoundedIcon />
-                                                </AdminSubListItem>
-                                            ))}
-                                        </MenuGroup>
-                                    );
-                                }
+                    <StickyContainer>
+                        <StyledMenuPaper>
+                            <SettingsHeader>Admin settings</SettingsHeader>
+                            <DashboardLink />
+                            <List>
+                                {items.map((item) => {
+                                    if (item.items) {
+                                        const isActiveMenu = item.items.find(
+                                            (itm) => isActiveItem(itm.href),
+                                        );
+                                        return (
+                                            <MenuGroup
+                                                title={item.text}
+                                                icon={item.icon}
+                                                activeIcon={item.activeIcon}
+                                                isActiveMenu={Boolean(
+                                                    isActiveMenu,
+                                                )}
+                                            >
+                                                {item.items.map((subItem) => (
+                                                    <AdminSubListItem
+                                                        href={subItem.href}
+                                                        text={subItem.text}
+                                                        selected={isActiveItem(
+                                                            subItem.href,
+                                                        )}
+                                                        onClick={onClick}
+                                                    >
+                                                        <StyledStopRoundedIcon />
+                                                    </AdminSubListItem>
+                                                ))}
+                                            </MenuGroup>
+                                        );
+                                    }
 
-                                return (
-                                    <AdminListItem
-                                        href={item.href}
-                                        text={item.text}
-                                        selected={isActiveItem(item.href)}
-                                    >
-                                        {item.icon}
-                                    </AdminListItem>
-                                );
-                            })}
-                        </List>
-                    </StyledMenuPaper>
+                                    return (
+                                        <AdminListItem
+                                            href={item.href}
+                                            text={item.text}
+                                            selected={isActiveItem(item.href)}
+                                            onClick={onClick}
+                                        >
+                                            {item.icon}
+                                        </AdminListItem>
+                                    );
+                                })}
+                            </List>
+                        </StyledMenuPaper>
+                    </StickyContainer>
                 </Grid>
                 <Grid item md={9}>
                     {children}

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -1,0 +1,268 @@
+import { Grid, styled, Paper, Typography, Button, List } from '@mui/material';
+import { useUiFlag } from 'hooks/useUiFlag';
+import type { ReactNode } from 'react';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import HomeIcon from '@mui/icons-material/Home';
+import LaptopIcon from '@mui/icons-material/Laptop';
+import StopRoundedIcon from '@mui/icons-material/StopRounded';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import PeopleOutlineRoundedIcon from '@mui/icons-material/PeopleOutlineRounded';
+import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
+import CloudIcon from '@mui/icons-material/Cloud';
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
+import { AdminListItem, AdminSubListItem, MenuGroup } from './AdminListItem';
+import { useLocation } from 'react-router-dom';
+
+const StyledAdminMainGrid = styled(Grid)(({ theme }) => ({
+    minWidth: 0, // this is a fix for overflowing flex
+    maxWidth: '1812px',
+    margin: '0 auto',
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    [theme.breakpoints.up(2156)]: {
+        width: '100%',
+    },
+    [theme.breakpoints.down(2156)]: {
+        marginLeft: theme.spacing(7),
+        marginRight: theme.spacing(7),
+    },
+    [theme.breakpoints.down('lg')]: {
+        maxWidth: '1550px',
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(1),
+    },
+    [theme.breakpoints.down(1024)]: {
+        marginLeft: 0,
+        marginRight: 0,
+    },
+    [theme.breakpoints.down('sm')]: {
+        minWidth: '100%',
+    },
+    minHeight: '94vh',
+}));
+
+const StyledMenuPaper = styled(Paper)(({ theme }) => ({
+    width: '100%',
+    minWidth: 320,
+    padding: theme.spacing(3),
+    marginTop: theme.spacing(6.5),
+    borderRadius: `${theme.shape.borderRadiusLarge}px`,
+    boxShadow: 'none',
+}));
+
+const SettingsHeader = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.mainHeader,
+    fontWeight: theme.fontWeight.bold,
+}));
+
+const StyledButton = styled(Button)(({ theme }) => ({
+    paddingLeft: theme.spacing(0),
+    marginBottom: theme.spacing(3),
+}));
+
+const StyledStopRoundedIcon = styled(StopRoundedIcon)(({ theme }) => ({
+    color: theme.palette.primary.main,
+}));
+
+const StyledPeopleOutlineRoundedIcon = styled(PeopleOutlineRoundedIcon)(
+    ({ theme }) => ({
+        color: theme.palette.primary.main,
+    }),
+);
+
+const StyledKeyRoundedIcon = styled(KeyRoundedIcon)(({ theme }) => ({
+    color: theme.palette.primary.main,
+}));
+
+const StyledCloudIcon = styled(CloudIcon)(({ theme }) => ({
+    color: theme.palette.primary.main,
+}));
+
+const StyledHubOutlinedIcon = styled(HubOutlinedIcon)(({ theme }) => ({
+    color: theme.palette.primary.main,
+}));
+
+const StyledBuildOutlinedIcon = styled(BuildOutlinedIcon)(({ theme }) => ({
+    color: theme.palette.primary.main,
+}));
+
+const RotatedKeyRoundedIcon = styled(KeyRoundedIcon)(({ theme }) => ({
+    transform: 'rotate(-45deg)',
+}));
+
+interface IWrapIfAdminSubpageProps {
+    children: ReactNode;
+}
+
+export const WrapIfAdminSubpage = ({ children }: IWrapIfAdminSubpageProps) => {
+    const newAdminUIEnabled = useUiFlag('adminNavUI');
+    const showOnlyAdminMenu =
+        newAdminUIEnabled && location.pathname.indexOf('/admin') === 0;
+
+    if (showOnlyAdminMenu) {
+        return <AdminMenu>{children}</AdminMenu>;
+    }
+
+    return <>{children}</>;
+};
+
+const DashboardLink = () => {
+    return (
+        <>
+            <StyledButton
+                href='/personal'
+                rel='noreferrer'
+                startIcon={<ArrowBackIcon />}
+            >
+                Back to Unleash
+            </StyledButton>
+        </>
+    );
+};
+
+interface IAdminMenuProps {
+    children: ReactNode;
+}
+
+export const AdminMenu = ({ children }: IAdminMenuProps) => {
+    const isActiveItem = (item: string) => location.pathname === item;
+    const location = useLocation();
+
+    const userAdmItems = [
+        { href: '/admin/users', text: 'Users' },
+        { href: '/admin/groups', text: 'Groups' },
+        { href: '/admin/roles/project-roles', text: 'Project roles' },
+        { href: '/admin/roles', text: 'Root roles' },
+        { href: '/admin/logins', text: 'Login history' },
+    ];
+
+    const accessControlItems = [
+        { href: '/admin/api', text: 'API access' },
+        { href: '/admin/cors', text: 'CORS origins' },
+    ];
+
+    const ssoItems = [
+        { href: '/admin/auth', text: 'OpenID Connect' },
+        { href: '/admin/auth', text: 'SAML 2.0' },
+        { href: '/admin/auth', text: 'Password' },
+        { href: '/admin/auth', text: 'SCIM' },
+    ];
+
+    const networkItems = [
+        { href: '/admin/network', text: 'Overview' },
+        { href: '/admin/network/traffic', text: 'Traffic' },
+        { href: '/admin/network/connected-edges', text: 'Connected edges' },
+        {
+            href: '/admin/network/backend-connections',
+            text: 'Backend Connections',
+        },
+        {
+            href: '/admin/network/frontend-data-usage',
+            text: 'Frontend Traffic',
+        },
+    ];
+
+    const instanceConfItems = [
+        { href: '/admin/maintenance', text: 'Maintenance' },
+        { href: '/admin/banners', text: 'Banners' },
+        { href: '/admin/license', text: 'License' },
+        { href: '/admin/instance', text: 'Instance stats' },
+        { href: '/admin/instance-privacy', text: 'Instance privacy' },
+    ];
+
+    const items = [
+        { href: '/admin', text: 'Admin home', icon: <HomeIcon /> },
+        {
+            text: 'User administration',
+            icon: <PeopleOutlineRoundedIcon />,
+            activeIcon: <StyledPeopleOutlineRoundedIcon />,
+            items: userAdmItems,
+        },
+        {
+            href: '/admin/service-accounts',
+            text: 'Service accounts',
+            icon: <LaptopIcon />,
+        },
+        {
+            text: 'Access control',
+            icon: <KeyRoundedIcon />,
+            activeIcon: <StyledKeyRoundedIcon />,
+            items: accessControlItems,
+        },
+        {
+            text: 'Single sign-on',
+            icon: <CloudIcon />,
+            activeIcon: <StyledCloudIcon />,
+            items: ssoItems,
+        },
+        {
+            text: 'Network',
+            icon: <HubOutlinedIcon />,
+            activeIcon: <StyledHubOutlinedIcon />,
+            items: networkItems,
+        },
+        {
+            text: 'Instance configuration',
+            icon: <BuildOutlinedIcon />,
+            activeIcon: <StyledBuildOutlinedIcon />,
+            items: instanceConfItems,
+        },
+        { href: '/history', text: 'Event log', icon: <EventNoteIcon /> },
+    ];
+
+    return (
+        <>
+            <StyledAdminMainGrid container spacing={1}>
+                <Grid item>
+                    <StyledMenuPaper>
+                        <SettingsHeader>Admin settings</SettingsHeader>
+                        <DashboardLink />
+                        <List>
+                            {items.map((item) => {
+                                if (item.items) {
+                                    const isActiveMenu = item.items.find(
+                                        (itm) => isActiveItem(itm.href),
+                                    );
+                                    return (
+                                        <MenuGroup
+                                            title={item.text}
+                                            icon={item.icon}
+                                            activeIcon={item.activeIcon}
+                                            isActiveMenu={Boolean(isActiveMenu)}
+                                        >
+                                            {item.items.map((subItem) => (
+                                                <AdminSubListItem
+                                                    href={subItem.href}
+                                                    text={subItem.text}
+                                                    selected={isActiveItem(
+                                                        subItem.href,
+                                                    )}
+                                                >
+                                                    <StyledStopRoundedIcon />
+                                                </AdminSubListItem>
+                                            ))}
+                                        </MenuGroup>
+                                    );
+                                }
+
+                                return (
+                                    <AdminListItem
+                                        href={item.href}
+                                        text={item.text}
+                                        selected={isActiveItem(item.href)}
+                                    >
+                                        {item.icon}
+                                    </AdminListItem>
+                                );
+                            })}
+                        </List>
+                    </StyledMenuPaper>
+                </Grid>
+                <Grid item md={9}>
+                    {children}
+                </Grid>
+            </StyledAdminMainGrid>
+        </>
+    );
+};

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
@@ -1,0 +1,43 @@
+import type SvgIcon from '@mui/material/SvgIcon/SvgIcon';
+import HomeIcon from '@mui/icons-material/Home';
+import LaptopIcon from '@mui/icons-material/Laptop';
+import EventNoteIcon from '@mui/icons-material/EventNote';
+import BillingIcon from '@mui/icons-material/CreditCardOutlined';
+import PeopleOutlineRoundedIcon from '@mui/icons-material/PeopleOutlineRounded';
+import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
+import CloudIcon from '@mui/icons-material/Cloud';
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
+import EmptyIcon from '@mui/icons-material/CheckBoxOutlineBlankOutlined';
+import type { FC } from 'react';
+
+const icons: Record<string, typeof SvgIcon> = {
+    '/admin': HomeIcon,
+    users: PeopleOutlineRoundedIcon,
+    '/admin/service-accounts': LaptopIcon,
+    access: KeyRoundedIcon,
+    sso: CloudIcon,
+    network: HubOutlinedIcon,
+    instance: BuildOutlinedIcon,
+    '/admin/billing': BillingIcon,
+    '/history': EventNoteIcon,
+};
+
+const findIcon = (key: string) => {
+    return icons[key] || EmptyIcon;
+};
+
+export const IconRenderer: FC<{ path: string; active: boolean }> = ({
+    path,
+    active = false,
+}) => {
+    const IconComponent = findIcon(path); // Fallback to 'default' if the type is not found
+
+    return (
+        <IconComponent
+            sx={{
+                color: active ? 'primary.main' : 'inherit',
+            }}
+        />
+    );
+};

--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -19,6 +19,7 @@ import { NavigationSidebar } from './NavigationSidebar/NavigationSidebar';
 import { EventTimelineProvider } from 'component/events/EventTimeline/EventTimelineProvider';
 import { NewInUnleash } from './NavigationSidebar/NewInUnleash/NewInUnleash';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { WrapIfAdminSubpage } from './AdminMenu/AdminMenu';
 
 interface IMainLayoutProps {
     children: ReactNode;
@@ -145,14 +146,18 @@ export const MainLayout = forwardRef<HTMLDivElement, IMainLayoutProps>(
                             >
                                 <Header />
 
-                                <MainLayoutContent>
-                                    <SkipNavTarget />
-                                    <MainLayoutContentContainer ref={ref}>
-                                        <BreadcrumbNav />
-                                        <Proclamation toast={uiConfig.toast} />
-                                        {children}
-                                    </MainLayoutContentContainer>
-                                </MainLayoutContent>
+                                <WrapIfAdminSubpage>
+                                    <MainLayoutContent>
+                                        <SkipNavTarget />
+                                        <MainLayoutContentContainer ref={ref}>
+                                            <BreadcrumbNav />
+                                            <Proclamation
+                                                toast={uiConfig.toast}
+                                            />
+                                            {children}
+                                        </MainLayoutContentContainer>
+                                    </MainLayoutContent>
+                                </WrapIfAdminSubpage>
                             </Box>
                         </Box>
 


### PR DESCRIPTION
Adds an admin menu to the page when visiting a /admin sub page

- introduces a new adminRoutes.ts and moves the existing usage to oldAdminRoutes.ts (we'll remove that when we remove the flag)
- introduces a new AuthSettings so that we can control page with a route - the old behavior is kept in OldAuthSettings.tsx which will be removed when we remove the flag
- also introduces a WrapIfAdminSubpage component that just renders the children prop if flag disabled or page not a sub page of /admin. This is the scariest part of this PR so if you want to be spending some extra time reviewing thoroughly - this is a good candidate for that time

![image](https://github.com/user-attachments/assets/214f0dea-2c71-451e-ad3a-13c4b4457bc4)
