### PR TITLE
chore: second design pass for editable constraints

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintOperatorSelect.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintOperatorSelect.tsx
@@ -47,6 +47,9 @@ const StyledSelect = styled(Select)(({ theme }) => ({
     '.MuiInput-input': {
         paddingBlock: theme.spacing(0.25),
     },
+    ':focus-within .MuiSelect-select': {
+        background: 'none',
+    },
 }));
 
 const StyledMenuItem = styled(MenuItem, {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -107,6 +107,9 @@ const InputContainer = styled('div')(({ theme }) => ({
 const StyledSelect = styled(GeneralSelect)(({ theme }) => ({
     fieldset: { border: 'none', borderRadius: 0 },
     maxWidth: '25ch',
+    ':focus-within .MuiSelect-select': {
+        background: 'none',
+    },
     ':focus-within fieldset': { borderBottomStyle: 'solid' },
     'label + &': {
         // mui adds a margin top to 'standard' selects with labels

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -35,6 +35,7 @@ const Container = styled('article')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     borderRadius: theme.shape.borderRadiusLarge,
     border: `1px solid ${theme.palette.divider}`,
+    containerType: 'inline-size',
 }));
 
 const TopRow = styled('div')(({ theme }) => ({
@@ -44,6 +45,13 @@ const TopRow = styled('div')(({ theme }) => ({
     alignItems: 'flex-start',
     justifyItems: 'space-between',
     borderBottom: `1px dashed ${theme.palette.divider}`,
+}));
+
+const ConstraintOptions = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    gap: theme.spacing(1),
+    alignSelf: 'flex-start',
 }));
 
 const resolveLegalValues = (
@@ -78,6 +86,9 @@ const ConstraintDetails = styled('div')(({ theme }) => ({
     flexFlow: 'row nowrap',
     width: '100%',
     height: 'min-content',
+    '@container (max-width: 700px)': {
+        flexDirection: 'column',
+    },
 }));
 
 const InputContainer = styled('div')(({ theme }) => ({
@@ -246,52 +257,53 @@ export const EditableConstraint: FC<Props> = ({
         <Container>
             <TopRow>
                 <ConstraintDetails>
-                    <StyledSelect
-                        visuallyHideLabel
-                        id='context-field-select'
-                        name='contextName'
-                        label='Context Field'
-                        autoFocus
-                        options={constraintNameOptions}
-                        value={contextName || ''}
-                        onChange={setContextName}
-                        variant='standard'
-                    />
+                    <ConstraintOptions>
+                        <StyledSelect
+                            visuallyHideLabel
+                            id='context-field-select'
+                            name='contextName'
+                            label='Context Field'
+                            autoFocus
+                            options={constraintNameOptions}
+                            value={contextName || ''}
+                            onChange={setContextName}
+                            variant='standard'
+                        />
 
-                    <StyledButton
-                        type='button'
-                        onClick={toggleInvertedOperator}
-                    >
-                        {localConstraint.inverted ? 'aint' : 'is'}
-                    </StyledButton>
-
-                    <ConstraintOperatorSelect
-                        options={operatorsForContext(contextName)}
-                        value={operator}
-                        onChange={onOperatorChange}
-                        inverted={localConstraint.inverted}
-                    />
-
-                    {showCaseSensitiveButton ? (
-                        <CaseButton
+                        <StyledButton
                             type='button'
-                            onClick={toggleCaseSensitivity}
+                            onClick={toggleInvertedOperator}
                         >
-                            {localConstraint.caseInsensitive ? (
-                                <StyledCaseInsensitiveIcon aria-label='The match is not case sensitive.' />
-                            ) : (
-                                <StyledCaseSensitiveIcon aria-label='The match is case sensitive.' />
-                            )}
-                            <ScreenReaderOnly>
-                                Make match
-                                {localConstraint.caseInsensitive
-                                    ? ' '
-                                    : ' not '}
-                                case sensitive
-                            </ScreenReaderOnly>
-                        </CaseButton>
-                    ) : null}
+                            {localConstraint.inverted ? 'aint' : 'is'}
+                        </StyledButton>
 
+                        <ConstraintOperatorSelect
+                            options={operatorsForContext(contextName)}
+                            value={operator}
+                            onChange={onOperatorChange}
+                            inverted={localConstraint.inverted}
+                        />
+
+                        {showCaseSensitiveButton ? (
+                            <CaseButton
+                                type='button'
+                                onClick={toggleCaseSensitivity}
+                            >
+                                {localConstraint.caseInsensitive ? (
+                                    <StyledCaseInsensitiveIcon aria-label='The match is not case sensitive.' />
+                                ) : (
+                                    <StyledCaseSensitiveIcon aria-label='The match is case sensitive.' />
+                                )}
+                                <ScreenReaderOnly>
+                                    Make match
+                                    {localConstraint.caseInsensitive
+                                        ? ' '
+                                        : ' not '}
+                                    case sensitive
+                                </ScreenReaderOnly>
+                            </CaseButton>
+                        ) : null}
+                    </ConstraintOptions>
                     <ValueList
                         values={localConstraint.values}
                         removeValue={removeValue}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -123,9 +123,13 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
 }));
 
 const StyledButton = styled('button')(({ theme }) => ({
+    // todo (`addEditStrategy`): this is pretty rough, but it needs to be the
+    // same height as the input fields, which are 27.25 px at the moment.
+    // Consider editing this when we get new icons for the buttons. There may be
+    // a better solution.
+    height: `calc(${theme.typography.body1.fontSize} + ${theme.spacing(1.5)})`,
     width: '5ch',
     borderRadius: theme.shape.borderRadius,
-    padding: theme.spacing(0.25, 0),
     fontSize: theme.fontSizes.smallerBody,
     background: theme.palette.secondary.light,
     border: `1px solid ${theme.palette.secondary.border}`,

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -44,7 +44,6 @@ const TopRow = styled('div')(({ theme }) => ({
     flexFlow: 'row nowrap',
     alignItems: 'flex-start',
     justifyItems: 'space-between',
-    borderBottom: `1px dashed ${theme.palette.divider}`,
     gap: 'var(--gap)',
 }));
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -39,19 +39,28 @@ const Container = styled('article')(({ theme }) => ({
 }));
 
 const TopRow = styled('div')(({ theme }) => ({
+    '--gap': theme.spacing(1),
     padding: 'var(--padding)',
     display: 'flex',
     flexFlow: 'row nowrap',
     alignItems: 'flex-start',
     justifyItems: 'space-between',
     borderBottom: `1px dashed ${theme.palette.divider}`,
+    gap: 'var(--gap)',
 }));
 
 const ConstraintOptions = styled('div')(({ theme }) => ({
     display: 'flex',
     flexFlow: 'row nowrap',
-    gap: theme.spacing(1),
+    gap: 'var(--gap)',
     alignSelf: 'flex-start',
+    '@container (max-width: 700px)': {
+        flexFlow: 'row wrap',
+    },
+}));
+
+const OperatorOptions = styled(ConstraintOptions)(({ theme }) => ({
+    flexFlow: 'row nowrap',
 }));
 
 const resolveLegalValues = (
@@ -82,7 +91,7 @@ const resolveLegalValues = (
 
 const ConstraintDetails = styled('div')(({ theme }) => ({
     display: 'flex',
-    gap: theme.spacing(1),
+    gap: 'var(--gap)',
     flexFlow: 'row nowrap',
     width: '100%',
     height: 'min-content',
@@ -97,6 +106,7 @@ const InputContainer = styled('div')(({ theme }) => ({
 
 const StyledSelect = styled(GeneralSelect)(({ theme }) => ({
     fieldset: { border: 'none', borderRadius: 0 },
+    maxWidth: '25ch',
     ':focus-within fieldset': { borderBottomStyle: 'solid' },
     'label + &': {
         // mui adds a margin top to 'standard' selects with labels
@@ -105,6 +115,11 @@ const StyledSelect = styled(GeneralSelect)(({ theme }) => ({
     '&::before': {
         border: 'none',
     },
+}));
+
+const StyledIconButton = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    right: theme.spacing(1),
 }));
 
 const StyledButton = styled('button')(({ theme }) => ({
@@ -120,6 +135,10 @@ const StyledButton = styled('button')(({ theme }) => ({
     '&:is(:hover, :focus-visible)': {
         outline: `1px solid ${theme.palette.primary.main}`,
     },
+}));
+
+const ButtonPlaceholder = styled('div')(({ theme }) => ({
+    width: theme.spacing(2),
 }));
 
 const StyledCaseInsensitiveIcon = styled(CaseInsensitiveIcon)(({ theme }) => ({
@@ -270,39 +289,41 @@ export const EditableConstraint: FC<Props> = ({
                             variant='standard'
                         />
 
-                        <StyledButton
-                            type='button'
-                            onClick={toggleInvertedOperator}
-                        >
-                            {localConstraint.inverted ? 'aint' : 'is'}
-                        </StyledButton>
-
-                        <ConstraintOperatorSelect
-                            options={operatorsForContext(contextName)}
-                            value={operator}
-                            onChange={onOperatorChange}
-                            inverted={localConstraint.inverted}
-                        />
-
-                        {showCaseSensitiveButton ? (
-                            <CaseButton
+                        <OperatorOptions>
+                            <StyledButton
                                 type='button'
-                                onClick={toggleCaseSensitivity}
+                                onClick={toggleInvertedOperator}
                             >
-                                {localConstraint.caseInsensitive ? (
-                                    <StyledCaseInsensitiveIcon aria-label='The match is not case sensitive.' />
-                                ) : (
-                                    <StyledCaseSensitiveIcon aria-label='The match is case sensitive.' />
-                                )}
-                                <ScreenReaderOnly>
-                                    Make match
-                                    {localConstraint.caseInsensitive
-                                        ? ' '
-                                        : ' not '}
-                                    case sensitive
-                                </ScreenReaderOnly>
-                            </CaseButton>
-                        ) : null}
+                                {localConstraint.inverted ? 'aint' : 'is'}
+                            </StyledButton>
+
+                            <ConstraintOperatorSelect
+                                options={operatorsForContext(contextName)}
+                                value={operator}
+                                onChange={onOperatorChange}
+                                inverted={localConstraint.inverted}
+                            />
+
+                            {showCaseSensitiveButton ? (
+                                <CaseButton
+                                    type='button'
+                                    onClick={toggleCaseSensitivity}
+                                >
+                                    {localConstraint.caseInsensitive ? (
+                                        <StyledCaseInsensitiveIcon aria-label='The match is not case sensitive.' />
+                                    ) : (
+                                        <StyledCaseSensitiveIcon aria-label='The match is case sensitive.' />
+                                    )}
+                                    <ScreenReaderOnly>
+                                        Make match
+                                        {localConstraint.caseInsensitive
+                                            ? ' '
+                                            : ' not '}
+                                        case sensitive
+                                    </ScreenReaderOnly>
+                                </CaseButton>
+                            ) : null}
+                        </OperatorOptions>
                     </ConstraintOptions>
                     <ValueList
                         values={localConstraint.values}
@@ -330,16 +351,16 @@ export const EditableConstraint: FC<Props> = ({
                         ) : null}
                     </ValueList>
                 </ConstraintDetails>
-
+                <ButtonPlaceholder />
                 <HtmlTooltip title='Delete constraint' arrow>
-                    <IconButton
+                    <StyledIconButton
                         type='button'
                         size='small'
                         onClick={onDelete}
                         ref={deleteButtonRef}
                     >
                         <Delete fontSize='inherit' />
-                    </IconButton>
+                    </StyledIconButton>
                 </HtmlTooltip>
             </TopRow>
             <InputContainer>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -138,6 +138,10 @@ const StyledButton = styled('button')(({ theme }) => ({
 }));
 
 const ButtonPlaceholder = styled('div')(({ theme }) => ({
+    // this is a trick that lets us use absolute positioning for the button so
+    // that it can go over the operator context fields when necessary (narrow
+    // screens), but still retain necessary space for the button when it's all
+    // on one line.
     width: theme.spacing(2),
 }));
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -338,7 +338,7 @@ export const EditableConstraint: FC<Props> = ({
                         onClick={onDelete}
                         ref={deleteButtonRef}
                     >
-                        <Delete />
+                        <Delete fontSize='inherit' />
                     </IconButton>
                 </HtmlTooltip>
             </TopRow>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -38,6 +38,8 @@ const Container = styled('article')(({ theme }) => ({
     containerType: 'inline-size',
 }));
 
+const onNarrowContainer = '@container (max-width: 700px)';
+
 const TopRow = styled('div')(({ theme }) => ({
     '--gap': theme.spacing(1),
     padding: 'var(--padding)',
@@ -54,7 +56,7 @@ const ConstraintOptions = styled('div')(({ theme }) => ({
     flexFlow: 'row nowrap',
     gap: 'var(--gap)',
     alignSelf: 'flex-start',
-    '@container (max-width: 700px)': {
+    [onNarrowContainer]: {
         flexFlow: 'row wrap',
     },
 }));
@@ -95,7 +97,7 @@ const ConstraintDetails = styled('div')(({ theme }) => ({
     flexFlow: 'row nowrap',
     width: '100%',
     height: 'min-content',
-    '@container (max-width: 700px)': {
+    [onNarrowContainer]: {
         flexDirection: 'column',
     },
 }));

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
@@ -94,6 +94,13 @@ export const ValueList: FC<PropsWithChildren<Props>> = ({
                             ref={(el) => {
                                 constraintElementRefs.current[index] = el;
                             }}
+                            sx={{
+                                height: 'auto',
+                                '& .MuiChip-label': {
+                                    display: 'block',
+                                    whiteSpace: 'normal',
+                                },
+                            }}
                             deleteIcon={<Clear />}
                             label={value}
                             onDelete={() => {


### PR DESCRIPTION
Fix a number of visual issues with the main editable constraint component.

I've introduced a few more layers of container nesting to make the layout break the right ways:
- Put everything on the same line when on wide.
- At 700px place selected values on the row below
- From 700px down, when necessary, also wrap operator options


Support super long context names without breaking layout
<img width="399" alt="image" src="https://github.com/user-attachments/assets/07555e9c-d875-417f-ae6b-d4600731d5eb" />

Wrap values at 700px width container:
<img width="703" alt="image" src="https://github.com/user-attachments/assets/deb6e059-57d4-4e47-88da-3ec5d6bce751" />

Wrap operator options when necessary
<img width="359" alt="image" src="https://github.com/user-attachments/assets/ff96db40-f47d-4ddf-bed7-dfced4d69973" />

Absolutely position delete button to allow to not push it out of the container on narrow screens: 
<img width="330" alt="image" src="https://github.com/user-attachments/assets/c7b8f88d-538a-46a1-ae3f-e5a761b50289" />

Remove extra focus styling from MUI (darken select background):
Before:
<img width="348" alt="image" src="https://github.com/user-attachments/assets/99aff08d-c1af-46c0-8a75-40c1ea3c103f" />

<img width="357" alt="image" src="https://github.com/user-attachments/assets/b7a0edac-2716-48a7-b50c-b3437e5f5be8" />

After:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/74da884c-7b1a-4b9a-8383-31592326a71b" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/0ebea696-5f7d-4d4e-b91c-b087a8fc56a3" />

