### PR TITLE
1-3687/input mode separation

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput.tsx
@@ -69,7 +69,7 @@ const resolveLegalValues = (
  *
  * For the case of `ProjectActionsFilterItem.tsx`: it already excludes legal
  * values and date operators. This leaves only free text and single value
- * text/numeric operators.
+ * text/numeric operators. Alternatively, consider rewriting this component to only handle those cases.
  */
 export const ResolveInput = ({
     input,

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput.tsx
@@ -64,6 +64,13 @@ const resolveLegalValues = (
     };
 };
 
+/**
+ * @deprecated; remove with `addEditStrategy` flag. Need an input? Prefer using specific input components.
+ *
+ * For the case of `ProjectActionsFilterItem.tsx`: it already excludes legal
+ * values and date operators. This leaves only free text and single value
+ * text/numeric operators.
+ */
 export const ResolveInput = ({
     input,
     contextDefinition,

--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/useConstraintInput/useConstraintInput.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/useConstraintInput/useConstraintInput.tsx
@@ -68,7 +68,7 @@ export const useConstraintInput = ({
     contextDefinition,
     localConstraint,
 }: IUseConstraintInputProps): IUseConstraintOutput => {
-    const [input, setInput] = useState<Input>(IN_OPERATORS_LEGAL_VALUES);
+    const [input, setInput] = useState<Input>(IN_OPERATORS_FREETEXT);
     const [validator, setValidator] = useState<Validator>(
         STRING_ARRAY_VALIDATOR,
     );

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -9,9 +9,12 @@ import {
     type Operator,
 } from 'constants/operators';
 import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
-import type { IUnleashContextDefinition } from 'interfaces/context';
+import type {
+    ILegalValue,
+    IUnleashContextDefinition,
+} from 'interfaces/context';
 import type { IConstraint } from 'interfaces/strategy';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { oneOf } from 'utils/oneOf';
 import {
     CURRENT_TIME_CONTEXT_FIELD,
@@ -25,12 +28,12 @@ import { ReactComponent as CaseSensitiveIcon } from 'assets/icons/case-sensitive
 import { ReactComponent as CaseInsensitiveIcon } from 'assets/icons/case-insensitive.svg';
 import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
 import { AddValuesWidget } from './AddValuesWidget';
-import { ResolveInput } from 'component/common/NewConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/ResolveInput/ResolveInput';
 
 import { ReactComponent as EqualsIcon } from 'assets/icons/constraint-equals.svg';
 import { ReactComponent as NotEqualsIcon } from 'assets/icons/constraint-not-equals.svg';
 import { AddSingleValueWidget } from './AddSingleValueWidget';
 import { ConstraintDateInput } from './ConstraintDateInput';
+import { LegalValuesSelector } from './LegalValuesSelector';
 
 const Container = styled('article')(({ theme }) => ({
     '--padding': theme.spacing(2),
@@ -145,15 +148,49 @@ const StyledCaseSensitiveIcon = styled(CaseSensitiveIcon)(({ theme }) => ({
     fill: 'currentcolor',
 }));
 
-const OPERATORS_WITH_ADD_VALUES_WIDGET = [
-    'IN_OPERATORS_FREETEXT',
-    'STRING_OPERATORS_FREETEXT',
-];
+const getInputType = (input: Input) => {
+    switch (input) {
+        case 'IN_OPERATORS_LEGAL_VALUES':
+        case 'STRING_OPERATORS_LEGAL_VALUES':
+        case 'NUM_OPERATORS_LEGAL_VALUES':
+        case 'SEMVER_OPERATORS_LEGAL_VALUES':
+            return 'legal values';
+        case 'DATE_OPERATORS_SINGLE_VALUE':
+            return 'date input';
+        case 'NUM_OPERATORS_SINGLE_VALUE':
+        case 'SEMVER_OPERATORS_SINGLE_VALUE':
+            return 'single text value';
+        case 'IN_OPERATORS_FREETEXT':
+        case 'STRING_OPERATORS_FREETEXT':
+            return 'free text';
+    }
+};
 
-const SINGLE_VALUE_OPERATORS = [
-    'NUM_OPERATORS_SINGLE_VALUE',
-    'SEMVER_OPERATORS_SINGLE_VALUE',
-];
+const resolveLegalValues = (
+    values: IConstraint['values'],
+    legalValues: IUnleashContextDefinition['legalValues'],
+): { legalValues: ILegalValue[]; deletedLegalValues: ILegalValue[] } => {
+    if (legalValues?.length === 0) {
+        return {
+            legalValues: [],
+            deletedLegalValues: [],
+        };
+    }
+
+    const deletedLegalValues = (values || [])
+        .filter(
+            (value) =>
+                !(legalValues || []).some(
+                    ({ value: legalValue }) => legalValue === value,
+                ),
+        )
+        .map((v) => ({ value: v, description: '' }));
+
+    return {
+        legalValues: legalValues || [],
+        deletedLegalValues,
+    };
+};
 
 type Props = {
     constraint: IConstraint;
@@ -206,11 +243,12 @@ export const EditableConstraint: FC<Props> = ({
         useState(false);
     const deleteButtonRef = useRef<HTMLButtonElement>(null);
     const addValuesButtonRef = useRef<HTMLButtonElement>(null);
-    const showSingleValueButton = SINGLE_VALUE_OPERATORS.includes(input);
-    const showAddValuesButton =
-        OPERATORS_WITH_ADD_VALUES_WIDGET.includes(input);
-    const showDateInput = input.includes('DATE');
-    const showInputField = input.includes('LEGAL_VALUES');
+    const resolvedLegalValues = useMemo(
+        () =>
+            resolveLegalValues(constraintValues, contextDefinition.legalValues),
+        [constraintValues, JSON.stringify(contextDefinition.legalValues)],
+    );
+    const inputType = getInputType(input);
 
     /* We need a special case to handle the currentTime context field. Since
     this field will be the only one to allow DATE_BEFORE and DATE_AFTER operators
@@ -264,6 +302,46 @@ export const EditableConstraint: FC<Props> = ({
             }));
         } else {
             setOperator(operator);
+        }
+    };
+
+    const TopRowInput = () => {
+        switch (inputType) {
+            case 'date input':
+                return (
+                    <ConstraintDateInput
+                        setValue={setValue}
+                        value={localConstraint.value}
+                        error={error}
+                        setError={setError}
+                    />
+                );
+            case 'single text value':
+                return (
+                    <AddSingleValueWidget
+                        onAddValue={(newValue) => {
+                            setValue(newValue);
+                        }}
+                        removeValue={() => setValue('')}
+                        currentValue={localConstraint.value}
+                    />
+                );
+            case 'free text':
+                return (
+                    <AddValuesWidget
+                        ref={addValuesButtonRef}
+                        onAddValues={(newValues) => {
+                            // todo (`addEditStrategy`): move deduplication logic higher up in the context handling
+                            const combinedValues = new Set([
+                                ...(localConstraint.values || []),
+                                ...newValues,
+                            ]);
+                            setValuesWithRecord(Array.from(combinedValues));
+                        }}
+                    />
+                );
+            default:
+                return null;
         }
     };
 
@@ -339,39 +417,8 @@ export const EditableConstraint: FC<Props> = ({
                             deleteButtonRef.current
                         }
                     >
-                        {showAddValuesButton ? (
-                            <AddValuesWidget
-                                ref={addValuesButtonRef}
-                                onAddValues={(newValues) => {
-                                    // todo (`addEditStrategy`): move deduplication logic higher up in the context handling
-                                    const combinedValues = new Set([
-                                        ...(localConstraint.values || []),
-                                        ...newValues,
-                                    ]);
-                                    setValuesWithRecord(
-                                        Array.from(combinedValues),
-                                    );
-                                }}
-                            />
-                        ) : null}
+                        <TopRowInput />
                     </ValueList>
-                    {showSingleValueButton ? (
-                        <AddSingleValueWidget
-                            onAddValue={(newValue) => {
-                                setValue(newValue);
-                            }}
-                            removeValue={() => setValue('')}
-                            currentValue={localConstraint.value}
-                        />
-                    ) : null}
-                    {showDateInput ? (
-                        <ConstraintDateInput
-                            setValue={setValue}
-                            value={localConstraint.value}
-                            error={error}
-                            setError={setError}
-                        />
-                    ) : null}
                 </ConstraintDetails>
                 <ButtonPlaceholder />
                 <HtmlTooltip title='Delete constraint' arrow>
@@ -386,21 +433,15 @@ export const EditableConstraint: FC<Props> = ({
                     </StyledIconButton>
                 </HtmlTooltip>
             </TopRow>
-            {showInputField ? (
+            {inputType === 'legal values' ? (
                 <InputContainer>
-                    <ResolveInput
-                        setValues={setValues}
+                    <LegalValuesSelector
+                        data={resolvedLegalValues}
+                        constraintValues={constraintValues}
+                        values={localConstraint.values || []}
                         setValuesWithRecord={setValuesWithRecord}
-                        setValue={setValue}
-                        setError={setError}
-                        localConstraint={localConstraint}
-                        constraintValues={constraint?.values || []}
-                        constraintValue={constraint?.value || ''}
-                        input={input}
-                        error={error}
-                        contextDefinition={contextDefinition}
-                        removeValue={removeValue}
-                    />
+                        setValues={setValues}
+                    />{' '}
                 </InputContainer>
             ) : null}
         </Container>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/resolve-legal-values.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/resolve-legal-values.ts
@@ -1,0 +1,27 @@
+import type {
+    IUnleashContextDefinition,
+    ILegalValue,
+} from 'interfaces/context';
+import type { IConstraint } from 'interfaces/strategy';
+
+export const resolveLegalValues = (
+    values: IConstraint['values'] = [],
+    legalValues: IUnleashContextDefinition['legalValues'] = [],
+): { legalValues: ILegalValue[]; deletedLegalValues: ILegalValue[] } => {
+    if (legalValues.length === 0) {
+        return {
+            legalValues: [],
+            deletedLegalValues: [],
+        };
+    }
+
+    const existingLegalValues = new Set(legalValues.map(({ value }) => value));
+    const deletedLegalValues = values
+        .filter((value) => !existingLegalValues.has(value))
+        .map((v) => ({ value: v, description: '' }));
+
+    return {
+        legalValues,
+        deletedLegalValues,
+    };
+};


### PR DESCRIPTION
Slight organizational update to get rid of the four different boolean states we had going on.

Primarily:
- creates `TopRowInput` component that gives you the right kind of input for the top row (all cases except for legal values, for which it returns null).
- Checks whether the input type is `legal values` before rendering the legal values input container.

Secondarily:
- Fixes the jank when adding new constraints
- extracts resolveLegalValues and improves performance (refer to the inline note)