### PR TITLE
fix: now feature component is not loaded before we have feature infor…

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -53,7 +53,10 @@ export const FeatureOverview = () => {
     const { splash } = useAuthSplash();
     const [showTooltip, setShowTooltip] = useState(false);
     const [hasClosedTooltip, setHasClosedTooltip] = useState(false);
-    const { feature, refetchFeature } = useFeature(projectId, featureId);
+    const { feature, refetchFeature, loading } = useFeature(
+        projectId,
+        featureId,
+    );
     const cleanupReminderEnabled = useUiFlag('cleanupReminder');
     const dragTooltipSplashId = 'strategy-drag-tooltip';
     const shouldShowStrategyDragTooltip = !splash?.[dragTooltipSplashId];
@@ -74,14 +77,16 @@ export const FeatureOverview = () => {
             ) : null}
             <StyledContainer>
                 <div>
-                    <FeatureOverviewMetaData
-                        hiddenEnvironments={hiddenEnvironments}
-                        onEnvironmentVisibilityChange={
-                            onEnvironmentVisibilityChange
-                        }
-                        feature={feature}
-                        onChange={refetchFeature}
-                    />
+                    {!loading ? (
+                        <FeatureOverviewMetaData
+                            hiddenEnvironments={hiddenEnvironments}
+                            onEnvironmentVisibilityChange={
+                                onEnvironmentVisibilityChange
+                            }
+                            feature={feature}
+                            onChange={refetchFeature}
+                        />
+                    ) : null}
                 </div>
                 <StyledMainContent>
                     <FeatureOverviewEnvironments

--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -1,10 +1,9 @@
-import type { SWRConfiguration } from 'swr';
+import useSWR, { type SWRConfiguration } from 'swr';
 import { useCallback } from 'react';
-import { emptyFeature } from './emptyFeature.ts';
-import handleErrorResponses from '../httpErrorResponseHandler.ts';
+import { emptyFeature } from './emptyFeature.js';
+import handleErrorResponses from '../httpErrorResponseHandler.js';
 import { formatApiPath } from 'utils/formatPath';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
-import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR.ts';
 
 export interface IUseFeatureOutput {
     feature: IFeatureToggle;
@@ -26,9 +25,11 @@ export const useFeature = (
 ): IUseFeatureOutput => {
     const path = formatFeatureApiPath(projectId, featureId);
 
-    const { data, error, mutate } = useConditionalSWR<IFeatureResponse>(
-        Boolean(featureId && projectId),
-        { status: 404 },
+    if (!featureId) {
+        // console.trace("boom");
+    }
+
+    const { data, error, mutate } = useSWR<IFeatureResponse>(
         ['useFeature', path],
         () => featureFetcher(path),
         options,

--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -25,10 +25,6 @@ export const useFeature = (
 ): IUseFeatureOutput => {
     const path = formatFeatureApiPath(projectId, featureId);
 
-    if (!featureId) {
-        // console.trace("boom");
-    }
-
     const { data, error, mutate } = useSWR<IFeatureResponse>(
         ['useFeature', path],
         () => featureFetcher(path),

--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -1,7 +1,7 @@
 import useSWR, { type SWRConfiguration } from 'swr';
 import { useCallback } from 'react';
-import { emptyFeature } from './emptyFeature.js';
-import handleErrorResponses from '../httpErrorResponseHandler.js';
+import { emptyFeature } from './emptyFeature.ts';
+import handleErrorResponses from '../httpErrorResponseHandler.ts';
 import { formatApiPath } from 'utils/formatPath';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
 


### PR DESCRIPTION
We were seeing strange errors when the feature component was rendered before the feature data was returned from the backend. Now, we ensure the component is not rendered until the feature is available.