### PR TITLE
Fix invalid dom nesting error and remove redundant braces

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -217,28 +217,26 @@ export const FeatureStrategyMenu = ({
                 maxWidth='md'
                 PaperProps={{
                     sx: {
-                        borderRadius: (theme) => '12px',
+                        borderRadius: '12px',
                     },
                 }}
             >
-                {
-                    <FeatureStrategyMenuCards
-                        projectId={projectId}
-                        featureId={featureId}
-                        environmentId={environmentId}
-                        onlyReleasePlans={onlyReleasePlans}
-                        onAddReleasePlan={(template) => {
-                            setSelectedTemplate(template);
-                            addReleasePlan(template);
-                        }}
-                        onReviewReleasePlan={(template) => {
-                            setSelectedTemplate(template);
-                            setAddReleasePlanOpen(true);
-                            onClose();
-                        }}
-                        onClose={onClose}
-                    />
-                }
+                <FeatureStrategyMenuCards
+                    projectId={projectId}
+                    featureId={featureId}
+                    environmentId={environmentId}
+                    onlyReleasePlans={onlyReleasePlans}
+                    onAddReleasePlan={(template) => {
+                        setSelectedTemplate(template);
+                        addReleasePlan(template);
+                    }}
+                    onReviewReleasePlan={(template) => {
+                        setSelectedTemplate(template);
+                        setAddReleasePlanOpen(true);
+                        onClose();
+                    }}
+                    onClose={onClose}
+                />
             </Dialog>
             {selectedTemplate && (
                 <ReleasePlanReviewDialog

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -91,7 +91,7 @@ const StyledInfoIcon = styled(InfoOutlinedIcon)(({ theme }) => ({
     color: theme.palette.text.secondary,
 }));
 
-const StyledIcon = styled('div')(({ theme }) => ({
+const StyledIcon = styled('span')(({ theme }) => ({
     width: theme.spacing(3),
     '& > svg': {
         fill: theme.palette.primary.main,


### PR DESCRIPTION
Fixes a console log about invalid dom nesting:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/0849103c-6901-4b64-a124-00eaf8cc7dde" />

I've changed the offending div to a span. We set `display: flex` on it, anyway, so it shouldn't make a difference.

I've also removed some redundant functions and braces that we don't need.