### PR TITLE
test(1-3734): test constraint reducer

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -156,7 +156,7 @@ const TopRowInput: FC<{
             <ConstraintDateInput
                 setValue={(value: string) =>
                     updateConstraint({
-                        type: 'set value',
+                        type: 'add value(s)',
                         payload: value,
                     })
                 }
@@ -171,7 +171,7 @@ const TopRowInput: FC<{
                 validator={validator}
                 onAddValue={(newValue) => {
                     updateConstraint({
-                        type: 'set value',
+                        type: 'add value(s)',
                         payload: newValue,
                     });
                 }}
@@ -188,7 +188,7 @@ const TopRowInput: FC<{
                 validator={validator}
                 onAddValue={(newValue) => {
                     updateConstraint({
-                        type: 'set value',
+                        type: 'add value(s)',
                         payload: newValue,
                     });
                 }}
@@ -338,17 +338,10 @@ export const EditableConstraint: FC<Props> = ({
                                   : undefined
                         }
                         removeValue={(value) => {
-                            if (isMultiValueConstraint(localConstraint)) {
-                                updateConstraint({
-                                    type: 'remove value',
-                                    payload: value,
-                                });
-                            } else {
-                                updateConstraint({
-                                    type: 'set value',
-                                    payload: '',
-                                });
-                            }
+                            updateConstraint({
+                                type: 'remove value',
+                                payload: value,
+                            });
                         }}
                         getExternalFocusTarget={() =>
                             addValuesButtonRef.current ??
@@ -412,7 +405,7 @@ export const EditableConstraint: FC<Props> = ({
                             }
                             addValue={(newValues) =>
                                 updateConstraint({
-                                    type: 'set value',
+                                    type: 'add value(s)',
                                     payload: newValues,
                                 })
                             }

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -340,7 +340,7 @@ export const EditableConstraint: FC<Props> = ({
                         removeValue={(value) => {
                             if (isMultiValueConstraint(localConstraint)) {
                                 updateConstraint({
-                                    type: 'remove value from list',
+                                    type: 'remove value',
                                     payload: value,
                                 });
                             } else {
@@ -396,7 +396,7 @@ export const EditableConstraint: FC<Props> = ({
                             }
                             removeValue={(value) =>
                                 updateConstraint({
-                                    type: 'remove value from list',
+                                    type: 'remove value',
                                     payload: value,
                                 })
                             }

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -338,12 +338,64 @@ describe('adding values', () => {
 });
 describe('removing / clearing values', () => {
     describe('single-value constraints', () => {
-        test('removing a value removes the existing value if it matches', () => {});
-        test('clearing a value removes the existing value', () => {});
+        test('removing a value removes the existing value if it matches', () => {
+            const input = singleValueConstraint('context-field');
+            const noChange = constraintReducer(input, {
+                type: 'remove value',
+                payload: '55422b90-9bc4-4847-8a61-17fc928069ff',
+            });
+            expect(noChange).toStrictEqual(input);
+
+            const removed = constraintReducer(input, {
+                type: 'remove value',
+                payload: input.value,
+            });
+
+            expect(removed).toStrictEqual({ ...input, value: '' });
+        });
+        test('clearing a value removes the existing value', () => {
+            const input = singleValueConstraint('context-field');
+            const cleared = constraintReducer(input, {
+                type: 'clear values',
+            });
+
+            expect(cleared).toStrictEqual({ ...input, value: '' });
+        });
     });
     describe('multi-value constraints', () => {
-        test('removing a value removes it from the set', () => {});
-        test('clearing values removes all values from the set', () => {});
+        test('removing a value removes it from the set if it exists', () => {
+            const values = ['A', 'B', 'C'];
+            const input = {
+                ...multiValueConstraint('context-field'),
+                values: new Set(values),
+            };
+            const noChange = constraintReducer(input, {
+                type: 'remove value',
+                payload: '55422b90-9bc4-4847-8a61-17fc928069ff',
+            });
+            expect(noChange).toStrictEqual(input);
+
+            const removed = constraintReducer(input, {
+                type: 'remove value',
+                payload: 'B',
+            });
+
+            expect(removed).toStrictEqual({
+                ...input,
+                values: new Set(['A', 'C']),
+            });
+        });
+        test('clearing values removes all values from the set', () => {
+            const input = multiValueConstraint('context-field');
+            const cleared = constraintReducer(input, {
+                type: 'clear values',
+            });
+
+            expect(cleared).toStrictEqual({
+                ...input,
+                values: new Set(),
+            });
+        });
     });
 });
 describe('toggle options', () => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -216,8 +216,9 @@ describe('changing operator', () => {
                 type: 'set operator',
                 payload: operatorB,
             });
-            // @ts-expect-error
-            expect(input.value).toBe(output.value);
+            expect(input.value).toBe(
+                (output as EditableSingleValueConstraint).value,
+            );
         },
     );
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -1,9 +1,37 @@
 describe('changing context field', () => {
     test('changing context field to the same field is a no-op', () => {});
+    test('changing context field to anything except currentTime clears value/values', () => {});
 });
 describe('changing operator', () => {
     test('changing operator to the same operator field is a no-op', () => {});
+    test("changing the operator to anything that isn't date based clears the value", () => {});
+    test('changing the operator to a non-date operator to a date operator sets the value to the current time', () => {});
+    test('changing the operator from one date operator to another date operator leaves the value untouched', () => {});
 });
-describe('adding values', () => {});
-describe('clearing values', () => {});
-describe('toggle options', () => {});
+describe('adding values', () => {
+    describe('single-value constraints', () => {
+        test('adding a value replaces the existing value', () => {});
+    });
+    describe('multi-value constraints', () => {
+        test('adding a value to a multi-value constraint adds it to the set', () => {});
+        test('adding a value to a multi-value constraint adds it to the list', () => {});
+    });
+});
+describe('removing / clearing values', () => {
+    describe('single-value constraints', () => {
+        test('removing a value removes the existing value if it matches', () => {});
+        test('clearing a value removes the existing value', () => {});
+    });
+    describe('multi-value constraints', () => {
+        test('removing a value removes it from the set', () => {});
+        test('clearing values removes all values from the set', () => {});
+    });
+});
+describe('toggle options', () => {
+    test('case sensitivity', () => {});
+});
+
+describe('match inversion / inclusive/exclusive operator (`constraint.inverted`)', () => {
+    test('match inversion', () => {});
+    test('inverting the operator does not affect selected values', () => {});
+});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -293,12 +293,47 @@ describe('adding values', () => {
             });
             expect(output).toStrictEqual({
                 ...input,
-                value: new Set([...input.values, 'new-value']),
+                values: new Set([...input.values, 'new-value']),
             });
         });
-        test('adding a list to a multi-value constraint adds all new elements to the set', () => {});
-        test('adding an empty list to a multi-value constraint has no effect', () => {});
-        test('deleted legal values are removed from the set upon saving new values', () => {});
+        test('adding a list to a multi-value constraint adds all new elements to the set', () => {
+            const input = multiValueConstraint('context-field');
+            const output = constraintReducer(input, {
+                type: 'add value(s)',
+                payload: ['X', 'Y'],
+            });
+            expect(output).toStrictEqual({
+                ...input,
+                values: new Set([...input.values, 'X', 'Y']),
+            });
+        });
+        test('adding an empty list to a multi-value constraint has no effect', () => {
+            const input = multiValueConstraint('context-field');
+            const output = constraintReducer(input, {
+                type: 'add value(s)',
+                payload: [],
+            });
+            expect(output).toStrictEqual(input);
+        });
+
+        test('deleted legal values are removed from the set before saving new values', () => {
+            const input = {
+                ...multiValueConstraint('context-field'),
+                values: new Set(['deleted-old', 'A']),
+            };
+            const output = constraintReducer(
+                input,
+                {
+                    type: 'add value(s)',
+                    payload: ['deleted-new', 'B'],
+                },
+                new Set(['deleted-old', 'deleted-new']),
+            );
+            expect(output).toStrictEqual({
+                ...input,
+                values: new Set(['A', 'B']),
+            });
+        });
     });
 });
 describe('removing / clearing values', () => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -1,0 +1,9 @@
+describe('changing context field', () => {
+    test('changing context field to the same field is a no-op', () => {});
+});
+describe('changing operator', () => {
+    test('changing operator to the same operator field is a no-op', () => {});
+});
+describe('adding values', () => {});
+describe('clearing values', () => {});
+describe('toggle options', () => {});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -399,74 +399,40 @@ describe('removing / clearing values', () => {
     });
 });
 describe('toggle options', () => {
-    test('case sensitivity', () => {
-        const { caseInsensitive, ...input } =
-            multiValueConstraint('context-field');
-        expect(
-            constraintReducer(input, {
-                type: 'toggle case sensitivity',
-            }),
-        ).toStrictEqual({
-            ...input,
-            caseInsensitive: true,
-        });
-        expect(
-            constraintReducer(
-                { ...input, caseInsensitive },
-                {
+    const stateTransitions = [
+        [undefined, true],
+        [true, false],
+        [false, true],
+    ];
+    test.each(stateTransitions)(
+        'toggle case sensitivity: %s -> %s',
+        (from, to) => {
+            const input = {
+                ...multiValueConstraint('context-field'),
+                caseInsensitive: from,
+            };
+            expect(
+                constraintReducer(input, {
                     type: 'toggle case sensitivity',
-                },
-            ),
-        ).toStrictEqual({
-            ...input,
-            caseInsensitive: !caseInsensitive,
-        });
-        expect(
-            constraintReducer(
-                { ...input, caseInsensitive: !caseInsensitive },
-                {
-                    type: 'toggle case sensitivity',
-                },
-            ),
-        ).toStrictEqual({
-            ...input,
-            caseInsensitive: caseInsensitive,
-        });
-    });
-});
-
-describe('match inversion / inclusive/exclusive operator (`constraint.inverted`)', () => {
-    test('match inversion', () => {
-        const { inverted, ...input } = multiValueConstraint('context-field');
+                }),
+            ).toStrictEqual({
+                ...input,
+                caseInsensitive: to,
+            });
+        },
+    );
+    test.each(stateTransitions)('match inversion: %s -> %s', (from, to) => {
+        const input = {
+            ...multiValueConstraint('context-field'),
+            inverted: from,
+        };
         expect(
             constraintReducer(input, {
                 type: 'toggle inverted operator',
             }),
         ).toStrictEqual({
             ...input,
-            inverted: true,
-        });
-        expect(
-            constraintReducer(
-                { ...input, inverted },
-                {
-                    type: 'toggle inverted operator',
-                },
-            ),
-        ).toStrictEqual({
-            ...input,
-            inverted: !inverted,
-        });
-        expect(
-            constraintReducer(
-                { ...input, inverted: !inverted },
-                {
-                    type: 'toggle inverted operator',
-                },
-            ),
-        ).toStrictEqual({
-            ...input,
-            inverted: inverted,
+            inverted: to,
         });
     });
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -399,10 +399,74 @@ describe('removing / clearing values', () => {
     });
 });
 describe('toggle options', () => {
-    test('case sensitivity', () => {});
+    test('case sensitivity', () => {
+        const { caseInsensitive, ...input } =
+            multiValueConstraint('context-field');
+        expect(
+            constraintReducer(input, {
+                type: 'toggle case sensitivity',
+            }),
+        ).toStrictEqual({
+            ...input,
+            caseInsensitive: true,
+        });
+        expect(
+            constraintReducer(
+                { ...input, caseInsensitive },
+                {
+                    type: 'toggle case sensitivity',
+                },
+            ),
+        ).toStrictEqual({
+            ...input,
+            caseInsensitive: !caseInsensitive,
+        });
+        expect(
+            constraintReducer(
+                { ...input, caseInsensitive: !caseInsensitive },
+                {
+                    type: 'toggle case sensitivity',
+                },
+            ),
+        ).toStrictEqual({
+            ...input,
+            caseInsensitive: caseInsensitive,
+        });
+    });
 });
 
 describe('match inversion / inclusive/exclusive operator (`constraint.inverted`)', () => {
-    test('match inversion', () => {});
-    test('inverting the operator does not affect selected values', () => {});
+    test('match inversion', () => {
+        const { inverted, ...input } = multiValueConstraint('context-field');
+        expect(
+            constraintReducer(input, {
+                type: 'toggle inverted operator',
+            }),
+        ).toStrictEqual({
+            ...input,
+            inverted: true,
+        });
+        expect(
+            constraintReducer(
+                { ...input, inverted },
+                {
+                    type: 'toggle inverted operator',
+                },
+            ),
+        ).toStrictEqual({
+            ...input,
+            inverted: !inverted,
+        });
+        expect(
+            constraintReducer(
+                { ...input, inverted: !inverted },
+                {
+                    type: 'toggle inverted operator',
+                },
+            ),
+        ).toStrictEqual({
+            ...input,
+            inverted: inverted,
+        });
+    });
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.test.ts
@@ -1,5 +1,47 @@
+import { NOT_IN, NUM_EQ } from 'constants/operators';
+import type {
+    EditableDateConstraint,
+    EditableMultiValueConstraint,
+    EditableSingleValueConstraint,
+} from './editable-constraint-type';
+import { DATE_AFTER } from '@server/util/constants';
+import { constraintReducer } from './constraint-reducer';
+
+const multiValueConstraint = (
+    contextField: string,
+): EditableMultiValueConstraint => ({
+    contextName: contextField,
+    operator: NOT_IN,
+    values: new Set(['2023-01-01T00:00:00Z', '2023-01-02T00:00:00Z']),
+});
+
+const singleValueConstraint = (
+    contextField: string,
+): EditableSingleValueConstraint => ({
+    contextName: contextField,
+    operator: NUM_EQ,
+    value: '5',
+});
+
+const dateConstraint = (contextField: string): EditableDateConstraint => ({
+    contextName: contextField,
+    operator: DATE_AFTER,
+    value: '2024-05-05T00:00:00Z',
+});
+
 describe('changing context field', () => {
-    test('changing context field to the same field is a no-op', () => {});
+    test.each([multiValueConstraint, singleValueConstraint, dateConstraint])(
+        'changing context field to the same field is a no-op',
+        (constraint) => {
+            const input = constraint('test-context-field');
+            expect(
+                constraintReducer(input, {
+                    type: 'set context field',
+                    payload: input.contextName,
+                }),
+            ).toStrictEqual(input);
+        },
+    );
     test('changing context field to anything except currentTime clears value/values', () => {});
 });
 describe('changing operator', () => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -8,7 +8,7 @@ import {
 } from 'constants/operators';
 import { CURRENT_TIME_CONTEXT_FIELD } from 'utils/operatorsForContext';
 import {
-    type EditableSingleValueConstraint,
+    type EditableDateConstraint,
     isDateConstraint,
     isMultiValueConstraint,
     isSingleValueConstraint,
@@ -55,22 +55,22 @@ const resetValues = (state: EditableConstraint): EditableConstraint => {
     };
 };
 
-const setValue = (
-    state: EditableConstraint,
-    value?: string,
-): EditableConstraint => {
+const withValue = <T extends EditableConstraint>(
+    value: string | null,
+    constraint: T,
+): T => {
     // @ts-expect-error
-    const { value: _, values, ...rest } = state;
-    if (isMultiValueOperator(state.operator)) {
+    const { value: _, values, ...rest } = constraint;
+    if (isMultiValueOperator(constraint.operator)) {
         return {
             ...rest,
             values: new Set([value].filter(Boolean)),
-        } as EditableMultiValueConstraint;
+        } as T;
     }
     return {
         ...rest,
         value: value ?? '',
-    } as EditableSingleValueConstraint;
+    } as T;
 };
 
 export const constraintReducer = (
@@ -87,27 +87,23 @@ export const constraintReducer = (
                 action.payload === CURRENT_TIME_CONTEXT_FIELD &&
                 !isDateOperator(state.operator)
             ) {
-                return setValue(
-                    {
-                        ...state,
-                        contextName: action.payload,
-                        operator: DATE_AFTER,
-                    } as EditableConstraint,
-                    new Date().toISOString(),
-                );
+                return withValue(new Date().toISOString(), {
+                    ...state,
+                    contextName: action.payload,
+                    operator: DATE_AFTER,
+                } as EditableDateConstraint);
             } else if (
                 action.payload !== CURRENT_TIME_CONTEXT_FIELD &&
                 isDateOperator(state.operator)
             ) {
-                return resetValues({
+                return withValue(null, {
                     ...state,
                     operator: IN,
                     contextName: action.payload,
-                    values: new Set(),
-                });
+                } as EditableMultiValueConstraint);
             }
 
-            return resetValues({
+            return withValue(null, {
                 ...state,
                 contextName: action.payload,
             });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -59,6 +59,9 @@ export const constraintReducer = (
 ): EditableConstraint => {
     switch (action.type) {
         case 'set context field':
+            if (action.payload === state.contextName) {
+                return state;
+            }
             if (
                 action.payload === CURRENT_TIME_CONTEXT_FIELD &&
                 !isDateOperator(state.operator)

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -20,7 +20,7 @@ import { difference, union } from './set-functions';
 export type ConstraintUpdateAction =
     | { type: 'add value(s)'; payload: string | string[] }
     | { type: 'clear values' }
-    | { type: 'remove value from list'; payload: string }
+    | { type: 'remove value'; payload: string }
     | { type: 'set context field'; payload: string }
     | { type: 'set operator'; payload: Operator }
     | { type: 'toggle case sensitivity' }
@@ -138,9 +138,16 @@ export const constraintReducer = (
             return { ...state, inverted: !state.inverted };
         case 'toggle case sensitivity':
             return { ...state, caseInsensitive: !state.inverted };
-        case 'remove value from list':
+        case 'remove value':
             if (isSingleValueConstraint(state)) {
-                return state;
+                if (state.value === action.payload) {
+                    return {
+                        ...state,
+                        value: '',
+                    };
+                } else {
+                    return state;
+                }
             }
             state.values.delete(action.payload);
             return {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -56,20 +56,22 @@ const resetValues = (state: EditableConstraint): EditableConstraint => {
 };
 
 const withValue = <T extends EditableConstraint>(
-    value: string | null,
+    newValue: string | null,
     constraint: T,
 ): T => {
-    // @ts-expect-error
-    const { value: _, values, ...rest } = constraint;
+    // @ts-expect-error only one of these will be exist, but we want to take
+    // both of them out. TS doesn't allow you to extract `undefined` properties
+    // of an object, but it's perfectly legal in JS.
+    const { value, values, ...rest } = constraint;
     if (isMultiValueOperator(constraint.operator)) {
         return {
             ...rest,
-            values: new Set([value].filter(Boolean)),
+            values: new Set([newValue].filter(Boolean)),
         } as T;
     }
     return {
         ...rest,
-        value: value ?? '',
+        value: newValue ?? '',
     } as T;
 };
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -137,7 +137,7 @@ export const constraintReducer = (
         case 'toggle inverted operator':
             return { ...state, inverted: !state.inverted };
         case 'toggle case sensitivity':
-            return { ...state, caseInsensitive: !state.inverted };
+            return { ...state, caseInsensitive: !state.caseInsensitive };
         case 'remove value':
             if (isSingleValueConstraint(state)) {
                 if (state.value === action.payload) {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/constraint-reducer.ts
@@ -55,24 +55,23 @@ const resetValues = (state: EditableConstraint): EditableConstraint => {
     };
 };
 
-const withValue = <T extends EditableConstraint>(
+const withValue = <
+    T extends EditableConstraint & { value?: string; values?: Set<string> },
+>(
     newValue: string | null,
     constraint: T,
-): T => {
-    // @ts-expect-error only one of these will be exist, but we want to take
-    // both of them out. TS doesn't allow you to extract `undefined` properties
-    // of an object, but it's perfectly legal in JS.
+): EditableConstraint => {
     const { value, values, ...rest } = constraint;
     if (isMultiValueOperator(constraint.operator)) {
         return {
             ...rest,
             values: new Set([newValue].filter(Boolean)),
-        } as T;
+        } as EditableConstraint;
     }
     return {
         ...rest,
         value: newValue ?? '',
-    } as T;
+    } as EditableConstraint;
 };
 
 export const constraintReducer = (


### PR DESCRIPTION
Adds a fairly comprehensive test suite for the constraint reducer. I put in all cases I thought were relevant. 

As part of this, I discovered one bug, and changed two actions.

The bug was toggling on the wrong property when you tried to invert case sensitivity.

The action changes are:
- rename "remove value from list" to "remove value"
- remove "set value" in favor of instead letting "add value(s)" work in single-value constraints too.