### PR TITLE
chore: remove deprecation of instance stats endpoint

### DIFF
--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -75,7 +75,6 @@ class InstanceAdminController extends Controller {
                     responses: {
                         200: createResponseSchema('instanceAdminStatsSchema'),
                     },
-                    deprecated: true,
                 }),
             ],
         });


### PR DESCRIPTION
This endpoint has been marked as deprecated [from the start](https://github.com/Unleash/unleash/pull/2211/files#diff-39ae0262f5b07cc6d23d35d76dba1d516dd8bef6ee6a44eabc6bf3aac2202c9f). Since it's in active use in 2 places but there's no deprecation description in openapi spec, and the hook that implements it isn't deprecated, we should probably remove the deprecation