### PR TITLE
Remove feature flag: registerFrontendClient

### DIFF
--- a/frontend/src/component/application/ApplicationChart.tsx
+++ b/frontend/src/component/application/ApplicationChart.tsx
@@ -16,7 +16,6 @@ import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
 import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { getApplicationIssues } from './ApplicationIssues/ApplicationIssues.tsx';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledTable = styled('table')(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
@@ -197,7 +196,6 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
     const { elementRef, width } = useElementWidth();
     const navigate = useNavigate();
     const theme = useTheme();
-    const registerFrontendClientEnabled = useUiFlag('registerFrontendClient');
 
     const mode = getApplicationIssues(data);
 
@@ -296,23 +294,8 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                 {environment.instanceCount}
                                             </StyledCell>
                                         </tr>
-                                        {!registerFrontendClientEnabled ? (
-                                            <tr>
-                                                <StyledCell>SDK:</StyledCell>
-                                                <StyledCell>
-                                                    {environment.sdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
 
-                                        {registerFrontendClientEnabled &&
-                                        environment.backendSdks.length > 0 ? (
+                                        {environment.backendSdks.length > 0 ? (
                                             <tr>
                                                 <StyledCell>
                                                     Backend SDK:
@@ -329,8 +312,7 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                             </tr>
                                         ) : null}
 
-                                        {registerFrontendClientEnabled &&
-                                        environment.frontendSdks.length > 0 ? (
+                                        {environment.frontendSdks.length > 0 ? (
                                             <tr>
                                                 <StyledCell>
                                                     Frontend SDK:

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -88,7 +88,6 @@ export type UiFlags = {
     edgeObservability?: boolean;
     addEditStrategy?: boolean;
     cleanupReminder?: boolean;
-    registerFrontendClient?: boolean;
     featureLinks?: boolean;
     projectLinkTemplates?: boolean;
 };

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -137,8 +137,7 @@ export class FrontendApiService {
 
         if (
             metrics.instanceId &&
-            typeof sdkVersion === 'string' &&
-            this.flagResolver.isEnabled('registerFrontendClient')
+            typeof sdkVersion === 'string'
         ) {
             const client = {
                 appName: metrics.appName,

--- a/src/lib/features/metrics/instance/metrics.test.ts
+++ b/src/lib/features/metrics/instance/metrics.test.ts
@@ -46,9 +46,7 @@ let destroy: () => Promise<void>;
 beforeAll(async () => {
     const setup = await getSetup({
         experimental: {
-            flags: {
-                registerFrontendClient: true,
-            },
+            flags: {},
         },
     });
     request = setup.request;

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -228,20 +228,14 @@ export default class ClientMetricsController extends Controller {
                         app.sdkType === 'frontend' &&
                         typeof app.sdkVersion === 'string'
                     ) {
-                        if (
-                            this.flagResolver.isEnabled(
-                                'registerFrontendClient',
-                            )
-                        ) {
-                            this.clientInstanceService.registerFrontendClient({
-                                appName: app.appName,
-                                instanceId: app.instanceId,
+                        this.clientInstanceService.registerFrontendClient({
+                            appName: app.appName,
+                            instanceId: app.instanceId,
                                 environment: app.environment,
                                 sdkType: app.sdkType,
                                 sdkVersion: app.sdkVersion,
                                 projects: app.projects,
                             });
-                        }
                     } else {
                         promises.push(
                             this.clientInstanceService.registerBackendClient(

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -59,7 +59,6 @@ export type IFlagKey =
     | 'addEditStrategy'
     | 'cleanupReminder'
     | 'removeInactiveApplications'
-    | 'registerFrontendClient'
     | 'featureLinks'
     | 'projectLinkTemplates'
     | 'reportUnknownFlags'
@@ -281,10 +280,6 @@ const flags: IFlags = {
     ),
     removeInactiveApplications: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_REMOVE_INACTIVE_APPLICATIONS,
-        false,
-    ),
-    registerFrontendClient: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_REGISTER_FRONTEND_CLIENT,
         false,
     ),
     featureLinks: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -53,7 +53,6 @@ process.nextTick(async () => {
                         addEditStrategy: true,
                         cleanupReminder: true,
                         strictSchemaValidation: true,
-                        registerFrontendClient: true,
                         featureLinks: true,
                         projectLinkTemplates: true,
                         reportUnknownFlags: true,

--- a/src/test/e2e/api/admin/applications.e2e.test.ts
+++ b/src/test/e2e/api/admin/applications.e2e.test.ts
@@ -54,7 +54,6 @@ beforeAll(async () => {
             experimental: {
                 flags: {
                     strictSchemaValidation: true,
-                    registerFrontendClient: true,
                 },
             },
         },


### PR DESCRIPTION
## Feature Flag Removal: registerFrontendClient

This PR removes the `registerFrontendClient` feature flag from the codebase. The changes have been automatically applied using Henry, our automated flag removal assistant.

**Flag Value:** `kept`


The feature flag registerFrontendClient has been removed from the codebase. The 
feature it controlled, which pertains to how frontend client SDKs register      
themselves and report metrics, has been permanently enabled.                    

What was removed:                                                               

 • The registerFrontendClient flag checks using useUiFlag in                    
   frontend/src/component/application/ApplicationChart.tsx.                     
 • The registerFrontendClient flag checks using this.flagResolver.isEnabled()   
   in:                                                                          
    • src/lib/features/frontend-api/frontend-api-service.ts                     
    • src/lib/features/metrics/instance/metrics.ts                              
 • The flag definition from src/lib/types/experimental.ts (both IFlagKey and the
   flags object).                                                               
 • The flag definition from frontend/src/interfaces/uiConfig.ts (UiFlags        
   interface).                                                                  
 • The flag from experimental configurations in:                                
    • src/server-dev.ts                                                         
    • src/test/e2e/api/admin/applications.e2e.test.ts                           
    • src/lib/features/metrics/instance/metrics.test.ts                         
 • An unused import for useUiFlag in                                            
   frontend/src/component/application/ApplicationChart.tsx.                     
 • The registerFrontendClientEnabled variable in                                
   frontend/src/component/application/ApplicationChart.tsx.                     

What was kept:                                                                  

 • The code paths that were executed when registerFrontendClient was true are   
   now the default behavior:                                                    
    • In frontend/src/component/application/ApplicationChart.tsx, the logic to  
      display "Backend SDK" and "Frontend SDK" sections (if data exists) is now 
      always active, while the generic "SDK" section (previously shown when the 
      flag was false) has been removed.                                         
    • In src/lib/features/frontend-api/frontend-api-service.ts, frontend client 
      registration via clientInstanceService.registerFrontendClient() will occur
      if metrics.instanceId and sdkVersion are present.                         
    • In src/lib/features/metrics/instance/metrics.ts, frontend client          
      registration via clientInstanceService.registerFrontendClient() will occur
      for applications with sdkType === 'frontend' and a valid sdkVersion.      

Why these changes were made:                                                    

The registerFrontendClient feature has been deemed stable and beneficial, so the
decision was made to make it a permanent part of the application. Removing the  
feature flag simplifies the codebase by eliminating conditional logic and dead  
code paths associated with the "off" state of the flag. This improves           
maintainability and readability.                                                

Tokens: 46k sent, 2.9k received. Cost: $0.09 message, $0.09 session.
Applied edit to src/test/e2e/api/admin/applications.e2e.test.ts
Applied edit to src/server-dev.ts
Applied edit to src/lib/types/experimental.ts
Applied edit to frontend/src/component/application/ApplicationChart.tsx
Applied edit to src/lib/features/frontend-api/frontend-api-service.ts
Applied edit to frontend/src/interfaces/uiConfig.ts
Applied edit to src/lib/features/metrics/instance/metrics.ts
Applied edit to src/lib/features/metrics/instance/metrics.test.ts
Commit 4106a3a chore: remove registerFrontendClient flag, keep feature