### PR TITLE
 Hide env metrics when an env has no strategies.

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -108,7 +108,6 @@ export const FeatureOverviewEnvironment = ({
                     ) : (
                         <FeatureOverviewEnvironmentMetrics
                             environmentMetric={metrics}
-                            collapsed={!hasActivations}
                         />
                     )}
                 </EnvironmentHeader>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -105,11 +105,12 @@ export const FeatureOverviewEnvironment = ({
                             variant='outlined'
                             size='small'
                         />
-                    ) : null}
-                    <FeatureOverviewEnvironmentMetrics
-                        environmentMetric={metrics}
-                        collapsed={!hasActivations}
-                    />
+                    ) : (
+                        <FeatureOverviewEnvironmentMetrics
+                            environmentMetric={metrics}
+                            collapsed={!hasActivations}
+                        />
+                    )}
                 </EnvironmentHeader>
                 <NewStyledAccordionDetails>
                     <StyledEnvironmentAccordionContainer>


### PR DESCRIPTION
 Changes the logic in when we display metrics for an env to not showing
 them unless we have strategies.

![image](https://github.com/user-attachments/assets/83dc2465-b3fb-49d1-a9fe-886fd16fea25)
