### PR TITLE
chore: rename insights -> analytics

### DIFF
--- a/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
+++ b/frontend/src/component/insights/components/InsightsHeader/InsightsHeader.tsx
@@ -49,6 +49,7 @@ const StyledActionsSmallScreen = styled('div')(({ theme }) => ({
 
 export const InsightsHeader: VFC<DashboardHeaderProps> = ({ actions }) => {
     const showInactiveUsers = useUiFlag('showInactiveUsers');
+    const pageName = useUiFlag('sideMenuCleanup') ? 'Analytics' : 'Insights';
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -69,7 +70,7 @@ export const InsightsHeader: VFC<DashboardHeaderProps> = ({ actions }) => {
     return (
         <>
             <PageHeader
-                title='Insights'
+                title={pageName}
                 titleElement={
                     <Typography
                         variant='h1'
@@ -80,7 +81,7 @@ export const InsightsHeader: VFC<DashboardHeaderProps> = ({ actions }) => {
                             gap: theme.spacing(1),
                         })}
                     >
-                        Insights
+                        {pageName}
                     </Typography>
                 }
                 actions={

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
@@ -26,7 +26,9 @@ const listItemButtonStyle = (theme: Theme) => ({
     },
 });
 
-const CappedText = styled(Typography)<{
+const CappedText = styled(Typography, {
+    shouldForwardProp: (prop) => prop !== 'bold',
+})<{
     bold?: boolean;
 }>(({ theme, bold }) => ({
     whiteSpace: 'nowrap',


### PR DESCRIPTION
Update the title of the insights / analytics page when the menu item changes

While the side menu item has already changed, this change also updates the page header and title.

Also fixes an error with a prop that shouldn't have been forwarded.