### PR TITLE
Remove margin right for cleanup box

### DIFF
--- a/frontend/src/component/feature/FeatureView/CleanupReminder/CleanupReminder.tsx
+++ b/frontend/src/component/feature/FeatureView/CleanupReminder/CleanupReminder.tsx
@@ -22,7 +22,6 @@ import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { useUncomplete } from '../FeatureOverview/FeatureLifecycle/useUncomplete.ts';
 
 const StyledBox = styled(Box)(({ theme }) => ({
-    marginRight: theme.spacing(2),
     marginBottom: theme.spacing(2),
 }));
 


### PR DESCRIPTION
It was misaligned with the rest of the content with this margin. The original author doesn't remember why it was there, so it's probably safe to remove.

Before:
![image](https://github.com/user-attachments/assets/444a46c0-1f95-48c0-97a2-b3077a49dfb3)

After:
![image](https://github.com/user-attachments/assets/9d0f085d-437d-46bb-a167-4f9019589c8c)
