### PR TITLE
feat: show only link to /admin in mobile menu

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -12,6 +12,7 @@ import {
     SecondaryNavigation,
     SecondaryNavigationList,
     AdminSettingsNavigation,
+    AdminSettingsLink,
 } from './NavigationList';
 import { FullListItem, MiniListItem } from './ListItems';
 import { useInitialPathname } from './useInitialPathname';
@@ -35,6 +36,7 @@ export const MobileNavigationSidebar: FC<{
     NewInUnleash?: typeof NewInUnleash;
 }> = ({ onClick, NewInUnleash }) => {
     const { routes } = useRoutes();
+    const newAdminUIEnabled = useUiFlag('adminNavUI');
 
     return (
         <>
@@ -45,11 +47,15 @@ export const MobileNavigationSidebar: FC<{
                 mode='full'
                 onClick={onClick}
             />
-            <SecondaryNavigationList
-                routes={routes.adminRoutes}
-                mode='full'
-                onClick={onClick}
-            />
+            {newAdminUIEnabled ? (
+                <AdminSettingsLink mode={'full'} onClick={onClick} />
+            ) : (
+                <SecondaryNavigationList
+                    routes={routes.adminRoutes}
+                    mode='full'
+                    onClick={onClick}
+                />
+            )}
             <OtherLinksList />
         </>
     );

--- a/frontend/src/component/menu/Header/DrawerMenu/DrawerMenu.tsx
+++ b/frontend/src/component/menu/Header/DrawerMenu/DrawerMenu.tsx
@@ -1,5 +1,5 @@
 import type { VFC } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Divider, Drawer, styled } from '@mui/material';
 import { ReactComponent as UnleashLogo } from 'assets/img/logoDarkWithText.svg';
 import { ReactComponent as UnleashLogoWhite } from 'assets/img/logoWithWhiteText.svg';
@@ -8,8 +8,8 @@ import theme from 'themes/theme';
 import { ThemeMode } from 'component/common/ThemeMode/ThemeMode';
 import { MobileNavigationSidebar } from 'component/layout/MainLayout/NavigationSidebar/NavigationSidebar';
 import { NewInUnleash } from 'component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleash';
-import { useUiFlag } from 'hooks/useUiFlag';
 import { AdminMobileNavigation } from 'component/layout/MainLayout/AdminMenu/AdminNavigationItems';
+import { useNewAdminMenu } from 'hooks/useNewAdminMenu';
 
 const StyledDrawerHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -33,10 +33,7 @@ export const DrawerMenu: VFC<IDrawerMenuProps> = ({
     open = false,
     toggleDrawer,
 }) => {
-    const newAdminUIEnabled = useUiFlag('adminNavUI');
-    const location = useLocation();
-    const showOnlyAdminMenu =
-        newAdminUIEnabled && location.pathname.indexOf('/admin') === 0;
+    const showOnlyAdminMenu = useNewAdminMenu();
     const onClick = () => {
         toggleDrawer();
     };


### PR DESCRIPTION
Replaces a long list of admin links with a link to the /admin section

![image](https://github.com/user-attachments/assets/954fa9c2-c155-42e9-832c-380706254ccc)
