### PR TITLE
fix: demo flow step 4 is too eager on add strategy

### DIFF
--- a/frontend/src/component/demo/demo-topics.tsx
+++ b/frontend/src/component/demo/demo-topics.tsx
@@ -495,7 +495,6 @@ export const TOPICS: ITutorialTopic[] = [
                 delay: 500,
             },
             {
-                href: `/projects/${PROJECT}/features/demoApp.step4`,
                 target: `div[data-testid="FEATURE_ENVIRONMENT_ACCORDION_${ENVIRONMENT}"] button[data-testid="ADD_STRATEGY_BUTTON"]`,
                 content: (
                     <Description>
@@ -503,6 +502,8 @@ export const TOPICS: ITutorialTopic[] = [
                         button.
                     </Description>
                 ),
+                delay: 500,
+                backCollapseExpanded: true,
             },
             {
                 target: `a[href="${basePath}/projects/${PROJECT}/features/demoApp.step4/strategies/create?environmentId=${ENVIRONMENT}&strategyName=flexibleRollout&defaultStrategy=true"]`,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3512/bug-flow-2-enable-for-a-specific-user-doesnt-work
https://linear.app/unleash/issue/2-3513/bug-flow-4-adjust-variants-doesnt-work

Follow-up to #9770 

This "add strategy" step of `demoApp.step4` was a bit too eager and did not properly wait for the accordion to be fully expanded. This change makes it consistent with the same step in `demoApp.step2`, also improving its "back" behavior.