### PR TITLE
feat: remove warning boxes for empty values

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
@@ -47,7 +47,9 @@ export const getIllegalValues = (
 ) => {
     const deletedValuesSet = getLegalValueSet(deletedLegalValues);
 
-    return constraintValues.filter((value) => deletedValuesSet.has(value));
+    return constraintValues.filter(
+        (value) => value !== '' && deletedValuesSet.has(value),
+    );
 };
 
 const StyledValuesContainer = styled('div')(({ theme }) => ({


### PR DESCRIPTION
We had issues, where when you selected the operator, these boxes were jumping up. The problem was that the illegal value checker was marking empty values as illegal also.

Now empty value is not included in illegal values.

![image](https://github.com/user-attachments/assets/13c6b21e-6b7e-40ac-bade-4496e65f10ba)
