### PR TITLE
chore: feedback link on feature strategy

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -5,7 +5,7 @@ import PermissionButton, {
     type IPermissionButtonProps,
 } from 'component/common/PermissionButton/PermissionButton';
 import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
-import { Popover, styled } from '@mui/material';
+import { Popover, styled, Link } from '@mui/material';
 import { FeatureStrategyMenuCards } from './FeatureStrategyMenuCards/FeatureStrategyMenuCards';
 import { formatCreateStrategyPath } from '../FeatureStrategyCreate/FeatureStrategyCreate';
 import MoreVert from '@mui/icons-material/MoreVert';
@@ -20,7 +20,9 @@ import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePla
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useUiFlag } from 'hooks/useUiFlag';
+import type { Link as RouterLink } from 'react-router-dom';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { RELEASE_TEMPLATE_FEEDBACK } from 'constants/links';
 
 interface IFeatureStrategyMenuProps {
     label: string;
@@ -36,8 +38,12 @@ interface IFeatureStrategyMenuProps {
 const StyledStrategyMenu = styled('div')(({ theme }) => ({
     flexShrink: 0,
     display: 'flex',
+    width: '100%',
     flexFlow: 'row',
     gap: theme.spacing(1),
+    '& > :nth-child(2)': {
+        marginLeft: 'auto',
+    },
 }));
 
 const StyledAdditionalMenuButton = styled(PermissionButton)(({ theme }) => ({
@@ -45,6 +51,15 @@ const StyledAdditionalMenuButton = styled(PermissionButton)(({ theme }) => ({
     width: theme.spacing(4.5),
     alignSelf: 'stretch',
     paddingBlock: 0,
+}));
+
+const StyledLink = styled(Link<typeof RouterLink | 'a'>)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.palette.links,
+    fontWeight: theme.typography.fontWeightMedium,
+    textDecoration: 'none',
 }));
 
 export const FeatureStrategyMenu = ({
@@ -162,6 +177,15 @@ export const FeatureStrategyMenu = ({
         <StyledStrategyMenu onClick={(event) => event.stopPropagation()}>
             {displayReleasePlanButton ? (
                 <>
+                    <StyledLink
+                        component='a'
+                        href={RELEASE_TEMPLATE_FEEDBACK}
+                        underline='hover'
+                        rel='noopener noreferrer'
+                        target='_blank'
+                    >
+                        Give feedback to release templates
+                    </StyledLink>
                     <PermissionButton
                         data-testid='ADD_TEMPLATE_BUTTON'
                         permission={CREATE_FEATURE_STRATEGY}

--- a/frontend/src/component/releases/ReleaseManagement/ReleasesFeedback.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleasesFeedback.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material';
 import { Card } from 'component/common/Card/Card';
+import { RELEASE_TEMPLATE_FEEDBACK } from 'constants/links';
 import { Link } from 'react-router-dom';
 
 const StyledCardLink = styled(Link)(({ theme }) => ({
@@ -11,9 +12,6 @@ const StyledCardLink = styled(Link)(({ theme }) => ({
     },
 }));
 
-const feedbackLink =
-    'https://docs.google.com/forms/d/1ElbScYxbAhFcjQWgRinifoymYHeuXzqIoQXfpUVYGR8/preview';
-
 export const ReleasesFeedback: React.FC<{
     title: string;
     children: React.ReactNode;
@@ -24,7 +22,7 @@ export const ReleasesFeedback: React.FC<{
             title={title}
             footer={
                 <StyledCardLink
-                    to={feedbackLink}
+                    to={RELEASE_TEMPLATE_FEEDBACK}
                     target='_blank'
                     rel='noreferrer'
                 >

--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -1,4 +1,4 @@
 // honestly there's no nice place for this in our folder structure and I really, really need this to change in one place
 // might be deletable once we're done with the initial feedback phase
 export const RELEASE_TEMPLATE_FEEDBACK =
-    'https://docs.google.com/forms/d/1ElbScYxbAhFcjQWgRinifoymYHeuXzqIoQXfpUVYGR8/preview';
+    'https://docs.google.com/forms/d/e/1FAIpQLSfbbqsz6wQSgTuJ0NO6ooykTGC_osrzB5-qMrQkbda9SRwnxg/viewform?usp=preview';

--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -1,0 +1,4 @@
+// honestly there's no nice place for this in our folder structure and I really, really need this to change in one place
+// might be deletable once we're done with the initial feedback phase
+export const RELEASE_TEMPLATE_FEEDBACK =
+    'https://docs.google.com/forms/d/1ElbScYxbAhFcjQWgRinifoymYHeuXzqIoQXfpUVYGR8/preview';


### PR DESCRIPTION
Adds a new link on the feature strategy that points to the feedback link (pops out new window, only renders if release plans are enabled). I moved the feedback link out to a constant but mostly only because I am 100% going to forget to update one of the places it exists

![image](https://github.com/user-attachments/assets/bd965b88-4d95-4e75-a931-af365fe777dc)
