### PR TITLE
feat: remove + from the segment dropdown

### DIFF
--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import type { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 
 interface IAutocompleteBoxProps {
     label: string;
@@ -15,6 +16,7 @@ interface IAutocompleteBoxProps {
     value?: IAutocompleteBoxOption[];
     onChange: (value: IAutocompleteBoxOption[]) => void;
     disabled?: boolean;
+    icon?: ReactNode | null;
 }
 
 export interface IAutocompleteBoxOption {
@@ -41,28 +43,37 @@ export const AutocompleteBox = ({
     value = [],
     onChange,
     disabled,
+    icon,
 }: IAutocompleteBoxProps) => {
     const [_, setPlaceholder] = useState('Add Segments');
     const theme = useTheme();
 
     const renderCustomInput = (params: AutocompleteRenderInputParams) => {
         const { InputProps } = params;
+
+        let startAdornment = undefined;
+        if (icon !== null) {
+            startAdornment = (
+                <InputAdornment position='start'>
+                    {icon || (
+                        <Add
+                            sx={{
+                                height: 20,
+                                width: 20,
+                                color: theme.palette.primary.main,
+                            }}
+                        />
+                    )}
+                </InputAdornment>
+            );
+        }
+
         return (
             <TextField
                 {...params}
                 InputProps={{
                     ...InputProps,
-                    startAdornment: (
-                        <InputAdornment position='start'>
-                            <Add
-                                sx={{
-                                    height: 20,
-                                    width: 20,
-                                    color: theme.palette.primary.main,
-                                }}
-                            />
-                        </InputAdornment>
-                    ),
+                    startAdornment,
                 }}
                 variant='outlined'
                 sx={{

--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -7,7 +7,6 @@ import {
     useTheme,
 } from '@mui/material';
 import type { AutocompleteRenderInputParams } from '@mui/material/Autocomplete';
-import { useState } from 'react';
 import type { ReactNode } from 'react';
 
 interface IAutocompleteBoxProps {
@@ -47,7 +46,6 @@ export const AutocompleteBox = ({
     icon,
     width = '215px',
 }: IAutocompleteBoxProps) => {
-    const [_, setPlaceholder] = useState('Add Segments');
     const theme = useTheme();
 
     const renderCustomInput = (params: AutocompleteRenderInputParams) => {
@@ -100,8 +98,6 @@ export const AutocompleteBox = ({
                     },
                 }}
                 placeholder={label}
-                onFocus={() => setPlaceholder('')}
-                onBlur={() => setPlaceholder(label)}
             />
         );
     };

--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -17,6 +17,7 @@ interface IAutocompleteBoxProps {
     onChange: (value: IAutocompleteBoxOption[]) => void;
     disabled?: boolean;
     icon?: ReactNode | null;
+    width?: string | number;
 }
 
 export interface IAutocompleteBoxOption {
@@ -44,6 +45,7 @@ export const AutocompleteBox = ({
     onChange,
     disabled,
     icon,
+    width = '215px',
 }: IAutocompleteBoxProps) => {
     const [_, setPlaceholder] = useState('Add Segments');
     const theme = useTheme();
@@ -77,7 +79,7 @@ export const AutocompleteBox = ({
                 }}
                 variant='outlined'
                 sx={{
-                    width: '215px',
+                    width,
                     '& .MuiOutlinedInput-root': {
                         '& .MuiInputBase-input': {
                             color: theme.palette.primary.main,

--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -1,4 +1,3 @@
-import { useStyles } from 'component/common/AutocompleteBox/AutocompleteBox.styles';
 import Add from '@mui/icons-material/Add';
 import {
     Autocomplete,
@@ -32,23 +31,6 @@ const StyledContainer = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledIcon = styled('div', {
-    shouldForwardProp: (prop: string) => !prop.startsWith('$'),
-})<{ $disabled: boolean }>(({ theme, $disabled }) => ({
-    background: $disabled
-        ? theme.palette.primary.light
-        : theme.palette.primary.main,
-    height: '48px',
-    width: '48px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingLeft: 6,
-    borderTopLeftRadius: '40px',
-    borderBottomLeftRadius: '40px',
-    color: theme.palette.primary.contrastText,
-}));
-
 const StyledAutocomplete = styled(Autocomplete)({
     flex: 1,
 }) as typeof Autocomplete;
@@ -60,13 +42,8 @@ export const AutocompleteBox = ({
     onChange,
     disabled,
 }: IAutocompleteBoxProps) => {
-    const [placeHolder, setPlaceholder] = useState('Add Segments');
-    const { classes: styles } = useStyles();
+    const [_, setPlaceholder] = useState('Add Segments');
     const theme = useTheme();
-
-    const renderInput = (params: AutocompleteRenderInputParams) => {
-        return <TextField {...params} variant='outlined' label={label} />;
-    };
 
     const renderCustomInput = (params: AutocompleteRenderInputParams) => {
         const { InputProps } = params;
@@ -120,7 +97,7 @@ export const AutocompleteBox = ({
             <StyledAutocomplete
                 options={options}
                 value={value}
-                onChange={(event, value) => onChange(value || [])}
+                onChange={(_, value) => onChange(value || [])}
                 renderInput={renderCustomInput}
                 getOptionLabel={(value) => value.label}
                 disabled={disabled}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
@@ -100,6 +100,7 @@ export const FeatureStrategySegment = ({
                 options={autocompleteOptions}
                 onChange={onChange}
                 disabled={atStrategySegmentsLimit}
+                icon={null}
             />
             <FeatureStrategySegmentList
                 segments={selectedSegments}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
@@ -101,6 +101,7 @@ export const FeatureStrategySegment = ({
                 onChange={onChange}
                 disabled={atStrategySegmentsLimit}
                 icon={null}
+                width={'175px'}
             />
             <FeatureStrategySegmentList
                 segments={selectedSegments}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
@@ -8,18 +8,15 @@ import {
 import { FeatureStrategySegmentList } from 'component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentList';
 import { SegmentDocsStrategyWarning } from 'component/segments/SegmentDocs';
 import { useSegmentLimits } from 'hooks/api/getters/useSegmentLimits/useSegmentLimits';
-import { Box, Divider, styled, Typography } from '@mui/material';
+import { Box, styled, Typography } from '@mui/material';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IFeatureStrategySegmentProps {
     segments: ISegment[];
     setSegments: React.Dispatch<React.SetStateAction<ISegment[]>>;
     projectId: string;
 }
-
-const StyledDivider = styled(Divider)(({ theme }) => ({
-    fontSize: theme.fontSizes.smallBody,
-}));
 
 const StyledHelpIconBox = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -33,6 +30,7 @@ export const FeatureStrategySegment = ({
     setSegments: setSelectedSegments,
     projectId,
 }: IFeatureStrategySegmentProps) => {
+    const addEditStrategy = useUiFlag('addEditStrategy');
     const { segments: allSegments } = useSegments();
     const { strategySegmentsLimit } = useSegmentLimits();
 
@@ -100,7 +98,7 @@ export const FeatureStrategySegment = ({
                 options={autocompleteOptions}
                 onChange={onChange}
                 disabled={atStrategySegmentsLimit}
-                icon={null}
+                icon={addEditStrategy ? null : undefined}
                 width={'175px'}
             />
             <FeatureStrategySegmentList

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegment.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegment.tsx
@@ -88,6 +88,8 @@ export const MilestoneStrategySegment = ({
                 options={autocompleteOptions}
                 onChange={onChange}
                 disabled={atStrategySegmentsLimit}
+                icon={null}
+                width={'175px'}
             />
             <MilestoneStrategySegmentList
                 segments={selectedSegments}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegment.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegment.tsx
@@ -9,6 +9,7 @@ import {
     type IAutocompleteBoxOption,
 } from 'component/common/AutocompleteBox/AutocompleteBox';
 import { MilestoneStrategySegmentList } from './MilestoneStrategySegmentList';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledHelpIconBox = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -26,6 +27,7 @@ export const MilestoneStrategySegment = ({
     segments: selectedSegments,
     setSegments: setSelectedSegments,
 }: IMilestoneStrategySegmentProps) => {
+    const addEditStrategy = useUiFlag('addEditStrategy');
     const { segments: allSegments } = useSegments();
     const { strategySegmentsLimit } = useSegmentLimits();
 
@@ -88,7 +90,7 @@ export const MilestoneStrategySegment = ({
                 options={autocompleteOptions}
                 onChange={onChange}
                 disabled={atStrategySegmentsLimit}
-                icon={null}
+                icon={addEditStrategy ? null : undefined}
                 width={'175px'}
             />
             <MilestoneStrategySegmentList


### PR DESCRIPTION
Removing it from strategy and also from milestone creation.

![image](https://github.com/user-attachments/assets/46b3f244-f31c-442f-b35c-3c92db3820c8)
