### PR TITLE
Test(1-3733): get invalid and deleted legal values

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.test.ts
@@ -13,8 +13,8 @@ test('should return deleted legal values', () => {
 
 test('should return invalid legal values', () => {
     const invalidLegalValues = getInvalidLegalValues(
-        [{ value: 'A' }, { value: 'B' }],
         (value: string) => value === 'B',
+        [{ value: 'A' }, { value: 'B' }],
     );
     expect([...invalidLegalValues]).toEqual(['A']);
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.test.ts
@@ -1,0 +1,20 @@
+import {
+    getDeletedLegalValues,
+    getInvalidLegalValues,
+} from './legal-value-functions';
+
+test('should return deleted legal values', () => {
+    const deletedLegalValues = getDeletedLegalValues(
+        [{ value: 'A' }, { value: 'B' }],
+        ['A', 'C'],
+    );
+    expect([...deletedLegalValues]).toStrictEqual(['C']);
+});
+
+test('should return invalid legal values', () => {
+    const invalidLegalValues = getInvalidLegalValues(
+        [{ value: 'A' }, { value: 'B' }],
+        (value: string) => value === 'B',
+    );
+    expect([...invalidLegalValues]).toEqual(['A']);
+});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.ts
@@ -1,0 +1,25 @@
+import type { ILegalValue } from 'interfaces/context';
+import { difference } from './set-functions';
+
+export const getDeletedLegalValues = (
+    allLegalValues: ILegalValue[],
+    selectedLegalValues: string[],
+): Set<string> => {
+    const currentLegalValues = new Set(
+        allLegalValues.map(({ value }) => value),
+    );
+    const deletedValues = difference(selectedLegalValues, currentLegalValues);
+
+    return deletedValues;
+};
+
+export const getInvalidLegalValues = (
+    allLegalValues: ILegalValue[],
+    validate: (value: string) => boolean,
+): Set<string> => {
+    return new Set(
+        allLegalValues
+            .filter(({ value }) => !validate(value))
+            .map(({ value }) => value),
+    );
+};

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/legal-value-functions.ts
@@ -14,8 +14,8 @@ export const getDeletedLegalValues = (
 };
 
 export const getInvalidLegalValues = (
-    allLegalValues: ILegalValue[],
     validate: (value: string) => boolean,
+    allLegalValues: ILegalValue[],
 ): Set<string> => {
     return new Set(
         allLegalValues

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -108,8 +108,8 @@ export const useEditableConstraint = (
             isSingleValueConstraint(localConstraint)
         ) {
             return getInvalidLegalValues(
-                contextDefinition.legalValues,
                 (value) => validator(value)[0],
+                contextDefinition.legalValues,
             );
         }
         return undefined;

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -20,7 +20,10 @@ import {
     type ConstraintValidationResult,
     constraintValidator,
 } from './constraint-validator';
-import { difference } from './set-functions';
+import {
+    getDeletedLegalValues,
+    getInvalidLegalValues,
+} from './legal-value-functions';
 
 const resolveContextDefinition = (
     context: IUnleashContextDefinition[],
@@ -88,16 +91,10 @@ export const useEditableConstraint = (
             contextDefinition.legalValues?.length &&
             constraint.values?.length
         ) {
-            // todo: extract and test
-            const currentLegalValues = new Set(
-                contextDefinition.legalValues.map(({ value }) => value),
-            );
-            const deletedValues = difference(
+            return getDeletedLegalValues(
+                contextDefinition.legalValues,
                 constraint.values,
-                currentLegalValues,
             );
-
-            return deletedValues;
         }
         return undefined;
     }, [
@@ -110,11 +107,9 @@ export const useEditableConstraint = (
             contextDefinition.legalValues?.length &&
             isSingleValueConstraint(localConstraint)
         ) {
-            // todo: extract and test
-            return new Set(
-                contextDefinition.legalValues
-                    .filter(({ value }) => !validator(value)[0])
-                    .map(({ value }) => value),
+            return getInvalidLegalValues(
+                contextDefinition.legalValues,
+                (value) => validator(value)[0],
             );
         }
         return undefined;


### PR DESCRIPTION
Extracts and tests the implementation of the functions to get deleted and invalid legal values.

This is pretty straightforward stuff and arguably not crucial, but it was an easy place to start and I don't think it hurts to have these in place anyway.