### PR TITLE
fix: only display feedback component on opened strategy panes

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -33,17 +33,16 @@ interface IFeatureStrategyMenuProps {
     matchWidth?: boolean;
     size?: IPermissionButtonProps['size'];
     disableReason?: string;
+    allowReleasePlanFeedback?: boolean;
 }
 
 const StyledStrategyMenu = styled('div')(({ theme }) => ({
     flexShrink: 0,
     display: 'flex',
-    width: '100%',
     flexFlow: 'row',
+    flex: 1,
+    justifyContent: 'flex-end',
     gap: theme.spacing(1),
-    '& > :nth-child(2)': {
-        marginLeft: 'auto',
-    },
 }));
 
 const StyledAdditionalMenuButton = styled(PermissionButton)(({ theme }) => ({
@@ -62,6 +61,10 @@ const StyledLink = styled(Link<typeof RouterLink | 'a'>)(({ theme }) => ({
     textDecoration: 'none',
 }));
 
+const Spacer = styled('div')(({ theme }) => ({
+    flex: 1,
+}));
+
 export const FeatureStrategyMenu = ({
     label,
     projectId,
@@ -71,6 +74,7 @@ export const FeatureStrategyMenu = ({
     size,
     matchWidth,
     disableReason,
+    allowReleasePlanFeedback = false,
 }: IFeatureStrategyMenuProps) => {
     const [anchor, setAnchor] = useState<Element>();
     const [onlyReleasePlans, setOnlyReleasePlans] = useState<boolean>(false);
@@ -177,15 +181,20 @@ export const FeatureStrategyMenu = ({
         <StyledStrategyMenu onClick={(event) => event.stopPropagation()}>
             {displayReleasePlanButton ? (
                 <>
-                    <StyledLink
-                        component='a'
-                        href={RELEASE_TEMPLATE_FEEDBACK}
-                        underline='hover'
-                        rel='noopener noreferrer'
-                        target='_blank'
-                    >
-                        Give feedback to release templates
-                    </StyledLink>
+                    {allowReleasePlanFeedback ? (
+                        <>
+                            <StyledLink
+                                component='a'
+                                href={RELEASE_TEMPLATE_FEEDBACK}
+                                underline='hover'
+                                rel='noopener noreferrer'
+                                target='_blank'
+                            >
+                                Give feedback to release templates
+                            </StyledLink>
+                            <Spacer />
+                        </>
+                    ) : null}
                     <PermissionButton
                         data-testid='ADD_TEMPLATE_BUTTON'
                         permission={CREATE_FEATURE_STRATEGY}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -43,8 +43,8 @@ const NewStyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
 const StyledAccordionFooter = styled('footer')(({ theme }) => ({
     padding: theme.spacing(2, 3, 3),
     display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-end',
+    flexDirection: 'row',
+    justifyContent: 'end',
     gap: theme.spacing(2),
 }));
 
@@ -131,6 +131,7 @@ export const FeatureOverviewEnvironment = ({
                             projectId={projectId}
                             featureId={featureId}
                             environmentId={environment.name}
+                            allowReleasePlanFeedback={true}
                         />
                         {isOss() && environment?.type === 'production' ? (
                             <UpgradeChangeRequests />


### PR DESCRIPTION
Fixes an issue where the new feedback button on the config strategy pane would affect environments without strategies configured

I've made the following changes here:
- The feedback button is now disabled by default, the parent needs to request that it be turned on and that's only done in one place
- CSS has been reworked so that it behaves when that component doesn't exist on the DOM (just flex align to the right and a spacer component that expands to eat whatever space it finds)
- Swapped the CSS on the parent that was originally causing the parent component not to fill the container (looks to be flex used to align on a different axis)