### PR TITLE
feat: add prometheusImpactMetricsApi option to configuration

### DIFF
--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -101,6 +101,7 @@ exports[`should create default config 1`] = `
   "preHook": undefined,
   "preRouterHook": undefined,
   "prometheusApi": undefined,
+  "prometheusImpactMetricsApi": undefined,
   "publicFolder": undefined,
   "rateLimiting": {
     "callSignalEndpointMaxPerSecond": 1,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -773,6 +773,10 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
             defaultDaysToBeConsideredInactive,
         );
 
+    const prometheusImpactMetricsApi =
+        options.prometheusImpactMetricsApi ||
+        process.env.PROMETHEUS_IMPACT_METRICS_API;
+
     return {
         db,
         session,
@@ -804,6 +808,7 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         clientFeatureCaching,
         accessControlMaxAge,
         prometheusApi,
+        prometheusImpactMetricsApi,
         publicFolder: options.publicFolder,
         disableScheduler: options.disableScheduler,
         isEnterprise: isEnterprise,

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -164,6 +164,7 @@ export interface IUnleashOptions {
     clientFeatureCaching?: Partial<IClientCachingOption>;
     accessControlMaxAge?: number;
     prometheusApi?: string;
+    prometheusImpactMetricsApi?: string;
     publicFolder?: string;
     disableScheduler?: boolean;
     metricsRateLimiting?: Partial<IMetricsRateLimiting>;
@@ -288,6 +289,7 @@ export interface IUnleashConfig {
     clientFeatureCaching: IClientCachingOption;
     accessControlMaxAge: number;
     prometheusApi?: string;
+    prometheusImpactMetricsApi?: string;
     publicFolder?: string;
     disableScheduler?: boolean;
     isEnterprise: boolean;

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -69,6 +69,7 @@ process.nextTick(async () => {
                         },
                     ],
                 },
+                prometheusImpactMetricsApi: 'http://localhost:9090',
                 /* can be tweaked to control configuration caching for /api/client/features
                 clientFeatureCaching: {
                     enabled: true,


### PR DESCRIPTION
## About the changes
API url, similar to `config.prometheusApi`, for impact metrics