### PR TITLE
feat: fail in dev when usign deprecated endpoints

### DIFF
--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -51,6 +51,20 @@ export class OpenApiService {
             
             `
             : '';
+
+        const failDeprecated =
+            (op.deprecated ?? false) && process.env.NODE_ENV === 'development';
+
+        if (failDeprecated) {
+            return (req, res, next) => {
+                this.logger.warn(
+                    `Deprecated endpoint: ${op.operationId} at ${req.path}`,
+                );
+                return res.status(410).json({
+                    message: `The endpoint ${op.operationId} at ${req.path} is deprecated and should not be used.`,
+                });
+            };
+        }
         return this.api.validPath({
             ...rest,
             description:


### PR DESCRIPTION
As an example, I've deprecated the endpoint to get environments for a project and this is how it's reflected in the UI and the web console:
![Screenshot from 2025-05-29 12-05-51](https://github.com/user-attachments/assets/da1da2c0-d8af-41a8-9972-ec0a49fb5d78)

Also logs will output:
```
[2025-05-29T10:05:45.198] [WARN] openapi-service.ts - Deprecated endpoint: getProjectEnvironments at /project/default
```
