### PR TITLE
fix: strategy-reorder tooltip padding

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -122,12 +122,8 @@ export const FeatureOverview = () => {
                         }
                     />
                 </Routes>
-
-                <StrategyDragTooltip
-                    show={showTooltip}
-                    onClose={onTooltipClose}
-                />
             </StyledContainer>
+            <StrategyDragTooltip show={showTooltip} onClose={onTooltipClose} />
         </div>
     );
 };


### PR DESCRIPTION
## About the changes
Tooltip is causing gap to add padding to the right side of flag overview page

![image](https://github.com/user-attachments/assets/b92ca0d0-c978-4688-8876-c8cf1275fd2b)
