### PR TITLE
feat: report hostedBy and licenseType

### DIFF
--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -433,6 +433,8 @@ export class InstanceStatsService {
             userActive,
             productionChanges,
             postgresVersion,
+            licenseType,
+            hostedBy,
         ] = await Promise.all([
             this.getToggleCount(),
             this.getRegisteredUsers(),
@@ -454,6 +456,8 @@ export class InstanceStatsService {
             this.getActiveUsers(),
             this.getProductionChanges(),
             this.postgresVersion(),
+            this.getLicenseType(),
+            this.getHostedBy(),
         ]);
         const versionInfo = await this.versionService.getVersionInfo();
 
@@ -487,8 +491,18 @@ export class InstanceStatsService {
             productionChanges60: productionChanges.last60,
             productionChanges90: productionChanges.last90,
             postgresVersion,
+            licenseType,
+            hostedBy,
         };
         return featureInfo;
+    }
+
+    getHostedBy(): string {
+        return 'self-hosted';
+    }
+
+    getLicenseType(): string {
+        return 'oss';
     }
 
     featuresExported(): Promise<number> {

--- a/src/lib/services/version-service.test.ts
+++ b/src/lib/services/version-service.test.ts
@@ -41,6 +41,8 @@ const fakeTelemetryData = {
     productionChanges60: 0,
     productionChanges90: 0,
     postgresVersion: '17.1 (Debian 17.1-1.pgdg120+1)',
+    licenseType: 'test',
+    hostedBy: 'self-hosted',
 };
 
 test('yields current versions', async () => {

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -50,6 +50,8 @@ export interface IFeatureUsageInfo {
     productionChanges60: number;
     productionChanges90: number;
     postgresVersion: string;
+    licenseType: string;
+    hostedBy: string;
 }
 
 export default class VersionService {


### PR DESCRIPTION
Added two new fields to FeatureInfo (what gets reported as telemetry) reporting license type and hostedBy. Will be overriden in Enterprise.