### PR TITLE
feat: support event id in search

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -222,7 +222,7 @@ export default class EventService {
             if (parsed) queryParams.push(parsed);
         }
 
-        ['project', 'type', 'environment'].forEach((field) => {
+        ['project', 'type', 'environment', 'id'].forEach((field) => {
             if (params[field]) {
                 const parsed = parseSearchOperatorValue(field, params[field]);
                 if (parsed) queryParams.push(parsed);

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -12,6 +12,17 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
+        name: 'id',
+        schema: {
+            type: 'string',
+            example: 'IS:123',
+            pattern: '^(IS|IS_ANY_OF):(.*?)(,([0-9]+))*$',
+        },
+        description:
+            'Filter by event ID using supported operators: IS, IS_ANY_OF.',
+        in: 'query',
+    },
+    {
         name: 'feature',
         schema: {
             type: 'string',

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -6,6 +6,7 @@ import type { IQueryOperations } from '../../features/events/event-store.js';
 import type { IQueryParam } from '../../features/feature-toggle/types/feature-toggle-strategies-store-type.js';
 
 export interface IEventSearchParams {
+    id?: string;
     project?: string;
     query?: string;
     feature?: string;


### PR DESCRIPTION
We added `id` as one of the query parameters for searching events.