### PR TITLE
we don't have historical data available for purchased traffic

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -65,11 +65,11 @@ const NetworkTrafficUsage: FC = () => {
         usageTotal - totalTraffic > 0 &&
         estimateTrafficDataCost;
 
+    const isCurrentMonth =
+        chartDataSelection.grouping === 'monthly' ||
+        chartDataSelection.month === currentMonth;
     const showConsumptionBillingWarning =
-        (chartDataSelection.grouping === 'monthly' ||
-            chartDataSelection.month === currentMonth) &&
-        totalTraffic > 0 &&
-        overageCost > 0;
+        isCurrentMonth && totalTraffic > 0 && overageCost > 0;
 
     return (
         <ConditionallyRender
@@ -109,6 +109,7 @@ const NetworkTrafficUsage: FC = () => {
                                     purchasedTraffic={
                                         trafficBundles.purchasedTraffic
                                     }
+                                    currentMonth={isCurrentMonth}
                                 />
                                 {showOverageCalculations && (
                                     <OverageInfo

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/NetworkTrafficUsage.tsx
@@ -66,7 +66,7 @@ const NetworkTrafficUsage: FC = () => {
         estimateTrafficDataCost;
 
     const isCurrentMonth =
-        chartDataSelection.grouping === 'monthly' ||
+        chartDataSelection.grouping === 'daily' &&
         chartDataSelection.month === currentMonth;
     const showConsumptionBillingWarning =
         isCurrentMonth && totalTraffic > 0 && overageCost > 0;

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/RequestSummary.tsx
@@ -11,6 +11,7 @@ type Props = {
     usageTotal: number;
     includedTraffic: number;
     purchasedTraffic: number;
+    currentMonth: boolean;
 };
 
 const Container = styled('article')(({ theme }) => ({
@@ -64,7 +65,7 @@ const incomingRequestsText = (period: ChartDataSelection): string => {
         return `Average requests from ${formatMonth(fromMonth)} to ${formatMonth(toMonth)}`;
     }
 
-    return `Incoming requests in ${formatMonth(parseMonthString(period.month))}`;
+    return `Requests used in ${formatMonth(parseMonthString(period.month))}`;
 };
 
 export const RequestSummary: FC<Props> = ({
@@ -72,6 +73,7 @@ export const RequestSummary: FC<Props> = ({
     usageTotal,
     includedTraffic,
     purchasedTraffic,
+    currentMonth,
 }) => {
     const { locationSettings } = useLocationSettings();
 
@@ -100,13 +102,13 @@ export const RequestSummary: FC<Props> = ({
                 </Row>
                 {includedTraffic > 0 && (
                     <Row>
-                        <dt>Included in your plan monthly</dt>
+                        <dt>Included in your plan</dt>
                         <dd>
                             {includedTraffic.toLocaleString('en-US')} requests
                         </dd>
                     </Row>
                 )}
-                {purchasedTraffic > 0 && (
+                {purchasedTraffic > 0 && currentMonth && (
                     <Row>
                         <dt>Additional traffic purchased</dt>
                         <dd>
@@ -114,9 +116,9 @@ export const RequestSummary: FC<Props> = ({
                         </dd>
                     </Row>
                 )}
-                {includedTraffic > 0 && (
+                {includedTraffic > 0 && currentMonth && (
                     <Row>
-                        <dt>Total traffic</dt>
+                        <dt>Total traffic available</dt>
                         <dd>
                             {(
                                 includedTraffic + purchasedTraffic


### PR DESCRIPTION
So this PR removes the purchased dt point, as well as the total available. Using the same check our overageCalculation does (it also only works on current month)