### PR TITLE
chore: remove registerFrontendClient flag ws-swe1 [discard]

### DIFF
--- a/frontend/src/component/application/ApplicationChart.tsx
+++ b/frontend/src/component/application/ApplicationChart.tsx
@@ -16,7 +16,6 @@ import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
 import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { getApplicationIssues } from './ApplicationIssues/ApplicationIssues.tsx';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledTable = styled('table')(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
@@ -197,7 +196,6 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
     const { elementRef, width } = useElementWidth();
     const navigate = useNavigate();
     const theme = useTheme();
-    const registerFrontendClientEnabled = useUiFlag('registerFrontendClient');
 
     const mode = getApplicationIssues(data);
 
@@ -296,56 +294,14 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                 {environment.instanceCount}
                                             </StyledCell>
                                         </tr>
-                                        {!registerFrontendClientEnabled ? (
-                                            <tr>
-                                                <StyledCell>SDK:</StyledCell>
-                                                <StyledCell>
-                                                    {environment.sdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
-
-                                        {registerFrontendClientEnabled &&
-                                        environment.backendSdks.length > 0 ? (
-                                            <tr>
-                                                <StyledCell>
-                                                    Backend SDK:
-                                                </StyledCell>
-                                                <StyledCell>
-                                                    {environment.backendSdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
-
-                                        {registerFrontendClientEnabled &&
-                                        environment.frontendSdks.length > 0 ? (
-                                            <tr>
-                                                <StyledCell>
-                                                    Frontend SDK:
-                                                </StyledCell>
-                                                <StyledCell>
-                                                    {environment.frontendSdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
+                                        <tr>
+                                            <StyledCell>SDK:</StyledCell>
+                                            <StyledCell>
+                                                {environment.sdks.map((sdk) => (
+                                                    <div key={sdk}>{sdk}</div>
+                                                ))}
+                                            </StyledCell>
+                                        </tr>
 
                                         <tr>
                                             <StyledCell>Last seen:</StyledCell>

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -135,21 +135,7 @@ export class FrontendApiService {
             ip,
         );
 
-        if (
-            metrics.instanceId &&
-            typeof sdkVersion === 'string' &&
-            this.flagResolver.isEnabled('registerFrontendClient')
-        ) {
-            const client = {
-                appName: metrics.appName,
-                instanceId: metrics.instanceId,
-                sdkVersion: sdkVersion,
-                sdkType: 'frontend' as const,
-                environment: environment,
-                projects: this.resolveProject(token),
-            };
-            this.services.clientInstanceService.registerFrontendClient(client);
-        }
+        // Frontend client registration has been removed as part of the registerFrontendClient flag removal
     }
 
     private async clientForFrontendApiToken(token: IApiUser): Promise<Unleash> {

--- a/src/lib/features/metrics/instance/metrics.test.ts
+++ b/src/lib/features/metrics/instance/metrics.test.ts
@@ -45,13 +45,7 @@ let services: IUnleashServices;
 let destroy: () => Promise<void>;
 
 beforeAll(async () => {
-    const setup = await getSetup({
-        experimental: {
-            flags: {
-                registerFrontendClient: true,
-            },
-        },
-    });
+    const setup = await getSetup();
     request = setup.request;
     stores = setup.stores;
     destroy = setup.destroy;

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -223,24 +223,9 @@ export default class ClientMetricsController extends Controller {
                 const promises: Promise<void>[] = [];
                 for (const app of applications) {
                     if (
-                        app.sdkType === 'frontend' &&
-                        typeof app.sdkVersion === 'string'
+                        app.sdkType !== 'frontend' ||
+                        typeof app.sdkVersion !== 'string'
                     ) {
-                        if (
-                            this.flagResolver.isEnabled(
-                                'registerFrontendClient',
-                            )
-                        ) {
-                            this.clientInstanceService.registerFrontendClient({
-                                appName: app.appName,
-                                instanceId: app.instanceId,
-                                environment: app.environment,
-                                sdkType: app.sdkType,
-                                sdkVersion: app.sdkVersion,
-                                projects: app.projects,
-                            });
-                        }
-                    } else {
                         promises.push(
                             this.clientInstanceService.registerBackendClient(
                                 app,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -55,7 +55,6 @@ export type IFlagKey =
     | 'uniqueSdkTracking'
     | 'consumptionModel'
     | 'edgeObservability'
-    | 'registerFrontendClient'
     | 'reportUnknownFlags'
     | 'lastSeenBulkQuery'
     | 'lifecycleMetrics'
@@ -262,10 +261,6 @@ const flags: IFlags = {
     ),
     edgeObservability: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_EDGE_OBSERVABILITY,
-        false,
-    ),
-    registerFrontendClient: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_REGISTER_FRONTEND_CLIENT,
         false,
     ),
     reportUnknownFlags: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -51,7 +51,6 @@ process.nextTick(async () => {
                         deltaApi: true,
                         uniqueSdkTracking: true,
                         strictSchemaValidation: true,
-                        registerFrontendClient: true,
                         reportUnknownFlags: true,
                         customMetrics: true,
                         lifecycleMetrics: true,


### PR DESCRIPTION
Flag removal with WS SWE-1, using our flag cleanup instructions.

Outcome: **Discard**

Agent last output:

```
I've successfully removed the 
registerFrontendClient
 feature flag from the codebase. Here's a summary of the changes made:

1. Frontend Changes
Removed the 
registerFrontendClient
 flag check from 
ApplicationChart.tsx
Kept the original SDK display logic (the "off" path of the flag)
Removed the unused useUiFlag import
2. Backend Changes
Frontend API Service: Removed the frontend client registration code block that was behind the flag
Metrics Controller: Removed the flag check and kept only the backend client registration logic
Experimental Types: Removed the flag from the 
IFlagKey
 type and its default value
3. Test and Configuration Updates
Removed the flag from the metrics test setup
Removed the flag from the server-dev.ts configuration
4. Cleanup
Removed all references to the flag throughout the codebase
Ensured the code remains functional with the flag removed
The changes maintain the application's functionality while removing the feature flag and its associated code paths. The SDK display in the application will now always show a single list of SDKs rather than separating them by frontend/backend.
```