### PR TITLE
chore!: remove deprecated get metrics traffic

### DIFF
--- a/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
+++ b/frontend/src/hooks/api/getters/useInstanceTrafficMetrics/useInstanceTrafficMetrics.ts
@@ -23,7 +23,7 @@ export const useTrafficSearch = (
         to: string;
     },
 ): InstanceTrafficMetricsResponse => {
-    const apiPath = `api/admin/metrics/traffic-search?grouping=${grouping}&from=${from}&to=${to}`;
+    const apiPath = `api/admin/metrics/traffic?grouping=${grouping}&from=${from}&to=${to}`;
 
     const { data, error, mutate } = useSWR(formatApiPath(apiPath), fetcher);
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3370/remove-get-apiadminmetricstrafficperiod-deprecated-in-680

Removes GET `/api/admin/metrics/traffic/{period}` which was deprecated in v6.8.
Also cleans up related code.

For OSS this means switching to `/traffic` using an expand and contract approach. We can drop the `/traffic-search` endpoint in Enterprise after this is merged.