### PR TITLE
fix: tooltips not working after base element is also clicked

### DIFF
--- a/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
+++ b/frontend/src/component/common/HtmlTooltip/HtmlTooltip.tsx
@@ -73,5 +73,9 @@ export interface IHtmlTooltipProps extends TooltipProps {
 
 export const HtmlTooltip = (props: IHtmlTooltipProps) => {
     if (!props.title) return props.children;
-    return <StyledHtmlTooltip {...props}>{props.children}</StyledHtmlTooltip>;
+    return (
+        <StyledHtmlTooltip {...props} disableFocusListener>
+            {props.children}
+        </StyledHtmlTooltip>
+    );
 };


### PR DESCRIPTION
All our HTML tooltips shared a similar problem. If the user also clicked on the source element while hovering, the HTML tooltip would not work at all. I'm sharing two videos as examples, but there are dozens of instances where it wasn’t working. After this PR, they all work as expected.

[Lifecycle not working](https://github.com/user-attachments/assets/b9f2317c-5f46-4d26-b423-8e373a5397b0)
[Dependencies not working](https://github.com/user-attachments/assets/8d51ff1c-6634-4175-b1b0-8a2954ecb780)
