### PR TITLE
chore: flag cleanup simplifyDisableFeature

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -792,35 +792,15 @@ class FeatureToggleService {
         auditUser: IAuditUser,
         user?: IUser,
     ): Promise<void> {
-        if (this.flagResolver.isEnabled('simplifyDisableFeature')) {
-            const strategies =
-                await this.featureStrategiesStore.getStrategiesForFeatureEnv(
-                    projectId,
-                    featureName,
-                    environment,
-                );
-            const hasOnlyDisabledStrategies = strategies.every(
-                (strategy) => strategy.disabled,
+        const strategies =
+            await this.featureStrategiesStore.getStrategiesForFeatureEnv(
+                projectId,
+                featureName,
+                environment,
             );
-            if (hasOnlyDisabledStrategies) {
-                await this.unprotectedUpdateEnabled(
-                    projectId,
-                    featureName,
-                    environment,
-                    false,
-                    auditUser,
-                    user,
-                );
-            }
-            return;
-        }
-        const feature = await this.getFeature({ featureName });
-
-        const env = feature.environments.find((e) => e.name === environment);
-        const hasOnlyDisabledStrategies = env?.strategies.every(
+        const hasOnlyDisabledStrategies = strategies.every(
             (strategy) => strategy.disabled,
         );
-
         if (hasOnlyDisabledStrategies) {
             await this.unprotectedUpdateEnabled(
                 projectId,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -61,7 +61,6 @@ export type IFlagKey =
     | 'consumptionModel'
     | 'teamsIntegrationChangeRequests'
     | 'edgeObservability'
-    | 'simplifyDisableFeature'
     | 'adminNavUI'
     | 'tagTypeColor'
     | 'addEditStrategy'
@@ -293,10 +292,6 @@ const flags: IFlags = {
     ),
     edgeObservability: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_EDGE_OBSERVABILITY,
-        false,
-    ),
-    simplifyDisableFeature: parseEnvVarBoolean(
-        process.env.EXPERIMENTAL_SIMPLIFY_DISABLE_FEATURE,
         false,
     ),
     adminNavUI: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -55,7 +55,6 @@ process.nextTick(async () => {
                         uniqueSdkTracking: true,
                         filterExistingFlagNames: true,
                         teamsIntegrationChangeRequests: true,
-                        simplifyDisableFeature: true,
                         adminNavUI: true,
                         tagTypeColor: true,
                         newStrategyDropdown: true,


### PR DESCRIPTION
Cleans up the simplifyDisableFeature flag, and in doing so we're choosing the behavior that was put behind the flag.
This has been out for our hosted customers for a long time and we've not received any bug reports around it