### PR TITLE
Remove feature flag: registerFrontendClient

### DIFF
--- a/frontend/src/component/application/ApplicationChart.tsx
+++ b/frontend/src/component/application/ApplicationChart.tsx
@@ -197,7 +197,6 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
     const { elementRef, width } = useElementWidth();
     const navigate = useNavigate();
     const theme = useTheme();
-    const registerFrontendClientEnabled = useUiFlag('registerFrontendClient');
 
     const mode = getApplicationIssues(data);
 
@@ -296,23 +295,8 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                 {environment.instanceCount}
                                             </StyledCell>
                                         </tr>
-                                        {!registerFrontendClientEnabled ? (
-                                            <tr>
-                                                <StyledCell>SDK:</StyledCell>
-                                                <StyledCell>
-                                                    {environment.sdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
 
-                                        {registerFrontendClientEnabled &&
-                                        environment.backendSdks.length > 0 ? (
+                                        {environment.backendSdks.length > 0 ? (
                                             <tr>
                                                 <StyledCell>
                                                     Backend SDK:
@@ -329,8 +313,7 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                             </tr>
                                         ) : null}
 
-                                        {registerFrontendClientEnabled &&
-                                        environment.frontendSdks.length > 0 ? (
+                                        {environment.frontendSdks.length > 0 ? (
                                             <tr>
                                                 <StyledCell>
                                                     Frontend SDK:

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -88,7 +88,6 @@ export type UiFlags = {
     edgeObservability?: boolean;
     addEditStrategy?: boolean;
     cleanupReminder?: boolean;
-    registerFrontendClient?: boolean;
     featureLinks?: boolean;
     projectLinkTemplates?: boolean;
     customMetrics?: boolean;

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -135,11 +135,7 @@ export class FrontendApiService {
             ip,
         );
 
-        if (
-            metrics.instanceId &&
-            typeof sdkVersion === 'string' &&
-            this.flagResolver.isEnabled('registerFrontendClient')
-        ) {
+        if (metrics.instanceId && typeof sdkVersion === 'string') {
             const client = {
                 appName: metrics.appName,
                 instanceId: metrics.instanceId,

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -228,20 +228,14 @@ export default class ClientMetricsController extends Controller {
                         app.sdkType === 'frontend' &&
                         typeof app.sdkVersion === 'string'
                     ) {
-                        if (
-                            this.flagResolver.isEnabled(
-                                'registerFrontendClient',
-                            )
-                        ) {
-                            this.clientInstanceService.registerFrontendClient({
-                                appName: app.appName,
-                                instanceId: app.instanceId,
-                                environment: app.environment,
-                                sdkType: app.sdkType,
-                                sdkVersion: app.sdkVersion,
-                                projects: app.projects,
-                            });
-                        }
+                        this.clientInstanceService.registerFrontendClient({
+                            appName: app.appName,
+                            instanceId: app.instanceId,
+                            environment: app.environment,
+                            sdkType: app.sdkType,
+                            sdkVersion: app.sdkVersion,
+                            projects: app.projects,
+                        });
                     } else {
                         promises.push(
                             this.clientInstanceService.registerBackendClient(

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -59,7 +59,6 @@ export type IFlagKey =
     | 'addEditStrategy'
     | 'cleanupReminder'
     | 'removeInactiveApplications'
-    | 'registerFrontendClient'
     | 'featureLinks'
     | 'projectLinkTemplates'
     | 'reportUnknownFlags'
@@ -281,10 +280,6 @@ const flags: IFlags = {
     ),
     removeInactiveApplications: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_REMOVE_INACTIVE_APPLICATIONS,
-        false,
-    ),
-    registerFrontendClient: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_REGISTER_FRONTEND_CLIENT,
         false,
     ),
     featureLinks: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -53,7 +53,6 @@ process.nextTick(async () => {
                         addEditStrategy: true,
                         cleanupReminder: true,
                         strictSchemaValidation: true,
-                        registerFrontendClient: true,
                         featureLinks: true,
                         projectLinkTemplates: true,
                         reportUnknownFlags: true,

--- a/src/test/e2e/api/admin/applications.e2e.test.ts
+++ b/src/test/e2e/api/admin/applications.e2e.test.ts
@@ -54,7 +54,6 @@ beforeAll(async () => {
             experimental: {
                 flags: {
                     strictSchemaValidation: true,
-                    registerFrontendClient: true,
                 },
             },
         },


### PR DESCRIPTION
## Feature Flag Removal: registerFrontendClient

This PR removes the `registerFrontendClient` feature flag from the codebase. The changes have been automatically applied using Henry, our automated flag removal assistant.

**Flag Value:** `kept`


This change removes the registerFrontendClient feature flag from the codebase.  
The feature controlled by this flag has been kept, meaning its functionality is 
now permanently enabled.                                                        

What was removed:                                                               

 • The registerFrontendClient flag definition in src/lib/types/experimental.ts. 
 • The registerFrontendClient flag from the UiFlags interface in                
   frontend/src/interfaces/uiConfig.ts.                                         
 • The flag from experimental flag configurations in src/server-dev.ts and      
   src/test/e2e/api/admin/applications.e2e.test.ts.                             
 • Conditional checks for this.flagResolver.isEnabled('registerFrontendClient') 
   in:                                                                          
    • src/lib/features/frontend-api/frontend-api-service.ts                     
    • src/lib/features/metrics/instance/metrics.ts                              
 • The useUiFlag('registerFrontendClient') hook call and associated conditional 
   rendering logic in frontend/src/component/application/ApplicationChart.tsx.  

What was kept:                                                                  

 • The core functionality of registering frontend clients.                      
    • In src/lib/features/frontend-api/frontend-api-service.ts, the logic to    
      register frontend clients via                                             
      this.services.clientInstanceService.registerFrontendClient(client) will   
      now always execute if metrics.instanceId and sdkVersion are present.      
    • In src/lib/features/metrics/instance/metrics.ts, the logic to register    
      frontend clients via                                                      
      this.clientInstanceService.registerFrontendClient(...) during bulk metrics
      processing will now always execute for applications with sdkType ===      
      'frontend' and a valid sdkVersion.                                        
 • In frontend/src/component/application/ApplicationChart.tsx, the UI will now  
   consistently display separate "Backend SDK" and "Frontend SDK" sections if   
   data for them exists, instead of a generic "SDK" section.                    

Why these changes were made:                                                    

The registerFrontendClient feature flag was deemed stable and ready for         
permanent activation. Removing the flag simplifies the codebase by eliminating  
conditional logic and makes the frontend client registration behavior standard. 

Tokens: 46k sent, 2.0k received. Cost: $0.08 message, $0.08 session.
Applied edit to frontend/src/interfaces/uiConfig.ts
Applied edit to src/server-dev.ts
Applied edit to src/test/e2e/api/admin/applications.e2e.test.ts
Applied edit to src/lib/types/experimental.ts
Applied edit to frontend/src/component/application/ApplicationChart.tsx
Applied edit to src/lib/features/frontend-api/frontend-api-service.ts
Applied edit to src/lib/features/metrics/instance/metrics.ts
Commit e20ff3c chore: remove registerFrontendClient flag, keep feature