### PR TITLE
feat: add required cdn events

### DIFF
--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -213,6 +213,8 @@ export const USER_PREFERENCE_UPDATED = 'user-preference-updated' as const;
 export const SCIM_USERS_DELETED = 'scim-users-deleted' as const;
 export const SCIM_GROUPS_DELETED = 'scim-groups-deleted' as const;
 
+export const CDN_TOKEN_CREATED = 'cdn-token-created' as const;
+
 export const IEventTypes = [
     APPLICATION_CREATED,
     FEATURE_CREATED,
@@ -373,6 +375,7 @@ export const IEventTypes = [
     USER_PREFERENCE_UPDATED,
     SCIM_USERS_DELETED,
     SCIM_GROUPS_DELETED,
+    CDN_TOKEN_CREATED,
 ] as const;
 export type IEventType = (typeof IEventTypes)[number];
 

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -181,6 +181,7 @@ import {
 import { getDbConfig } from '../test/e2e/helpers/database-config.js';
 import { testDbPrefix } from '../test/e2e/helpers/database-init.js';
 import type { RequestHandler } from 'express';
+import { UPDATE_REVISION } from './features/feature-toggle/configuration-revision-service.js';
 
 export async function initialServiceSetup(
     { authentication }: Pick<IUnleashConfig, 'authentication'>,
@@ -420,6 +421,7 @@ export {
     CUSTOM_ROOT_ROLE_TYPE,
     getVariantValue,
     UPDATE_DELTA,
+    UPDATE_REVISION,
     applyGenericQueryParams,
     normalizeQueryParams,
     parseSearchOperatorValue,


### PR DESCRIPTION
## About the changes
Exposes configuration revision service UPDATE_EVENT constant so it can be used, and we also add a new event for cdn token created