### PR TITLE
fix: Back to Unleash onClick+useNavigate instead of href

### DIFF
--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminNavigationItems.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminNavigationItems.tsx
@@ -6,7 +6,7 @@ import { AdminListItem, AdminSubListItem, MenuGroup } from './AdminListItem';
 import { IconRenderer } from './AdminMenuIcons';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { filterByConfig } from 'component/common/util';
 import { filterAdminRoutes } from 'component/admin/filterAdminRoutes';
 import { adminGroups, adminRoutes } from 'component/admin/adminRoutes';
@@ -43,9 +43,12 @@ const StyledStopRoundedIcon = styled(StopRoundedIcon)(({ theme }) => ({
 }));
 
 export const DashboardLink = () => {
+    const navigate = useNavigate();
     return (
         <StyledButton
-            href='/personal'
+            onClick={() => {
+                navigate(`/personal`);
+            }}
             rel='noreferrer'
             startIcon={<ArrowBackIcon />}
         >


### PR DESCRIPTION
makes the button use useNavigate() instead of href - lets react sort the routing (works better with hosted instances path variables)