### PR TITLE
feat: ability to run npm release from branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,11 @@
 name: 'Publish to npm'
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Which version number should we use for the release"
+        type: 'string'
+        required: true
   workflow_call:
     inputs:
       version:

--- a/scripts/npm-tag.js
+++ b/scripts/npm-tag.js
@@ -1,8 +1,9 @@
-const semver = require('semver');
+import semver from 'semver';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
 
 const latestUnleashVersion = process.argv[2];
-
-const version = require('../package.json').version;
 
 function isPrerelease(version) {
     const arr = semver.prerelease(version);


### PR DESCRIPTION
This is to be able to release 7.0.0 from the branch 7.0, due to this failed job https://github.com/Unleash/unleash/actions/runs/15586992840/job/43895801674

Failure was because package.json already had 7.0.0 and I don't want to use --force