### PR TITLE
fix: focus styles for env headers

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionView/ConstraintAccordionView.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionView/ConstraintAccordionView.tsx
@@ -95,6 +95,7 @@ export const ConstraintAccordionView = ({
                         cursor: expandable ? 'pointer' : 'default!important',
                     },
                 }}
+                tabIndex={expandable ? 0 : -1}
             >
                 <StyledWrapper>
                     <ConstraintAccordionViewHeader

--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -96,6 +96,7 @@ export const StrategyItemContainer: FC<StrategyItemContainerProps> = ({
                 <StyledHeader disabled={Boolean(strategy?.disabled)}>
                     {onDragStart ? (
                         <DragIcon
+                            tabIndex={-1}
                             className='strategy-drag-handle'
                             draggable
                             disableRipple

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -20,15 +20,13 @@ const StyledAccordionSummary = styled(AccordionSummary, {
     borderRadius: theme.shape.borderRadiusLarge,
     pointerEvents: 'auto',
     opacity: 1,
+    border: `1px solid #0000`,
     '&&&': {
         cursor: expandable ? 'pointer' : 'default',
     },
 
     ':focus-within': {
         background: 'none',
-    },
-    ':focus-visible': {
-        background: 'var(--focus-background-color)',
     },
 }));
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -20,7 +20,6 @@ const StyledAccordionSummary = styled(AccordionSummary, {
     borderRadius: theme.shape.borderRadiusLarge,
     pointerEvents: 'auto',
     opacity: 1,
-    border: `1px solid #0000`,
     '&&&': {
         cursor: expandable ? 'pointer' : 'default',
     },

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -139,6 +139,7 @@ export const EnvironmentHeader: FC<
             id={id}
             aria-controls={`environment-accordion-${id}-content`}
             expandable={expandable}
+            tabIndex={expandable ? 0 : -1}
             className={environmentAccordionSummaryClassName}
         >
             <StyledHeader data-loading>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -17,19 +17,18 @@ const StyledAccordionSummary = styled(AccordionSummary, {
     padding: theme.spacing(0.5, 3, 0.5, 2),
     display: 'flex',
     alignItems: 'center',
+    borderRadius: theme.shape.borderRadiusLarge,
+    pointerEvents: 'auto',
+    opacity: 1,
     '&&&': {
         cursor: expandable ? 'pointer' : 'default',
     },
 
-    borderRadius: theme.shape.borderRadiusLarge,
-    pointerEvents: 'auto',
-    opacity: 1,
-
-    ':focus-visible': {
-        background: theme.palette.table.headerHover,
-    },
     ':focus-within': {
         background: 'none',
+    },
+    ':focus-visible': {
+        background: theme.palette.table.headerHover,
     },
 }));
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -28,7 +28,7 @@ const StyledAccordionSummary = styled(AccordionSummary, {
         background: 'none',
     },
     ':focus-visible': {
-        background: theme.palette.table.headerHover,
+        background: 'var(--focus-background-color)',
     },
 }));
 
@@ -118,6 +118,9 @@ const MetadataChip = ({
     return <StyledStrategyCount>{text}</StyledStrategyCount>;
 };
 
+export const environmentAccordionSummaryClassName =
+    'environment-accordion-summary';
+
 export const EnvironmentHeader: FC<
     PropsWithChildren<EnvironmentHeaderProps>
 > = ({
@@ -139,6 +142,7 @@ export const EnvironmentHeader: FC<
             id={id}
             aria-controls={`environment-accordion-${id}-content`}
             expandable={expandable}
+            className={environmentAccordionSummaryClassName}
         >
             <StyledHeader data-loading>
                 <StyledHeaderTitle>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -20,6 +20,17 @@ const StyledAccordionSummary = styled(AccordionSummary, {
     '&&&': {
         cursor: expandable ? 'pointer' : 'default',
     },
+
+    borderRadius: theme.shape.borderRadiusLarge,
+    pointerEvents: 'auto',
+    opacity: 1,
+
+    ':focus-visible': {
+        background: theme.palette.table.headerHover,
+    },
+    ':focus-within': {
+        background: 'none',
+    },
 }));
 
 const StyledHeader = styled('header')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -23,13 +23,7 @@ const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
     boxShadow: 'none',
-    background: 'none',
-    '&&& .MuiAccordionSummary-root': {
-        borderRadius: theme.shape.borderRadiusLarge,
-        pointerEvents: 'auto',
-        opacity: 1,
-        backgroundColor: theme.palette.background.paper,
-    },
+    background: 'transparent',
 }));
 
 const NewStyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -26,7 +26,7 @@ const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
     boxShadow: 'none',
-    background: 'transparent',
+    background: 'none',
     [`&:has(.${environmentAccordionSummaryClassName}:focus-visible)`]: {
         background: theme.palette.table.headerHover,
     },

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -84,7 +84,6 @@ export const FeatureOverviewEnvironment = ({
                 TransitionProps={{ mountOnEnter: true, unmountOnExit: true }}
                 data-testid={`${FEATURE_ENVIRONMENT_ACCORDION}_${environment.name}`}
                 expanded={isOpen && hasActivations}
-                disabled={!hasActivations}
                 onChange={() => {
                     const state = isOpen ? !isOpen : hasActivations;
                     onToggleEnvOpen(state);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -25,11 +25,10 @@ const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
 }));
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
-    '--focus-background-color': theme.palette.table.headerHover,
     boxShadow: 'none',
     background: 'transparent',
     [`&:has(.${environmentAccordionSummaryClassName}:focus-visible)`]: {
-        background: 'var(--focus-background-color)',
+        background: theme.palette.table.headerHover,
     },
 }));
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -8,7 +8,10 @@ import { FEATURE_ENVIRONMENT_ACCORDION } from 'utils/testIds';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { UpgradeChangeRequests } from './UpgradeChangeRequests/UpgradeChangeRequests';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
-import { EnvironmentHeader } from './EnvironmentHeader/EnvironmentHeader';
+import {
+    environmentAccordionSummaryClassName,
+    EnvironmentHeader,
+} from './EnvironmentHeader/EnvironmentHeader';
 import FeatureOverviewEnvironmentMetrics from './EnvironmentHeader/FeatureOverviewEnvironmentMetrics/FeatureOverviewEnvironmentMetrics';
 import { FeatureOverviewEnvironmentToggle } from './EnvironmentHeader/FeatureOverviewEnvironmentToggle/FeatureOverviewEnvironmentToggle';
 import { useState } from 'react';
@@ -22,8 +25,12 @@ const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
 }));
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
+    '--focus-background-color': theme.palette.table.headerHover,
     boxShadow: 'none',
     background: 'transparent',
+    [`&:has(.${environmentAccordionSummaryClassName}:focus-visible)`]: {
+        background: 'var(--focus-background-color)',
+    },
 }));
 
 const NewStyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -24,9 +24,7 @@ import { StartMilestoneChangeRequestDialog } from './ChangeRequest/StartMileston
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { Truncator } from 'component/common/Truncator/Truncator';
 
-const StyledContainer = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'readonly',
-})<{ readonly?: boolean }>(({ theme, readonly }) => ({
+const StyledContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(2),
     paddingTop: theme.spacing(0),
     background: 'inherit',
@@ -235,7 +233,7 @@ export const ReleasePlan = ({
     );
 
     return (
-        <StyledContainer readonly={readonly}>
+        <StyledContainer>
             <StyledHeader>
                 <StyledHeaderGroup>
                     <StyledHeaderTitleLabel>


### PR DESCRIPTION
Adds focus styles to the env accordion header only when the focus is on the header itself (not on the env toggle inside the header). The focus style is consistent with what we do for other accordions (dashboard, milestones).

Middle one is focused:
![image](https://github.com/user-attachments/assets/df87bd99-8fe2-4093-afd8-4cbce9f2c943)


Focus is on the toggle inside the top one (yeh, we should have better focus styles for toggles; but that's not for now):
![image](https://github.com/user-attachments/assets/2a046d4c-8585-4021-a58e-32ef81b1f701)

Open and focused: 
![image](https://github.com/user-attachments/assets/fdbb5bda-4be5-4354-b213-5e2c7a59eb59)

Getting the consistent background for the header when it's open is a little tricky because the accordion container and summary are split into different files. ~~This first iteration used a class name for the specific header (because envs can have multiple accordion headers inside them, e.g. release plans) and setting a CSS variable in the summary, so that the background matches.~~ I found out that I only need to set it in the parent anyway 😄 

Without it, you get this (notice that there is a little white outside the lower corners): 
![image](https://github.com/user-attachments/assets/4d71d73c-7f45-46b5-811d-c6e36f9be5ce)
