### PR TITLE
chore: ignore sample cdn url

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,6 +6,7 @@ www.instagram.com/getunleash
 twitter.com/getunleash
 www.java.com/*
 myoidchost.azure.com
+mycdn.com
 
 .*.unleash.host.*.com.*
 unleash.*.com/api/


### PR DESCRIPTION
This url is used as an example in a page