### PR TITLE
chore: undeprecate custom strategies

### DIFF
--- a/src/lib/routes/admin-api/strategy.ts
+++ b/src/lib/routes/admin-api/strategy.ts
@@ -122,12 +122,11 @@ class StrategyController extends Controller {
             permission: CREATE_STRATEGY,
             middleware: [
                 openApiService.validPath({
-                    deprecated: true,
                     tags: ['Strategies'],
                     operationId: 'createStrategy',
                     summary: 'Create a strategy',
                     description:
-                        'Creates a custom strategy type based on the supplied data. Custom strategies are deprecated and should not be used. Prefer using built in strategies with constraints instead.',
+                        'Creates a custom strategy type based on the supplied data.',
                     requestBody: createRequestSchema('createStrategySchema'),
                     responses: {
                         201: resourceCreatedResponseSchema('strategySchema'),

--- a/website/docs/reference/activation-strategies.md
+++ b/website/docs/reference/activation-strategies.md
@@ -158,14 +158,12 @@ If the constraint uses a standard Unleash context field, set the context field t
 
 Unleash SDKs expect all context values to be strings. If you use an operator that acts on non-string values, such as [numeric operators](#numeric-operators) or [date and time operators](#date-and-time-operators), the SDKs attempt to convert the string into the expected type. If the conversion fails, the constraint evaluates to `false`.
 
+## Custom activation strategies
+
+[Custom activation strategies](/reference/custom-activation-strategies)
+
 ## Predefined strategy types
 
 :::caution
 [Predefined strategy types](/reference/predefined-strategy-types), such as UserIDs, IPs, and Hosts are a legacy implementation. Please use the default strategy with constraints to achieve your desired targeting.
-:::
-
-## Custom activation strategies
-
-:::caution
-[Custom activation strategies](/reference/custom-activation-strategies) are deprecated. Please use the default strategy with constraints.
 :::

--- a/website/docs/reference/custom-activation-strategies.md
+++ b/website/docs/reference/custom-activation-strategies.md
@@ -2,10 +2,6 @@
 title: Custom Activation Strategies
 ---
 
-:::caution
-[Custom activation strategies](/reference/custom-activation-strategies) are deprecated. Please use the [default activation strategy](/reference/activation-strategies) with constraints.
-:::
-
 **Custom activation strategies** let you define your own activation strategies to use with Unleash. When the [built-in activation strategies](../reference/activation-strategies.md) aren't enough, custom activation strategies are there to provide you with the flexibility you need.
 
 Custom activation strategies work exactly like the built-in activation strategies when working in the admin UI.


### PR DESCRIPTION
Removes the deprecation notice on custom strategies, also removes these notices from docs