### PR TITLE
fix: docker oss image now running with ESM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,9 @@ ENV TZ=UTC
 
 WORKDIR /unleash
 
-COPY --from=builder /unleash/build /unleash/build
+COPY --from=builder /unleash/build /unleash/
 
 COPY --from=builder /unleash/node_modules /unleash/node_modules
-
-COPY ./docker/index.js /unleash/index.js
 
 RUN rm -rf /usr/local/lib/node_modules/npm/
 
@@ -37,4 +35,4 @@ EXPOSE 4242
 
 USER node
 
-CMD ["node", "index.js"]
+CMD ["node", "dist/server.js"]

--- a/docker/index.js
+++ b/docker/index.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const unleash = require('./build');
-
-let options = {};
-
-unleash.start(options);


### PR DESCRIPTION
The docker image was trying to load as CJS module:
```
unleash-1  | node:internal/modules/cjs/loader:1404
unleash-1  |   throw err;
unleash-1  |   ^
unleash-1  | 
unleash-1  | Error: Cannot find module './build'
unleash-1  | Require stack:
unleash-1  | - /unleash/index.js
unleash-1  |     at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
unleash-1  |     at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
unleash-1  |     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
unleash-1  |     at Function._load (node:internal/modules/cjs/loader:1211:37)
unleash-1  |     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
unleash-1  |     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
unleash-1  |     at Module.require (node:internal/modules/cjs/loader:1487:12)
unleash-1  |     at require (node:internal/modules/helpers:135:16)
unleash-1  |     at Object.<anonymous> (/unleash/index.js:3:17)
unleash-1  |     at Module._compile (node:internal/modules/cjs/loader:1730:14) {
unleash-1  |   code: 'MODULE_NOT_FOUND',
unleash-1  |   requireStack: [ '/unleash/index.js' ]
unleash-1  | }
unleash-1  | 
unleash-1  | Node.js v22.15.1
```

This PR makes use of the existing server.ts file instead of having a specific index.js inside the docker folder, because they both do the same thing