### PR TITLE
chore: make operator checking more ergonomic and type-ful

### DIFF
--- a/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.test.ts
+++ b/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.test.ts
@@ -1,6 +1,7 @@
 import {
     allOperators,
     inOperators,
+    isInOperator,
     stringOperators,
 } from 'constants/operators';
 import { isCaseSensitive } from './isCaseSensitive';
@@ -20,7 +21,7 @@ test('`IN` and `NOT_IN` are always case sensitive', () => {
 test('If `caseInsensitive` is true, all operators except for `IN` and `NOT_IN` are considered case insensitive', () => {
     expect(
         allOperators
-            .filter((operator) => !inOperators.includes(operator))
+            .filter((operator) => !isInOperator(operator))
             .map((operator) => isCaseSensitive(operator, true))
             .every((result) => result === false),
     ).toBe(true);
@@ -35,7 +36,9 @@ test.each([false, undefined])(
         const nonStringResults = allOperators
             .filter(
                 (operator) =>
-                    ![...stringOperators, ...inOperators].includes(operator),
+                    !(
+                        [...stringOperators, ...inOperators] as string[]
+                    ).includes(operator),
             )
             .map((operator) => isCaseSensitive(operator, caseInsensitive));
 

--- a/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.test.ts
+++ b/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.test.ts
@@ -2,6 +2,7 @@ import {
     allOperators,
     inOperators,
     isInOperator,
+    isStringOperator,
     stringOperators,
 } from 'constants/operators';
 import { isCaseSensitive } from './isCaseSensitive';
@@ -36,9 +37,7 @@ test.each([false, undefined])(
         const nonStringResults = allOperators
             .filter(
                 (operator) =>
-                    !(
-                        [...stringOperators, ...inOperators] as string[]
-                    ).includes(operator),
+                    !(isStringOperator(operator) || isInOperator(operator)),
             )
             .map((operator) => isCaseSensitive(operator, caseInsensitive));
 

--- a/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.ts
+++ b/frontend/src/component/common/ConstraintsList/ConstraintItemHeader/isCaseSensitive.ts
@@ -1,12 +1,10 @@
 import {
-    inOperators,
-    stringOperators,
+    isInOperator,
+    isStringOperator,
     type Operator,
 } from 'constants/operators';
 
 export const isCaseSensitive = (
     operator: Operator,
     caseInsensitive?: boolean,
-) =>
-    inOperators.includes(operator) ||
-    (stringOperators.includes(operator) && !caseInsensitive);
+) => isInOperator(operator) || (isStringOperator(operator) && !caseInsensitive);

--- a/frontend/src/constants/operators.test.ts
+++ b/frontend/src/constants/operators.test.ts
@@ -10,67 +10,64 @@ import {
     isSingleValueOperator,
     isStringOperator,
     multipleValueOperators,
+    newOperators,
+    numOperators,
+    semVerOperators,
+    singleValueOperators,
+    stringOperators,
     type Operator,
 } from './operators';
 
 describe('operators are correctly identified', () => {
-    const allOperatorsAre = (
-        operators: Operator[],
-        types: Array<
-            | 'date'
-            | 'in'
-            | 'multi-value'
-            | 'new'
-            | 'number'
-            | 'semver'
-            | 'single-value'
-            | 'string'
-        >,
-    ) => {
-        expect(operators.every(isDateOperator)).toBe('date' in types);
-        expect(operators.every(isInOperator)).toBe('in' in types);
-        expect(operators.every(isMultiValueOperator)).toBe(
-            'multi-value' in types,
-        );
-        expect(operators.every(isNumOperator)).toBe('number' in types);
-        expect(operators.every(isSemVerOperator)).toBe('semver' in types);
-        expect(operators.every(isSingleValueOperator)).toBe(
-            'single-value' in types,
-        );
-        expect(operators.every(isStringOperator)).toBe('string' in types);
-        expect(operators.every(isNewOperator)).toBe('new' in types);
-    };
     test('date operators', () => {
-        allOperatorsAre(dateOperators, ['date', 'single-value']);
-        expect(dateOperators.every(isDateOperator)).toBe(true);
-        expect(dateOperators.every(isInOperator)).toBe(false);
-        expect(dateOperators.every(isMultiValueOperator)).toBe(false);
-        expect(dateOperators.every(isNumOperator)).toBe(false);
-        expect(dateOperators.every(isSemVerOperator)).toBe(false);
-        expect(dateOperators.every(isSingleValueOperator)).toBe(true);
-        expect(dateOperators.every(isStringOperator)).toBe(false);
+        expectOperatorTypes(dateOperators, ['date', 'single-value', 'new']);
     });
     test('in operators', () => {
-        expect(inOperators.every(isDateOperator)).toBe(false);
-        expect(inOperators.every(isInOperator)).toBe(true);
-        expect(inOperators.every(isMultiValueOperator)).toBe(true);
-        expect(inOperators.every(isNumOperator)).toBe(false);
-        expect(inOperators.every(isSemVerOperator)).toBe(false);
-        expect(inOperators.every(isSingleValueOperator)).toBe(false);
-        expect(inOperators.every(isStringOperator)).toBe(false);
+        expectOperatorTypes(inOperators, ['in', 'multi-value']);
     });
     test('multi-value operators', () => {
-        expect(multipleValueOperators.every(isDateOperator)).toBe(false);
-        expect(multipleValueOperators.every(isInOperator)).toBe(false);
-        expect(multipleValueOperators.every(isMultiValueOperator)).toBe(true);
-        expect(multipleValueOperators.every(isNumOperator)).toBe(false);
-        expect(multipleValueOperators.every(isSemVerOperator)).toBe(false);
-        expect(multipleValueOperators.every(isSingleValueOperator)).toBe(false);
-        expect(multipleValueOperators.every(isStringOperator)).toBe(false);
+        expectOperatorTypes(multipleValueOperators, ['multi-value']);
     });
-    test('new operators', () => {});
-    test('number operators', () => {});
-    test('semver operators', () => {});
-    test('single-value operators', () => {});
-    test('string operators', () => {});
+    test('new operators', () => {
+        expectOperatorTypes(newOperators, ['new']);
+    });
+    test('number operators', () => {
+        expectOperatorTypes(numOperators, ['single-value', 'number', 'new']);
+    });
+    test('semver operators', () => {
+        expectOperatorTypes(semVerOperators, ['single-value', 'semver', 'new']);
+    });
+    test('single-value operators', () => {
+        expectOperatorTypes(singleValueOperators, ['single-value', 'new']);
+    });
+    test('string operators', () => {
+        expectOperatorTypes(stringOperators, ['multi-value', 'string', 'new']);
+    });
 });
+
+const expectOperatorTypes = (
+    operators: Operator[],
+    types: Array<
+        | 'date'
+        | 'in'
+        | 'multi-value'
+        | 'new'
+        | 'number'
+        | 'semver'
+        | 'single-value'
+        | 'string'
+    >,
+) => {
+    expect(operators.every(isDateOperator)).toBe(types.includes('date'));
+    expect(operators.every(isInOperator)).toBe(types.includes('in'));
+    expect(operators.every(isMultiValueOperator)).toBe(
+        types.includes('multi-value'),
+    );
+    expect(operators.every(isNumOperator)).toBe(types.includes('number'));
+    expect(operators.every(isSemVerOperator)).toBe(types.includes('semver'));
+    expect(operators.every(isSingleValueOperator)).toBe(
+        types.includes('single-value'),
+    );
+    expect(operators.every(isStringOperator)).toBe(types.includes('string'));
+    expect(operators.every(isNewOperator)).toBe(types.includes('new'));
+};

--- a/frontend/src/constants/operators.test.ts
+++ b/frontend/src/constants/operators.test.ts
@@ -45,29 +45,30 @@ describe('operators are correctly identified', () => {
     });
 });
 
+type OperatorCategory =
+    | 'date'
+    | 'in'
+    | 'multi-value'
+    | 'new'
+    | 'number'
+    | 'semver'
+    | 'single-value'
+    | 'string';
+
 const expectOperatorTypes = (
     operators: Operator[],
-    types: Array<
-        | 'date'
-        | 'in'
-        | 'multi-value'
-        | 'new'
-        | 'number'
-        | 'semver'
-        | 'single-value'
-        | 'string'
-    >,
+    categories: OperatorCategory[],
 ) => {
-    expect(operators.every(isDateOperator)).toBe(types.includes('date'));
-    expect(operators.every(isInOperator)).toBe(types.includes('in'));
-    expect(operators.every(isMultiValueOperator)).toBe(
-        types.includes('multi-value'),
-    );
-    expect(operators.every(isNumOperator)).toBe(types.includes('number'));
-    expect(operators.every(isSemVerOperator)).toBe(types.includes('semver'));
-    expect(operators.every(isSingleValueOperator)).toBe(
-        types.includes('single-value'),
-    );
-    expect(operators.every(isStringOperator)).toBe(types.includes('string'));
-    expect(operators.every(isNewOperator)).toBe(types.includes('new'));
+    const successfulChecks = [
+        operators.every(isDateOperator) && 'date',
+        operators.every(isInOperator) && 'in',
+        operators.every(isMultiValueOperator) && 'multi-value',
+        operators.every(isNumOperator) && 'number',
+        operators.every(isSemVerOperator) && 'semver',
+        operators.every(isSingleValueOperator) && 'single-value',
+        operators.every(isStringOperator) && 'string',
+        operators.every(isNewOperator) && 'new',
+    ].filter(Boolean);
+
+    expect(categories.toSorted()).toStrictEqual(successfulChecks.toSorted());
 };

--- a/frontend/src/constants/operators.test.ts
+++ b/frontend/src/constants/operators.test.ts
@@ -1,0 +1,76 @@
+import {
+    dateOperators,
+    inOperators,
+    isDateOperator,
+    isInOperator,
+    isMultiValueOperator,
+    isNewOperator,
+    isNumOperator,
+    isSemVerOperator,
+    isSingleValueOperator,
+    isStringOperator,
+    multipleValueOperators,
+    type Operator,
+} from './operators';
+
+describe('operators are correctly identified', () => {
+    const allOperatorsAre = (
+        operators: Operator[],
+        types: Array<
+            | 'date'
+            | 'in'
+            | 'multi-value'
+            | 'new'
+            | 'number'
+            | 'semver'
+            | 'single-value'
+            | 'string'
+        >,
+    ) => {
+        expect(operators.every(isDateOperator)).toBe('date' in types);
+        expect(operators.every(isInOperator)).toBe('in' in types);
+        expect(operators.every(isMultiValueOperator)).toBe(
+            'multi-value' in types,
+        );
+        expect(operators.every(isNumOperator)).toBe('number' in types);
+        expect(operators.every(isSemVerOperator)).toBe('semver' in types);
+        expect(operators.every(isSingleValueOperator)).toBe(
+            'single-value' in types,
+        );
+        expect(operators.every(isStringOperator)).toBe('string' in types);
+        expect(operators.every(isNewOperator)).toBe('new' in types);
+    };
+    test('date operators', () => {
+        allOperatorsAre(dateOperators, ['date', 'single-value']);
+        expect(dateOperators.every(isDateOperator)).toBe(true);
+        expect(dateOperators.every(isInOperator)).toBe(false);
+        expect(dateOperators.every(isMultiValueOperator)).toBe(false);
+        expect(dateOperators.every(isNumOperator)).toBe(false);
+        expect(dateOperators.every(isSemVerOperator)).toBe(false);
+        expect(dateOperators.every(isSingleValueOperator)).toBe(true);
+        expect(dateOperators.every(isStringOperator)).toBe(false);
+    });
+    test('in operators', () => {
+        expect(inOperators.every(isDateOperator)).toBe(false);
+        expect(inOperators.every(isInOperator)).toBe(true);
+        expect(inOperators.every(isMultiValueOperator)).toBe(true);
+        expect(inOperators.every(isNumOperator)).toBe(false);
+        expect(inOperators.every(isSemVerOperator)).toBe(false);
+        expect(inOperators.every(isSingleValueOperator)).toBe(false);
+        expect(inOperators.every(isStringOperator)).toBe(false);
+    });
+    test('multi-value operators', () => {
+        expect(multipleValueOperators.every(isDateOperator)).toBe(false);
+        expect(multipleValueOperators.every(isInOperator)).toBe(false);
+        expect(multipleValueOperators.every(isMultiValueOperator)).toBe(true);
+        expect(multipleValueOperators.every(isNumOperator)).toBe(false);
+        expect(multipleValueOperators.every(isSemVerOperator)).toBe(false);
+        expect(multipleValueOperators.every(isSingleValueOperator)).toBe(false);
+        expect(multipleValueOperators.every(isStringOperator)).toBe(false);
+    });
+    test('new operators', () => {});
+    test('number operators', () => {});
+    test('semver operators', () => {});
+    test('single-value operators', () => {});
+    test('string operators', () => {});
+});

--- a/frontend/src/constants/operators.ts
+++ b/frontend/src/constants/operators.ts
@@ -15,21 +15,21 @@ export type Operator =
     | 'SEMVER_GT'
     | 'SEMVER_LT';
 
-export const NOT_IN = 'NOT_IN';
-export const IN = 'IN';
-export const STR_ENDS_WITH = 'STR_ENDS_WITH';
-export const STR_STARTS_WITH = 'STR_STARTS_WITH';
-export const STR_CONTAINS = 'STR_CONTAINS';
-export const NUM_EQ = 'NUM_EQ';
-export const NUM_GT = 'NUM_GT';
-export const NUM_GTE = 'NUM_GTE';
-export const NUM_LT = 'NUM_LT';
-export const NUM_LTE = 'NUM_LTE';
-export const DATE_AFTER = 'DATE_AFTER';
-export const DATE_BEFORE = 'DATE_BEFORE';
-export const SEMVER_EQ = 'SEMVER_EQ';
-export const SEMVER_GT = 'SEMVER_GT';
-export const SEMVER_LT = 'SEMVER_LT';
+export const NOT_IN = 'NOT_IN' as const;
+export const IN = 'IN' as const;
+export const STR_ENDS_WITH = 'STR_ENDS_WITH' as const;
+export const STR_STARTS_WITH = 'STR_STARTS_WITH' as const;
+export const STR_CONTAINS = 'STR_CONTAINS' as const;
+export const NUM_EQ = 'NUM_EQ' as const;
+export const NUM_GT = 'NUM_GT' as const;
+export const NUM_GTE = 'NUM_GTE' as const;
+export const NUM_LT = 'NUM_LT' as const;
+export const NUM_LTE = 'NUM_LTE' as const;
+export const DATE_AFTER = 'DATE_AFTER' as const;
+export const DATE_BEFORE = 'DATE_BEFORE' as const;
+export const SEMVER_EQ = 'SEMVER_EQ' as const;
+export const SEMVER_GT = 'SEMVER_GT' as const;
+export const SEMVER_LT = 'SEMVER_LT' as const;
 
 export const allOperators: Operator[] = [
     IN,
@@ -49,39 +49,66 @@ export const allOperators: Operator[] = [
     SEMVER_LT,
 ];
 
-export const stringOperators: Operator[] = [
-    STR_CONTAINS,
-    STR_STARTS_WITH,
-    STR_ENDS_WITH,
-];
+export const stringOperators = [STR_CONTAINS, STR_STARTS_WITH, STR_ENDS_WITH];
+export type StringOperator = (typeof stringOperators)[number];
 
-export const inOperators: Operator[] = [IN, NOT_IN];
+export const inOperators = [IN, NOT_IN];
+export type InOperator = (typeof inOperators)[number];
 
-export const numOperators: Operator[] = [
-    NUM_EQ,
-    NUM_GT,
-    NUM_GTE,
-    NUM_LT,
-    NUM_LTE,
-];
+export const numOperators = [NUM_EQ, NUM_GT, NUM_GTE, NUM_LT, NUM_LTE];
+export type NumOperator = (typeof numOperators)[number];
 
-export const dateOperators: Operator[] = [DATE_BEFORE, DATE_AFTER];
+export const dateOperators = [DATE_BEFORE, DATE_AFTER];
+export type DateOperator = (typeof dateOperators)[number];
 
-export const semVerOperators: Operator[] = [SEMVER_EQ, SEMVER_GT, SEMVER_LT];
+export const semVerOperators = [SEMVER_EQ, SEMVER_GT, SEMVER_LT];
+export type SemVerOperator = (typeof semVerOperators)[number];
 
-export const singleValueOperators: Operator[] = [
+export const singleValueOperators = [
     ...semVerOperators,
     ...dateOperators,
     ...numOperators,
 ];
+export type SingleValueOperator = (typeof singleValueOperators)[number];
 
-export const multipleValueOperators: Operator[] = [
-    ...stringOperators,
-    ...inOperators,
-];
+export const multipleValueOperators = [...stringOperators, ...inOperators];
+export type MultiValueOperator = (typeof multipleValueOperators)[number];
 
-export const newOperators: Operator[] = [
+export const newOperators = [
     ...stringOperators,
     ...dateOperators,
     ...singleValueOperators,
 ];
+export type NewOperator = (typeof newOperators)[number];
+
+export const isSingleValueOperator = (
+    operator: string,
+): operator is SingleValueOperator =>
+    singleValueOperators.includes(operator as SingleValueOperator);
+
+export const isMultiValueOperator = (
+    operator: string,
+): operator is MultiValueOperator =>
+    multipleValueOperators.includes(operator as MultiValueOperator);
+
+export const isStringOperator = (
+    operator: string,
+): operator is StringOperator =>
+    stringOperators.includes(operator as StringOperator);
+
+export const isInOperator = (operator: string): operator is InOperator =>
+    inOperators.includes(operator as InOperator);
+
+export const isNumOperator = (operator: string): operator is NumOperator =>
+    numOperators.includes(operator as NumOperator);
+
+export const isDateOperator = (operator: string): operator is DateOperator =>
+    dateOperators.includes(operator as DateOperator);
+
+export const isSemVerOperator = (
+    operator: string,
+): operator is SemVerOperator =>
+    semVerOperators.includes(operator as SemVerOperator);
+
+export const isNewOperator = (operator: string): operator is NewOperator =>
+    newOperators.includes(operator as NewOperator);

--- a/frontend/src/constants/operators.ts
+++ b/frontend/src/constants/operators.ts
@@ -49,20 +49,30 @@ export const allOperators: Operator[] = [
     SEMVER_LT,
 ];
 
+const isOperator =
+    <T extends string>(operators: T[]) =>
+    (operator: string): operator is T =>
+        operators.includes(operator as T);
+
 export const stringOperators = [STR_CONTAINS, STR_STARTS_WITH, STR_ENDS_WITH];
 export type StringOperator = (typeof stringOperators)[number];
+export const isStringOperator = isOperator(stringOperators);
 
 export const inOperators = [IN, NOT_IN];
 export type InOperator = (typeof inOperators)[number];
+export const isInOperator = isOperator(inOperators);
 
 export const numOperators = [NUM_EQ, NUM_GT, NUM_GTE, NUM_LT, NUM_LTE];
 export type NumOperator = (typeof numOperators)[number];
+export const isNumOperator = isOperator(numOperators);
 
 export const dateOperators = [DATE_BEFORE, DATE_AFTER];
 export type DateOperator = (typeof dateOperators)[number];
+export const isDateOperator = isOperator(dateOperators);
 
 export const semVerOperators = [SEMVER_EQ, SEMVER_GT, SEMVER_LT];
 export type SemVerOperator = (typeof semVerOperators)[number];
+export const isSemVerOperator = isOperator(semVerOperators);
 
 export const singleValueOperators = [
     ...semVerOperators,
@@ -70,9 +80,11 @@ export const singleValueOperators = [
     ...numOperators,
 ];
 export type SingleValueOperator = (typeof singleValueOperators)[number];
+export const isSingleValueOperator = isOperator(singleValueOperators);
 
 export const multipleValueOperators = [...stringOperators, ...inOperators];
 export type MultiValueOperator = (typeof multipleValueOperators)[number];
+export const isMultiValueOperator = isOperator(multipleValueOperators);
 
 export const newOperators = [
     ...stringOperators,
@@ -80,35 +92,4 @@ export const newOperators = [
     ...singleValueOperators,
 ];
 export type NewOperator = (typeof newOperators)[number];
-
-export const isSingleValueOperator = (
-    operator: string,
-): operator is SingleValueOperator =>
-    singleValueOperators.includes(operator as SingleValueOperator);
-
-export const isMultiValueOperator = (
-    operator: string,
-): operator is MultiValueOperator =>
-    multipleValueOperators.includes(operator as MultiValueOperator);
-
-export const isStringOperator = (
-    operator: string,
-): operator is StringOperator =>
-    stringOperators.includes(operator as StringOperator);
-
-export const isInOperator = (operator: string): operator is InOperator =>
-    inOperators.includes(operator as InOperator);
-
-export const isNumOperator = (operator: string): operator is NumOperator =>
-    numOperators.includes(operator as NumOperator);
-
-export const isDateOperator = (operator: string): operator is DateOperator =>
-    dateOperators.includes(operator as DateOperator);
-
-export const isSemVerOperator = (
-    operator: string,
-): operator is SemVerOperator =>
-    semVerOperators.includes(operator as SemVerOperator);
-
-export const isNewOperator = (operator: string): operator is NewOperator =>
-    newOperators.includes(operator as NewOperator);
+export const isNewOperator = isOperator(newOperators);


### PR DESCRIPTION
This is a helper PR for a refactor I'm working on for the new constraint inputs. In the refactoring, it's useful to have individual subtypes for the various subgroups of operators and to be able to easily assert whether something is X operator or not.

The only change required in the code base is a single check for operators, which is now handled by using the new `isXOperator` functions instead.

Yes, the operator file in constants now includes functions, but it seemed useful to put the identification functions there instead of somewhere unrelated. The tests are primarily to ensure that the identifier function works, and I'd be happy to remove them if we think it's necessary. That said, they're pretty simple unit tests, so I think it's fine to leave them.

The main bulk of the change is: removing the explicit `: Operator[]` typing to the various sub-sets of operators and instead adding explicit types. Additionally, there's the new identifier functions.