### PR TITLE
chore: don't include passwordLink if it's unleashUrl

### DIFF
--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -430,6 +430,9 @@ export class EmailService {
             let gettingStartedTemplate = 'getting-started';
             if (this.flagResolver.isEnabled('newGettingStartedEmail')) {
                 gettingStartedTemplate = 'getting-started-new';
+                if (passwordLink === unleashUrl) {
+                    delete context.passwordLink;
+                }
             }
 
             const bodyHtml = await this.compileTemplate(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3572/fix-dont-include-passwordlink-if-its-the-same-as-unleashurl

In case we don't have password auth enabled (`passwordLink === unleashUrl`), we should see the alternative branch in our getting started email:

https://github.com/Unleash/unleash/blob/e52fcd11e06256a6158a0fe321a322d0259c5bf6/src/mailtemplates/getting-started-new/getting-started-new.html.mustache#L40-L45

This change helps us validate this behavior within the `newGettingStartedEmail`. If it works correctly for both cases (password auth enabled/disabled) we can probably clean this up as part of our flag removal.