### PR TITLE
Task/bump docker base image

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [20.18.1-alpine]
+        version: [20.19.0-alpine3.21]
     steps:
       - name: Checkout tag v${{ inputs.version }}
         if: ${{ inputs.version != '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20.18.3-alpine
+ARG NODE_VERSION=20.19.0-alpine3.21
 
 FROM node:$NODE_VERSION AS builder
 


### PR DESCRIPTION
As reported in #9710 . This PR updates to 20.19.0-alpine3.21 which according to docker's own scan now longer is affected by the CVE