### PR TITLE
feat: remove inactive applications

### DIFF
--- a/src/lib/db/client-applications-store.ts
+++ b/src/lib/db/client-applications-store.ts
@@ -449,4 +449,16 @@ export default class ClientApplicationsStore
             }));
         }
     };
+
+    async removeInactiveApplications(): Promise<number> {
+        const rows = await this.db(TABLE)
+            .whereRaw("seen_at < now() - interval '30 days'")
+            .del();
+
+        if (rows > 0) {
+            this.logger.debug(`Deleted ${rows} applications`);
+        }
+
+        return rows;
+    }
 }

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -298,6 +298,13 @@ export default class ClientInstanceService {
         return this.clientInstanceStore.removeInstancesOlderThanTwoDays();
     }
 
+    async removeInactiveApplications(): Promise<number> {
+        if (this.flagResolver.isEnabled('removeInactiveApplications')) {
+            return this.clientApplicationsStore.removeInactiveApplications();
+        }
+        return 0;
+    }
+
     async getOutdatedSdks(): Promise<OutdatedSdksSchema['sdks']> {
         const sdkApps = await this.clientInstanceStore.groupApplicationsBySdk();
 

--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -79,6 +79,14 @@ export const scheduleServices = async (
     );
 
     schedulerService.schedule(
+        clientInstanceService.removeInactiveApplications.bind(
+            clientInstanceService,
+        ),
+        hoursToMilliseconds(24),
+        'removeInactiveApplications',
+    );
+
+    schedulerService.schedule(
         clientInstanceService.bulkAdd.bind(clientInstanceService),
         secondsToMilliseconds(5),
         'bulkAddInstances',

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -69,7 +69,8 @@ export type IFlagKey =
     | 'newStrategyDropdown'
     | 'flagsOverviewSearch'
     | 'flagsReleaseManagementUI'
-    | 'cleanupReminder';
+    | 'cleanupReminder'
+    | 'removeInactiveApplications';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -328,6 +329,10 @@ const flags: IFlags = {
     ),
     cleanupReminder: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_CLEANUP_REMINDER,
+        false,
+    ),
+    removeInactiveApplications: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_REMOVE_INACTIVE_APPLICATIONS,
         false,
     ),
 };

--- a/src/lib/types/stores/client-applications-store.ts
+++ b/src/lib/types/stores/client-applications-store.ts
@@ -44,4 +44,5 @@ export interface IClientApplicationsStore
     getUnannounced(): Promise<IClientApplication[]>;
     setUnannouncedToAnnounced(): Promise<IClientApplication[]>;
     getApplicationOverview(appName: string): Promise<IApplicationOverview>;
+    removeInactiveApplications(): Promise<number>;
 }

--- a/src/test/fixtures/fake-client-applications-store.ts
+++ b/src/test/fixtures/fake-client-applications-store.ts
@@ -82,4 +82,8 @@ export default class FakeClientApplicationsStore
     getApplicationOverview(appName: string): Promise<IApplicationOverview> {
         throw new Error('Method not implemented.');
     }
+
+    async removeInactiveApplications(): Promise<number> {
+        return 0;
+    }
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Remove inactive applications (last_seen older than 30 days) from the application list

<img width="1002" alt="Screenshot 2025-04-24 at 13 54 42" src="https://github.com/user-attachments/assets/e365c70e-63a4-4c1b-be55-2b839e0335c0" />

There is a delete cascade to client_applications_usage so this will be removed too.

The new capability is behind a flag.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
There's seet_at and updated_at column and they seem to have the same value