### PR TITLE
docs: add Go impression data support

### DIFF
--- a/website/docs/reference/sdks/index.mdx
+++ b/website/docs/reference/sdks/index.mdx
@@ -112,7 +112,7 @@ Static fields (`environment`, `appName`), defined fields, and custom properties 
 | Capability | [Java](/docs/generated/sdks/server-side/java.md) | [Node.js](/docs/generated/sdks/server-side/node.md) | [Go](/docs/generated/sdks/server-side/go.md) | [Python](/docs/generated/sdks/server-side/python.md) | [Ruby](/docs/generated/sdks/server-side/ruby.md) | [.NET](/docs/generated/sdks/server-side/dotnet.md) | [PHP](/docs/generated/sdks/server-side/php.md) | [Rust](/docs/generated/sdks/server-side/rust.md) |
 | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 | Usage metrics | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |    
-| [Impression data](./impression-data) | ✅ | ✅ | ⭕ | ✅ | ⭕ | ✅  | ✅ | ⭕ |
+| [Impression data](./impression-data) | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅  | ✅ | ⭕ |
 
 #### Bootstrap
 | Capability | [Java](/docs/generated/sdks/server-side/java.md) | [Node.js](/docs/generated/sdks/server-side/node.md) | [Go](/docs/generated/sdks/server-side/go.md) | [Python](/docs/generated/sdks/server-side/python.md) | [Ruby](/docs/generated/sdks/server-side/ruby.md) | [.NET](/docs/generated/sdks/server-side/dotnet.md) | [PHP](/docs/generated/sdks/server-side/php.md) | [Rust](/docs/generated/sdks/server-side/rust.md) |


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3494/go-sdk-impression-event-support

Adds Go impression data support.

See: https://github.com/Unleash/unleash-client-go/pull/194