### PR TITLE
fix: removed docs folder and replaced with openapi-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "files": [
     "dist",
-    "docs",
+    "openapi-static",
     "frontend/build",
     "frontend/build/*",
     "frontend/build/**/*",
@@ -50,7 +50,7 @@
     "db-migrate": "db-migrate --migrations-dir ./src/migrations",
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
-    "local:package": "del-cli --force build && mkdir build && cp -r dist docs CHANGELOG.md LICENSE README.md package.json build",
+    "local:package": "del-cli --force build && mkdir build && cp -r dist openapi-static CHANGELOG.md LICENSE README.md package.json build",
     "build:watch": "tsc -w",
     "prepare": "husky && yarn --cwd ./frontend install && if [ ! -d ./dist ]; then yarn build; fi",
     "test": "PORT=4243 vitest run",


### PR DESCRIPTION
https://github.com/Unleash/unleash/actions/runs/15298694489/job/43037677429#step:10:360 we are failing to copy docs because we removed them