### PR TITLE
Updates lifecycle trend chart colors for dark mode.

### DIFF
--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -35,6 +35,12 @@ type LifecycleInsights = {
 
 const useChartColors = () => {
     const theme = useTheme();
+    if (theme.mode === 'dark') {
+        return {
+            olderThanWeek: '#5A5CAC',
+            newThisWeek: '#698745',
+        };
+    }
     return {
         olderThanWeek: theme.palette.primary.light,
         newThisWeek: theme.palette.success.border,


### PR DESCRIPTION
It doesn't match any existing colors we have, but it's a nice set of colors for the graphs in dark mode, as agreed on with UX.

Before:
<img width="1558" alt="image" src="https://github.com/user-attachments/assets/26e048df-283e-47ae-8c9e-906730324091" />

After:

<img width="1544" alt="image" src="https://github.com/user-attachments/assets/17b66622-65b7-41e7-8a5f-d6d98bc85d12" />
