### PR TITLE
test/refactor: useEditableConstraint hook

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintsList/EditableConstraintsList.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintsList/EditableConstraintsList.tsx
@@ -75,7 +75,7 @@ export const EditableConstraintsList = forwardRef<
                         key={constraint[constraintId]}
                         constraint={constraint}
                         onDelete={() => onDelete(index)}
-                        onAutoSave={onAutoSave(constraint[constraintId])}
+                        onUpdate={onAutoSave(constraint[constraintId])}
                     />
                 ))}
             </ConstraintsList>

--- a/frontend/src/component/common/NewConstraintAccordion/NewConstraintAccordionList/NewConstraintAccordionList.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/NewConstraintAccordionList/NewConstraintAccordionList.tsx
@@ -155,7 +155,7 @@ export const NewConstraintAccordionList = forwardRef<
                                 // @ts-ignore todo: find a better way to do this
                                 onDelete={() => onRemove(index)}
                                 // @ts-ignore
-                                onAutoSave={onAutoSave(constraintId)}
+                                onUpdate={onAutoSave(constraintId)}
                             />
                         ) : (
                             <ConstraintAccordionView

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -230,10 +230,8 @@ export const EditableConstraint: FC<Props> = ({
         constraint: localConstraint,
         updateConstraint,
         validator,
-        ...legalValueData
+        legalValues,
     } = useEditableConstraint(constraint, onUpdate);
-
-    const isLegalValueConstraint = 'legalValues' in legalValueData;
 
     const { context } = useUnleashContext();
     const { contextName, operator } = localConstraint;
@@ -332,8 +330,7 @@ export const EditableConstraint: FC<Props> = ({
                         values={
                             isMultiValueConstraint(localConstraint)
                                 ? Array.from(localConstraint.values)
-                                : 'legalValues' in legalValueData &&
-                                    localConstraint.value
+                                : legalValues && localConstraint.value
                                   ? [localConstraint.value]
                                   : undefined
                         }
@@ -348,7 +345,7 @@ export const EditableConstraint: FC<Props> = ({
                             deleteButtonRef.current
                         }
                     >
-                        {isLegalValueConstraint ? null : (
+                        {legalValues ? null : (
                             <TopRowInput
                                 localConstraint={localConstraint}
                                 updateConstraint={updateConstraint}
@@ -371,7 +368,7 @@ export const EditableConstraint: FC<Props> = ({
                     </StyledIconButton>
                 </HtmlTooltip>
             </TopRow>
-            {'legalValues' in legalValueData ? (
+            {legalValues ? (
                 <LegalValuesContainer>
                     {isMultiValueConstraint(localConstraint) ? (
                         <LegalValuesSelector
@@ -393,7 +390,7 @@ export const EditableConstraint: FC<Props> = ({
                                     payload: value,
                                 })
                             }
-                            {...legalValueData}
+                            {...legalValues}
                         />
                     ) : (
                         <SingleLegalValueSelector
@@ -409,7 +406,7 @@ export const EditableConstraint: FC<Props> = ({
                                     payload: newValues,
                                 })
                             }
-                            {...legalValueData}
+                            {...legalValues}
                         />
                     )}
                 </LegalValuesContainer>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -218,20 +218,20 @@ const TopRowInput: FC<{
 type Props = {
     constraint: IConstraint;
     onDelete: () => void;
-    onAutoSave: (constraint: IConstraint) => void;
+    onUpdate: (constraint: IConstraint) => void;
 };
 
 export const EditableConstraint: FC<Props> = ({
     onDelete,
     constraint,
-    onAutoSave,
+    onUpdate,
 }) => {
     const {
         constraint: localConstraint,
         updateConstraint,
         validator,
         ...legalValueData
-    } = useEditableConstraint(constraint, onAutoSave);
+    } = useEditableConstraint(constraint, onUpdate);
 
     const isLegalValueConstraint = 'legalValues' in legalValueData;
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -230,7 +230,7 @@ export const EditableConstraint: FC<Props> = ({
         constraint: localConstraint,
         updateConstraint,
         validator,
-        legalValues,
+        legalValueData,
     } = useEditableConstraint(constraint, onUpdate);
 
     const { context } = useUnleashContext();
@@ -330,7 +330,7 @@ export const EditableConstraint: FC<Props> = ({
                         values={
                             isMultiValueConstraint(localConstraint)
                                 ? Array.from(localConstraint.values)
-                                : legalValues && localConstraint.value
+                                : legalValueData && localConstraint.value
                                   ? [localConstraint.value]
                                   : undefined
                         }
@@ -345,7 +345,7 @@ export const EditableConstraint: FC<Props> = ({
                             deleteButtonRef.current
                         }
                     >
-                        {legalValues ? null : (
+                        {legalValueData ? null : (
                             <TopRowInput
                                 localConstraint={localConstraint}
                                 updateConstraint={updateConstraint}
@@ -368,7 +368,7 @@ export const EditableConstraint: FC<Props> = ({
                     </StyledIconButton>
                 </HtmlTooltip>
             </TopRow>
-            {legalValues ? (
+            {legalValueData ? (
                 <LegalValuesContainer>
                     {isMultiValueConstraint(localConstraint) ? (
                         <LegalValuesSelector
@@ -390,7 +390,7 @@ export const EditableConstraint: FC<Props> = ({
                                     payload: value,
                                 })
                             }
-                            {...legalValues}
+                            {...legalValueData}
                         />
                     ) : (
                         <SingleLegalValueSelector
@@ -406,7 +406,7 @@ export const EditableConstraint: FC<Props> = ({
                                     payload: newValues,
                                 })
                             }
-                            {...legalValues}
+                            {...legalValueData}
                         />
                     )}
                 </LegalValuesContainer>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.test.tsx
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react';
+import {
+    dateOperators,
+    IN,
+    multipleValueOperators,
+    NOT_IN,
+    numOperators,
+    semVerOperators,
+} from 'constants/operators';
+import type { IConstraint } from 'interfaces/strategy';
+import { useEditableConstraint } from './useEditableConstraint';
+import { vi } from 'vitest';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+
+const server = testServerSetup();
+
+const setupApi = (existingTokensCount: number) => {
+    testServerRoute(server, '/api/admin/context', {
+        what: 'mock me',
+    });
+};
+
+test('calls onUpdate with new state', () => {
+    const initial: IConstraint = {
+        contextName: 'context-field',
+        operator: NOT_IN,
+        values: ['A', 'B'],
+    };
+
+    const onUpdate = vi.fn();
+
+    const { result } = renderHook(() =>
+        useEditableConstraint(initial, onUpdate),
+    );
+    result.current.updateConstraint({
+        type: 'set operator',
+        payload: IN,
+    });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+        contextName: 'context-field',
+        operator: IN,
+        values: [],
+    });
+});
+
+describe('validators', () => {
+    const checkValidator = (
+        validator: (...values: string[]) => [boolean, string],
+        expectations: [string | string[], boolean][],
+    ) => {
+        expect(
+            expectations.every(([value, outcome]) =>
+                Array.isArray(value)
+                    ? validator(...value)[0] === outcome
+                    : validator(value)[0] === outcome,
+            ),
+        ).toBe(true);
+    };
+
+    test.each(numOperators)(
+        'picks the right validator for num operator: %s',
+        (operator) => {
+            const initial: IConstraint = {
+                contextName: 'context-field',
+                operator: operator,
+                value: '',
+            };
+
+            const { result } = renderHook(() =>
+                useEditableConstraint(initial, () => {}),
+            );
+
+            checkValidator(result.current.validator, [
+                ['5', true],
+                ['5.6', true],
+                ['5,6', false],
+                ['not a number', false],
+                ['1.2.6', false],
+                ['2025-05-13T07:39:23.053Z', false],
+            ]);
+        },
+    );
+    test.each(semVerOperators)(
+        'picks the right validator for semVer operator: %s',
+        (operator) => {
+            const initial: IConstraint = {
+                contextName: 'context-field',
+                operator: operator,
+                value: '',
+            };
+
+            const { result } = renderHook(() =>
+                useEditableConstraint(initial, () => {}),
+            );
+
+            checkValidator(result.current.validator, [
+                ['5', false],
+                ['5.6', false],
+                ['5,6', false],
+                ['not a number', false],
+                ['1.2.6', true],
+                ['2025-05-13T07:39:23.053Z', false],
+            ]);
+        },
+    );
+    test.each(dateOperators)(
+        'picks the right validator for date operator: %s',
+        (operator) => {
+            const initial: IConstraint = {
+                contextName: 'context-field',
+                operator: operator,
+                value: '',
+            };
+
+            const { result } = renderHook(() =>
+                useEditableConstraint(initial, () => {}),
+            );
+
+            checkValidator(result.current.validator, [
+                ['5', false],
+                ['5.6', false],
+                ['5,6', false],
+                ['not a number', false],
+                ['1.2.6', false],
+                ['2025-05-13T07:39:23.053Z', true],
+            ]);
+        },
+    );
+    test.each(multipleValueOperators)(
+        'picks the right value for multi-value operator: %s',
+        (operator) => {
+            const initial: IConstraint = {
+                contextName: 'context-field',
+                operator: operator,
+                values: [],
+            };
+
+            const { result } = renderHook(() =>
+                useEditableConstraint(initial, () => {}),
+            );
+
+            checkValidator(result.current.validator, [
+                ['5', true],
+                [['hey'], true],
+                // @ts-expect-error
+                [[5, 6], false],
+            ]);
+        },
+    );
+});
+describe('legal values', () => {
+    test('provides them if present', () => {});
+    test('does not add them if no legal values', () => {});
+    test('identifies deleted legal values', () => {});
+    test('identifies invalid legal values', () => {});
+});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.test.tsx
@@ -168,7 +168,7 @@ describe('legal values', () => {
             useEditableConstraint(initial, () => {}),
         );
         await waitFor(() => {
-            expect(result.current.legalValues?.legalValues).toStrictEqual(
+            expect(result.current.legalValueData?.legalValues).toStrictEqual(
                 definition.legalValues,
             );
         });
@@ -185,7 +185,7 @@ describe('legal values', () => {
             useEditableConstraint(initial, () => {}),
         );
         await waitFor(() => {
-            expect(result.current.legalValues?.legalValues).toStrictEqual(
+            expect(result.current.legalValueData?.legalValues).toStrictEqual(
                 definition.legalValues,
             );
         });
@@ -196,7 +196,7 @@ describe('legal values', () => {
         });
 
         await waitFor(() => {
-            expect(result.current.legalValues).toBeUndefined();
+            expect(result.current.legalValueData).toBeUndefined();
         });
     });
     test('does not add them if no legal values', () => {
@@ -210,7 +210,7 @@ describe('legal values', () => {
             useEditableConstraint(initial, () => {}),
         );
 
-        expect(result.current.legalValues).toBeUndefined();
+        expect(result.current.legalValueData).toBeUndefined();
     });
     test('identifies deleted legal values', async () => {
         const initial: IConstraint = {
@@ -224,7 +224,7 @@ describe('legal values', () => {
         );
         await waitFor(() => {
             expect(
-                result.current.legalValues?.deletedLegalValues,
+                result.current.legalValueData?.deletedLegalValues,
             ).toStrictEqual(new Set(['B']));
         });
     });
@@ -240,7 +240,7 @@ describe('legal values', () => {
         );
         await waitFor(() => {
             expect(
-                result.current.legalValues?.invalidLegalValues,
+                result.current.legalValueData?.invalidLegalValues,
             ).toStrictEqual(new Set(['A']));
         });
     });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -73,7 +73,7 @@ type EditableConstraintState = {
 
 export const useEditableConstraint = (
     constraint: IConstraint,
-    onAutoSave: (constraint: IConstraint) => void,
+    onUpdate: (constraint: IConstraint) => void,
 ): EditableConstraintState => {
     const [localConstraint, setLocalConstraint] = useState(() => {
         return fromIConstraint(constraint);
@@ -128,7 +128,7 @@ export const useEditableConstraint = (
             localConstraint.contextName !== nextState.contextName;
 
         setLocalConstraint(nextState);
-        onAutoSave(toIConstraint(nextState));
+        onUpdate(toIConstraint(nextState));
 
         if (contextFieldHasChanged) {
             setContextDefinition(

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -65,8 +65,10 @@ export const useEditableConstraint = (
     });
 
     const { context } = useUnleashContext();
-    const [contextDefinition, setContextDefinition] = useState(
-        resolveContextDefinition(context, localConstraint.contextName),
+
+    const contextDefinition = useMemo(
+        () => resolveContextDefinition(context, localConstraint.contextName),
+        [JSON.stringify(context), localConstraint.contextName],
     );
 
     const validator = constraintValidator(localConstraint);
@@ -109,17 +111,9 @@ export const useEditableConstraint = (
             action,
             deletedLegalValues,
         );
-        const contextFieldHasChanged =
-            localConstraint.contextName !== nextState.contextName;
 
         setLocalConstraint(nextState);
         onUpdate(toIConstraint(nextState));
-
-        if (contextFieldHasChanged) {
-            setContextDefinition(
-                resolveContextDefinition(context, nextState.contextName),
-            );
-        }
     };
 
     const legalValues = contextDefinition.legalValues?.length

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -138,16 +138,6 @@ export const useEditableConstraint = (
     };
 
     if (contextDefinition.legalValues?.length) {
-        if (isSingleValueConstraint(localConstraint)) {
-            return {
-                updateConstraint,
-                constraint: localConstraint,
-                validator,
-                legalValues: contextDefinition.legalValues,
-                invalidLegalValues,
-                deletedLegalValues,
-            };
-        }
         return {
             updateConstraint,
             constraint: localConstraint,
@@ -155,19 +145,12 @@ export const useEditableConstraint = (
             legalValues: contextDefinition.legalValues,
             invalidLegalValues,
             deletedLegalValues,
-        };
-    }
-    if (isSingleValueConstraint(localConstraint)) {
-        return {
-            updateConstraint,
-            constraint: localConstraint,
-            validator,
-        };
+        } as EditableConstraintState;
     }
 
     return {
         updateConstraint,
         constraint: localConstraint,
         validator,
-    };
+    } as EditableConstraintState;
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -52,7 +52,7 @@ type LegalValueData = {
 type EditableConstraintState = {
     updateConstraint: (action: ConstraintUpdateAction) => void;
     validator: (...values: string[]) => ConstraintValidationResult;
-    legalValues?: LegalValueData;
+    legalValueData?: LegalValueData;
     constraint: EditableConstraint;
 };
 
@@ -116,7 +116,7 @@ export const useEditableConstraint = (
         onUpdate(toIConstraint(nextState));
     };
 
-    const legalValues = contextDefinition.legalValues?.length
+    const legalValueData = contextDefinition.legalValues?.length
         ? {
               legalValues: contextDefinition.legalValues,
               invalidLegalValues,
@@ -128,6 +128,6 @@ export const useEditableConstraint = (
         updateConstraint,
         constraint: localConstraint,
         validator,
-        legalValues,
+        legalValueData,
     } as EditableConstraintState;
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/useEditableConstraint/useEditableConstraint.tsx
@@ -2,8 +2,7 @@ import { useMemo, useState } from 'react';
 import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
 import type { IConstraint } from 'interfaces/strategy';
 import {
-    type EditableMultiValueConstraint,
-    type EditableSingleValueConstraint,
+    type EditableConstraint,
     fromIConstraint,
     isSingleValueConstraint,
     toIConstraint,
@@ -44,32 +43,18 @@ const resolveContextDefinition = (
     );
 };
 
-type SingleValueConstraintState = {
-    constraint: EditableSingleValueConstraint;
-};
-
-type MultiValueConstraintState = {
-    constraint: EditableMultiValueConstraint;
-};
-
 type LegalValueData = {
     legalValues: ILegalValue[];
     deletedLegalValues?: Set<string>;
     invalidLegalValues?: Set<string>;
 };
 
-type LegalValueConstraintState = {
-    constraint: EditableMultiValueConstraint;
-} & LegalValueData;
-
 type EditableConstraintState = {
     updateConstraint: (action: ConstraintUpdateAction) => void;
     validator: (...values: string[]) => ConstraintValidationResult;
-} & (
-    | SingleValueConstraintState
-    | MultiValueConstraintState
-    | LegalValueConstraintState
-);
+    legalValues?: LegalValueData;
+    constraint: EditableConstraint;
+};
 
 export const useEditableConstraint = (
     constraint: IConstraint,
@@ -137,20 +122,18 @@ export const useEditableConstraint = (
         }
     };
 
-    if (contextDefinition.legalValues?.length) {
-        return {
-            updateConstraint,
-            constraint: localConstraint,
-            validator,
-            legalValues: contextDefinition.legalValues,
-            invalidLegalValues,
-            deletedLegalValues,
-        } as EditableConstraintState;
-    }
+    const legalValues = contextDefinition.legalValues?.length
+        ? {
+              legalValues: contextDefinition.legalValues,
+              invalidLegalValues,
+              deletedLegalValues,
+          }
+        : undefined;
 
     return {
         updateConstraint,
         constraint: localConstraint,
         validator,
+        legalValues,
     } as EditableConstraintState;
 };


### PR DESCRIPTION
Adds a test suite for the useEditableConstraint hook, attempting to test all the parts of it that we can't test in isolation. 

Plus: a few, small refactorings:
- Renames `onAutoSave` on `onUpdate` to better match `onDelete` (and because autosave doesn't really mean anything anymore).
- Simplifies and collapses some types