### PR TITLE
chore: remove console.log and reuse package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dev:frontend:cloud": "UNLEASH_BASE_PATH=/demo/ yarn run dev:frontend",
     "dev": "concurrently \"yarn:dev:backend\" \"yarn:dev:frontend\"",
     "prepare:backend": "concurrently \"yarn:copy-templates\" \"yarn:build:backend\"",
-    "start:dev": "yarn run clean && TZ=UTC NODE_ENV=development tsc-watch --onSuccess \"node dist/server-dev.js\"",
+    "start:dev": "yarn run clean && yarn dev:backend",
     "db-migrate": "db-migrate --migrations-dir ./src/migrations",
     "lint": "biome check .",
     "lint:fix": "biome check . --write",

--- a/src/lib/addons/teams.ts
+++ b/src/lib/addons/teams.ts
@@ -94,7 +94,7 @@ export default class TeamsAddon extends Addon {
             headers: { 'Content-Type': 'application/json', ...extraHeaders },
             body: JSON.stringify(body),
         };
-        console.log(`${url} Request options: ${JSON.stringify(requestOpts)}`);
+
         const res = await this.fetchRetry(url, requestOpts);
 
         this.logger.info(`Handled event "${event.type}".`);

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -180,8 +180,6 @@ export default class ClientMetricsController extends Controller {
             try {
                 const { body } = req;
 
-                console.log(body);
-
                 // Use Joi validation for custom metrics
                 await customMetricsSchema.validateAsync(body);
 


### PR DESCRIPTION
Make `start:dev` re-use `dev:backend`, the only difference is start:dev runs a clean before running