### PR TITLE
task: added notified at to change request requested approvals

### DIFF
--- a/src/migrations/20250623100820-cr-requested-approvals-add-notified-at-column.js
+++ b/src/migrations/20250623100820-cr-requested-approvals-add-notified-at-column.js
@@ -5,6 +5,6 @@ exports.up = function(db, cb) {
 
 exports.down = function(db, cb) {
   db.runSql(`
-DROP INDEX IF EXISTS cr_req_approvers_notifiied_at_idx;
+DROP INDEX IF EXISTS cr_req_approvers_notified_at_idx;
 ALTER TABLE change_request_requested_approvers DROP COLUMN notified_at;`, cb);
 };

--- a/src/migrations/20250623100820-cr-requested-approvals-add-notified-at-column.js
+++ b/src/migrations/20250623100820-cr-requested-approvals-add-notified-at-column.js
@@ -1,0 +1,10 @@
+exports.up = function(db, cb) {
+  db.runSql(`ALTER TABLE change_request_requested_approvers ADD COLUMN notified_at TIMESTAMP WITH TIME ZONE;
+             CREATE INDEX IF NOT EXISTS cr_req_approvers_notified_at_idx ON change_request_requested_approvers(notified_at);`, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`
+DROP INDEX IF EXISTS cr_req_approvers_notifiied_at_idx;
+ALTER TABLE change_request_requested_approvers DROP COLUMN notified_at;`, cb);
+};


### PR DESCRIPTION
Adding this should allow us to only notify users that haven't been notified before.

Necessary because the change_added event does not include a preData that allowed us to diff requestedApprovers based on the event alone. 

Also added a index on this column, since we're going to be using it to filter.