### PR TITLE
chore: accept 429 responses

### DIFF
--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -24,10 +24,10 @@ jobs:
           restore-keys: cache-lychee-
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.3.0
+        uses: lycheeverse/lychee-action@v2
         with:
           fail: true
-          args: '"./website/docs/**/*.md" "./website/docs/**/*.mdx" "./src/mailtemplates/*.mustache" --scheme http --scheme https --cache --max-cache-age 7d --exclude-mail --verbose' # other excludes are in .lycheeignore
+          args: '"./website/docs/**/*.md" "./website/docs/**/*.mdx" "./src/mailtemplates/*.mustache" --scheme http --scheme https --cache --max-cache-age 7d --exclude-mail --verbose --accept 200,429' # other excludes are in .lycheeignore
           output: ${{ env.issue-content }}
 
       # Permissions (issues: read)


### PR DESCRIPTION
When being throttled assume the link is ok, eventually someday it will be checked

Already tested it works on this branch: https://github.com/Unleash/unleash/actions/runs/14993127371