### PR TITLE
chore: use tokenname instead of username in frontend for api-token creation

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenForm/TokenInfo/TokenInfo.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/TokenInfo/TokenInfo.tsx
@@ -26,8 +26,8 @@ export const TokenInfo = ({
                 onChange={(e) => setTokenName(e.target.value)}
                 label='Token name'
                 error={errors.tokenName !== undefined}
-                errorText={errors.tokenname}
-                onFocus={() => clearErrors('tokenname')}
+                errorText={errors.tokenName}
+                onFocus={() => clearErrors('tokenName')}
                 autoFocus
             />
         </>

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/TokenInfo/TokenInfo.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/TokenInfo/TokenInfo.tsx
@@ -3,15 +3,15 @@ import { StyledInput, StyledInputDescription } from '../ApiTokenForm.styles';
 import type { ApiTokenFormErrorType } from '../useApiTokenForm';
 
 interface ITokenInfoProps {
-    username: string;
-    setUsername: React.Dispatch<React.SetStateAction<string>>;
+    tokenName: string;
+    setTokenName: React.Dispatch<React.SetStateAction<string>>;
 
     errors: { [key: string]: string };
     clearErrors: (error?: ApiTokenFormErrorType) => void;
 }
 export const TokenInfo = ({
-    username,
-    setUsername,
+    tokenName,
+    setTokenName,
     errors,
     clearErrors,
 }: ITokenInfoProps) => {
@@ -21,13 +21,13 @@ export const TokenInfo = ({
                 What would you like to call this token?
             </StyledInputDescription>
             <StyledInput
-                value={username}
-                name='username'
-                onChange={(e) => setUsername(e.target.value)}
+                value={tokenName}
+                name='tokenName'
+                onChange={(e) => setTokenName(e.target.value)}
                 label='Token name'
-                error={errors.username !== undefined}
-                errorText={errors.username}
-                onFocus={() => clearErrors('username')}
+                error={errors.tokenName !== undefined}
+                errorText={errors.tokenname}
+                onFocus={() => clearErrors('tokenname')}
                 autoFocus
             />
         </>

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -11,7 +11,7 @@ import {
 import { useHasRootAccess } from 'hooks/useHasAccess';
 import type { SelectOption } from './TokenTypeSelector/TokenTypeSelector';
 
-export type ApiTokenFormErrorType = 'username' | 'projects';
+export type ApiTokenFormErrorType = 'tokenname' | 'projects';
 export const useApiTokenForm = (project?: string) => {
     const { environments } = useEnvironments();
     const { uiConfig } = useUiConfig();
@@ -50,7 +50,7 @@ export const useApiTokenForm = (project?: string) => {
 
     const firstAccessibleType = apiTokenTypes.find((t) => t.enabled)?.key;
 
-    const [username, setUsername] = useState('');
+    const [tokenName, setTokenName] = useState('');
     const [type, setType] = useState(firstAccessibleType || TokenType.CLIENT);
     const [projects, setProjects] = useState<string[]>([
         project ? project : '*',
@@ -80,7 +80,7 @@ export const useApiTokenForm = (project?: string) => {
     };
 
     const getApiTokenPayload = (): IApiTokenCreate => ({
-        username,
+        tokenName,
         type,
         environment,
         projects,
@@ -88,8 +88,8 @@ export const useApiTokenForm = (project?: string) => {
 
     const isValid = () => {
         const newErrors: Partial<Record<ApiTokenFormErrorType, string>> = {};
-        if (!username) {
-            newErrors.username = 'Username is required';
+        if (!tokenName) {
+            newErrors.tokenname = 'Tokenname is required';
         }
         if (projects.length === 0) {
             newErrors.projects = 'At least one project is required';
@@ -110,12 +110,12 @@ export const useApiTokenForm = (project?: string) => {
     };
 
     return {
-        username,
+        tokenName,
         type,
         apiTokenTypes,
         projects,
         environment,
-        setUsername,
+        setTokenName,
         setTokenType,
         setProjects,
         setEnvironment,

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -89,7 +89,7 @@ export const useApiTokenForm = (project?: string) => {
     const isValid = () => {
         const newErrors: Partial<Record<ApiTokenFormErrorType, string>> = {};
         if (!tokenName) {
-            newErrors.tokenName = 'Tokenname is required';
+            newErrors.tokenName = 'Token name is required';
         }
         if (projects.length === 0) {
             newErrors.projects = 'At least one project is required';

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -11,7 +11,7 @@ import {
 import { useHasRootAccess } from 'hooks/useHasAccess';
 import type { SelectOption } from './TokenTypeSelector/TokenTypeSelector';
 
-export type ApiTokenFormErrorType = 'tokenname' | 'projects';
+export type ApiTokenFormErrorType = 'tokenName' | 'projects';
 export const useApiTokenForm = (project?: string) => {
     const { environments } = useEnvironments();
     const { uiConfig } = useUiConfig();
@@ -89,7 +89,7 @@ export const useApiTokenForm = (project?: string) => {
     const isValid = () => {
         const newErrors: Partial<Record<ApiTokenFormErrorType, string>> = {};
         if (!tokenName) {
-            newErrors.tokenname = 'Tokenname is required';
+            newErrors.tokenName = 'Tokenname is required';
         }
         if (projects.length === 0) {
             newErrors.projects = 'At least one project is required';

--- a/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
+++ b/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
@@ -62,11 +62,11 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
 
     const {
         getApiTokenPayload,
-        username,
+        tokenName,
         type,
         projects,
         environment,
-        setUsername,
+        setTokenName,
         setTokenType,
         setProjects,
         setEnvironment,
@@ -149,8 +149,8 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
                 }
             >
                 <TokenInfo
-                    username={username}
-                    setUsername={setUsername}
+                    tokenName={tokenName}
+                    setTokenName={setTokenName}
                     errors={errors}
                     clearErrors={clearErrors}
                 />

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -164,7 +164,7 @@ export const EnvironmentCloneModal = ({
     });
 
     const getApiTokenCreatePayload = (): IApiTokenCreate => ({
-        username: `${name}_token`,
+        tokenName: `${name}_token`,
         type: 'CLIENT',
         environment: name,
         projects: tokenProjects,

--- a/frontend/src/component/onboarding/dialog/GenerateApiKey.tsx
+++ b/frontend/src/component/onboarding/dialog/GenerateApiKey.tsx
@@ -217,7 +217,7 @@ export const GenerateApiKey = ({
                     environment,
                     type: sdkType,
                     projects: [project],
-                    username: `api-key-${project}-${environment}`,
+                    tokenName: `api-key-${project}-${environment}`,
                 },
                 project,
             );

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/CreateProjectApiTokenForm.tsx
@@ -34,11 +34,11 @@ export const CreateProjectApiTokenForm = () => {
 
     const {
         getApiTokenPayload,
-        username,
+        tokenName,
         type,
         apiTokenTypes,
         environment,
-        setUsername,
+        setTokenName,
         setTokenType,
         setEnvironment,
         isValid,
@@ -120,8 +120,8 @@ export const CreateProjectApiTokenForm = () => {
                 }
             >
                 <TokenInfo
-                    username={username}
-                    setUsername={setUsername}
+                    tokenName={tokenName}
+                    setTokenName={setTokenName}
                     errors={errors}
                     clearErrors={clearErrors}
                 />

--- a/frontend/src/hooks/api/actions/useApiTokensApi/useApiTokensApi.ts
+++ b/frontend/src/hooks/api/actions/useApiTokensApi/useApiTokensApi.ts
@@ -1,7 +1,7 @@
 import useAPI from '../useApi/useApi';
 
 export interface IApiTokenCreate {
-    username: string;
+    tokenName: string;
     type: string;
     environment?: string;
     projects: string[];

--- a/frontend/src/hooks/api/actions/useProjectApiTokensApi/useProjectApiTokensApi.ts
+++ b/frontend/src/hooks/api/actions/useProjectApiTokensApi/useProjectApiTokensApi.ts
@@ -1,7 +1,7 @@
 import useAPI from '../useApi/useApi';
 
 export interface IApiTokenCreate {
-    username: string;
+    tokenName: string;
     type: string;
     environment?: string;
     projects: string[];


### PR DESCRIPTION
PR: Stop using username and switch to tokenname when creating tokens in the frontend

Splitting up the work on API-Token username->tokenname refactor into separate PRs for separate things. This PR should be able to go to main since we've already introduced tokenname in the API and deprecated username.