### PR TITLE
feat: do not lock until migrations are needed

### DIFF
--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -40,6 +40,27 @@ export async function migrateDb(
     });
 }
 
+export async function requiresMigration({
+    db,
+}: Pick<IUnleashConfig, 'db'>): Promise<boolean> {
+    return noDatabaseUrl(async () => {
+        const custom = {
+            ...db,
+            connectionTimeoutMillis: secondsToMilliseconds(10),
+        };
+
+        // disable Intellij/WebStorm from setting verbose CLI argument to db-migrator
+        process.argv = process.argv.filter((it) => !it.includes('--verbose'));
+        const dbm = getInstance(true, {
+            cwd: __dirname,
+            config: { custom },
+            env: 'custom',
+        });
+
+        return dbm.check();
+    });
+}
+
 // This exists to ease testing
 export async function resetDb({ db }: IUnleashConfig): Promise<void> {
     return noDatabaseUrl(async () => {


### PR DESCRIPTION
Test to see if we can skip locking the db until we actually realize we need to run migrations