### PR TITLE
task(ci): Bump base image for OSS docker

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [20.19.0-alpine3.21]
+        version: [22.15.1-alpine3.21]
     steps:
       - name: Checkout tag v${{ inputs.version }}
         if: ${{ inputs.version != '' }}


### PR DESCRIPTION
We're building with node 22 locally, so our docker image should also use node 22. This PR bumps our docker workflow to use 22.15.1 image.