### PR TITLE
refactor: lax newUserInviteLink user arg

### DIFF
--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -295,7 +295,7 @@ class UserService {
     }
 
     async newUserInviteLink(
-        user: IUserWithRootRole,
+        { id: userId }: Pick<IUserWithRootRole, 'id'>,
         auditUser: IAuditUser = SYSTEM_USER_AUDIT,
     ): Promise<string> {
         const passwordAuthSettings =
@@ -307,7 +307,7 @@ class UserService {
         let inviteLink = this.unleashUrl;
         if (!passwordAuthSettings.disabled) {
             const inviteUrl = await this.resetTokenService.createNewUserUrl(
-                user.id,
+                userId,
                 auditUser.username,
             );
             inviteLink = inviteUrl.toString();


### PR DESCRIPTION
Part of: https://linear.app/unleash/issue/2-3560/payg-flow-sends-2-email-one-from-bluebird-and-one-from-unleash-we-want

This laxes our `user` argument in `newUserInviteLink` to just pick the id, since that's the only property we're interested in. This allows us to send `{ id }` when we don't have the full `IUserWithRootRole` available while keeping compatibility intact.