### PR TITLE
feat: support id in search event

### DIFF
--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -72,6 +72,7 @@ export const useEventLogSearch = (
         createdBy: FilterItemParam,
         type: FilterItemParam,
         environment: FilterItemParam,
+        id: StringParam,
         ...extraParameters(logType),
     };
 


### PR DESCRIPTION
Now id will be parsed from query, it will be StringParam, as it is not coming from UI filters, its coming directly from query params.