### PR TITLE
fix: demo flow consistency with new flag page

### DIFF
--- a/frontend/src/component/demo/demo-topics.tsx
+++ b/frontend/src/component/demo/demo-topics.tsx
@@ -131,24 +131,26 @@ export const TOPICS: ITutorialTopic[] = [
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step2`,
-                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] .MuiAccordionSummary-expandIconWrapper`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] > div[aria-expanded="false"]`,
                 content: (
                     <Description>
                         Expand the environment card to see all the defined
-                        strategies by using the arrow button.
+                        strategies.
                     </Description>
                 ),
                 optional: true,
+                delay: 500,
             },
             {
-                href: `/projects/${PROJECT}/features/demoApp.step2`,
-                target: 'button[data-testid="ADD_STRATEGY_BUTTON"]',
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] button[data-testid="ADD_STRATEGY_BUTTON"]`,
                 content: (
                     <Description>
                         Add a new strategy to this environment by using this
                         button.
                     </Description>
                 ),
+                delay: 500,
+                backCollapseExpanded: true,
             },
             {
                 target: `a[href="${basePath}/projects/${PROJECT}/features/demoApp.step2/strategies/create?environmentId=${ENVIRONMENT}&strategyName=flexibleRollout&defaultStrategy=true"]`,
@@ -365,17 +367,18 @@ export const TOPICS: ITutorialTopic[] = [
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step3`,
-                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] .MuiAccordionSummary-expandIconWrapper`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] > div[aria-expanded="false"]`,
                 content: (
                     <Description>
                         Expand the environment card to see all the defined
-                        strategies by using the arrow button.
+                        strategies.
                     </Description>
                 ),
                 optional: true,
+                delay: 500,
             },
             {
-                target: `a[data-testid="STRATEGY_EDIT-flexibleRollout"]`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] a[data-testid="STRATEGY_EDIT-flexibleRollout"]`,
                 content: (
                     <Description>
                         Edit the existing gradual rollout strategy by using the
@@ -481,18 +484,19 @@ export const TOPICS: ITutorialTopic[] = [
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step4`,
-                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] .MuiAccordionSummary-expandIconWrapper`,
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] > div[aria-expanded="false"]`,
                 content: (
                     <Description>
                         Expand the environment card to see all the defined
-                        strategies by using the arrow button.
+                        strategies.
                     </Description>
                 ),
                 optional: true,
+                delay: 500,
             },
             {
                 href: `/projects/${PROJECT}/features/demoApp.step4`,
-                target: 'button[data-testid="ADD_STRATEGY_BUTTON"]',
+                target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] button[data-testid="ADD_STRATEGY_BUTTON"]`,
                 content: (
                     <Description>
                         Add a new strategy to this environment by using this


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3512/bug-flow-2-enable-for-a-specific-user-doesnt-work
https://linear.app/unleash/issue/2-3513/bug-flow-4-adjust-variants-doesnt-work

Follow-up to #9765 

This should make the demo flow a bit more consistent with the new page design.

The page seems a bit slower in general, so we're being a bit more aggressive on the cleaning up of demo data to make it faster as well as adding some delays in key steps of the flow.