### PR TITLE
WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,11 +113,16 @@
       "/src/migrations",
       "/src/test"
     ],
-    "extensionsToTreatAsEsm": [".ts", ".tsx"],
+    "extensionsToTreatAsEsm": [
+      ".ts",
+      ".tsx"
+    ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
-    "transformIgnorePatterns": ["node_modules"]
+    "transformIgnorePatterns": [
+      "node_modules"
+    ]
   },
   "dependencies": {
     "@slack/web-api": "^7.9.1",

--- a/src/lib/addons/datadog.test.ts
+++ b/src/lib/addons/datadog.test.ts
@@ -16,6 +16,7 @@ import {
     type IFlagResolver,
 } from '../types/index.js';
 import type { IntegrationEventsService } from '../services/index.js';
+import { jest } from '@jest/globals';
 
 let fetchRetryCalls: any[] = [];
 const registerEventMock = jest.fn();

--- a/src/lib/addons/new-relic.test.ts
+++ b/src/lib/addons/new-relic.test.ts
@@ -18,6 +18,7 @@ import {
     FEATURE_ARCHIVED,
     FEATURE_ENVIRONMENT_DISABLED,
 } from '../events/index.js';
+import { jest } from '@jest/globals';
 
 const asyncGunzip = promisify(gunzip);
 

--- a/src/lib/addons/slack.test.ts
+++ b/src/lib/addons/slack.test.ts
@@ -18,6 +18,8 @@ import {
 } from '../types/index.js';
 import type { IntegrationEventsService } from '../services/index.js';
 
+import { jest } from '@jest/globals';
+
 let fetchRetryCalls: any[] = [];
 const registerEventMock = jest.fn();
 

--- a/src/lib/addons/teams.test.ts
+++ b/src/lib/addons/teams.test.ts
@@ -19,6 +19,8 @@ import {
 } from '../types/index.js';
 import type { IntegrationEventsService } from '../services/index.js';
 
+import { jest } from '@jest/globals';
+
 let fetchRetryCalls: any[];
 const registerEventMock = jest.fn();
 

--- a/src/lib/addons/webhook.test.ts
+++ b/src/lib/addons/webhook.test.ts
@@ -3,7 +3,6 @@ import type { Logger } from '../logger.js';
 import { FEATURE_CREATED, type IEvent } from '../events/index.js';
 
 import WebhookAddon from './webhook.js';
-import { jest } from '@jest/globals';
 
 import noLogger from '../../test/fixtures/no-logger.js';
 import {
@@ -14,6 +13,8 @@ import {
     SYSTEM_USER_ID,
 } from '../types/index.js';
 import type { IntegrationEventsService } from '../services/index.js';
+
+import { jest } from '@jest/globals';
 
 let fetchRetryCalls: any[] = [];
 const registerEventMock = jest.fn();

--- a/src/lib/app.test.ts
+++ b/src/lib/app.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { createTestConfig } from '../test/config/test-config.js';
 import compression from 'compression';
+import { jest } from '@jest/globals';
 
 jest.mock('compression', () =>
     jest.fn().mockImplementation(() => (req, res, next) => {

--- a/src/lib/error/exceeds-limit-error.test.ts
+++ b/src/lib/error/exceeds-limit-error.test.ts
@@ -5,6 +5,8 @@ import {
     throwExceedsLimitError,
 } from './exceeds-limit-error.js';
 
+import { jest } from '@jest/globals';
+
 it('emits events event when created through the external function', () => {
     const emitEvent = jest.fn();
     const resource = 'some-resource';

--- a/src/lib/features/client-feature-toggles/tests/client-feature-toggle.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/tests/client-feature-toggle.e2e.test.ts
@@ -11,6 +11,8 @@ import type { Application } from 'express';
 import type { IFlagResolver } from '../../../types/index.js';
 import type TestAgent from 'supertest/lib/agent.d.ts';
 
+import { jest } from '@jest/globals';
+
 let app: Application;
 
 async function getSetup() {

--- a/src/lib/features/events/event-service.test.ts
+++ b/src/lib/features/events/event-service.test.ts
@@ -10,6 +10,8 @@ import type { ProjectAccess } from '../private-project/privateProjectStore.js';
 import EventService, { filterAccessibleProjects } from './event-service.js';
 import { type IBaseEvent, USER_UPDATED } from '../../events/index.js';
 
+import { jest } from '@jest/globals';
+
 describe('filterPrivateProjectsFromParams', () => {
     it('should return IS_ANY_OF with allowed projects when projectParam is undefined and mode is limited', () => {
         const projectAccess: ProjectAccess = {

--- a/src/lib/features/frontend-api/frontend-api.concurrency.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.concurrency.e2e.test.ts
@@ -9,6 +9,8 @@ import getLogger from '../../../test/fixtures/no-logger.js';
 import { randomId } from '../../util/index.js';
 import { ApiTokenType } from '../../types/models/api-token.js';
 
+import { jest } from '@jest/globals';
+
 let app: IUnleashNoSupertest;
 let db: ITestDb;
 let appErrorLogs: string[] = [];

--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -21,6 +21,8 @@ import {
 } from '../../types/index.js';
 import type { FrontendApiService } from './frontend-api-service.js';
 
+import { jest } from '@jest/globals';
+
 let app: IUnleashTest;
 let db: ITestDb;
 let frontendApiService: FrontendApiService;

--- a/src/lib/features/frontend-api/global-frontend-api-cache.test.ts
+++ b/src/lib/features/frontend-api/global-frontend-api-cache.test.ts
@@ -14,6 +14,8 @@ import type {
 } from '../../types/index.js';
 import { UPDATE_REVISION } from '../feature-toggle/configuration-revision-service.js';
 
+import { jest } from '@jest/globals';
+
 const state = async (
     cache: GlobalFrontendApiCache,
     state: GlobalFrontendApiCacheState,

--- a/src/lib/features/instance-stats/instance-stats-service.test.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.test.ts
@@ -12,6 +12,8 @@ import type {
     IUnleashStores,
 } from '../../types/index.js';
 import { createFakeGetLicensedUsers } from './getLicensedUsers.js';
+import { jest } from '@jest/globals';
+
 let instanceStatsService: InstanceStatsService;
 let versionService: VersionService;
 let clientInstanceStore: IClientInstanceStore;

--- a/src/lib/features/maintenance/maintenance-service.test.ts
+++ b/src/lib/features/maintenance/maintenance-service.test.ts
@@ -5,6 +5,7 @@ import { createTestConfig } from '../../../test/config/test-config.js';
 import FakeSettingStore from '../../../test/fixtures/fake-setting-store.js';
 import type EventService from '../events/event-service.js';
 import { TEST_AUDIT_USER } from '../../types/index.js';
+import { jest } from '@jest/globals';
 
 test('Scheduler should run scheduled functions if maintenance mode is off', async () => {
     const config = createTestConfig();

--- a/src/lib/features/maintenance/maintenance-service.test.ts
+++ b/src/lib/features/maintenance/maintenance-service.test.ts
@@ -22,9 +22,15 @@ test('Scheduler should run scheduled functions if maintenance mode is off', asyn
 
     const job = jest.fn();
 
-    await schedulerService.schedule(job, 10, 'test-id');
+    await schedulerService.schedule(
+        async () => {
+            job();
+        },
+        10,
+        'test-id',
+    );
 
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
     schedulerService.stop();
 });
 
@@ -48,8 +54,14 @@ test('Scheduler should not run scheduled functions if maintenance mode is on', a
 
     const job = jest.fn();
 
-    await schedulerService.schedule(job, 10, 'test-id');
+    await schedulerService.schedule(
+        async () => {
+            job();
+        },
+        10,
+        'test-id',
+    );
 
-    expect(job).toBeCalledTimes(0);
+    expect(job).toHaveBeenCalledTimes(0);
     schedulerService.stop();
 });

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
@@ -12,6 +12,8 @@ import type {
 import { endOfDay, startOfHour, subDays, subHours } from 'date-fns';
 import type { IClientMetricsEnv } from './client-metrics-store-v2-type.js';
 
+import { jest } from '@jest/globals';
+
 function initClientMetrics(flagEnabled = true) {
     const stores = createStores();
 

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
@@ -18,7 +18,7 @@ function initClientMetrics(flagEnabled = true) {
     const stores = createStores();
 
     const eventBus = new EventEmitter();
-    eventBus.emit = jest.fn();
+    eventBus.emit = jest.fn(() => true);
 
     const config = {
         eventBus,

--- a/src/lib/features/metrics/instance/instance-service.test.ts
+++ b/src/lib/features/metrics/instance/instance-service.test.ts
@@ -56,7 +56,8 @@ test('Multiple registrations of same appname and instanceid within same time per
     expect(appStoreSpy).toHaveBeenCalledTimes(1);
     expect(bulkSpy).toHaveBeenCalledTimes(1);
 
-    const registrations = appStoreSpy.mock.calls[0][0];
+    const registrations: IClientApp[] = appStoreSpy.mock
+        .calls[0][0] as IClientApp[];
 
     expect(registrations.length).toBe(1);
     expect(registrations[0].appName).toBe(client1.appName);
@@ -111,8 +112,8 @@ test('Multiple unique clients causes multiple registrations', async () => {
     await clientMetrics.registerClient(client2, '127.0.0.1');
 
     await clientMetrics.bulkAdd(); // in prod called by a SchedulerService
-
-    const registrations = appStoreSpy.mock.calls[0][0];
+    const registrations: IClientApp[] = appStoreSpy.mock
+        .calls[0][0] as IClientApp[];
 
     expect(registrations.length).toBe(2);
 });
@@ -161,7 +162,9 @@ test('Same client registered outside of dedup interval will be registered twice'
     expect(appStoreSpy).toHaveBeenCalledTimes(2);
     expect(bulkSpy).toHaveBeenCalledTimes(2);
 
+    // @ts-expect-error unknown type
     const firstRegistrations = appStoreSpy.mock.calls[0][0][0];
+    // @ts-expect-error unknown type
     const secondRegistrations = appStoreSpy.mock.calls[1][0][0];
 
     expect(firstRegistrations.appName).toBe(secondRegistrations.appName);

--- a/src/lib/features/metrics/instance/instance-service.test.ts
+++ b/src/lib/features/metrics/instance/instance-service.test.ts
@@ -12,6 +12,8 @@ import FakeStrategiesStore from '../../../../test/fixtures/fake-strategies-store
 import FakeFeatureToggleStore from '../../feature-toggle/fakes/fake-feature-toggle-store.js';
 import type { IApplicationOverview } from './models.js';
 
+import { jest } from '@jest/globals';
+
 let config: IUnleashConfig;
 beforeAll(() => {
     config = createTestConfig({});

--- a/src/lib/features/metrics/last-seen/tests/last-seen-service.test.ts
+++ b/src/lib/features/metrics/last-seen/tests/last-seen-service.test.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 import getLogger from '../../../../../test/fixtures/no-logger.js';
 import type { IUnleashConfig } from '../../../../types/index.js';
 import { LastSeenService } from '../last-seen-service.js';
+import { jest } from '@jest/globals';
 
 function initLastSeenService(flagEnabled = true) {
     const stores = createStores();

--- a/src/lib/features/metrics/last-seen/tests/last-seen-service.test.ts
+++ b/src/lib/features/metrics/last-seen/tests/last-seen-service.test.ts
@@ -2,14 +2,14 @@ import createStores from '../../../../../test/fixtures/store.js';
 import EventEmitter from 'events';
 import getLogger from '../../../../../test/fixtures/no-logger.js';
 import type { IUnleashConfig } from '../../../../types/index.js';
-import { LastSeenService } from '../last-seen-service.js';
+import { type LastSeenInput, LastSeenService } from '../last-seen-service.js';
 import { jest } from '@jest/globals';
 
 function initLastSeenService(flagEnabled = true) {
     const stores = createStores();
 
     const eventBus = new EventEmitter();
-    eventBus.emit = jest.fn();
+    eventBus.emit = jest.fn() as () => boolean;
 
     const config = {
         eventBus,
@@ -95,7 +95,9 @@ test('should call last seen at store with correct data', async () => {
             timestamp: new Date(),
         },
     ]);
-    lastSeenStore.setLastSeen = jest.fn();
+    lastSeenStore.setLastSeen = jest.fn() as (
+        data: LastSeenInput[],
+    ) => Promise<void>;
     await lastSeenService.store();
 
     expect(lastSeenStore.setLastSeen).toHaveBeenCalledWith([

--- a/src/lib/features/onboarding/onboarding-service.e2e.test.ts
+++ b/src/lib/features/onboarding/onboarding-service.e2e.test.ts
@@ -12,6 +12,7 @@ import { createTestConfig } from '../../../test/config/test-config.js';
 import { createOnboardingService } from './createOnboardingService.js';
 import type EventEmitter from 'events';
 import { STAGE_ENTERED, USER_LOGIN } from '../../metric-events.js';
+import { jest } from '@jest/globals';
 
 let db: ITestDb;
 let stores: IUnleashStores;

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -6,8 +6,10 @@ import { type IUser, RoleName, type IGroup } from '../../types/index.js';
 import { randomId } from '../../util/index.js';
 import { ProjectOwnersReadModel } from './project-owners-read-model.js';
 import type { ProjectForUi } from './project-read-model-type.js';
+import { jest } from '@jest/globals';
 
 jest.mock('../../util', () => ({
+    // @ts-ignore spread can only be called on objects and this is unknown
     ...jest.requireActual('../../util'),
     generateImageUrl: jest.fn((input) => `https://${input.image_url}`),
 }));

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -11,7 +11,9 @@ import { jest } from '@jest/globals';
 jest.mock('../../util', () => ({
     // @ts-ignore spread can only be called on objects and this is unknown
     ...jest.requireActual('../../util'),
-    generateImageUrl: jest.fn((input) => `https://${input.image_url}`),
+    generateImageUrl: jest.fn(
+        (input: { image_url: string }) => `https://${input.image_url}`,
+    ),
 }));
 
 const mockProjectData = (name: string): ProjectForUi => ({

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -75,7 +75,9 @@ describe('enterprise extension: enable change requests', () => {
     test("it does not call the change request enablement function if we're not enterprise", async () => {
         const { service } = createService('oss');
 
-        const fn = jest.fn();
+        const fn = jest.fn() as () => Promise<
+            { name: string; requiredApprovals: number }[] | undefined
+        >;
 
         const projectId = 'fake-project-id';
         await service.createProject(

--- a/src/lib/features/project/project-service.test.ts
+++ b/src/lib/features/project/project-service.test.ts
@@ -8,6 +8,8 @@ import {
 } from '../../types/index.js';
 import { createFakeProjectService } from './createProjectService.js';
 
+import { jest } from '@jest/globals';
+
 describe('enterprise extension: enable change requests', () => {
     const createService = (mode: 'oss' | 'enterprise' = 'enterprise') => {
         const config = createTestConfig();

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -8,6 +8,7 @@ import type EventService from '../events/event-service.js';
 import { SCHEDULER_JOB_TIME } from '../../metric-events.js';
 import EventEmitter from 'events';
 import { TEST_AUDIT_USER } from '../../types/index.js';
+import { jest } from '@jest/globals';
 
 function ms(timeMs) {
     return new Promise((resolve) => setTimeout(resolve, timeMs));

--- a/src/lib/features/scheduler/scheduler-service.test.ts
+++ b/src/lib/features/scheduler/scheduler-service.test.ts
@@ -72,11 +72,11 @@ test('Schedules job immediately', async () => {
     const { schedulerService } = createSchedulerTestService();
     const NO_JITTER = 0;
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 10, 'test-id', NO_JITTER);
 
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
     schedulerService.stop();
 });
 
@@ -84,24 +84,24 @@ test('Does not schedule job immediately when paused', async () => {
     const { schedulerService, maintenanceService } =
         createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     await toggleMaintenanceMode(maintenanceService, true);
     await schedulerService.schedule(job, 10, 'test-id-2');
 
-    expect(job).toBeCalledTimes(0);
+    expect(job).toHaveBeenCalledTimes(0);
     schedulerService.stop();
 });
 
 test('Can schedule a single regular job', async () => {
     const { schedulerService } = createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 50, 'test-id-3');
     await ms(75);
 
-    expect(job).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 
@@ -109,13 +109,13 @@ test('Scheduled job ignored in a paused mode', async () => {
     const { schedulerService, maintenanceService } =
         createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     await toggleMaintenanceMode(maintenanceService, true);
     await schedulerService.schedule(job, 50, 'test-id-4');
     await ms(75);
 
-    expect(job).toBeCalledTimes(0);
+    expect(job).toHaveBeenCalledTimes(0);
     schedulerService.stop();
 });
 
@@ -123,44 +123,44 @@ test('Can resume paused job', async () => {
     const { schedulerService, maintenanceService } =
         createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     await toggleMaintenanceMode(maintenanceService, true);
     await schedulerService.schedule(job, 50, 'test-id-5');
     await toggleMaintenanceMode(maintenanceService, false);
     await ms(75);
 
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
     schedulerService.stop();
 });
 
 test('Can schedule multiple jobs at the same interval', async () => {
     const { schedulerService } = createSchedulerTestService();
 
-    const job = jest.fn();
-    const anotherJob = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
+    const anotherJob = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 50, 'test-id-6');
     await schedulerService.schedule(anotherJob, 50, 'test-id-7');
     await ms(75);
 
-    expect(job).toBeCalledTimes(2);
-    expect(anotherJob).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(2);
+    expect(anotherJob).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 
 test('Can schedule multiple jobs at the different intervals', async () => {
     const { schedulerService } = createSchedulerTestService();
 
-    const job = jest.fn();
-    const anotherJob = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
+    const anotherJob = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 100, 'test-id-8');
     await schedulerService.schedule(anotherJob, 200, 'test-id-9');
     await ms(250);
 
-    expect(job).toBeCalledTimes(3);
-    expect(anotherJob).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(3);
+    expect(anotherJob).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 
@@ -242,25 +242,25 @@ it('should emit scheduler job time event when scheduled function is run', async 
 test('Delays initial job execution by jitter duration', async () => {
     const { schedulerService } = createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
     const jitterMs = 10;
 
     await schedulerService.schedule(job, 10000, 'test-id', jitterMs);
-    expect(job).toBeCalledTimes(0);
+    expect(job).toHaveBeenCalledTimes(0);
 
     await ms(50);
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
     schedulerService.stop();
 });
 
 test('Does not apply jitter if schedule interval is smaller than max jitter', async () => {
     const { schedulerService } = createSchedulerTestService();
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
 
     // default jitter 2s-30s
     await schedulerService.schedule(job, 1000, 'test-id');
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
 
     schedulerService.stop();
 });
@@ -269,7 +269,7 @@ test('Does not allow to run scheduled job when it is already pending', async () 
     const { schedulerService } = createSchedulerTestService();
     const NO_JITTER = 0;
 
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
     const slowJob = async () => {
         job();
         await ms(25);
@@ -280,7 +280,7 @@ test('Does not allow to run scheduled job when it is already pending', async () 
     // scheduler had 2 chances to run but the initial slowJob was pending
     await ms(25);
 
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
 
     schedulerService.stop();
 });

--- a/src/lib/middleware/api-token-middleware.test.ts
+++ b/src/lib/middleware/api-token-middleware.test.ts
@@ -8,6 +8,7 @@ import apiTokenMiddleware, {
 } from './api-token-middleware.js';
 import type { ApiTokenService } from '../services/index.js';
 import type { IUnleashConfig } from '../types/index.js';
+import { jest } from '@jest/globals';
 
 let config: IUnleashConfig;
 

--- a/src/lib/middleware/bearer-token-middleware.test.ts
+++ b/src/lib/middleware/bearer-token-middleware.test.ts
@@ -3,6 +3,7 @@ import type { IUnleashConfig } from '../types/index.js';
 import { createTestConfig } from '../../test/config/test-config.js';
 import getLogger from '../../test/fixtures/no-logger.js';
 import type { Request, Response } from 'express';
+import { jest } from '@jest/globals';
 
 const exampleSignalToken = 'signal_tokensecret';
 

--- a/src/lib/middleware/content_type_checker.test.ts
+++ b/src/lib/middleware/content_type_checker.test.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import requireContentType from './content_type_checker.js';
+import { jest } from '@jest/globals';
 
 const mockRequest: (contentType: string) => Request = (contentType) => ({
     // @ts-ignore

--- a/src/lib/middleware/origin-middleware.test.ts
+++ b/src/lib/middleware/origin-middleware.test.ts
@@ -22,7 +22,7 @@ describe('originMiddleware', () => {
     };
     const getLogger = jest.fn(() => loggerMock);
     const eventBus = new EventEmitter();
-    eventBus.emit = jest.fn();
+    eventBus.emit = jest.fn() as () => boolean;
 
     let config: IUnleashConfig;
 

--- a/src/lib/middleware/origin-middleware.test.ts
+++ b/src/lib/middleware/origin-middleware.test.ts
@@ -4,6 +4,7 @@ import { createTestConfig } from '../../test/config/test-config.js';
 import type { Request, Response } from 'express';
 import { EventEmitter } from 'events';
 import { REQUEST_ORIGIN } from '../metric-events.js';
+import { jest } from '@jest/globals';
 
 const TEST_UNLEASH_TOKEN = 'TEST_UNLEASH_TOKEN';
 const TEST_USER_AGENT = 'TEST_USER_AGENT';

--- a/src/lib/middleware/pat-middleware.test.ts
+++ b/src/lib/middleware/pat-middleware.test.ts
@@ -4,6 +4,8 @@ import User from '../types/user.js';
 import NotFoundError from '../error/notfound-error.js';
 import type { AccountService } from '../services/account-service.js';
 
+import { jest } from '@jest/globals';
+
 let config: any;
 
 beforeEach(() => {

--- a/src/lib/middleware/rbac-middleware.test.ts
+++ b/src/lib/middleware/rbac-middleware.test.ts
@@ -10,6 +10,8 @@ import { ApiTokenType } from '../types/models/api-token.js';
 import { type ISegmentStore, SYSTEM_USER_ID } from '../types/index.js';
 import FakeSegmentStore from '../../test/fixtures/fake-segment-store.js';
 
+import { jest } from '@jest/globals';
+
 let config: IUnleashConfig;
 let featureToggleStore: IFeatureToggleStore;
 let segmentStore: ISegmentStore;

--- a/src/lib/middleware/rbac-middleware.test.ts
+++ b/src/lib/middleware/rbac-middleware.test.ts
@@ -1,4 +1,4 @@
-import rbacMiddleware from './rbac-middleware.js';
+import rbacMiddleware, { type PermissionChecker } from './rbac-middleware.js';
 import User from '../types/user.js';
 import * as perms from '../types/permissions.js';
 import type { IUnleashConfig } from '../types/option.js';
@@ -25,7 +25,7 @@ beforeEach(() => {
 test('should add checkRbac to request', () => {
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -48,7 +48,7 @@ test('should add checkRbac to request', () => {
 test('should give api-user ADMIN permission', async () => {
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -80,7 +80,7 @@ describe('ADMIN tokens should have user id -1337 when only passed through rbac-m
     test('Should give ADMIN api-user userid -1337 (SYSTEM_USER_ID)', async () => {
         const accessService = {
             hasPermission: jest.fn(),
-        };
+        } as PermissionChecker;
 
         const func = rbacMiddleware(
             config,
@@ -108,7 +108,7 @@ describe('ADMIN tokens should have user id -1337 when only passed through rbac-m
     test('Also when checking against permission NONE, userid should still be -1337', async () => {
         const accessService = {
             hasPermission: jest.fn(),
-        };
+        } as PermissionChecker;
 
         const func = rbacMiddleware(
             config,
@@ -137,7 +137,7 @@ describe('ADMIN tokens should have user id -1337 when only passed through rbac-m
 test('should not give api-user ADMIN permission', async () => {
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -169,7 +169,7 @@ test('should not allow user to miss userId', async () => {
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -195,7 +195,7 @@ test('should return false for missing user', async () => {
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -217,7 +217,7 @@ test('should return false for missing user', async () => {
 test('should verify permission for root resource', async () => {
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -250,7 +250,7 @@ test('should verify permission for root resource', async () => {
 test('should lookup projectId from params', async () => {
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -287,8 +287,9 @@ test('should lookup projectId from feature flag', async () => {
 
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
+    // @ts-expect-error unknown fn type
     featureToggleStore.getProjectId = jest.fn().mockReturnValue(projectId);
 
     const func = rbacMiddleware(
@@ -326,7 +327,7 @@ test('should lookup projectId from data', async () => {
 
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -364,7 +365,8 @@ test('Does not double check permission if not changing project when updating fla
     const featureName = 'some-feature-flag';
     const accessService = {
         hasPermission: jest.fn().mockReturnValue(true),
-    };
+    } as PermissionChecker;
+    // @ts-expect-error unknown fn type
     featureToggleStore.getProjectId = jest.fn().mockReturnValue(oldProjectId);
 
     const func = rbacMiddleware(
@@ -393,7 +395,7 @@ test('Does not double check permission if not changing project when updating fla
 test('CREATE_TAG_TYPE does not need projectId', async () => {
     const accessService = {
         hasPermission: jest.fn().mockReturnValue(true),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -421,7 +423,7 @@ test('CREATE_TAG_TYPE does not need projectId', async () => {
 test('UPDATE_TAG_TYPE does not need projectId', async () => {
     const accessService = {
         hasPermission: jest.fn().mockReturnValue(true),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -449,7 +451,7 @@ test('UPDATE_TAG_TYPE does not need projectId', async () => {
 test('DELETE_TAG_TYPE does not need projectId', async () => {
     const accessService = {
         hasPermission: jest.fn().mockReturnValue(true),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,
@@ -479,7 +481,7 @@ test('should not expect featureName for UPDATE_FEATURE when projectId specified'
 
     const accessService = {
         hasPermission: jest.fn(),
-    };
+    } as PermissionChecker;
 
     const func = rbacMiddleware(
         config,

--- a/src/lib/middleware/rbac-middleware.ts
+++ b/src/lib/middleware/rbac-middleware.ts
@@ -11,7 +11,7 @@ import type User from '../types/user.js';
 import type { Request } from 'express';
 import { extractUserId } from '../util/index.js';
 
-interface PermissionChecker {
+export interface PermissionChecker {
     hasPermission(
         user: User,
         permissions: string[],

--- a/src/lib/middleware/response-time-metrics.test.ts
+++ b/src/lib/middleware/response-time-metrics.test.ts
@@ -4,6 +4,7 @@ import {
     storeRequestedRoute,
 } from './response-time-metrics.js';
 import { REQUEST_TIME } from '../metric-events.js';
+import { jest } from '@jest/globals';
 
 const fixedResponseTime = 100;
 // mock response-time library

--- a/src/lib/middleware/response-time-metrics.test.ts
+++ b/src/lib/middleware/response-time-metrics.test.ts
@@ -1,10 +1,11 @@
-import { EventEmitter } from 'stream';
 import {
     responseTimeMetrics,
     storeRequestedRoute,
 } from './response-time-metrics.js';
 import { REQUEST_TIME } from '../metric-events.js';
 import { jest } from '@jest/globals';
+import type { IFlagResolver } from '../server-impl.js';
+import EventEmitter from 'events';
 
 const fixedResponseTime = 100;
 // mock response-time library
@@ -33,7 +34,7 @@ const flagResolver = {
     getAll: jest.fn(),
     getVariant: jest.fn(),
     getStaticContext: jest.fn(),
-};
+} as IFlagResolver;
 
 // Make sure it's always cleaned up
 let res: any;
@@ -46,7 +47,7 @@ beforeEach(() => {
 
 describe('responseTimeMetrics new behavior', () => {
     const instanceStatsService = {
-        getAppCountSnapshot: jest.fn(),
+        getAppCountSnapshot: jest.fn() as () => number | undefined,
     };
     const eventBus = new EventEmitter();
 
@@ -142,7 +143,7 @@ describe('responseTimeMetrics new behavior', () => {
         // @ts-expect-error req and res doesn't have all properties
         storeRequestedRoute(req, res, () => {});
         // @ts-expect-error req and res doesn't have all properties
-        middleware(reqWithoutRoute, res);
+        middleware(reqWithoutRoute, res, () => {});
 
         await isDefined(timeInfo);
         expect(timeInfo).toMatchObject({
@@ -222,7 +223,7 @@ describe('responseTimeMetrics new behavior', () => {
             // @ts-expect-error req and res doesn't have all properties
             storeRequestedRoute(req, res, () => {});
             // @ts-expect-error req and res doesn't have all properties
-            middleware(reqWithoutRoute, res);
+            middleware(reqWithoutRoute, res, () => {});
 
             await isDefined(timeInfo);
             expect(timeInfo).toMatchObject({

--- a/src/lib/routes/admin-api/public-signup.test.ts
+++ b/src/lib/routes/admin-api/public-signup.test.ts
@@ -7,6 +7,7 @@ import permissions from '../../../test/fixtures/permissions.js';
 import { RoleName, RoleType } from '../../types/model.js';
 import type { IUnleashStores } from '../../types/index.js';
 import type TestAgent from 'supertest/lib/agent.d.ts';
+import { jest } from '@jest/globals';
 
 describe('Public Signup API', () => {
     async function getSetup() {

--- a/src/lib/routes/admin-api/public-signup.test.ts
+++ b/src/lib/routes/admin-api/public-signup.test.ts
@@ -19,8 +19,8 @@ describe('Public Signup API', () => {
 
         stores.accessStore = {
             ...stores.accessStore,
-            addUserToRole: jest.fn(),
-            removeRolesOfTypeForUser: jest.fn(),
+            addUserToRole: jest.fn() as () => Promise<void>,
+            removeRolesOfTypeForUser: jest.fn() as () => Promise<void>,
         };
 
         const services = createServices(stores, config);

--- a/src/lib/routes/admin-api/strategy.test.ts
+++ b/src/lib/routes/admin-api/strategy.test.ts
@@ -4,6 +4,7 @@ import createStores from '../../../test/fixtures/store.js';
 import permissions from '../../../test/fixtures/permissions.js';
 import getApp from '../../app.js';
 import { createServices } from '../../services/index.js';
+import { jest } from '@jest/globals';
 
 async function getSetup() {
     const randomBase = `/random${Math.round(Math.random() * 1000)}`;

--- a/src/lib/routes/logout.test.ts
+++ b/src/lib/routes/logout.test.ts
@@ -8,6 +8,7 @@ import SessionService from '../services/session-service.js';
 import FakeSessionStore from '../../test/fixtures/fake-session-store.js';
 import noLogger from '../../test/fixtures/no-logger.js';
 import { addDays } from 'date-fns';
+import { jest } from '@jest/globals';
 
 test('should redirect to "/" after logout', async () => {
     const baseUriPath = '';

--- a/src/lib/routes/public-invite.test.ts
+++ b/src/lib/routes/public-invite.test.ts
@@ -7,6 +7,7 @@ import permissions from '../../test/fixtures/permissions.js';
 import { RoleName, RoleType } from '../types/model.js';
 import type { IUnleashStores } from '../types/index.js';
 import type TestAgent from 'supertest/lib/agent.d.ts';
+import { jest } from '@jest/globals';
 
 describe('Public Signup API', () => {
     async function getSetup() {

--- a/src/lib/routes/public-invite.test.ts
+++ b/src/lib/routes/public-invite.test.ts
@@ -19,8 +19,8 @@ describe('Public Signup API', () => {
 
         stores.accessStore = {
             ...stores.accessStore,
-            addUserToRole: jest.fn(),
-            removeRolesOfTypeForUser: jest.fn(),
+            addUserToRole: jest.fn() as () => Promise<void>,
+            removeRolesOfTypeForUser: jest.fn() as () => Promise<void>,
             getRolesForUserId: () => Promise.resolve([]),
             getRootRoleForUser: () =>
                 Promise.resolve({

--- a/src/lib/server-impl.test.ts
+++ b/src/lib/server-impl.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { createTestConfig } from '../test/config/test-config.js';
 import { create, start } from './server-impl.js';
+import { jest } from '@jest/globals';
 
 jest.mock(
     './routes',

--- a/src/lib/services/api-token-service.test.ts
+++ b/src/lib/services/api-token-service.test.ts
@@ -17,6 +17,7 @@ import {
     API_TOKEN_DELETED,
     API_TOKEN_UPDATED,
 } from '../events/index.js';
+import { jest } from '@jest/globals';
 
 test('Should init api token', async () => {
     const token = {

--- a/src/lib/services/email-service.test.ts
+++ b/src/lib/services/email-service.test.ts
@@ -2,6 +2,7 @@ import nodemailer from 'nodemailer';
 import { EmailService } from './email-service.js';
 import noLoggerProvider from '../../test/fixtures/no-logger.js';
 import type { IUnleashConfig } from '../types/index.js';
+import { jest } from '@jest/globals';
 
 test('Can send reset email', async () => {
     const emailService = new EmailService({

--- a/src/lib/services/scheduler-service.test.ts
+++ b/src/lib/services/scheduler-service.test.ts
@@ -51,45 +51,45 @@ beforeEach(() => {
 });
 
 test('Schedules job immediately', async () => {
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void> as () => Promise<void>;
     await schedulerService.schedule(job, 10, 'test-id');
 
-    expect(job).toBeCalledTimes(1);
+    expect(job).toHaveBeenCalledTimes(1);
     schedulerService.stop();
 });
 
 test('Can schedule a single regular job', async () => {
-    const job = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
     await schedulerService.schedule(job, 50, 'test-id-3');
     await ms(75);
 
-    expect(job).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 
 test('Can schedule multiple jobs at the same interval', async () => {
-    const job = jest.fn();
-    const anotherJob = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
+    const anotherJob = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 50, 'test-id-6');
     await schedulerService.schedule(anotherJob, 50, 'test-id-7');
     await ms(75);
 
-    expect(job).toBeCalledTimes(2);
-    expect(anotherJob).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(2);
+    expect(anotherJob).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 
 test('Can schedule multiple jobs at the different intervals', async () => {
-    const job = jest.fn();
-    const anotherJob = jest.fn();
+    const job = jest.fn() as () => Promise<void>;
+    const anotherJob = jest.fn() as () => Promise<void>;
 
     await schedulerService.schedule(job, 100, 'test-id-8');
     await schedulerService.schedule(anotherJob, 200, 'test-id-9');
     await ms(250);
 
-    expect(job).toBeCalledTimes(3);
-    expect(anotherJob).toBeCalledTimes(2);
+    expect(job).toHaveBeenCalledTimes(3);
+    expect(anotherJob).toHaveBeenCalledTimes(2);
     schedulerService.stop();
 });
 

--- a/src/lib/services/scheduler-service.test.ts
+++ b/src/lib/services/scheduler-service.test.ts
@@ -6,6 +6,8 @@ import SettingService from './setting-service.js';
 import type EventService from '../features/events/event-service.js';
 import MaintenanceService from '../features/maintenance/maintenance-service.js';
 
+import { jest } from '@jest/globals';
+
 function ms(timeMs: number) {
     return new Promise((resolve) => setTimeout(resolve, timeMs));
 }

--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -15,6 +15,8 @@ import SettingService from './setting-service.js';
 import FakeSettingStore from '../../test/fixtures/fake-setting-store.js';
 import { extractAuditInfoFromUser } from '../util/index.js';
 import { createFakeEventsService } from '../features/index.js';
+import { jest } from '@jest/globals';
+
 const config: IUnleashConfig = createTestConfig();
 
 const systemUser = new User({ id: -1, username: 'system' });

--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -3,7 +3,7 @@ import UserService from './user-service.js';
 import UserStoreMock from '../../test/fixtures/fake-user-store.js';
 import AccessServiceMock from '../../test/fixtures/access-service-mock.js';
 import ResetTokenService from './reset-token-service.js';
-import { EmailService } from './email-service.js';
+import { EmailService, type IEmailEnvelope } from './email-service.js';
 import OwaspValidationError from '../error/owasp-validation-error.js';
 import type { IUnleashConfig } from '../types/option.js';
 import { createTestConfig } from '../../test/config/test-config.js';
@@ -76,7 +76,8 @@ describe('Default admin initialization', () => {
     const CUSTOM_ADMIN_PASSWORD = 'custom-password';
 
     let userService: UserService;
-    const sendGettingStartedMailMock = jest.fn();
+    const sendGettingStartedMailMock =
+        jest.fn() as () => Promise<IEmailEnvelope>;
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/src/lib/types/core.test.ts
+++ b/src/lib/types/core.test.ts
@@ -1,6 +1,7 @@
 import dbInit, { type ITestDb } from '../../test/e2e/helpers/database-init.js';
 import { SYSTEM_USER } from './core.js';
 import getLogger from '../../test/fixtures/no-logger.js';
+import { jest } from '@jest/globals';
 
 describe('System user definitions in code and db', () => {
     let dbDefinition: {

--- a/src/lib/util/postgres-version-checker.test.ts
+++ b/src/lib/util/postgres-version-checker.test.ts
@@ -3,6 +3,8 @@ import { createTestConfig } from '../../test/config/test-config.js';
 import { compareAndLogPostgresVersion } from './postgres-version-checker.js';
 import FakeSettingStore from '../../test/fixtures/fake-setting-store.js';
 
+import { jest } from '@jest/globals';
+
 let config: IUnleashConfig;
 let settingStore: ISettingStore;
 let infoMessages: string[];

--- a/src/lib/util/timer.test.ts
+++ b/src/lib/util/timer.test.ts
@@ -1,4 +1,5 @@
 import timer from './timer.js';
+import { jest } from '@jest/globals';
 
 function timeout(fn, ms): Promise<void> {
     return new Promise((resolve) =>

--- a/src/migrations/20141020151056-initial-schema.js
+++ b/src/migrations/20141020151056-initial-schema.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 CREATE TABLE strategies (
@@ -28,7 +29,7 @@ CREATE TABLE events (
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 DROP TABLE events;

--- a/src/migrations/20141110144153-add-description-to-features.js
+++ b/src/migrations/20141110144153-add-description-to-features.js
@@ -1,8 +1,9 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql('ALTER TABLE features ADD "description" text;', callback);
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('ALTER TABLE features DROP COLUMN "description";', callback);
 };

--- a/src/migrations/20141117200435-add-parameters-template-to-strategies.js
+++ b/src/migrations/20141117200435-add-parameters-template-to-strategies.js
@@ -1,12 +1,13 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         'ALTER TABLE strategies ADD "parameters_template" json;',
         callback,
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         'ALTER TABLE strategies DROP COLUMN "parameters_template";',
         callback,

--- a/src/migrations/20141117202209-insert-default-strategy.js
+++ b/src/migrations/20141117202209-insert-default-strategy.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 INSERT INTO strategies(name, description) 
@@ -9,7 +10,7 @@ VALUES ('default', 'Default on/off strategy.');
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 DELETE FROM strategies where name='default';`,

--- a/src/migrations/20141118071458-default-strategy-event.js
+++ b/src/migrations/20141118071458-default-strategy-event.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 INSERT INTO events(type, created_by, data) 
@@ -9,7 +10,7 @@ VALUES ('strategy-created', 'migration', '{"name":"default","description":"Defau
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 delete from events where type='strategy-created' and data->>'name' = 'default';`,

--- a/src/migrations/20141215210141-005-archived-flag-to-features.js
+++ b/src/migrations/20141215210141-005-archived-flag-to-features.js
@@ -1,8 +1,9 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql('ALTER TABLE features ADD archived integer DEFAULT 0;', callback);
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('ALTER TABLE features DROP COLUMN "archived";', callback);
 };

--- a/src/migrations/20150210152531-006-rename-eventtype.js
+++ b/src/migrations/20150210152531-006-rename-eventtype.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 UPDATE events SET type='feature-revived' WHERE type='feature-revive';
@@ -9,7 +10,7 @@ UPDATE events SET type='feature-archived' WHERE type='feature-archive';
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 UPDATE events SET type='feature-revive' WHERE type='feature-revived';

--- a/src/migrations/20160618193924-add-strategies-to-features.js
+++ b/src/migrations/20160618193924-add-strategies-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 --create new strategies-column
@@ -19,7 +20,7 @@ ALTER TABLE features DROP COLUMN "parameters";
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 --create old columns

--- a/src/migrations/20161027134128-create-metrics.js
+++ b/src/migrations/20161027134128-create-metrics.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 CREATE TABLE client_metrics (
@@ -11,6 +12,6 @@ CREATE TABLE client_metrics (
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('DROP TABLE client_metrics;', callback);
 };

--- a/src/migrations/20161104074441-create-client-instances.js
+++ b/src/migrations/20161104074441-create-client-instances.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         CREATE TABLE client_instances (
@@ -13,6 +14,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('DROP TABLE client_instances;', callback);
 };

--- a/src/migrations/20161205203516-create-client-applications.js
+++ b/src/migrations/20161205203516-create-client-applications.js
@@ -1,7 +1,8 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.createTable(
         'client_applications',
         {
@@ -24,6 +25,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('client_applications', cb);
 };

--- a/src/migrations/20161212101749-better-strategy-parameter-definitions.js
+++ b/src/migrations/20161212101749-better-strategy-parameter-definitions.js
@@ -1,9 +1,10 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     const populateNewData = (cb) => {
         db.all(
             'select name, parameters_template from strategies',
@@ -44,7 +45,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     const populateOldData = (cb) => {
         db.all('select name, parameters from strategies', (err, results) => {
             const updateSQL = results

--- a/src/migrations/20170211085502-built-in-strategies.js
+++ b/src/migrations/20170211085502-built-in-strategies.js
@@ -1,7 +1,8 @@
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     async.series(
         [
             db.addColumn.bind(db, 'strategies', 'built_in', {
@@ -17,6 +18,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.removeColumn('strategies', 'built_in', cb);
 };

--- a/src/migrations/20170211090541-add-default-strategies.js
+++ b/src/migrations/20170211090541-add-default-strategies.js
@@ -1,49 +1,7 @@
+'use strict';
 
-import async from 'async';
-const strategies = [
-    {
-      "name": "default",
-      "description": "Default on/off strategy.",
-      "parameters": []
-    },
-    {
-      "name": "userWithId",
-      "description": "Active for users with a userId defined in the userIds-list",
-      "parameters": [
-        {
-          "name": "userIds",
-          "type": "list",
-          "description": "",
-          "required": false
-        }
-      ]
-    },
-    {
-      "name": "applicationHostname",
-      "description": "Active for client instances with a hostName in the hostNames-list.",
-      "parameters": [
-        {
-          "name": "hostNames",
-          "type": "list",
-          "description": "List of hostnames to enable the feature toggle for.",
-          "required": false
-        }
-      ]
-    },
-    {
-      "name": "remoteAddress",
-      "description": "Active for remote addresses defined in the IPs list.",
-      "parameters": [
-        {
-          "name": "IPs",
-          "type": "list",
-          "description": "List of IPs to enable the feature toggle for.",
-          "required": true
-        }
-      ]
-    }
-  ]
-;  
+const async = require('async');
+const strategies = require('./default-strategies.json');
 
 function insertStrategySQL(strategy) {
     return `
@@ -85,7 +43,7 @@ function removeStrategySQL(strategy) {
         WHERE name = '${strategy.name}' AND built_in = 1`;
 }
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     const insertStrategies = strategies.map((s) => (cb) => {
         async.series(
             [
@@ -98,7 +56,7 @@ export async function up(db, callback) {
     async.series(insertStrategies, callback);
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     const removeStrategies = strategies
         .filter((s) => s.name !== 'default')
         .map((s) => (cb) => {

--- a/src/migrations/20170306233934-timestamp-with-tz.js
+++ b/src/migrations/20170306233934-timestamp-with-tz.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
 ALTER TABLE events ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
@@ -16,6 +17,6 @@ ALTER TABLE client_metrics ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20170628205541-add-sdk-version-to-client-instances.js
+++ b/src/migrations/20170628205541-add-sdk-version-to-client-instances.js
@@ -1,12 +1,13 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         'ALTER TABLE client_instances ADD "sdk_version" varchar(255);',
         callback,
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         'ALTER TABLE client_instances DROP COLUMN "sdk_version";',
         callback,

--- a/src/migrations/20190123204125-add-variants-to-features.js
+++ b/src/migrations/20190123204125-add-variants-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features ADD "variants" json;
@@ -9,6 +10,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('ALTER TABLE features DROP COLUMN "variants";', callback);
 };

--- a/src/migrations/20191023184858-flexible-rollout-strategy.js
+++ b/src/migrations/20191023184858-flexible-rollout-strategy.js
@@ -1,29 +1,7 @@
+'use strict';
 
-import async from 'async';
-const flexibleRollout = {
-    "name": "flexibleRollout",
-    "description": "Gradually activate feature toggle based on sane stickiness",
-    "parameters": [
-      {
-        "name": "rollout",
-        "type": "percentage",
-        "description": "",
-        "required": false
-      },
-      {
-        "name": "stickiness",
-        "type": "string",
-        "description": "Used define stickiness. Possible values: default, userId, sessionId, random",
-        "required": true
-      },
-      {
-        "name": "groupId",
-        "type": "string",
-        "description": "Used to define a activation groups, which allows you to correlate across feature toggles.",
-        "required": true
-      }
-    ]
-  };
+const async = require('async');
+const flexibleRollout = require('./flexible-rollout-strategy.json');
 
 function insertStrategySQL(strategy) {
     return `
@@ -65,7 +43,7 @@ function removeStrategySQL(strategy) {
         WHERE name = '${strategy.name}' AND built_in = 1`;
 }
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     async.series(
         [
             db.runSql.bind(db, insertEventsSQL(flexibleRollout)),
@@ -75,7 +53,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     async.series(
         [
             db.runSql.bind(db, removeEventsSQL(flexibleRollout)),

--- a/src/migrations/20200102184820-create-context-fields.js
+++ b/src/migrations/20200102184820-create-context-fields.js
@@ -1,9 +1,10 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     async.series(
         [
             db.createTable.bind(db, 'context_fields', {
@@ -32,6 +33,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('context_fields', cb);
 };

--- a/src/migrations/20200227202711-settings.js
+++ b/src/migrations/20200227202711-settings.js
@@ -1,7 +1,8 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     return db.createTable(
         'settings',
         {
@@ -17,6 +18,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('settings', cb);
 };

--- a/src/migrations/20200329191251-settings-secret.js
+++ b/src/migrations/20200329191251-settings-secret.js
@@ -1,11 +1,12 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-import crypto from 'crypto';
+const crypto = require('crypto');
 
 const settingsName = 'unleash.secret';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     const secret = crypto.randomBytes(20).toString('hex');
 
     db.runSql(
@@ -16,6 +17,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`DELETE FROM settings WHERE name = '${settingsName}'`, cb);
 };

--- a/src/migrations/20200416201319-create-users.js
+++ b/src/migrations/20200416201319-create-users.js
@@ -1,7 +1,8 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     return db.createTable(
         'users',
         {
@@ -25,6 +26,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('users', cb);
 };

--- a/src/migrations/20200429175747-users-settings.js
+++ b/src/migrations/20200429175747-users-settings.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE users ADD "settings" json;
@@ -11,7 +12,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
       ALTER TABLE users DROP COLUMN "settings";

--- a/src/migrations/20200805091409-add-feature-toggle-type.js
+++ b/src/migrations/20200805091409-add-feature-toggle-type.js
@@ -1,9 +1,10 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     async.series(
         [
             db.createTable.bind(db, 'feature_types', {
@@ -32,6 +33,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('feature_types', cb);
 };

--- a/src/migrations/20200805094311-add-feature-type-to-features.js
+++ b/src/migrations/20200805094311-add-feature-type-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     return db.addColumn(
         'features',
         'type',
@@ -11,6 +12,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.removeColumn('features', 'type', cb);
 };

--- a/src/migrations/20200806091734-add-stale-flag-to-features.js
+++ b/src/migrations/20200806091734-add-stale-flag-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     return db.addColumn(
         'features',
         'stale',
@@ -11,6 +12,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.removeColumn('features', 'stale', cb);
 };

--- a/src/migrations/20200810200901-add-created-at-to-feature-types.js
+++ b/src/migrations/20200810200901-add-created-at-to-feature-types.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         'ALTER TABLE feature_types ADD "created_at" TIMESTAMP WITH TIME ZONE default now();',
         callback,
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('ALTER TABLE feature_types DROP COLUMN "created_at";', callback);
 };

--- a/src/migrations/20200928194947-add-projects.js
+++ b/src/migrations/20200928194947-add-projects.js
@@ -1,9 +1,10 @@
 /* eslint camelcase: "off" */
 
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     async.series(
         [
             db.createTable.bind(db, 'projects', {
@@ -28,6 +29,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.dropTable('projects', cb);
 };

--- a/src/migrations/20200928195238-add-project-id-to-features.js
+++ b/src/migrations/20200928195238-add-project-id-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     return db.addColumn(
         'features',
         'project',
@@ -11,6 +12,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.removeColumn('features', 'project', cb);
 };

--- a/src/migrations/20201216140726-add-last-seen-to-features.js
+++ b/src/migrations/20201216140726-add-last-seen-to-features.js
@@ -1,10 +1,10 @@
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         'ALTER TABLE features ADD "last_seen_at" TIMESTAMP WITH TIME ZONE;',
         callback,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     return db.removeColumn('features', 'last_seen_at', cb);
 };

--- a/src/migrations/20210105083014-add-tag-and-tag-types.js
+++ b/src/migrations/20210105083014-add-tag-and-tag-types.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE TABLE IF NOT EXISTS tag_types
          (
@@ -30,7 +30,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `DROP TABLE feature_tag;
         DROP TABLE tags;

--- a/src/migrations/20210119084617-add-addon-table.js
+++ b/src/migrations/20210119084617-add-addon-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE TABLE IF NOT EXISTS addons
        (
@@ -15,6 +15,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DROP TABLE addons;', cb);
 };

--- a/src/migrations/20210121115438-add-deprecated-column-to-strategies.js
+++ b/src/migrations/20210121115438-add-deprecated-column-to-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE strategies ADD COLUMN deprecated boolean default false
@@ -8,10 +9,10 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE strategies DROP COLUMN deprecated', cb);
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210127094440-add-tags-column-to-events.js
+++ b/src/migrations/20210127094440-add-tags-column-to-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE events ADD COLUMN IF NOT EXISTS tags json DEFAULT '[]'
@@ -7,7 +8,7 @@ export async function up(db, cb) {
         cb,
     );
 };
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE events DROP COLUMN IF EXISTS tags;

--- a/src/migrations/20210208203708-add-stickiness-to-context.js
+++ b/src/migrations/20210208203708-add-stickiness-to-context.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE context_fields ADD COLUMN IF NOT EXISTS stickiness boolean DEFAULT false
@@ -7,7 +8,7 @@ export async function up(db, cb) {
         cb,
     );
 };
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE context_fields DROP COLUMN IF EXISTS stickiness;

--- a/src/migrations/20210212114759-add-session-table.js
+++ b/src/migrations/20210212114759-add-session-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE unleash_session (
@@ -13,7 +13,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX idx_unleash_session_expired;

--- a/src/migrations/20210217195834-rbac-tables.js
+++ b/src/migrations/20210217195834-rbac-tables.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE TABLE IF NOT EXISTS roles
        (
@@ -69,7 +69,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       DROP TABLE role_user;

--- a/src/migrations/20210218090213-generate-server-identifier.js
+++ b/src/migrations/20210218090213-generate-server-identifier.js
@@ -1,7 +1,8 @@
+'use strict';
 
-import { v4 as uuidv4 } from 'uuid';
+const { v4: uuidv4 } = require('uuid');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     const instanceId = uuidv4();
     db.runSql(
         `
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM settings WHERE name = 'instanceInfo'

--- a/src/migrations/20210302080040-add-pk-to-client-instances.js
+++ b/src/migrations/20210302080040-add-pk-to-client-instances.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     DELETE FROM client_instances a USING client_instances b WHERE a.app_name = b.app_name AND a.instance_id = b.instance_id AND a.created_at < b.created_at;
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE client_instances DROP CONSTRAINT client_instances_pkey;

--- a/src/migrations/20210304115810-change-default-timestamp-to-now.js
+++ b/src/migrations/20210304115810-change-default-timestamp-to-now.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE client_applications ALTER COLUMN created_at SET DEFAULT now();
@@ -13,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE client_applications ALTER COLUMN created_at SET DEFAULT 'now()';

--- a/src/migrations/20210304141005-add-announce-field-to-application.js
+++ b/src/migrations/20210304141005-add-announce-field-to-application.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE client_applications ADD COLUMN announced boolean DEFAULT false;
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE client_applications DROP COLUMN announced;
@@ -18,6 +19,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210304150739-add-created-by-to-application.js
+++ b/src/migrations/20210304150739-add-created-by-to-application.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE client_applications ADD COLUMN created_by TEXT;
@@ -8,11 +9,10 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE client_applications DROP COLUMN created_by;', cb);
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };
-

--- a/src/migrations/20210322104356-api-tokens-table.js
+++ b/src/migrations/20210322104356-api-tokens-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE TABLE IF NOT EXISTS api_tokens
           (
@@ -15,6 +16,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DROP TABLE IF EXISTS api_tokens;', cb);
 };

--- a/src/migrations/20210322104357-api-tokens-convert-enterprise.js
+++ b/src/migrations/20210322104357-api-tokens-convert-enterprise.js
@@ -1,5 +1,6 @@
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
 const settingsId = 'unleash.enterprise.api.keys';
 
@@ -12,7 +13,7 @@ const toApiToken = (legacyToken) => ({
         : 'client',
 });
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `SELECT * from settings where name = '${settingsId}';`,
         (err, results) => {
@@ -35,6 +36,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20210323073508-reset-application-announcements.js
+++ b/src/migrations/20210323073508-reset-application-announcements.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     DELETE FROM events WHERE type = 'application-created';
@@ -9,6 +10,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20210409120136-create-reset-token-table.js
+++ b/src/migrations/20210409120136-create-reset-token-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS reset_tokens
@@ -17,10 +17,10 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DROP TABLE reset_tokens;', cb);
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210414141220-fix-misspellings-in-role-descriptions.js
+++ b/src/migrations/20210414141220-fix-misspellings-in-role-descriptions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE roles SET description = 'As an Editor you have access to most features in Unleash, but you can not manage users and roles in the global scope. If you create a project, you will become a project owner and receive superuser rights within the context of that project.' WHERE name = 'Regular';
@@ -7,6 +7,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('', cb);
 };

--- a/src/migrations/20210415173116-rbac-rename-roles.js
+++ b/src/migrations/20210415173116-rbac-rename-roles.js
@@ -1,3 +1,4 @@
+'use strict';
 
 const DESCRIPTION = {
     EDITOR: 'Users with this role have access most features in Unleash, but can not manage users and roles in the global scope. If a user with a global regular role creates a project, they will become a project admin and receive superuser rights within the context of that project.',
@@ -5,7 +6,7 @@ const DESCRIPTION = {
     MEMBER: 'Users with this role within a project are allowed to view, create and update feature toggles, but have limited permissions in regards to managing the projects user access and can not archive or delete the project.',
 };
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE roles set name = 'Editor', description = '${DESCRIPTION.EDITOR}' where name = 'Regular' AND type = 'root';
@@ -17,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     UPDATE roles set name = 'Regular' where name = 'Editor' AND type = 'root';

--- a/src/migrations/20210421133845-add-sort-order-to-strategies.js
+++ b/src/migrations/20210421133845-add-sort-order-to-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE strategies ADD COLUMN sort_order integer DEFAULT 9999;
@@ -13,6 +14,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE strategies DROP COLUMN sort_order;', cb);
 };

--- a/src/migrations/20210421135405-add-display-name-and-update-description-for-strategies.js
+++ b/src/migrations/20210421135405-add-display-name-and-update-description-for-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE strategies ADD COLUMN display_name text;
@@ -13,6 +14,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE strategies DROP COLUMN display_name;', cb);
 };

--- a/src/migrations/20210423103647-lowercase-all-emails.js
+++ b/src/migrations/20210423103647-lowercase-all-emails.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       DELETE FROM users WHERE id IN
@@ -12,6 +12,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('', cb);
 };

--- a/src/migrations/20210428062103-user-permission-to-rbac.js
+++ b/src/migrations/20210428062103-user-permission-to-rbac.js
@@ -1,5 +1,6 @@
+'use strict';
 
-import async from 'async';
+const async = require('async');
 
 function resolveRoleName(permissions) {
     if (!permissions || permissions.length === 0) {
@@ -11,7 +12,7 @@ function resolveRoleName(permissions) {
     return 'Editor';
 }
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         'SELECT id, permissions from users WHERE id NOT IN (select user_id from role_user);',
         (err, results) => {
@@ -35,7 +36,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     // We can't just remove roles for users as we don't know if there has been any manual additions.
     cb();
 };

--- a/src/migrations/20210428103922-patch-role-table.js
+++ b/src/migrations/20210428103922-patch-role-table.js
@@ -1,8 +1,9 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql('ALTER TABLE roles ADD COLUMN IF NOT EXISTS project text', cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20210428103923-onboard-projects-to-rbac.js
+++ b/src/migrations/20210428103923-onboard-projects-to-rbac.js
@@ -1,10 +1,10 @@
-import async from 'async';
+const async = require('async');
 
 const DESCRIPTION = {
     OWNER: 'Users with this role have full control over the project, and can add and manage other users within the project context, manage feature toggles within the project, and control advanced project features like archiving and deleting the project.',
     MEMBER: 'Users with this role within a project are allowed to view, create and update feature toggles, but have limited permissions in regards to managing the projects user access and can not archive or delete the project.',
 };
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         'SELECT id AS name from projects WHERE id NOT IN (SELECT DISTINCT project FROM roles WHERE project IS NOT null)',
         (err, results) => {
@@ -53,6 +53,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb(); // Can't really roll this back since more roles could have been added afterwards
 };

--- a/src/migrations/20210428103924-patch-admin-role-name.js
+++ b/src/migrations/20210428103924-patch-admin-role-name.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE roles set name='Admin' where name='Super User';
@@ -8,6 +9,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20210428103924-patch-admin_role.js
+++ b/src/migrations/20210428103924-patch-admin_role.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DO $$
@@ -20,7 +21,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     // We can't just remove roles for users as we don't know if there has been any manual additions.
     cb();
 };

--- a/src/migrations/20210428103924-patch-role_permissions.js
+++ b/src/migrations/20210428103924-patch-role_permissions.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DO $$
@@ -47,6 +48,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20210504101429-deprecate-strategies.js
+++ b/src/migrations/20210504101429-deprecate-strategies.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       UPDATE strategies
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       UPDATE strategies

--- a/src/migrations/20210520171325-update-role-descriptions.js
+++ b/src/migrations/20210520171325-update-role-descriptions.js
@@ -1,3 +1,4 @@
+'use strict';
 
 const DESCRIPTION = {
     EDITOR: 'Users with the editor role have access to most features in Unleash, but can not manage users and roles in the global scope. Editors will be added as project owner when creating projects and get superuser rights within the context of these projects.',
@@ -5,7 +6,7 @@ const DESCRIPTION = {
     VIEWER: 'Users with this role can only read root resources in Unleash. The viewer can be added to specific projects as project member.',
 };
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE roles set description = '${DESCRIPTION.EDITOR}' where name = 'Editor' AND type = 'root';
@@ -16,7 +17,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     `,

--- a/src/migrations/20210602115555-create-feedback-table.js
+++ b/src/migrations/20210602115555-create-feedback-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       CREATE TABLE IF NOT EXISTS user_feedback 
@@ -14,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX user_feedback_user_id_idx;

--- a/src/migrations/20210610085817-features-strategies-table.js
+++ b/src/migrations/20210610085817-features-strategies-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS environments (
@@ -34,7 +35,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE feature_strategies;

--- a/src/migrations/20210615115226-migrate-strategies-to-feature-strategies.js
+++ b/src/migrations/20210615115226-migrate-strategies-to-feature-strategies.js
@@ -1,6 +1,6 @@
-import { v4 as uuid } from 'uuid';
+const { v4: uuid } = require('uuid');
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `SELECT *
                                    FROM features`,
@@ -30,7 +30,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         'DELETE FROM feature_strategies; DELETE FROM feature_environments;',
         cb,

--- a/src/migrations/20210618091331-project-environments-table.js
+++ b/src/migrations/20210618091331-project-environments-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE project_environments (
@@ -11,10 +11,10 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DROP TABLE project_environments', cb);
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210618100913-add-cascade-for-user-feedback.js
+++ b/src/migrations/20210618100913-add-cascade-for-user-feedback.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE user_feedback DROP CONSTRAINT user_feedback_user_id_fkey;
@@ -11,6 +11,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('', cb);
 };

--- a/src/migrations/20210624114602-change-type-of-feature-archived.js
+++ b/src/migrations/20210624114602-change-type-of-feature-archived.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE features ALTER COLUMN archived DROP DEFAULT;
@@ -10,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE features ALTER COLUMN archived DROP DEFAULT;

--- a/src/migrations/20210624114855-drop-strategies-column-from-features.js
+++ b/src/migrations/20210624114855-drop-strategies-column-from-features.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features
@@ -18,6 +18,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210624115109-drop-enabled-column-from-features.js
+++ b/src/migrations/20210624115109-drop-enabled-column-from-features.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features
@@ -18,6 +18,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210625102126-connect-default-project-to-global-environment.js
+++ b/src/migrations/20210625102126-connect-default-project-to-global-environment.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     INSERT INTO project_environments(project_id, environment_name) VALUES ('default', ':global:');
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     DELETE FROM project_environments WHERE project_id = 'default' AND environment_name = ':global:';
@@ -16,6 +16,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210629130734-add-health-rating-to-project.js
+++ b/src/migrations/20210629130734-add-health-rating-to-project.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE projects ADD COLUMN health integer DEFAULT 100;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE projects DROP COLUMN health;
@@ -16,6 +16,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210830113948-connect-projects-to-global-envrionments.js
+++ b/src/migrations/20210830113948-connect-projects-to-global-envrionments.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `SELECT id
                                    FROM projects`,
@@ -14,6 +14,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DELETE FROM project_environments', cb);
 };

--- a/src/migrations/20210831072631-add-sort-order-and-type-to-env.js
+++ b/src/migrations/20210831072631-add-sort-order-and-type-to-env.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments ADD COLUMN sort_order integer DEFAULT 9999, ADD COLUMN type text;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments DROP COLUMN sort_order, DROP COLUMN type;
@@ -16,6 +16,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210907124058-add-dbcritic-indices.js
+++ b/src/migrations/20210907124058-add-dbcritic-indices.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE INDEX feature_environments_feature_name_idx ON feature_environments(feature_name);
@@ -15,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     DROP INDEX feature_environments_feature_name_idx;
@@ -32,6 +32,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210907124850-add-dbcritic-primary-keys.js
+++ b/src/migrations/20210907124850-add-dbcritic-primary-keys.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE feature_tag
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `ALTER TABLE feature_tag
         DROP constraint feature_tag_pkey;
@@ -20,6 +20,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210908100701-add-enabled-to-environments.js
+++ b/src/migrations/20210908100701-add-enabled-to-environments.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments ADD COLUMN enabled BOOLEAN DEFAULT true;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments DROP COLUMN enabled;
@@ -16,6 +16,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210909085651-add-protected-field-to-environments.js
+++ b/src/migrations/20210909085651-add-protected-field-to-environments.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments ADD COLUMN protected BOOLEAN DEFAULT false;
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE environments DROP COLUMN protected;
@@ -17,6 +17,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20210913103159-api-keys-scoping.js
+++ b/src/migrations/20210913103159-api-keys-scoping.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
           ALTER TABLE api_tokens ADD COLUMN project VARCHAR REFERENCES PROJECTS(id) ON DELETE CASCADE;; 
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE api_tokens DROP COLUMN project;

--- a/src/migrations/20210915122001-add-project-and-environment-columns-to-events.js
+++ b/src/migrations/20210915122001-add-project-and-environment-columns-to-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE events
@@ -13,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX events_environment_idx;

--- a/src/migrations/20210920104218-rename-global-env-to-default-env.js
+++ b/src/migrations/20210920104218-rename-global-env-to-default-env.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export const up = function (db, cb) {
+const up = function (db, cb) {
     db.runSql(
         `
        INSERT INTO environments(name, display_name, protected, sort_order, type) VALUES ('default', 'Default Environment', true, 1, 'production');
@@ -14,7 +15,7 @@ export const up = function (db, cb) {
     );
 };
 
-export const down = function (db, cb) {
+const down = function (db, cb) {
     db.runSql(
         `
         INSERT INTO environments(name, display_name, protected, type) VALUES (':global:', 'Across all environments', true, 'production');
@@ -28,3 +29,5 @@ export const down = function (db, cb) {
         cb,
     );
 };
+
+module.exports = { up, down };

--- a/src/migrations/20210921105032-client-api-tokens-default.js
+++ b/src/migrations/20210921105032-client-api-tokens-default.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE api_tokens SET environment = 'default' WHERE environment = ':global:';
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
   UPDATE api_tokens SET environment = null WHERE type='client' AND environment = 'default';

--- a/src/migrations/20210922084509-add-non-null-constraint-to-environment-type.js
+++ b/src/migrations/20210922084509-add-non-null-constraint-to-environment-type.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE environments SET type = 'production' WHERE type IS null;
@@ -8,6 +9,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE environments ALTER COLUMN type DROP NOT NULL`, cb);
 };

--- a/src/migrations/20210922120521-add-tag-type-permission.js
+++ b/src/migrations/20210922120521-add-tag-type-permission.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO role_permission(role_id, permission)
@@ -13,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE

--- a/src/migrations/20210928065411-remove-displayname-from-environments.js
+++ b/src/migrations/20210928065411-remove-displayname-from-environments.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE environments
         DROP COLUMN display_name`,
@@ -7,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `ALTER TABLE environments
         ADD COLUMN display_name TEXT`,

--- a/src/migrations/20210928080601-add-development-and-production-environments.js
+++ b/src/migrations/20210928080601-add-development-and-production-environments.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             INSERT INTO environments(name, type, enabled, sort_order)
@@ -10,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE

--- a/src/migrations/20210928082228-connect-default-environment-to-all-existing-projects.js
+++ b/src/migrations/20210928082228-connect-default-environment-to-all-existing-projects.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO project_environments(project_id, environment_name)
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE

--- a/src/migrations/20211004104917-client-metrics-env.js
+++ b/src/migrations/20211004104917-client-metrics-env.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     // TODO: foreign key on env.
     db.runSql(
         `
@@ -18,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE client_metrics_env;

--- a/src/migrations/20211011094226-add-environment-to-client-instances.js
+++ b/src/migrations/20211011094226-add-environment-to-client-instances.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE client_instances DROP CONSTRAINT client_instances_pkey;
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       DROP INDEX client_instances_environment_idx;
@@ -23,6 +24,6 @@ export async function down(db, cb) {
     );
 };
 
-export const _meta = {
+exports._meta = {
     version: 1,
 };

--- a/src/migrations/20211013093114-feature-strategies-parameters-not-null.js
+++ b/src/migrations/20211013093114-feature-strategies-parameters-not-null.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
           ALTER TABLE feature_strategies ALTER COLUMN parameters SET DEFAULT '{}';
@@ -10,6 +11,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20211029094324-set-sort-order-env.js
+++ b/src/migrations/20211029094324-set-sort-order-env.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             UPDATE environments set sort_order = 100 where name = 'development' AND sort_order = 9999;
@@ -9,6 +10,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20211105104316-add-feature-name-column-to-events.js
+++ b/src/migrations/20211105104316-add-feature-name-column-to-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE events
@@ -10,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX feature_name_idx;

--- a/src/migrations/20211105105509-add-predata-column-to-events.js
+++ b/src/migrations/20211105105509-add-predata-column-to-events.js
@@ -1,8 +1,9 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`ALTER TABLE events ADD COLUMN pre_data jsonb;`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE events DROP COLUMN pre_data;`, cb);
 };

--- a/src/migrations/20211108130333-create-user-splash-table.js
+++ b/src/migrations/20211108130333-create-user-splash-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS user_splash 
@@ -13,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     DROP INDEX user_splash_user_id_idx;

--- a/src/migrations/20211109103930-add-splash-entry-for-users.js
+++ b/src/migrations/20211109103930-add-splash-entry-for-users.js
@@ -1,10 +1,10 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `INSERT INTO user_splash(splash_id, user_id, seen) SELECT 'environment', u.id, false FROM users u`,
         cb,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('DELETE FROM user_splash', cb);
 };

--- a/src/migrations/20211126112551-disable-default-environment.js
+++ b/src/migrations/20211126112551-disable-default-environment.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE environments 
@@ -22,6 +22,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('', cb);
 };

--- a/src/migrations/20211130142314-add-updated-at-to-projects.js
+++ b/src/migrations/20211130142314-add-updated-at-to-projects.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         'ALTER TABLE projects ADD COLUMN "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT now();',
         callback,
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql('ALTER TABLE projects DROP COLUMN "updated_at";', callback);
 };

--- a/src/migrations/20211202120808-add-custom-roles.js
+++ b/src/migrations/20211202120808-add-custom-roles.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS permissions
@@ -183,7 +183,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE role_user DROP COLUMN project;

--- a/src/migrations/20211209205201-drop-client-metrics.js
+++ b/src/migrations/20211209205201-drop-client-metrics.js
@@ -1,9 +1,10 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql('DROP TABLE client_metrics;', callback);
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 CREATE TABLE client_metrics (

--- a/src/migrations/20220103134659-add-permissions-to-project-roles.js
+++ b/src/migrations/20220103134659-add-permissions-to-project-roles.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO role_permission (role_id, permission_id, environment)
@@ -31,7 +31,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
   `,

--- a/src/migrations/20220103143843-add-permissions-to-editor-role.js
+++ b/src/migrations/20220103143843-add-permissions-to-editor-role.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO role_permission (role_id, permission_id, environment)
@@ -18,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
   `,

--- a/src/migrations/20220111112804-update-permission-descriptions.js
+++ b/src/migrations/20220111112804-update-permission-descriptions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE permissions SET display_name = 'Admin' WHERE permission = 'ADMIN';
@@ -36,7 +36,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
 `,

--- a/src/migrations/20220111115613-move-feature-toggle-permission.js
+++ b/src/migrations/20220111115613-move-feature-toggle-permission.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('MOVE_FEATURE_TOGGLE', 'Change feature toggle project', 'project');
@@ -25,7 +25,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'MOVE_FEATURE_TOGGLE';

--- a/src/migrations/20220111120346-roles-unique-name.js
+++ b/src/migrations/20220111120346-roles-unique-name.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE roles ADD CONSTRAINT unique_name UNIQUE (name);
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE roles DROP CONSTRAINT unique_name;

--- a/src/migrations/20220111121010-update-project-for-editor-role.js
+++ b/src/migrations/20220111121010-update-project-for-editor-role.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE role_user set project = 'default' where role_id 
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       UPDATE role_user set project = '*' where role_id 

--- a/src/migrations/20220111125620-role-permission-empty-string-for-non-environment-type.js
+++ b/src/migrations/20220111125620-role-permission-empty-string-for-non-environment-type.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
   UPDATE role_permission SET environment = '' where permission_id NOT IN 
@@ -8,6 +8,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220119182603-update-toggle-types-description.js
+++ b/src/migrations/20220119182603-update-toggle-types-description.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: "off" */
+'use strict';
 
 const DESCRIPTION = {
     RELEASE: 'Release feature toggles are used to release new features.',
@@ -12,7 +13,7 @@ const DESCRIPTION = {
         'Permission feature toggles are used to control permissions in your system.',
 };
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE feature_types set description = '${DESCRIPTION.RELEASE}' where id = 'release';
@@ -25,7 +26,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     `,

--- a/src/migrations/20220125200908-convert-old-feature-events.js
+++ b/src/migrations/20220125200908-convert-old-feature-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE events
@@ -16,6 +17,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220128081242-add-impressiondata-to-features.js
+++ b/src/migrations/20220128081242-add-impressiondata-to-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features ADD COLUMN "impression_data" BOOLEAN DEFAULT FALSE;
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features DROP COLUMN "impression_data";

--- a/src/migrations/20220129113106-metrics-counters-as-bigint.js
+++ b/src/migrations/20220129113106-metrics-counters-as-bigint.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE client_metrics_env
@@ -10,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE client_metrics_env

--- a/src/migrations/20220131082150-reset-feedback-form.js
+++ b/src/migrations/20220131082150-reset-feedback-form.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
        DELETE FROM user_feedback WHERE nevershow = false;
@@ -8,6 +9,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220224081422-remove-project-column-from-roles.js
+++ b/src/migrations/20220224081422-remove-project-column-from-roles.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql('ALTER TABLE roles DROP COLUMN IF EXISTS project', cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE roles ADD COLUMN IF NOT EXISTS project text', cb);
 };

--- a/src/migrations/20220224111626-add-current-time-context-field.js
+++ b/src/migrations/20220224111626-add-current-time-context-field.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
        INSERT INTO context_fields(name, description, sort_order) VALUES('currentTime', 'Allows you to constrain on date values', 3);
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
        DELETE FROM context_fields WHERE name = 'currentTime';

--- a/src/migrations/20220307130902-add-segments.js
+++ b/src/migrations/20220307130902-add-segments.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         create table segments
@@ -48,7 +49,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         delete from role_permission where permission_id in (

--- a/src/migrations/20220331085057-add-api-link-table.js
+++ b/src/migrations/20220331085057-add-api-link-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS api_token_project
@@ -19,7 +20,7 @@ export async function up(db, cb) {
 };
 
 //This is a lossy down migration, tokens with multiple projects are discarded
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE api_tokens ADD COLUMN project VARCHAR REFERENCES PROJECTS(id) ON DELETE CASCADE;

--- a/src/migrations/20220405103233-add-segments-name-index.js
+++ b/src/migrations/20220405103233-add-segments-name-index.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         create index segments_name_index on segments (name);
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         drop index segments_name_index;

--- a/src/migrations/20220408081222-clean-up-duplicate-foreign-key-role-permission.js
+++ b/src/migrations/20220408081222-clean-up-duplicate-foreign-key-role-permission.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE role_permission DROP CONSTRAINT fk_role_permission;
@@ -7,6 +7,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220411103724-add-legal-value-description.js
+++ b/src/migrations/20220411103724-add-legal-value-description.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         -- 1. Convert '1,2,3'::text to "1,2,3"::json
@@ -25,7 +26,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         -- 1. Revert []::json to null.

--- a/src/migrations/20220425090847-add-token-permission.js
+++ b/src/migrations/20220425090847-add-token-permission.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES
@@ -20,7 +21,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission WHERE permission_id = (

--- a/src/migrations/20220511111823-patch-broken-feature-strategies.js
+++ b/src/migrations/20220511111823-patch-broken-feature-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
           UPDATE feature_strategies
@@ -12,6 +13,6 @@ export async function up(db, cb) {
 };
 
 // This is a fix for a broken state, we don't want this to be rolled back
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220511124923-fix-patch-broken-feature-strategies.js
+++ b/src/migrations/20220511124923-fix-patch-broken-feature-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
           UPDATE feature_strategies
@@ -13,6 +14,6 @@ export async function up(db, cb) {
 };
 
 // This is a fix for a broken state, we don't want this to be rolled back
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20220528143630-dont-cascade-environment-deletion-to-apitokens.js
+++ b/src/migrations/20220528143630-dont-cascade-environment-deletion-to-apitokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
           ALTER TABLE api_tokens DROP CONSTRAINT api_tokens_environment_fkey;
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
           ALTER TABLE api_tokens ADD CONSTRAINT api_tokens_environment_fkey FOREIGN KEY(environment) REFERENCES environments(name) ON DELETE CASCADE;

--- a/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
+++ b/src/migrations/20220603081324-add-archive-at-to-feature-toggle.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features ADD archived_at TIMESTAMP WITH TIME ZONE;
@@ -25,7 +26,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         UPDATE features

--- a/src/migrations/20220704115624-add-user-groups.js
+++ b/src/migrations/20220704115624-add-user-groups.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             create table IF NOT EXISTS groups
@@ -34,7 +35,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         drop table group_role;

--- a/src/migrations/20220711084613-add-projects-and-environments-for-addons.js
+++ b/src/migrations/20220711084613-add-projects-and-environments-for-addons.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE addons
             ADD COLUMN
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE addons DROP COLUMN projects;

--- a/src/migrations/20220808084524-add-group-permissions.js
+++ b/src/migrations/20220808084524-add-group-permissions.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE group_user DROP COLUMN IF EXISTS role;
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE group_user ADD COLUMN role text check(role in ('Owner', 'Member')) default 'Member';

--- a/src/migrations/20220808110415-add-projects-foreign-key.js
+++ b/src/migrations/20220808110415-add-projects-foreign-key.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             delete from group_role where project not in (select id from projects);
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE group_role DROP CONSTRAINT fk_group_role_project;

--- a/src/migrations/20220816121136-add-metadata-to-api-keys.js
+++ b/src/migrations/20220816121136-add-metadata-to-api-keys.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE api_tokens ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}'::jsonb;`,
         cb,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('ALTER TABLE api_tokens DROP COLUMN metadata;', cb);
 };

--- a/src/migrations/20220817130250-alter-api-tokens.js
+++ b/src/migrations/20220817130250-alter-api-tokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE api_tokens DROP COLUMN metadata;
          ALTER TABLE api_tokens ADD COLUMN alias text;`,
@@ -7,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `ALTER TABLE api_tokens ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}'::jsonb; 
         ALTER TABLE api_tokens DROP COLUMN alias;`,

--- a/src/migrations/20220908093515-add-public-signup-tokens.js
+++ b/src/migrations/20220908093515-add-public-signup-tokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             create table IF NOT EXISTS public_signup_tokens
@@ -24,7 +25,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 DROP TABLE IF EXISTS public_signup_tokens_user;

--- a/src/migrations/20220912165344-pat-tokens.js
+++ b/src/migrations/20220912165344-pat-tokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE personal_access_tokens (
@@ -14,6 +15,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`drop table personal_access_tokens`, cb);
 };

--- a/src/migrations/20220916093515-add-url-to-public-signup-tokens.js
+++ b/src/migrations/20220916093515-add-url-to-public-signup-tokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER table public_signup_tokens
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER table public_signup_tokens

--- a/src/migrations/20220927110212-add-enabled-to-public-signup-tokens.js
+++ b/src/migrations/20220927110212-add-enabled-to-public-signup-tokens.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER table public_signup_tokens
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER table public_signup_tokens

--- a/src/migrations/20221010114644-pat-auto-increment.js
+++ b/src/migrations/20221010114644-pat-auto-increment.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             alter table personal_access_tokens
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             alter table personal_access_tokens

--- a/src/migrations/20221011155007-add-user-groups-mappings.js
+++ b/src/migrations/20221011155007-add-user-groups-mappings.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE groups
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE groups

--- a/src/migrations/20221103111940-fix-migrations.js
+++ b/src/migrations/20221103111940-fix-migrations.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         delete from migrations where name in ('/20221901130645-add-change-requests-table', '/20221810114644-add-suggest-changes-table');
@@ -8,6 +9,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(``, callback);
 };

--- a/src/migrations/20221103112200-change-request.js
+++ b/src/migrations/20221103112200-change-request.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_requests (
@@ -26,7 +27,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP TABLE IF EXISTS change_request_events;

--- a/src/migrations/20221103125732-change-request-remove-unique.js
+++ b/src/migrations/20221103125732-change-request-remove-unique.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_events
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_events

--- a/src/migrations/20221104123349-change-request-approval.js
+++ b/src/migrations/20221104123349-change-request-approval.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_request_approvals (
@@ -13,7 +14,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS change_request_approvals;

--- a/src/migrations/20221107121635-move-variants-to-per-environment.js
+++ b/src/migrations/20221107121635-move-variants-to-per-environment.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE feature_environments ADD COLUMN variants JSONB DEFAULT '[]'::jsonb NOT NULL;
@@ -42,7 +43,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP VIEW features_view;

--- a/src/migrations/20221107132528-change-request-project-options.js
+++ b/src/migrations/20221107132528-change-request-project-options.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments add column if not exists change_request_enabled bool default false;
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments drop column if exists change_request_enabled;

--- a/src/migrations/20221108114358-add-change-request-permissions.js
+++ b/src/migrations/20221108114358-add-change-request-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('APPROVE_CHANGE_REQUEST', 'Approve a change request', 'environment');
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'APPROVE_CHANGE_REQUEST';

--- a/src/migrations/20221110104933-add-change-request-settings.js
+++ b/src/migrations/20221110104933-add-change-request-settings.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_request_settings (
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS change_request_settings;

--- a/src/migrations/20221110144113-revert-change-request-project-options.js
+++ b/src/migrations/20221110144113-revert-change-request-project-options.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments drop column if exists change_request_enabled;
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments add column if not exists change_request_enabled bool default false;

--- a/src/migrations/20221114150559-change-request-comments.js
+++ b/src/migrations/20221114150559-change-request-comments.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_request_comments (
@@ -14,7 +15,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS change_request_comments;

--- a/src/migrations/20221115072335-add-required-approvals.js
+++ b/src/migrations/20221115072335-add-required-approvals.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_settings ADD COLUMN required_approvals integer default 1;
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_settings DROP COLUMN IF EXISTS required_approvals;

--- a/src/migrations/20221121114357-add-permission-for-environment-variants.js
+++ b/src/migrations/20221121114357-add-permission-for-environment-variants.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           INSERT INTO permissions (permission, display_name, type)
@@ -16,7 +17,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DELETE FROM role_permission WHERE permission_id =

--- a/src/migrations/20221121133546-soft-delete-user.js
+++ b/src/migrations/20221121133546-soft-delete-user.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE users DROP COLUMN IF EXISTS deleted_at;

--- a/src/migrations/20221124123914-add-favorites.js
+++ b/src/migrations/20221124123914-add-favorites.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS favorite_features
@@ -22,7 +23,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS favorite_features;

--- a/src/migrations/20221125185244-change-request-unique-approvals.js
+++ b/src/migrations/20221125185244-change-request-unique-approvals.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE change_request_approvals ADD CONSTRAINT unique_approvals UNIQUE (change_request_id, created_by);
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE change_request_approvals DROP CONSTRAINT unique_approvals;

--- a/src/migrations/20221128165141-change-request-min-approvals.js
+++ b/src/migrations/20221128165141-change-request-min-approvals.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE change_requests ADD COLUMN min_approvals INTEGER DEFAULT 1;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
       ALTER TABLE change_requests DROP COLUMN min_approvals;

--- a/src/migrations/20221205122253-skip-change-request.js
+++ b/src/migrations/20221205122253-skip-change-request.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('SKIP_CHANGE_REQUEST', 'Skip change request process', 'environment');
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'SKIP_CHANGE_REQUEST';

--- a/src/migrations/20221220160345-user-pat-permissions.js
+++ b/src/migrations/20221220160345-user-pat-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('READ_USER_PAT', 'Read PATs for a specific user', 'root');
@@ -9,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'READ_USER_PAT';

--- a/src/migrations/20221221144132-service-account-users.js
+++ b/src/migrations/20221221144132-service-account-users.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER table users
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER table users

--- a/src/migrations/20230125065315-project-stats-table.js
+++ b/src/migrations/20230125065315-project-stats-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE TABLE IF NOT EXISTS project_stats (
              project VARCHAR(255) NOT NULL,
@@ -18,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE project_stats;

--- a/src/migrations/20230127111638-new-project-stats-field.js
+++ b/src/migrations/20230127111638-new-project-stats-field.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER table project_stats
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER table project_stats

--- a/src/migrations/20230130113337-revert-user-pat-permissions.js
+++ b/src/migrations/20230130113337-revert-user-pat-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'READ_USER_PAT';
@@ -9,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('READ_USER_PAT', 'Read PATs for a specific user', 'root');

--- a/src/migrations/20230208084046-project-api-token-permissions.js
+++ b/src/migrations/20230208084046-project-api-token-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('READ_PROJECT_API_TOKEN', 'Read api tokens for a specific project', 'project');
@@ -9,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'READ_PROJECT_API_TOKEN';

--- a/src/migrations/20230208093627-assign-project-api-token-permissions-editor.js
+++ b/src/migrations/20230208093627-assign-project-api-token-permissions-editor.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             INSERT INTO role_permission (role_id, permission_id)
@@ -15,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission

--- a/src/migrations/20230208093750-assign-project-api-token-permissions-owner.js
+++ b/src/migrations/20230208093750-assign-project-api-token-permissions-owner.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             INSERT INTO role_permission (role_id, permission_id)
@@ -14,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission

--- a/src/migrations/20230208093942-assign-project-api-token-permissions-member.js
+++ b/src/migrations/20230208093942-assign-project-api-token-permissions-member.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             INSERT INTO role_permission (role_id, permission_id)
@@ -14,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission

--- a/src/migrations/20230222084211-add-login-events-table.js
+++ b/src/migrations/20230222084211-add-login-events-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS login_events (
@@ -16,7 +16,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS login_events_ip_idx;

--- a/src/migrations/20230222154915-create-notiications-table.js
+++ b/src/migrations/20230222154915-create-notiications-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS notifications (
@@ -21,7 +22,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE IF EXISTS user_notifications;

--- a/src/migrations/20230224093446-drop-createdBy-from-notifications-table.js
+++ b/src/migrations/20230224093446-drop-createdBy-from-notifications-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE notifications
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE notifications

--- a/src/migrations/20230227115320-rename-login-events-table-to-sign-on-log.js
+++ b/src/migrations/20230227115320-rename-login-events-table-to-sign-on-log.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`ALTER TABLE login_events RENAME TO sign_on_log`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE sign_on_log RENAME TO login_events`, cb);
 };

--- a/src/migrations/20230227120500-change-display-name-for-variants-per-env-permission.js
+++ b/src/migrations/20230227120500-change-display-name-for-variants-per-env-permission.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           UPDATE permissions SET display_name='Update variants' WHERE permission = 'UPDATE_FEATURE_ENVIRONMENT_VARIANTS';
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         `,

--- a/src/migrations/20230227123106-add-setting-for-sign-on-log-retention.js
+++ b/src/migrations/20230227123106-add-setting-for-sign-on-log-retention.js
@@ -1,10 +1,10 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `INSERT INTO settings(name, content) VALUES ('sign_on_log_retention', '{"hours": 336}')`,
         cb,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`DELETE FROM settings WHERE name = 'sign_on_log_retention'`, cb);
 };

--- a/src/migrations/20230302133740-rename-sign-on-log-table-to-login-history.js
+++ b/src/migrations/20230302133740-rename-sign-on-log-table-to-login-history.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`ALTER TABLE sign_on_log RENAME TO login_history`, cb);
     db.runSql(`DELETE FROM settings WHERE name = 'sign_on_log_retention'`, cb);
     db.runSql(
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE login_history RENAME TO sign_on_log`, cb);
     db.runSql(
         `DELETE FROM settings WHERE name = 'login_history_retention'`,

--- a/src/migrations/20230306103400-add-project-column-to-segments.js
+++ b/src/migrations/20230306103400-add-project-column-to-segments.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE segments ADD COLUMN segment_project_id varchar(255) REFERENCES projects(id) ON DELETE CASCADE;`,
         cb,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `ALTER TABLE segments DROP COLUMN IF EXISTS segment_project_id;`,
         cb,

--- a/src/migrations/20230306103400-remove-direct-link-from-segment-permissions-to-admin.js
+++ b/src/migrations/20230306103400-remove-direct-link-from-segment-permissions-to-admin.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission 
@@ -14,7 +14,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         insert into role_permission (role_id, permission_id)

--- a/src/migrations/20230309174400-add-project-segment-permission.js
+++ b/src/migrations/20230309174400-add-project-segment-permission.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `INSERT INTO permissions (permission, display_name, type) VALUES
         ('UPDATE_PROJECT_SEGMENT', 'Create/edit project segment', 'project');`,
@@ -6,7 +6,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `DELETE FROM permissions WHERE permission = 'UPDATE_PROJECT_SEGMENT';`,
         cb,

--- a/src/migrations/20230314131041-project-settings.js
+++ b/src/migrations/20230314131041-project-settings.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS project_settings (
@@ -13,7 +14,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS project_settings;

--- a/src/migrations/20230316092547-remove-project-stats-column.js
+++ b/src/migrations/20230316092547-remove-project-stats-column.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER table project_stats
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER table project_stats

--- a/src/migrations/20230411085947-skip-change-request-ui.js
+++ b/src/migrations/20230411085947-skip-change-request-ui.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           UPDATE permissions SET display_name = 'Skip change request process' WHERE permission = 'SKIP_CHANGE_REQUEST';
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         UPDATE permissions SET display_name = 'Skip change request process (API-only)' WHERE permission = 'SKIP_CHANGE_REQUEST';

--- a/src/migrations/20230412062635-add-change-request-title.js
+++ b/src/migrations/20230412062635-add-change-request-title.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE change_requests ADD COLUMN title TEXT;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE change_requests DROP COLUMN title;

--- a/src/migrations/20230412125618-add-title-to-strategy.js
+++ b/src/migrations/20230412125618-add-title-to-strategy.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE strategies ADD COLUMN IF NOT EXISTS title TEXT;
@@ -41,7 +42,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20230414105818-add-root-role-to-groups.js
+++ b/src/migrations/20230414105818-add-root-role-to-groups.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE groups ADD COLUMN root_role_id INTEGER DEFAULT NULL;
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE groups DROP CONSTRAINT fk_group_role_id;

--- a/src/migrations/20230419104126-add-disabled-field-to-feature-strategy.js
+++ b/src/migrations/20230419104126-add-disabled-field-to-feature-strategy.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE feature_strategies ADD COLUMN IF NOT EXISTS disabled BOOLEAN default false;
@@ -41,7 +42,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20230420125500-v5-strategy-changes.js
+++ b/src/migrations/20230420125500-v5-strategy-changes.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         -- delete deprecated strategies still present in v4
@@ -20,7 +21,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
 

--- a/src/migrations/20230420211308-update-context-fields-add-sessionId.js
+++ b/src/migrations/20230420211308-update-context-fields-add-sessionId.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             INSERT INTO context_fields(name, description, sort_order, stickiness) VALUES('sessionId', 'Allows you to constrain on sessionId', 4, true) ON CONFLICT DO NOTHING;
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         `,

--- a/src/migrations/20230424090942-project-default-strategy-settings.js
+++ b/src/migrations/20230424090942-project-default-strategy-settings.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE project_environments

--- a/src/migrations/20230504145945-variant-metrics.js
+++ b/src/migrations/20230504145945-variant-metrics.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS client_metrics_env_variants (
@@ -27,7 +28,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS client_metrics_env_variants;

--- a/src/migrations/20230510113903-fix-api-token-username-migration.js
+++ b/src/migrations/20230510113903-fix-api-token-username-migration.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         SELECT * FROM migrations WHERE name = '/20230426110026-rename-api-token-username-field';
@@ -27,7 +28,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `ALTER TABLE api_tokens DROP COLUMN IF EXISTS "token_name";`,
         callback,

--- a/src/migrations/20230615122909-fix-env-sort-order.js
+++ b/src/migrations/20230615122909-fix-env-sort-order.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             WITH sorted_environments AS (
@@ -26,6 +27,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(``, callback);
 };

--- a/src/migrations/20230619105029-new-fine-grained-api-token-permissions.js
+++ b/src/migrations/20230619105029-new-fine-grained-api-token-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     INSERT INTO permissions(permission, display_name, type) VALUES
@@ -19,7 +19,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission IN ('CREATE_ADMIN_API_TOKEN', 'UPDATE_ADMIN_API_TOKEN', 'DELETE_ADMIN_API_TOKEN', 'READ_ADMIN_API_TOKEN');

--- a/src/migrations/20230619110243-assign-apitoken-permissions-to-rootroles.js
+++ b/src/migrations/20230619110243-assign-apitoken-permissions-to-rootroles.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     CREATE OR REPLACE FUNCTION assign_unleash_permission_to_role(permission_name text, role_name text) returns void as
@@ -19,7 +19,7 @@ $$ language plpgsql;
         cb,
     );
 };
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `DROP FUNCTION IF EXISTS assign_unleash_permission_to_role(text, text)`,
         cb,

--- a/src/migrations/20230621141239-refactor-api-token-permissions.js
+++ b/src/migrations/20230621141239-refactor-api-token-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     UPDATE permissions SET display_name = 'Create CLIENT API tokens' WHERE permission = 'CREATE_CLIENT_API_TOKEN';
@@ -15,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20230630080126-delete-deprecated-permissions.js
+++ b/src/migrations/20230630080126-delete-deprecated-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission IN ('CREATE_API_TOKEN', 'UPDATE_API_TOKEN', 'DELETE_API_TOKEN', 'READ_API_TOKEN');
@@ -11,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20230706123907-events-announced-column.js
+++ b/src/migrations/20230706123907-events-announced-column.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     // mark existing events as announced, set the default to false for future events.
     db.runSql(
         `
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE events DROP COLUMN IF EXISTS "announced";

--- a/src/migrations/20230711094214-add-potentially-stale-flag.js
+++ b/src/migrations/20230711094214-add-potentially-stale-flag.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features ADD COLUMN IF NOT EXISTS potentially_stale boolean;
@@ -14,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER table features DROP COLUMN IF EXISTS potentially_stale;

--- a/src/migrations/20230711163311-project-feature-limit.js
+++ b/src/migrations/20230711163311-project-feature-limit.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings DROP COLUMN IF EXISTS "feature_limit";

--- a/src/migrations/20230712091834-strategy-variants.js
+++ b/src/migrations/20230712091834-strategy-variants.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE feature_strategies ADD COLUMN IF NOT EXISTS variants JSONB DEFAULT '[]'::jsonb NOT NULL;
@@ -42,7 +43,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20230802092725-add-last-seen-column-to-feature-environments.js
+++ b/src/migrations/20230802092725-add-last-seen-column-to-feature-environments.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE feature_environments ADD COLUMN IF NOT EXISTS last_seen_at timestamp with time zone;
@@ -44,7 +45,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20230802141830-add-feature-and-environment-last-seen-at-to-features-view.js
+++ b/src/migrations/20230802141830-add-feature-and-environment-last-seen-at-to-features-view.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           ALTER TABLE feature_environments ADD COLUMN IF NOT EXISTS last_seen_at timestamp with time zone;
@@ -45,7 +46,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20230803061359-change-request-optional-feature.js
+++ b/src/migrations/20230803061359-change-request-optional-feature.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_events ALTER COLUMN feature DROP NOT NULL;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DELETE FROM change_request_events WHERE feature IS NULL;

--- a/src/migrations/20230808104232-update-root-roles-descriptions.js
+++ b/src/migrations/20230808104232-update-root-roles-descriptions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE roles SET description = 'Users with the root admin role have superuser access to Unleash and can perform any operation within the Unleash platform.' WHERE name = 'Admin';
@@ -11,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20230814095253-change-request-rejections.js
+++ b/src/migrations/20230814095253-change-request-rejections.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_request_rejections (
@@ -14,7 +15,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS change_request_rejections;

--- a/src/migrations/20230814115436-change-request-timzone-timestamps.js
+++ b/src/migrations/20230814115436-change-request-timzone-timestamps.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE change_request_rejections ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE;
@@ -13,6 +14,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20230815065908-change-request-approve-reject-permission.js
+++ b/src/migrations/20230815065908-change-request-approve-reject-permission.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           UPDATE permissions SET display_name = 'Approve/Reject change requests' WHERE permission = 'APPROVE_CHANGE_REQUEST';
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
            UPDATE permissions SET display_name = 'Approve change requests' WHERE permission = 'APPROVE_CHANGE_REQUEST';

--- a/src/migrations/20230817095805-client-applications-usage-table.js
+++ b/src/migrations/20230817095805-client-applications-usage-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           CREATE TABLE IF NOT EXISTS client_applications_usage (
@@ -13,7 +14,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
            DROP TABLE IF EXISTS client_applications_usage;

--- a/src/migrations/20230818124614-update-client-applications-usage-table.js
+++ b/src/migrations/20230818124614-update-client-applications-usage-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         DROP TABLE IF EXISTS client_applications_usage;
@@ -15,7 +16,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP TABLE IF EXISTS client_applications_usage;

--- a/src/migrations/20230830121352-update-client-applications-usage-table.js
+++ b/src/migrations/20230830121352-update-client-applications-usage-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings DROP COLUMN IF EXISTS "feature_naming_pattern";

--- a/src/migrations/20230905122605-add-feature-naming-description.js
+++ b/src/migrations/20230905122605-add-feature-naming-description.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE project_settings DROP COLUMN IF EXISTS "feature_naming_description";

--- a/src/migrations/20230919104006-dependent-features.js
+++ b/src/migrations/20230919104006-dependent-features.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS dependent_features
@@ -17,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE dependent_features;

--- a/src/migrations/20230927071830-reset-pnps-feedback.js
+++ b/src/migrations/20230927071830-reset-pnps-feedback.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
        DELETE FROM user_feedback WHERE feedback_id = 'pnps' AND given < NOW() - INTERVAL '3 months';
@@ -8,6 +9,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20230927172930-events-announced-index.js
+++ b/src/migrations/20230927172930-events-announced-index.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         UPDATE events set announced = false where announced IS NULL;
@@ -11,6 +12,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20231002122426-update-dependency-permission.js
+++ b/src/migrations/20231002122426-update-dependency-permission.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('UPDATE_FEATURE_DEPENDENCY', 'Update feature dependency', 'project');
@@ -9,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'UPDATE_FEATURE_DEPENDENCY';

--- a/src/migrations/20231003113443-last-seen-at-metrics-table.js
+++ b/src/migrations/20231003113443-last-seen-at-metrics-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
       CREATE TABLE last_seen_at_metrics (
@@ -16,7 +17,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
       db.runSql(
         `DROP TABLE last_seen_at_metrics;
       `,

--- a/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
+++ b/src/migrations/20231004120900-create-changes-stats-table-and-trigger.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`
     CREATE TABLE stat_environment_updates(
         day DATE NOT NULL,
@@ -23,7 +23,7 @@ export async function up(db, cb) {
   `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`
     DROP TRIGGER IF EXISTS unleash_update_stat_environment_changes ON events;
     DROP FUNCTION IF EXISTS unleash_update_stat_environment_changes_counter;

--- a/src/migrations/20231012082537-message-banners.js
+++ b/src/migrations/20231012082537-message-banners.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS message_banners
@@ -21,7 +22,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE IF EXISTS message_banners;

--- a/src/migrations/20231019110154-rename-message-banners-table-to-banners.js
+++ b/src/migrations/20231019110154-rename-message-banners-table-to-banners.js
@@ -1,8 +1,9 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`ALTER TABLE message_banners RENAME TO banners`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE banners RENAME TO message_banners`, cb);
 };

--- a/src/migrations/20231024121307-add-change-request-schedule.js
+++ b/src/migrations/20231024121307-add-change-request-schedule.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS change_request_schedule (
@@ -11,7 +12,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             DROP TABLE IF EXISTS change_request_schedule;

--- a/src/migrations/20231025093422-default-project-mode.js
+++ b/src/migrations/20231025093422-default-project-mode.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         ALTER TABLE project_settings
             ALTER COLUMN project_mode SET DEFAULT 'open';
@@ -17,7 +18,7 @@ export async function up(db, cb) {
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`
         ALTER TABLE project_settings
             ALTER COLUMN project_mode DROP DEFAULT;

--- a/src/migrations/20231030091931-add-created-by-and-status-change-request-schedule.js
+++ b/src/migrations/20231030091931-add-created-by-and-status-change-request-schedule.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
   db.runSql(`
         CREATE TYPE change_request_schedule_status AS ENUM ('pending', 'failed');
 
@@ -12,7 +13,7 @@ export async function up(db, cb) {
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
   db.runSql(`
       ALTER TABLE change_request_schedule
           DROP COLUMN IF EXISTS created_by;

--- a/src/migrations/20231103064746-change-request-schedule-change-type.js
+++ b/src/migrations/20231103064746-change-request-schedule-change-type.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
   db.runSql(`
         ALTER TABLE change_request_schedule
         ALTER COLUMN status TYPE text USING status::text;
@@ -10,7 +11,7 @@ export async function up(db, cb) {
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
   db.runSql(`
       CREATE TYPE change_request_schedule_status AS ENUM ('pending', 'failed');
 

--- a/src/migrations/20231121153304-add-permission-create-tag-type.js
+++ b/src/migrations/20231121153304-add-permission-create-tag-type.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO permissions (permission, display_name, type) VALUES ('CREATE_TAG_TYPE', 'Create tag types', 'root');
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM permissions WHERE permission = 'CREATE_TAG_TYPE';

--- a/src/migrations/20231122121456-dedupe-any-duplicate-permissions.js
+++ b/src/migrations/20231122121456-dedupe-any-duplicate-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
 -- STEP 1: Update references in the role_permission table, setting the permission to the lowest ID for each duplicate permission
@@ -67,6 +67,6 @@ AND permission IN (
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20231123100052-drop-last-seen-foreign-key.js
+++ b/src/migrations/20231123100052-drop-last-seen-foreign-key.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
   db.runSql(
     `
     ALTER TABLE last_seen_at_metrics DROP CONSTRAINT last_seen_at_metrics_environment_fkey;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
   );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
   db.runSql(
     `
     ALTER TABLE last_seen_at_metrics ADD CONSTRAINT last_seen_at_metrics_environment_fkey FOREIGN KEY (environment) REFERENCES environments(name);

--- a/src/migrations/20231123155649-favor-permission-name-over-id.js
+++ b/src/migrations/20231123155649-favor-permission-name-over-id.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
 -- STEP 1: Ensure 'permission' column contains unique values
@@ -211,7 +211,7 @@ SELECT assign_unleash_permission_to_role('UPDATE_FEATURE_DEPENDENCY', 'Member');
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
 -- STEP 1: Undo foreign key constraint on 'role_permission'

--- a/src/migrations/20231211121444-features-created-by.js
+++ b/src/migrations/20231211121444-features-created-by.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features ADD COLUMN IF NOT EXISTS created_by INTEGER;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features DROP COLUMN IF EXISTS created_by;

--- a/src/migrations/20231211122322-feature-types-created-by.js
+++ b/src/migrations/20231211122322-feature-types-created-by.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_types ADD COLUMN IF NOT EXISTS created_by INTEGER;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_types DROP COLUMN IF EXISTS created_by;

--- a/src/migrations/20231211122351-feature-tag-created-by.js
+++ b/src/migrations/20231211122351-feature-tag-created-by.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_tag ADD COLUMN IF NOT EXISTS created_by INTEGER;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_tag DROP COLUMN IF EXISTS created_by;

--- a/src/migrations/20231211122426-feature-strategies-created-by.js
+++ b/src/migrations/20231211122426-feature-strategies-created-by.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_strategies ADD COLUMN IF NOT EXISTS created_by INTEGER;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE feature_strategies DROP COLUMN IF EXISTS created_by;

--- a/src/migrations/20231211132341-add-created-by-to-role-permission.js
+++ b/src/migrations/20231211132341-add-created-by-to-role-permission.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`ALTER TABLE role_permission ADD COLUMN created_by INTEGER`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`ALTER TABLE role_permission DROP COLUMN created_by`, cb);
 };

--- a/src/migrations/20231211133008-add-created-by-to-role-user.js
+++ b/src/migrations/20231211133008-add-created-by-to-role-user.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`ALTER TABLE role_user ADD COLUMN created_by INTEGER`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`ALTER TABLE role_user DROP COLUMN created_by`, cb);
 };

--- a/src/migrations/20231211133920-add-created-by-to-roles.js
+++ b/src/migrations/20231211133920-add-created-by-to-roles.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`ALTER TABLE roles ADD COLUMN created_by INTEGER`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`ALTER TABLE roles DROP COLUMN created_by`, cb);
 };

--- a/src/migrations/20231211134130-add-created-by-to-users.js
+++ b/src/migrations/20231211134130-add-created-by-to-users.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`ALTER TABLE users ADD COLUMN created_by INTEGER`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`ALTER TABLE users DROP COLUMN created_by`, cb);
 };

--- a/src/migrations/20231211134633-add-created-by-to-apitokens.js
+++ b/src/migrations/20231211134633-add-created-by-to-apitokens.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`ALTER TABLE api_tokens ADD COLUMN created_by INTEGER`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`ALTER TABLE api_tokens DROP COLUMN created_by`, cb);
 };

--- a/src/migrations/20231212094044-event-created-by-user-id.js
+++ b/src/migrations/20231212094044-event-created-by-user-id.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE events ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER;
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP INDEX IF EXISTS events_created_by_user_id_idx;

--- a/src/migrations/20231213111906-add-reason-to-change-request-schedule.js
+++ b/src/migrations/20231213111906-add-reason-to-change-request-schedule.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`ALTER TABLE change_request_schedule ADD COLUMN failure_reason text`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`ALTER TABLE change_request_schedule DROP COLUMN failure_reason`, cb);
 };

--- a/src/migrations/20231215105713-incoming-webhooks.js
+++ b/src/migrations/20231215105713-incoming-webhooks.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS incoming_webhooks
@@ -26,7 +26,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS incoming_webhooks_enabled_idx;

--- a/src/migrations/20231218165612-inc-webhook-tokens-rename-secret-to-token.js
+++ b/src/migrations/20231218165612-inc-webhook-tokens-rename-secret-to-token.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE incoming_webhook_tokens RENAME COLUMN secret TO token;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE incoming_webhook_tokens RENAME COLUMN token TO secret;

--- a/src/migrations/20231219100343-rename-new-columns-to-created-by-user-id.js
+++ b/src/migrations/20231219100343-rename-new-columns-to-created-by-user-id.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features RENAME COLUMN created_by TO created_by_user_id;
@@ -16,7 +17,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE features RENAME COLUMN created_by_user_id TO created_by;

--- a/src/migrations/20231221143955-feedback-table.js
+++ b/src/migrations/20231221143955-feedback-table.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS feedback
@@ -17,7 +18,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP TABLE IF EXISTS feedback;

--- a/src/migrations/20231222071533-unleash-system-user.js
+++ b/src/migrations/20231222071533-unleash-system-user.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE users ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE;
@@ -12,7 +13,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE users DROP COLUMN IF EXISTS is_system;

--- a/src/migrations/20240102142100-incoming-webhooks-created-by.js
+++ b/src/migrations/20240102142100-incoming-webhooks-created-by.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE incoming_webhooks ALTER COLUMN created_by_user_id DROP NOT NULL;
@@ -8,6 +8,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20240102205517-observable-events.js
+++ b/src/migrations/20240102205517-observable-events.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS observable_events
@@ -19,7 +19,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS observable_events_source_and_source_id_idx;

--- a/src/migrations/20240108151652-add-daily-metrics.js
+++ b/src/migrations/20240108151652-add-daily-metrics.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
       CREATE TABLE IF NOT EXISTS client_metrics_env_daily (
@@ -34,7 +34,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE client_metrics_env_variants_daily;

--- a/src/migrations/20240109093021-incoming-webhooks-description.js
+++ b/src/migrations/20240109093021-incoming-webhooks-description.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE incoming_webhooks ADD COLUMN IF NOT EXISTS description TEXT;
@@ -7,6 +7,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20240109095348-add-reason-column-to-schedule.js
+++ b/src/migrations/20240109095348-add-reason-column-to-schedule.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `ALTER TABLE change_request_schedule ADD COLUMN reason TEXT;
          UPDATE change_request_schedule SET reason = failure_reason;`,
@@ -7,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `ALTER TABLE change_request_schedule DROP COLUMN reason;`,
         cb,

--- a/src/migrations/20240111075911-update-system-user-email.js
+++ b/src/migrations/20240111075911-update-system-user-email.js
@@ -1,12 +1,13 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `UPDATE users SET email = NULL WHERE id = -1337;`,
         callback,
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `UPDATE users SET email = 'system@getunleash.io' WHERE id = -1337;`,
         callback,

--- a/src/migrations/20240111125100-automated-actions.js
+++ b/src/migrations/20240111125100-automated-actions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS action_sets
@@ -32,7 +32,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_action_sets_project;

--- a/src/migrations/20240116104456-drop-unused-column-permissionid.js
+++ b/src/migrations/20240116104456-drop-unused-column-permissionid.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE role_permission
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE role_permission

--- a/src/migrations/20240116154700-unleash-admin-token-user.js
+++ b/src/migrations/20240116154700-unleash-admin-token-user.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         INSERT INTO users
@@ -11,7 +12,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DELETE FROM users WHERE id = -42;

--- a/src/migrations/20240117093601-add-more-granular-project-permissions.js
+++ b/src/migrations/20240117093601-add-more-granular-project-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`
     INSERT INTO permissions(permission, display_name, type) VALUES
         ('PROJECT_USER_ACCESS_READ', 'View only access to Project User Access', 'project'),
@@ -12,7 +12,7 @@ export async function up(db, cb) {
   `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         DELETE FROM permissions WHERE permission IN ('PROJECT_USER_ACCESS_READ',
                                                      'PROJECT_DEFAULT_STRATEGY_READ',

--- a/src/migrations/20240118093611-missing-primary-keys.js
+++ b/src/migrations/20240118093611-missing-primary-keys.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE project_stats ADD PRIMARY KEY (project);
@@ -10,7 +11,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE project_stats DROP CONSTRAINT project_stats_pkey;

--- a/src/migrations/20240119171200-action-states.js
+++ b/src/migrations/20240119171200-action-states.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS action_states
@@ -17,7 +17,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_state_to_observable_event_id;

--- a/src/migrations/20240124123000-add-enabled-to-action-sets.js
+++ b/src/migrations/20240124123000-add-enabled-to-action-sets.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE action_sets ADD COLUMN enabled BOOLEAN DEFAULT true;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE action_sets DROP COLUMN enabled;

--- a/src/migrations/20240125084701-add-user-trends.js
+++ b/src/migrations/20240125084701-add-user-trends.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS user_trends (
@@ -12,6 +13,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql('DROP TABLE IF EXISTS user_trends;', cb);
 };

--- a/src/migrations/20240125085703-users-table-increae-image-url-size.js
+++ b/src/migrations/20240125085703-users-table-increae-image-url-size.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE users
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE users

--- a/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
+++ b/src/migrations/20240125090553-events-fix-incorrectly-assigned-sysuser-id.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
   db.runSql(
       `
       UPDATE events SET created_by_user_id = null
@@ -15,6 +15,6 @@ export async function up(db, cb) {
   );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     cb();
 };

--- a/src/migrations/20240125100000-events-system-user-old2new.js
+++ b/src/migrations/20240125100000-events-system-user-old2new.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         UPDATE events SET created_by_user_id = -1337 WHERE created_by_user_id = -1;
@@ -8,6 +9,6 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     callback();
 };

--- a/src/migrations/20240126095544-add-flag-trends.js
+++ b/src/migrations/20240126095544-add-flag-trends.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS flag_trends (
@@ -15,6 +16,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql('DROP TABLE IF EXISTS flag_trends;', cb);
 };

--- a/src/migrations/20240130104757-flag-trends-health-time-to-production.js
+++ b/src/migrations/20240130104757-flag-trends-health-time-to-production.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         ALTER TABLE flag_trends ADD COLUMN IF NOT EXISTS health INTEGER DEFAULT 100;
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         ALTER TABLE flag_trends DROP COLUMN IF EXISTS health;
         ALTER TABLE flag_trends DROP COLUMN IF EXISTS time_to_production;

--- a/src/migrations/20240207164033-client-applications-announced-index.js
+++ b/src/migrations/20240207164033-client-applications-announced-index.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
             CREATE INDEX IF NOT EXISTS idx_client_applications_announced_false ON client_applications (announced)
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         DROP INDEX IF EXISTS idx_client_applications_announced_false;
     `, cb);

--- a/src/migrations/20240208123212-create-stat-traffic-usage-table.js
+++ b/src/migrations/20240208123212-create-stat-traffic-usage-table.js
@@ -1,5 +1,5 @@
 
-export async function up (db, callback) {
+exports.up = (db, callback) => {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS stat_traffic_usage(
@@ -17,7 +17,7 @@ export async function up (db, callback) {
     );
 };
 
-export async function down (db, callback) {
+exports.down = (db, callback) => {
     db.runSql(
         `
         DROP INDEX IF EXISTS stat_traffic_usage_day_idx;

--- a/src/migrations/20240208130439-events-revision-id-index.js
+++ b/src/migrations/20240208130439-events-revision-id-index.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
             CREATE INDEX IF NOT EXISTS idx_events_feature_type_id ON events (id)
@@ -11,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         DROP INDEX IF EXISTS idx_events_feature_type_id;
     `, cb);

--- a/src/migrations/20240215133213-flag-trends-users.js
+++ b/src/migrations/20240215133213-flag-trends-users.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         ALTER TABLE flag_trends ADD COLUMN IF NOT EXISTS users INTEGER DEFAULT 0;
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         ALTER TABLE flag_trends DROP COLUMN IF EXISTS users;
     `, cb);

--- a/src/migrations/20240220130622-add-action-state-indexes.js
+++ b/src/migrations/20240220130622-add-action-state-indexes.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE INDEX IF NOT EXISTS idx_action_states_action_id ON action_states(action_id);
@@ -9,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_action_states_action_id;

--- a/src/migrations/20240221082758-action-events.js
+++ b/src/migrations/20240221082758-action-events.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS action_set_events
@@ -19,7 +19,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_action_set_events_observable_event_id;

--- a/src/migrations/20240221115502-drop-action-states.js
+++ b/src/migrations/20240221115502-drop-action-states.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_action_states_action_id;
@@ -11,7 +11,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS action_states

--- a/src/migrations/20240222123532-project-metrics-summary-trends.js
+++ b/src/migrations/20240222123532-project-metrics-summary-trends.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS project_client_metrics_trends
@@ -17,7 +17,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP TABLE IF EXISTS project_client_metrics_trends

--- a/src/migrations/20240229093231-drop-fk-and-cascade-in-trends.js
+++ b/src/migrations/20240229093231-drop-fk-and-cascade-in-trends.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE flag_trends DROP CONSTRAINT IF EXISTS flag_trends_project_fkey;
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
 

--- a/src/migrations/20240304084102-rename-observable-events-to-signals.js
+++ b/src/migrations/20240304084102-rename-observable-events-to-signals.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         -- Drop existing indexes that will be recreated with new names
@@ -37,7 +37,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         -- Remove the indexes added in the up migration

--- a/src/migrations/20240304160659-add-environment-type-trends.js
+++ b/src/migrations/20240304160659-add-environment-type-trends.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS environment_type_trends (
@@ -12,6 +13,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql('DROP TABLE IF EXISTS environment_type_trends;', cb);
 };

--- a/src/migrations/20240305094305-features-remove-archived.js
+++ b/src/migrations/20240305094305-features-remove-archived.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE features DROP COLUMN IF EXISTS archived;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;

--- a/src/migrations/20240305121426-add-created-at-environment-type-trends.js
+++ b/src/migrations/20240305121426-add-created-at-environment-type-trends.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         ALTER TABLE IF EXISTS environment_type_trends
@@ -9,6 +10,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql('ALTER TABLE IF EXISTS environment_type_trends DROP COLUMN IF EXISTS created_at;', cb);
 };

--- a/src/migrations/20240305121702-add-metrics-summary-columns-to-flag-trends.js
+++ b/src/migrations/20240305121702-add-metrics-summary-columns-to-flag-trends.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         ALTER TABLE IF EXISTS flag_trends
@@ -12,7 +13,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`ALTER TABLE IF EXISTS flag_trends
         DROP COLUMN IF EXISTS total_no,
         DROP COLUMN IF EXISTS total_apps,

--- a/src/migrations/20240305131822-add-scim-id-column-to-user.js
+++ b/src/migrations/20240305131822-add-scim-id-column-to-user.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`
     ALTER TABLE users ADD COLUMN scim_id TEXT;
     CREATE INDEX IF NOT EXISTS users_scim_id_uniq_idx ON users (scim_id) WHERE scim_id IS NOT NULL;
   `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`
     DROP INDEX IF EXISTS users_scim_id_uniq_idx;
     ALTER TABLE users DROP COLUMN scim_id;

--- a/src/migrations/20240306145609-make-scim-id-idx-unique.js
+++ b/src/migrations/20240306145609-make-scim-id-idx-unique.js
@@ -1,8 +1,8 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`DROP INDEX IF EXISTS users_scim_id_uniq_idx;
              CREATE UNIQUE INDEX users_scim_id_unique_idx ON users(scim_id) WHERE scim_id IS NOT NULL`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`DROP INDEX IF EXISTS users_scim_id_unique_idx;`, cb);
 };

--- a/src/migrations/20240325081847-add-scim-id-for-groups.js
+++ b/src/migrations/20240325081847-add-scim-id-for-groups.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
 	db.runSql(
 		`
   ALTER TABLE groups ADD COLUMN scim_id TEXT;
@@ -8,7 +8,7 @@ export async function up(db, cb) {
 	);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
 	db.runSql(
 		`
   DROP INDEX IF EXISTS groups_scim_id_unique_idx;

--- a/src/migrations/20240326122126-add-index-on-group-name.js
+++ b/src/migrations/20240326122126-add-index-on-group-name.js
@@ -1,10 +1,10 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE INDEX IF NOT EXISTS groups_group_name_idx ON groups(name)`,
         cb,
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`DROP INDEX IF EXISTS groups_group_name_idx`, cb);
 };

--- a/src/migrations/20240329064629-revert-feature-archived.js
+++ b/src/migrations/20240329064629-revert-feature-archived.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE features ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT FALSE;
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE features DROP COLUMN IF EXISTS archived;

--- a/src/migrations/20240405120422-add-feature-lifecycles.js
+++ b/src/migrations/20240405120422-add-feature-lifecycles.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS feature_lifecycles (
@@ -12,6 +13,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql('DROP TABLE IF EXISTS feature_lifecycles;', cb);
 };

--- a/src/migrations/20240405174629-jobs.js
+++ b/src/migrations/20240405174629-jobs.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
 -- this function rounds a date to the nearest interval
@@ -24,7 +24,7 @@ CREATE INDEX IF NOT EXISTS idx_job_stage ON jobs(stage);
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             DROP INDEX IF EXISTS idx_job_finished;

--- a/src/migrations/20240408104624-fix-environment-type-trends.js
+++ b/src/migrations/20240408104624-fix-environment-type-trends.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     -- 1. Clear the environment_type_trends table
@@ -58,7 +58,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20240418140646-add-ip-column-to-events-table.js
+++ b/src/migrations/20240418140646-add-ip-column-to-events-table.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`ALTER TABLE events ADD COLUMN ip TEXT`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`ALTER TABLE events DROP COLUMN ip`, cb);
 };

--- a/src/migrations/20240425132155-flag-trends-bigint.js
+++ b/src/migrations/20240425132155-flag-trends-bigint.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         ALTER TABLE flag_trends ALTER COLUMN total_yes TYPE bigint;
         ALTER TABLE flag_trends ALTER COLUMN total_no TYPE bigint;
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20240430075605-add-scim-external-id.js
+++ b/src/migrations/20240430075605-add-scim-external-id.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE users ADD COLUMN scim_external_id TEXT;
@@ -10,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
     DROP INDEX IF EXISTS users_scim_external_id_uniq_idx;

--- a/src/migrations/20240506141345-lifecycle-initial-stage.js
+++ b/src/migrations/20240506141345-lifecycle-initial-stage.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
             INSERT INTO feature_lifecycles (feature, stage, created_at)
@@ -11,7 +11,7 @@ export async function up(db, cb) {
     );
 }
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(
         ``,
         cb,

--- a/src/migrations/20240507075431-client-metrics-env-daily-bigint.js
+++ b/src/migrations/20240507075431-client-metrics-env-daily-bigint.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         ALTER TABLE client_metrics_env_daily ALTER COLUMN yes TYPE bigint;
         ALTER TABLE client_metrics_env_daily ALTER COLUMN no TYPE bigint;
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         `,

--- a/src/migrations/20240508153244-feature-lifecycles-status.js
+++ b/src/migrations/20240508153244-feature-lifecycles-status.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         ALTER TABLE feature_lifecycles ADD COLUMN IF NOT EXISTS status TEXT;
         ALTER TABLE feature_lifecycles ADD COLUMN IF NOT EXISTS status_value TEXT;
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
          ALTER TABLE feature_lifecycles DROP COLUMN IF EXISTS status;

--- a/src/migrations/20240523093355-toggle-to-flag-rename.js
+++ b/src/migrations/20240523093355-toggle-to-flag-rename.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         UPDATE permissions SET display_name = 'Create feature flags' WHERE permission = 'CREATE_FEATURE' AND type = 'project';
         UPDATE permissions SET display_name = 'Update feature flags' WHERE permission = 'UPDATE_FEATURE' AND type = 'project';
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             UPDATE permissions

--- a/src/migrations/20240523113322-roles-toggle-to-flag-rename.js
+++ b/src/migrations/20240523113322-roles-toggle-to-flag-rename.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         UPDATE roles
         SET description = 'Users with the project owner role have full control over the project, and can add and manage other users within the project context, manage feature flags within the project, and control advanced project features like archiving and deleting the project.'
@@ -13,7 +13,7 @@ export async function up(db, cb) {
     `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             UPDATE roles

--- a/src/migrations/20240611092538-add-created-by-to-features-view.js
+++ b/src/migrations/20240611092538-add-created-by-to-features-view.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;
@@ -48,7 +49,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20240705111827-used-passwords-table.js
+++ b/src/migrations/20240705111827-used-passwords-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
   db.runSql(`
     CREATE TABLE used_passwords(user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
                                 password_hash TEXT NOT NULL,
@@ -10,6 +10,6 @@ export async function up(db, cb) {
 `, cb)
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
   db.runSql(`DROP TABLE used_passwords;`, cb);
 };

--- a/src/migrations/20240716135038-integration-events.js
+++ b/src/migrations/20240716135038-integration-events.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS integration_events
@@ -18,7 +18,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_integration_events_integration_id;

--- a/src/migrations/20240806140453-add-archived-at-to-projects.js
+++ b/src/migrations/20240806140453-add-archived-at-to-projects.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE projects ADD archived_at TIMESTAMP WITH TIME ZONE;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         ALTER TABLE projects DROP COLUMN archived_at;

--- a/src/migrations/20240812120954-add-archived-at-to-projects.js
+++ b/src/migrations/20240812120954-add-archived-at-to-projects.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         CREATE INDEX idx_events_created_at_desc ON events (created_at DESC);
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_events_created_at_desc;

--- a/src/migrations/20240812132633-events-type-index.js
+++ b/src/migrations/20240812132633-events-type-index.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         CREATE INDEX idx_events_type ON events (type);
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_events_type;

--- a/src/migrations/20240821141555-segment-no-project-cleanup.js
+++ b/src/migrations/20240821141555-segment-no-project-cleanup.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
         UPDATE events
@@ -16,7 +17,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         ``,
         callback,

--- a/src/migrations/20240823091442-normalize-token-types.js
+++ b/src/migrations/20240823091442-normalize-token-types.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE api_tokens
@@ -18,6 +19,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(``, cb);
 };

--- a/src/migrations/20240828154255-user-first-seen-at.js
+++ b/src/migrations/20240828154255-user-first-seen-at.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE users ADD COLUMN first_seen_at TIMESTAMP WITHOUT TIME ZONE;
@@ -8,7 +9,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             ALTER TABLE users DROP COLUMN first_seen_at;

--- a/src/migrations/20240830102144-onboarding-events.js
+++ b/src/migrations/20240830102144-onboarding-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             CREATE TABLE IF NOT EXISTS onboarding_events_instance (
@@ -19,7 +20,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
             DROP TABLE IF EXISTS onboarding_events_instance;

--- a/src/migrations/20240903152133-clear-onboarding-events.js
+++ b/src/migrations/20240903152133-clear-onboarding-events.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
             DELETE FROM onboarding_events_instance;
@@ -9,7 +10,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         ``,
         cb);

--- a/src/migrations/20240904084114-add-update-feature-dependency-editor.js
+++ b/src/migrations/20240904084114-add-update-feature-dependency-editor.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         INSERT INTO role_permission (role_id, permission)
@@ -16,7 +16,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DELETE FROM role_permission

--- a/src/migrations/20240919083625-client-metrics-env-variants-daily-to-bigint.js
+++ b/src/migrations/20240919083625-client-metrics-env-variants-daily-to-bigint.js
@@ -1,7 +1,7 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`ALTER TABLE client_metrics_env_variants_daily ALTER COLUMN count TYPE BIGINT`, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`ALTER TABLE client_metrics_env_variants_daily ALTER COLUMN count TYPE INT`, cb);
 };

--- a/src/migrations/20241016090534-ai-chats.js
+++ b/src/migrations/20241016090534-ai-chats.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS ai_chats
@@ -15,7 +15,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_ai_chats_user_id;

--- a/src/migrations/20241016123833-ai-chats-rename-chat-col-to-messages.js
+++ b/src/migrations/20241016123833-ai-chats-rename-chat-col-to-messages.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE ai_chats RENAME COLUMN chat TO messages;
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE ai_chats RENAME COLUMN messages TO chat;

--- a/src/migrations/20241024062521-add-release-plans-milestones-strategies.js
+++ b/src/migrations/20241024062521-add-release-plans-milestones-strategies.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS release_plan_definitions
@@ -47,7 +47,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_milestone_strategies_strategy_name;

--- a/src/migrations/20241024081537-sent-emails-table.js
+++ b/src/migrations/20241024081537-sent-emails-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`
     CREATE TABLE IF NOT EXISTS emails_sent
     (
@@ -11,6 +11,6 @@ export async function up(db, cb) {
 `, cb)
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`DROP TABLE emails_sent;`, cb);
 };

--- a/src/migrations/20241030093439-release-plans-template-ref-and-missing-strategy-fields.js
+++ b/src/migrations/20241030093439-release-plans-template-ref-and-missing-strategy-fields.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions ADD COLUMN release_plan_template_id TEXT REFERENCES release_plan_definitions(id) ON DELETE CASCADE;
         CREATE INDEX idx_release_plan_template_definition_id ON release_plan_definitions (release_plan_template_id) WHERE release_plan_template_id IS NOT NULL;
@@ -17,7 +17,7 @@ export async function up(db, cb) {
     `, cb)
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions DROP COLUMN release_plan_template_id;
         ALTER TABLE feature_strategies DROP COLUMN milestone_id;

--- a/src/migrations/20241031102325-user-unsubscription.js
+++ b/src/migrations/20241031102325-user-unsubscription.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`
     CREATE TABLE IF NOT EXISTS user_unsubscription
     (
@@ -10,6 +10,6 @@ export async function up(db, cb) {
 `, cb);
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`DROP TABLE IF EXISTS user_unsubscription;`, cb);
 };

--- a/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
+++ b/src/migrations/20241031123526-release-plan-definition-remove-fk-constraint-on-userid.js
@@ -1,11 +1,11 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions DROP CONSTRAINT release_plan_definitions_created_by_user_id_fkey;
         CREATE INDEX idx_release_plan_definitions_created_by_user_id ON release_plan_definitions (created_by_user_id);
     `, cb)
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`
         ALTER TABLE release_plan_definitions ADD CONSTRAINT release_plan_definitions_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES users(id);
         DROP INDEX idx_release_plan_definitions_created_by_user_id;

--- a/src/migrations/20241105123918-add-cascade-for-user-unsubscription.js
+++ b/src/migrations/20241105123918-add-cascade-for-user-unsubscription.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
     ALTER TABLE user_unsubscription DROP CONSTRAINT user_unsubscription_user_id_fkey;
@@ -11,6 +11,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql('', cb);
 };

--- a/src/migrations/20241111085745-release-plan-template-permissions.js
+++ b/src/migrations/20241111085745-release-plan-template-permissions.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`
     INSERT INTO permissions(permission, display_name, type) VALUES
     ('RELEASE_PLAN_TEMPLATE_VIEW_OVERVIEW', 'View overview of release plan templates', 'root'),
@@ -18,7 +18,7 @@ export async function up (db, cb) {
 
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(`
       DELETE
       FROM permissions

--- a/src/migrations/20241112113555-user-email-hash.js
+++ b/src/migrations/20241112113555-user-email-hash.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`
       ALTER TABLE users
           ADD COLUMN IF NOT EXISTS email_hash VARCHAR(32);
@@ -9,7 +9,7 @@ export async function up (db, cb) {
 
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(`
       ALTER TABLE users
           DROP COLUMN IF EXISTS email_hash;

--- a/src/migrations/20241114103646-licensed-users.js
+++ b/src/migrations/20241114103646-licensed-users.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`
       CREATE TABLE IF NOT EXISTS licensed_users (
         count INT,
@@ -8,7 +8,7 @@ export async function up (db, cb) {
 
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(`
       DROP TABLE IF EXISTS licensed_users;
   `, cb);

--- a/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
+++ b/src/migrations/20241119103819-make-potentially-stale-non-nullable.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         UPDATE features
@@ -15,7 +16,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE features

--- a/src/migrations/20241119105837-licensed-users-backfill.js
+++ b/src/migrations/20241119105837-licensed-users-backfill.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`
         WITH user_events AS (
           SELECT
@@ -79,7 +79,7 @@ export async function up (db, cb) {
 
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(``, cb);
 };
 

--- a/src/migrations/20241125080935-add-unique-idx-to-release-plan-discriminator.js
+++ b/src/migrations/20241125080935-add-unique-idx-to-release-plan-discriminator.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `CREATE UNIQUE INDEX idx_uniq_release_plan_definitions_discriminator_template
          ON release_plan_definitions(name)
@@ -7,7 +7,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `DROP INDEX IF EXISTS idx_uniq_release_plan_definitions_discriminator_template`,
         cb,

--- a/src/migrations/20241127074206-milestone-strategy-title-nullable.js
+++ b/src/migrations/20241127074206-milestone-strategy-title-nullable.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(
         `
         ALTER TABLE milestone_strategies ALTER COLUMN title DROP NOT NULL;
@@ -7,6 +7,6 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     cb();
 };

--- a/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
+++ b/src/migrations/20241128152334-features-view-filter-out-milestone-strategies.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;
@@ -52,7 +53,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
           DROP VIEW features_view;

--- a/src/migrations/20241129102205-add-foreign-key-to-role-permissions.js
+++ b/src/migrations/20241129102205-add-foreign-key-to-role-permissions.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
 	db.runSql(
 		`
         UPDATE role_permission SET environment = null where environment = '';
@@ -9,7 +9,7 @@ export async function up(db, cb) {
 	);
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
 	db.runSql(
 		`
         ALTER TABLE role_permission

--- a/src/migrations/20241211143944-events-index-project-feature-created.js
+++ b/src/migrations/20241211143944-events-index-project-feature-created.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
           CREATE INDEX idx_events_project_feature_created
@@ -9,7 +10,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
            DROP INDEX idx_events_project_feature_created;

--- a/src/migrations/20241212122149-add-permissions-maintenance.js
+++ b/src/migrations/20241212122149-add-permissions-maintenance.js
@@ -1,12 +1,13 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         INSERT INTO permissions (permission, display_name, type) VALUES ('UPDATE_MAINTENANCE_MODE', 'Change maintenance mode state', 'root');
         INSERT INTO permissions (permission, display_name, type) VALUES ('UPDATE_INSTANCE_BANNERS', 'Change instance banners', 'root');
     `, cb);
 }
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`
         DELETE FROM permissions WHERE permission IN ('UPDATE_MAINTENANCE_MODE', 'UPDATE_INSTANCE_BANNERS');
     `, cb);

--- a/src/migrations/20241216141201-add-permission-auth-config.js
+++ b/src/migrations/20241216141201-add-permission-auth-config.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         INSERT INTO permissions (permission, display_name, type) VALUES ('UPDATE_AUTH_CONFIGURATION', 'Change authentication settings (SSO)', 'root');
     `, cb);
 }
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`
         DELETE FROM permissions WHERE permission IN ('UPDATE_AUTH_CONFIGURATION');
     `, cb);

--- a/src/migrations/20241220102327-drop-ai-chats.js
+++ b/src/migrations/20241220102327-drop-ai-chats.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         DROP INDEX IF EXISTS idx_ai_chats_user_id;
@@ -8,7 +8,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS ai_chats

--- a/src/migrations/20250102150900-add-permission-read-logs.js
+++ b/src/migrations/20250102150900-add-permission-read-logs.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         INSERT INTO permissions (permission, display_name, type) VALUES ('READ_LOGS', 'Read instance logs and login history', 'root');
     `, cb);
 }
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`
         DELETE FROM permissions WHERE permission IN ('READ_LOGS');
     `, cb);

--- a/src/migrations/20250109150818-unique-connections-table.js
+++ b/src/migrations/20250109150818-unique-connections-table.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function(db, cb) {
     db.runSql(`
     CREATE TABLE IF NOT EXISTS unique_connections
     (
@@ -9,6 +9,6 @@ export async function up(db, cb) {
 `, cb)
 };
 
-export async function down(db, cb) {
+exports.down = function(db, cb) {
     db.runSql(`DROP TABLE unique_connections;`, cb);
 };

--- a/src/migrations/20250110130010-add-permission-cors.js
+++ b/src/migrations/20250110130010-add-permission-cors.js
@@ -1,11 +1,12 @@
+'use strict';
 
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(`
         INSERT INTO permissions (permission, display_name, type) VALUES ('UPDATE_CORS', 'Update CORS settings', 'root');
     `, cb);
 }
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(`
         DELETE FROM permissions WHERE permission IN ('UPDATE_CORS');
     `, cb);

--- a/src/migrations/20250203145735-drop-rp-view-permissions.js
+++ b/src/migrations/20250203145735-drop-rp-view-permissions.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
     db.runSql(`
         DELETE
         FROM permissions
@@ -8,7 +8,7 @@ export async function up (db, cb) {
 
   };
 
-  export async function down (db, cb) {
+  exports.down = (db, cb) => {
     db.runSql(`
         INSERT INTO permissions(permission, display_name, type) VALUES
             ('RELEASE_PLAN_TEMPLATE_VIEW_OVERVIEW', 'View overview of release plan templates', 'root'),

--- a/src/migrations/20250205072305-clean-scim-id-from-deleted-users.js
+++ b/src/migrations/20250205072305-clean-scim-id-from-deleted-users.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
     db.runSql(`
         UPDATE users
         SET
@@ -9,6 +9,6 @@ export async function up (db, cb) {
 
   };
 
-  export async function down (db, cb) {
+  exports.down = (db, cb) => {
     cb();
   };

--- a/src/migrations/20250210130408-add-edge-observability-tables.js
+++ b/src/migrations/20250210130408-add-edge-observability-tables.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`
     CREATE TABLE stat_edge_observability (
         instance_id TEXT NOT NULL PRIMARY KEY,
@@ -27,6 +27,6 @@ export async function up (db, cb) {
   `, cb);
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(`DROP TABLE IF EXISTS stat_edge_observability;`, cb);
 };

--- a/src/migrations/20250211114205-scim-email-hash-backfill.js
+++ b/src/migrations/20250211114205-scim-email-hash-backfill.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
     db.runSql(`
         UPDATE users
         SET email_hash = md5(email::text)
@@ -7,7 +7,7 @@ export async function up (db, cb) {
   
   };
   
-  export async function down (db, cb) {
+  exports.down = (db, cb) => {
     cb();
   };
   

--- a/src/migrations/20250212130610-add-stat-edge-traffic-table.js
+++ b/src/migrations/20250212130610-add-stat-edge-traffic-table.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
   db.runSql(`CREATE TABLE stat_edge_traffic_usage(
     instance_id TEXT NOT NULL,
     day DATE NOT NULL,
@@ -11,6 +11,6 @@ export async function up (db, cb) {
 `, cb);
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
   db.runSql(`DROP TABLE stat_edge_traffic_usage;`, cb);
 };

--- a/src/migrations/20250214104741-add-status-code-to-edge-traffic-table.js
+++ b/src/migrations/20250214104741-add-status-code-to-edge-traffic-table.js
@@ -1,4 +1,4 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
     db.runSql(`
     ALTER TABLE stat_edge_traffic_usage ADD COLUMN status_code INT NOT NULL DEFAULT 200;
     CREATE INDEX stat_edge_traffic_usage_traffic_group_status_code_idx ON stat_edge_traffic_usage(status_code, traffic_group);
@@ -8,7 +8,7 @@ export async function up (db, cb) {
     `, cb);
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
     db.runSql(`
         ALTER TABLE stat_edge_traffic_usage DROP CONSTRAINT stat_edge_traffic_usage_pkey;
         DROP INDEX IF EXISTS stat_edge_traffic_usage_traffic_group_status_code_idx;

--- a/src/migrations/20250304122705-archive-release-template.js
+++ b/src/migrations/20250304122705-archive-release-template.js
@@ -1,10 +1,10 @@
-export async function up (db, cb) {
+exports.up = (db, cb) => {
     db.runSql(`
         ALTER TABLE release_plan_definitions ADD COLUMN archived_at TIMESTAMP WITH TIME ZONE;
     `, cb);
 };
 
-export async function down (db, cb) {
+exports.down = (db, cb) => {
     db.runSql(`
         ALTER TABLE release_plan_definitions DROP COLUMN archived_at;
     `, cb);

--- a/src/migrations/20250307124449-connection-count-consumption-table.js
+++ b/src/migrations/20250307124449-connection-count-consumption-table.js
@@ -1,5 +1,5 @@
 
-export async function up (db, callback) {
+exports.up = (db, callback) => {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS connection_count_consumption(
@@ -14,7 +14,7 @@ export async function up (db, callback) {
     );
 };
 
-export async function down (db, callback) {
+exports.down = (db, callback) => {
     db.runSql(
         `
         DROP TABLE IF EXISTS connection_count_consumption;

--- a/src/migrations/20250312162155-connection-count-consumption-table.js
+++ b/src/migrations/20250312162155-connection-count-consumption-table.js
@@ -1,5 +1,5 @@
 
-export async function up (db, callback) {
+exports.up = (db, callback) => {
     db.runSql(
         `
         CREATE TABLE IF NOT EXISTS request_count_consumption(
@@ -13,7 +13,7 @@ export async function up (db, callback) {
     );
 };
 
-export async function down (db, callback) {
+exports.down = (db, callback) => {
     db.runSql(
         `
         DROP TABLE IF EXISTS request_count_consumption;

--- a/src/migrations/20250318091635-add-tag-type-color.js
+++ b/src/migrations/20250318091635-add-tag-type-color.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE tag_types
@@ -12,7 +12,7 @@ export async function up(db, cb) {
     );
 };
 
-export async function down(db, cb) {
+exports.down = function (db, cb) {
     db.runSql(
         `
         ALTER TABLE tag_types

--- a/src/migrations/20250320121200-all-users-have-a-root-role.js
+++ b/src/migrations/20250320121200-all-users-have-a-root-role.js
@@ -1,4 +1,4 @@
-export async function up(db, cb) {
+exports.up = function (db, cb) {
     // add root role Viewer (id 3) to all users who don't have a root role
     db.runSql(
         `INSERT INTO role_user(role_id, user_id, project) SELECT 3, u.id, 'default'
@@ -14,7 +14,7 @@ WHERE u.id > 0 AND u.deleted_at IS NULL AND NOT EXISTS (
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     // No rollback
     callback();
 };

--- a/src/migrations/20250325124224-environment-required-approvals.js
+++ b/src/migrations/20250325124224-environment-required-approvals.js
@@ -1,5 +1,6 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE environments ADD COLUMN required_approvals INTEGER;
@@ -8,7 +9,7 @@ export async function up(db, callback) {
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `
             ALTER TABLE environments DROP COLUMN IF EXISTS required_approvals;

--- a/src/migrations/20250425091940-client-instance-sdk-type.js
+++ b/src/migrations/20250425091940-client-instance-sdk-type.js
@@ -1,12 +1,13 @@
+'use strict';
 
-export async function up(db, callback) {
+exports.up = function (db, callback) {
     db.runSql(
         `ALTER TABLE client_instances ADD COLUMN sdk_type varchar(255);`,
         callback
     );
 };
 
-export async function down(db, callback) {
+exports.down = function (db, callback) {
     db.runSql(
         `ALTER TABLE client_instances DROP COLUMN sdk_type;`,
         callback

--- a/src/migrations/package.json
+++ b/src/migrations/package.json
@@ -1,0 +1,4 @@
+{
+    "type": "commonjs"
+}
+  

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -19,6 +19,7 @@ import { omitKeys } from '../../../../lib/util/omit-keys.js';
 import type { ISessionStore } from '../../../../lib/types/stores/session-store.js';
 import type { IUnleashStores } from '../../../../lib/types/index.js';
 import { createHash } from 'crypto';
+import { jest } from '@jest/globals';
 
 let stores: IUnleashStores;
 let db: ITestDb;

--- a/src/test/e2e/api/client/register.e2e.test.ts
+++ b/src/test/e2e/api/client/register.e2e.test.ts
@@ -3,6 +3,7 @@ import { type IUnleashTest, setupApp } from '../../helpers/test-helper.js';
 import dbInit, { type ITestDb } from '../../helpers/database-init.js';
 import getLogger from '../../../fixtures/no-logger.js';
 import version from '../../../../lib/util/version.js';
+import { jest } from '@jest/globals';
 
 const asyncFilter = async (arr, predicate) => {
     const results = await Promise.all(arr.map(predicate));

--- a/src/test/e2e/custom-auth.test.ts
+++ b/src/test/e2e/custom-auth.test.ts
@@ -2,6 +2,7 @@ import dbInit, { type ITestDb } from './helpers/database-init.js';
 import { setupAppWithCustomAuth } from './helpers/test-helper.js';
 import { type IUnleashStores, RoleName } from '../../lib/types/index.js';
 import type { IUnleashServices } from '../../lib/services/index.js';
+import { jest } from '@jest/globals';
 
 let db: ITestDb;
 let stores: IUnleashStores;

--- a/src/test/e2e/dedupe-permissions.e2e.test.ts
+++ b/src/test/e2e/dedupe-permissions.e2e.test.ts
@@ -5,6 +5,7 @@ import { log } from 'db-migrate-shared';
 import postgresPkg from 'pg';
 const { Client } = postgresPkg;
 import type { IDBOption } from '../../lib/types/index.js';
+import { jest } from '@jest/globals';
 
 log.setLogLevel('error');
 

--- a/src/test/e2e/services/addon-service.e2e.test.ts
+++ b/src/test/e2e/services/addon-service.e2e.test.ts
@@ -13,6 +13,8 @@ import { FEATURE_CREATED } from '../../../lib/events/index.js';
 import { IntegrationEventsService } from '../../../lib/services/index.js';
 import { createEventsService } from '../../../lib/features/index.js';
 
+import { jest } from '@jest/globals';
+
 const addonProvider = { simple: new SimpleAddon() };
 
 let db: ITestDb;

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -14,6 +14,8 @@ import getLogger from '../../fixtures/no-logger.js';
 import type { IEventStore } from '../../../lib/types/stores/event-store.js';
 import type { IAuditUser, IUnleashStores } from '../../../lib/types/index.js';
 
+import { jest } from '@jest/globals';
+
 let db: ITestDb;
 let stores: IUnleashStores;
 let eventStore: IEventStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,181 +1021,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/aix-ppc64@npm:0.25.3"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/android-arm64@npm:0.25.3"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/android-arm@npm:0.25.3"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/android-x64@npm:0.25.3"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/darwin-arm64@npm:0.25.3"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/darwin-x64@npm:0.25.3"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.3"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/freebsd-x64@npm:0.25.3"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-arm64@npm:0.25.3"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-arm@npm:0.25.3"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-ia32@npm:0.25.3"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-loong64@npm:0.25.3"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-mips64el@npm:0.25.3"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-ppc64@npm:0.25.3"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-riscv64@npm:0.25.3"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-s390x@npm:0.25.3"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/linux-x64@npm:0.25.3"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.3"
-  conditions: os=netbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/netbsd-x64@npm:0.25.3"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.3"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/openbsd-x64@npm:0.25.3"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/sunos-x64@npm:0.25.3"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/win32-arm64@npm:0.25.3"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-ia32@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/win32-ia32@npm:0.25.3"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.25.3":
-  version: 0.25.3
-  resolution: "@esbuild/win32-x64@npm:0.25.3"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@ewoudenberg/difflib@npm:0.1.0":
   version: 0.1.0
   resolution: "@ewoudenberg/difflib@npm:0.1.0"
@@ -2169,7 +1994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^29.5.14":
+"@types/jest@npm:29.5.14":
   version: 29.5.14
   resolution: "@types/jest@npm:29.5.14"
   dependencies:
@@ -3017,15 +2842,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs-logger@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "bs-logger@npm:0.2.6"
-  dependencies:
-    fast-json-stable-stringify: "npm:2.x"
-  checksum: 10c0/80e89aaaed4b68e3374ce936f2eb097456a0dddbf11f75238dbd53140b1e39259f0d248a5089ed456f1158984f22191c3658d54a713982f676709fbe1a6fa5a0
-  languageName: node
-  linkType: hard
-
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -3161,7 +2977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4005,17 +3821,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^3.1.10":
-  version: 3.1.10
-  resolution: "ejs@npm:3.1.10"
-  dependencies:
-    jake: "npm:^10.8.5"
-  bin:
-    ejs: bin/cli.js
-  checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.4.251":
   version: 1.4.284
   resolution: "electron-to-chromium@npm:1.4.284"
@@ -4179,92 +3984,6 @@ __metadata:
     es6-iterator: "npm:^2.0.3"
     es6-symbol: "npm:^3.1.1"
   checksum: 10c0/460932be9542473dbbddd183e21c15a66cfec1b2c17dae2b514e190d6fb2896b7eb683783d4b36da036609d2e1c93d2815f21b374dfccaf02a8978694c2f7b67
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:~0.25.0":
-  version: 0.25.3
-  resolution: "esbuild@npm:0.25.3"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.3"
-    "@esbuild/android-arm": "npm:0.25.3"
-    "@esbuild/android-arm64": "npm:0.25.3"
-    "@esbuild/android-x64": "npm:0.25.3"
-    "@esbuild/darwin-arm64": "npm:0.25.3"
-    "@esbuild/darwin-x64": "npm:0.25.3"
-    "@esbuild/freebsd-arm64": "npm:0.25.3"
-    "@esbuild/freebsd-x64": "npm:0.25.3"
-    "@esbuild/linux-arm": "npm:0.25.3"
-    "@esbuild/linux-arm64": "npm:0.25.3"
-    "@esbuild/linux-ia32": "npm:0.25.3"
-    "@esbuild/linux-loong64": "npm:0.25.3"
-    "@esbuild/linux-mips64el": "npm:0.25.3"
-    "@esbuild/linux-ppc64": "npm:0.25.3"
-    "@esbuild/linux-riscv64": "npm:0.25.3"
-    "@esbuild/linux-s390x": "npm:0.25.3"
-    "@esbuild/linux-x64": "npm:0.25.3"
-    "@esbuild/netbsd-arm64": "npm:0.25.3"
-    "@esbuild/netbsd-x64": "npm:0.25.3"
-    "@esbuild/openbsd-arm64": "npm:0.25.3"
-    "@esbuild/openbsd-x64": "npm:0.25.3"
-    "@esbuild/sunos-x64": "npm:0.25.3"
-    "@esbuild/win32-arm64": "npm:0.25.3"
-    "@esbuild/win32-ia32": "npm:0.25.3"
-    "@esbuild/win32-x64": "npm:0.25.3"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/127aff654310ede4e2eb232a7b1d8823f5b5d69222caf17aa7f172574a5b6b75f71ce78c6d8a40030421d7c75b784dc640de0fb1b87b7ea77ab2a1c832fa8df8
   languageName: node
   linkType: hard
 
@@ -4596,7 +4315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
@@ -4644,15 +4363,6 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     regexparam: "npm:^3.0.0"
   checksum: 10c0/015ca2c7eba304beb0df06e15399c50ed0f3e167a2b1ea218a8505c468ddeae0cfab1e5d4efcdee2a62aa17c9c8a1d8ccb5e1683b00a55e7a93bb5b31b183688
-  languageName: node
-  linkType: hard
-
-"filelist@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "filelist@npm:1.0.4"
-  dependencies:
-    minimatch: "npm:^5.0.1"
-  checksum: 10c0/426b1de3944a3d153b053f1c0ebfd02dccd0308a4f9e832ad220707a6d1f1b3c9784d6cadf6b2f68f09a57565f63ebc7bcdc913ccf8012d834f472c46e596f41
   languageName: node
   linkType: hard
 
@@ -4890,28 +4600,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.3":
-  version: 2.3.3
-  resolution: "fsevents@npm:2.3.3"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
 "fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
-  version: 2.3.3
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
@@ -4977,15 +4668,6 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
-  languageName: node
-  linkType: hard
-
-"get-tsconfig@npm:^4.7.5":
-  version: 4.10.0
-  resolution: "get-tsconfig@npm:4.10.0"
-  dependencies:
-    resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10c0/c9b5572c5118923c491c04285c73bd55b19e214992af957c502a3be0fc0043bb421386ffd45ca3433c0a7fba81221ca300479e8393960acf15d0ed4563f38a86
   languageName: node
   linkType: hard
 
@@ -5786,20 +5468,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jake@npm:^10.8.5":
-  version: 10.9.2
-  resolution: "jake@npm:10.9.2"
-  dependencies:
-    async: "npm:^3.2.3"
-    chalk: "npm:^4.0.2"
-    filelist: "npm:^1.0.4"
-    minimatch: "npm:^3.1.2"
-  bin:
-    jake: bin/cli.js
-  checksum: 10c0/c4597b5ed9b6a908252feab296485a4f87cba9e26d6c20e0ca144fb69e0c40203d34a2efddb33b3d297b8bd59605e6c1f44f6221ca1e10e69175ecbf3ff5fe31
-  languageName: node
-  linkType: hard
-
 "jest-changed-files@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-changed-files@npm:29.7.0"
@@ -6224,20 +5892,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-util@npm:29.7.0"
-  dependencies:
-    "@jest/types": "npm:^29.6.3"
-    "@types/node": "npm:*"
-    chalk: "npm:^4.0.0"
-    ci-info: "npm:^3.2.0"
-    graceful-fs: "npm:^4.2.9"
-    picomatch: "npm:^2.2.3"
-  checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
-  languageName: node
-  linkType: hard
-
 "jest-util@npm:^29.3.1":
   version: 29.3.1
   resolution: "jest-util@npm:29.3.1"
@@ -6249,6 +5903,20 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     picomatch: "npm:^2.2.3"
   checksum: 10c0/c03606c389cf6f454962e4670fcb5d346e0cef166d71a6d70cde2ffaff9a0744fbf7b0651a01ac07e5ade790e95937bcaa604601ebb4c8dbf3e4c641027e61d0
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    graceful-fs: "npm:^4.2.9"
+    picomatch: "npm:^2.2.3"
+  checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
   languageName: node
   linkType: hard
 
@@ -6732,13 +6400,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.memoize@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "lodash.memoize@npm:4.1.2"
-  checksum: 10c0/c8713e51eccc650422716a14cece1809cfe34bc5ab5e242b7f8b4e2241c2483697b971a604252807689b9dd69bfe3a98852e19a5b89d506b000b4187a1285df8
-  languageName: node
-  linkType: hard
-
 "lodash.sortby@npm:^4.7.0":
   version: 4.7.0
   resolution: "lodash.sortby@npm:4.7.0"
@@ -6836,7 +6497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.1.1, make-error@npm:^1.3.6":
+"make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
@@ -7063,21 +6724,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
   languageName: node
   linkType: hard
 
@@ -8480,13 +8132,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-pkg-maps@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "resolve-pkg-maps@npm:1.0.0"
-  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
-  languageName: node
-  linkType: hard
-
 "resolve.exports@npm:^2.0.0":
   version: 2.0.0
   resolution: "resolve.exports@npm:2.0.0"
@@ -9506,44 +9151,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.3.2":
-  version: 29.3.2
-  resolution: "ts-jest@npm:29.3.2"
-  dependencies:
-    bs-logger: "npm:^0.2.6"
-    ejs: "npm:^3.1.10"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    jest-util: "npm:^29.0.0"
-    json5: "npm:^2.2.3"
-    lodash.memoize: "npm:^4.1.2"
-    make-error: "npm:^1.3.6"
-    semver: "npm:^7.7.1"
-    type-fest: "npm:^4.39.1"
-    yargs-parser: "npm:^21.1.1"
-  peerDependencies:
-    "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/transform": ^29.0.0
-    "@jest/types": ^29.0.0
-    babel-jest: ^29.0.0
-    jest: ^29.0.0
-    typescript: ">=4.3 <6"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@jest/transform":
-      optional: true
-    "@jest/types":
-      optional: true
-    babel-jest:
-      optional: true
-    esbuild:
-      optional: true
-  bin:
-    ts-jest: cli.js
-  checksum: 10c0/84762720dbef45c1644348d67d0dcb8b7ad6369a16628c4752aceeb47f0ccdad63ae14485048b641c20ce096337a160ab816881361ef5517325bac6a5b3756e0
-  languageName: node
-  linkType: hard
-
 "ts-node@npm:10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
@@ -9619,22 +9226,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.19.4":
-  version: 4.19.4
-  resolution: "tsx@npm:4.19.4"
-  dependencies:
-    esbuild: "npm:~0.25.0"
-    fsevents: "npm:~2.3.3"
-    get-tsconfig: "npm:^4.7.5"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    tsx: dist/cli.mjs
-  checksum: 10c0/f7b8d44362343fbde1f2ecc9832d243a450e1168dd09702a545ebe5f699aa6912e45b431a54b885466db414cceda48e5067b36d182027c43b2c02a4f99d8721e
-  languageName: node
-  linkType: hard
-
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -9680,13 +9271,6 @@ __metadata:
   version: 1.4.0
   resolution: "type-fest@npm:1.4.0"
   checksum: 10c0/a3c0f4ee28ff6ddf800d769eafafcdeab32efa38763c1a1b8daeae681920f6e345d7920bf277245235561d8117dab765cb5f829c76b713b4c9de0998a5397141
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.39.1":
-  version: 4.40.1
-  resolution: "type-fest@npm:4.40.1"
-  checksum: 10c0/590cb7d4dcd3da83efe49b5b52cd041661f6fa29f18cb76650fe1fdeb4090688e92955656e9d981e606abb13d25c0418be8c6c6504d80e87fe18dc9ca0888392
   languageName: node
   linkType: hard
 
@@ -9824,7 +9408,7 @@ __metadata:
     "@types/express-session": "npm:1.18.1"
     "@types/faker": "npm:5.5.9"
     "@types/hash-sum": "npm:^1.0.0"
-    "@types/jest": "npm:^29.5.14"
+    "@types/jest": "npm:29.5.14"
     "@types/js-yaml": "npm:4.0.9"
     "@types/lodash.groupby": "npm:4.6.9"
     "@types/lodash.isequal": "npm:^4.5.8"
@@ -9915,11 +9499,9 @@ __metadata:
     stoppable: "npm:^1.1.0"
     superagent: "npm:10.2.0"
     supertest: "npm:7.0.0"
-    ts-jest: "npm:^29.3.2"
     ts-node: "npm:10.9.2"
     ts-toolbelt: "npm:^9.6.0"
     tsc-watch: "npm:6.2.1"
-    tsx: "npm:^4.19.4"
     type-is: "npm:^1.6.18"
     typescript: "npm:5.8.3"
     ulidx: "npm:^2.4.1"


### PR DESCRIPTION
Changed locally:
- **Migrations treated as CommonJS**: there's a problem with running migrations from within tests (the legacy tests that are not using the template db)
- The change above required undoing the migration of migrations to ESM. Alternatively, we could consider knex-migrate
- Added `import { jest } from '@jest/globals';` where needed

With these changes I got down to 28 test suites failures out of 345:
```shell
Test Suites: 28 failed, 317 passed, 345 total
Tests:       72 failed, 3 skipped, 2954 passed, 3029 total
Snapshots:   82 passed, 82 total
```