### PR TITLE
chore: remove proxy from integrations

### DIFF
--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
@@ -150,15 +150,6 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                         link='/integrations/view/edge'
                         configureActionText='Learn more'
                     />
-                    <IntegrationCard
-                        icon='unleash'
-                        title='Unleash Proxy'
-                        description='The Unleash Proxy is a lightweight, stateless proxy that sits between your Unleash client SDKs and the Unleash API.'
-                        link='https://docs.getunleash.io/reference/unleash-proxy'
-                        configureActionText='View documentation'
-                        deprecated='Try Unleash Edge instead. It has all the features of Unleash Proxy and more.'
-                        isExternal
-                    />
                 </StyledCardsGrid>
             </StyledSection>
             <StyledSection>

--- a/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
+++ b/frontend/src/component/menu/Footer/ApiDetails/ApiDetails.tsx
@@ -17,13 +17,17 @@ export const ApiDetails = (props: IApiDetailsProps): ReactElement => {
     const { environment, billing } = props.uiConfig;
     const updateNotification = formatUpdateNotification(props.uiConfig);
 
-    const buildInfo = buildNumber ? <small>({buildNumber})</small> : '';
+    const displayVersion = buildNumber ? (
+        <small>build {buildNumber}</small>
+    ) : (
+        version
+    );
     return (
         <section title='API details'>
             <FooterTitle>
                 {name} {environment ? environment : ''}
-                {billing === 'pay-as-you-go' ? ' Pay-as-You-Go' : ''} {version}{' '}
-                {buildInfo}
+                {billing === 'pay-as-you-go' ? ' Pay-as-You-Go' : ''}{' '}
+                {displayVersion}
             </FooterTitle>
             <ConditionallyRender
                 condition={Boolean(updateNotification)}

--- a/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/ApiDetails/__snapshots__/ApiDetails.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`renders correctly with empty version 1`] = `
          
         test
          
-         
       </h2>
       <br />
       <small>
@@ -46,7 +45,6 @@ exports[`renders correctly with ui-config 1`] = `
         test
          
         1.1.0
-         
       </h2>
       <br />
       <small>
@@ -78,7 +76,6 @@ exports[`renders correctly with versionInfo 1`] = `
          
          
         1.2.3
-         
       </h2>
       <small>
         Upgrade available - Latest Enterprise release: 1.2.4
@@ -115,7 +112,6 @@ exports[`renders correctly without uiConfig 1`] = `
          
          
         1.1.0
-         
       </h2>
       <br />
       <small />

--- a/frontend/src/component/menu/Footer/Footer.tsx
+++ b/frontend/src/component/menu/Footer/Footer.tsx
@@ -182,19 +182,6 @@ export const Footer: VFC = () => {
                                         <ListItemText
                                             primary={
                                                 <a
-                                                    href='https://docs.getunleash.io/reference/unleash-proxy'
-                                                    target='_blank'
-                                                    rel='noreferrer'
-                                                >
-                                                    Unleash Proxy
-                                                </a>
-                                            }
-                                        />
-                                    </StyledListItem>
-                                    <StyledListItem>
-                                        <ListItemText
-                                            primary={
-                                                <a
                                                     href='https://docs.getunleash.io/reference/sdks/javascript-browser'
                                                     target='_blank'
                                                     rel='noreferrer'

--- a/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/frontend/src/component/menu/Footer/__snapshots__/Footer.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`should render DrawerMenu 1`] = `
              
              
             5.x
-             
           </h2>
           <br />
           <small>
@@ -255,26 +254,6 @@ exports[`should render DrawerMenu 1`] = `
               <ul
                 className="MuiList-root MuiList-padding MuiList-dense css-zin4jp-MuiList-root"
               >
-                <li
-                  className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-rw9v7e-MuiListItem-root"
-                  disabled={false}
-                >
-                  <div
-                    className="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-                  >
-                    <span
-                      className="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-1f1ka7g-MuiTypography-root"
-                    >
-                      <a
-                        href="https://docs.getunleash.io/reference/unleash-proxy"
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Unleash Proxy
-                      </a>
-                    </span>
-                  </div>
-                </li>
                 <li
                   className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-rw9v7e-MuiListItem-root"
                   disabled={false}
@@ -573,7 +552,6 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
              
              
             5.x
-             
           </h2>
           <br />
           <small>
@@ -802,26 +780,6 @@ exports[`should render DrawerMenu with "features" selected 1`] = `
               <ul
                 className="MuiList-root MuiList-padding MuiList-dense css-zin4jp-MuiList-root"
               >
-                <li
-                  className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-rw9v7e-MuiListItem-root"
-                  disabled={false}
-                >
-                  <div
-                    className="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
-                  >
-                    <span
-                      className="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-1f1ka7g-MuiTypography-root"
-                    >
-                      <a
-                        href="https://docs.getunleash.io/reference/unleash-proxy"
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Unleash Proxy
-                      </a>
-                    </span>
-                  </div>
-                </li>
                 <li
                   className="MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding css-rw9v7e-MuiListItem-root"
                   disabled={false}


### PR DESCRIPTION
Removing proxy from integrations as it's been deprecated while ago and currently unmaintained