### PR TITLE
fix: improve health rating job performance

### DIFF
--- a/src/test/e2e/api/admin/project/project.health.e2e.test.ts
+++ b/src/test/e2e/api/admin/project/project.health.e2e.test.ts
@@ -112,7 +112,7 @@ test('Health rating endpoint yields stale, potentially stale and active count on
             stale: true,
         })
         .expect(201);
-    await app.services.projectHealthService.setHealthRating();
+    await app.services.projectHealthService.setProjectHealthRating(project.id);
     await app.request
         .get(`/api/admin/projects/${project.id}/health-report`)
         .expect(200)
@@ -177,7 +177,7 @@ test('Health rating endpoint does not include archived toggles when calculating 
         })
         .expect(201);
 
-    await app.services.projectHealthService.setHealthRating();
+    await app.services.projectHealthService.setProjectHealthRating(project.id);
     await app.request
         .get(`/api/admin/projects/${project.id}/health-report`)
         .expect(200)
@@ -232,7 +232,7 @@ test('Health rating endpoint correctly handles potentially stale toggles', async
             createdAt: new Date(2019, 5, 1),
         })
         .expect(201);
-    await app.services.projectHealthService.setHealthRating();
+    await app.services.projectHealthService.setProjectHealthRating(project.id);
     await app.request
         .get(`/api/admin/projects/${project.id}/health-report`)
         .expect(200)
@@ -339,7 +339,7 @@ test('Sorts environments correctly if sort order is equal', async () => {
 });
 
 test('Update update_at when setHealth runs', async () => {
-    await app.services.projectHealthService.setHealthRating();
+    await app.services.projectHealthService.setProjectHealthRating('default');
     await app.request
         .get('/api/admin/projects/default/health-report')
         .expect(200)


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

setHealthRating job was running project health calculation for multiple projects in parallel. Now we spread it into single project chunks run every 5s.
Also adding some instrumentation for the function execution time and query execution time.

This is similar improvement to statusJob: https://github.com/Unleash/unleash/pull/9755

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
