### PR TITLE
Prevent legal value selection from triggering form submit

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/RestrictiveLegalValues/RestrictiveLegalValues.tsx
@@ -155,6 +155,7 @@ export const RestrictiveLegalValues = ({
 
     const handleSearchKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === 'Enter' && filteredValues.length > 0) {
+            event.preventDefault();
             const firstValue = filteredValues[0].value;
             onChange(firstValue);
         }


### PR DESCRIPTION
Use event.preventDefault to prevent the app from trying to submit the legal values (or the strategy) form when you hit "enter" in the legal values filter input.
