### PR TITLE
fix: hide project archive in OSS

### DIFF
--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "component": [Function],
+    "enterprise": true,
     "menu": {},
     "path": "/projects-archive",
     "title": "Projects archive",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -125,6 +125,7 @@ export const routes: IRoute[] = [
         component: ArchiveProjectList,
         type: 'protected',
         menu: {},
+        enterprise: true,
     },
 
     // Flags overview

--- a/frontend/src/component/project/ProjectList/ProjectArchiveLink/ProjectArchiveLink.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectArchiveLink/ProjectArchiveLink.tsx
@@ -9,15 +9,11 @@ import ArchiveIcon from '@mui/icons-material/Inventory2Outlined';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import type { FC } from 'react';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 export const ProjectArchiveLink: FC = () => {
     const navigate = useNavigate();
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-    const { isOss } = useUiConfig();
-
-    if (isOss()) return null;
 
     if (isSmallScreen) {
         return (

--- a/frontend/src/component/project/ProjectList/ProjectArchiveLink/ProjectArchiveLink.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectArchiveLink/ProjectArchiveLink.tsx
@@ -9,11 +9,15 @@ import ArchiveIcon from '@mui/icons-material/Inventory2Outlined';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import type { FC } from 'react';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 export const ProjectArchiveLink: FC = () => {
     const navigate = useNavigate();
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+    const { isOss } = useUiConfig();
+
+    if (isOss()) return null;
 
     if (isSmallScreen) {
         return (

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -78,7 +78,7 @@ export const ProjectList = () => {
                                 }
                             />
 
-                            <ProjectArchiveLink />
+                            {!isOss() && <ProjectArchiveLink />}
                             <ProjectCreationButton
                                 isDialogOpen={Boolean(state.create)}
                                 setIsDialogOpen={(create) =>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3569/fix-hide-project-archive-in-oss

Hides "project archive" in OSS.

I believe this is a bug. OSS only has one project and the project archive was acting unexpectedly anyways since it was showing the same default project as being archived. This is because in OSS we use the OSS project-controller, not the Enterprise version (override) of it.