### PR TITLE
Stop "add values" from closing on adding a value

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
@@ -152,14 +152,6 @@ const AddValues = forwardRef<HTMLButtonElement, AddValuesProps>(
             onAddValues(newValues);
             setInputValues('');
             setError('');
-            setOpen(false);
-        };
-
-        const handleKeyPress = (event: React.KeyboardEvent) => {
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                handleAdd();
-            }
         };
 
         return (
@@ -186,7 +178,13 @@ const AddValues = forwardRef<HTMLButtonElement, AddValuesProps>(
                         horizontal: 'left',
                     }}
                 >
-                    <div>
+                    <form
+                        onSubmit={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            handleAdd();
+                        }}
+                    >
                         {error && <ErrorMessage>{error}</ErrorMessage>}
                         <InputRow>
                             <StyledTextField
@@ -196,7 +194,6 @@ const AddValues = forwardRef<HTMLButtonElement, AddValuesProps>(
                                     setInputValues(e.target.value);
                                     setError('');
                                 }}
-                                onKeyPress={handleKeyPress}
                                 size='small'
                                 variant='standard'
                                 fullWidth
@@ -211,7 +208,7 @@ const AddValues = forwardRef<HTMLButtonElement, AddValuesProps>(
                                 Add
                             </Button>
                         </InputRow>
-                    </div>
+                    </form>
                 </StyledPopover>
             </>
         );


### PR DESCRIPTION
Instead of closing the "add values" popover when you add a value, we now keep it open to facilitate rapid entry of multiple values. It already clears successfully and adds the new value to the list, so it's actually quite smooth to use from just the keyboard now!

Additionally, I propose using a `form` element for the add values popover, because it really is just a tiny form. This also allows us to use regular form handling instead for submission instead of checking what key the user pressed.

