### PR TITLE
chore: fix weird button styling

### DIFF
--- a/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.test.tsx
+++ b/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.test.tsx
@@ -41,7 +41,7 @@ test('Enabled new token button when limits, version and permission allow for it'
 
     await waitFor(async () => {
         const button = await screen.findByText('Create token');
-        expect(button).not.toBeDisabled();
+        expect(button).not.toHaveAttribute('aria-disabled');
     });
 });
 
@@ -54,5 +54,5 @@ test('Token limit reached', async () => {
     await screen.findByText('You have reached the limit for API tokens');
 
     const button = await screen.findByText('Create token');
-    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
 });

--- a/frontend/src/component/common/ApiTokenTable/CreateApiTokenButton/CreateApiTokenButton.test.tsx
+++ b/frontend/src/component/common/ApiTokenTable/CreateApiTokenButton/CreateApiTokenButton.test.tsx
@@ -57,6 +57,6 @@ test('should not allow you to create API tokens when you have reached the limit'
 
     await waitFor(async () => {
         const button = await screen.findByRole('button');
-        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 });

--- a/frontend/src/component/common/PermissionButton/PermissionButton.tsx
+++ b/frontend/src/component/common/PermissionButton/PermissionButton.tsx
@@ -117,7 +117,7 @@ const BasePermissionButton = React.forwardRef<
                 <StyledButton
                     ref={ref}
                     onClick={disableButton ? undefined : onClick}
-                    aria-disabled={disableButton || !access}
+                    aria-disabled={disableButton || undefined}
                     aria-labelledby={id}
                     variant={variant}
                     color={color}

--- a/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.test.tsx
+++ b/frontend/src/component/environments/CreateEnvironment/CreateEnvironment.test.tsx
@@ -31,7 +31,7 @@ test('show limit reached info', async () => {
     const createButton = await screen.findByText('Create environment', {
         selector: 'button',
     });
-    expect(createButton).toBeDisabled();
+    expect(createButton).toHaveAttribute('aria-disabled', 'true');
 });
 
 test('show approaching limit info', async () => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.test.tsx
@@ -61,6 +61,6 @@ describe('FeatureOverviewEnvironment', () => {
         );
 
         const button = await screen.findByText('Add strategy');
-        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 });

--- a/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.test.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypeEdit/FeatureTypeForm/FeatureTypeForm.test.tsx
@@ -29,7 +29,10 @@ describe('FeatureTypeForm', () => {
         );
         expect(screen.getByLabelText('Expected lifetime')).toBeDisabled();
         expect(screen.getByLabelText("doesn't expire")).toBeDisabled();
-        expect(screen.getByText('Save feature flag type')).toBeDisabled();
+        expect(screen.getByText('Save feature flag type')).toHaveAttribute(
+            'aria-disabled',
+            'true',
+        );
     });
 
     it('should check "doesn\'t expire" when lifetime is 0', () => {
@@ -87,6 +90,9 @@ describe('FeatureTypeForm', () => {
                 loading={false}
             />,
         );
-        expect(screen.getByText('Save feature flag type')).toBeDisabled();
+        expect(screen.getByText('Save feature flag type')).toHaveAttribute(
+            'aria-disabled',
+            'true',
+        );
     });
 });

--- a/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.test.tsx
+++ b/frontend/src/component/project/Project/CreateProject/NewCreateProjectForm/CreateProjectDialog.test.tsx
@@ -46,5 +46,5 @@ test('Project limit reached', async () => {
     const button = await screen.findByRole('button', {
         name: 'Create project',
     });
-    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
 });

--- a/frontend/src/component/project/Project/Import/Import.test.tsx
+++ b/frontend/src/component/project/Project/Import/Import.test.tsx
@@ -148,5 +148,5 @@ test('Show validation errors', async () => {
     await screen.findByText('itemF');
 
     const importButton = screen.getByText('Import configuration');
-    expect(importButton).toBeDisabled();
+    expect(importButton).toHaveAttribute('aria-disabled', 'true');
 });

--- a/frontend/src/component/project/ProjectList/ProjectList.test.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.test.tsx
@@ -26,10 +26,10 @@ test('Enabled new project button when version and permission allow for it and li
     });
 
     const button = await screen.findByText('New project');
-    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
 
     await waitFor(async () => {
         const button = await screen.findByText('New project');
-        expect(button).not.toBeDisabled();
+        expect(button).not.toHaveAttribute('aria-disabled', 'true');
     });
 });

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -73,33 +73,31 @@ exports[`renders an empty list correctly 1`] = `
               <hr
                 className="MuiDivider-root MuiDivider-middle MuiDivider-vertical css-1cqsk4j-MuiDivider-root"
               />
-              <span>
-                <button
-                  aria-labelledby="useId-0"
-                  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1ind840-MuiButtonBase-root-MuiButton-root"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  New tag type
-                  <span
-                    className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
-              </span>
+              <button
+                aria-labelledby="useId-0"
+                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-9qsbea-MuiButtonBase-root-MuiButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                New tag type
+                <span
+                  className="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The permission button was recently wrapped in a span to avoid causing console errors because disabled elements don't fire events:

<img width="617" alt="image" src="https://github.com/user-attachments/assets/4f40e52c-6945-4b39-b550-92a32f356ccd" />

However, because the button itself has some intrinsic styling, this wrapping caused some issues, most notably on the flag page  where the additional strategies button was too short for its container:

<img width="396" alt="image" src="https://github.com/user-attachments/assets/6070baf6-a62d-4b1c-a95e-f1102f121083" />

## Final solution

To get around both the styling issue and the focus / tooltip issue, I've changed the button to not use the disabled prop directly. This is the same solution that MUI introduces in v6 with the [focusableWhenDisabled prop](https://v6.mui.com/base-ui/react-button/#focus-on-disabled-buttons). So we set `aria-disabled=true` if the button should be disabled and also disabled the onClick function and add the Mui-disabled class to give it the appropriate styling. To allow the tooltip to still show up when the button is disabled and hovered, we set pointer events: auto.

An added benefit is that permission buttons are now always tabbable, which means that keyboard and screen reader users can still find them and get the "access denied" tooltip when they reach them.

The tooltips look like this (left is hover, middle is tab focus, right is nothing)

<img width="459" alt="image" src="https://github.com/user-attachments/assets/c3ad3553-1d81-4e7d-8512-9c79d491a00b" />

The main potential drawback that I can think of is that if the button is just disabled (not because of permission but because of the "disabled" attribute), then we don't have a tooltip or reason displayed to the user. However, they can still discover the button, so I think it's a net win.

## Original Solution

To avoid this, I'm making the span `display: contents`, which effectively makes it lay out and render as if the span wasn't there at all, but it retains the element so that MUI doesn't complain.

However: the tooltip still doesn't work with display contents, because the anchor element (the span) is effectively gone.