### PR TITLE
chore: replace flags per user with total number of flags

### DIFF
--- a/frontend/src/component/common/HelpIcon/HelpIcon.tsx
+++ b/frontend/src/component/common/HelpIcon/HelpIcon.tsx
@@ -71,7 +71,7 @@ export const HelpIcon = ({
     }
 
     return (
-        <Tooltip title={tooltip} placement={placement} arrow>
+        <Tooltip title={tooltip} placement={placement} arrow id={tooltipId}>
             <StyledContainer size={size} tabIndex={0} aria-label='Help'>
                 {children ?? <HelpOutline />}
             </StyledContainer>

--- a/frontend/src/component/common/HelpIcon/HelpIcon.tsx
+++ b/frontend/src/component/common/HelpIcon/HelpIcon.tsx
@@ -29,6 +29,7 @@ const StyledContainer = styled('span')<{ size: string | undefined }>(
 
 type IHelpIconProps = {
     tooltip: React.ReactNode;
+    tooltipId?: string;
     placement?: TooltipProps['placement'];
     children?: React.ReactNode;
     size?: string;
@@ -43,6 +44,7 @@ type IHelpIconProps = {
 export const HelpIcon = ({
     tooltip,
     htmlTooltip,
+    tooltipId,
     placement,
     children,
     size,
@@ -55,6 +57,7 @@ export const HelpIcon = ({
 
         return (
             <HtmlTooltip
+                id={tooltipId}
                 title={tooltip}
                 placement={placement}
                 arrow

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -114,7 +114,9 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
 
             {hideFlagsPerUser ? (
                 <LabelContainer>
-                    <Typography id={labelId} variant="body2">Total number of flags</Typography>
+                    <Typography id={labelId} variant='body2'>
+                        Total number of flags
+                    </Typography>
                     <HelpIcon
                         htmlTooltip
                         tooltipId={descriptionId}

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -1,6 +1,11 @@
 import Icon from '@mui/material/Icon';
 import { Box, Typography, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useId } from 'hooks/useId';
+import { ScreenReaderOnly } from 'component/common/ScreenReaderOnly/ScreenReaderOnly';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 
 const StyledRingContainer = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -65,6 +70,13 @@ const StyledIcon = styled(Icon)(({ theme }) => ({
     fontSize: '15px!important',
 }));
 
+const LabelContainer = styled('div')({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+});
+
 interface IFlagStatsProps {
     count: number;
     flagsPerUser?: string;
@@ -76,41 +88,68 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
     flagsPerUser,
     isLoading,
 }) => {
+    const hideFlagsPerUser = useUiFlag('lifecycleMetrics');
+    const labelId = hideFlagsPerUser ? useId() : '';
+    const descriptionId = hideFlagsPerUser ? useId() : '';
     return (
         <>
             <StyledRingContainer>
                 <StyledRing>
-                    <StyledRingContent>
-                        {isLoading ? '' : count}
+                    <StyledRingContent
+                        aria-labelledby={labelId}
+                        aria-describedby={descriptionId}
+                    >
+                        {isLoading ? (
+                            <ScreenReaderOnly>Loading data</ScreenReaderOnly>
+                        ) : (
+                            count
+                        )}
                     </StyledRingContent>
                 </StyledRing>
             </StyledRingContainer>
 
-            <ConditionallyRender
-                condition={flagsPerUser !== undefined && flagsPerUser !== ''}
-                show={
-                    <StyledInsightsContainer>
-                        <StyledTextContainer>
-                            <StyledHeaderContainer>
-                                <StyledIcon>award_star</StyledIcon>
-                                <Typography
-                                    fontWeight='bold'
-                                    variant='body2'
-                                    color='primary'
-                                >
-                                    Insights
+            {hideFlagsPerUser ? (
+                <LabelContainer>
+                    <p id={labelId}>Total number of flags</p>
+                    <HelpIcon
+                        htmlTooltip
+                        tooltipId={descriptionId}
+                        tooltip={
+                            'This includes the four lifecycle stages define, develop, production and cleanup'
+                        }
+                    >
+                        <InfoOutlined />
+                    </HelpIcon>
+                </LabelContainer>
+            ) : (
+                <ConditionallyRender
+                    condition={
+                        flagsPerUser !== undefined && flagsPerUser !== ''
+                    }
+                    show={
+                        <StyledInsightsContainer>
+                            <StyledTextContainer>
+                                <StyledHeaderContainer>
+                                    <StyledIcon>award_star</StyledIcon>
+                                    <Typography
+                                        fontWeight='bold'
+                                        variant='body2'
+                                        color='primary'
+                                    >
+                                        Insights
+                                    </Typography>
+                                </StyledHeaderContainer>
+                                <Typography variant='body2'>
+                                    Flags per user
                                 </Typography>
-                            </StyledHeaderContainer>
-                            <Typography variant='body2'>
-                                Flags per user
-                            </Typography>
-                        </StyledTextContainer>
-                        <StyledFlagCountPerUser>
-                            {flagsPerUser}
-                        </StyledFlagCountPerUser>
-                    </StyledInsightsContainer>
-                }
-            />
+                            </StyledTextContainer>
+                            <StyledFlagCountPerUser>
+                                {flagsPerUser}
+                            </StyledFlagCountPerUser>
+                        </StyledInsightsContainer>
+                    }
+                />
+            )}
         </>
     );
 };

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -96,8 +96,10 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
             <StyledRingContainer>
                 <StyledRing>
                     <StyledRingContent
-                        aria-labelledby={labelId}
-                        aria-describedby={descriptionId}
+                        {...(hideFlagsPerUser && {
+                            'aria-labelledby': labelId,
+                            'aria-describedby': descriptionId,
+                        })}
                     >
                         {isLoading ? (
                             <ScreenReaderOnly>

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -119,7 +119,7 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
                         htmlTooltip
                         tooltipId={descriptionId}
                         tooltip={
-                            'This includes the four lifecycle stages define, develop, production and cleanup'
+                            'This includes the four lifecycle stages define, develop, production, and cleanup'
                         }
                     >
                         <InfoOutlined />

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -100,7 +100,9 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
                         aria-describedby={descriptionId}
                     >
                         {isLoading ? (
-                            <ScreenReaderOnly>Loading data</ScreenReaderOnly>
+                            <ScreenReaderOnly>
+                                Loading total flag count
+                            </ScreenReaderOnly>
                         ) : (
                             count
                         )}

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -79,7 +79,7 @@ const LabelContainer = styled('div')({
 
 interface IFlagStatsProps {
     count: number;
-    flagsPerUser?: string;
+    flagsPerUser?: string; // todo: remove this prop with the lifecycleMetrics flag
     isLoading?: boolean;
 }
 

--- a/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
+++ b/frontend/src/component/insights/componentsStat/FlagStats/FlagStats.tsx
@@ -114,7 +114,7 @@ export const FlagStats: React.FC<IFlagStatsProps> = ({
 
             {hideFlagsPerUser ? (
                 <LabelContainer>
-                    <p id={labelId}>Total number of flags</p>
+                    <Typography id={labelId} variant="body2">Total number of flags</Typography>
                     <HelpIcon
                         htmlTooltip
                         tooltipId={descriptionId}


### PR DESCRIPTION
Switches the "flags per user" box with a "total number of flags" label for the number in the box and an additional description available via the help icon.

To accurately label the help text and link it to the figure, I've added a tooltipId prop to the HelpIcon component.

<img width="551" alt="image" src="https://github.com/user-attachments/assets/f3227e74-5976-454e-9b7d-db0d05927261" />

