### PR TITLE
chore: fix rendering issue without setConstraints

### DIFF
--- a/frontend/src/component/segments/SegmentFormStepTwo.tsx
+++ b/frontend/src/component/segments/SegmentFormStepTwo.tsx
@@ -202,14 +202,14 @@ export const SegmentFormStepTwo: React.FC<ISegmentFormPartTwoProps> = ({
                     }
                 />
                 <StyledConstraintContainer>
-                    {addEditStrategy &&
-                    hasAccess(modePermission, project) &&
-                    setConstraints ? (
-                        <EditableConstraintsList
-                            ref={constraintsAccordionListRef}
-                            constraints={constraints}
-                            setConstraints={setConstraints}
-                        />
+                    {addEditStrategy ? (
+                        hasAccess(modePermission, project) && setConstraints ? (
+                            <EditableConstraintsList
+                                ref={constraintsAccordionListRef}
+                                constraints={constraints}
+                                setConstraints={setConstraints}
+                            />
+                        ) : null
                     ) : (
                         <ConstraintAccordionList
                             ref={constraintsAccordionListRef}


### PR DESCRIPTION
The current implementation states that if you do not have access—typically as a viewer user—it renders the old component. Rendering an empty view is acceptable, as this is part of the segment creation flow, and if you do not have permissions, you do not need to see it.