### PR TITLE
feat: add getProjectLinkTemplates method

### DIFF
--- a/src/lib/features/project/project-store-type.ts
+++ b/src/lib/features/project/project-store-type.ts
@@ -130,6 +130,8 @@ export interface IProjectStore extends Store<IProject, string> {
 
     isFeatureLimitReached(id: string): Promise<boolean>;
 
+    getProjectLinkTemplates(projectId: string): Promise<IProjectLinkTemplate[]>;
+
     getProjectModeCounts(): Promise<ProjectModeCount[]>;
     getApplicationsByProject(
         searchParams: IProjectApplicationsSearchParams,

--- a/src/lib/features/project/project-store.e2e.test.ts
+++ b/src/lib/features/project/project-store.e2e.test.ts
@@ -229,4 +229,17 @@ test('should update project enterprise settings', async () => {
             }),
         ]),
     );
+
+    const linkTemplates = await projectStore.getProjectLinkTemplates(
+        project.id,
+    );
+
+    expect(linkTemplates).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                title: 'My Link',
+                urlTemplate: 'https://example.com/{{flag}}',
+            }),
+        ]),
+    );
 });

--- a/src/lib/features/project/project-store.ts
+++ b/src/lib/features/project/project-store.ts
@@ -7,6 +7,7 @@ import type {
     IProject,
     IProjectApplication,
     IProjectApplications,
+    IProjectLinkTemplate,
     IProjectUpdate,
     IUnleashConfig,
     ProjectMode,
@@ -120,6 +121,16 @@ class ProjectStore implements IProjectStore {
         );
         const { present } = result.rows[0];
         return present;
+    }
+
+    async getProjectLinkTemplates(id: string): Promise<IProjectLinkTemplate[]> {
+        const result = await this.db
+            .select('link_templates')
+            .from(SETTINGS_TABLE)
+            .where({ project: id })
+            .first();
+
+        return result?.link_templates || [];
     }
 
     async getAll(query: IProjectQuery = {}): Promise<IProject[]> {

--- a/src/test/fixtures/fake-project-store.ts
+++ b/src/test/fixtures/fake-project-store.ts
@@ -2,6 +2,7 @@ import type {
     IEnvironment,
     IProject,
     IProjectApplications,
+    IProjectLinkTemplate,
     IProjectStore,
 } from '../../lib/types';
 import NotFoundError from '../../lib/error/notfound-error';
@@ -188,6 +189,10 @@ export default class FakeProjectStore implements IProjectStore {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isFeatureLimitReached(id: string): Promise<boolean> {
         return Promise.resolve(false);
+    }
+
+    async getProjectLinkTemplates(id: string): Promise<IProjectLinkTemplate[]> {
+        return [] as IProjectLinkTemplate[];
     }
 
     getProjectModeCounts(): Promise<ProjectModeCount[]> {


### PR DESCRIPTION
Add `getProjectLinkTemplates` method to ProjectStore and corresponding test. Ideally this should be in a read-model, but let's finish link templates end to end