### PR TITLE
fix(1-3740): Don't autofocus the editable constraint field.

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint.tsx
@@ -261,7 +261,6 @@ export const EditableConstraint: FC<Props> = ({
                             id='context-field-select'
                             name='contextName'
                             label='Context Field'
-                            autoFocus
                             options={constraintNameOptions}
                             value={contextName || ''}
                             onChange={(contextField) =>


### PR DESCRIPTION
There can be any number of these on a page, so setting autofocus here is a Bad Idea (TM). It's probably a holdover from when the input was an accordion and we wanted to give you focus when you opened it (we do a similar thing for the popover, for instance).

This property will cause you to focus (and potentially scroll) to the last constraint on the page.
