### PR TITLE
refactor: move away from "setValues"

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -166,6 +166,7 @@ type Props = {
     setValues: (values: string[]) => void;
     setValuesWithRecord: (values: string[]) => void;
     setError: React.Dispatch<React.SetStateAction<string>>;
+    addValues: (...values: string[]) => void;
     removeValue: (index: number) => void;
     input: Input;
     error: string;
@@ -187,6 +188,7 @@ export const EditableConstraint: FC<Props> = ({
     constraintValue,
     setValue,
     setValues,
+    addValues,
     setValuesWithRecord,
     setError,
     removeValue,
@@ -313,7 +315,6 @@ export const EditableConstraint: FC<Props> = ({
                     <ValueList
                         values={localConstraint.values}
                         removeValue={removeValue}
-                        setValues={setValuesWithRecord}
                         getExternalFocusTarget={() =>
                             addValuesButtonRef.current ??
                             deleteButtonRef.current
@@ -323,14 +324,11 @@ export const EditableConstraint: FC<Props> = ({
                             <AddValuesWidget
                                 ref={addValuesButtonRef}
                                 onAddValues={(newValues) => {
-                                    // todo (`addEditStrategy`): move deduplication logic higher up in the context handling
-                                    const combinedValues = new Set([
-                                        ...(localConstraint.values || []),
-                                        ...newValues,
-                                    ]);
-                                    setValuesWithRecord(
-                                        Array.from(combinedValues),
-                                    );
+                                    addValues(...newValues);
+                                    // setValuesWithRecord([
+                                    //     ...(localConstraint.values || []),
+                                    //     ...newValues,
+                                    // ]);
                                 }}
                             />
                         ) : null}
@@ -351,7 +349,7 @@ export const EditableConstraint: FC<Props> = ({
             </TopRow>
             {showInputField ? (
                 <InputContainer>
-                    <ResolveInput
+                    <ResolveInput // todo (`addEditStrategy`) can we get rid of `setValues` in favor of `addValues` (and removeValues / clearValues)? that way, downstream components don't need to know anything about how to handle constraint values. Only that they need to call these functions. Can also be grouped into `constraintValueActions: { add, remove, clear }` or something.
                         setValues={setValues}
                         setValuesWithRecord={setValuesWithRecord}
                         setValue={setValue}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraintWrapper.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraintWrapper.tsx
@@ -125,7 +125,10 @@ export const EditableConstraintWrapper = ({
 
     const setValuesWithRecord = useCallback((values: string[]) => {
         setLocalConstraint((prev) => {
-            const localConstraint = { ...prev, values };
+            const localConstraint = {
+                ...prev,
+                values: Array.from(new Set(values)),
+            };
 
             recordChange(localConstraint);
 
@@ -135,7 +138,10 @@ export const EditableConstraintWrapper = ({
 
     const setValues = useCallback((values: string[]) => {
         setLocalConstraint((prev) => {
-            const localConstraint = { ...prev, values };
+            const localConstraint = {
+                ...prev,
+                values: Array.from(new Set(values)),
+            };
 
             return localConstraint;
         });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ValueList.tsx
@@ -58,7 +58,6 @@ const ValueChip = styled(ValueChipBase)(({ theme }) => ({
 type Props = {
     values: string[] | undefined;
     removeValue: (index: number) => void;
-    setValues: (values: string[]) => void;
     // the element that should receive focus when all value chips are deleted
     getExternalFocusTarget: () => HTMLElement | null;
 };


### PR DESCRIPTION
This is a draft PR and a work in progress. The ultimate goal of it is to move away from the "setValues" function that we pass around in favor of more action-oriented "addValues", "clearValues", "removeValues" functions. 

Why? Initially, it was to take away the burden of having to deduplicate incoming values and merging them with the existing values downstream. This feels like internal logic that they shouldn't have to deal with. Locking down the API like that also makes it easier to test.

