### PR TITLE
fix: linter rule for useHookAtTopLevel

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
         "noUnsafeOptionalChaining": "off",
         "useExhaustiveDependencies": "off",
         "noUnusedImports": "warn",
-        "useJsxKeyInIterable": "off"
+        "useJsxKeyInIterable": "off",
+        "useHookAtTopLevel": "error"
       },
       "complexity": {
         "noBannedTypes": "off",

--- a/biome.json
+++ b/biome.json
@@ -104,7 +104,7 @@
   },
   "overrides": [
     {
-      "include": ["!frontend/**"],
+      "include": ["src/**"],
       "linter": {
         "rules": {
           "correctness": {

--- a/biome.json
+++ b/biome.json
@@ -101,5 +101,17 @@
     "formatter": {
       "indentWidth": 2
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": ["!frontend/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useHookAtTopLevel": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPAYG.tsx
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPAYG.tsx
@@ -45,8 +45,7 @@ export const BillingDetailsPAYG = ({
     const billableUsers = Math.max(eligibleUsers.length, minSeats);
     const usersCost = seatPrice * billableUsers;
 
-    const includedTraffic = BILLING_INCLUDED_REQUESTS;
-    const overageCost = useOverageCost(includedTraffic);
+    const overageCost = useOverageCost(BILLING_INCLUDED_REQUESTS);
 
     const totalCost = usersCost + overageCost;
 

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPro.tsx
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/BillingDetailsPro.tsx
@@ -52,8 +52,7 @@ export const BillingDetailsPro = ({
     const freeAssigned = Math.min(eligibleUsers.length, seats);
     const paidAssigned = eligibleUsers.length - freeAssigned;
     const paidAssignedPrice = seatPrice * paidAssigned;
-    const includedTraffic = BILLING_INCLUDED_REQUESTS;
-    const overageCost = useOverageCost(includedTraffic);
+    const overageCost = useOverageCost(BILLING_INCLUDED_REQUESTS);
 
     const totalCost = planPrice + paidAssignedPrice + overageCost;
 

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -18,13 +18,16 @@ export const useOverageCost = (includedTraffic: number) => {
     const from = formatDate(startOfMonth(now));
     const to = formatDate(endOfMonth(now));
 
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const { instanceStatus } = useInstanceStatus();
     const trafficPrice =
         instanceStatus?.prices?.[
             instanceStatus?.billing === 'pay-as-you-go' ? 'payg' : 'pro'
         ]?.traffic ?? BILLING_TRAFFIC_PRICE;
 
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const { result } = useTrafficSearch('daily', { from, to });
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const overageCost = useMemo(() => {
         if (result.state !== 'success') {
             return 0;

--- a/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
+++ b/frontend/src/component/admin/billing/BillingDashboard/BillingPlan/useOverageCost.ts
@@ -9,25 +9,18 @@ import { BILLING_TRAFFIC_PRICE } from './BillingPlan';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
 
 export const useOverageCost = (includedTraffic: number) => {
-    if (!includedTraffic) {
-        return 0;
-    }
-
     const now = new Date();
     const formatDate = (date: Date) => format(date, 'yyyy-MM-dd');
     const from = formatDate(startOfMonth(now));
     const to = formatDate(endOfMonth(now));
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const { instanceStatus } = useInstanceStatus();
     const trafficPrice =
         instanceStatus?.prices?.[
             instanceStatus?.billing === 'pay-as-you-go' ? 'payg' : 'pro'
         ]?.traffic ?? BILLING_TRAFFIC_PRICE;
 
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const { result } = useTrafficSearch('daily', { from, to });
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter -- how to skip it if `includedTraffic` is 0?
     const overageCost = useMemo(() => {
         if (result.state !== 'success') {
             return 0;

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -12,7 +12,10 @@ import type {
 } from '../../changeRequest.types';
 import { HtmlTooltip } from '../../../common/HtmlTooltip/HtmlTooltip';
 import ErrorIcon from '@mui/icons-material/Error';
-import { useLocationSettings } from 'hooks/useLocationSettings';
+import {
+    type ILocationSettings,
+    useLocationSettings,
+} from 'hooks/useLocationSettings';
 import { formatDateYMDHMS } from 'utils/formatDate';
 
 export type ISuggestChangeTimelineProps =
@@ -99,6 +102,7 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
             data = steps;
     }
     const activeIndex = data.findIndex((item) => item === state);
+    const { locationSettings } = useLocationSettings();
 
     return (
         <StyledPaper elevation={0}>
@@ -106,7 +110,10 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
                 <StyledTimeline>
                     {data.map((title, index) => {
                         if (schedule && title === 'Scheduled') {
-                            return createTimelineScheduleItem(schedule);
+                            return createTimelineScheduleItem(
+                                schedule,
+                                locationSettings,
+                            );
                         }
 
                         const color = determineColor(
@@ -195,9 +202,10 @@ export const getScheduleProps = (
     }
 };
 
-const createTimelineScheduleItem = (schedule: ChangeRequestSchedule) => {
-    const { locationSettings } = useLocationSettings();
-
+const createTimelineScheduleItem = (
+    schedule: ChangeRequestSchedule,
+    locationSettings: ILocationSettings,
+) => {
     const time = formatDateYMDHMS(
         new Date(schedule.scheduledAt),
         locationSettings?.locale,

--- a/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
+++ b/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
@@ -169,9 +169,8 @@ export const RecentlyVisitedFeatureButton = ({
     featureId: string;
     onClick: () => void;
 }) => {
+    const { trackEvent } = usePlausibleTracker();
     const onItemClick = () => {
-        const { trackEvent } = usePlausibleTracker();
-
         trackEvent('command-bar', {
             props: {
                 eventType: `click`,

--- a/frontend/src/component/common/Table/SearchHighlightContext/SearchHighlightContext.tsx
+++ b/frontend/src/component/common/Table/SearchHighlightContext/SearchHighlightContext.tsx
@@ -5,5 +5,6 @@ const SearchHighlightContext = createContext('');
 export const SearchHighlightProvider = SearchHighlightContext.Provider;
 
 export const useSearchHighlightContext = (): { searchQuery: string } => {
-    return { searchQuery: useContext(SearchHighlightContext) };
+    const searchQuery = useContext(SearchHighlightContext);
+    return { searchQuery };
 };

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.test.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.test.tsx
@@ -1,11 +1,11 @@
 import { screen } from '@testing-library/react';
 import { render } from 'utils/testRenderer';
-import { FeatureOverviewCell as makeFeatureOverviewCell } from './FeatureOverviewCell';
+import { createFeatureOverviewCell } from './FeatureOverviewCell';
 
 const noOp = () => {};
 
 test('Display full overview information', () => {
-    const FeatureOverviewCell = makeFeatureOverviewCell(noOp, noOp);
+    const FeatureOverviewCell = createFeatureOverviewCell(noOp, noOp);
 
     render(
         <FeatureOverviewCell
@@ -43,7 +43,7 @@ test('Display full overview information', () => {
 });
 
 test('Display minimal overview information', () => {
-    const FeatureOverviewCell = makeFeatureOverviewCell(noOp, noOp);
+    const FeatureOverviewCell = createFeatureOverviewCell(noOp, noOp);
 
     render(
         <FeatureOverviewCell
@@ -69,7 +69,7 @@ test('Display minimal overview information', () => {
 });
 
 test('show archived information', () => {
-    const FeatureOverviewCell = makeFeatureOverviewCell(noOp, noOp);
+    const FeatureOverviewCell = createFeatureOverviewCell(noOp, noOp);
 
     render(
         <FeatureOverviewCell

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -436,14 +436,12 @@ const SecondaryFeatureInfo: FC<{
     );
 };
 
-export const FeatureOverviewCell =
-    (
-        onTagClick: (tag: string) => void,
-        onFlagTypeClick: (type: string) => void,
-    ): FC<IFeatureNameCellProps> =>
-    ({ row }) => {
-        const { searchQuery } = useSearchHighlightContext();
-
+export const FeatureOverviewCell = (
+    onTagClick: (tag: string) => void,
+    onFlagTypeClick: (type: string) => void,
+): FC<IFeatureNameCellProps> => {
+    const { searchQuery } = useSearchHighlightContext();
+    return ({ row }) => {
         return (
             <Container>
                 <PrimaryFeatureInfo
@@ -463,3 +461,4 @@ export const FeatureOverviewCell =
             </Container>
         );
     };
+};

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -436,29 +436,44 @@ const SecondaryFeatureInfo: FC<{
     );
 };
 
-export const FeatureOverviewCell = (
-    onTagClick: (tag: string) => void,
-    onFlagTypeClick: (type: string) => void,
-): FC<IFeatureNameCellProps> => {
+const FeatureOverviewCell = ({
+    row,
+}: IFeatureNameCellProps & {
+    onTagClick: (tag: string) => void;
+    onFlagTypeClick: (type: string) => void;
+}): JSX.Element => {
     const { searchQuery } = useSearchHighlightContext();
-    return ({ row }) => {
-        return (
-            <Container>
-                <PrimaryFeatureInfo
-                    project={row.original.project || ''}
-                    feature={row.original.name}
-                    archivedAt={row.original.archivedAt}
-                    searchQuery={searchQuery}
-                    type={row.original.type || ''}
-                    dependencyType={row.original.dependencyType || ''}
-                    onTypeClick={onFlagTypeClick}
-                />
-                <SecondaryFeatureInfo
-                    description={row.original.description || ''}
-                    searchQuery={searchQuery}
-                />
-                <Tags tags={row.original.tags} onClick={onTagClick} />
-            </Container>
-        );
-    };
+    const { archivedAt, project, name } = row.original;
+
+    return (
+        <Container>
+            <PrimaryFeatureInfo
+                project={project || ''}
+                feature={name}
+                archivedAt={archivedAt}
+                searchQuery={searchQuery}
+                type={row.original.type || ''}
+                dependencyType={row.original.dependencyType || ''}
+                onTypeClick={() => {}}
+            />
+            <SecondaryFeatureInfo
+                description={row.original.description || ''}
+                searchQuery={searchQuery}
+            />
+            <Tags tags={row.original.tags} onClick={() => {}} />
+        </Container>
+    );
 };
+
+export const createFeatureOverviewCell =
+    (
+        onTagClick: (tag: string) => void,
+        onFlagTypeClick: (type: string) => void,
+    ): FC<IFeatureNameCellProps> =>
+    ({ row }) => (
+        <FeatureOverviewCell
+            row={row}
+            onTagClick={onTagClick}
+            onFlagTypeClick={onFlagTypeClick}
+        />
+    );

--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -436,44 +436,30 @@ const SecondaryFeatureInfo: FC<{
     );
 };
 
-const FeatureOverviewCell = ({
-    row,
-}: IFeatureNameCellProps & {
-    onTagClick: (tag: string) => void;
-    onFlagTypeClick: (type: string) => void;
-}): JSX.Element => {
-    const { searchQuery } = useSearchHighlightContext();
-    const { archivedAt, project, name } = row.original;
-
-    return (
-        <Container>
-            <PrimaryFeatureInfo
-                project={project || ''}
-                feature={name}
-                archivedAt={archivedAt}
-                searchQuery={searchQuery}
-                type={row.original.type || ''}
-                dependencyType={row.original.dependencyType || ''}
-                onTypeClick={() => {}}
-            />
-            <SecondaryFeatureInfo
-                description={row.original.description || ''}
-                searchQuery={searchQuery}
-            />
-            <Tags tags={row.original.tags} onClick={() => {}} />
-        </Container>
-    );
-};
-
 export const createFeatureOverviewCell =
     (
         onTagClick: (tag: string) => void,
         onFlagTypeClick: (type: string) => void,
     ): FC<IFeatureNameCellProps> =>
-    ({ row }) => (
-        <FeatureOverviewCell
-            row={row}
-            onTagClick={onTagClick}
-            onFlagTypeClick={onFlagTypeClick}
-        />
-    );
+    ({ row }) => {
+        const { searchQuery } = useSearchHighlightContext();
+
+        return (
+            <Container>
+                <PrimaryFeatureInfo
+                    project={row.original.project || ''}
+                    feature={row.original.name}
+                    archivedAt={row.original.archivedAt}
+                    searchQuery={searchQuery}
+                    type={row.original.type || ''}
+                    dependencyType={row.original.dependencyType || ''}
+                    onTypeClick={onFlagTypeClick}
+                />
+                <SecondaryFeatureInfo
+                    description={row.original.description || ''}
+                    searchQuery={searchQuery}
+                />
+                <Tags tags={row.original.tags} onClick={onTagClick} />
+            </Container>
+        );
+    };

--- a/frontend/src/component/events/EventLog/EventLogFilters.test.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.test.tsx
@@ -6,12 +6,7 @@ const allFilterKeys = ['from', 'to', 'createdBy', 'type', 'project', 'feature'];
 allFilterKeys.sort();
 
 test('When you have no projects or flags, you should not get a project or flag filters', () => {
-    const { result } = renderHook(() =>
-        useEventLogFilters(
-            () => ({ projects: [] }),
-            () => ({ features: [] }),
-        ),
-    );
+    const { result } = renderHook(() => useEventLogFilters([], []));
     const filterKeys = result.current.map((filter) => filter.filterKey);
     filterKeys.sort();
 
@@ -22,9 +17,9 @@ test('When you have no projects or flags, you should not get a project or flag f
 test('When you have no projects, you should not get a project filter', () => {
     const { result } = renderHook(() =>
         useEventLogFilters(
-            () => ({ projects: [] }),
+            [],
             // @ts-expect-error: omitting other properties we don't need
-            () => ({ features: [{ name: 'flag' }] }),
+            [{ name: 'flag' }],
         ),
     );
     const filterKeys = result.current.map((filter) => filter.filterKey);
@@ -35,10 +30,7 @@ test('When you have no projects, you should not get a project filter', () => {
 
 test('When you have only one project, you should not get a project filter', () => {
     const { result } = renderHook(() =>
-        useEventLogFilters(
-            () => ({ projects: [{ id: 'a', name: 'A' }] }),
-            () => ({ features: [] }),
-        ),
+        useEventLogFilters([{ id: 'a', name: 'A' }], []),
     );
     const filterKeys = result.current.map((filter) => filter.filterKey);
     filterKeys.sort();
@@ -49,13 +41,11 @@ test('When you have only one project, you should not get a project filter', () =
 test('When you have two one project, you should not get a project filter', () => {
     const { result } = renderHook(() =>
         useEventLogFilters(
-            () => ({
-                projects: [
-                    { id: 'a', name: 'A' },
-                    { id: 'b', name: 'B' },
-                ],
-            }),
-            () => ({ features: [] }),
+            [
+                { id: 'a', name: 'A' },
+                { id: 'b', name: 'B' },
+            ],
+            [],
         ),
     );
     const filterKeys = result.current.map((filter) => filter.filterKey);

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -22,9 +22,11 @@ export const useEventLogFilters = (
 ) => {
     const { projects } = projectsHook();
     const { features } = featuresHook({});
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     const { eventCreators } = useEventCreators();
-
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
+    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     useEffect(() => {
         const projectOptions =
             projects?.map((project: ProjectSchema) => ({
@@ -127,16 +129,19 @@ type LogType = 'flag' | 'project' | 'global';
 const useEventLogFiltersFromLogType = (logType: LogType) => {
     switch (logType) {
         case 'flag':
+            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
             return useEventLogFilters(
                 () => ({ projects: [] }),
                 () => ({ features: [] }),
             );
         case 'project':
+            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
             return useEventLogFilters(
                 () => ({ projects: [] }),
                 useFeatureSearch,
             );
         case 'global':
+            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
             return useEventLogFilters(useProjects, useFeatureSearch);
     }
 };

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -6,27 +6,16 @@ import {
 } from 'component/filter/Filters/Filters';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
-import {
-    EventSchemaType,
-    type FeatureSearchResponseSchema,
-    type SearchFeaturesParams,
-} from 'openapi';
+import { EventSchemaType, type FeatureSearchResponseSchema } from 'openapi';
 import type { ProjectSchema } from 'openapi';
 import { useEventCreators } from 'hooks/api/getters/useEventCreators/useEventCreators';
 
 export const useEventLogFilters = (
-    projectsHook: () => { projects: ProjectSchema[] },
-    featuresHook: (params: SearchFeaturesParams) => {
-        features: FeatureSearchResponseSchema[];
-    },
+    projects: ProjectSchema[],
+    features: FeatureSearchResponseSchema[],
 ) => {
-    const { projects } = projectsHook();
-    const { features } = featuresHook({});
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     const { eventCreators } = useEventCreators();
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
-    // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
     useEffect(() => {
         const projectOptions =
             projects?.map((project: ProjectSchema) => ({
@@ -126,25 +115,6 @@ export const useEventLogFilters = (
 };
 
 type LogType = 'flag' | 'project' | 'global';
-const useEventLogFiltersFromLogType = (logType: LogType) => {
-    switch (logType) {
-        case 'flag':
-            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
-            return useEventLogFilters(
-                () => ({ projects: [] }),
-                () => ({ features: [] }),
-            );
-        case 'project':
-            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
-            return useEventLogFilters(
-                () => ({ projects: [] }),
-                useFeatureSearch,
-            );
-        case 'global':
-            // biome-ignore lint/correctness/useHookAtTopLevel: // FIXME: linter
-            return useEventLogFilters(useProjects, useFeatureSearch);
-    }
-};
 
 type EventLogFiltersProps = {
     logType: LogType;
@@ -159,7 +129,14 @@ export const EventLogFilters: FC<EventLogFiltersProps> = ({
     state,
     onChange,
 }) => {
-    const availableFilters = useEventLogFiltersFromLogType(logType);
+    const { features } = useFeatureSearch({});
+    const { projects } = useProjects();
+    const featuresToFilter = logType !== 'flag' ? features : [];
+    const projectsToFilter = logType === 'global' ? projects : [];
+    const availableFilters = useEventLogFilters(
+        projectsToFilter,
+        featuresToFilter,
+    );
 
     return (
         <Filters

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -50,16 +50,17 @@ export const FeatureOverview = () => {
     }, [featureId]);
     const flagOverviewRedesign = useUiFlag('flagOverviewRedesign');
 
-    if (!flagOverviewRedesign) {
-        return <LegacyFleatureOverview />;
-    }
-
     const { setSplashSeen } = useSplashApi();
     const { splash } = useAuthSplash();
     const dragTooltipSplashId = 'strategy-drag-tooltip';
     const shouldShowStrategyDragTooltip = !splash?.[dragTooltipSplashId];
     const [showTooltip, setShowTooltip] = useState(false);
     const [hasClosedTooltip, setHasClosedTooltip] = useState(false);
+
+    if (!flagOverviewRedesign) {
+        return <LegacyFleatureOverview />;
+    }
+
     const toggleShowTooltip = (envIsOpen: boolean) => {
         setShowTooltip(
             !hasClosedTooltip && shouldShowStrategyDragTooltip && envIsOpen,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -60,7 +60,6 @@ export const FeatureOverview = () => {
 
     const dragTooltipSplashId = 'strategy-drag-tooltip';
     const shouldShowStrategyDragTooltip = !splash?.[dragTooltipSplashId];
-
     const toggleShowTooltip = (envIsOpen: boolean) => {
         setShowTooltip(
             !hasClosedTooltip && shouldShowStrategyDragTooltip && envIsOpen,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -89,13 +89,13 @@ export const EnvironmentAccordionBody = ({
         }
     }, []);
 
-    if (!featureEnvironment) {
-        return null;
-    }
-
     const pageSize = 20;
     const { page, pages, setPageIndex, pageIndex } =
         usePagination<IFeatureStrategy>(strategies, pageSize);
+
+    if (!featureEnvironment) {
+        return null;
+    }
 
     const onReorder = async (payload: { id: string; sortOrder: number }[]) => {
         try {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/LegacyEnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/LegacyEnvironmentAccordionBody.tsx
@@ -101,13 +101,13 @@ const EnvironmentAccordionBody = ({
         }
     }, []);
 
-    if (!featureEnvironment) {
-        return null;
-    }
-
     const pageSize = 20;
     const { page, pages, setPageIndex, pageIndex } =
         usePagination<IFeatureStrategy>(strategies, pageSize);
+
+    if (!featureEnvironment) {
+        return null;
+    }
 
     const onReorder = async (payload: { id: string; sortOrder: number }[]) => {
         try {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
@@ -11,7 +11,7 @@ import { TagTypeSelect } from './TagTypeSelect';
 import { type TagOption, TagsInput } from './TagsInput';
 import useTags from 'hooks/api/getters/useTags/useTags';
 import useTagTypes from 'hooks/api/getters/useTagTypes/useTagTypes';
-import type { ITag, ITagType } from 'interfaces/tags';
+import type { ITagType } from 'interfaces/tags';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
 import type { TagSchema } from 'openapi';

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -35,7 +35,7 @@ import { useDefaultColumnVisibility } from './hooks/useDefaultColumnVisibility';
 import { TableEmptyState } from './TableEmptyState/TableEmptyState';
 import { useRowActions } from './hooks/useRowActions';
 import { useSelectedData } from './hooks/useSelectedData';
-import { FeatureOverviewCell } from 'component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell';
+import { createFeatureOverviewCell } from 'component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell';
 import {
     useProjectFeatureSearch,
     useProjectFeatureSearchActions,
@@ -213,7 +213,7 @@ export const ProjectFeatureToggles = ({
             columnHelper.accessor('name', {
                 id: 'name',
                 header: 'Name',
-                cell: FeatureOverviewCell(onTagClick, onFlagTypeClick),
+                cell: createFeatureOverviewCell(onTagClick, onFlagTypeClick),
                 enableHiding: false,
             }),
             columnHelper.accessor('createdAt', {

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState, type VFC } from 'react';
 import { Button } from '@mui/material';
 import { ManageBulkTagsDialog } from 'component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog';
 import type { FeatureSchema, TagSchema } from 'openapi';
-import type { ITag } from 'interfaces/tags';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';

--- a/frontend/src/component/project/Project/ProjectInsights/ProjectInsightsStats/ProjectInsightsStats.tsx
+++ b/frontend/src/component/project/Project/ProjectInsights/ProjectInsightsStats/ProjectInsightsStats.tsx
@@ -38,10 +38,10 @@ interface IProjectStatsProps {
 }
 
 export const ProjectInsightsStats = ({ stats }: IProjectStatsProps) => {
+    const projectId = useRequiredPathParam('projectId');
     if (Object.keys(stats).length === 0) {
         return null;
     }
-    const projectId = useRequiredPathParam('projectId');
 
     const {
         avgTimeToProdCurrentWindow,

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState, type VFC } from 'react';
+import { useContext, useMemo, useState, type VFC as FC } from 'react';
 import { type HeaderGroup, useGlobalFilter, useTable } from 'react-table';
 import { Alert, Box, styled, Typography } from '@mui/material';
 import {
@@ -41,8 +41,9 @@ const StyledBox = styled(Box)(({ theme }) => ({
     },
 }));
 
-export const ChangeRequestTable: VFC = () => {
+export const ChangeRequestTable: FC = () => {
     const { trackEvent } = usePlausibleTracker();
+    const { hasAccess } = useContext(AccessContext);
     const [dialogState, setDialogState] = useState<{
         isOpen: boolean;
         enableEnvironment: string;
@@ -139,43 +140,33 @@ export const ChangeRequestTable: VFC = () => {
             },
             {
                 Header: 'Required approvals',
-                Cell: ({ row: { original } }: any) => {
-                    const { hasAccess } = useContext(AccessContext);
-
-                    return (
-                        <ConditionallyRender
-                            condition={original.changeRequestEnabled}
-                            show={
-                                <StyledBox data-loading>
-                                    <GeneralSelect
-                                        sx={{ width: '140px', marginLeft: 1 }}
-                                        options={approvalOptions}
-                                        value={original.requiredApprovals || 1}
-                                        onChange={(approvals) => {
-                                            onRequiredApprovalsChange(
-                                                original,
-                                                approvals,
-                                            );
-                                        }}
-                                        disabled={
-                                            !hasAccess(
-                                                [
-                                                    UPDATE_PROJECT,
-                                                    PROJECT_CHANGE_REQUEST_WRITE,
-                                                ],
-                                                projectId,
-                                            )
-                                        }
-                                        IconComponent={
-                                            KeyboardArrowDownOutlined
-                                        }
-                                        fullWidth
-                                    />
-                                </StyledBox>
-                            }
-                        />
-                    );
-                },
+                Cell: ({ row: { original } }: any) =>
+                    original.changeRequestEnabled ? (
+                        <StyledBox data-loading>
+                            <GeneralSelect
+                                sx={{ width: '140px', marginLeft: 1 }}
+                                options={approvalOptions}
+                                value={original.requiredApprovals || 1}
+                                onChange={(approvals) => {
+                                    onRequiredApprovalsChange(
+                                        original,
+                                        approvals,
+                                    );
+                                }}
+                                disabled={
+                                    !hasAccess(
+                                        [
+                                            UPDATE_PROJECT,
+                                            PROJECT_CHANGE_REQUEST_WRITE,
+                                        ],
+                                        projectId,
+                                    )
+                                }
+                                IconComponent={KeyboardArrowDownOutlined}
+                                fullWidth
+                            />
+                        </StyledBox>
+                    ) : null,
                 width: 100,
                 disableGlobalFilter: true,
                 disableSortBy: true,


### PR DESCRIPTION
React can crash an app if rules of hooks are broken. This occurs if there is a return statement before a hook, causing a different number of hook calls between component renders. To prevent this I'm reintroducing a linting rule. We probably had it before we switched from ESLint to Biome. This PR is also fixing all of the issues introduced in the code that where flagged by Biome.