### PR TITLE
fix(frontend): Now only shows average daily requests when viewing daily

### DIFF
--- a/frontend/src/component/admin/network/NetworkTrafficUsage/bar-chart-options.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/bar-chart-options.ts
@@ -6,6 +6,7 @@ export const createBarChartOptions = (
     theme: Theme,
     tooltipTitleCallback: (tooltipItems: any) => string,
     includedTraffic?: number,
+    showAverageDaily?: boolean,
 ): ChartOptions<'bar'> => ({
     plugins: {
         annotation: {
@@ -18,7 +19,7 @@ export const createBarChartOptions = (
                     yMax: includedTraffic ? includedTraffic / 30 : 0,
                     borderColor: 'gray',
                     borderWidth: 1,
-                    display: !!includedTraffic,
+                    display: !!includedTraffic && !!showAverageDaily,
 
                     label: {
                         backgroundColor: 'rgba(192, 192, 192,  0.8)',

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/hooks/useChartDataSelection.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/hooks/useChartDataSelection.ts
@@ -17,6 +17,7 @@ export const useChartDataSelection = (includedTraffic?: number) => {
         });
 
     const options = useMemo(() => {
+        console.log(includedTraffic);
         return createBarChartOptions(
             theme,
             (tooltipItems: any) => {
@@ -50,6 +51,7 @@ export const useChartDataSelection = (includedTraffic?: number) => {
                 }
             },
             includedTraffic,
+            chartDataSelection.grouping === 'daily',
         );
     }, [theme, chartDataSelection, includedTraffic]);
 

--- a/frontend/src/component/admin/network/NetworkTrafficUsage/hooks/useChartDataSelection.ts
+++ b/frontend/src/component/admin/network/NetworkTrafficUsage/hooks/useChartDataSelection.ts
@@ -17,7 +17,6 @@ export const useChartDataSelection = (includedTraffic?: number) => {
         });
 
     const options = useMemo(() => {
-        console.log(includedTraffic);
         return createBarChartOptions(
             theme,
             (tooltipItems: any) => {


### PR DESCRIPTION
As reported by Ivar, there's no point in displaying the average daily traffic when grouping monthly.