### PR TITLE
fix: now feature is not pulled from server if not defined

### DIFF
--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -1,9 +1,10 @@
-import useSWR, { type SWRConfiguration } from 'swr';
+import type { SWRConfiguration } from 'swr';
 import { useCallback } from 'react';
-import { emptyFeature } from './emptyFeature.js';
-import handleErrorResponses from '../httpErrorResponseHandler.js';
+import { emptyFeature } from './emptyFeature.ts';
+import handleErrorResponses from '../httpErrorResponseHandler.ts';
 import { formatApiPath } from 'utils/formatPath';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR.ts';
 
 export interface IUseFeatureOutput {
     feature: IFeatureToggle;
@@ -25,7 +26,9 @@ export const useFeature = (
 ): IUseFeatureOutput => {
     const path = formatFeatureApiPath(projectId, featureId);
 
-    const { data, error, mutate } = useSWR<IFeatureResponse>(
+    const { data, error, mutate } = useConditionalSWR<IFeatureResponse>(
+        Boolean(featureId && projectId),
+        { status: 404 },
         ['useFeature', path],
         () => featureFetcher(path),
         options,


### PR DESCRIPTION
All our servers have had this for a while on every feature open.
![image](https://github.com/user-attachments/assets/ae9bfc59-0365-48fc-a4d9-40a039391207)


This PR fixes it by making request only conditionally.

The featureFetcher function also specifically handles 404 responses by returning `{ status: 404 }`, which makes the behavior consistent whether the API returns a 404 or the condition prevents the API call from happening at all.

This approach avoids unnecessary API calls when parameters are missing and provides a consistent interface for handling "not found" scenarios in the component that uses this hook.