### PR TITLE
chore: make demo back button variant text

### DIFF
--- a/frontend/src/component/demo/DemoSteps/DemoStepTooltip/DemoStepTooltip.tsx
+++ b/frontend/src/component/demo/DemoSteps/DemoStepTooltip/DemoStepTooltip.tsx
@@ -129,7 +129,7 @@ export const DemoStepTooltip = ({
                                 condition={topic > 0 || stepIndex > 0}
                                 show={
                                     <Button
-                                        variant='outlined'
+                                        variant='text'
                                         onClick={() => onBack(step)}
                                     >
                                         Back

--- a/frontend/src/component/demo/DemoSteps/DemoStepTooltip/DemoStepTooltip.tsx
+++ b/frontend/src/component/demo/DemoSteps/DemoStepTooltip/DemoStepTooltip.tsx
@@ -180,10 +180,7 @@ export const DemoStepTooltip = ({
                     <ConditionallyRender
                         condition={topic > 0 || stepIndex > 0}
                         show={
-                            <Button
-                                variant='outlined'
-                                onClick={() => onBack(step)}
-                            >
+                            <Button variant='text' onClick={() => onBack(step)}>
                                 Back
                             </Button>
                         }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2576/make-back-button-less-dominant

Make demo "Back" button `variant='text'` so it's less predominant visually.

### Before

![image](https://github.com/user-attachments/assets/d4378975-483a-4478-a7c9-9698a466f918)

### After

![image](https://github.com/user-attachments/assets/1349454b-73aa-465e-9a15-cd7f52cedb75)