### PR TITLE
chore: remove z-index from sticky admin menu as its probably not needed

### DIFF
--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenu.tsx
@@ -99,7 +99,6 @@ const StyledMenuPaper = styled(Paper)(({ theme }) => ({
 const StickyContainer = styled(Sticky)(({ theme }) => ({
     position: 'sticky',
     top: 0,
-    zIndex: theme.zIndex.sticky,
     background: theme.palette.background.application,
     transition: 'padding 0.3s ease',
 }));


### PR DESCRIPTION
Fixes issues where very large popups get covered by the admin menu