### PR TITLE
Feat(1-3801)/add more data to lifecycle tiles

### DIFF
--- a/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx
+++ b/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx
@@ -21,20 +21,24 @@ interface IPrettifyLargeNumberProps {
     precision?: number;
 }
 
+export const prettifyLargeNumber = (
+    value: number,
+    threshold: number = 1_000_000,
+    precision: number = 2,
+) => {
+    if (value < threshold) {
+        return value.toLocaleString();
+    }
+    return millify(value, { precision });
+};
+
 export const PrettifyLargeNumber: FC<IPrettifyLargeNumberProps> = ({
     value,
     threshold = 1_000_000,
     precision = 2,
 }) => {
-    let prettyValue: string;
-    let showTooltip = false;
-
-    if (value < threshold) {
-        prettyValue = value.toLocaleString();
-    } else {
-        prettyValue = millify(value, { precision });
-        showTooltip = true;
-    }
+    const prettyValue = prettifyLargeNumber(value, threshold, precision);
+    const showTooltip = value > threshold;
 
     const valueSpan = (
         <span data-testid={LARGE_NUMBER_PRETTIFIED}>{prettyValue}</span>

--- a/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx
+++ b/frontend/src/component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx
@@ -21,23 +21,21 @@ interface IPrettifyLargeNumberProps {
     precision?: number;
 }
 
-export const prettifyLargeNumber = (
-    value: number,
-    threshold: number = 1_000_000,
-    precision: number = 2,
-) => {
-    if (value < threshold) {
-        return value.toLocaleString();
-    }
-    return millify(value, { precision });
-};
+export const prettifyLargeNumber =
+    (threshold: number = 1_000_000, precision: number = 2) =>
+    (value: number) => {
+        if (value < threshold) {
+            return value.toLocaleString();
+        }
+        return millify(value, { precision });
+    };
 
 export const PrettifyLargeNumber: FC<IPrettifyLargeNumberProps> = ({
     value,
     threshold = 1_000_000,
     precision = 2,
 }) => {
-    const prettyValue = prettifyLargeNumber(value, threshold, precision);
+    const prettyValue = prettifyLargeNumber(threshold, precision)(value);
     const showTooltip = value > threshold;
 
     const valueSpan = (

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -7,7 +7,10 @@ import { allOption } from 'component/common/ProjectSelect/ProjectSelect';
 import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 import { LifecycleChart } from '../components/LifecycleChart/LifecycleChart.tsx';
 import { styled, useTheme } from '@mui/material';
-import { PrettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx';
+import {
+    prettifyLargeNumber,
+    PrettifyLargeNumber,
+} from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx';
 import { FeatureLifecycleStageIcon } from 'component/common/FeatureLifecycle/FeatureLifecycleStageIcon.tsx';
 import { normalizeDays } from './normalize-days.ts';
 
@@ -192,6 +195,9 @@ export const LifecycleInsights: FC = () => {
     );
 };
 
+const prettifyFlagCount = (value: number): string =>
+    prettifyLargeNumber(value, 1000, 2);
+
 const Chart: React.FC<{ stage: string; data: LifecycleTrend }> = ({
     stage,
     data,
@@ -243,7 +249,7 @@ const Chart: React.FC<{ stage: string; data: LifecycleTrend }> = ({
                                             context.chart.legend
                                                 ?.legendItems?.[1].hidden
                                         ) {
-                                            return value;
+                                            return prettifyFlagCount(value);
                                         }
                                         return '';
                                     },
@@ -269,10 +275,10 @@ const Chart: React.FC<{ stage: string; data: LifecycleTrend }> = ({
                                             context.chart.legend
                                                 ?.legendItems?.[0].hidden
                                         ) {
-                                            return value;
+                                            return prettifyFlagCount(value);
                                         }
-                                        return (
-                                            value + oldData[context.dataIndex]
+                                        return prettifyFlagCount(
+                                            value + oldData[context.dataIndex],
                                         );
                                     },
                                 },

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -7,6 +7,9 @@ import { allOption } from 'component/common/ProjectSelect/ProjectSelect';
 import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 import { LifecycleChart } from '../components/LifecycleChart/LifecycleChart.tsx';
 import { styled, useTheme } from '@mui/material';
+import { PrettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber.tsx';
+import { FeatureLifecycleStageIcon } from 'component/common/FeatureLifecycle/FeatureLifecycleStageIcon.tsx';
+import { normalizeDays } from './normalize-days.ts';
 
 type LifecycleTrend = {
     totalFlags: number;
@@ -53,11 +56,63 @@ const ChartRow = styled('div')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
-const ChartContainer = styled('article')(({ theme }) => ({
+const LifecycleTile = styled('article')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
     background: theme.palette.background.default,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(2),
     minWidth: 0,
+}));
+
+const lifecycleStageMap = {
+    develop: 'pre-live',
+    production: 'live',
+    cleanup: 'completed',
+};
+
+const TileHeader = styled('h3')(({ theme }) => ({
+    margin: 0,
+    // display: 'flex',
+    // flexFlow: 'column',
+    fontSize: theme.typography.body1.fontSize,
+    fontWeight: 'normal',
+}));
+
+const HeaderNumber = styled('span')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    fontSize: theme.typography.h1.fontSize,
+    fontWeight: 'bold',
+}));
+
+const HeaderText = styled(HeaderNumber)(({ theme }) => ({}));
+
+const Stats = styled('dl')(({ theme }) => ({
+    background: theme.palette.background.elevation1,
+    borderRadius: theme.shape.borderRadiusMedium,
+    margin: 0,
+    fontSize: theme.typography.body2.fontSize,
+    '& dt::after': {
+        content: '":"',
+    },
+    '& dd': {
+        margin: 0,
+        fontWeight: 'bold',
+    },
+    paddingInline: theme.spacing(2),
+    paddingBlock: theme.spacing(1.5),
+    gap: theme.spacing(1.5),
+}));
+
+const StatRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row wrap',
+    gap: theme.spacing(0.5),
+    fontSize: theme.typography.body2.fontSize,
 }));
 
 export const LifecycleInsights: FC = () => {
@@ -90,9 +145,46 @@ export const LifecycleInsights: FC = () => {
             <ChartRow>
                 {Object.entries(mockData).map(([stage, data]) => {
                     return (
-                        <ChartContainer key={stage}>
+                        <LifecycleTile key={stage}>
+                            <TileHeader>
+                                <HeaderNumber>
+                                    <PrettifyLargeNumber
+                                        value={data.totalFlags ?? 0}
+                                        threshold={1000}
+                                        precision={1}
+                                    />
+                                    <FeatureLifecycleStageIcon
+                                        aria-hidden='true'
+                                        stage={{
+                                            name: lifecycleStageMap[stage],
+                                        }}
+                                    />
+                                </HeaderNumber>
+                                <span>Flags in {stage} stage</span>
+                            </TileHeader>
                             <Chart data={data} stage={stage} />
-                        </ChartContainer>
+
+                            <Stats>
+                                <StatRow>
+                                    <dt>Current median time spent in stage</dt>
+                                    <dd data-loading-project-lifecycle-summary>
+                                        {normalizeDays(
+                                            data.averageTimeInStageDays,
+                                        )}
+                                    </dd>
+                                </StatRow>
+                                <StatRow>
+                                    <dt>
+                                        Historical median time spent in stage
+                                    </dt>
+                                    <dd data-loading-project-lifecycle-summary>
+                                        {normalizeDays(
+                                            data.averageTimeInStageDays,
+                                        )}
+                                    </dd>
+                                </StatRow>
+                            </Stats>
+                        </LifecycleTile>
                     );
                 })}
             </ChartRow>

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -195,8 +195,7 @@ export const LifecycleInsights: FC = () => {
     );
 };
 
-const prettifyFlagCount = (value: number): string =>
-    prettifyLargeNumber(value, 1000, 2);
+const prettifyFlagCount = prettifyLargeNumber(1000, 2);
 
 const Chart: React.FC<{ stage: string; data: LifecycleTrend }> = ({
     stage,

--- a/frontend/src/component/insights/sections/normalize-days.test.ts
+++ b/frontend/src/component/insights/sections/normalize-days.test.ts
@@ -1,0 +1,37 @@
+import { normalizeDays } from './normalize-days.ts';
+
+test('0 or less', () => {
+    const testCases = [0, -1];
+    expect(
+        testCases.map(normalizeDays).every((text) => text === 'No data'),
+    ).toBeTruthy();
+});
+
+test('less than one', () => {
+    const testCases = [0.1, 0.25, 0.5, 0.9, 0.9999999];
+    expect(
+        testCases.map(normalizeDays).every((text) => text === '<1 day'),
+    ).toBeTruthy();
+});
+
+test('rounds to one', () => {
+    const testCases = [1.1, 1.25, 1.33, 1.499999];
+    expect(
+        testCases.map(normalizeDays).every((text) => text === '1 day'),
+    ).toBeTruthy();
+});
+
+test('1.5 or more', () => {
+    const testCases = [1.5, 2.4];
+    expect(
+        testCases.map(normalizeDays).every((text) => text === '2 days'),
+    ).toBeTruthy();
+});
+
+test.each([
+    [10_000, '10K'],
+    [100_000, '100K'],
+    [1_000_000, '1M'],
+])('Big numbers: %s -> %s', (number, rendered) => {
+    expect(normalizeDays(number)).toBe(`${rendered} days`);
+});

--- a/frontend/src/component/insights/sections/normalize-days.ts
+++ b/frontend/src/component/insights/sections/normalize-days.ts
@@ -1,5 +1,7 @@
 import { prettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber';
 
+const prettifyNumber = prettifyLargeNumber(1000, 2);
+
 export const normalizeDays = (days: number) => {
     if (days <= 0) {
         return 'No data';
@@ -11,5 +13,5 @@ export const normalizeDays = (days: number) => {
     if (rounded === 1) {
         return '1 day';
     }
-    return `${prettifyLargeNumber(rounded, 1000, 2)} days`;
+    return `${prettifyNumber(rounded)} days`;
 };

--- a/frontend/src/component/insights/sections/normalize-days.ts
+++ b/frontend/src/component/insights/sections/normalize-days.ts
@@ -1,0 +1,22 @@
+import millify from 'millify';
+
+const prettifyLargeNumber = (value: number, precision = 2): string => {
+    if (value < 1000) {
+        return value.toLocaleString();
+    }
+    return millify(value, { precision });
+};
+
+export const normalizeDays = (days: number) => {
+    if (days <= 0) {
+        return 'No data';
+    }
+    if (days < 1) {
+        return '<1 day';
+    }
+    const rounded = Math.round(days);
+    if (rounded === 1) {
+        return '1 day';
+    }
+    return `${prettifyLargeNumber(rounded)} days`;
+};

--- a/frontend/src/component/insights/sections/normalize-days.ts
+++ b/frontend/src/component/insights/sections/normalize-days.ts
@@ -1,11 +1,4 @@
-import millify from 'millify';
-
-const prettifyLargeNumber = (value: number, precision = 2): string => {
-    if (value < 1000) {
-        return value.toLocaleString();
-    }
-    return millify(value, { precision });
-};
+import { prettifyLargeNumber } from 'component/common/PrettifyLargeNumber/PrettifyLargeNumber';
 
 export const normalizeDays = (days: number) => {
     if (days <= 0) {
@@ -18,5 +11,5 @@ export const normalizeDays = (days: number) => {
     if (rounded === 1) {
         return '1 day';
     }
-    return `${prettifyLargeNumber(rounded)} days`;
+    return `${prettifyLargeNumber(rounded, 1000, 2)} days`;
 };


### PR DESCRIPTION
This is the first pass at the full lifecycle tiles. It adds the tile header and current and historical median data.

I have also added large number handling to all the number instances in the tile: in the header, the graph, and the median data. In doing so, I exposed the algorithm we use in the PrettifyLargeNumber component. Returning a react component isn't always a valid option (such as in the chart). This does mean that you don't get a tooltip when you use the function directly, but in things like the chart and the median measurement that makes sense to me.

I've decided to return "No data" if the median days value is 0 or lower.  