### PR TITLE
fix: increase line height for project title

### DIFF
--- a/frontend/src/component/project/Project/Project.styles.ts
+++ b/frontend/src/component/project/Project/Project.styles.ts
@@ -59,6 +59,7 @@ export const StyledProjectTitle = styled('h1')(({ theme }) => ({
     alignItems: 'center',
     gap: theme.spacing(2),
     overflow: 'hidden',
+    lineHeight: 1.5,
 }));
 
 export const StyledSeparator = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Removing overflow hidden did not fix it, also it breaks the overflow.

Line height is by default 1.4, bumped it up to 1.5. This solved it.