### PR TITLE
fix: constraint editing is broken in segment form

### DIFF
--- a/frontend/src/component/common/NewConstraintAccordion/ConstraintsList/EditableConstraintsList.tsx
+++ b/frontend/src/component/common/NewConstraintAccordion/ConstraintsList/EditableConstraintsList.tsx
@@ -70,7 +70,7 @@ export const EditableConstraintsList = forwardRef<
             <ConstraintsList>
                 {constraints.map((constraint, index) => (
                     <EditableConstraint
-                        key={constraint[constraintId]}
+                        key={constraint[constraintId] || index}
                         constraint={constraint}
                         onDelete={() => onDelete(index)}
                         onUpdate={onAutoSave(constraint[constraintId])}

--- a/frontend/src/component/segments/EditSegment/EditSegment.tsx
+++ b/frontend/src/component/segments/EditSegment/EditSegment.tsx
@@ -24,15 +24,31 @@ import { useSegmentLimits } from 'hooks/api/getters/useSegmentLimits/useSegmentL
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 import { useHighestPermissionChangeRequestEnvironment } from 'hooks/useHighestPermissionChangeRequestEnvironment';
+import type { ISegment } from 'interfaces/segment.ts';
+import { constraintId } from 'constants/constraintId.ts';
+import { v4 as uuidv4 } from 'uuid';
 
 interface IEditSegmentProps {
     modal?: boolean;
 }
 
+const addIdSymbolToConstraints = (segment?: ISegment): ISegment | undefined => {
+    if (!segment) return;
+
+    const constraints = segment.constraints.map((constraint) => {
+        return { ...constraint, [constraintId]: uuidv4() };
+    });
+
+    return { ...segment, constraints };
+};
+
 export const EditSegment = ({ modal }: IEditSegmentProps) => {
     const projectId = useOptionalPathParam('projectId');
     const segmentId = useRequiredPathParam('segmentId');
-    const { segment } = useSegment(Number(segmentId));
+    const { segment: segmentWithoutConstraintIds } = useSegment(
+        Number(segmentId),
+    );
+    const segment = addIdSymbolToConstraints(segmentWithoutConstraintIds);
     const { uiConfig } = useUiConfig();
     const { setToastData, setToastApiError } = useToast();
     const navigate = useNavigate();


### PR DESCRIPTION
This adds constraint ids to segment constraints used in editing segments. Without them, there was a bug where when you went to edit the segment, all constraints would be invisibly set to the same constraint.

This was extra insidious because the edit form would show you the correct set of constraints, but the API payload would update to only repeat the one constraint over and over again. You'd only notice the next time you went into the segment, when both constraints would be the same 🐛 