### PR TITLE
chore: prevent duplicate key errors in unknown flags

### DIFF
--- a/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
@@ -36,7 +36,7 @@ export class UnknownFlagsStore implements IUnknownFlagsStore {
                 await tx(TABLE)
                     .insert(rows)
                     .onConflict(['name', 'app_name'])
-                    .merge();
+                    .merge(['seen_at']);
             }
         });
     }

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
@@ -33,7 +33,10 @@ export class UnknownFlagsStore implements IUnknownFlagsStore {
                     app_name: flag.appName,
                     seen_at: flag.seenAt,
                 }));
-                await tx(TABLE).insert(rows);
+                await tx(TABLE)
+                    .insert(rows)
+                    .onConflict(['name', 'app_name'])
+                    .merge();
             }
         });
     }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3561/fix-duplicate-key-errors-in-unknown-flags

This should prevent `duplicate_key` errors in unknown flags.

Follow-up to: https://github.com/Unleash/unleash/pull/9837