### PR TITLE
chore: remove registerFrontendClient flag ws-swe1 [keep]

### DIFF
--- a/frontend/src/component/application/ApplicationChart.tsx
+++ b/frontend/src/component/application/ApplicationChart.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, styled, Typography, useTheme } from '@mui/material';
 import { ArcherContainer, ArcherElement } from 'react-archer';
 import { useNavigate } from 'react-router-dom';
 import type React from 'react';
-import { type FC, useLayoutEffect, useRef, useState } from 'react';
+import { useRef, useState, useLayoutEffect } from 'react';
 import type {
     ApplicationOverviewEnvironmentSchema,
     ApplicationOverviewSchema,
@@ -16,7 +16,6 @@ import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
 import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { getApplicationIssues } from './ApplicationIssues/ApplicationIssues.tsx';
-import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledTable = styled('table')(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
@@ -141,7 +140,7 @@ const SuccessStatus = () => (
     </StyledStatus>
 );
 
-const WarningStatus: FC<{ children?: React.ReactNode }> = ({ children }) => (
+const WarningStatus = ({ children }: { children?: React.ReactNode }) => (
     <StyledStatus mode='warning'>
         <WarningAmberRounded
             sx={(theme) => ({
@@ -197,8 +196,6 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
     const { elementRef, width } = useElementWidth();
     const navigate = useNavigate();
     const theme = useTheme();
-    const registerFrontendClientEnabled = useUiFlag('registerFrontendClient');
-
     const mode = getApplicationIssues(data);
 
     return (
@@ -296,23 +293,7 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                 {environment.instanceCount}
                                             </StyledCell>
                                         </tr>
-                                        {!registerFrontendClientEnabled ? (
-                                            <tr>
-                                                <StyledCell>SDK:</StyledCell>
-                                                <StyledCell>
-                                                    {environment.sdks.map(
-                                                        (sdk) => (
-                                                            <div key={sdk}>
-                                                                {sdk}
-                                                            </div>
-                                                        ),
-                                                    )}
-                                                </StyledCell>
-                                            </tr>
-                                        ) : null}
-
-                                        {registerFrontendClientEnabled &&
-                                        environment.backendSdks.length > 0 ? (
+                                        {environment.backendSdks.length > 0 && (
                                             <tr>
                                                 <StyledCell>
                                                     Backend SDK:
@@ -327,10 +308,10 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                     )}
                                                 </StyledCell>
                                             </tr>
-                                        ) : null}
+                                        )}
 
-                                        {registerFrontendClientEnabled &&
-                                        environment.frontendSdks.length > 0 ? (
+                                        {environment.frontendSdks.length >
+                                            0 && (
                                             <tr>
                                                 <StyledCell>
                                                     Frontend SDK:
@@ -345,7 +326,7 @@ export const ApplicationChart = ({ data }: IApplicationChartProps) => {
                                                     )}
                                                 </StyledCell>
                                             </tr>
-                                        ) : null}
+                                        )}
 
                                         <tr>
                                             <StyledCell>Last seen:</StyledCell>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -85,7 +85,6 @@ export type UiFlags = {
     showUserDeviceCount?: boolean;
     consumptionModel?: boolean;
     edgeObservability?: boolean;
-    registerFrontendClient?: boolean;
     customMetrics?: boolean;
     lifecycleMetrics?: boolean;
     createFlagDialogCache?: boolean;

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -135,11 +135,7 @@ export class FrontendApiService {
             ip,
         );
 
-        if (
-            metrics.instanceId &&
-            typeof sdkVersion === 'string' &&
-            this.flagResolver.isEnabled('registerFrontendClient')
-        ) {
+        if (metrics.instanceId && typeof sdkVersion === 'string') {
             const client = {
                 appName: metrics.appName,
                 instanceId: metrics.instanceId,

--- a/src/lib/features/metrics/instance/metrics.test.ts
+++ b/src/lib/features/metrics/instance/metrics.test.ts
@@ -45,13 +45,7 @@ let services: IUnleashServices;
 let destroy: () => Promise<void>;
 
 beforeAll(async () => {
-    const setup = await getSetup({
-        experimental: {
-            flags: {
-                registerFrontendClient: true,
-            },
-        },
-    });
+    const setup = await getSetup();
     request = setup.request;
     stores = setup.stores;
     destroy = setup.destroy;

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -226,20 +226,14 @@ export default class ClientMetricsController extends Controller {
                         app.sdkType === 'frontend' &&
                         typeof app.sdkVersion === 'string'
                     ) {
-                        if (
-                            this.flagResolver.isEnabled(
-                                'registerFrontendClient',
-                            )
-                        ) {
-                            this.clientInstanceService.registerFrontendClient({
-                                appName: app.appName,
-                                instanceId: app.instanceId,
-                                environment: app.environment,
-                                sdkType: app.sdkType,
-                                sdkVersion: app.sdkVersion,
-                                projects: app.projects,
-                            });
-                        }
+                        this.clientInstanceService.registerFrontendClient({
+                            appName: app.appName,
+                            instanceId: app.instanceId,
+                            environment: app.environment,
+                            sdkType: app.sdkType,
+                            sdkVersion: app.sdkVersion,
+                            projects: app.projects,
+                        });
                     } else {
                         promises.push(
                             this.clientInstanceService.registerBackendClient(

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -55,7 +55,6 @@ export type IFlagKey =
     | 'uniqueSdkTracking'
     | 'consumptionModel'
     | 'edgeObservability'
-    | 'registerFrontendClient'
     | 'reportUnknownFlags'
     | 'lastSeenBulkQuery'
     | 'lifecycleMetrics'
@@ -262,10 +261,6 @@ const flags: IFlags = {
     ),
     edgeObservability: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_EDGE_OBSERVABILITY,
-        false,
-    ),
-    registerFrontendClient: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_REGISTER_FRONTEND_CLIENT,
         false,
     ),
     reportUnknownFlags: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -51,7 +51,6 @@ process.nextTick(async () => {
                         deltaApi: true,
                         uniqueSdkTracking: true,
                         strictSchemaValidation: true,
-                        registerFrontendClient: true,
                         reportUnknownFlags: true,
                         customMetrics: true,
                         lifecycleMetrics: true,

--- a/src/test/e2e/api/admin/applications.e2e.test.ts
+++ b/src/test/e2e/api/admin/applications.e2e.test.ts
@@ -55,7 +55,6 @@ beforeAll(async () => {
             experimental: {
                 flags: {
                     strictSchemaValidation: true,
-                    registerFrontendClient: true,
                 },
             },
         },


### PR DESCRIPTION
Flag removal with WS SWE-1, using our flag cleanup instructions.

Outcome: **Keep**

Agent last output:

```
The remaining references are all valid and should be kept:

instance-service.ts
: The actual implementation of the 
registerFrontendClient
 method that we're keeping.
metrics.ts
: The call to 
registerFrontendClient
 that we updated to remove the flag check.
frontend-api-controller.ts
: The OpenAPI operation ID for the endpoint.
frontend-api-service.ts
: The call to 
registerFrontendClient
/Users/nunogois/dev/unleash/unleash/src/lib/features/metrics/instance/instance-service.ts
 that we updated to remove the flag check.
OpenAPI model files: These are generated files that should be updated when the API changes.
Summary of Changes
I've successfully removed the 
registerFrontendClient
 feature flag while keeping the feature enabled. Here's a summary of the changes made:

Frontend API Service:
Removed the flag check in 
frontend-api-service.ts
 and kept the feature enabled.
Application Chart Component:
Removed the flag check in 
ApplicationChart.tsx
 and kept the frontend SDKs display.
Fixed various lint errors and improved code quality.
Experimental Types:
Removed the 
registerFrontendClient
 flag from the 
IFlagKey
 type.
Removed the flag configuration from the experimental flags.
Metrics Controller:
Removed the flag check in 
metrics.ts
 and always register frontend clients.
Test Files:
Updated test files to remove references to the removed flag.
UI Configuration:
Removed the 
registerFrontendClient
 property from the 
UiFlags
 interface.
Server Configuration:
Removed the flag from the server configuration in 
server-dev.ts
.
The feature is now permanently enabled, and all the flag-related code has been cleaned up. The codebase is now simpler and more maintainable.
```