### PR TITLE
feat: lifecycle trends migration

### DIFF
--- a/src/migrations/20250530103216-lifecycle-trends.js
+++ b/src/migrations/20250530103216-lifecycle-trends.js
@@ -6,7 +6,7 @@ exports.up = function(db, cb) {
             CREATE TABLE IF NOT EXISTS lifecycle_trends (
                 id TEXT NOT NULL,
                 stage TEXT NOT NULL CHECK (stage IN ('develop', 'production', 'cleanup')),
-                flag_type TEXT NOT NULL CHECK (category IN ('experimental', 'release', 'permanent')),
+                flag_type TEXT NOT NULL CHECK (flag_type IN ('experimental', 'release', 'permanent')),
                 median_time_in_stage_days DECIMAL(10,2) DEFAULT 0,
                 flags_older_than_week INTEGER DEFAULT 0,
                 new_flags_this_week INTEGER DEFAULT 0,

--- a/src/migrations/20250530103216-lifecycle-trends.js
+++ b/src/migrations/20250530103216-lifecycle-trends.js
@@ -11,7 +11,7 @@ exports.up = function(db, cb) {
                 flags_older_than_week INTEGER DEFAULT 0,
                 new_flags_this_week INTEGER DEFAULT 0,
                 created_at TIMESTAMP DEFAULT now(),
-                PRIMARY KEY (id, stage, flag_type)
+                PRIMARY KEY (id, stage, flag_type, project)
                 );
         `,
         cb,

--- a/src/migrations/20250530103216-lifecycle-trends.js
+++ b/src/migrations/20250530103216-lifecycle-trends.js
@@ -5,14 +5,15 @@ exports.up = function(db, cb) {
         `
             CREATE TABLE IF NOT EXISTS lifecycle_trends (
                 id TEXT NOT NULL,
-                stage TEXT NOT NULL CHECK (stage IN ('develop', 'production', 'cleanup')),
+                stage TEXT NOT NULL CHECK (stage IN ('initial','develop', 'production', 'cleanup', 'archived')),
                 flag_type TEXT NOT NULL CHECK (flag_type IN ('experimental', 'release', 'permanent')),
-                median_time_in_stage_days DECIMAL(10,2) DEFAULT 0,
+                project VARCHAR(255) NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
                 flags_older_than_week INTEGER DEFAULT 0,
                 new_flags_this_week INTEGER DEFAULT 0,
                 created_at TIMESTAMP DEFAULT now(),
                 PRIMARY KEY (id, stage, flag_type)
-                );`,
+                );
+        `,
         cb,
     );
 };

--- a/src/migrations/20250530103216-lifecycle-trends.js
+++ b/src/migrations/20250530103216-lifecycle-trends.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = function(db, cb) {
+    db.runSql(
+        `
+            CREATE TABLE IF NOT EXISTS lifecycle_trends (
+                id TEXT NOT NULL,
+                stage TEXT NOT NULL CHECK (stage IN ('develop', 'production', 'cleanup')),
+                flag_type TEXT NOT NULL CHECK (category IN ('experimental', 'release', 'permanent')),
+                median_time_in_stage_days DECIMAL(10,2) DEFAULT 0,
+                flags_older_than_week INTEGER DEFAULT 0,
+                new_flags_this_week INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT now(),
+                PRIMARY KEY (id, stage, flag_type)
+                );`,
+        cb,
+    );
+};
+
+exports.down = function(db, cb) {
+    db.runSql('DROP TABLE IF EXISTS lifecycle_trends;', cb);
+};


### PR DESCRIPTION
Adding a single table to capture all lifecycle trends data.

One field presents a challenge: `median_time_in_stage_days`. This value is calculated per `stage`, not per `flag_type`. As a result, we would need to duplicate the total median time across each flag type. This isn’t a major issue.

An alternative would be to create a separate table solely for the median values, but that seems like overkill.
