### PR TITLE
refactor: migration

### DIFF
--- a/src/migrations/20250331115805-alter-tag-type-color.js
+++ b/src/migrations/20250331115805-alter-tag-type-color.js
@@ -16,9 +16,6 @@ exports.down = function (db, cb) {
         `
         ALTER TABLE tag_types
         ALTER COLUMN color TYPE VARCHAR(10);
-        
-        UPDATE tag_types
-        SET color = '#FFFFFF';
         `,
         cb,
     );

--- a/src/migrations/20250331115805-alter-tag-type-color.js
+++ b/src/migrations/20250331115805-alter-tag-type-color.js
@@ -1,0 +1,25 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE tag_types
+        ALTER COLUMN color TYPE VARCHAR(50);
+        
+        UPDATE tag_types
+        SET color = 'common.white';
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        ALTER TABLE tag_types
+        ALTER COLUMN color TYPE VARCHAR(10);
+        
+        UPDATE tag_types
+        SET color = '#FFFFFF';
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
Prepare the ground for the next PR that will use references to theme colors instead of hex colors so that we can map the correct colors in each theme. 

Changes:
- Color is now VARCHAR(50)
- Default color is set to "common.white"