### PR TITLE
fix: remove outdated INIT_FRONTEND_API_TOKENS and INIT_CLIENT_API_TOKENS from  docker-compose.yml 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,6 @@ services:
       DATABASE_SSL: "false"
       # Changing log levels:
       LOG_LEVEL: "warn"
-      # Proxy clients must use one of these keys to connect to the
-      # Proxy. To add more keys, separate them with a comma (`key1,key2`).
-      INIT_FRONTEND_API_TOKENS: "default:development.unleash-insecure-frontend-api-token"
-      # Initialize Unleash with a default set of client API tokens. To
-      # initialize Unleash with multiple tokens, separate them with a
-      # comma (`token1,token2`).
-      INIT_CLIENT_API_TOKENS: "default:development.unleash-insecure-api-token"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
### Changes  
- Removes deprecated `INIT_FRONTEND_API_TOKENS` and `INIT_CLIENT_API_TOKENS`.  


### Why?  
The old variables cause startup errors (`Unable to create initial Admin API tokens`).  
Fixes #9775
