### PR TITLE
chore: remove filterExistingFlagNames feature flag

### DIFF
--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -363,7 +363,7 @@ test('should store frontend api client metrics', async () => {
 
     // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
-        .fn()
+        .fn<() => Promise<string[]>>()
         .mockResolvedValue([featureName]);
 
     await app.request

--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -360,6 +360,12 @@ test('should store frontend api client metrics', async () => {
         projects: ['*'],
         environment: '*',
     });
+
+    // @ts-expect-error
+    app.services.clientMetricsServiceV2.cachedFeatureNames = jest
+        .fn()
+        .mockResolvedValue([featureName]);
+
     await app.request
         .get(`/api/admin/client-metrics/features/${featureName}`)
         .set('Authorization', adminToken.secret)

--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -361,7 +361,7 @@ test('should store frontend api client metrics', async () => {
         environment: '*',
     });
 
-    // @ts-expect-error
+    // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
         .fn()
         .mockResolvedValue([featureName]);

--- a/src/lib/features/metrics/client-metrics/fake-client-metrics-store-v2.ts
+++ b/src/lib/features/metrics/client-metrics/fake-client-metrics-store-v2.ts
@@ -19,7 +19,7 @@ export default class FakeClientMetricsStoreV2
     }
 
     getFeatureFlagNames(): Promise<string[]> {
-        throw new Error('Method not implemented.');
+        return Promise.resolve([]);
     }
 
     getSeenTogglesForApp(

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
@@ -57,7 +57,7 @@ test('process metrics properly', async () => {
         initClientMetrics();
 
     stores.clientMetricsStoreV2.getFeatureFlagNames = jest
-        .fn()
+        .fn<() => Promise<string[]>>()
         .mockResolvedValue(['myCoolToggle', 'myOtherToggle']);
 
     await clientMetricsService.registerClientMetrics(

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -20,7 +20,6 @@ export type IFlagKey =
     | 'disableBulkToggle'
     | 'advancedPlayground'
     | 'filterInvalidClientMetrics'
-    | 'filterExistingFlagNames'
     | 'disableMetrics'
     | 'signals'
     | 'automatedActions'
@@ -115,10 +114,6 @@ const flags: IFlags = {
         false,
     ),
     filterInvalidClientMetrics: parseEnvVarBoolean(
-        process.env.FILTER_INVALID_CLIENT_METRICS,
-        false,
-    ),
-    filterExistingFlagNames: parseEnvVarBoolean(
         process.env.FILTER_INVALID_CLIENT_METRICS,
         false,
     ),

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -50,7 +50,6 @@ process.nextTick(async () => {
                         showUserDeviceCount: true,
                         deltaApi: true,
                         uniqueSdkTracking: true,
-                        filterExistingFlagNames: true,
                         teamsIntegrationChangeRequests: true,
                         addEditStrategy: true,
                         flagsOverviewSearch: true,

--- a/src/test/e2e/api/client/metrics.access.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.access.e2e.test.ts
@@ -39,7 +39,7 @@ test('should enrich metrics with environment from api-token', async () => {
     });
 
     const featureName = Object.keys(metricsExample.bucket.toggles)[0];
-    // @ts-expect-error
+    // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
         .fn()
         .mockResolvedValue([featureName]);

--- a/src/test/e2e/api/client/metrics.access.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.access.e2e.test.ts
@@ -9,6 +9,8 @@ import dbInit, { type ITestDb } from '../../helpers/database-init.js';
 import getLogger from '../../../fixtures/no-logger.js';
 import { ApiTokenType } from '../../../../lib/types/model.js';
 
+import { jest } from '@jest/globals';
+
 let app: IUnleashTest;
 let db: ITestDb;
 
@@ -41,7 +43,7 @@ test('should enrich metrics with environment from api-token', async () => {
     const featureName = Object.keys(metricsExample.bucket.toggles)[0];
     // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
-        .fn()
+        .fn<() => Promise<string[]>>()
         .mockResolvedValue([featureName]);
 
     await app.request

--- a/src/test/e2e/api/client/metrics.access.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.access.e2e.test.ts
@@ -38,6 +38,12 @@ test('should enrich metrics with environment from api-token', async () => {
         project: '*',
     });
 
+    const featureName = Object.keys(metricsExample.bucket.toggles)[0];
+    // @ts-expect-error
+    app.services.clientMetricsServiceV2.cachedFeatureNames = jest
+        .fn()
+        .mockResolvedValue([featureName]);
+
     await app.request
         .post('/api/client/metrics')
         .set('Authorization', token.secret)

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -10,6 +10,8 @@ import getLogger from '../../../fixtures/no-logger.js';
 import { ApiTokenType, type IApiToken } from '../../../../lib/types/model.js';
 import { TEST_AUDIT_USER } from '../../../../lib/types/index.js';
 
+import { jest } from '@jest/globals';
+
 let app: IUnleashTest;
 let db: ITestDb;
 
@@ -83,7 +85,7 @@ test('should pick up environment from token', async () => {
 
     // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
-        .fn()
+        .fn<() => Promise<string[]>>()
         .mockResolvedValue(['test']);
 
     await app.request
@@ -126,7 +128,7 @@ test('should set lastSeen for toggles with metrics both for toggle and toggle en
 
     // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
-        .fn()
+        .fn<() => Promise<string[]>>()
         .mockResolvedValue(['t1', 't2']);
 
     const token = await app.services.apiTokenService.createApiToken({

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -124,6 +124,11 @@ test('should set lastSeen for toggles with metrics both for toggle and toggle en
         TEST_AUDIT_USER,
     );
 
+    // @ts-expect-error
+    app.services.clientMetricsServiceV2.cachedFeatureNames = jest
+        .fn()
+        .mockResolvedValue(['t1', 't2']);
+
     const token = await app.services.apiTokenService.createApiToken({
         type: ApiTokenType.CLIENT,
         project: 'default',

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -81,7 +81,7 @@ test('should pick up environment from token', async () => {
         tokenName: 'tester',
     });
 
-    // @ts-expect-error
+    // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
         .fn()
         .mockResolvedValue(['test']);
@@ -124,7 +124,7 @@ test('should set lastSeen for toggles with metrics both for toggle and toggle en
         TEST_AUDIT_USER,
     );
 
-    // @ts-expect-error
+    // @ts-expect-error - cachedFeatureNames is a private property in ClientMetricsServiceV2
     app.services.clientMetricsServiceV2.cachedFeatureNames = jest
         .fn()
         .mockResolvedValue(['t1', 't2']);

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -81,6 +81,12 @@ test('should pick up environment from token', async () => {
         tokenName: 'tester',
     });
 
+    await app.services.featureToggleService.createFeatureToggle(
+        'default',
+        { name: 'test' },
+        TEST_AUDIT_USER,
+    );
+
     await app.request
         .post('/api/client/metrics')
         .set('Authorization', token.secret)

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -81,11 +81,10 @@ test('should pick up environment from token', async () => {
         tokenName: 'tester',
     });
 
-    await app.services.featureToggleService.createFeatureToggle(
-        'default',
-        { name: 'test' },
-        TEST_AUDIT_USER,
-    );
+    // @ts-expect-error
+    app.services.clientMetricsServiceV2.cachedFeatureNames = jest
+        .fn()
+        .mockResolvedValue(['test']);
 
     await app.request
         .post('/api/client/metrics')


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3564/remove-filterexistingflagnames-feature-flag

We're removing the `filterExistingFlagNames` feature flag since we've decided we want this to be the default behavior.

We don't need to rush to merge it, just in case we need to disable this for any reason. However it should also be pretty easy to just revert if needed.

Changes in tests are a bit tricky since they assumed the previous behavior where we always registered metrics, even for non existing flag names. `cachedFeatureNames` is also memoized with a TTL of 10s, so the easiest way to overcome this was to override `cachedFeatureNames` to return what we expected. As long as they return the same flag names that we expect, we're able to register their metrics.

Let me know if you can think of a better approach.