### PR TITLE
Fix(1-3485)/handle deleted constraints

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
@@ -205,6 +205,23 @@ const TopRowInput: FC<{
     );
 };
 
+const getContextFieldOptions = (
+    contextFields: string[],
+    selectedContextField: string,
+) => {
+    const contextFieldHasBeenDeleted =
+        !contextFields.includes(selectedContextField);
+
+    const availableContextFieldNames = contextFieldHasBeenDeleted
+        ? [...contextFields, selectedContextField].toSorted()
+        : contextFields;
+
+    return availableContextFieldNames.map((option) => ({
+        key: option,
+        label: option,
+    }));
+};
+
 type Props = {
     constraint: IConstraint;
     onDelete: () => void;
@@ -258,14 +275,10 @@ export const EditableConstraint: FC<Props> = ({
         return null;
     }
 
-    const allConstraintOptions = [
-        ...new Set([
-            ...context.map((context) => context.name),
-            localConstraint.contextName,
-        ]),
-    ]
-        .toSorted()
-        .map((option) => ({ key: option, label: option }));
+    const contextFieldOptions = getContextFieldOptions(
+        context.map((contextField) => contextField.name),
+        localConstraint.contextName,
+    );
 
     return (
         <Container>
@@ -277,7 +290,12 @@ export const EditableConstraint: FC<Props> = ({
                             id='context-field-select'
                             name='contextName'
                             label='Context Field'
-                            options={allConstraintOptions}
+                            options={contextFieldOptions}
+                            // helperText={'oh no'
+                            //     contextFieldHasBeenDeleted
+                            //         ? "This context field has been deleted. You can still edit this instance, but won't be able to use it for other constraints."
+                            //         : ''
+                            // }
                             value={contextName || ''}
                             onChange={(contextField) =>
                                 updateConstraint({

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
@@ -205,23 +205,6 @@ const TopRowInput: FC<{
     );
 };
 
-const getContextFieldOptions = (
-    contextFields: string[],
-    selectedContextField: string,
-) => {
-    const contextFieldHasBeenDeleted =
-        !contextFields.includes(selectedContextField);
-
-    const availableContextFieldNames = contextFieldHasBeenDeleted
-        ? [...contextFields, selectedContextField].toSorted()
-        : contextFields;
-
-    return availableContextFieldNames.map((option) => ({
-        key: option,
-        label: option,
-    }));
-};
-
 type Props = {
     constraint: IConstraint;
     onDelete: () => void;
@@ -275,10 +258,19 @@ export const EditableConstraint: FC<Props> = ({
         return null;
     }
 
-    const contextFieldOptions = getContextFieldOptions(
-        context.map((contextField) => contextField.name),
+    const extantContextFieldNames = context.map((context) => context.name);
+    const contextFieldHasBeenDeleted = !extantContextFieldNames.includes(
         localConstraint.contextName,
     );
+
+    const availableContextFieldNames = contextFieldHasBeenDeleted
+        ? [...extantContextFieldNames, localConstraint.contextName].toSorted()
+        : extantContextFieldNames;
+
+    const contextFieldOptions = availableContextFieldNames.map((option) => ({
+        key: option,
+        label: option,
+    }));
 
     return (
         <Container>
@@ -291,11 +283,6 @@ export const EditableConstraint: FC<Props> = ({
                             name='contextName'
                             label='Context Field'
                             options={contextFieldOptions}
-                            // helperText={'oh no'
-                            //     contextFieldHasBeenDeleted
-                            //         ? "This context field has been deleted. You can still edit this instance, but won't be able to use it for other constraints."
-                            //         : ''
-                            // }
                             value={contextName || ''}
                             onChange={(contextField) =>
                                 updateConstraint({

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
@@ -258,9 +258,14 @@ export const EditableConstraint: FC<Props> = ({
         return null;
     }
 
-    const constraintNameOptions = context.map((context) => {
-        return { key: context.name, label: context.name };
-    });
+    const allConstraintOptions = [
+        ...new Set([
+            ...context.map((context) => context.name),
+            localConstraint.contextName,
+        ]),
+    ]
+        .toSorted()
+        .map((option) => ({ key: option, label: option }));
 
     return (
         <Container>
@@ -272,7 +277,7 @@ export const EditableConstraint: FC<Props> = ({
                             id='context-field-select'
                             name='contextName'
                             label='Context Field'
-                            options={constraintNameOptions}
+                            options={allConstraintOptions}
                             value={contextName || ''}
                             onChange={(contextField) =>
                                 updateConstraint({

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -245,7 +245,7 @@ export class ContextController extends Controller {
                     tags: ['Context'],
                     summary: 'Validate a context field',
                     description:
-                        'Check whether the provided data can be used to create a context field. If the data is not valid, ...?',
+                        'Check whether the provided data can be used to create a context field. If the data is not valid, returns a 400 status code with the reason why it is not valid.',
                     operationId: 'validate',
                     requestBody: createRequestSchema('nameSchema'),
                     responses: {

--- a/src/test/e2e/api/admin/constraints.e2e.test.ts
+++ b/src/test/e2e/api/admin/constraints.e2e.test.ts
@@ -54,3 +54,14 @@ test('should allow unknown constraints if their values are valid', async () => {
         })
         .expect(204);
 });
+
+test('should block unknown constraints if their values are invalid', async () => {
+    await app.request
+        .post(PATH)
+        .send({
+            contextName: 'not-a-default-context-value',
+            operator: 'IN',
+            value: 1,
+        })
+        .expect(400);
+});

--- a/src/test/e2e/api/admin/constraints.e2e.test.ts
+++ b/src/test/e2e/api/admin/constraints.e2e.test.ts
@@ -43,3 +43,14 @@ test('should accept valid constraints', async () => {
         .send({ contextName: 'environment', operator: 'IN', values: ['a'] })
         .expect(204);
 });
+
+test('should allow unknown constraints if their values are valid', async () => {
+    await app.request
+        .post(PATH)
+        .send({
+            contextName: 'not-a-default-context-value',
+            operator: 'NUM_EQ',
+            value: 1,
+        })
+        .expect(204);
+});


### PR DESCRIPTION
Improves handling of constraints in use that have been deleted.

This change implments a few small changes on both the front and the back end on how we deal with constraints that have been deleted.

The most important change is on the back end, in the `/constraints/validate` endpoint. We used to throw here if the constraint couldn't be found, but the only reason we wanted to look for the constraint in the db was to check for legal values. Now, instead, we'll allow you to pass a constraint field that doesn't exist in the database. We'll still check the values against the operator for validity, we just don't control legal values anymore (because there aren't any).

On the front end, we improve the handling by showing the deleted context filed in the dropdown, both when the selector dropdown is closed and when it is open. However, if you change the context field, we remove the deleted field from the list. This seems like a sensible tradeoff. Means you can't select it if you've deselected it.