### PR TITLE
feat: add lifecycle trend graphs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,6 +159,7 @@
   },
   "packageManager": "yarn@4.9.1",
   "dependencies": {
+    "chartjs-plugin-datalabels": "^2.2.0",
     "json-2-csv": "^5.5.5"
   }
 }

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChart.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChart.tsx
@@ -1,0 +1,5 @@
+import { lazy } from 'react';
+
+export const LifecycleChart = lazy(
+    () => import('./LifecycleChartComponent.tsx'),
+);

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -60,6 +60,7 @@ export const createOptions = (theme: Theme): ChartOptions<'bar'> => {
                     drawBorder: false,
                 },
                 ticks: {
+                    stepSize: 1,
                     color: theme.palette.text.disabled,
                     font: {
                         size: fontSize,

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode, useState, type FC } from 'react';
+import {
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Tooltip,
+    Legend,
+    TimeScale,
+    Chart,
+    Filler,
+    type ChartData,
+    type ChartOptions,
+    BarElement,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import 'chartjs-adapter-date-fns';
+import { useTheme } from '@mui/material';
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import merge from 'deepmerge';
+import {
+    ChartTooltip,
+    type TooltipState,
+} from '../LineChart/ChartTooltip/ChartTooltip.tsx';
+
+function mergeAll<T>(objects: Partial<T>[]): T {
+    return merge.all<T>(objects.filter((i) => i));
+}
+
+const LifecycleChartComponent: FC<{
+    data: ChartData<'bar', unknown>;
+    aspectRatio?: number;
+    cover?: ReactNode;
+    overrideOptions?: ChartOptions<'bar'>;
+    TooltipComponent?: ({
+        tooltip,
+    }: { tooltip: TooltipState | null }) => ReturnType<FC>;
+}> = ({
+    data,
+    aspectRatio = 2.5,
+    cover,
+    overrideOptions,
+    TooltipComponent,
+}) => {
+    const theme = useTheme();
+    const { locationSettings } = useLocationSettings();
+
+    const [tooltip, setTooltip] = useState<null | TooltipState>(null);
+
+    // const options = useMemo(
+    //     () =>
+    //         mergeAll([
+    //             createOptions(
+    //                 theme,
+    //                 locationSettings,
+    //                 setTooltip,
+    //                 Boolean(cover),
+    //             ),
+    //             overrideOptions ?? {},
+    //         ]),
+    //     [theme, locationSettings, overrideOptions, cover],
+    // );
+
+    return (
+        <>
+            <Bar
+                key={cover ? 'cover' : 'chart'}
+                // options={options}
+                data={data}
+                // plugins={[customHighlightPlugin]}
+                height={100}
+                width={100 * aspectRatio}
+            />
+            <ChartTooltip tooltip={tooltip} />
+        </>
+    );
+};
+
+Chart.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    BarElement,
+    TimeScale,
+    Tooltip,
+    Legend,
+    Filler,
+);
+
+// for lazy-loading
+export default LifecycleChartComponent;

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -57,6 +57,7 @@ export const createOptions = (
             },
         },
         responsive: true,
+        maintainAspectRatio: false,
         color: theme.palette.text.secondary,
         scales: {
             y: {

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -21,6 +21,7 @@ import {
     ChartTooltip,
     type TooltipState,
 } from '../LineChart/ChartTooltip/ChartTooltip.tsx';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 export const createOptions = (
     theme: Theme,
@@ -35,7 +36,28 @@ export const createOptions = (
                 align: 'start',
                 labels: {
                     usePointStyle: true,
+                    padding: 21,
                 },
+            },
+            datalabels: {
+                color: theme.palette.text.primary,
+                font: {
+                    weight: 'bold',
+                },
+                anchor: 'end',
+                align: 'top',
+                offset: -6,
+                // formatter: (value: number, context: Context) => {
+                //     console.log(context);
+                //     // return context.dataset.data.reduce((acc, curr) => {
+                //     //     console.log(context);
+                //     //     // if (Number.) {
+                //     //     //     return acc + curr;
+                //     //     // }
+                //     //     return acc + 1;
+                //     // }, 0);
+                //     return 17;
+                // },
             },
         },
         responsive: true,
@@ -109,7 +131,7 @@ const LifecycleChartComponent: FC<{
                 key={cover ? 'cover' : 'chart'}
                 options={options}
                 data={data}
-                // plugins={[customHighlightPlugin]}
+                plugins={[ChartDataLabels]}
                 height={100}
                 width={100 * aspectRatio}
             />

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -47,17 +47,6 @@ export const createOptions = (
                 anchor: 'end',
                 align: 'top',
                 offset: -6,
-                // formatter: (value: number, context: Context) => {
-                //     console.log(context);
-                //     // return context.dataset.data.reduce((acc, curr) => {
-                //     //     console.log(context);
-                //     //     // if (Number.) {
-                //     //     //     return acc + curr;
-                //     //     // }
-                //     //     return acc + 1;
-                //     // }, 0);
-                //     return 17;
-                // },
             },
         },
         responsive: true,
@@ -71,27 +60,12 @@ export const createOptions = (
                     borderColor: theme.palette.divider,
                     drawBorder: false,
                 },
-                ticks: {
-                    // major: { enabled: true },
-                    // stepSize: 1,
-                    // color: theme.palette.text.secondary,
-                    // display: !isPlaceholder,
-                    // precision: 0,
-                },
             },
             x: {
                 stacked: true,
                 grid: {
                     display: false,
                 },
-
-                // ticks: {
-                //     color: theme.palette.text.secondary,
-                //     display: !isPlaceholder,
-                //     source: 'data',
-                //     maxRotation: 90,
-                //     minRotation: 23.5,
-                // },
             },
         },
     }) as const;

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -28,21 +28,28 @@ export const createOptions = (
     // locationSettings: ILocationSettings,
     // setTooltip: React.Dispatch<React.SetStateAction<TooltipState | null>>,
     isPlaceholder?: boolean,
-): ChartOptions<'bar'> =>
-    ({
+): ChartOptions<'bar'> => {
+    const fontSize = 10;
+    return {
         plugins: {
             legend: {
                 position: 'right',
                 align: 'start',
                 labels: {
+                    color: theme.palette.text.secondary,
                     usePointStyle: true,
                     padding: 21,
+                    boxHeight: 8,
+                    font: {
+                        size: fontSize,
+                    },
                 },
             },
             datalabels: {
                 color: theme.palette.text.primary,
                 font: {
                     weight: 'bold',
+                    size: fontSize,
                 },
                 anchor: 'end',
                 align: 'top',
@@ -54,21 +61,32 @@ export const createOptions = (
         scales: {
             y: {
                 beginAtZero: true,
-                stacked: true,
                 grid: {
                     color: theme.palette.divider,
                     borderColor: theme.palette.divider,
                     drawBorder: false,
                 },
+                ticks: {
+                    color: theme.palette.text.disabled,
+                    font: {
+                        size: fontSize,
+                    },
+                },
             },
             x: {
-                stacked: true,
                 grid: {
                     display: false,
                 },
+                ticks: {
+                    color: theme.palette.text.primary,
+                    font: {
+                        size: fontSize,
+                    },
+                },
             },
         },
-    }) as const;
+    } as const;
+};
 
 function mergeAll<T>(objects: Partial<T>[]): T {
     return merge.all<T>(objects.filter((i) => i));

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -34,6 +34,7 @@ export const createOptions = (
         plugins: {
             legend: {
                 position: 'right',
+                maxWidth: 150,
                 align: 'start',
                 labels: {
                     color: theme.palette.text.secondary,

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, type FC, useMemo } from 'react';
+import { type FC, useMemo } from 'react';
 import {
     CategoryScale,
     LinearScale,
@@ -17,18 +17,9 @@ import 'chartjs-adapter-date-fns';
 import { type Theme, useTheme } from '@mui/material';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import merge from 'deepmerge';
-import {
-    ChartTooltip,
-    type TooltipState,
-} from '../LineChart/ChartTooltip/ChartTooltip.tsx';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
-export const createOptions = (
-    theme: Theme,
-    // locationSettings: ILocationSettings,
-    // setTooltip: React.Dispatch<React.SetStateAction<TooltipState | null>>,
-    isPlaceholder?: boolean,
-): ChartOptions<'bar'> => {
+export const createOptions = (theme: Theme): ChartOptions<'bar'> => {
     const fontSize = 10;
     return {
         plugins: {
@@ -96,40 +87,20 @@ function mergeAll<T>(objects: Partial<T>[]): T {
 
 const LifecycleChartComponent: FC<{
     data: ChartData<'bar', unknown>;
-    aspectRatio?: number;
-    cover?: ReactNode;
     overrideOptions?: ChartOptions<'bar'>;
-    TooltipComponent?: ({
-        tooltip,
-    }: { tooltip: TooltipState | null }) => ReturnType<FC>;
-}> = ({
-    data,
-    aspectRatio = 2.5,
-    cover,
-    overrideOptions,
-    TooltipComponent,
-}) => {
+}> = ({ data, overrideOptions }) => {
     const theme = useTheme();
     const { locationSettings } = useLocationSettings();
 
-    const [tooltip, setTooltip] = useState<null | TooltipState>(null);
-
     const options = useMemo(
         () => mergeAll([createOptions(theme)]),
-        [theme, locationSettings, overrideOptions, cover],
+        [theme, locationSettings, overrideOptions],
     );
 
     return (
         <>
-            <Bar
-                key={cover ? 'cover' : 'chart'}
-                options={options}
-                data={data}
-                plugins={[ChartDataLabels]}
-                height={100}
-                width={100 * aspectRatio}
-            />
-            <ChartTooltip tooltip={tooltip} />
+            <Bar options={options} data={data} plugins={[ChartDataLabels]} />
+            {/* todo: implement fallback for screen readers */}
         </>
     );
 };

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -57,8 +57,8 @@ export const createOptions = (
                 offset: -6,
             },
         },
+        aspectRatio: 2 / 1,
         responsive: true,
-        maintainAspectRatio: false,
         color: theme.palette.text.secondary,
         scales: {
             y: {

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -1,9 +1,8 @@
-import { type ReactNode, useState, type FC } from 'react';
+import { type ReactNode, useState, type FC, useMemo } from 'react';
 import {
     CategoryScale,
     LinearScale,
     PointElement,
-    LineElement,
     Tooltip,
     Legend,
     TimeScale,
@@ -15,13 +14,58 @@ import {
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import 'chartjs-adapter-date-fns';
-import { useTheme } from '@mui/material';
+import { type Theme, useTheme } from '@mui/material';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 import merge from 'deepmerge';
 import {
     ChartTooltip,
     type TooltipState,
 } from '../LineChart/ChartTooltip/ChartTooltip.tsx';
+
+export const createOptions = (
+    theme: Theme,
+    // locationSettings: ILocationSettings,
+    // setTooltip: React.Dispatch<React.SetStateAction<TooltipState | null>>,
+    isPlaceholder?: boolean,
+): ChartOptions<'bar'> =>
+    ({
+        responsive: true,
+        color: theme.palette.text.secondary,
+        scales: {
+            y: {
+                beginAtZero: true,
+                stacked: true,
+                // grid: {
+                //     color: theme.palette.divider,
+                //     borderColor: theme.palette.divider,
+                // },
+                // ticks: {
+                //     color: theme.palette.text.secondary,
+                //     display: !isPlaceholder,
+                //     precision: 0,
+                // },
+            },
+            x: {
+                stacked: true,
+                // type: 'time',
+                // time: {
+                //     unit: 'week',
+                //     tooltipFormat: 'PPP',
+                // },
+                // grid: {
+                //     color: 'transparent',
+                //     borderColor: 'transparent',
+                // },
+                // ticks: {
+                //     color: theme.palette.text.secondary,
+                //     display: !isPlaceholder,
+                //     source: 'data',
+                //     maxRotation: 90,
+                //     minRotation: 23.5,
+                // },
+            },
+        },
+    }) as const;
 
 function mergeAll<T>(objects: Partial<T>[]): T {
     return merge.all<T>(objects.filter((i) => i));
@@ -47,25 +91,16 @@ const LifecycleChartComponent: FC<{
 
     const [tooltip, setTooltip] = useState<null | TooltipState>(null);
 
-    // const options = useMemo(
-    //     () =>
-    //         mergeAll([
-    //             createOptions(
-    //                 theme,
-    //                 locationSettings,
-    //                 setTooltip,
-    //                 Boolean(cover),
-    //             ),
-    //             overrideOptions ?? {},
-    //         ]),
-    //     [theme, locationSettings, overrideOptions, cover],
-    // );
+    const options = useMemo(
+        () => mergeAll([createOptions(theme)]),
+        [theme, locationSettings, overrideOptions, cover],
+    );
 
     return (
         <>
             <Bar
                 key={cover ? 'cover' : 'chart'}
-                // options={options}
+                options={options}
                 data={data}
                 // plugins={[customHighlightPlugin]}
                 height={100}
@@ -80,7 +115,6 @@ Chart.register(
     CategoryScale,
     LinearScale,
     PointElement,
-    LineElement,
     BarElement,
     TimeScale,
     Tooltip,

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -29,6 +29,15 @@ export const createOptions = (
     isPlaceholder?: boolean,
 ): ChartOptions<'bar'> =>
     ({
+        plugins: {
+            legend: {
+                position: 'right',
+                align: 'start',
+                labels: {
+                    usePointStyle: true,
+                },
+            },
+        },
         responsive: true,
         color: theme.palette.text.secondary,
         scales: {

--- a/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
+++ b/frontend/src/component/insights/components/LifecycleChart/LifecycleChartComponent.tsx
@@ -35,27 +35,25 @@ export const createOptions = (
             y: {
                 beginAtZero: true,
                 stacked: true,
-                // grid: {
-                //     color: theme.palette.divider,
-                //     borderColor: theme.palette.divider,
-                // },
-                // ticks: {
-                //     color: theme.palette.text.secondary,
-                //     display: !isPlaceholder,
-                //     precision: 0,
-                // },
+                grid: {
+                    color: theme.palette.divider,
+                    borderColor: theme.palette.divider,
+                    drawBorder: false,
+                },
+                ticks: {
+                    // major: { enabled: true },
+                    // stepSize: 1,
+                    // color: theme.palette.text.secondary,
+                    // display: !isPlaceholder,
+                    // precision: 0,
+                },
             },
             x: {
                 stacked: true,
-                // type: 'time',
-                // time: {
-                //     unit: 'week',
-                //     tooltipFormat: 'PPP',
-                // },
-                // grid: {
-                //     color: 'transparent',
-                //     borderColor: 'transparent',
-                // },
+                grid: {
+                    display: false,
+                },
+
                 // ticks: {
                 //     color: theme.palette.text.secondary,
                 //     display: !isPlaceholder,

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -51,7 +51,6 @@ const ChartContainer = styled('article')(({ theme }) => ({
     background: theme.palette.background.default,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(2),
-    aspectRatio: '5/4', // todo: temp
     minWidth: 0,
 }));
 
@@ -155,7 +154,7 @@ export const LifecycleInsights: FC = () => {
                                 ],
                                 datasets: [
                                     {
-                                        label: '> 1 week old',
+                                        label: 'Flags > 1 week old',
                                         data: [
                                             data.categories.experimental
                                                 .flagsOlderThanWeek,
@@ -168,9 +167,18 @@ export const LifecycleInsights: FC = () => {
                                         backgroundColor:
                                             chartColors.olderThanWeek,
                                         borderRadius: 4,
+                                        datalabels: {
+                                            labels: {
+                                                value: {
+                                                    formatter: () => {
+                                                        return '';
+                                                    },
+                                                },
+                                            },
+                                        },
                                     },
                                     {
-                                        label: 'New this week',
+                                        label: 'New flags this week',
                                         data: [
                                             data.categories.experimental
                                                 .newFlagsThisWeek,
@@ -183,6 +191,35 @@ export const LifecycleInsights: FC = () => {
                                         backgroundColor:
                                             chartColors.newThisWeek,
                                         borderRadius: 4,
+                                        datalabels: {
+                                            labels: {
+                                                value: {
+                                                    formatter: (
+                                                        value,
+                                                        context,
+                                                    ) => {
+                                                        const dataSets = [
+                                                            data.categories
+                                                                .experimental
+                                                                .flagsOlderThanWeek,
+                                                            data.categories
+                                                                .release
+                                                                .flagsOlderThanWeek,
+                                                            data.categories
+                                                                .permanent
+                                                                .flagsOlderThanWeek,
+                                                        ];
+                                                        return (
+                                                            value +
+                                                            dataSets[
+                                                                context
+                                                                    .dataIndex
+                                                            ]
+                                                        );
+                                                    },
+                                                },
+                                            },
+                                        },
                                     },
                                 ],
                             }}

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -41,10 +41,18 @@ const useChartColors = () => {
     };
 };
 
+const ChartRow = styled('div')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: theme.spacing(2),
+}));
+
 const ChartContainer = styled('article')(({ theme }) => ({
     background: theme.palette.background.default,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(2),
+    aspectRatio: '5/4', // todo: temp
+    minWidth: 0,
 }));
 
 export const LifecycleInsights: FC = () => {
@@ -163,45 +171,53 @@ export const LifecycleInsights: FC = () => {
                 />
             }
         >
-            {/* <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre> */}
-            {Object.entries(mockData).map(([stage, data]) => (
-                <ChartContainer>
-                    <LifecycleChart
-                        key={stage}
-                        data={{
-                            labels: [`Experimental`, `Release`, `Other flags`],
-                            datasets: [
-                                {
-                                    label: '> 1 week old',
-                                    data: [
-                                        data.categories.experimental
-                                            .flagsOlderThanWeek,
-                                        data.categories.release
-                                            .flagsOlderThanWeek,
-                                        data.categories.permanent
-                                            .flagsOlderThanWeek,
-                                    ],
-                                    stack: '1',
-                                    backgroundColor: chartColors.olderThanWeek,
-                                },
-                                {
-                                    label: 'New this week',
-                                    data: [
-                                        data.categories.experimental
-                                            .newFlagsThisWeek,
-                                        data.categories.release
-                                            .newFlagsThisWeek,
-                                        data.categories.permanent
-                                            .newFlagsThisWeek,
-                                    ],
-                                    stack: '1',
-                                    backgroundColor: chartColors.newThisWeek,
-                                },
-                            ],
-                        }}
-                    />
-                </ChartContainer>
-            ))}
+            <ChartRow>
+                {/* <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre> */}
+                {Object.entries(mockData).map(([stage, data]) => (
+                    <ChartContainer>
+                        <LifecycleChart
+                            key={stage}
+                            data={{
+                                labels: [
+                                    `Experimental`,
+                                    `Release`,
+                                    `Other flags`,
+                                ],
+                                datasets: [
+                                    {
+                                        label: '> 1 week old',
+                                        data: [
+                                            data.categories.experimental
+                                                .flagsOlderThanWeek,
+                                            data.categories.release
+                                                .flagsOlderThanWeek,
+                                            data.categories.permanent
+                                                .flagsOlderThanWeek,
+                                        ],
+                                        stack: '1',
+                                        backgroundColor:
+                                            chartColors.olderThanWeek,
+                                    },
+                                    {
+                                        label: 'New this week',
+                                        data: [
+                                            data.categories.experimental
+                                                .newFlagsThisWeek,
+                                            data.categories.release
+                                                .newFlagsThisWeek,
+                                            data.categories.permanent
+                                                .newFlagsThisWeek,
+                                        ],
+                                        stack: '1',
+                                        backgroundColor:
+                                            chartColors.newThisWeek,
+                                    },
+                                ],
+                            }}
+                        />
+                    </ChartContainer>
+                ))}
+            </ChartRow>
         </InsightsSection>
     );
 };

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -70,7 +70,6 @@ export const LifecycleInsights: FC = () => {
 
     // @ts-expect-error (lifecycleMetrics): The schema hasn't been updated yet.
     const { lifecycleTrends } = insights;
-    console.log('lifecycleTrends', lifecycleTrends);
 
     const mockData: LifecycleInsights = {
         develop: {
@@ -141,7 +140,6 @@ export const LifecycleInsights: FC = () => {
             }
         >
             <ChartRow>
-                {/* <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre> */}
                 {Object.entries(mockData).map(([stage, data]) => {
                     const oldData = [
                         data.categories.experimental.flagsOlderThanWeek,
@@ -149,9 +147,8 @@ export const LifecycleInsights: FC = () => {
                         data.categories.permanent.flagsOlderThanWeek,
                     ];
                     return (
-                        <ChartContainer>
+                        <ChartContainer key={stage}>
                             <LifecycleChart
-                                key={stage}
                                 data={{
                                     labels: [
                                         `Experimental`,

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -3,13 +3,25 @@ import type { FC } from 'react';
 import { FilterItemParam } from 'utils/serializeQueryParams';
 import { InsightsSection } from 'component/insights/sections/InsightsSection';
 import { InsightsFilters } from 'component/insights/InsightsFilters';
+import { allOption } from 'component/common/ProjectSelect/ProjectSelect';
+import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 
 export const LifecycleInsights: FC = () => {
     const statePrefix = 'lifecycle-';
     const stateConfig = {
         [`${statePrefix}project`]: FilterItemParam,
     };
-    const [state, setState] = usePersistentTableState('insights', stateConfig);
+    const [state, setState] = usePersistentTableState(
+        'insights-lifecycle',
+        stateConfig,
+    );
+
+    const projects = state[`${statePrefix}project`]?.values ?? [allOption.id];
+    const { insights, loading } = useInsights();
+
+    // @ts-expect-error (lifecycleMetrics): The schema hasn't been updated yet.
+    const { lifecycleTrends } = insights;
+    console.log('lifecycleTrends', lifecycleTrends);
 
     return (
         <InsightsSection
@@ -21,6 +33,8 @@ export const LifecycleInsights: FC = () => {
                     filterNamePrefix={statePrefix}
                 />
             }
-        />
+        >
+            <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre>
+        </InsightsSection>
     );
 };

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -5,6 +5,47 @@ import { InsightsSection } from 'component/insights/sections/InsightsSection';
 import { InsightsFilters } from 'component/insights/InsightsFilters';
 import { allOption } from 'component/common/ProjectSelect/ProjectSelect';
 import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
+import { LifecycleChart } from '../components/LifecycleChart/LifecycleChart.tsx';
+import { styled, useTheme } from '@mui/material';
+
+type LifecycleTrend = {
+    totalFlags: number;
+    averageTimeInStageDays: number;
+    categories: {
+        experimental: {
+            flagsOlderThanWeek: number;
+            newFlagsThisWeek: number;
+        };
+        release: {
+            flagsOlderThanWeek: number;
+            newFlagsThisWeek: number;
+        };
+        permanent: {
+            flagsOlderThanWeek: number;
+            newFlagsThisWeek: number;
+        };
+    };
+};
+
+type LifecycleInsights = {
+    develop: LifecycleTrend;
+    production: LifecycleTrend;
+    cleanup: LifecycleTrend;
+};
+
+const useChartColors = () => {
+    const theme = useTheme();
+    return {
+        olderThanWeek: theme.palette.primary.light,
+        newThisWeek: theme.palette.success.border,
+    };
+};
+
+const ChartContainer = styled('article')(({ theme }) => ({
+    background: theme.palette.background.default,
+    borderRadius: theme.shape.borderRadiusLarge,
+    padding: theme.spacing(2),
+}));
 
 export const LifecycleInsights: FC = () => {
     const statePrefix = 'lifecycle-';
@@ -15,6 +56,7 @@ export const LifecycleInsights: FC = () => {
         'insights-lifecycle',
         stateConfig,
     );
+    const chartColors = useChartColors();
 
     const projects = state[`${statePrefix}project`]?.values ?? [allOption.id];
     const { insights, loading } = useInsights();
@@ -22,6 +64,93 @@ export const LifecycleInsights: FC = () => {
     // @ts-expect-error (lifecycleMetrics): The schema hasn't been updated yet.
     const { lifecycleTrends } = insights;
     console.log('lifecycleTrends', lifecycleTrends);
+
+    const mockData: LifecycleInsights = {
+        develop: {
+            totalFlags: 35,
+            averageTimeInStageDays: 28,
+            categories: {
+                experimental: {
+                    flagsOlderThanWeek: 11,
+                    newFlagsThisWeek: 4,
+                },
+                release: {
+                    flagsOlderThanWeek: 12,
+                    newFlagsThisWeek: 1,
+                },
+                permanent: {
+                    flagsOlderThanWeek: 7,
+                    newFlagsThisWeek: 0,
+                },
+            },
+        },
+        production: {
+            totalFlags: 10,
+            averageTimeInStageDays: 14,
+            categories: {
+                experimental: {
+                    flagsOlderThanWeek: 2,
+                    newFlagsThisWeek: 3,
+                },
+                release: {
+                    flagsOlderThanWeek: 1,
+                    newFlagsThisWeek: 1,
+                },
+                permanent: {
+                    flagsOlderThanWeek: 3,
+                    newFlagsThisWeek: 0,
+                },
+            },
+        },
+        cleanup: {
+            totalFlags: 5,
+            averageTimeInStageDays: 16,
+            categories: {
+                experimental: {
+                    flagsOlderThanWeek: 0,
+                    newFlagsThisWeek: 3,
+                },
+                release: {
+                    flagsOlderThanWeek: 0,
+                    newFlagsThisWeek: 1,
+                },
+                permanent: {
+                    flagsOlderThanWeek: 1,
+                    newFlagsThisWeek: 0,
+                },
+            },
+        },
+    };
+
+    // const f = (
+    //     input: LifecycleTrend,
+    // ): { labels: string[]; datasets: { data: number[] }[] } => {
+    //     const flat = Object.entries(input.categories).map(([key, value]) => ({
+    //         label: key,
+    //         data: [value.flagsOlderThanWeek, value.newFlagsThisWeek],
+    //     }));
+    //     const result = Object.entries(input.categories).reduce(
+    //         (acc, [key, value]) => {
+    //             return {
+    //                 ...acc,
+    //                 labels: [...acc.labels, key],
+    //                 datasets: [
+    //                     ...acc.datasets,
+    //                     {
+    //                         data: [
+    //                             value.flagsOlderThanWeek,
+    //                             value.newFlagsThisWeek,
+    //                         ],
+    //                     },
+    //                 ],
+    //             };
+    //         },
+    //         { labels: [], datasets: [] },
+    //     );
+    //     return result;
+    // };
+
+    // console.log(mockData.develop, f(mockData.develop));
 
     return (
         <InsightsSection
@@ -34,7 +163,79 @@ export const LifecycleInsights: FC = () => {
                 />
             }
         >
-            <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre>
+            {/* <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre> */}
+            {Object.entries(mockData).map(([stage, data]) => (
+                <ChartContainer>
+                    <LifecycleChart
+                        key={stage}
+                        data={{
+                            labels: [
+                                `${stage} Experimental`,
+                                `${stage} Release`,
+                                `${stage} Other flags`,
+                            ],
+                            datasets: [
+                                {
+                                    label: 'Experimental Flags old',
+                                    data: [
+                                        data.categories.experimental
+                                            .flagsOlderThanWeek,
+                                    ],
+                                    stack: 'experimental',
+                                    backgroundColor: chartColors.olderThanWeek,
+                                },
+                                {
+                                    label: 'Experimental Flags new',
+                                    data: [
+                                        data.categories.experimental
+                                            .newFlagsThisWeek,
+                                    ],
+                                    stack: 'experimental',
+                                    backgroundColor: chartColors.newThisWeek,
+                                },
+
+                                {
+                                    label: 'Release Flags old',
+                                    data: [
+                                        data.categories.release
+                                            .flagsOlderThanWeek,
+                                    ],
+                                    stack: 'release',
+                                    backgroundColor: chartColors.olderThanWeek,
+                                },
+                                {
+                                    label: 'Release Flags new',
+                                    data: [
+                                        data.categories.release
+                                            .newFlagsThisWeek,
+                                    ],
+                                    stack: 'release',
+                                    backgroundColor: chartColors.newThisWeek,
+                                },
+
+                                {
+                                    label: 'Other Flags old',
+                                    data: [
+                                        data.categories.permanent
+                                            .flagsOlderThanWeek,
+                                    ],
+                                    stack: 'other',
+                                    backgroundColor: chartColors.olderThanWeek,
+                                },
+                                {
+                                    label: 'Other Flags new',
+                                    data: [
+                                        data.categories.permanent
+                                            .newFlagsThisWeek,
+                                    ],
+                                    stack: 'other',
+                                    backgroundColor: chartColors.newThisWeek,
+                                },
+                            ],
+                        }}
+                    />
+                </ChartContainer>
+            ))}
         </InsightsSection>
     );
 };

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -142,90 +142,79 @@ export const LifecycleInsights: FC = () => {
         >
             <ChartRow>
                 {/* <pre>{JSON.stringify(lifecycleTrends, null, 2)}</pre> */}
-                {Object.entries(mockData).map(([stage, data]) => (
-                    <ChartContainer>
-                        <LifecycleChart
-                            key={stage}
-                            data={{
-                                labels: [
-                                    `Experimental`,
-                                    `Release`,
-                                    `Other flags`,
-                                ],
-                                datasets: [
-                                    {
-                                        label: 'Flags > 1 week old',
-                                        data: [
-                                            data.categories.experimental
-                                                .flagsOlderThanWeek,
-                                            data.categories.release
-                                                .flagsOlderThanWeek,
-                                            data.categories.permanent
-                                                .flagsOlderThanWeek,
-                                        ],
-                                        stack: '1',
-                                        backgroundColor:
-                                            chartColors.olderThanWeek,
-                                        borderRadius: 4,
-                                        datalabels: {
-                                            labels: {
-                                                value: {
-                                                    formatter: () => {
-                                                        return '';
+                {Object.entries(mockData).map(([stage, data]) => {
+                    const oldData = [
+                        data.categories.experimental.flagsOlderThanWeek,
+                        data.categories.release.flagsOlderThanWeek,
+                        data.categories.permanent.flagsOlderThanWeek,
+                    ];
+                    return (
+                        <ChartContainer>
+                            <LifecycleChart
+                                key={stage}
+                                data={{
+                                    labels: [
+                                        `Experimental`,
+                                        `Release`,
+                                        `Other flags`,
+                                    ],
+                                    datasets: [
+                                        {
+                                            label: 'Flags > 1 week old',
+                                            data: oldData,
+                                            stack: '1',
+                                            backgroundColor:
+                                                chartColors.olderThanWeek,
+                                            borderRadius: 4,
+                                            datalabels: {
+                                                labels: {
+                                                    value: {
+                                                        formatter: () => {
+                                                            return '';
+                                                        },
                                                     },
                                                 },
                                             },
                                         },
-                                    },
-                                    {
-                                        label: 'New flags this week',
-                                        data: [
-                                            data.categories.experimental
-                                                .newFlagsThisWeek,
-                                            data.categories.release
-                                                .newFlagsThisWeek,
-                                            data.categories.permanent
-                                                .newFlagsThisWeek,
-                                        ],
-                                        stack: '1',
-                                        backgroundColor:
-                                            chartColors.newThisWeek,
-                                        borderRadius: 4,
-                                        datalabels: {
-                                            labels: {
-                                                value: {
-                                                    formatter: (
-                                                        value,
-                                                        context,
-                                                    ) => {
-                                                        const dataSets = [
-                                                            data.categories
-                                                                .experimental
-                                                                .flagsOlderThanWeek,
-                                                            data.categories
-                                                                .release
-                                                                .flagsOlderThanWeek,
-                                                            data.categories
-                                                                .permanent
-                                                                .flagsOlderThanWeek,
-                                                        ];
-                                                        return (
-                                                            value +
-                                                            dataSets[
-                                                                context
-                                                                    .dataIndex
-                                                            ]
-                                                        );
+                                        {
+                                            label: 'New flags this week',
+                                            data: [
+                                                data.categories.experimental
+                                                    .newFlagsThisWeek,
+                                                data.categories.release
+                                                    .newFlagsThisWeek,
+                                                data.categories.permanent
+                                                    .newFlagsThisWeek,
+                                            ],
+                                            stack: '1',
+                                            backgroundColor:
+                                                chartColors.newThisWeek,
+                                            borderRadius: 4,
+                                            datalabels: {
+                                                labels: {
+                                                    value: {
+                                                        formatter: (
+                                                            value,
+                                                            context,
+                                                        ) => {
+                                                            return (
+                                                                value +
+                                                                oldData[
+                                                                    context
+                                                                        .dataIndex
+                                                                ]
+                                                            );
+                                                        },
                                                     },
                                                 },
                                             },
                                         },
-                                    },
-                                ],
-                            }}
-                        />
-                    </ChartContainer>
-                ))}
+                                    ],
+                                }}
+                            />
+                        </ChartContainer>
+                    );
+                })}
             </ChartRow>
         </InsightsSection>
     );

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -130,36 +130,6 @@ export const LifecycleInsights: FC = () => {
         },
     };
 
-    // const f = (
-    //     input: LifecycleTrend,
-    // ): { labels: string[]; datasets: { data: number[] }[] } => {
-    //     const flat = Object.entries(input.categories).map(([key, value]) => ({
-    //         label: key,
-    //         data: [value.flagsOlderThanWeek, value.newFlagsThisWeek],
-    //     }));
-    //     const result = Object.entries(input.categories).reduce(
-    //         (acc, [key, value]) => {
-    //             return {
-    //                 ...acc,
-    //                 labels: [...acc.labels, key],
-    //                 datasets: [
-    //                     ...acc.datasets,
-    //                     {
-    //                         data: [
-    //                             value.flagsOlderThanWeek,
-    //                             value.newFlagsThisWeek,
-    //                         ],
-    //                     },
-    //                 ],
-    //             };
-    //         },
-    //         { labels: [], datasets: [] },
-    //     );
-    //     return result;
-    // };
-
-    // console.log(mockData.develop, f(mockData.develop));
-
     return (
         <InsightsSection
             title='Flags lifecycle currently'
@@ -197,6 +167,7 @@ export const LifecycleInsights: FC = () => {
                                         stack: '1',
                                         backgroundColor:
                                             chartColors.olderThanWeek,
+                                        borderRadius: 4,
                                     },
                                     {
                                         label: 'New this week',
@@ -211,6 +182,7 @@ export const LifecycleInsights: FC = () => {
                                         stack: '1',
                                         backgroundColor:
                                             chartColors.newThisWeek,
+                                        borderRadius: 4,
                                     },
                                 ],
                             }}

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -170,6 +170,7 @@ export const LifecycleInsights: FC = () => {
                                                             value,
                                                             context,
                                                         ) => {
+                                                            // todo (lifecycleMetrics): use a nice formatter here, so that 1,000,000 flags are instead formatted as 1M
                                                             if (
                                                                 context.chart
                                                                     .legend

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -166,7 +166,18 @@ export const LifecycleInsights: FC = () => {
                                             datalabels: {
                                                 labels: {
                                                     value: {
-                                                        formatter: () => {
+                                                        formatter: (
+                                                            value,
+                                                            context,
+                                                        ) => {
+                                                            if (
+                                                                context.chart
+                                                                    .legend
+                                                                    ?.legendItems?.[1]
+                                                                    .hidden
+                                                            ) {
+                                                                return value;
+                                                            }
                                                             return '';
                                                         },
                                                     },
@@ -194,6 +205,14 @@ export const LifecycleInsights: FC = () => {
                                                             value,
                                                             context,
                                                         ) => {
+                                                            if (
+                                                                context.chart
+                                                                    .legend
+                                                                    ?.legendItems?.[0]
+                                                                    .hidden
+                                                            ) {
+                                                                return value;
+                                                            }
                                                             return (
                                                                 value +
                                                                 oldData[

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -169,66 +169,32 @@ export const LifecycleInsights: FC = () => {
                     <LifecycleChart
                         key={stage}
                         data={{
-                            labels: [
-                                `${stage} Experimental`,
-                                `${stage} Release`,
-                                `${stage} Other flags`,
-                            ],
+                            labels: [`Experimental`, `Release`, `Other flags`],
                             datasets: [
                                 {
-                                    label: 'Experimental Flags old',
+                                    label: '> 1 week old',
                                     data: [
                                         data.categories.experimental
                                             .flagsOlderThanWeek,
+                                        data.categories.release
+                                            .flagsOlderThanWeek,
+                                        data.categories.permanent
+                                            .flagsOlderThanWeek,
                                     ],
-                                    stack: 'experimental',
+                                    stack: '1',
                                     backgroundColor: chartColors.olderThanWeek,
                                 },
                                 {
-                                    label: 'Experimental Flags new',
+                                    label: 'New this week',
                                     data: [
                                         data.categories.experimental
                                             .newFlagsThisWeek,
-                                    ],
-                                    stack: 'experimental',
-                                    backgroundColor: chartColors.newThisWeek,
-                                },
-
-                                {
-                                    label: 'Release Flags old',
-                                    data: [
-                                        data.categories.release
-                                            .flagsOlderThanWeek,
-                                    ],
-                                    stack: 'release',
-                                    backgroundColor: chartColors.olderThanWeek,
-                                },
-                                {
-                                    label: 'Release Flags new',
-                                    data: [
                                         data.categories.release
                                             .newFlagsThisWeek,
-                                    ],
-                                    stack: 'release',
-                                    backgroundColor: chartColors.newThisWeek,
-                                },
-
-                                {
-                                    label: 'Other Flags old',
-                                    data: [
-                                        data.categories.permanent
-                                            .flagsOlderThanWeek,
-                                    ],
-                                    stack: 'other',
-                                    backgroundColor: chartColors.olderThanWeek,
-                                },
-                                {
-                                    label: 'Other Flags new',
-                                    data: [
                                         data.categories.permanent
                                             .newFlagsThisWeek,
                                     ],
-                                    stack: 'other',
+                                    stack: '1',
                                     backgroundColor: chartColors.newThisWeek,
                                 },
                             ],

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -63,70 +63,13 @@ export const LifecycleInsights: FC = () => {
         'insights-lifecycle',
         stateConfig,
     );
-    const chartColors = useChartColors();
 
+    // todo: use data from the actual endpoint when we have something useful to return
     const projects = state[`${statePrefix}project`]?.values ?? [allOption.id];
     const { insights, loading } = useInsights();
 
     // @ts-expect-error (lifecycleMetrics): The schema hasn't been updated yet.
     const { lifecycleTrends } = insights;
-
-    const mockData: LifecycleInsights = {
-        develop: {
-            totalFlags: 35,
-            averageTimeInStageDays: 28,
-            categories: {
-                experimental: {
-                    flagsOlderThanWeek: 11,
-                    newFlagsThisWeek: 4,
-                },
-                release: {
-                    flagsOlderThanWeek: 12,
-                    newFlagsThisWeek: 1,
-                },
-                permanent: {
-                    flagsOlderThanWeek: 7,
-                    newFlagsThisWeek: 0,
-                },
-            },
-        },
-        production: {
-            totalFlags: 10,
-            averageTimeInStageDays: 14,
-            categories: {
-                experimental: {
-                    flagsOlderThanWeek: 2,
-                    newFlagsThisWeek: 3,
-                },
-                release: {
-                    flagsOlderThanWeek: 1,
-                    newFlagsThisWeek: 1,
-                },
-                permanent: {
-                    flagsOlderThanWeek: 3,
-                    newFlagsThisWeek: 0,
-                },
-            },
-        },
-        cleanup: {
-            totalFlags: 5,
-            averageTimeInStageDays: 16,
-            categories: {
-                experimental: {
-                    flagsOlderThanWeek: 0,
-                    newFlagsThisWeek: 3,
-                },
-                release: {
-                    flagsOlderThanWeek: 0,
-                    newFlagsThisWeek: 1,
-                },
-                permanent: {
-                    flagsOlderThanWeek: 1,
-                    newFlagsThisWeek: 0,
-                },
-            },
-        },
-    };
 
     return (
         <InsightsSection
@@ -141,98 +84,141 @@ export const LifecycleInsights: FC = () => {
         >
             <ChartRow>
                 {Object.entries(mockData).map(([stage, data]) => {
-                    const oldData = [
-                        data.categories.experimental.flagsOlderThanWeek,
-                        data.categories.release.flagsOlderThanWeek,
-                        data.categories.permanent.flagsOlderThanWeek,
-                    ];
                     return (
                         <ChartContainer key={stage}>
-                            <LifecycleChart
-                                data={{
-                                    labels: [
-                                        `Experimental`,
-                                        `Release`,
-                                        `Other flags`,
-                                    ],
-                                    datasets: [
-                                        {
-                                            label: 'Flags > 1 week old',
-                                            data: oldData,
-                                            stack: '1',
-                                            backgroundColor:
-                                                chartColors.olderThanWeek,
-                                            borderRadius: 4,
-                                            datalabels: {
-                                                labels: {
-                                                    value: {
-                                                        formatter: (
-                                                            value,
-                                                            context,
-                                                        ) => {
-                                                            // todo (lifecycleMetrics): use a nice formatter here, so that 1,000,000 flags are instead formatted as 1M
-                                                            if (
-                                                                context.chart
-                                                                    .legend
-                                                                    ?.legendItems?.[1]
-                                                                    .hidden
-                                                            ) {
-                                                                return value;
-                                                            }
-                                                            return '';
-                                                        },
-                                                    },
-                                                },
-                                            },
-                                        },
-                                        {
-                                            label: 'New flags this week',
-                                            data: [
-                                                data.categories.experimental
-                                                    .newFlagsThisWeek,
-                                                data.categories.release
-                                                    .newFlagsThisWeek,
-                                                data.categories.permanent
-                                                    .newFlagsThisWeek,
-                                            ],
-                                            stack: '1',
-                                            backgroundColor:
-                                                chartColors.newThisWeek,
-                                            borderRadius: 4,
-                                            datalabels: {
-                                                labels: {
-                                                    value: {
-                                                        formatter: (
-                                                            value,
-                                                            context,
-                                                        ) => {
-                                                            if (
-                                                                context.chart
-                                                                    .legend
-                                                                    ?.legendItems?.[0]
-                                                                    .hidden
-                                                            ) {
-                                                                return value;
-                                                            }
-                                                            return (
-                                                                value +
-                                                                oldData[
-                                                                    context
-                                                                        .dataIndex
-                                                                ]
-                                                            );
-                                                        },
-                                                    },
-                                                },
-                                            },
-                                        },
-                                    ],
-                                }}
-                            />
+                            <Chart data={data} />
                         </ChartContainer>
                     );
                 })}
             </ChartRow>
         </InsightsSection>
     );
+};
+
+const Chart: React.FC<{ data: LifecycleTrend }> = ({ data }) => {
+    const chartColors = useChartColors();
+    const oldData = [
+        data.categories.experimental.flagsOlderThanWeek,
+        data.categories.release.flagsOlderThanWeek,
+        data.categories.permanent.flagsOlderThanWeek,
+    ];
+    return (
+        <LifecycleChart
+            data={{
+                labels: [`Experimental`, `Release`, `Other flags`],
+                datasets: [
+                    {
+                        label: 'Flags > 1 week old',
+                        data: oldData,
+                        stack: '1',
+                        backgroundColor: chartColors.olderThanWeek,
+                        borderRadius: 4,
+                        datalabels: {
+                            labels: {
+                                value: {
+                                    formatter: (value, context) => {
+                                        // todo (lifecycleMetrics): use a nice
+                                        // formatter here, so that 1,000,000
+                                        // flags are instead formatted as 1M
+                                        if (
+                                            context.chart.legend
+                                                ?.legendItems?.[1].hidden
+                                        ) {
+                                            return value;
+                                        }
+                                        return '';
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        label: 'New flags this week',
+                        data: [
+                            data.categories.experimental.newFlagsThisWeek,
+                            data.categories.release.newFlagsThisWeek,
+                            data.categories.permanent.newFlagsThisWeek,
+                        ],
+                        stack: '1',
+                        backgroundColor: chartColors.newThisWeek,
+                        borderRadius: 4,
+                        datalabels: {
+                            labels: {
+                                value: {
+                                    formatter: (value, context) => {
+                                        if (
+                                            context.chart.legend
+                                                ?.legendItems?.[0].hidden
+                                        ) {
+                                            return value;
+                                        }
+                                        return (
+                                            value + oldData[context.dataIndex]
+                                        );
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            }}
+        />
+    );
+};
+
+const mockData: LifecycleInsights = {
+    develop: {
+        totalFlags: 35,
+        averageTimeInStageDays: 28,
+        categories: {
+            experimental: {
+                flagsOlderThanWeek: 11,
+                newFlagsThisWeek: 4,
+            },
+            release: {
+                flagsOlderThanWeek: 12,
+                newFlagsThisWeek: 1,
+            },
+            permanent: {
+                flagsOlderThanWeek: 7,
+                newFlagsThisWeek: 0,
+            },
+        },
+    },
+    production: {
+        totalFlags: 10,
+        averageTimeInStageDays: 14,
+        categories: {
+            experimental: {
+                flagsOlderThanWeek: 2,
+                newFlagsThisWeek: 3,
+            },
+            release: {
+                flagsOlderThanWeek: 1,
+                newFlagsThisWeek: 1,
+            },
+            permanent: {
+                flagsOlderThanWeek: 3,
+                newFlagsThisWeek: 0,
+            },
+        },
+    },
+    cleanup: {
+        totalFlags: 5,
+        averageTimeInStageDays: 16,
+        categories: {
+            experimental: {
+                flagsOlderThanWeek: 0,
+                newFlagsThisWeek: 3,
+            },
+            release: {
+                flagsOlderThanWeek: 0,
+                newFlagsThisWeek: 1,
+            },
+            permanent: {
+                flagsOlderThanWeek: 1,
+                newFlagsThisWeek: 0,
+            },
+        },
+    },
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4106,6 +4106,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chartjs-plugin-datalabels@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "chartjs-plugin-datalabels@npm:2.2.0"
+  peerDependencies:
+    chart.js: ">=3.0.0"
+  checksum: 10c0/de4855a795e4eef34869a16db1a8a0f905b6dfed0258c733338f472625361eb56fb899214b18651c1c1064cd343a78285ba576576693a40ec51285a84f022ea0
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^2.1.1":
   version: 2.1.1
   resolution: "check-error@npm:2.1.1"
@@ -10138,6 +10147,7 @@ __metadata:
     chart.js: "npm:3.9.1"
     chartjs-adapter-date-fns: "npm:3.0.0"
     chartjs-plugin-annotation: "npm:2.2.1"
+    chartjs-plugin-datalabels: "npm:^2.2.0"
     classnames: "npm:2.5.1"
     copy-to-clipboard: "npm:3.3.3"
     countries-and-timezones: "npm:^3.4.0"


### PR DESCRIPTION
Adds lifecycle trend graphs to the insights page.

The graphs are each placed within their own boxes. The boxes do not have any more information in them yet. 

Also, because the data returned from the API is still all zeroes, I've used mock data that matches the sketches.

Finally, the chart configuration and how it's split into a LifecycleChart that lazy loads a LifecycleChartComponent is based on the LineChart and LineChartComponent that we use elsewhere on the insights page.

Light mode:

<img width="1562" alt="image" src="https://github.com/user-attachments/assets/6dd11168-be24-42d4-aa97-a7a55651fa0e" />

We might want to tweak some colors in dark mode, but maybe not? 🤷🏼 
![image](https://github.com/user-attachments/assets/9647e6b8-d8ea-4eb5-b9fd-6f4a24692476)
