### PR TITLE
Feat/tag type frontend display

### DIFF
--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -1,5 +1,8 @@
-import type { FC, ReactElement } from 'react';
-import type { FeatureSearchResponseSchema } from '../../../../../openapi';
+import type { FC } from 'react';
+import type {
+    FeatureSearchResponseSchema,
+    TagSchema,
+} from '../../../../../openapi';
 import { Box, IconButton, styled, Chip } from '@mui/material';
 import useFeatureTypes from 'hooks/api/getters/useFeatureTypes/useFeatureTypes';
 import { getFeatureTypeIcons } from 'utils/getFeatureTypeIcons';
@@ -14,7 +17,6 @@ import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import { getLocalizedDateString } from '../../../util';
 import { Tag } from 'component/common/Tag/Tag';
-import type { ITag } from 'interfaces/tags';
 import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IFeatureNameCellProps {
@@ -57,10 +59,19 @@ const CustomTagButton = styled('button')(({ theme }) => ({
 const StyledTag = styled(Chip)(({ theme }) => ({
     overflowWrap: 'anywhere',
     lineHeight: theme.typography.body1.lineHeight,
-    backgroundColor: theme.palette.neutral.light,
+    backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
-    padding: theme.spacing(0.25),
-    height: theme.spacing(3.5),
+    padding: theme.spacing(0.25, 0.5),
+    height: 'auto',
+    fontSize: theme.fontSizes.smallerBody,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    '&:hover': {
+        backgroundColor: theme.palette.background.paper,
+    },
+    '& .MuiChip-label': {
+        padding: 0,
+    },
 }));
 
 const CappedDescription: FC<{ text: string; searchQuery: string }> = ({
@@ -158,7 +169,7 @@ const ArchivedFeatureName: FC<{
 };
 
 const RestTags: FC<{
-    tags: ITag[];
+    tags: TagSchema[];
     onClick: (tag: string) => void;
     isTagTypeColorEnabled: boolean;
 }> = ({ tags, onClick, isTagTypeColorEnabled }) => {
@@ -195,28 +206,20 @@ const Tags: FC<{
         return null;
     }
 
-    // Convert TagSchema to ITag for the Tag component
-    const tagsAsITag: ITag[] = tags.map((tag) => ({
-        type: tag.type,
-        value: tag.value,
-        color: (tag as ITag).color, // Cast to ITag to get the color if available
-    }));
+    const [tag1, tag2, tag3, ...restTags] = tags;
 
-    const [tag1, tag2, tag3, ...restTags] = tagsAsITag;
-
-    const handleTagClick = (tag: ITag) => {
+    const handleTagClick = (tag: TagSchema) => {
         onClick(`${tag.type}:${tag.value}`);
     };
 
-    const renderTag = (tag: ITag) => {
+    const renderTag = (tag: TagSchema) => {
         const tagFullText = `${tag.type}:${tag.value}`;
         const isOverflowing = tagFullText.length > 30;
 
         if (isTagTypeColorEnabled) {
-            // Create a tag object with truncated display value but keeping original values
             const displayTag = {
                 ...tag,
-                displayValue: isOverflowing
+                value: isOverflowing
                     ? `${tag.value.substring(0, Math.max(0, 30 - tag.type.length - 1))}...`
                     : tag.value,
             };
@@ -226,13 +229,7 @@ const Tags: FC<{
                     onClick={() => handleTagClick(tag)}
                     sx={{ cursor: 'pointer' }}
                 >
-                    <Tag
-                        tag={{
-                            type: tag.type,
-                            value: displayTag.displayValue,
-                            color: tag.color,
-                        }}
-                    />
+                    <Tag tag={displayTag} />
                 </Box>
             );
 

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -18,6 +18,7 @@ import { useLocationSettings } from 'hooks/useLocationSettings';
 import { getLocalizedDateString } from '../../../util';
 import { Tag } from 'component/common/Tag/Tag';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { formatTag } from 'utils/format-tag';
 
 interface IFeatureNameCellProps {
     row: {
@@ -175,7 +176,7 @@ interface ITagItemProps {
 
 const TagItem: FC<ITagItemProps> = ({ tag, onClick }) => {
     const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
-    const tagFullText = `${tag.type}:${tag.value}`;
+    const tagFullText = formatTag(tag);
 
     if (isTagTypeColorEnabled) {
         const tagComponent = (
@@ -217,19 +218,22 @@ const RestTags: FC<{
 
     return (
         <HtmlTooltip
-            title={tags.map((tag) => (
-                <Box
-                    sx={{ cursor: 'pointer' }}
-                    onClick={() => onClick(`${tag.type}:${tag.value}`)}
-                    key={`${tag.type}:${tag.value}`}
-                >
-                    {isTagTypeColorEnabled ? (
-                        <Tag tag={tag} maxLength={30} />
-                    ) : (
-                        `${tag.type}:${tag.value}`
-                    )}
-                </Box>
-            ))}
+            title={tags.map((tag) => {
+                const formattedTag = formatTag(tag);
+                return (
+                    <Box
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => onClick(formattedTag)}
+                        key={formattedTag}
+                    >
+                        {isTagTypeColorEnabled ? (
+                            <Tag tag={tag} maxLength={30} />
+                        ) : (
+                            formattedTag
+                        )}
+                    </Box>
+                );
+            })}
         >
             <CustomTagButton
                 sx={{
@@ -256,7 +260,7 @@ const Tags: FC<{
     const [tag1, tag2, tag3, ...restTags] = tags;
 
     const handleTagClick = (tag: TagSchema) => {
-        onClick(`${tag.type}:${tag.value}`);
+        onClick(formatTag(tag));
     };
 
     return (

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -168,11 +168,65 @@ const ArchivedFeatureName: FC<{
     );
 };
 
+interface ITagItemProps {
+    tag: TagSchema;
+    onClick: (tag: TagSchema) => void;
+}
+
+const TagItem: FC<ITagItemProps> = ({ tag, onClick }) => {
+    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
+    const tagFullText = `${tag.type}:${tag.value}`;
+    const isOverflowing = tagFullText.length > 30;
+
+    if (isTagTypeColorEnabled) {
+        const displayTag = {
+            ...tag,
+            value: isOverflowing
+                ? `${tag.value.substring(0, Math.max(0, 30 - tag.type.length - 1))}...`
+                : tag.value,
+        };
+
+        const tagComponent = (
+            <Box onClick={() => onClick(tag)} sx={{ cursor: 'pointer' }}>
+                <Tag tag={displayTag} />
+            </Box>
+        );
+
+        return (
+            <HtmlTooltip
+                key={tagFullText}
+                title={isOverflowing ? tagFullText : ''}
+                arrow
+            >
+                <span>{tagComponent}</span>
+            </HtmlTooltip>
+        );
+    }
+
+    return (
+        <StyledTag
+            key={tagFullText}
+            label={
+                <HtmlTooltip title={isOverflowing ? tagFullText : ''} arrow>
+                    <span>
+                        {tagFullText.substring(0, 30)}
+                        {isOverflowing ? '...' : ''}
+                    </span>
+                </HtmlTooltip>
+            }
+            size='small'
+            onClick={() => onClick(tag)}
+            sx={{ cursor: 'pointer' }}
+        />
+    );
+};
+
 const RestTags: FC<{
     tags: TagSchema[];
     onClick: (tag: string) => void;
-    isTagTypeColorEnabled: boolean;
-}> = ({ tags, onClick, isTagTypeColorEnabled }) => {
+}> = ({ tags, onClick }) => {
+    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
+
     return (
         <HtmlTooltip
             title={tags.map((tag) => (
@@ -189,7 +243,14 @@ const RestTags: FC<{
                 </Box>
             ))}
         >
-            <CustomTagButton sx={{ cursor: 'initial' }}>
+            <CustomTagButton
+                sx={{
+                    cursor: 'initial',
+                    ...(isTagTypeColorEnabled && {
+                        borderRadius: (theme) => theme.spacing(2),
+                    }),
+                }}
+            >
                 {tags.length} more...
             </CustomTagButton>
         </HtmlTooltip>
@@ -200,8 +261,6 @@ const Tags: FC<{
     tags: FeatureSearchResponseSchema['tags'];
     onClick: (tag: string) => void;
 }> = ({ tags, onClick }) => {
-    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
-
     if (!tags || tags.length === 0) {
         return null;
     }
@@ -212,70 +271,14 @@ const Tags: FC<{
         onClick(`${tag.type}:${tag.value}`);
     };
 
-    const renderTag = (tag: TagSchema) => {
-        const tagFullText = `${tag.type}:${tag.value}`;
-        const isOverflowing = tagFullText.length > 30;
-
-        if (isTagTypeColorEnabled) {
-            const displayTag = {
-                ...tag,
-                value: isOverflowing
-                    ? `${tag.value.substring(0, Math.max(0, 30 - tag.type.length - 1))}...`
-                    : tag.value,
-            };
-
-            const tagComponent = (
-                <Box
-                    onClick={() => handleTagClick(tag)}
-                    sx={{ cursor: 'pointer' }}
-                >
-                    <Tag tag={displayTag} />
-                </Box>
-            );
-
-            return (
-                <HtmlTooltip
-                    key={tagFullText}
-                    title={isOverflowing ? tagFullText : ''}
-                    arrow
-                >
-                    <span>{tagComponent}</span>
-                </HtmlTooltip>
-            );
-        }
-
-        return (
-            <StyledTag
-                key={tagFullText}
-                label={
-                    <HtmlTooltip title={isOverflowing ? tagFullText : ''} arrow>
-                        <span>
-                            {tagFullText.substring(0, 30)}
-                            {isOverflowing ? '...' : ''}
-                        </span>
-                    </HtmlTooltip>
-                }
-                size='small'
-                onClick={() => handleTagClick(tag)}
-                sx={{ cursor: 'pointer' }}
-            />
-        );
-    };
-
     return (
         <TagsContainer>
-            {tag1 && renderTag(tag1)}
-            {tag2 && renderTag(tag2)}
-            {tag3 && renderTag(tag3)}
+            {tag1 && <TagItem tag={tag1} onClick={handleTagClick} />}
+            {tag2 && <TagItem tag={tag2} onClick={handleTagClick} />}
+            {tag3 && <TagItem tag={tag3} onClick={handleTagClick} />}
             <ConditionallyRender
                 condition={restTags.length > 0}
-                show={
-                    <RestTags
-                        tags={restTags}
-                        onClick={onClick}
-                        isTagTypeColorEnabled={isTagTypeColorEnabled}
-                    />
-                }
+                show={<RestTags tags={restTags} onClick={onClick} />}
             />
         </TagsContainer>
     );

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -176,47 +176,35 @@ interface ITagItemProps {
 const TagItem: FC<ITagItemProps> = ({ tag, onClick }) => {
     const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
     const tagFullText = `${tag.type}:${tag.value}`;
-    const isOverflowing = tagFullText.length > 30;
 
     if (isTagTypeColorEnabled) {
-        const displayTag = {
-            ...tag,
-            value: isOverflowing
-                ? `${tag.value.substring(0, Math.max(0, 30 - tag.type.length - 1))}...`
-                : tag.value,
-        };
-
         const tagComponent = (
             <Box onClick={() => onClick(tag)} sx={{ cursor: 'pointer' }}>
-                <Tag tag={displayTag} />
+                <Tag tag={tag} maxLength={30} />
             </Box>
         );
 
         return (
-            <HtmlTooltip
-                key={tagFullText}
-                title={isOverflowing ? tagFullText : ''}
-                arrow
-            >
+            <HtmlTooltip key={tagFullText} title={tagFullText} arrow>
                 <span>{tagComponent}</span>
             </HtmlTooltip>
         );
     }
 
+    // For non-color tags, use the StyledTag approach
+    const isOverflowing = tagFullText.length > 30;
+    const displayText = isOverflowing
+        ? `${tagFullText.substring(0, 30)}...`
+        : tagFullText;
+
     return (
         <StyledTag
             key={tagFullText}
-            label={
-                <HtmlTooltip title={isOverflowing ? tagFullText : ''} arrow>
-                    <span>
-                        {tagFullText.substring(0, 30)}
-                        {isOverflowing ? '...' : ''}
-                    </span>
-                </HtmlTooltip>
-            }
+            label={displayText}
             size='small'
             onClick={() => onClick(tag)}
             sx={{ cursor: 'pointer' }}
+            title={isOverflowing ? tagFullText : undefined}
         />
     );
 };
@@ -236,7 +224,7 @@ const RestTags: FC<{
                     key={`${tag.type}:${tag.value}`}
                 >
                     {isTagTypeColorEnabled ? (
-                        <Tag tag={tag} />
+                        <Tag tag={tag} maxLength={30} />
                     ) : (
                         `${tag.type}:${tag.value}`
                     )}

--- a/frontend/src/component/common/Table/cells/FeatureTagCell/FeatureTagCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureTagCell/FeatureTagCell.tsx
@@ -1,10 +1,11 @@
 import type { VFC } from 'react';
-import type { FeatureSchema } from 'openapi';
+import type { FeatureSchema, TagSchema } from 'openapi';
 import { styled, Typography } from '@mui/material';
 import { TextCell } from '../TextCell/TextCell';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
+import { formatTag } from 'utils/format-tag';
 
 const StyledTag = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
@@ -23,9 +24,8 @@ export const FeatureTagCell: VFC<IFeatureTagCellProps> = ({ row }) => {
         return <TextCell />;
 
     const value =
-        row.original.tags
-            ?.map(({ type, value }) => `${type}:${value}`)
-            .join('\n') || '';
+        row.original.tags?.map((tag: TagSchema) => formatTag(tag)).join('\n') ||
+        '';
 
     return (
         <TextCell>
@@ -39,7 +39,7 @@ export const FeatureTagCell: VFC<IFeatureTagCellProps> = ({ row }) => {
                         {row.original.tags?.map((tag) => (
                             <StyledTag key={tag.type + tag.value}>
                                 <Highlighter search={searchQuery}>
-                                    {`${tag.type}:${tag.value}`}
+                                    {formatTag(tag)}
                                 </Highlighter>
                             </StyledTag>
                         ))}

--- a/frontend/src/component/common/Tag/Tag.tsx
+++ b/frontend/src/component/common/Tag/Tag.tsx
@@ -1,0 +1,52 @@
+import { styled } from '@mui/material';
+import { Chip } from '@mui/material';
+import type { ITag } from 'interfaces/tags';
+import type { ReactElement } from 'react';
+
+const StyledChip = styled(Chip)<{ $color?: string }>(({ theme, $color }) => ({
+    borderRadius: theme.spacing(2),
+    border: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    height: '26px',
+    '& .MuiChip-label': {
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing(1),
+    },
+}));
+
+const ColorDot = styled('div')<{ $color: string }>(({ theme, $color }) => ({
+    width: theme.spacing(1.3),
+    height: theme.spacing(1.3),
+    borderRadius: '50%',
+    backgroundColor: $color,
+    border: `1px solid ${$color === '#FFFFFF' ? theme.palette.divider : $color}`,
+    flexShrink: 0,
+}));
+
+interface ITagProps {
+    tag: ITag;
+    onDelete?: () => void;
+    deleteIcon?: ReactElement;
+}
+
+export const Tag = ({ tag, onDelete, deleteIcon }: ITagProps) => {
+    const label = `${tag.type}:${tag.value}`;
+    const showColorDot = tag.color && tag.color !== '#FFFFFF';
+
+    const labelContent = (
+        <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {showColorDot && <ColorDot $color={tag.color!} />}
+            <span>{label}</span>
+        </span>
+    ) as ReactElement;
+
+    return (
+        <StyledChip
+            label={labelContent}
+            onDelete={onDelete}
+            deleteIcon={deleteIcon}
+        />
+    );
+};

--- a/frontend/src/component/common/Tag/Tag.tsx
+++ b/frontend/src/component/common/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material';
 import { Chip } from '@mui/material';
-import type { ITag } from 'interfaces/tags';
+import type { TagSchema } from 'openapi';
 import type { ReactElement } from 'react';
 
 const StyledChip = styled(Chip)<{ $color?: string }>(({ theme, $color }) => ({
@@ -26,7 +26,7 @@ const ColorDot = styled('div')<{ $color: string }>(({ theme, $color }) => ({
 }));
 
 interface ITagProps {
-    tag: ITag;
+    tag: TagSchema;
     onDelete?: () => void;
     deleteIcon?: ReactElement;
 }

--- a/frontend/src/component/common/Tag/Tag.tsx
+++ b/frontend/src/component/common/Tag/Tag.tsx
@@ -36,9 +36,24 @@ export const Tag = ({ tag, onDelete, deleteIcon }: ITagProps) => {
     const showColorDot = tag.color && tag.color !== '#FFFFFF';
 
     const labelContent = (
-        <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <span
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                width: '100%',
+            }}
+        >
             {showColorDot && <ColorDot $color={tag.color!} />}
-            <span>{label}</span>
+            <span
+                style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {label}
+            </span>
         </span>
     ) as ReactElement;
 

--- a/frontend/src/component/common/Tag/Tag.tsx
+++ b/frontend/src/component/common/Tag/Tag.tsx
@@ -2,6 +2,7 @@ import { styled } from '@mui/material';
 import { Chip } from '@mui/material';
 import type { TagSchema } from 'openapi';
 import type { ReactElement } from 'react';
+import { formatTag } from 'utils/format-tag';
 
 const StyledChip = styled(Chip)<{ $color?: string }>(({ theme, $color }) => ({
     borderRadius: theme.spacing(2),
@@ -43,7 +44,7 @@ export const Tag = ({
     deleteIcon,
     maxLength = 30,
 }: ITagProps) => {
-    const fullLabel = `${tag.type}:${tag.value}`;
+    const fullLabel = formatTag(tag);
     const isOverflowing = fullLabel.length > maxLength;
     const showColorDot = tag.color && tag.color !== '#FFFFFF';
 

--- a/frontend/src/component/common/Tag/Tag.tsx
+++ b/frontend/src/component/common/Tag/Tag.tsx
@@ -13,6 +13,11 @@ const StyledChip = styled(Chip)<{ $color?: string }>(({ theme, $color }) => ({
         display: 'flex',
         alignItems: 'center',
         gap: theme.spacing(1),
+        paddingRight: theme.spacing(1),
+    },
+    '& .MuiChip-deleteIcon': {
+        marginLeft: theme.spacing(0.5),
+        marginRight: theme.spacing(0.5),
     },
 }));
 
@@ -29,11 +34,25 @@ interface ITagProps {
     tag: TagSchema;
     onDelete?: () => void;
     deleteIcon?: ReactElement;
+    maxLength?: number;
 }
 
-export const Tag = ({ tag, onDelete, deleteIcon }: ITagProps) => {
-    const label = `${tag.type}:${tag.value}`;
+export const Tag = ({
+    tag,
+    onDelete,
+    deleteIcon,
+    maxLength = 30,
+}: ITagProps) => {
+    const fullLabel = `${tag.type}:${tag.value}`;
+    const isOverflowing = fullLabel.length > maxLength;
     const showColorDot = tag.color && tag.color !== '#FFFFFF';
+
+    let displayValue = tag.value;
+    if (isOverflowing) {
+        // Calculate how much of the value we can show
+        const maxValueLength = Math.max(0, maxLength - tag.type.length - 1); // -1 for the colon
+        displayValue = `${tag.value.substring(0, maxValueLength)}...`;
+    }
 
     const labelContent = (
         <span
@@ -52,7 +71,7 @@ export const Tag = ({ tag, onDelete, deleteIcon }: ITagProps) => {
                     whiteSpace: 'nowrap',
                 }}
             >
-                {label}
+                {`${tag.type}:${displayValue}`}
             </span>
         </span>
     ) as ReactElement;
@@ -62,6 +81,7 @@ export const Tag = ({ tag, onDelete, deleteIcon }: ITagProps) => {
             label={labelContent}
             onDelete={onDelete}
             deleteIcon={deleteIcon}
+            title={isOverflowing ? fullLabel : undefined}
         />
     );
 };

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleFilters/FeatureToggleFilters.tsx
@@ -7,6 +7,7 @@ import {
     Filters,
     type IFilterItem,
 } from 'component/filter/Filters/Filters';
+import { formatTag } from 'utils/format-tag';
 
 interface IFeatureToggleFiltersProps {
     state: FilterItemParamHolder;
@@ -44,8 +45,8 @@ export const FeatureToggleFilters: VFC<IFeatureToggleFiltersProps> = ({
             value: segment.name,
         }));
         const tagsOptions = (tags || []).map((tag) => ({
-            label: `${tag.type}:${tag.value}`,
-            value: `${tag.type}:${tag.value}`,
+            label: formatTag(tag),
+            value: formatTag(tag),
         }));
 
         const hasMultipleProjects = projectsOptions.length > 1;

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
@@ -1,8 +1,9 @@
 import type { IFeatureToggle } from 'interfaces/featureToggle';
 import { useContext, useState } from 'react';
-import { Chip, styled, Tooltip } from '@mui/material';
+import { styled, Tooltip, Chip } from '@mui/material';
 import useFeatureTags from 'hooks/api/getters/useFeatureTags/useFeatureTags';
 import DeleteTagIcon from '@mui/icons-material/Cancel';
+import ClearIcon from '@mui/icons-material/Clear';
 import { ManageTagsDialog } from 'component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog';
 import { UPDATE_FEATURE } from 'component/providers/AccessProvider/permissions';
 import AccessContext from 'contexts/AccessContext';
@@ -13,6 +14,8 @@ import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { StyledMetaDataItem } from './FeatureOverviewMetaData';
 import { AddTagButton } from './AddTagButton';
+import { Tag } from 'component/common/Tag/Tag';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledLabel = styled('span')(({ theme }) => ({
     marginTop: theme.spacing(1),
@@ -56,6 +59,7 @@ interface IFeatureOverviewSidePanelTagsProps {
 export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
     const { tags, refetch } = useFeatureTags(feature.name);
     const { deleteTagFromFeature } = useFeatureApi();
+    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
 
     const [manageTagsOpen, setManageTagsOpen] = useState(false);
     const [removeTagOpen, setRemoveTagOpen] = useState(false);
@@ -87,6 +91,19 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
         }
     };
 
+    const renderTag = (tag: ITag) => (
+        <TagItem
+            key={`${tag.type}:${tag.value}`}
+            tag={tag}
+            isTagTypeColorEnabled={isTagTypeColorEnabled}
+            canUpdateTags={canUpdateTags}
+            onTagRemove={(tag) => {
+                setRemoveTagOpen(true);
+                setSelectedTag(tag);
+            }}
+        />
+    );
+
     return (
         <>
             {!tags.length ? (
@@ -103,49 +120,7 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
                 <StyledTagRow>
                     <StyledLabel>Tags:</StyledLabel>
                     <StyledTagContainer>
-                        {tags.map((tag) => {
-                            const tagLabel = `${tag.type}:${tag.value}`;
-                            const isOverflowing = tagLabel.length > 25;
-                            return (
-                                <StyledTag
-                                    key={tagLabel}
-                                    label={
-                                        <Tooltip
-                                            key={tagLabel}
-                                            title={
-                                                isOverflowing ? tagLabel : ''
-                                            }
-                                            arrow
-                                        >
-                                            <span>
-                                                {tagLabel.substring(0, 25)}
-                                                {isOverflowing ? (
-                                                    <StyledEllipsis>
-                                                        …
-                                                    </StyledEllipsis>
-                                                ) : (
-                                                    ''
-                                                )}
-                                            </span>
-                                        </Tooltip>
-                                    }
-                                    size='small'
-                                    deleteIcon={
-                                        <Tooltip title='Remove tag' arrow>
-                                            <DeleteTagIcon />
-                                        </Tooltip>
-                                    }
-                                    onDelete={
-                                        canUpdateTags
-                                            ? () => {
-                                                  setRemoveTagOpen(true);
-                                                  setSelectedTag(tag);
-                                              }
-                                            : undefined
-                                    }
-                                />
-                            );
-                        })}
+                        {tags.map(renderTag)}
                         {canUpdateTags ? (
                             <AddTagButton
                                 project={feature.project}
@@ -181,5 +156,73 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
                 </strong>
             </Dialogue>
         </>
+    );
+};
+
+interface ITagItemProps {
+    tag: ITag;
+    isTagTypeColorEnabled: boolean;
+    canUpdateTags: boolean;
+    onTagRemove: (tag: ITag) => void;
+}
+
+const TagItem = ({
+    tag,
+    isTagTypeColorEnabled,
+    canUpdateTags,
+    onTagRemove,
+}: ITagItemProps) => {
+    const tagLabel = `${tag.type}:${tag.value}`;
+    const isOverflowing = tagLabel.length > 25;
+    const deleteIcon = (
+        <Tooltip title='Remove tag' arrow>
+            <DeleteTagIcon />
+        </Tooltip>
+    );
+    const onDelete = canUpdateTags ? () => onTagRemove(tag) : undefined;
+
+    if (isTagTypeColorEnabled) {
+        const deleteIcon = (
+            <Tooltip title='Remove tag' arrow>
+                <ClearIcon sx={{ height: '20px', width: '20px' }} />
+            </Tooltip>
+        );
+
+        return (
+            <Tooltip key={tagLabel} title={isOverflowing ? tagLabel : ''} arrow>
+                <span>
+                    <Tag
+                        tag={tag}
+                        onDelete={onDelete}
+                        deleteIcon={deleteIcon}
+                    />
+                </span>
+            </Tooltip>
+        );
+    }
+
+    return (
+        <StyledTag
+            key={tagLabel}
+            label={
+                <Tooltip
+                    key={tagLabel}
+                    title={isOverflowing ? tagLabel : ''}
+                    arrow
+                >
+                    <span>
+                        {tagLabel.substring(0, 25)}
+                        {isOverflowing ? (
+                            <StyledEllipsis>…</StyledEllipsis>
+                        ) : (
+                            ''
+                        )}
+                    </span>
+                </Tooltip>
+            }
+            size='small'
+            deleteIcon={deleteIcon}
+            onDelete={onDelete}
+        />
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
@@ -59,8 +59,6 @@ interface IFeatureOverviewSidePanelTagsProps {
 export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
     const { tags, refetch } = useFeatureTags(feature.name);
     const { deleteTagFromFeature } = useFeatureApi();
-    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
-
     const [manageTagsOpen, setManageTagsOpen] = useState(false);
     const [removeTagOpen, setRemoveTagOpen] = useState(false);
     const [selectedTag, setSelectedTag] = useState<ITag>();
@@ -91,19 +89,6 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
         }
     };
 
-    const renderTag = (tag: ITag) => (
-        <TagItem
-            key={`${tag.type}:${tag.value}`}
-            tag={tag}
-            isTagTypeColorEnabled={isTagTypeColorEnabled}
-            canUpdateTags={canUpdateTags}
-            onTagRemove={(tag) => {
-                setRemoveTagOpen(true);
-                setSelectedTag(tag);
-            }}
-        />
-    );
-
     return (
         <>
             {!tags.length ? (
@@ -120,7 +105,17 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
                 <StyledTagRow>
                     <StyledLabel>Tags:</StyledLabel>
                     <StyledTagContainer>
-                        {tags.map(renderTag)}
+                        {tags.map((tag) => (
+                            <TagItem
+                                key={`${tag.type}:${tag.value}`}
+                                tag={tag}
+                                canUpdateTags={canUpdateTags}
+                                onTagRemove={(tag) => {
+                                    setRemoveTagOpen(true);
+                                    setSelectedTag(tag);
+                                }}
+                            />
+                        ))}
                         {canUpdateTags ? (
                             <AddTagButton
                                 project={feature.project}
@@ -161,17 +156,12 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
 
 interface ITagItemProps {
     tag: ITag;
-    isTagTypeColorEnabled: boolean;
     canUpdateTags: boolean;
     onTagRemove: (tag: ITag) => void;
 }
 
-const TagItem = ({
-    tag,
-    isTagTypeColorEnabled,
-    canUpdateTags,
-    onTagRemove,
-}: ITagItemProps) => {
+const TagItem = ({ tag, canUpdateTags, onTagRemove }: ITagItemProps) => {
+    const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
     const tagLabel = `${tag.type}:${tag.value}`;
     const isOverflowing = tagLabel.length > 25;
     const deleteIcon = (

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/TagRow.tsx
@@ -16,6 +16,7 @@ import { StyledMetaDataItem } from './FeatureOverviewMetaData';
 import { AddTagButton } from './AddTagButton';
 import { Tag } from 'component/common/Tag/Tag';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { formatTag } from 'utils/format-tag';
 
 const StyledLabel = styled('span')(({ theme }) => ({
     marginTop: theme.spacing(1),
@@ -107,7 +108,7 @@ export const TagRow = ({ feature }: IFeatureOverviewSidePanelTagsProps) => {
                     <StyledTagContainer>
                         {tags.map((tag) => (
                             <TagItem
-                                key={`${tag.type}:${tag.value}`}
+                                key={formatTag(tag)}
                                 tag={tag}
                                 canUpdateTags={canUpdateTags}
                                 onTagRemove={(tag) => {
@@ -162,7 +163,7 @@ interface ITagItemProps {
 
 const TagItem = ({ tag, canUpdateTags, onTagRemove }: ITagItemProps) => {
     const isTagTypeColorEnabled = useUiFlag('tagTypeColor');
-    const tagLabel = `${tag.type}:${tag.value}`;
+    const tagLabel = formatTag(tag);
     const isOverflowing = tagLabel.length > 25;
     const deleteIcon = (
         <Tooltip title='Remove tag' arrow>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelTags/FeatureOverviewSidePanelTags.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewSidePanel/FeatureOverviewSidePanelTags/FeatureOverviewSidePanelTags.tsx
@@ -13,6 +13,7 @@ import useFeatureApi from 'hooks/api/actions/useFeatureApi/useFeatureApi';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { formatTag } from 'utils/format-tag';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -83,7 +84,7 @@ export const FeatureOverviewSidePanelTags = ({
             {header}
             <StyledTagContainer>
                 {tags.map((tag) => {
-                    const tagLabel = `${tag.type}:${tag.value}`;
+                    const tagLabel = formatTag(tag);
                     return (
                         <StyledChip
                             key={tagLabel}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
@@ -14,16 +14,17 @@ import useTagTypes from 'hooks/api/getters/useTagTypes/useTagTypes';
 import type { ITag, ITagType } from 'interfaces/tags';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
+import type { TagSchema } from 'openapi';
 
 type Payload = {
-    addedTags: ITag[];
-    removedTags: ITag[];
+    addedTags: TagSchema[];
+    removedTags: TagSchema[];
 };
 
 interface IManageBulkTagsDialogProps {
     open: boolean;
-    initialValues: ITag[];
-    initialIndeterminateValues: ITag[];
+    initialValues: TagSchema[];
+    initialIndeterminateValues: TagSchema[];
     onCancel: () => void;
     onSubmit: (payload: Payload) => void;
 }
@@ -36,14 +37,14 @@ const StyledDialogFormContent = styled('section')(({ theme }) => ({
 
 const formId = 'manage-tags-form';
 
-const mergeTags = (tags: ITag[], newTag: ITag) => [
+const mergeTags = (tags: TagSchema[], newTag: TagSchema) => [
     ...tags,
     ...(tags.some((x) => x.value === newTag.value && x.type === newTag.type)
         ? []
         : [newTag]),
 ];
 
-const filterTags = (tags: ITag[], tag: ITag) =>
+const filterTags = (tags: TagSchema[], tag: TagSchema) =>
     tags.filter((x) => !(x.value === tag.value && x.type === tag.type));
 
 export const payloadReducer = (
@@ -51,11 +52,11 @@ export const payloadReducer = (
     action:
         | {
               type: 'add' | 'remove';
-              payload: ITag;
+              payload: TagSchema;
           }
         | {
               type: 'clear';
-              payload: ITag[];
+              payload: TagSchema[];
           }
         | { type: 'reset' },
 ) => {
@@ -171,7 +172,7 @@ export const ManageBulkTagsDialog: FC<IManageBulkTagsDialogProps> = ({
             value,
             type,
         }).then(async () => {
-            await refetchTags();
+            refetchTags();
             setSelectedTags((prev) => [...prev, { title: value }]);
             dispatch({
                 type: 'add',

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/TagsInput.tsx
@@ -10,9 +10,10 @@ import type React from 'react';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import IndeterminateCheckBoxIcon from '@mui/icons-material/IndeterminateCheckBox';
-import type { ITag, ITagType } from 'interfaces/tags';
+import type { ITagType } from 'interfaces/tags';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import Add from '@mui/icons-material/Add';
+import type { TagSchema } from 'openapi';
 
 export type TagOption = {
     title: string;
@@ -21,7 +22,7 @@ export type TagOption = {
 
 interface ITagsInputProps {
     options: TagOption[];
-    existingTags: ITag[];
+    existingTags: TagSchema[];
     tagType: ITagType;
     selectedOptions: TagOption[];
     indeterminateOptions?: TagOption[];

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -30,6 +30,7 @@ import type { ITag } from 'interfaces/tags';
 import { ToggleConfigButton } from 'component/common/DialogFormTemplate/ConfigButtons/ToggleConfigButton';
 import { useFlagLimits } from './useFlagLimits';
 import { useFeatureCreatedFeedback } from './hooks/useFeatureCreatedFeedback';
+import { formatTag } from 'utils/format-tag';
 
 interface ICreateFeatureDialogProps {
     open: boolean;
@@ -295,7 +296,7 @@ const CreateFeatureDialogContent = ({
                                 description={configButtonData.tags.text}
                                 selectedOptions={tags}
                                 options={allTags.map((tag) => ({
-                                    label: `${tag.type}:${tag.value}`,
+                                    label: formatTag(tag),
                                     value: tag,
                                 }))}
                                 onChange={setTags}

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -6,6 +6,7 @@ import {
     type IFilterItem,
 } from 'component/filter/Filters/Filters';
 import { useProjectFlagCreators } from 'hooks/api/getters/useProjectFlagCreators/useProjectFlagCreators';
+import { formatTag } from 'utils/format-tag';
 
 interface IProjectOverviewFilters {
     state: FilterItemParamHolder;
@@ -23,10 +24,13 @@ export const ProjectOverviewFilters: VFC<IProjectOverviewFilters> = ({
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
 
     useEffect(() => {
-        const tagsOptions = (tags || []).map((tag) => ({
-            label: `${tag.type}:${tag.value}`,
-            value: `${tag.type}:${tag.value}`,
-        }));
+        const tagsOptions = (tags || []).map((tag) => {
+            const tagString = formatTag(tag);
+            return {
+                label: tagString,
+                value: tagString,
+            };
+        });
 
         const flagCreatorsOptions = flagCreators.map((creator) => ({
             label: creator.name,

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type VFC } from 'react';
 import { Button } from '@mui/material';
 import { ManageBulkTagsDialog } from 'component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog';
-import type { FeatureSchema } from 'openapi';
+import type { FeatureSchema, TagSchema } from 'openapi';
 import type { ITag } from 'interfaces/tags';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
 import useToast from 'hooks/useToast';
@@ -28,7 +28,7 @@ export const ManageTags: VFC<IManageTagsProps> = ({
     const [initialValues, indeterminateValues] = useMemo(() => {
         const uniqueTags = data
             .flatMap(({ tags }) => tags || [])
-            .reduce<ITag[]>(
+            .reduce<TagSchema[]>(
                 (acc, tag) => [
                     ...acc,
                     ...(acc.some(
@@ -56,8 +56,8 @@ export const ManageTags: VFC<IManageTagsProps> = ({
         addedTags,
         removedTags,
     }: {
-        addedTags: ITag[];
-        removedTags: ITag[];
+        addedTags: TagSchema[];
+        removedTags: TagSchema[];
     }) => {
         const features = data.map(({ name }) => name);
         const payload = { features, tags: { addedTags, removedTags } };

--- a/frontend/src/interfaces/tags.ts
+++ b/frontend/src/interfaces/tags.ts
@@ -1,6 +1,7 @@
 export interface ITag {
     value: string;
     type: string;
+    color?: string;
 }
 
 export interface ITagType {

--- a/frontend/src/openapi/models/tagSchema.ts
+++ b/frontend/src/openapi/models/tagSchema.ts
@@ -9,6 +9,12 @@
  */
 export interface TagSchema {
     /**
+     * The hexadecimal color code for the tag type.
+     * @nullable
+     * @pattern ^#[0-9A-Fa-f]{6}$
+     */
+    color?: string | null;
+    /**
      * The [type](https://docs.getunleash.io/reference/feature-toggles#tags) of the tag
      * @minLength 2
      * @maxLength 50

--- a/frontend/src/utils/format-tag.ts
+++ b/frontend/src/utils/format-tag.ts
@@ -1,0 +1,8 @@
+import type { ITag } from 'interfaces/tags';
+import type { TagSchema } from 'openapi';
+
+// Use TagSchema or ITag for backwards compatability in components that
+// have not yet been refactored to use TagSchema
+export const formatTag = (tag: TagSchema | ITag) => {
+    return `${tag.type}:${tag.value}`;
+};


### PR DESCRIPTION
# Standardize Tag Component and Add Color Support

## Changes
- Used `tagTypeColor` feature flag to control tag color display
  - When enabled, tags show their associated colors with a dot indicator
  - When disabled, maintains existing plain tag appearance
- Created a centralized `Tag` component for consistent styling and behavior
  - Used across project list and feature overview
  - Handles text truncation and tooltips internally
  - Consistent border radius and spacing
- Migrated from `ITag` interface to OpenAPI-generated `TagSchema`
  - Improved type safety with API-aligned types
  - Removed manual type conversions
  - Better maintainability through generated types

New tags: 

<img width="1826" alt="Skjermbilde 2025-03-31 kl  10 48 16" src="https://github.com/user-attachments/assets/ee00872e-bb37-4b1f-b016-3f0f64e01fde" />
<img width="1786" alt="Skjermbilde 2025-03-31 kl  10 48 28" src="https://github.com/user-attachments/assets/3c138ced-e621-4d82-8b67-12887a3a490b" />

Old:

<img width="1792" alt="Skjermbilde 2025-03-31 kl  10 49 29" src="https://github.com/user-attachments/assets/d48d65c7-594f-4962-aee4-6bd92b5db620" />

<img width="1751" alt="Skjermbilde 2025-03-31 kl  10 49 15" src="https://github.com/user-attachments/assets/6a67e538-e6f2-466c-95b4-f4ae02b70485" />
