### PR TITLE
Remove caseInsensitiveInOperators flag

### DIFF
--- a/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
+++ b/frontend/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
@@ -9,7 +9,6 @@ import {
     DATE_AFTER,
     IN,
     stringOperators,
-    inOperators,
 } from 'constants/operators';
 import { resolveText } from './helpers';
 import { oneOf } from 'utils/oneOf';
@@ -25,7 +24,6 @@ import { InvertedOperatorButton } from '../StyledToggleButton/InvertedOperatorBu
 import { CaseSensitiveButton } from '../StyledToggleButton/CaseSensitiveButton/CaseSensitiveButton';
 import { ConstraintAccordionHeaderActions } from '../../ConstraintAccordionHeaderActions/ConstraintAccordionHeaderActions';
 import { styled } from '@mui/material';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 interface IConstraintAccordionViewHeader {
     localConstraint: IConstraint;
@@ -103,13 +101,8 @@ export const ConstraintAccordionEditHeader = ({
     const { contextName, operator } = localConstraint;
     const [showCaseSensitiveButton, setShowCaseSensitiveButton] =
         useState(false);
-    const { uiConfig } = useUiConfig();
 
-    const caseInsensitiveInOperators = Boolean(
-        uiConfig.flags.caseInsensitiveInOperators,
-    );
-
-    /* We need a special case to handle the currenTime context field. Since
+    /* We need a special case to handle the currentTime context field. Since
     this field will be the only one to allow DATE_BEFORE and DATE_AFTER operators
     this will check if the context field is the current time context field AND check
     if it is not already using one of the date operators (to not overwrite if there is existing
@@ -131,21 +124,12 @@ export const ConstraintAccordionEditHeader = ({
             setOperator(IN);
         }
 
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);
         }
-    }, [
-        contextName,
-        setOperator,
-        operator,
-        setLocalConstraint,
-        caseInsensitiveInOperators,
-    ]);
+    }, [contextName, setOperator, operator, setLocalConstraint]);
 
     if (!context) {
         return null;
@@ -156,10 +140,7 @@ export const ConstraintAccordionEditHeader = ({
     });
 
     const onOperatorChange = (operator: Operator) => {
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
@@ -9,7 +9,6 @@ import {
     DATE_AFTER,
     IN,
     stringOperators,
-    inOperators,
 } from 'constants/operators';
 import { resolveText } from './helpers';
 import { oneOf } from 'utils/oneOf';
@@ -25,7 +24,6 @@ import { InvertedOperatorButton } from '../StyledToggleButton/InvertedOperatorBu
 import { CaseSensitiveButton } from '../StyledToggleButton/CaseSensitiveButton/CaseSensitiveButton';
 import { ConstraintAccordionHeaderActions } from '../../ConstraintAccordionHeaderActions/ConstraintAccordionHeaderActions';
 import { styled } from '@mui/material';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 interface IConstraintAccordionViewHeader {
     localConstraint: IConstraint;
@@ -107,13 +105,8 @@ export const ConstraintAccordionEditHeader = ({
     const { contextName, operator } = localConstraint;
     const [showCaseSensitiveButton, setShowCaseSensitiveButton] =
         useState(false);
-    const { uiConfig } = useUiConfig();
 
-    const caseInsensitiveInOperators = Boolean(
-        uiConfig.flags.caseInsensitiveInOperators,
-    );
-
-    /* We need a special case to handle the currenTime context field. Since
+    /* We need a special case to handle the currentTime context field. Since
     this field will be the only one to allow DATE_BEFORE and DATE_AFTER operators
     this will check if the context field is the current time context field AND check
     if it is not already using one of the date operators (to not overwrite if there is existing
@@ -135,21 +128,12 @@ export const ConstraintAccordionEditHeader = ({
             setOperator(IN);
         }
 
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);
         }
-    }, [
-        contextName,
-        setOperator,
-        operator,
-        setLocalConstraint,
-        caseInsensitiveInOperators,
-    ]);
+    }, [contextName, setOperator, operator, setLocalConstraint]);
 
     if (!context) {
         return null;
@@ -160,10 +144,7 @@ export const ConstraintAccordionEditHeader = ({
     });
 
     const onOperatorChange = (operator: Operator) => {
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFilterItem.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFilterItem.tsx
@@ -14,7 +14,6 @@ import {
     type Operator,
     allOperators,
     dateOperators,
-    inOperators,
     stringOperators,
 } from 'constants/operators';
 import { useEffect, useState } from 'react';
@@ -24,7 +23,6 @@ import { CaseSensitiveButton } from 'component/common/NewConstraintAccordion/Con
 import { InvertedOperatorButton } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/StyledToggleButton/InvertedOperatorButton/InvertedOperatorButton';
 import { ResolveInput } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput';
 import { useConstraintInput } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/useConstraintInput/useConstraintInput';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledDeleteButton = styled(IconButton)({
     marginRight: '-6px',
@@ -136,8 +134,6 @@ export const ProjectActionsFilterItem = ({
     const [showCaseSensitiveButton, setShowCaseSensitiveButton] =
         useState(false);
 
-    const caseInsensitiveInOperators = useUiFlag('caseInsensitiveInOperators');
-
     const validOperators = allOperators.filter(
         (operator) => !oneOf(dateOperators, operator),
     );
@@ -167,21 +163,15 @@ export const ProjectActionsFilterItem = ({
     }, [value, error]);
 
     useEffect(() => {
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);
         }
-    }, [operator, caseInsensitiveInOperators]);
+    }, [operator]);
 
     const onOperatorChange = (operator: Operator) => {
-        if (
-            oneOf(stringOperators, operator) ||
-            (oneOf(inOperators, operator) && caseInsensitiveInOperators)
-        ) {
+        if (oneOf(stringOperators, operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -55,7 +55,6 @@ export type UiFlags = {
     maintenanceMode?: boolean;
     messageBanner?: Variant;
     banner?: Variant;
-    caseInsensitiveInOperators?: boolean;
     notifications?: boolean;
     personalAccessTokensKillSwitch?: boolean;
     demo?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -13,7 +13,6 @@ export type IFlagKey =
     | 'responseTimeWithAppNameKillSwitch'
     | 'maintenanceMode'
     | 'messageBanner'
-    | 'caseInsensitiveInOperators'
     | 'strictSchemaValidation'
     | 'personalAccessTokensKillSwitch'
     | 'migrationLock'
@@ -101,10 +100,6 @@ const flags: IFlags = {
                 process.env.UNLEASH_EXPERIMENTAL_MESSAGE_BANNER_PAYLOAD ?? '',
         },
     },
-    caseInsensitiveInOperators: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_CASE_INSENSITIVE_IN_OPERATORS,
-        false,
-    ),
     strictSchemaValidation: parseEnvVarBoolean(
         process.env.UNLEASH_STRICT_SCHEMA_VALIDTION,
         false,


### PR DESCRIPTION
The flag has never made it out of dev, and has not been turned on consistently since 2023. There was a project for it, but we have since abandoned it.

