### PR TITLE
fix: useLocation instead of browser location for resolving pathname

### DIFF
--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -3,6 +3,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import type { ReactNode } from 'react';
 import { Sticky } from 'component/common/Sticky/Sticky';
 import { AdminMenuNavigation } from './AdminNavigationItems';
+import { useLocation } from 'react-router-dom';
 
 const StyledAdminMainGrid = styled(Grid)(({ theme }) => ({
     minWidth: 0, // this is a fix for overflowing flex
@@ -56,6 +57,7 @@ interface IWrapIfAdminSubpageProps {
 export const WrapIfAdminSubpage = ({ children }: IWrapIfAdminSubpageProps) => {
     const newAdminUIEnabled = useUiFlag('adminNavUI');
     const theme = useTheme();
+    const location = useLocation();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
     const showAdminMenu =
         !isSmallScreen &&

--- a/frontend/src/component/menu/Header/DrawerMenu/DrawerMenu.tsx
+++ b/frontend/src/component/menu/Header/DrawerMenu/DrawerMenu.tsx
@@ -1,5 +1,5 @@
 import type { VFC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Divider, Drawer, styled } from '@mui/material';
 import { ReactComponent as UnleashLogo } from 'assets/img/logoDarkWithText.svg';
 import { ReactComponent as UnleashLogoWhite } from 'assets/img/logoWithWhiteText.svg';
@@ -34,6 +34,7 @@ export const DrawerMenu: VFC<IDrawerMenuProps> = ({
     toggleDrawer,
 }) => {
     const newAdminUIEnabled = useUiFlag('adminNavUI');
+    const location = useLocation();
     const showOnlyAdminMenu =
         newAdminUIEnabled && location.pathname.indexOf('/admin') === 0;
     const onClick = () => {


### PR DESCRIPTION
We accidentally used `location` (the browser variable) instead of the `const location = useLocation()` from react in 2 of 3 places. this results in main menu being hidden while admin menu not being shown