### PR TITLE
feat: enforce change request settings in create project dialog

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
@@ -37,8 +37,9 @@ type TableProps = {
     environments: {
         name: string;
         type: string;
-        requiredApprovals: number;
         changeRequestEnabled: boolean;
+        requiredApprovals: number;
+        configurable: boolean;
     }[];
     enableEnvironment: (name: string, requiredApprovals: number) => void;
     disableEnvironment: (name: string) => void;
@@ -111,6 +112,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                                                 approvals,
                                             );
                                         }}
+                                        disabled={!original.configurable}
                                         IconComponent={
                                             KeyboardArrowDownOutlined
                                         }
@@ -143,6 +145,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                                         original.environment
                                     }`,
                                 }}
+                                disabled={!original.configurable}
                                 onClick={onToggleEnvironment(
                                     original.environment,
                                     original.changeRequestEnabled,
@@ -171,6 +174,7 @@ export const ChangeRequestTable = (props: TableProps) => {
                         type: env.type,
                         changeRequestEnabled: env.changeRequestEnabled,
                         requiredApprovals: env.requiredApprovals ?? 1,
+                        configurable: env.configurable,
                     };
                 }),
 

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
@@ -26,6 +26,7 @@ type ChangeRequestTableConfigButtonProps = Pick<
     activeEnvironments: {
         name: string;
         type: string;
+        configurable: boolean;
     }[];
     projectChangeRequestConfiguration: Record<
         string,
@@ -56,9 +57,10 @@ export const ChangeRequestTableConfigButton: FC<
 
     const tableEnvs = useMemo(
         () =>
-            activeEnvironments.map(({ name, type }) => ({
+            activeEnvironments.map(({ name, type, configurable }) => ({
                 name,
                 type,
+                configurable,
                 ...(configured[name] ?? { changeRequestEnabled: false }),
             })),
         [configured, activeEnvironments],

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.tsx
@@ -234,6 +234,9 @@ export const CreateProjectDialog = ({
         name,
         type,
         requiredApprovals,
+        configurable: globalChangeRequestConfigEnabled
+            ? !Number.isInteger(requiredApprovals)
+            : true,
     }));
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Potential project environments with preconfigured change request approvals cannot be overwritten in the UI
<img width="800" alt="Screenshot 2025-03-27 at 15 59 54" src="https://github.com/user-attachments/assets/115057d2-996a-4903-84b9-441ba8bbf1f4" />

We need to check if we need similar check in the backend. Currently it's a soft enforcement but advanced users of the API can override this behavior.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
