### PR TITLE
refactor: remove deprecated post project role access endpoint

### DIFF
--- a/frontend/cypress/support/API.ts
+++ b/frontend/cypress/support/API.ts
@@ -105,10 +105,10 @@ export const addUserToProject_API = (
     const project = projectName || 'default';
     return cy.request(
         'POST',
-        `${baseUrl}/api/admin/projects/${project}/role/${role}/access`,
+        `${baseUrl}/api/admin/projects/${project}/access`,
         {
-            groups: [],
-            users: [{ id }],
+            roles: [role],
+            users: [id],
         },
     );
 };

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -843,6 +843,9 @@ export default class ProjectService {
         );
     }
 
+    /**
+     * @deprecated use `addAccess` instead
+     */
     async addRoleAccess(
         projectId: string,
         roleId: number,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3363/remove-post-apiadminprojectsprojectidroleroleidaccess-deprecated-in

Removes POST `/api/admin/projects/{projectId}/role/{roleId}/access` which was deprecated in v5.5.
Also cleans up related code.

Needs follow up PRs.