### PR TITLE
chore: disable delete button if a context field has usage

### DIFF
--- a/frontend/src/component/context/ContextList/ContextActionsCell.tsx
+++ b/frontend/src/component/context/ContextList/ContextActionsCell.tsx
@@ -12,11 +12,13 @@ import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 interface IContextActionsCellProps {
     name: string;
     onDelete: () => void;
+    allowDelete: boolean;
 }
 
 export const ContextActionsCell: VFC<IContextActionsCellProps> = ({
     name,
     onDelete,
+    allowDelete,
 }) => {
     const navigate = useNavigate();
 
@@ -37,6 +39,7 @@ export const ContextActionsCell: VFC<IContextActionsCellProps> = ({
                 permission={DELETE_CONTEXT_FIELD}
                 onClick={onDelete}
                 data-loading
+                disabled={!allowDelete}
                 aria-label='delete'
                 tooltipProps={{
                     title: 'Delete context field',

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -97,7 +97,7 @@ const ContextList: VFC = () => {
                 align: 'center',
                 Cell: ({
                     row: {
-                        original: { name },
+                        original: { name, usedInFeatures },
                     },
                 }: any) => (
                     <ContextActionsCell
@@ -106,6 +106,7 @@ const ContextList: VFC = () => {
                             setName(name);
                             setShowDelDialogue(true);
                         }}
+                        allowDelete={usedInFeatures === 0}
                     />
                 ),
                 width: 150,


### PR DESCRIPTION
Blocks deletion of context fields from the UI if the context field has any usage.

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/e6c26671-761b-4e54-9850-c505ba7b42f3" />
