### PR TITLE
fix: removed docs folder and replaced with openapi-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "files": [
     "dist",
-    "docs",
+    "openapi-static",
     "frontend/build",
     "frontend/build/*",
     "frontend/build/**/*",
@@ -50,7 +50,7 @@
     "db-migrate": "db-migrate --migrations-dir ./src/migrations",
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
-    "local:package": "del-cli --force build && mkdir build && cp -r dist docs CHANGELOG.md LICENSE README.md package.json build",
+    "local:package": "del-cli --force build && mkdir build && cp -r dist openapi-static CHANGELOG.md LICENSE README.md package.json build",
     "build:watch": "tsc -w",
     "prepare": "husky && yarn --cwd ./frontend install && if [ ! -d ./dist ]; then yarn build; fi",
     "test": "PORT=4243 vitest run",


### PR DESCRIPTION
Forgot to include the folder in docker

Related to: https://github.com/Unleash/unleash/pull/10038

![image](https://github.com/user-attachments/assets/9b86ef95-7791-460f-aaf0-7d9df414d966)
