### PR TITLE
Chore(1 3836)/no changes in json diff

### DIFF
--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -23,6 +23,7 @@ interface IEventDiffProps {
      * @deprecated remove with flag improvedJsonDiff
      */
     sort?: (a: IEventDiffResult, b: IEventDiffResult) => number;
+    excludeKeys?: string[];
 }
 
 const DiffStyles = styled('div')(({ theme }) => ({
@@ -74,7 +75,7 @@ const NewEventDiff: FC<IEventDiffProps> = ({ entry }) => {
                     jsonDiffOptions={{
                         full: full,
                         maxElisions: 2,
-                        excludeKeys: ['id', 'createdAt', 'updatedAt'],
+                        excludeKeys: excludeKeys,
                     }}
                 />
             </DiffStyles>

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -47,15 +47,21 @@ const DiffStyles = styled('div')(({ theme }) => ({
             content: '"+"',
         },
     },
+
     '.deletion': {
         color: theme.palette.eventLog.diffSub,
         '::before': {
             content: '"-"',
         },
     },
+
+    '&:not([data-change-type="edit"]) :where(.addition, .deletion)::before': {
+        content: 'none',
+    },
 }));
 
-const NewEventDiff: FC<IEventDiffProps> = ({ entry }) => {
+const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
+    const changeType = entry.preData && entry.data ? 'edit' : undefined;
     const [full, setFull] = useState(false);
     const diffId = useId();
 
@@ -68,7 +74,7 @@ const NewEventDiff: FC<IEventDiffProps> = ({ entry }) => {
             >
                 {full ? 'Show only changed properties' : 'Show all properties'}
             </Button>
-            <DiffStyles id={diffId}>
+            <DiffStyles data-change-type={changeType} id={diffId}>
                 <JsonDiffComponent
                     jsonA={(entry.preData ?? {}) as JsonValue}
                     jsonB={(entry.data ?? {}) as JsonValue}

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -62,18 +62,23 @@ const DiffStyles = styled('div')(({ theme }) => ({
 
 const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
     const changeType = entry.preData && entry.data ? 'edit' : undefined;
+    const showExpandButton = changeType === 'edit';
     const [full, setFull] = useState(false);
     const diffId = useId();
 
     return (
         <>
-            <Button
-                onClick={() => setFull(!full)}
-                aria-controls={diffId}
-                aria-expanded={full}
-            >
-                {full ? 'Show only changed properties' : 'Show all properties'}
-            </Button>
+            {showExpandButton ? (
+                <Button
+                    onClick={() => setFull(!full)}
+                    aria-controls={diffId}
+                    aria-expanded={full}
+                >
+                    {full
+                        ? 'Show only changed properties'
+                        : 'Show all properties'}
+                </Button>
+            ) : null}
             <DiffStyles data-change-type={changeType} id={diffId}>
                 <JsonDiffComponent
                     jsonA={(entry.preData ?? {}) as JsonValue}
@@ -191,7 +196,13 @@ const OldEventDiff: FC<IEventDiffProps> = ({
 const EventDiff: FC<IEventDiffProps> = (props) => {
     const useNewJsonDiff = useUiFlag('improvedJsonDiff');
     if (useNewJsonDiff) {
-        return <NewEventDiff {...props} />;
+        return (
+            <>
+                <NewEventDiff {...props} />
+                <hr />
+                <OldEventDiff {...props} />
+            </>
+        );
     }
     return <OldEventDiff {...props} />;
 };

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -55,8 +55,16 @@ const DiffStyles = styled('div')(({ theme }) => ({
         },
     },
 
-    '&:not([data-change-type="edit"]) :where(.addition, .deletion)::before': {
-        content: 'none',
+    '&[data-change-type="replacement"]': {
+        ':has(.addition)': {
+            color: theme.palette.eventLog.diffAdd,
+        },
+        ':has(.deletion)': {
+            color: theme.palette.eventLog.diffSub,
+        },
+        '.addition::before, .deletion::before': {
+            content: 'none',
+        },
     },
 
     '.diff:not(:has(*))': {
@@ -71,7 +79,7 @@ const ButtonIcon = styled('span')(({ theme }) => ({
 }));
 
 const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
-    const changeType = entry.preData && entry.data ? 'edit' : undefined;
+    const changeType = entry.preData && entry.data ? 'edit' : 'replacement';
     const showExpandButton = changeType === 'edit';
     const [full, setFull] = useState(false);
     const diffId = useId();
@@ -207,13 +215,7 @@ const OldEventDiff: FC<IEventDiffProps> = ({
 const EventDiff: FC<IEventDiffProps> = (props) => {
     const useNewJsonDiff = useUiFlag('improvedJsonDiff');
     if (useNewJsonDiff) {
-        return (
-            <>
-                <NewEventDiff {...props} />
-                <hr />
-                <OldEventDiff {...props} />
-            </>
-        );
+        return <NewEventDiff {...props} />;
     }
     return <OldEventDiff {...props} />;
 };

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -60,6 +60,11 @@ const DiffStyles = styled('div')(({ theme }) => ({
     },
 }));
 
+const ExpandButton = styled(Button)(({ theme }) => ({
+    display: 'inline-flex',
+    gap: theme.spacing(0.5),
+}));
+
 const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
     const changeType = entry.preData && entry.data ? 'edit' : undefined;
     const showExpandButton = changeType === 'edit';
@@ -69,15 +74,18 @@ const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
     return (
         <>
             {showExpandButton ? (
-                <Button
+                <ExpandButton
                     onClick={() => setFull(!full)}
                     aria-controls={diffId}
                     aria-expanded={full}
                 >
-                    {full
-                        ? 'Show only changed properties'
-                        : 'Show all properties'}
-                </Button>
+                    <span aria-hidden>{full ? '-' : '+'}</span>
+                    <span>
+                        {full
+                            ? 'Show only changed properties'
+                            : 'Show all properties'}
+                    </span>
+                </ExpandButton>
             ) : null}
             <DiffStyles data-change-type={changeType} id={diffId}>
                 <JsonDiffComponent

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -66,9 +66,8 @@ const DiffStyles = styled('div')(({ theme }) => ({
     },
 }));
 
-const ExpandButton = styled(Button)(({ theme }) => ({
-    display: 'inline-flex',
-    gap: theme.spacing(0.5),
+const ButtonIcon = styled('span')(({ theme }) => ({
+    marginInlineEnd: theme.spacing(0.5),
 }));
 
 const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
@@ -80,18 +79,16 @@ const NewEventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
     return (
         <>
             {showExpandButton ? (
-                <ExpandButton
+                <Button
                     onClick={() => setFull(!full)}
                     aria-controls={diffId}
                     aria-expanded={full}
                 >
-                    <span aria-hidden>{full ? '-' : '+'}</span>
-                    <span>
-                        {full
-                            ? 'Show only changed properties'
-                            : 'Show all properties'}
-                    </span>
-                </ExpandButton>
+                    <ButtonIcon aria-hidden>{full ? '-' : '+'}</ButtonIcon>
+                    {full
+                        ? 'Show only changed properties'
+                        : 'Show all properties'}
+                </Button>
             ) : null}
             <DiffStyles data-change-type={changeType} id={diffId}>
                 <JsonDiffComponent

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -58,6 +58,12 @@ const DiffStyles = styled('div')(({ theme }) => ({
     '&:not([data-change-type="edit"]) :where(.addition, .deletion)::before': {
         content: 'none',
     },
+
+    '.diff:not(:has(*))': {
+        '::before': {
+            content: '"(no changes)"',
+        },
+    },
 }));
 
 const ExpandButton = styled(Button)(({ theme }) => ({

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -37,7 +37,6 @@ const DiffStyles = styled('div')(({ theme }) => ({
             position: 'absolute',
             left: 0,
             top: 0,
-            marginLeft: '-10px',
         },
     },
 


### PR DESCRIPTION
Contains several improvements for the new json diff render:

1. Removes extra left-inset of the +/- icons for changed lines. This means that the +/- icons will now show up in the change request popover, whereas they were hidden (pushed outside the frame) previously).
2. Change styling based on whether it's an edit or a full replacement. If it's an edit, keep the +/- icons per changed line. If it's a full replacement (e.g. the object has been created or deleted), don't show the +/- icons, and make the whole object the right color (specifically: this also colors the surrounding braces that weren't colored before). Not showing +/- for new/deleted objects is in line with how the previous system worked.
3. If there are no changes, show `(no changes)`, as we did before. Unfortunately, I don't think the component has any fallback for this case, so we can't render arbitrary code. However, when it does happen, the .diff container doesn't have any children, so we can render it with CSS. It's not ideal for accessibility reasons etc, but it's better than nothing, I think.
4. Adds a +/- to the button to open and close the full diff to indicate better what it does. Also, only shows the button if it's an edit. When it's a replacement, we show the full diff anyway, so the button has no effect.
5. Does not exclude any keys by default anymore, but makes it a parameter

## Left inset change + no excluded keys:
Before:
<img width="277" alt="image" src="https://github.com/user-attachments/assets/65d4c972-ccbd-4202-b162-1c94a49920cc" />


After:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/14408bf2-cc00-4710-869b-83479d72f2f3" />


## Edit vs full replacement
Before:
<img width="324" alt="image" src="https://github.com/user-attachments/assets/5a7f6727-f4a6-40f1-becf-184f2f390e9b" />

(notice the surrounding braces (`{}`) aren't the right color)
<img width="339" alt="image" src="https://github.com/user-attachments/assets/65247bde-469d-4408-90da-3867c1b4d650" />


After:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/972fe602-fe2a-46b3-ba52-d13e4427db5b" />


<img width="374" alt="image" src="https://github.com/user-attachments/assets/0d2f194b-3194-469b-9096-9a946c362178" />


## No changes
Before:
<img width="276" alt="image" src="https://github.com/user-attachments/assets/dac79332-1739-4ee8-91ca-c0e5950424fa" />


After:
<img width="271" alt="image" src="https://github.com/user-attachments/assets/23f70e8e-c9ef-42e0-9862-303c5a7df0b9" />

(The show all props button will show the whole object regardless):
<img width="352" alt="image" src="https://github.com/user-attachments/assets/c2f7cba0-3afa-4c54-aa5a-6e01120a5eee" />


## Button
Before:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/45201048-5946-41fe-999c-b95c6617b384" />


After:
<img width="274" alt="image" src="https://github.com/user-attachments/assets/68cf96cf-4536-47db-903e-2e7884fa045f" />
