### PR TITLE
feat: new styling for strategy selector

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureReleasePlanCard/FeatureReleasePlanCard.tsx
@@ -24,6 +24,7 @@ const StyledContentContainer = styled('div')(() => ({
 
 const StyledName = styled(StringTruncator)(({ theme }) => ({
     fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.caption.fontSize,
     display: 'block',
     marginBottom: theme.spacing(0.5),
 }));
@@ -71,7 +72,7 @@ export const FeatureReleasePlanCard = ({
                     title={description}
                     arrow
                     sx={{
-                        fontSize: (theme) => theme.typography.body2.fontSize,
+                        fontSize: (theme) => theme.typography.caption.fontSize,
                         fontWeight: (theme) =>
                             theme.typography.fontWeightRegular,
                         width: '100%',

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -228,7 +228,6 @@ export const FeatureStrategyMenu = ({
                 }}
                 PaperProps={{
                     sx: (theme) => ({
-                        paddingBottom: theme.spacing(0),
                         width: 'auto',
                         maxWidth: '95vw',
                         maxHeight: '80vh',

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -226,15 +226,6 @@ export const FeatureStrategyMenu = ({
                     vertical: 'top',
                     horizontal: 'left',
                 }}
-                PaperProps={{
-                    sx: (theme) => ({
-                        width: 'auto',
-                        maxWidth: '95vw',
-                        maxHeight: '80vh',
-                        display: 'flex',
-                        flexDirection: 'column',
-                    }),
-                }}
                 disableScrollLock={true}
             >
                 {newStrategyDropdownEnabled ? (

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -222,14 +222,21 @@ export const FeatureStrategyMenu = ({
                     vertical: 'bottom',
                     horizontal: 'left',
                 }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
                 PaperProps={{
                     sx: (theme) => ({
-                        paddingBottom: theme.spacing(1),
+                        paddingBottom: theme.spacing(0),
                         width: 'auto',
                         maxWidth: '95vw',
-                        overflow: 'hidden',
+                        maxHeight: '80vh',
+                        display: 'flex',
+                        flexDirection: 'column',
                     }),
                 }}
+                disableScrollLock={true}
             >
                 {newStrategyDropdownEnabled ? (
                     <FeatureStrategyMenuCards

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -41,6 +41,7 @@ const StyledContentContainer = styled('div')(() => ({
 
 const StyledName = styled(StringTruncator)(({ theme }) => ({
     fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.caption.fontSize,
     display: 'block',
     marginBottom: theme.spacing(0.5),
 }));
@@ -107,7 +108,7 @@ export const FeatureStrategyMenuCard = ({
                     title={strategy.description}
                     arrow
                     sx={{
-                        fontSize: (theme) => theme.typography.body2.fontSize,
+                        fontSize: (theme) => theme.typography.caption.fontSize,
                         width: '100%',
                     }}
                 >

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -30,6 +30,15 @@ const StyledLink = styled(Link)(({ theme }) => ({
 
 const GridContainer = styled(Box)(() => ({
     width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+}));
+
+const ScrollableContent = styled(Box)(({ theme }) => ({
+    width: '100%',
+    maxHeight: '70vh', // Limit maximum height to 70% of viewport height
+    overflowY: 'auto', // Enable vertical scrolling
+    padding: theme.spacing(0, 0, 1, 0), // Add some bottom padding
 }));
 
 const GridSection = styled(Box)(({ theme }) => ({
@@ -102,113 +111,118 @@ export const FeatureStrategyMenuCards = ({
                     </IconButton>
                 )}
             </TitleRow>
-            {allStrategies ? (
-                <>
-                    <StyledTypography color='textSecondary'>
-                        Default strategy for {environmentId} environment
-                    </StyledTypography>
-                    <GridSection>
-                        <CardWrapper key={defaultStrategy.name}>
-                            <FeatureStrategyMenuCard
-                                projectId={projectId}
-                                featureId={featureId}
-                                environmentId={environmentId}
-                                strategy={defaultStrategy}
-                                defaultStrategy={true}
-                            />
-                        </CardWrapper>
-                    </GridSection>
-                </>
-            ) : null}
-            <ConditionallyRender
-                condition={templates.length > 0}
-                show={
+            <ScrollableContent>
+                {allStrategies ? (
                     <>
                         <StyledTypography color='textSecondary'>
-                            Release templates
+                            Default strategy for {environmentId} environment
                         </StyledTypography>
                         <GridSection>
-                            {templates.map((template) => (
-                                <CardWrapper key={template.id}>
-                                    <FeatureReleasePlanCard
-                                        template={template}
-                                        onClick={() =>
-                                            onAddReleasePlan(template)
-                                        }
-                                    />
-                                </CardWrapper>
-                            ))}
-                        </GridSection>
-                    </>
-                }
-            />
-            <ConditionallyRender
-                condition={templates.length === 0 && onlyReleasePlans}
-                show={
-                    <>
-                        <StyledTypography
-                            color='textSecondary'
-                            sx={{
-                                padding: (theme) => theme.spacing(1, 2, 0, 2),
-                            }}
-                        >
-                            <p>No templates created.</p>
-                            <p>
-                                Go to&nbsp;
-                                <StyledLink
-                                    onClick={() =>
-                                        navigate('/release-templates')
-                                    }
-                                >
-                                    Release templates
-                                </StyledLink>
-                                &nbsp;to get started
-                            </p>
-                        </StyledTypography>
-                    </>
-                }
-            />
-            {allStrategies ? (
-                <>
-                    <StyledTypography color='textSecondary'>
-                        Predefined strategy types
-                    </StyledTypography>
-                    <GridSection>
-                        {preDefinedStrategies.map((strategy) => (
-                            <CardWrapper key={strategy.name}>
+                            <CardWrapper key={defaultStrategy.name}>
                                 <FeatureStrategyMenuCard
                                     projectId={projectId}
                                     featureId={featureId}
                                     environmentId={environmentId}
-                                    strategy={strategy}
+                                    strategy={defaultStrategy}
+                                    defaultStrategy={true}
                                 />
                             </CardWrapper>
-                        ))}
-                    </GridSection>
-                    <ConditionallyRender
-                        condition={customStrategies.length > 0}
-                        show={
-                            <>
-                                <StyledTypography color='textSecondary'>
-                                    Custom strategies
-                                </StyledTypography>
-                                <GridSection>
-                                    {customStrategies.map((strategy) => (
-                                        <CardWrapper key={strategy.name}>
-                                            <FeatureStrategyMenuCard
-                                                projectId={projectId}
-                                                featureId={featureId}
-                                                environmentId={environmentId}
-                                                strategy={strategy}
-                                            />
-                                        </CardWrapper>
-                                    ))}
-                                </GridSection>
-                            </>
-                        }
-                    />
-                </>
-            ) : null}
+                        </GridSection>
+                    </>
+                ) : null}
+                <ConditionallyRender
+                    condition={templates.length > 0}
+                    show={
+                        <>
+                            <StyledTypography color='textSecondary'>
+                                Release templates
+                            </StyledTypography>
+                            <GridSection>
+                                {templates.map((template) => (
+                                    <CardWrapper key={template.id}>
+                                        <FeatureReleasePlanCard
+                                            template={template}
+                                            onClick={() =>
+                                                onAddReleasePlan(template)
+                                            }
+                                        />
+                                    </CardWrapper>
+                                ))}
+                            </GridSection>
+                        </>
+                    }
+                />
+                <ConditionallyRender
+                    condition={templates.length === 0 && onlyReleasePlans}
+                    show={
+                        <>
+                            <StyledTypography
+                                color='textSecondary'
+                                sx={{
+                                    padding: (theme) =>
+                                        theme.spacing(1, 2, 0, 2),
+                                }}
+                            >
+                                <p>No templates created.</p>
+                                <p>
+                                    Go to&nbsp;
+                                    <StyledLink
+                                        onClick={() =>
+                                            navigate('/release-templates')
+                                        }
+                                    >
+                                        Release templates
+                                    </StyledLink>
+                                    &nbsp;to get started
+                                </p>
+                            </StyledTypography>
+                        </>
+                    }
+                />
+                {allStrategies ? (
+                    <>
+                        <StyledTypography color='textSecondary'>
+                            Predefined strategy types
+                        </StyledTypography>
+                        <GridSection>
+                            {preDefinedStrategies.map((strategy) => (
+                                <CardWrapper key={strategy.name}>
+                                    <FeatureStrategyMenuCard
+                                        projectId={projectId}
+                                        featureId={featureId}
+                                        environmentId={environmentId}
+                                        strategy={strategy}
+                                    />
+                                </CardWrapper>
+                            ))}
+                        </GridSection>
+                        <ConditionallyRender
+                            condition={customStrategies.length > 0}
+                            show={
+                                <>
+                                    <StyledTypography color='textSecondary'>
+                                        Custom strategies
+                                    </StyledTypography>
+                                    <GridSection>
+                                        {customStrategies.map((strategy) => (
+                                            <CardWrapper key={strategy.name}>
+                                                <FeatureStrategyMenuCard
+                                                    projectId={projectId}
+                                                    featureId={featureId}
+                                                    environmentId={
+                                                        environmentId
+                                                    }
+                                                    strategy={strategy}
+                                                />
+                                            </CardWrapper>
+                                        ))}
+                                    </GridSection>
+                                </>
+                            }
+                        />
+                    </>
+                ) : null}
+            </ScrollableContent>
         </GridContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -87,7 +87,6 @@ const SectionTitle = styled(Box)(({ theme }) => ({
 const StyledInfoIcon = styled(InfoOutlinedIcon)(({ theme }) => ({
     fontSize: theme.typography.body2.fontSize,
     color: theme.palette.text.secondary,
-    cursor: 'help',
 }));
 
 export const FeatureStrategyMenuCards = ({

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -1,4 +1,11 @@
-import { Link, styled, Typography, Box, IconButton } from '@mui/material';
+import {
+    Link,
+    styled,
+    Typography,
+    Box,
+    IconButton,
+    Tooltip,
+} from '@mui/material';
 import { useStrategies } from 'hooks/api/getters/useStrategies/useStrategies';
 import { FeatureStrategyMenuCard } from '../FeatureStrategyMenuCard/FeatureStrategyMenuCard';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
@@ -7,6 +14,7 @@ import { FeatureReleasePlanCard } from '../FeatureReleasePlanCard/FeatureRelease
 import type { IReleasePlanTemplate } from 'interfaces/releasePlans';
 import { useNavigate } from 'react-router-dom';
 import CloseIcon from '@mui/icons-material/Close';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 interface IFeatureStrategyMenuCardsProps {
     projectId: string;
@@ -46,6 +54,7 @@ const GridSection = styled(Box)(({ theme }) => ({
     gridTemplateColumns: 'repeat(2, 1fr)',
     gap: theme.spacing(1.5),
     padding: theme.spacing(0, 2),
+    marginBottom: theme.spacing(3),
     width: '100%',
 }));
 
@@ -65,6 +74,20 @@ const TitleText = styled(Typography)(({ theme }) => ({
     fontSize: theme.typography.body1.fontSize,
     fontWeight: theme.typography.fontWeightBold,
     margin: 0,
+}));
+
+const SectionTitle = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(1, 2),
+    width: '100%',
+}));
+
+const StyledInfoIcon = styled(InfoOutlinedIcon)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+    cursor: 'help',
 }));
 
 export const FeatureStrategyMenuCards = ({
@@ -114,9 +137,17 @@ export const FeatureStrategyMenuCards = ({
             <ScrollableContent>
                 {allStrategies ? (
                     <>
-                        <StyledTypography color='textSecondary'>
-                            Default strategy for {environmentId} environment
-                        </StyledTypography>
+                        <SectionTitle>
+                            <Typography color='inherit' variant='body2'>
+                                Pre-defined strategy types
+                            </Typography>
+                            <Tooltip
+                                title='Select a starting setup, and customize the strategy to your need with targeting and variants'
+                                arrow
+                            >
+                                <StyledInfoIcon />
+                            </Tooltip>
+                        </SectionTitle>
                         <GridSection>
                             <CardWrapper key={defaultStrategy.name}>
                                 <FeatureStrategyMenuCard
@@ -127,6 +158,16 @@ export const FeatureStrategyMenuCards = ({
                                     defaultStrategy={true}
                                 />
                             </CardWrapper>
+                            {preDefinedStrategies.map((strategy) => (
+                                <CardWrapper key={strategy.name}>
+                                    <FeatureStrategyMenuCard
+                                        projectId={projectId}
+                                        featureId={featureId}
+                                        environmentId={environmentId}
+                                        strategy={strategy}
+                                    />
+                                </CardWrapper>
+                            ))}
                         </GridSection>
                     </>
                 ) : null}
@@ -134,9 +175,17 @@ export const FeatureStrategyMenuCards = ({
                     condition={templates.length > 0}
                     show={
                         <>
-                            <StyledTypography color='textSecondary'>
-                                Release templates
-                            </StyledTypography>
+                            <SectionTitle>
+                                <Typography color='inherit' variant='body2'>
+                                    Apply a release template
+                                </Typography>
+                                <Tooltip
+                                    title='Use one of the pre-defined templates defined in your company for rolling out features to users'
+                                    arrow
+                                >
+                                    <StyledInfoIcon />
+                                </Tooltip>
+                            </SectionTitle>
                             <GridSection>
                                 {templates.map((template) => (
                                     <CardWrapper key={template.id}>
@@ -181,28 +230,24 @@ export const FeatureStrategyMenuCards = ({
                 />
                 {allStrategies ? (
                     <>
-                        <StyledTypography color='textSecondary'>
-                            Predefined strategy types
-                        </StyledTypography>
-                        <GridSection>
-                            {preDefinedStrategies.map((strategy) => (
-                                <CardWrapper key={strategy.name}>
-                                    <FeatureStrategyMenuCard
-                                        projectId={projectId}
-                                        featureId={featureId}
-                                        environmentId={environmentId}
-                                        strategy={strategy}
-                                    />
-                                </CardWrapper>
-                            ))}
-                        </GridSection>
                         <ConditionallyRender
                             condition={customStrategies.length > 0}
                             show={
                                 <>
-                                    <StyledTypography color='textSecondary'>
-                                        Custom strategies
-                                    </StyledTypography>
+                                    <SectionTitle>
+                                        <Typography
+                                            color='inherit'
+                                            variant='body2'
+                                        >
+                                            Custom strategies
+                                        </Typography>
+                                        <Tooltip
+                                            title='Custom strategies you have defined in Unleash'
+                                            arrow
+                                        >
+                                            <StyledInfoIcon />
+                                        </Tooltip>
+                                    </SectionTitle>
                                     <GridSection>
                                         {customStrategies.map((strategy) => (
                                             <CardWrapper key={strategy.name}>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -44,9 +44,9 @@ const GridContainer = styled(Box)(() => ({
 
 const ScrollableContent = styled(Box)(({ theme }) => ({
     width: '100%',
-    maxHeight: '70vh', // Limit maximum height to 70% of viewport height
-    overflowY: 'auto', // Enable vertical scrolling
-    padding: theme.spacing(0, 0, 1, 0), // Add some bottom padding
+    maxHeight: '70vh',
+    overflowY: 'auto',
+    padding: theme.spacing(0, 0, 1, 0),
 }));
 
 const GridSection = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
- Updated all card titles and descriptions to use `theme.typography.caption.fontSize` (12px)
- Added proper spacing between card sections with `marginBottom: theme.spacing(3)`
- Made the section scrollable
- Added info icons with helpful tooltips to all strategy sections:
  - **Pre-defined strategy types**: "Select a starting setup, and customize the strategy to your need with targeting and variants"
  - **Apply a release template**: "Use one of the pre-defined templates defined in your company for rolling out features to users"
  - **Custom strategies**: "Custom strategies you have defined in Unleash"
- Fixed section organization by combining the default strategy with other predefined strategies under a single "Pre-defined strategy types" section


![image](https://github.com/user-attachments/assets/cc2e252a-c364-45b7-84f5-773a9e12cb8b)
