### PR TITLE
feat: local dev should honor our schemas

### DIFF
--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -62,6 +62,7 @@ process.nextTick(async () => {
                         addEditStrategy: true,
                         flagsOverviewSearch: true,
                         cleanupReminder: true,
+                        strictSchemaValidation: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Spotted this in local dev mode:
```
[2025-04-17T15:10:21.036] [DEBUG] openapi-service.ts - Invalid response: {
    "schema": "#/components/schemas/environmentsProjectSchema",
    "errors": [
        {
            "instancePath": "/environments/0",
            "schemaPath": "#/additionalProperties",
            "keyword": "additionalProperties",
            "params": {
                "additionalProperty": "requiredApprovals"
            },
            "message": "must NOT have additional properties"
        }
    ]
}
```
Enabling strictSchemaValidation in dev mode should help prevent these issues from going out to prod as developers would identify them while testing locally