### PR TITLE
fix: search page filtered placeholder

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
@@ -136,9 +136,7 @@ test('Filter table by project', async () => {
     setupNoFeaturesReturned();
     await filterFeaturesByProject('Project B');
 
-    await screen.findByText(
-        'No feature flags found matching your criteria. Get started by adding a new feature flag.',
-    );
+    await screen.findByText('No feature flags found matching your criteria.');
     expect(window.location.href).toContain(
         '?offset=0&columns=&project=IS%3Aproject-b',
     );

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -495,8 +495,7 @@ export const FeatureToggleListTable: FC = () => {
                             elseShow={
                                 <TablePlaceholder>
                                     No feature flags found matching your
-                                    criteria. Get started by adding a new
-                                    feature flag.
+                                    criteria.
                                 </TablePlaceholder>
                             }
                         />


### PR DESCRIPTION
It's weird that we encourage to create new flags in the cleanup stage