### PR TITLE
feat: add date type input field for constraints.

### DIFF
--- a/frontend/src/component/common/Input/Input.tsx
+++ b/frontend/src/component/common/Input/Input.tsx
@@ -14,7 +14,6 @@ interface IInputProps extends Omit<OutlinedTextFieldProps, 'variant'> {
     onBlur?: (e: any) => any;
     multiline?: boolean;
     rows?: number;
-    variant?: 'outlined' | 'filled' | 'standard';
 }
 
 const StyledDiv = styled('div')({
@@ -31,7 +30,6 @@ const Input = ({
     value,
     onChange,
     size = 'small',
-    variant = 'outlined',
     ...rest
 }: IInputProps) => {
     const { classes: styles } = useStyles();
@@ -39,7 +37,7 @@ const Input = ({
         <StyledDiv data-loading>
             <TextField
                 size={size}
-                variant={variant}
+                variant='outlined'
                 label={label}
                 placeholder={placeholder}
                 error={error}

--- a/frontend/src/component/common/Input/Input.tsx
+++ b/frontend/src/component/common/Input/Input.tsx
@@ -14,6 +14,7 @@ interface IInputProps extends Omit<OutlinedTextFieldProps, 'variant'> {
     onBlur?: (e: any) => any;
     multiline?: boolean;
     rows?: number;
+    variant?: 'outlined' | 'filled' | 'standard';
 }
 
 const StyledDiv = styled('div')({
@@ -30,6 +31,7 @@ const Input = ({
     value,
     onChange,
     size = 'small',
+    variant = 'outlined',
     ...rest
 }: IInputProps) => {
     const { classes: styles } = useStyles();
@@ -37,7 +39,7 @@ const Input = ({
         <StyledDiv data-loading>
             <TextField
                 size={size}
-                variant='outlined'
+                variant={variant}
                 label={label}
                 placeholder={placeholder}
                 error={error}

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -1,9 +1,10 @@
 import Input from 'component/common/Input/Input';
 import { parseDateValue, parseValidDate } from 'component/common/util';
 
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { styled } from '@mui/material';
 import TimezoneCountries from 'countries-and-timezones';
+import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
 
 interface IDateSingleValueProps {
     setValue: (value: string) => void;
@@ -47,6 +48,7 @@ export const DateSingleValue = ({
     const { timeZone: localTimezoneName } =
         Intl.DateTimeFormat().resolvedOptions();
     const [pickedDate, setPickedDate] = useState(value || '');
+    const inputId = useId();
 
     const timezoneText = useMemo<string>(() => {
         const localTimezone = timezones.find(
@@ -62,27 +64,31 @@ export const DateSingleValue = ({
     if (!value) return null;
 
     return (
-        <StyledInput
-            // variant='standard'
-            id='date'
-            hiddenLabel
-            label=''
-            size='small'
-            type='datetime-local'
-            value={parseDateValue(pickedDate)}
-            onChange={(e) => {
-                setError('');
-                const parsedDate = parseValidDate(e.target.value);
-                const dateString = parsedDate?.toISOString();
-                dateString && setPickedDate(dateString);
-                dateString && setValue(dateString);
-            }}
-            InputLabelProps={{
-                shrink: true,
-            }}
-            error={Boolean(error)}
-            errorText={error}
-            required
-        />
+        <>
+            <label htmlFor={inputId}>
+                <ScreenReaderOnly>Date</ScreenReaderOnly>
+            </label>
+            <StyledInput
+                id={inputId}
+                hiddenLabel
+                label=''
+                size='small'
+                type='datetime-local'
+                value={parseDateValue(pickedDate)}
+                onChange={(e) => {
+                    setError('');
+                    const parsedDate = parseValidDate(e.target.value);
+                    const dateString = parsedDate?.toISOString();
+                    dateString && setPickedDate(dateString);
+                    dateString && setValue(dateString);
+                }}
+                InputLabelProps={{
+                    shrink: true,
+                }}
+                error={Boolean(error)}
+                errorText={error}
+                required
+            />
+        </>
     );
 };

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -21,6 +21,10 @@ const StyledWrapper = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
+/**
+ * @deprecated use `component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintDateInput.tsx`
+ * Remove with flag `addEditStrategy`
+ */
 export const DateSingleValue = ({
     setValue,
     value,

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -1,11 +1,10 @@
+import { ConstraintFormHeader } from '../ConstraintFormHeader/ConstraintFormHeader';
 import Input from 'component/common/Input/Input';
 import { parseDateValue, parseValidDate } from 'component/common/util';
 
-import { useId, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { styled } from '@mui/material';
 import TimezoneCountries from 'countries-and-timezones';
-import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
-import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 
 interface IDateSingleValueProps {
     setValue: (value: string) => void;
@@ -14,18 +13,12 @@ interface IDateSingleValueProps {
     setError: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const StyledInput = styled(Input)({
-    border: 'none',
-    '*': {
-        border: 'none',
-        padding: 0,
-    },
-});
-
-const Container = styled('div')(({ theme }) => ({
+const StyledWrapper = styled('div')(({ theme }) => ({
     display: 'flex',
-    flexFlow: 'row nowrap',
+    flexDirection: 'row',
+    marginBottom: theme.spacing(1),
     alignItems: 'center',
+    gap: theme.spacing(1),
 }));
 
 export const DateSingleValue = ({
@@ -35,9 +28,7 @@ export const DateSingleValue = ({
     setError,
 }: IDateSingleValueProps) => {
     const timezones = Object.values(
-        TimezoneCountries.getAllTimezones({ deprecated: false }) as {
-            [timezone: string]: { name: string; utcOffsetStr: string };
-        },
+        TimezoneCountries.getAllTimezones({ deprecated: false }),
     ).map((timezone) => ({
         key: timezone.name,
         label: `${timezone.name}`,
@@ -46,8 +37,6 @@ export const DateSingleValue = ({
     const { timeZone: localTimezoneName } =
         Intl.DateTimeFormat().resolvedOptions();
     const [pickedDate, setPickedDate] = useState(value || '');
-    const inputId = useId();
-    const helpId = useId();
 
     const timezoneText = useMemo<string>(() => {
         const localTimezone = timezones.find(
@@ -63,33 +52,30 @@ export const DateSingleValue = ({
     if (!value) return null;
 
     return (
-        <Container>
-            <label htmlFor={inputId}>
-                <ScreenReaderOnly>Date</ScreenReaderOnly>
-            </label>
-            <StyledInput
-                id={inputId}
-                aria-describedby={helpId}
-                hiddenLabel
-                label=''
-                size='small'
-                type='datetime-local'
-                value={parseDateValue(pickedDate)}
-                onChange={(e) => {
-                    setError('');
-                    const parsedDate = parseValidDate(e.target.value);
-                    const dateString = parsedDate?.toISOString();
-                    dateString && setPickedDate(dateString);
-                    dateString && setValue(dateString);
-                }}
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                error={Boolean(error)}
-                errorText={error}
-                required
-            />
-            <HelpIcon htmlTooltip tooltip={<p id={helpId}>{timezoneText}</p>} />
-        </Container>
+        <>
+            <ConstraintFormHeader>Select a date</ConstraintFormHeader>
+            <StyledWrapper>
+                <Input
+                    id='date'
+                    label='Date'
+                    type='datetime-local'
+                    value={parseDateValue(pickedDate)}
+                    onChange={(e) => {
+                        setError('');
+                        const parsedDate = parseValidDate(e.target.value);
+                        const dateString = parsedDate?.toISOString();
+                        dateString && setPickedDate(dateString);
+                        dateString && setValue(dateString);
+                    }}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    error={Boolean(error)}
+                    errorText={error}
+                    required
+                />
+                <p>{timezoneText}</p>
+            </StyledWrapper>
+        </>
     );
 };

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -22,13 +22,13 @@ const StyledWrapper = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
-const StyledInput = styled(Input)(({ theme }) => ({
+const StyledInput = styled(Input)({
     border: 'none',
     '*': {
         border: 'none',
         padding: 0,
     },
-}));
+});
 
 const Container = styled('div')(({ theme }) => ({
     display: 'flex',

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -1,4 +1,3 @@
-import { ConstraintFormHeader } from '../ConstraintFormHeader/ConstraintFormHeader';
 import Input from 'component/common/Input/Input';
 import { parseDateValue, parseValidDate } from 'component/common/util';
 
@@ -19,6 +18,17 @@ const StyledWrapper = styled('div')(({ theme }) => ({
     marginBottom: theme.spacing(1),
     alignItems: 'center',
     gap: theme.spacing(1),
+}));
+
+const StyledInput = styled(Input)(({ theme }) => ({
+    border: 'none',
+    '*': {
+        border: 'none',
+        padding: 0,
+    },
+    // '&::before': {
+    //     border: 'none',
+    // },
 }));
 
 export const DateSingleValue = ({
@@ -52,30 +62,27 @@ export const DateSingleValue = ({
     if (!value) return null;
 
     return (
-        <>
-            <ConstraintFormHeader>Select a date</ConstraintFormHeader>
-            <StyledWrapper>
-                <Input
-                    id='date'
-                    label='Date'
-                    type='datetime-local'
-                    value={parseDateValue(pickedDate)}
-                    onChange={(e) => {
-                        setError('');
-                        const parsedDate = parseValidDate(e.target.value);
-                        const dateString = parsedDate?.toISOString();
-                        dateString && setPickedDate(dateString);
-                        dateString && setValue(dateString);
-                    }}
-                    InputLabelProps={{
-                        shrink: true,
-                    }}
-                    error={Boolean(error)}
-                    errorText={error}
-                    required
-                />
-                <p>{timezoneText}</p>
-            </StyledWrapper>
-        </>
+        <StyledInput
+            // variant='standard'
+            id='date'
+            hiddenLabel
+            label=''
+            size='small'
+            type='datetime-local'
+            value={parseDateValue(pickedDate)}
+            onChange={(e) => {
+                setError('');
+                const parsedDate = parseValidDate(e.target.value);
+                const dateString = parsedDate?.toISOString();
+                dateString && setPickedDate(dateString);
+                dateString && setValue(dateString);
+            }}
+            InputLabelProps={{
+                shrink: true,
+            }}
+            error={Boolean(error)}
+            errorText={error}
+            required
+        />
     );
 };

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -5,6 +5,7 @@ import { useId, useMemo, useState } from 'react';
 import { styled } from '@mui/material';
 import TimezoneCountries from 'countries-and-timezones';
 import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 
 interface IDateSingleValueProps {
     setValue: (value: string) => void;
@@ -27,9 +28,12 @@ const StyledInput = styled(Input)(({ theme }) => ({
         border: 'none',
         padding: 0,
     },
-    // '&::before': {
-    //     border: 'none',
-    // },
+}));
+
+const Container = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
 }));
 
 export const DateSingleValue = ({
@@ -39,7 +43,9 @@ export const DateSingleValue = ({
     setError,
 }: IDateSingleValueProps) => {
     const timezones = Object.values(
-        TimezoneCountries.getAllTimezones({ deprecated: false }),
+        TimezoneCountries.getAllTimezones({ deprecated: false }) as {
+            [timezone: string]: { name: string; utcOffsetStr: string };
+        },
     ).map((timezone) => ({
         key: timezone.name,
         label: `${timezone.name}`,
@@ -49,6 +55,7 @@ export const DateSingleValue = ({
         Intl.DateTimeFormat().resolvedOptions();
     const [pickedDate, setPickedDate] = useState(value || '');
     const inputId = useId();
+    const helpId = useId();
 
     const timezoneText = useMemo<string>(() => {
         const localTimezone = timezones.find(
@@ -64,12 +71,13 @@ export const DateSingleValue = ({
     if (!value) return null;
 
     return (
-        <>
+        <Container>
             <label htmlFor={inputId}>
                 <ScreenReaderOnly>Date</ScreenReaderOnly>
             </label>
             <StyledInput
                 id={inputId}
+                aria-describedby={helpId}
                 hiddenLabel
                 label=''
                 size='small'
@@ -89,6 +97,7 @@ export const DateSingleValue = ({
                 errorText={error}
                 required
             />
-        </>
+            <HelpIcon htmlTooltip tooltip={<p id={helpId}>{timezoneText}</p>} />
+        </Container>
     );
 };

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -14,14 +14,6 @@ interface IDateSingleValueProps {
     setError: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const StyledWrapper = styled('div')(({ theme }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    marginBottom: theme.spacing(1),
-    alignItems: 'center',
-    gap: theme.spacing(1),
-}));
-
 const StyledInput = styled(Input)({
     border: 'none',
     '*': {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/AddValuesPopover.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/AddValuesPopover.tsx
@@ -22,12 +22,6 @@ const InputRow = styled('div')(({ theme }) => ({
     width: '100%',
 }));
 
-const ErrorMessage = styled('div')(({ theme }) => ({
-    color: theme.palette.error.main,
-    fontSize: theme.typography.caption.fontSize,
-    marginBottom: theme.spacing(1),
-}));
-
 export type OnAddActions = {
     setError: (error: string) => void;
     clearInput: () => void;
@@ -93,7 +87,6 @@ export const AddValuesPopover: FC<AddValuesProps> = ({
                     }
                 }}
             >
-                {error && <ErrorMessage>{error}</ErrorMessage>}
                 <InputRow>
                     <ScreenReaderOnly>
                         <label htmlFor={inputId}>Constraint Value</label>
@@ -111,6 +104,8 @@ export const AddValuesPopover: FC<AddValuesProps> = ({
                         fullWidth
                         inputRef={inputRef}
                         autoFocus
+                        error={!!error}
+                        helperText={error}
                     />
                     <Button
                         variant='text'

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintDateInput.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintDateInput.tsx
@@ -24,7 +24,7 @@ const StyledInput = styled(Input)({
 
 const Container = styled('div')(({ theme }) => ({
     display: 'flex',
-    flexFlow: 'row nowrap',
+    flexFlow: 'row wrap',
     alignItems: 'center',
 }));
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintDateInput.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/ConstraintDateInput.tsx
@@ -1,0 +1,95 @@
+import Input from 'component/common/Input/Input';
+import { parseDateValue, parseValidDate } from 'component/common/util';
+
+import { useId, useMemo, useState } from 'react';
+import { styled } from '@mui/material';
+import TimezoneCountries from 'countries-and-timezones';
+import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+
+interface IDateSingleValueProps {
+    setValue: (value: string) => void;
+    value?: string;
+    error: string;
+    setError: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const StyledInput = styled(Input)({
+    border: 'none',
+    '*': {
+        border: 'none',
+        padding: 0,
+    },
+});
+
+const Container = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+}));
+
+export const ConstraintDateInput = ({
+    setValue,
+    value,
+    error,
+    setError,
+}: IDateSingleValueProps) => {
+    const timezones = Object.values(
+        TimezoneCountries.getAllTimezones({ deprecated: false }) as {
+            [timezone: string]: { name: string; utcOffsetStr: string };
+        },
+    ).map((timezone) => ({
+        key: timezone.name,
+        label: `${timezone.name}`,
+        utcOffset: timezone.utcOffsetStr,
+    }));
+    const { timeZone: localTimezoneName } =
+        Intl.DateTimeFormat().resolvedOptions();
+    const [pickedDate, setPickedDate] = useState(value || '');
+    const inputId = useId();
+    const helpId = useId();
+
+    const timezoneText = useMemo<string>(() => {
+        const localTimezone = timezones.find(
+            (t) => t.key === localTimezoneName,
+        );
+        if (localTimezone != null) {
+            return `${localTimezone.key} (UTC ${localTimezone.utcOffset})`;
+        } else {
+            return 'The time shown is in your local time zone according to your browser.';
+        }
+    }, [timezones, localTimezoneName]);
+
+    if (!value) return null;
+
+    return (
+        <Container>
+            <label htmlFor={inputId}>
+                <ScreenReaderOnly>Date</ScreenReaderOnly>
+            </label>
+            <StyledInput
+                id={inputId}
+                aria-describedby={helpId}
+                hiddenLabel
+                label=''
+                size='small'
+                type='datetime-local'
+                value={parseDateValue(pickedDate)}
+                onChange={(e) => {
+                    setError('');
+                    const parsedDate = parseValidDate(e.target.value);
+                    const dateString = parsedDate?.toISOString();
+                    dateString && setPickedDate(dateString);
+                    dateString && setValue(dateString);
+                }}
+                InputLabelProps={{
+                    shrink: true,
+                }}
+                error={Boolean(error)}
+                errorText={error}
+                required
+            />
+            <HelpIcon htmlTooltip tooltip={<p id={helpId}>{timezoneText}</p>} />
+        </Container>
+    );
+};

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -30,6 +30,7 @@ import { ResolveInput } from 'component/common/NewConstraintAccordion/Constraint
 import { ReactComponent as EqualsIcon } from 'assets/icons/constraint-equals.svg';
 import { ReactComponent as NotEqualsIcon } from 'assets/icons/constraint-not-equals.svg';
 import { AddSingleValueWidget } from './AddSingleValueWidget';
+import { DateSingleValue } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue';
 
 const Container = styled('article')(({ theme }) => ({
     '--padding': theme.spacing(2),
@@ -208,6 +209,7 @@ export const EditableConstraint: FC<Props> = ({
     const showSingleValueButton = SINGLE_VALUE_OPERATORS.includes(input);
     const showAddValuesButton =
         OPERATORS_WITH_ADD_VALUES_WIDGET.includes(input);
+    const showDateInput = input.includes('DATE');
     const showInputField = input.includes('LEGAL_VALUES');
 
     /* We need a special case to handle the currentTime context field. Since
@@ -360,6 +362,14 @@ export const EditableConstraint: FC<Props> = ({
                             }}
                             removeValue={() => setValue('')}
                             currentValue={localConstraint.value}
+                        />
+                    ) : null}
+                    {showDateInput ? (
+                        <DateSingleValue
+                            setValue={setValue}
+                            value={localConstraint.value}
+                            error={error}
+                            setError={setError}
                         />
                     ) : null}
                 </ConstraintDetails>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -30,7 +30,7 @@ import { ResolveInput } from 'component/common/NewConstraintAccordion/Constraint
 import { ReactComponent as EqualsIcon } from 'assets/icons/constraint-equals.svg';
 import { ReactComponent as NotEqualsIcon } from 'assets/icons/constraint-not-equals.svg';
 import { AddSingleValueWidget } from './AddSingleValueWidget';
-import { DateSingleValue } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue';
+import { ConstraintDateInput } from './ConstraintDateInput';
 
 const Container = styled('article')(({ theme }) => ({
     '--padding': theme.spacing(2),
@@ -365,7 +365,7 @@ export const EditableConstraint: FC<Props> = ({
                         />
                     ) : null}
                     {showDateInput ? (
-                        <DateSingleValue
+                        <ConstraintDateInput
                             setValue={setValue}
                             value={localConstraint.value}
                             error={error}


### PR DESCRIPTION
Adds a date input method for editable constraints.

Uses a modified version of `frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx`, which has been marked as deprecated.

<img width="971" alt="image" src="https://github.com/user-attachments/assets/3c6f6e1f-6156-444c-9a73-e0c9c1c52ad6" />

Wraps when necessary
<img width="471" alt="image" src="https://github.com/user-attachments/assets/786be9d0-e62e-4bc2-884d-ef6f4aaf6b51" />


Additionally, because I noticed how the old date input sets the error, I've switched to using the standard way of setting input errors in Unleash (and presumably for MUI)
<img width="359" alt="image" src="https://github.com/user-attachments/assets/31e6ce7c-ad5d-4432-a89f-b4d9d491bd99" />
