### PR TITLE
fix: update link text for archived feature navigation

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureNotFound/FeatureNotFound.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureNotFound/FeatureNotFound.tsx
@@ -30,8 +30,8 @@ export const FeatureNotFound = () => {
             <p>
                 The feature <StyledFeatureId>{featureId}</StyledFeatureId> has
                 been archived. You can find it on the{' '}
-                <Link to={`/projects/${projectId}/archive`}>
-                    project archive page
+                <Link to={`/projects/${projectId}?archived=IS%3Atrue`}>
+                    project overview with archived flags filter
                 </Link>
                 .
             </p>


### PR DESCRIPTION
## About the changes
If you try to visit an archived flag, you're told you can find it on the project archive page, but that page isn't visible by default anymore. This is an update to take you to the project overview with a filter for archived flags instead.