### PR TITLE
fix: return bad data error when failing to patch env variants

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -2226,19 +2226,27 @@ class FeatureToggleService {
             featureName,
             environment,
         );
-        const { newDocument } = await applyPatch(
-            deepClone(oldVariants),
-            newVariants,
-        );
-        return this.crProtectedSaveVariantsOnEnv(
-            project,
-            featureName,
-            environment,
-            newDocument,
-            user,
-            auditUser,
-            oldVariants,
-        );
+
+        try {
+            const { newDocument } = await applyPatch(
+                deepClone(oldVariants),
+                newVariants,
+            );
+
+            return this.crProtectedSaveVariantsOnEnv(
+                project,
+                featureName,
+                environment,
+                newDocument,
+                user,
+                auditUser,
+                oldVariants,
+            );
+        } catch (e) {
+            throw new BadDataError(
+                `Could not apply provided patch: ${e.message}`,
+            );
+        }
     }
 
     async saveVariants(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3483/variants-endpoint-should-return-400-or-other-more-appropriate-status

Throws BadDataError (returns 400) instead of 500 by wrapping the patch logic with a try catch. 

Added a test that validates the new behavior.