### PR TITLE
chore: remove flag enterprise-payg

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -81,7 +81,6 @@ export type UiFlags = {
     enableLegacyVariants?: boolean;
     flagCreator?: boolean;
     releasePlans?: boolean;
-    'enterprise-payg'?: boolean;
     productivityReportEmail?: boolean;
     showUserDeviceCount?: boolean;
     consumptionModel?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -47,7 +47,6 @@ export type IFlagKey =
     | 'releasePlans'
     | 'productivityReportEmail'
     | 'productivityReportUnsubscribers'
-    | 'enterprise-payg'
     | 'showUserDeviceCount'
     | 'memorizeStats'
     | 'streaming'
@@ -231,10 +230,6 @@ const flags: IFlags = {
     ),
     productivityReportUnsubscribers: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PRODUCTIVITY_REPORT_UNSUBSCRIBERS,
-        false,
-    ),
-    'enterprise-payg': parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_ENTERPRISE_PAYG,
         false,
     ),
     showUserDeviceCount: parseEnvVarBoolean(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3602/clean-up-flag-enterprise-payg

Removes [enterprise-payg](https://app.unleash-hosted.com/hosted/projects/eg/features/enterprise-payg)

Doesn't seem like this is being used anywhere.