### PR TITLE
chore!: remove deprecated put project groups roles endpoint

### DIFF
--- a/src/lib/db/access-store.ts
+++ b/src/lib/db/access-store.ts
@@ -571,23 +571,6 @@ export class AccessStore implements IAccessStore {
             .update('role_id', roleId);
     }
 
-    updateGroupProjectRole(
-        groupId: number,
-        roleId: number,
-        projectId: string,
-    ): Promise<void> {
-        return this.db(T.GROUP_ROLE)
-            .where({
-                group_id: groupId,
-                project: projectId,
-            })
-            .whereNotIn(
-                'role_id',
-                this.db(T.ROLES).select('id as role_id').where('type', 'root'),
-            )
-            .update('role_id', roleId);
-    }
-
     async addAccessToProject(
         roles: number[],
         groups: number[],

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -79,7 +79,6 @@ export const PROJECT_USER_ADDED = 'project-user-added' as const;
 export const PROJECT_USER_REMOVED = 'project-user-removed' as const;
 export const PROJECT_USER_ROLE_CHANGED = 'project-user-role-changed' as const;
 export const PROJECT_GROUP_ADDED = 'project-group-added' as const;
-export const PROJECT_GROUP_ROLE_CHANGED = 'project-group-role-changed' as const;
 export const DROP_PROJECTS = 'drop-projects' as const;
 export const TAG_CREATED = 'tag-created' as const;
 export const TAG_DELETED = 'tag-deleted' as const;
@@ -270,7 +269,6 @@ export const IEventTypes = [
     PROJECT_USER_ADDED,
     PROJECT_USER_REMOVED,
     PROJECT_USER_ROLE_CHANGED,
-    PROJECT_GROUP_ROLE_CHANGED,
     PROJECT_GROUP_ADDED,
     ROLE_CREATED,
     ROLE_UPDATED,

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -45,7 +45,6 @@ import {
     ProjectCreatedEvent,
     ProjectDeletedEvent,
     ProjectGroupAddedEvent,
-    ProjectGroupUpdateRoleEvent,
     ProjectRevivedEvent,
     ProjectUpdatedEvent,
     ProjectUserRemovedEvent,
@@ -63,7 +62,6 @@ import type { FeatureToggleService } from '../feature-toggle/feature-toggle-serv
 import IncompatibleProjectError from '../../error/incompatible-project-error.js';
 import { arraysHaveSameItems } from '../../util/index.js';
 import type { GroupService } from '../../services/group-service.js';
-import type { IGroupRole } from '../../types/group.js';
 import type { FavoritesService } from '../../services/favorites-service.js';
 import { calculateAverageTimeToProd } from '../feature-toggle/time-to-production/time-to-production.js';
 import type { IProjectStatsStore } from '../../types/stores/project-stats-store-type.js';
@@ -109,17 +107,6 @@ export interface IProjectStats {
 interface ICalculateStatus {
     projectId: string;
     updates: IProjectStats;
-}
-
-function includes(
-    list: number[],
-    {
-        id,
-    }: {
-        id: number;
-    },
-): boolean {
-    return list.some((l) => l === id);
 }
 
 export default class ProjectService {
@@ -993,20 +980,6 @@ export default class ProjectService {
         }
     }
 
-    async findProjectGroupRole(
-        projectId: string,
-        roleId: number,
-    ): Promise<IGroupRole> {
-        const roles = await this.groupService.getRolesForProject(projectId);
-        const role = roles.find((r) => r.roleId === roleId);
-        if (!role) {
-            throw new NotFoundError(
-                `Couldn't find roleId=${roleId} on project=${projectId}`,
-            );
-        }
-        return role;
-    }
-
     async findProjectRole(
         projectId: string,
         roleId: number,
@@ -1117,56 +1090,6 @@ export default class ProjectService {
                     roleId,
                     roleName: role.name,
                     email: user.email,
-                },
-            }),
-        );
-    }
-
-    async changeGroupRole(
-        projectId: string,
-        roleId: number,
-        userId: number,
-        auditUser: IAuditUser,
-    ): Promise<void> {
-        const usersWithRoles = await this.getAccessToProject(projectId);
-        const userGroup = usersWithRoles.groups.find((u) => u.id === userId);
-        if (!userGroup)
-            throw new ValidationError('Unexpected empty user', [], undefined);
-        const currentRole = usersWithRoles.roles.find((r) =>
-            userGroup.roles?.includes(r.id),
-        );
-        if (!currentRole)
-            throw new ValidationError(
-                'Unexpected empty current role',
-                [],
-                undefined,
-            );
-
-        if (currentRole.id === roleId) {
-            // Nothing to do....
-            return;
-        }
-
-        await this.accessService.updateGroupProjectRole(
-            userId,
-            roleId,
-            projectId,
-        );
-        const role = await this.findProjectGroupRole(projectId, roleId);
-
-        await this.eventService.storeEvent(
-            new ProjectGroupUpdateRoleEvent({
-                project: projectId,
-                auditUser,
-                preData: {
-                    userId,
-                    roleId: currentRole.id,
-                    roleName: currentRole.name,
-                },
-                data: {
-                    userId,
-                    roleId,
-                    roleName: role.name,
                 },
             }),
         );

--- a/src/lib/services/access-service.ts
+++ b/src/lib/services/access-service.ts
@@ -463,14 +463,6 @@ export class AccessService {
         return this.store.updateUserProjectRole(userId, roleId, projectId);
     }
 
-    async updateGroupProjectRole(
-        userId: number,
-        roleId: number,
-        projectId: string,
-    ): Promise<void> {
-        return this.store.updateGroupProjectRole(userId, roleId, projectId);
-    }
-
     //This actually only exists for testing purposes
     async addPermissionToRole(
         roleId: number,

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -77,7 +77,6 @@ import {
     PROJECT_ENVIRONMENT_REMOVED,
     PROJECT_FAVORITED,
     PROJECT_GROUP_ADDED,
-    PROJECT_GROUP_ROLE_CHANGED,
     PROJECT_IMPORT,
     PROJECT_REVIVED,
     PROJECT_UNFAVORITED,
@@ -1034,29 +1033,6 @@ export class ProjectGroupAddedEvent extends BaseEvent {
         this.project = project;
         this.data = data;
         this.preData = null;
-    }
-}
-
-export class ProjectGroupUpdateRoleEvent extends BaseEvent {
-    readonly project: string;
-
-    readonly data: any;
-
-    readonly preData: any;
-
-    /**
-     */
-    constructor(eventData: {
-        project: string;
-        data: any;
-        preData: any;
-        auditUser: IAuditUser;
-    }) {
-        super(PROJECT_GROUP_ROLE_CHANGED, eventData.auditUser);
-        const { project, data, preData } = eventData;
-        this.project = project;
-        this.data = data;
-        this.preData = preData;
     }
 }
 

--- a/src/lib/types/stores/access-store.ts
+++ b/src/lib/types/stores/access-store.ts
@@ -137,12 +137,6 @@ export interface IAccessStore extends Store<IRole, number> {
         projectId: string,
     ): Promise<void>;
 
-    updateGroupProjectRole(
-        userId: number,
-        roleId: number,
-        projectId: string,
-    ): Promise<void>;
-
     removeRolesOfTypeForUser(
         userId: number,
         roleTypes: string[],

--- a/src/test/fixtures/fake-access-store.ts
+++ b/src/test/fixtures/fake-access-store.ts
@@ -52,14 +52,6 @@ export class FakeAccessStore implements IAccessStore {
         throw new Error('Method not implemented.');
     }
 
-    updateGroupProjectRole(
-        userId: number,
-        roleId: number,
-        projectId: string,
-    ): Promise<void> {
-        throw new Error('Method not implemented.');
-    }
-
     addGroupToRole(
         groupId: number,
         roleId: number,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3361/remove-put-apiadminprojectsprojectidgroupsgroupidrolesroleid

Removes PUT `/api/admin/projects/{projectId}/groups/{groupId}/roles/{roleId}` which was deprecated in v5.5.
Also cleans up related code.