### PR TITLE
chore: ux feedback on release templates

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -242,6 +242,10 @@ export const FeatureStrategyMenu = ({
                 anchorEl={anchor}
                 onClose={onClose}
                 onClick={onClose}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left',
+                }}
                 PaperProps={{
                     sx: (theme) => ({
                         paddingBottom: theme.spacing(1),

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -97,13 +97,18 @@ export const FeatureStrategyMenuCards = ({
                                 padding: (theme) => theme.spacing(1, 2, 0, 2),
                             }}
                         >
-                            No templates created. Go to&nbsp;
-                            <StyledLink
-                                onClick={() => navigate('/release-templates')}
-                            >
-                                Release templates
-                            </StyledLink>
-                            &nbsp;to get started
+                            <p>No templates created.</p>
+                            <p>
+                                Go to&nbsp;
+                                <StyledLink
+                                    onClick={() =>
+                                        navigate('/release-templates')
+                                    }
+                                >
+                                    Release templates
+                                </StyledLink>
+                                &nbsp;to get started
+                            </p>
                         </StyledTypography>
                     </>
                 }

--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -97,25 +97,21 @@ export const ReleaseManagement = () => {
                 )}
             </PageContent>
 
-            {data.templates.length === 0 ? (
-                <>
-                    <CenteredHowTo>
-                        <ThemeMode
-                            darkmode={<HowToApplyReleaseTemplatesDark />}
-                            lightmode={<HowToApplyReleaseTemplates />}
-                        />
-                    </CenteredHowTo>
-                    <StyledLink
-                        component='a'
-                        href='https://docs.getunleash.io/reference/release-templates'
-                        underline='hover'
-                        rel='noopener noreferrer'
-                        target='_blank'
-                    >
-                        <StyledMenuBook /> Read more in our documentation
-                    </StyledLink>
-                </>
-            ) : null}
+            <CenteredHowTo>
+                <ThemeMode
+                    darkmode={<HowToApplyReleaseTemplatesDark />}
+                    lightmode={<HowToApplyReleaseTemplates />}
+                />
+            </CenteredHowTo>
+            <StyledLink
+                component='a'
+                href='https://docs.getunleash.io/reference/release-templates'
+                underline='hover'
+                rel='noopener noreferrer'
+                target='_blank'
+            >
+                <StyledMenuBook /> Read more in our documentation
+            </StyledLink>
         </>
     );
 };


### PR DESCRIPTION
Makes two small changes to the release template UI based on walkthrough feedback with UX

1) The how-to descriptions for creating release plans won't get hidden when the user has created release plans. We think too much is better than too little. At a later point we'll push users to documentation more aggressively
2) The warning for when the user taps the "Use template" button now has a line break to give it some breathing room and will render anchored to the bottom left of the originating button rather than covering it 