### PR TITLE
fix: demo topics should work with new flag design

### DIFF
--- a/frontend/src/component/demo/demo-topics.tsx
+++ b/frontend/src/component/demo/demo-topics.tsx
@@ -131,6 +131,17 @@ export const TOPICS: ITutorialTopic[] = [
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step2`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] .MuiAccordionSummary-expandIconWrapper`,
+                content: (
+                    <Description>
+                        Expand the environment card to see all the defined
+                        strategies by using the arrow button.
+                    </Description>
+                ),
+                optional: true,
+            },
+            {
+                href: `/projects/${PROJECT}/features/demoApp.step2`,
                 target: 'button[data-testid="ADD_STRATEGY_BUTTON"]',
                 content: (
                     <Description>
@@ -264,6 +275,7 @@ export const TOPICS: ITutorialTopic[] = [
                         Save the constraint by using this button.
                     </Description>
                 ),
+                optional: true,
             },
             {
                 target: 'button[data-testid="STRATEGY_FORM_SUBMIT_ID"]',
@@ -469,6 +481,17 @@ export const TOPICS: ITutorialTopic[] = [
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step4`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] .MuiAccordionSummary-expandIconWrapper`,
+                content: (
+                    <Description>
+                        Expand the environment card to see all the defined
+                        strategies by using the arrow button.
+                    </Description>
+                ),
+                optional: true,
+            },
+            {
+                href: `/projects/${PROJECT}/features/demoApp.step4`,
                 target: 'button[data-testid="ADD_STRATEGY_BUTTON"]',
                 content: (
                     <Description>
@@ -602,6 +625,7 @@ export const TOPICS: ITutorialTopic[] = [
                         Save the constraint by using this button.
                     </Description>
                 ),
+                optional: true,
             },
             {
                 target: 'button[data-testid="STRATEGY_VARIANTS_TAB"]',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3512/bug-flow-2-enable-for-a-specific-user-doesnt-work
https://linear.app/unleash/issue/2-3513/bug-flow-4-adjust-variants-doesnt-work

Fixes our demo topics by making them work with the new flag page design.

We achieve this by adding 2 new interactive steps in `demoApp.step2` and `demoApp.step4` to expand the respective environment accordions. We mark them as optional so they are not strictly required and will be skipped if not found. This means the demo will be resilient to rolling back the `flagOverviewRedesign` flag, for example.

We also mark 2 steps as optional: saving constraints in `demoApp.step2` and `demoApp.step4`. It seems like we no longer have an extra button to save the constraints after adding them, so by marking these steps as optional the demo flow is able to proceed without breaking.