### PR TITLE
feat: ingest new impact metrics

### DIFF
--- a/src/lib/routes/client-api/index.ts
+++ b/src/lib/routes/client-api/index.ts
@@ -4,13 +4,20 @@ import MetricsController from '../../features/metrics/instance/metrics.js';
 import RegisterController from '../../features/metrics/instance/register.js';
 import type { IUnleashConfig } from '../../types/index.js';
 import type { IUnleashServices } from '../../services/index.js';
+import { impactRegister } from '../../features/metrics/impact/impact-register.js';
+import { MetricsTranslator } from '../../features/metrics/impact/metrics-translator.js';
 
 export default class ClientApi extends Controller {
     constructor(config: IUnleashConfig, services: IUnleashServices) {
         super(config);
 
+        const metricsTranslator = new MetricsTranslator(impactRegister);
+
         this.use('/features', new FeatureController(services, config).router);
-        this.use('/metrics', new MetricsController(services, config).router);
+        this.use(
+            '/metrics',
+            new MetricsController(services, config, metricsTranslator).router,
+        );
         this.use('/register', new RegisterController(services, config).router);
     }
 }

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -292,6 +292,10 @@ const flags: IFlags = {
         process.env.UNLEASH_EXPERIMENTAL_IMPROVED_JSON_DIFF,
         false,
     ),
+    impactMetrics: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_IMPACT_METRICS,
+        false,
+    ),
 };
 
 export const defaultExperimentalOptions: IExperimentalOptions = {


### PR DESCRIPTION
Accepts the new impact metrics into the singleton registry and then does nothing with them. If the relevant flag is off, the metrics are stripped from the existing metrics data format and dropped on the floor