### PR TITLE
feat: add milestones to search results

### DIFF
--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1425,3 +1425,93 @@ test('should return change request ids per environment', async () => {
         ],
     });
 });
+
+const createReleasePlan = async ({
+    feature,
+    environment,
+    planId,
+}: { feature: string; environment: string; planId: string }) => {
+    await db.rawDatabase('release_plan_definitions').insert({
+        id: planId,
+        discriminator: 'plan',
+        name: 'plan',
+        feature_name: feature,
+        environment: environment,
+        created_by_user_id: 1,
+    });
+};
+
+const createMilestone = async ({
+    id,
+    name,
+    order,
+    planId,
+}: { id: string; name: string; order: number; planId: string }) => {
+    await db.rawDatabase('milestones').insert({
+        id,
+        name,
+        sort_order: order,
+        release_plan_definition_id: planId,
+    });
+};
+
+const activateMilestone = async ({
+    planId,
+    milestoneId,
+}: { planId: string; milestoneId: string }) => {
+    await db
+        .rawDatabase('release_plan_definitions')
+        .update({ active_milestone_id: milestoneId })
+        .where('id', planId);
+};
+
+test('should return release plan milestones', async () => {
+    await app.createFeature('my_feature_a');
+
+    await createReleasePlan({
+        feature: 'my_feature_a',
+        environment: 'development',
+        planId: 'plan0',
+    });
+    await createMilestone({
+        id: 'milestone0',
+        name: 'Milestone 1',
+        order: 0,
+        planId: 'plan0',
+    });
+    await createMilestone({
+        id: 'milestone1',
+        name: 'Milestone 2',
+        order: 1,
+        planId: 'plan0',
+    });
+    await createMilestone({
+        id: 'milestone3',
+        name: 'Milestone 3',
+        order: 2,
+        planId: 'plan0',
+    });
+    await activateMilestone({ planId: 'plan0', milestoneId: 'milestone1' });
+
+    const { body } = await searchFeatures({});
+
+    expect(body).toMatchObject({
+        features: [
+            {
+                name: 'my_feature_a',
+                environments: [
+                    { name: 'default' },
+                    {
+                        name: 'development',
+                        totalMilestones: 3,
+                        milestoneName: 'Milestone 2',
+                        milestoneOrder: 1,
+                    },
+                    { name: 'production' },
+                ],
+            },
+        ],
+    });
+    expect(body.features[0].environments[0].milestoneName).toBeUndefined();
+    expect(body.features[0].environments[2].milestoneName).toBeUndefined();
+});

--- a/src/lib/openapi/spec/feature-environment-schema.ts
+++ b/src/lib/openapi/spec/feature-environment-schema.ts
@@ -71,6 +71,24 @@ export const featureEnvironmentSchema = {
             description:
                 'Experimental. A list of change request identifiers for actionable change requests that are not Cancelled, Rejected or Approved.',
         },
+        milestoneName: {
+            type: 'string',
+            example: 'Phase One',
+            description:
+                'Experimental: The name of the currently active release plan milestone',
+        },
+        milestoneOrder: {
+            type: 'number',
+            example: 0,
+            description:
+                'Experimental: The zero-indexed order of currently active milestone in the list of all release plan milestones',
+        },
+        totalMilestones: {
+            type: 'number',
+            example: 0,
+            description:
+                'Experimental: The total number of milestones in the feature environment release plan',
+        },
         lastSeenAt: {
             type: 'string',
             format: 'date-time',

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -60,6 +60,7 @@ process.nextTick(async () => {
                         tagTypeColor: true,
                         newStrategyDropdown: true,
                         addEditStrategy: true,
+                        flagsOverviewSearch: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Feature search should include milestone name, milestone order and total number of milestones
<img width="1169" alt="Screenshot 2025-04-10 at 08 57 10" src="https://github.com/user-attachments/assets/678a2e21-5603-4ec9-baed-c22fa5f4f55d" />


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
@Tymek Jaanus has a good point that writing a query here allows for a faster iteration
@sjaanus please take a look at the query enhancement. I will be running explain plan for this part and change requests soon but I don't expect perf degradation due to early filtering happening before we join extra data.
@daveleek are you ok with me moving stores for release plans into OSS so that we can use them for the test setup? Also please check if the query makes sense to you since you know it well. I basically join two tables that you created with feature name and environments from the search result features.