### PR TITLE
feat: event log environment filter

### DIFF
--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -12,23 +12,25 @@ import { useEventCreators } from 'hooks/api/getters/useEventCreators/useEventCre
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 
 export const useEventLogFilters = (
-    projectsToFilter: any[],
-    featuresToFilter: any[],
+    projects: ProjectSchema[],
+    features: FeatureSearchResponseSchema[],
 ) => {
     const { environments } = useEnvironments();
     const { eventCreators } = useEventCreators();
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
 
     useEffect(() => {
-        const projectOptions = projectsToFilter.map((project) => ({
-            label: project.name,
-            value: project.id,
-        }));
+        const projectOptions =
+            projects?.map((project: ProjectSchema) => ({
+                label: project.name,
+                value: project.id,
+            })) ?? [];
 
-        const flagOptions = featuresToFilter.map((feature) => ({
-            label: feature.name,
-            value: feature.name,
-        }));
+        const flagOptions =
+            features?.map((flag) => ({
+                label: flag.name,
+                value: flag.name,
+            })) ?? [];
 
         const eventCreatorOptions = eventCreators.map((creator) => ({
             label: creator.name,
@@ -42,14 +44,15 @@ export const useEventLogFilters = (
             }),
         );
 
-        const environmentOptions = environments.map((env) => ({
-            label: env.name,
-            value: env.name,
-        }));
+        const environmentOptions =
+            environments?.map((env) => ({
+                label: env.name,
+                value: env.name,
+            })) ?? [];
 
         const availableFilters: IFilterItem[] = [
             {
-                label: 'Created date',
+                label: 'Date From',
                 icon: 'today',
                 options: [],
                 filterKey: 'from',
@@ -59,7 +62,7 @@ export const useEventLogFilters = (
                 persistent: true,
             },
             {
-                label: 'Created date',
+                label: 'Date To',
                 icon: 'today',
                 options: [],
                 filterKey: 'to',
@@ -124,8 +127,9 @@ export const useEventLogFilters = (
 
         setAvailableFilters(availableFilters);
     }, [
-        JSON.stringify(featuresToFilter),
-        JSON.stringify(projectsToFilter),
+        JSON.stringify(features),
+        JSON.stringify(projects),
+        JSON.stringify(eventCreators),
         JSON.stringify(environments),
     ]);
 

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -9,25 +9,26 @@ import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureS
 import { EventSchemaType, type FeatureSearchResponseSchema } from 'openapi';
 import type { ProjectSchema } from 'openapi';
 import { useEventCreators } from 'hooks/api/getters/useEventCreators/useEventCreators';
+import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 
 export const useEventLogFilters = (
-    projects: ProjectSchema[],
-    features: FeatureSearchResponseSchema[],
+    projectsToFilter: any[],
+    featuresToFilter: any[],
 ) => {
+    const { environments } = useEnvironments();
     const { eventCreators } = useEventCreators();
     const [availableFilters, setAvailableFilters] = useState<IFilterItem[]>([]);
-    useEffect(() => {
-        const projectOptions =
-            projects?.map((project: ProjectSchema) => ({
-                label: project.name,
-                value: project.id,
-            })) ?? [];
 
-        const flagOptions =
-            features?.map((flag) => ({
-                label: flag.name,
-                value: flag.name,
-            })) ?? [];
+    useEffect(() => {
+        const projectOptions = projectsToFilter.map((project) => ({
+            label: project.name,
+            value: project.id,
+        }));
+
+        const flagOptions = featuresToFilter.map((feature) => ({
+            label: feature.name,
+            value: feature.name,
+        }));
 
         const eventCreatorOptions = eventCreators.map((creator) => ({
             label: creator.name,
@@ -41,9 +42,14 @@ export const useEventLogFilters = (
             }),
         );
 
+        const environmentOptions = environments.map((env) => ({
+            label: env.name,
+            value: env.name,
+        }));
+
         const availableFilters: IFilterItem[] = [
             {
-                label: 'Date From',
+                label: 'Created date',
                 icon: 'today',
                 options: [],
                 filterKey: 'from',
@@ -53,7 +59,7 @@ export const useEventLogFilters = (
                 persistent: true,
             },
             {
-                label: 'Date To',
+                label: 'Created date',
                 icon: 'today',
                 options: [],
                 filterKey: 'to',
@@ -102,13 +108,25 @@ export const useEventLogFilters = (
                       },
                   ] as IFilterItem[])
                 : []),
+            ...(environmentOptions.length > 0
+                ? ([
+                      {
+                          label: 'Environment',
+                          icon: 'cloud',
+                          options: environmentOptions,
+                          filterKey: 'environment',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      },
+                  ] as IFilterItem[])
+                : []),
         ];
 
         setAvailableFilters(availableFilters);
     }, [
-        JSON.stringify(features),
-        JSON.stringify(projects),
-        JSON.stringify(eventCreators),
+        JSON.stringify(featuresToFilter),
+        JSON.stringify(projectsToFilter),
+        JSON.stringify(environments),
     ]);
 
     return availableFilters;

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -71,6 +71,7 @@ export const useEventLogSearch = (
         }),
         createdBy: FilterItemParam,
         type: FilterItemParam,
+        environment: FilterItemParam,
         ...extraParameters(logType),
     };
 

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -213,7 +213,6 @@ export default class EventService {
                             representation: 'date',
                         }),
                     );
-
                 queryParams.push({
                     field: parsed.field,
                     operator: 'IS_BEFORE',
@@ -238,7 +237,7 @@ export default class EventService {
             if (parsed) queryParams.push(parsed);
         }
 
-        ['project', 'type'].forEach((field) => {
+        ['project', 'type', 'environment'].forEach((field) => {
             if (params[field]) {
                 const parsed = parseSearchOperatorValue(field, params[field]);
                 if (parsed) queryParams.push(parsed);

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -100,6 +100,17 @@ export const eventSearchQueryParameters = [
             'The number of feature environments to return in a page. By default it is set to 50. The maximum is 1000.',
         in: 'query',
     },
+    {
+        name: 'environment',
+        schema: {
+            type: 'string',
+            example: 'IS:production',
+            pattern: '^(IS|IS_ANY_OF):(.*?)(,([a-zA-Z0-9_]+))*$',
+        },
+        description:
+            'Filter by environment name using supported operators: IS, IS_ANY_OF.',
+        in: 'query',
+    },
 ] as const;
 
 export type EventSearchQueryParameters = Partial<

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -16,6 +16,7 @@ export interface IEventSearchParams {
     to?: string;
     createdBy?: string;
     type?: string;
+    environment?: string;
     offset: number;
     limit: number;
 }

--- a/src/test/e2e/api/admin/event-search.e2e.test.ts
+++ b/src/test/e2e/api/admin/event-search.e2e.test.ts
@@ -575,3 +575,82 @@ test('should show user creation events for admins', async () => {
         total: 2,
     });
 });
+
+test('should filter events by environment', async () => {
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        environment: 'production',
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        environment: 'staging',
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    const { body } = await searchEvents({ environment: 'IS:production' });
+
+    expect(body).toMatchObject({
+        events: [
+            {
+                type: 'feature-created',
+                environment: 'production',
+            },
+        ],
+        total: 1,
+    });
+});
+
+test('should filter events by environment using IS_ANY_OF', async () => {
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        environment: 'production',
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        environment: 'staging',
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    await eventService.storeEvent({
+        type: FEATURE_CREATED,
+        project: 'default',
+        environment: 'development',
+        createdBy: 'test-user',
+        createdByUserId: TEST_USER_ID,
+        ip: '127.0.0.1',
+    });
+
+    const { body } = await searchEvents({
+        environment: 'IS_ANY_OF:production,staging',
+    });
+
+    expect(body).toMatchObject({
+        events: [
+            {
+                type: 'feature-created',
+                environment: 'staging',
+            },
+            {
+                type: 'feature-created',
+                environment: 'production',
+            },
+        ],
+        total: 2,
+    });
+});


### PR DESCRIPTION
# Add Environment Filter to Event Log

## Changes
- Added environment filter to the event log search functionality
- Added end-to-end tests for environment filtering

## Details
### Environment Filter Implementation
- Added environment filter to the `EventLogFilters` component
- Integrated with the existing `useEnvironments` hook to fetch available environments
- Added support for both single and multiple environment selection using `IS` and `IS_ANY_OF` operators

### End-to-End Tests
Added two new test cases in `event-search.e2e.test.ts`:
1. `should filter events by environment` - Tests basic environment filtering with `IS` operator
2. `should filter events by environment using IS_ANY_OF` - Tests multi-select environment filtering


## Testing
The changes have been verified through:
- End-to-end tests for environment filtering
- Existing test suite for event log functionality
- Manual testing of the environment filter UI