### PR TITLE
feat: futureproofing last viewed page redirect

### DIFF
--- a/frontend/src/component/InitialRedirect.tsx
+++ b/frontend/src/component/InitialRedirect.tsx
@@ -6,10 +6,12 @@ import Loader from './common/Loader/Loader';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 
+const defaultPage = '/personal';
+
 export const useLastViewedPage = (location?: Location) => {
     const [state, setState] = useLocalStorageState<string>(
         'lastViewedPage',
-        '/personal',
+        defaultPage,
         7 * 24 * 60 * 60 * 1000, // 7 days, left to promote seeing Personal dashboard from time to time
     );
 
@@ -55,5 +57,9 @@ export const InitialRedirect = () => {
         return <Navigate to={`/projects/${lastViewedProject}`} replace />;
     }
 
-    return <Navigate to={lastViewedPage} replace />;
+    if (lastViewedPage && lastViewedPage !== '/') {
+        return <Navigate to={lastViewedPage} replace />;
+    }
+
+    return <Navigate to={defaultPage} replace />;
 };


### PR DESCRIPTION
You should not be able to break initial page redirect even if you set '/' as target. While this is not strictly needed in the current code path, it makes this part safer if it is ever modified.