### PR TITLE
chore: hide/disallow new instances of deprecated integrations

### DIFF
--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
@@ -56,6 +56,7 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
 }) => {
     const { isEnterprise } = useUiConfig();
     const signalsEnabled = useUiFlag('signals');
+    const filtered = providers?.filter((provider) => !provider.deprecated);
 
     const customProviders = [JIRA_INFO];
     const serverSdks = OFFICIAL_SDKS.filter((sdk) => sdk.type === 'server');
@@ -74,7 +75,7 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                     </Typography>
                 </div>
                 <StyledCardsGrid>
-                    {providers
+                    {filtered
                         ?.sort(
                             (a, b) =>
                                 a.displayName?.localeCompare(b.displayName) ||

--- a/frontend/src/component/integrations/IntegrationList/ConfiguredIntegrations/ConfiguredIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/ConfiguredIntegrations/ConfiguredIntegrations.tsx
@@ -70,6 +70,7 @@ export const ConfiguredIntegrations: VFC<ConfiguredIntegrationsProps> = ({
                                 description={description || ''}
                                 link={`/integrations/edit/${id}`}
                                 configureActionText='Open'
+                                deprecated={providerConfig?.deprecated}
                             />
                         );
                     })}

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -28,7 +28,7 @@ import type { IAddonDefinition } from '../types/model.js';
 import { minutesToMilliseconds } from 'date-fns';
 import type EventService from '../features/events/event-service.js';
 import { omitKeys } from '../util/index.js';
-import { NotFoundError } from '../error/index.js';
+import { BadDataError, NotFoundError } from '../error/index.js';
 import type { IntegrationEventsService } from '../features/integration-events/integration-events-service.js';
 import type { IEvent } from '../events/index.js';
 
@@ -224,6 +224,10 @@ export default class AddonService {
         const addonConfig = await addonSchema.validateAsync(data);
         await this.validateKnownProvider(addonConfig);
         await this.validateRequiredParameters(addonConfig);
+        const addon = this.addonProviders[addonConfig.provider];
+        if (addon.definition.deprecated) {
+            throw new BadDataError(addon.definition.deprecated);
+        }
 
         const createdAddon = await this.addonStore.insert(addonConfig);
         await this.addTagTypes(createdAddon.provider);


### PR DESCRIPTION
- Marks instances of deprecated integrations as deprecated
- Hides option to create new instances of deprecated integrations
- Throws a bad data error when attempting to create a new instance of a deprecated integration

![image](https://github.com/user-attachments/assets/fb77590e-b46e-42e8-9b9e-40ccc0334128)
