### PR TITLE
fix: double token initialization

### DIFF
--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -499,6 +499,42 @@ test('Config with enterpriseVersion set and not pro environment should set isEnt
     expect(config.isEnterprise).toBe(true);
 });
 
+test('create config should be idempotent in terms of tokens', async () => {
+    // two admin tokens
+    process.env.INIT_ADMIN_API_TOKENS = '*:*.some-token1, *:*.some-token2';
+    process.env.INIT_CLIENT_API_TOKENS = 'default:development.some-token1';
+    process.env.INIT_FRONTEND_API_TOKENS = 'frontend:development.some-token1';
+    const token = {
+        environment: '*',
+        project: '*',
+        secret: '*:*.some-random-string',
+        type: ApiTokenType.ADMIN,
+        tokenName: 'admin',
+    };
+    const config = createConfig({
+        db: {
+            host: 'localhost',
+            port: 4242,
+            user: 'unleash',
+            password: 'password',
+            database: 'unleash_db',
+        },
+        server: {
+            port: 4242,
+        },
+        authentication: {
+            initApiTokens: [token],
+        },
+    });
+    expect(config.authentication.initApiTokens.length).toStrictEqual(
+        createConfig(config).authentication.initApiTokens.length,
+    );
+    expect(config.authentication.initApiTokens).toHaveLength(5);
+    delete process.env.INIT_ADMIN_API_TOKENS;
+    delete process.env.INIT_CLIENT_API_TOKENS;
+    delete process.env.INIT_FRONTEND_API_TOKENS;
+});
+
 describe('isOSS', () => {
     test('Config with pro environment should set isOss to false regardless of pro casing', async () => {
         const isOss = resolveIsOss(false, false, 'Pro');

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -574,6 +574,15 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             : options.authentication) || {},
         { initApiTokens: initApiTokens },
     ]);
+    // make sure init tokens appear only once
+    authentication.initApiTokens = [
+        ...new Map(
+            authentication.initApiTokens.map((token) => [
+                `${token.type}${token.project}${token.projects?.join(',')}${token.environment}${token.secret}`,
+                token,
+            ]),
+        ).values(),
+    ];
 
     const environmentEnableOverrides = loadEnvironmentEnableOverrides();
 

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -577,10 +577,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
     // make sure init tokens appear only once
     authentication.initApiTokens = [
         ...new Map(
-            authentication.initApiTokens.map((token) => [
-                `${token.type}${token.project}${token.projects?.join(',')}${token.environment}${token.secret}`,
-                token,
-            ]),
+            authentication.initApiTokens.map((token) => [token.secret, token]),
         ).values(),
     ];
 

--- a/src/lib/server-impl.test.ts
+++ b/src/lib/server-impl.test.ts
@@ -38,6 +38,8 @@ jest.mock('./services', () => ({
             featureLifecycleService: { listen() {} },
             schedulerService: { stop() {}, start() {} },
             addonService: { destroy() {} },
+            userService: { initAdminUser() {} },
+            apiTokenService: { initApiTokens() {} },
         };
     },
 }));

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -32,11 +32,12 @@ test('Should init api token', async () => {
             },
         },
     });
-    const { apiTokenStore } = createFakeApiTokenService(config);
+    const { apiTokenService, apiTokenStore } =
+        createFakeApiTokenService(config);
     const insertCalled = new Promise((resolve) => {
         apiTokenStore.on('insert', resolve);
     });
-
+    apiTokenService.initApiTokens([token]);
     await insertCalled;
 
     const tokens = await apiTokenStore.getAll();

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -106,18 +106,12 @@ class UserService {
         {
             server,
             getLogger,
-            authentication,
             eventBus,
             flagResolver,
             session,
         }: Pick<
             IUnleashConfig,
-            | 'getLogger'
-            | 'authentication'
-            | 'server'
-            | 'eventBus'
-            | 'flagResolver'
-            | 'session'
+            'getLogger' | 'server' | 'eventBus' | 'flagResolver' | 'session'
         >,
         services: {
             accessService: AccessService;
@@ -139,9 +133,6 @@ class UserService {
         this.settingService = services.settingService;
         this.flagResolver = flagResolver;
         this.maxParallelSessions = session.maxParallelSessions;
-
-        process.nextTick(() => this.initAdminUser(authentication));
-
         this.baseUriPath = server.baseUriPath || '';
         this.unleashUrl = server.unleashUrl;
     }

--- a/src/test/e2e/helpers/test-helper.ts
+++ b/src/test/e2e/helpers/test-helper.ts
@@ -24,6 +24,7 @@ import type { Knex } from 'knex';
 import type TestAgent from 'supertest/lib/agent';
 import type Test from 'supertest/lib/test';
 import type { Server } from 'node:http';
+import { initialServiceSetup } from '../../../lib/server-impl';
 process.env.NODE_ENV = 'test';
 
 export interface IUnleashTest extends IUnleashHttpAPI {
@@ -357,6 +358,7 @@ async function createApp(
         },
     });
     const services = createServices(stores, config, db);
+    await initialServiceSetup(config, services);
     // @ts-expect-error We don't have a database for sessions here.
     const unleashSession = sessionDb(config, undefined);
     const app = await getApp(config, stores, services, unleashSession, db);
@@ -412,6 +414,7 @@ export async function setupAppWithoutSupertest(
         },
     });
     const services = createServices(stores, config, db);
+    await initialServiceSetup(config, services);
     // @ts-expect-error we don't have a db for the session here
     const unleashSession = sessionDb(config, undefined);
     const app = await getApp(config, stores, services, unleashSession, db);


### PR DESCRIPTION
## About the changes
Initially at Unleash we started using `process.nextTick` inside constructors to delay initialization of services. 
Later we stared using a pattern where we instantiate services multiple times. 
The problem is the first pattern implies we have singleton services, while the second pattern breaks the singleton.

There are reasons for both patterns, but we've decided that `process.nextTick` inside constructors is not something we want to keep as it creates side effects from creating objects. Instead this PR proposes a more explicit approach.

Fixes #9775