### PR TITLE
feat: new feature strategy menu

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
@@ -1,7 +1,8 @@
 import { getFeatureStrategyIcon } from 'utils/strategyNames';
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
-import { Button, styled, Tooltip } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
+import { Truncator } from 'component/common/Truncator/Truncator';
 
 const StyledIcon = styled('div')(({ theme }) => ({
     width: theme.spacing(4),
@@ -14,16 +15,6 @@ const StyledIcon = styled('div')(({ theme }) => ({
         marginLeft: '-.75rem',
         color: theme.palette.primary.main,
     },
-}));
-
-const StyledDescription = styled('div')(({ theme }) => ({
-    fontSize: theme.typography.body2.fontSize,
-    fontWeight: theme.typography.fontWeightMedium,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    width: '100%',
-    boxSizing: 'border-box',
 }));
 
 const StyledContentContainer = styled('div')(() => ({
@@ -75,9 +66,19 @@ export const FeatureReleasePlanCard = ({
             </StyledIcon>
             <StyledContentContainer>
                 <StyledName text={name} maxWidth='200' maxLength={25} />
-                <Tooltip title={description} arrow placement='top'>
-                    <StyledDescription>{description}</StyledDescription>
-                </Tooltip>
+                <Truncator
+                    lines={1}
+                    title={description}
+                    arrow
+                    sx={{
+                        fontSize: (theme) => theme.typography.body2.fontSize,
+                        fontWeight: (theme) =>
+                            theme.typography.fontWeightRegular,
+                        width: '100%',
+                    }}
+                >
+                    {description}
+                </Truncator>
             </StyledContentContainer>
         </StyledCard>
     );

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/OldFeatureReleasePlanCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/OldFeatureReleasePlanCard.tsx
@@ -1,6 +1,6 @@
 import { getFeatureStrategyIcon } from 'utils/strategyNames';
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
-import { Button, styled, Tooltip } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
 
 const StyledIcon = styled('div')(({ theme }) => ({
@@ -17,31 +17,18 @@ const StyledIcon = styled('div')(({ theme }) => ({
 }));
 
 const StyledDescription = styled('div')(({ theme }) => ({
-    fontSize: theme.typography.body2.fontSize,
-    fontWeight: theme.typography.fontWeightMedium,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    width: '100%',
-    boxSizing: 'border-box',
-}));
-
-const StyledContentContainer = styled('div')(() => ({
-    overflow: 'hidden',
-    width: '100%',
+    fontSize: theme.fontSizes.smallBody,
+    fontWeight: theme.fontWeight.medium,
 }));
 
 const StyledName = styled(StringTruncator)(({ theme }) => ({
-    fontWeight: theme.typography.fontWeightBold,
-    display: 'block',
-    marginBottom: theme.spacing(0.5),
+    fontWeight: theme.fontWeight.bold,
 }));
 
 const StyledCard = styled(Button)(({ theme }) => ({
     display: 'grid',
-    gridTemplateColumns: '2.5rem 1fr',
-    width: '100%',
-    maxWidth: '30rem',
+    gridTemplateColumns: '3rem 1fr',
+    width: '20rem',
     padding: theme.spacing(2),
     color: 'inherit',
     textDecoration: 'inherit',
@@ -51,7 +38,6 @@ const StyledCard = styled(Button)(({ theme }) => ({
     borderColor: theme.palette.divider,
     borderRadius: theme.spacing(1),
     textAlign: 'left',
-    overflow: 'hidden',
     '&:hover, &:focus': {
         borderColor: theme.palette.primary.main,
     },
@@ -62,7 +48,7 @@ interface IFeatureReleasePlanCardProps {
     onClick: () => void;
 }
 
-export const FeatureReleasePlanCard = ({
+export const OldFeatureReleasePlanCard = ({
     template: { name, description },
     onClick,
 }: IFeatureReleasePlanCardProps) => {
@@ -73,12 +59,10 @@ export const FeatureReleasePlanCard = ({
             <StyledIcon>
                 <Icon />
             </StyledIcon>
-            <StyledContentContainer>
+            <div>
                 <StyledName text={name} maxWidth='200' maxLength={25} />
-                <Tooltip title={description} arrow placement='top'>
-                    <StyledDescription>{description}</StyledDescription>
-                </Tooltip>
-            </StyledContentContainer>
+                <StyledDescription>{description}</StyledDescription>
+            </div>
         </StyledCard>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -21,6 +21,7 @@ import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useUiFlag } from 'hooks/useUiFlag';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { OldFeatureStrategyMenuCards } from './FeatureStrategyMenuCards/OldFeatureStrategyMenuCards';
 
 interface IFeatureStrategyMenuProps {
     label: string;
@@ -75,6 +76,7 @@ export const FeatureStrategyMenu = ({
     const { addReleasePlanToFeature } = useReleasePlansApi();
     const { isOss } = useUiConfig();
     const releasePlansEnabled = useUiFlag('releasePlans');
+    const newStrategyDropdownEnabled = useUiFlag('newStrategyDropdown');
     const displayReleasePlanButton = !isOss() && releasePlansEnabled;
     const crProtected =
         releasePlansEnabled && isChangeRequestConfigured(environmentId);
@@ -223,19 +225,36 @@ export const FeatureStrategyMenu = ({
                 PaperProps={{
                     sx: (theme) => ({
                         paddingBottom: theme.spacing(1),
+                        width: 'auto',
+                        maxWidth: '95vw',
+                        overflow: 'hidden',
                     }),
                 }}
             >
-                <FeatureStrategyMenuCards
-                    projectId={projectId}
-                    featureId={featureId}
-                    environmentId={environmentId}
-                    onlyReleasePlans={onlyReleasePlans}
-                    onAddReleasePlan={(template) => {
-                        setSelectedTemplate(template);
-                        setAddReleasePlanOpen(true);
-                    }}
-                />
+                {newStrategyDropdownEnabled ? (
+                    <FeatureStrategyMenuCards
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={environmentId}
+                        onlyReleasePlans={onlyReleasePlans}
+                        onAddReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            setAddReleasePlanOpen(true);
+                        }}
+                        onClose={onClose}
+                    />
+                ) : (
+                    <OldFeatureStrategyMenuCards
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={environmentId}
+                        onlyReleasePlans={onlyReleasePlans}
+                        onAddReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            setAddReleasePlanOpen(true);
+                        }}
+                    />
+                )}
             </Popover>
             {selectedTemplate && (
                 <ReleasePlanAddDialog

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -231,7 +231,7 @@ export const FeatureStrategyMenu = ({
                     }),
                 }}
             >
-                {newStrategyDropdownEnabled ? (
+                {!newStrategyDropdownEnabled ? (
                     <FeatureStrategyMenuCards
                         projectId={projectId}
                         featureId={featureId}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -231,7 +231,7 @@ export const FeatureStrategyMenu = ({
                     }),
                 }}
             >
-                {!newStrategyDropdownEnabled ? (
+                {newStrategyDropdownEnabled ? (
                     <FeatureStrategyMenuCards
                         projectId={projectId}
                         featureId={featureId}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -43,7 +43,7 @@ const StyledDescription = styled('div')(({ theme }) => ({
 }));
 
 const StyledContentContainer = styled('div')(() => ({
-    overflow: 'hidden', // Ensure content doesn't overflow
+    overflow: 'hidden',
     width: '100%',
 }));
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -6,8 +6,9 @@ import {
 } from 'utils/strategyNames';
 import { formatCreateStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate';
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
-import { styled, Tooltip } from '@mui/material';
+import { styled } from '@mui/material';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { Truncator } from 'component/common/Truncator/Truncator';
 
 interface IFeatureStrategyMenuCardProps {
     projectId: string;
@@ -31,15 +32,6 @@ const StyledIcon = styled('div')(({ theme }) => ({
         marginLeft: '-.75rem',
         color: theme.palette.primary.main,
     },
-}));
-
-const StyledDescription = styled('div')(({ theme }) => ({
-    fontSize: theme.typography.body2.fontSize,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    width: '100%',
-    boxSizing: 'border-box',
 }));
 
 const StyledContentContainer = styled('div')(() => ({
@@ -110,11 +102,17 @@ export const FeatureStrategyMenuCard = ({
                     maxWidth='200'
                     maxLength={25}
                 />
-                <Tooltip title={strategy.description} arrow placement='top'>
-                    <StyledDescription>
-                        {strategy.description}
-                    </StyledDescription>
-                </Tooltip>
+                <Truncator
+                    lines={1}
+                    title={strategy.description}
+                    arrow
+                    sx={{
+                        fontSize: (theme) => theme.typography.body2.fontSize,
+                        width: '100%',
+                    }}
+                >
+                    {strategy.description}
+                </Truncator>
             </StyledContentContainer>
         </StyledCard>
     );

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/OldFeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/OldFeatureStrategyMenuCard.tsx
@@ -6,7 +6,7 @@ import {
 } from 'utils/strategyNames';
 import { formatCreateStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate';
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
-import { styled, Tooltip } from '@mui/material';
+import { styled } from '@mui/material';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 interface IFeatureStrategyMenuCardProps {
@@ -34,30 +34,17 @@ const StyledIcon = styled('div')(({ theme }) => ({
 }));
 
 const StyledDescription = styled('div')(({ theme }) => ({
-    fontSize: theme.typography.body2.fontSize,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    width: '100%',
-    boxSizing: 'border-box',
-}));
-
-const StyledContentContainer = styled('div')(() => ({
-    overflow: 'hidden', // Ensure content doesn't overflow
-    width: '100%',
+    fontSize: theme.fontSizes.smallBody,
 }));
 
 const StyledName = styled(StringTruncator)(({ theme }) => ({
-    fontWeight: theme.typography.fontWeightBold,
-    display: 'block',
-    marginBottom: theme.spacing(0.5),
+    fontWeight: theme.fontWeight.bold,
 }));
 
 const StyledCard = styled(Link)(({ theme }) => ({
     display: 'grid',
-    gridTemplateColumns: '2.5rem 1fr',
-    width: '100%',
-    maxWidth: '30rem',
+    gridTemplateColumns: '3rem 1fr',
+    width: '20rem',
     padding: theme.spacing(2),
     color: 'inherit',
     textDecoration: 'inherit',
@@ -66,13 +53,12 @@ const StyledCard = styled(Link)(({ theme }) => ({
     borderStyle: 'solid',
     borderColor: theme.palette.divider,
     borderRadius: theme.spacing(1),
-    overflow: 'hidden',
     '&:hover, &:focus': {
         borderColor: theme.palette.primary.main,
     },
 }));
 
-export const FeatureStrategyMenuCard = ({
+export const OldFeatureStrategyMenuCard = ({
     projectId,
     featureId,
     environmentId,
@@ -104,18 +90,14 @@ export const FeatureStrategyMenuCard = ({
             <StyledIcon>
                 <StrategyIcon />
             </StyledIcon>
-            <StyledContentContainer>
+            <div>
                 <StyledName
                     text={strategy.displayName || strategyName}
                     maxWidth='200'
                     maxLength={25}
                 />
-                <Tooltip title={strategy.description} arrow placement='top'>
-                    <StyledDescription>
-                        {strategy.description}
-                    </StyledDescription>
-                </Tooltip>
-            </StyledContentContainer>
+                <StyledDescription>{strategy.description}</StyledDescription>
+            </div>
         </StyledCard>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -40,7 +40,6 @@ const GridSection = styled(Box)(({ theme }) => ({
     width: '100%',
 }));
 
-// Card wrapper to ensure consistent sizing in the grid
 const CardWrapper = styled(Box)(() => ({
     width: '100%',
     minWidth: 0,

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -34,7 +34,7 @@ const GridContainer = styled(Box)(() => ({
 
 const GridSection = styled(Box)(({ theme }) => ({
     display: 'grid',
-    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gridTemplateColumns: 'repeat(2, 1fr)',
     gap: theme.spacing(1.5),
     padding: theme.spacing(0, 2),
     width: '100%',
@@ -55,6 +55,7 @@ const TitleRow = styled(Box)(({ theme }) => ({
 const TitleText = styled(Typography)(({ theme }) => ({
     fontSize: theme.typography.body1.fontSize,
     fontWeight: theme.typography.fontWeightBold,
+    margin: 0,
 }));
 
 export const FeatureStrategyMenuCards = ({
@@ -87,7 +88,7 @@ export const FeatureStrategyMenuCards = ({
     return (
         <GridContainer>
             <TitleRow>
-                <TitleText>
+                <TitleText variant='h2'>
                     {onlyReleasePlans ? 'Select template' : 'Select strategy'}
                 </TitleText>
                 {onClose && (

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -1,4 +1,4 @@
-import { Link, List, ListItem, styled, Typography } from '@mui/material';
+import { Link, styled, Typography, Box, IconButton } from '@mui/material';
 import { useStrategies } from 'hooks/api/getters/useStrategies/useStrategies';
 import { FeatureStrategyMenuCard } from '../FeatureStrategyMenuCard/FeatureStrategyMenuCard';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
@@ -6,6 +6,7 @@ import { useReleasePlanTemplates } from 'hooks/api/getters/useReleasePlanTemplat
 import { FeatureReleasePlanCard } from '../FeatureReleasePlanCard/FeatureReleasePlanCard';
 import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
 import { useNavigate } from 'react-router-dom';
+import CloseIcon from '@mui/icons-material/Close';
 
 interface IFeatureStrategyMenuCardsProps {
     projectId: string;
@@ -13,11 +14,13 @@ interface IFeatureStrategyMenuCardsProps {
     environmentId: string;
     onlyReleasePlans: boolean;
     onAddReleasePlan: (template: IReleasePlanTemplate) => void;
+    onClose?: () => void;
 }
 
 const StyledTypography = styled(Typography)(({ theme }) => ({
     fontSize: theme.fontSizes.smallBody,
     padding: theme.spacing(1, 2),
+    width: '100%',
 }));
 
 const StyledLink = styled(Link)(({ theme }) => ({
@@ -25,12 +28,43 @@ const StyledLink = styled(Link)(({ theme }) => ({
     cursor: 'pointer',
 })) as typeof Link;
 
+const GridContainer = styled(Box)(() => ({
+    width: '100%',
+}));
+
+const GridSection = styled(Box)(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(0, 2),
+    width: '100%',
+}));
+
+// Card wrapper to ensure consistent sizing in the grid
+const CardWrapper = styled(Box)(() => ({
+    width: '100%',
+    minWidth: 0,
+}));
+
+const TitleRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: theme.spacing(1, 2),
+}));
+
+const TitleText = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body1.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
 export const FeatureStrategyMenuCards = ({
     projectId,
     featureId,
     environmentId,
     onlyReleasePlans,
     onAddReleasePlan,
+    onClose,
 }: IFeatureStrategyMenuCardsProps) => {
     const { strategies } = useStrategies();
     const { templates } = useReleasePlanTemplates();
@@ -52,21 +86,38 @@ export const FeatureStrategyMenuCards = ({
             'This is the default strategy defined for this environment in the project',
     };
     return (
-        <List dense>
+        <GridContainer>
+            <TitleRow>
+                <TitleText>
+                    {onlyReleasePlans ? 'Select template' : 'Select strategy'}
+                </TitleText>
+                {onClose && (
+                    <IconButton
+                        size='small'
+                        onClick={onClose}
+                        edge='end'
+                        aria-label='close'
+                    >
+                        <CloseIcon fontSize='small' />
+                    </IconButton>
+                )}
+            </TitleRow>
             {allStrategies ? (
                 <>
                     <StyledTypography color='textSecondary'>
                         Default strategy for {environmentId} environment
                     </StyledTypography>
-                    <ListItem key={defaultStrategy.name}>
-                        <FeatureStrategyMenuCard
-                            projectId={projectId}
-                            featureId={featureId}
-                            environmentId={environmentId}
-                            strategy={defaultStrategy}
-                            defaultStrategy={true}
-                        />
-                    </ListItem>
+                    <GridSection>
+                        <CardWrapper key={defaultStrategy.name}>
+                            <FeatureStrategyMenuCard
+                                projectId={projectId}
+                                featureId={featureId}
+                                environmentId={environmentId}
+                                strategy={defaultStrategy}
+                                defaultStrategy={true}
+                            />
+                        </CardWrapper>
+                    </GridSection>
                 </>
             ) : null}
             <ConditionallyRender
@@ -76,14 +127,18 @@ export const FeatureStrategyMenuCards = ({
                         <StyledTypography color='textSecondary'>
                             Release templates
                         </StyledTypography>
-                        {templates.map((template) => (
-                            <ListItem key={template.id}>
-                                <FeatureReleasePlanCard
-                                    template={template}
-                                    onClick={() => onAddReleasePlan(template)}
-                                />
-                            </ListItem>
-                        ))}
+                        <GridSection>
+                            {templates.map((template) => (
+                                <CardWrapper key={template.id}>
+                                    <FeatureReleasePlanCard
+                                        template={template}
+                                        onClick={() =>
+                                            onAddReleasePlan(template)
+                                        }
+                                    />
+                                </CardWrapper>
+                            ))}
+                        </GridSection>
                     </>
                 }
             />
@@ -118,16 +173,18 @@ export const FeatureStrategyMenuCards = ({
                     <StyledTypography color='textSecondary'>
                         Predefined strategy types
                     </StyledTypography>
-                    {preDefinedStrategies.map((strategy) => (
-                        <ListItem key={strategy.name}>
-                            <FeatureStrategyMenuCard
-                                projectId={projectId}
-                                featureId={featureId}
-                                environmentId={environmentId}
-                                strategy={strategy}
-                            />
-                        </ListItem>
-                    ))}
+                    <GridSection>
+                        {preDefinedStrategies.map((strategy) => (
+                            <CardWrapper key={strategy.name}>
+                                <FeatureStrategyMenuCard
+                                    projectId={projectId}
+                                    featureId={featureId}
+                                    environmentId={environmentId}
+                                    strategy={strategy}
+                                />
+                            </CardWrapper>
+                        ))}
+                    </GridSection>
                     <ConditionallyRender
                         condition={customStrategies.length > 0}
                         show={
@@ -135,21 +192,23 @@ export const FeatureStrategyMenuCards = ({
                                 <StyledTypography color='textSecondary'>
                                     Custom strategies
                                 </StyledTypography>
-                                {customStrategies.map((strategy) => (
-                                    <ListItem key={strategy.name}>
-                                        <FeatureStrategyMenuCard
-                                            projectId={projectId}
-                                            featureId={featureId}
-                                            environmentId={environmentId}
-                                            strategy={strategy}
-                                        />
-                                    </ListItem>
-                                ))}
+                                <GridSection>
+                                    {customStrategies.map((strategy) => (
+                                        <CardWrapper key={strategy.name}>
+                                            <FeatureStrategyMenuCard
+                                                projectId={projectId}
+                                                featureId={featureId}
+                                                environmentId={environmentId}
+                                                strategy={strategy}
+                                            />
+                                        </CardWrapper>
+                                    ))}
+                                </GridSection>
                             </>
                         }
                     />
                 </>
             ) : null}
-        </List>
+        </GridContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/OldFeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/OldFeatureStrategyMenuCards.tsx
@@ -1,0 +1,155 @@
+import { Link, List, ListItem, styled, Typography } from '@mui/material';
+import { useStrategies } from 'hooks/api/getters/useStrategies/useStrategies';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useReleasePlanTemplates } from 'hooks/api/getters/useReleasePlanTemplates/useReleasePlanTemplates';
+import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
+import { useNavigate } from 'react-router-dom';
+import { OldFeatureStrategyMenuCard } from '../FeatureStrategyMenuCard/OldFeatureStrategyMenuCard';
+import { OldFeatureReleasePlanCard } from '../FeatureReleasePlanCard/OldFeatureReleasePlanCard';
+
+interface IFeatureStrategyMenuCardsProps {
+    projectId: string;
+    featureId: string;
+    environmentId: string;
+    onlyReleasePlans: boolean;
+    onAddReleasePlan: (template: IReleasePlanTemplate) => void;
+}
+
+const StyledTypography = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallBody,
+    padding: theme.spacing(1, 2),
+}));
+
+const StyledLink = styled(Link)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallBody,
+    cursor: 'pointer',
+})) as typeof Link;
+
+export const OldFeatureStrategyMenuCards = ({
+    projectId,
+    featureId,
+    environmentId,
+    onlyReleasePlans,
+    onAddReleasePlan,
+}: IFeatureStrategyMenuCardsProps) => {
+    const { strategies } = useStrategies();
+    const { templates } = useReleasePlanTemplates();
+    const navigate = useNavigate();
+    const allStrategies = !onlyReleasePlans;
+
+    const preDefinedStrategies = strategies.filter(
+        (strategy) => !strategy.deprecated && !strategy.editable,
+    );
+
+    const customStrategies = strategies.filter(
+        (strategy) => !strategy.deprecated && strategy.editable,
+    );
+
+    const defaultStrategy = {
+        name: 'flexibleRollout',
+        displayName: 'Default strategy',
+        description:
+            'This is the default strategy defined for this environment in the project',
+    };
+    return (
+        <List dense>
+            {allStrategies ? (
+                <>
+                    <StyledTypography color='textSecondary'>
+                        Default strategy for {environmentId} environment
+                    </StyledTypography>
+                    <ListItem key={defaultStrategy.name}>
+                        <OldFeatureStrategyMenuCard
+                            projectId={projectId}
+                            featureId={featureId}
+                            environmentId={environmentId}
+                            strategy={defaultStrategy}
+                            defaultStrategy={true}
+                        />
+                    </ListItem>
+                </>
+            ) : null}
+            <ConditionallyRender
+                condition={templates.length > 0}
+                show={
+                    <>
+                        <StyledTypography color='textSecondary'>
+                            Release templates
+                        </StyledTypography>
+                        {templates.map((template) => (
+                            <ListItem key={template.id}>
+                                <OldFeatureReleasePlanCard
+                                    template={template}
+                                    onClick={() => onAddReleasePlan(template)}
+                                />
+                            </ListItem>
+                        ))}
+                    </>
+                }
+            />
+            <ConditionallyRender
+                condition={templates.length === 0 && onlyReleasePlans}
+                show={
+                    <>
+                        <StyledTypography
+                            color='textSecondary'
+                            sx={{
+                                padding: (theme) => theme.spacing(1, 2, 0, 2),
+                            }}
+                        >
+                            <p>No templates created.</p>
+                            <p>
+                                Go to&nbsp;
+                                <StyledLink
+                                    onClick={() =>
+                                        navigate('/release-templates')
+                                    }
+                                >
+                                    Release templates
+                                </StyledLink>
+                                &nbsp;to get started
+                            </p>
+                        </StyledTypography>
+                    </>
+                }
+            />
+            {allStrategies ? (
+                <>
+                    <StyledTypography color='textSecondary'>
+                        Predefined strategy types
+                    </StyledTypography>
+                    {preDefinedStrategies.map((strategy) => (
+                        <ListItem key={strategy.name}>
+                            <OldFeatureStrategyMenuCard
+                                projectId={projectId}
+                                featureId={featureId}
+                                environmentId={environmentId}
+                                strategy={strategy}
+                            />
+                        </ListItem>
+                    ))}
+                    <ConditionallyRender
+                        condition={customStrategies.length > 0}
+                        show={
+                            <>
+                                <StyledTypography color='textSecondary'>
+                                    Custom strategies
+                                </StyledTypography>
+                                {customStrategies.map((strategy) => (
+                                    <ListItem key={strategy.name}>
+                                        <OldFeatureStrategyMenuCard
+                                            projectId={projectId}
+                                            featureId={featureId}
+                                            environmentId={environmentId}
+                                            strategy={strategy}
+                                        />
+                                    </ListItem>
+                                ))}
+                            </>
+                        }
+                    />
+                </>
+            ) : null}
+        </List>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
@@ -11,7 +11,7 @@ import { TagTypeSelect } from './TagTypeSelect';
 import { type TagOption, TagsInput } from './TagsInput';
 import useTags from 'hooks/api/getters/useTags/useTags';
 import useTagTypes from 'hooks/api/getters/useTagTypes/useTagTypes';
-import type { ITag, ITagType } from 'interfaces/tags';
+import type { ITagType } from 'interfaces/tags';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
 import type { TagSchema } from 'openapi';

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/ManageTags.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState, type VFC } from 'react';
 import { Button } from '@mui/material';
 import { ManageBulkTagsDialog } from 'component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog';
 import type { FeatureSchema, TagSchema } from 'openapi';
-import type { ITag } from 'interfaces/tags';
 import useTagApi from 'hooks/api/actions/useTagApi/useTagApi';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     adminNavUI?: boolean;
     tagTypeColor?: boolean;
     globalChangeRequestConfig?: boolean;
+    newStrategyDropdown?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -65,7 +65,8 @@ export type IFlagKey =
     | 'simplifyDisableFeature'
     | 'adminNavUI'
     | 'tagTypeColor'
-    | 'globalChangeRequestConfig';
+    | 'globalChangeRequestConfig'
+    | 'newStrategyDropdown';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -312,6 +313,10 @@ const flags: IFlags = {
     ),
     globalChangeRequestConfig: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_GLOBAL_CHANGE_REQUEST_CONFIG,
+        false,
+    ),
+    newStrategyDropdown: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_STRATEGY_DROPDOWN,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,6 +58,7 @@ process.nextTick(async () => {
                         simplifyDisableFeature: true,
                         adminNavUI: true,
                         tagTypeColor: true,
+                        newStrategyDropdown: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
1. Creating new component files to keep them behind flag
2. Long descriptions for cards are showed with ellipis and tooltip.
3. Renamed old components to format Old..., so we can track all the changes in new files.

![Screenshot from 2025-04-01 19-41-59](https://github.com/user-attachments/assets/24f1f03c-5a79-4b5d-8ca4-7b772ef7fd7c)
