### PR TITLE
docs: explain health API properly

### DIFF
--- a/src/lib/openapi/spec/health-check-schema.ts
+++ b/src/lib/openapi/spec/health-check-schema.ts
@@ -10,7 +10,7 @@ export const healthCheckSchema = {
     properties: {
         health: {
             description:
-                'The state this Unleash instance is in. GOOD if everything is ok, BAD if the instance should be restarted',
+                'The state this Unleash instance is in. GOOD if the server is up and running. It never returns BAD, if the server is unhealthy you will get an unsuccessful http response.',
             type: 'string',
             enum: ['GOOD', 'BAD'],
             example: 'GOOD',

--- a/website/docs/reference/api/legacy/unleash/internal/health.md
+++ b/website/docs/reference/api/legacy/unleash/internal/health.md
@@ -16,14 +16,8 @@ Used to check the health of the running Unleash instance. This endpoint has two 
 }
 ```
 
-This response means everything is OK. Unleash is able to talk to the PostgreSQL
+This response means Unleash server is up.
 
 `Status: 500`
 
-```json
-{
-  "health": "BAD"
-}
-```
-
-This response indicates that Unleash is not able to talk to PostgreSQL and will not be able to serve requests.
+This response indicates that Unleash server is unhealthy.


### PR DESCRIPTION
## About the changes
Our health implementation always returns GOOD if the server is up: https://github.com/Unleash/unleash/blob/beb29f5b5bbff620097fa822e2dff6b68a11adab/src/lib/routes/health-check.ts#L46-L51

Currently our documentation of the endpoint is misleading saying that it will return BAD if unable to connect to PostgreSQL

Closes #9965

