### PR TITLE
chore: update Slack App to App for Slack

### DIFF
--- a/src/lib/addons/slack-app-definition.ts
+++ b/src/lib/addons/slack-app-definition.ts
@@ -62,16 +62,16 @@ import type { IAddonDefinition } from '../types/model.js';
 
 const slackAppDefinition: IAddonDefinition = {
     name: 'slack-app',
-    displayName: 'Slack App',
+    displayName: 'App for Slack',
     description:
-        'The Unleash Slack App posts messages to the selected channels in your Slack workspace.',
-    howTo: 'Below you can specify which Slack channels receive event notifications. The configuration settings allow you to choose the events and whether you want to filter them by projects and environments.\n\nYou can also select which channels to post to by configuring your feature flags with “slack” tags. For example, if you’d like the bot to post messages to the #general channel, you can configure your feature flag with the “slack:general” tag.\n\nThe Unleash Slack App bot has access to public channels by default. If you want the bot to post messages to private channels, you’ll need to invite it to those channels.',
+        'The Unleash App for Slack posts messages to the selected channels in your Slack workspace.',
+    howTo: 'Below you can specify which Slack channels receive event notifications. The configuration settings allow you to choose the events and whether you want to filter them by projects and environments.\n\nYou can also select which channels to post to by configuring your feature flags with “slack” tags. For example, if you’d like the bot to post messages to the #general channel, you can configure your feature flag with the “slack:general” tag.\n\nThe Unleash App for Slack bot has access to public channels by default. If you want the bot to post messages to private channels, you’ll need to invite it to those channels.',
     documentationUrl: 'https://docs.getunleash.io/docs/addons/slack-app',
     installation: {
-        url: 'https://slack-app.getunleash.io/install',
-        title: 'Slack App installation',
+        url: 'https://app-for-slack.getunleash.io/install',
+        title: 'App for Slack installation',
         helpText:
-            'After installing the Unleash Slack app in your Slack workspace, paste the access token into the appropriate field below in order to configure this integration.',
+            'After installing the Unleash App for Slack in your Slack workspace, paste the access token into the appropriate field below in order to configure this integration.',
     },
     parameters: [
         {

--- a/src/lib/addons/slack-definition.ts
+++ b/src/lib/addons/slack-definition.ts
@@ -23,11 +23,11 @@ const slackDefinition: IAddonDefinition = {
     description: 'Allows Unleash to post updates to Slack.',
     documentationUrl: 'https://docs.getunleash.io/docs/addons/slack',
     deprecated:
-        'This integration is deprecated. Please try the new Slack App integration instead.',
+        'This integration is deprecated. Please try the new App for Slack integration instead.',
     alerts: [
         {
             type: 'warning',
-            text: `This integration is deprecated. Please try the new Slack App integration instead.`,
+            text: `This integration is deprecated. Please try the new App for Slack integration instead.`,
         },
     ],
     parameters: [

--- a/src/lib/openapi/spec/addon-type-schema.ts
+++ b/src/lib/openapi/spec/addon-type-schema.ts
@@ -136,20 +136,20 @@ export const addonTypeSchema = {
                     type: 'string',
                     description:
                         'A URL to where the addon configuration should redirect to install addons of this type.',
-                    example: 'https://slack-app.getunleash.io/install',
+                    example: 'https://app-for-slack.getunleash.io/install',
                 },
                 title: {
                     type: 'string',
                     description:
                         'The title of the installation configuration. This will be displayed to the user when installing addons of this type.',
-                    example: 'Slack App installation',
+                    example: 'App for Slack installation',
                 },
                 helpText: {
                     type: 'string',
                     description:
                         'The help text of the installation configuration. This will be displayed to the user when installing addons of this type.',
                     example:
-                        'Clicking the Install button will send you to Slack to initiate the installation procedure for the Unleash Slack app for your workspace',
+                        'Clicking the Install button will send you to Slack to initiate the installation procedure for the Unleash App for Slack for your workspace',
                 },
             },
         },
@@ -174,7 +174,7 @@ export const addonTypeSchema = {
                         description:
                             'The text of the alert. This is what will be displayed to the user.',
                         example:
-                            "Please ensure you have the Unleash Slack App installed in your Slack workspace if you haven't installed it already. If you want the Unleash Slack App bot to post messages to private channels, you'll need to invite it to those channels.",
+                            "Please ensure you have the Unleash App for Slack installed in your Slack workspace if you haven't installed it already. If you want the Unleash App for Slack bot to post messages to private channels, you'll need to invite it to those channels.",
                     },
                 },
             },

--- a/website/docs/reference/integrations/integrations.mdx
+++ b/website/docs/reference/integrations/integrations.mdx
@@ -22,7 +22,7 @@ Unleash currently supports the following integrations out of the box:
 - [Jira Cloud](./integrations/jira-cloud-plugin-usage) - Allows you to create, view and manage Unleash feature flags directly from a Jira Cloud issue
 - [Jira Server](./integrations/jira-server-plugin-usage) - Allows you to create and link Unleash feature flags directly from a Jira Server issue
 - [Microsoft Teams](./integrations/teams) - Allows Unleash to post updates to Microsoft Teams.
-- [Slack App](./integrations/slack-app) - The Unleash Slack App posts messages to the selected channels in your Slack workspace.
+- [App for Slack](./integrations/slack-app) - The Unleash App for Slack posts messages to the selected channels in your Slack workspace.
 - [Webhook](./integrations/webhook) - A generic way to post messages from Unleash to third party services.
 
 :::tip Missing an integration? Request it!
@@ -35,7 +35,7 @@ If you're looking for an integration that Unleash doesn't have at the moment, yo
 
 These integrations are deprecated and will be removed in a future release:
 
-- [Slack](./integrations/slack) - Allows Unleash to post updates to Slack. Please try the new [Slack App](./integrations/slack-app) integration instead.
+- [Slack](./integrations/slack) - Allows Unleash to post updates to Slack. Please try the new [App for Slack](./integrations/slack-app) integration instead.
 
 ## Community integrations
 
@@ -62,7 +62,7 @@ Integration events are logged for all outgoing integrations configured in Unleas
  - [Microsoft Teams](./integrations/teams)
  - New Relic
  - [Slack (deprecated)](./integrations/slack)
- - [Slack App](./integrations/slack-app)
+ - [App for Slack](./integrations/slack-app)
  - [Webhook](./integrations/webhook)
 
 ### Viewing integration events

--- a/website/docs/reference/integrations/slack-app.mdx
+++ b/website/docs/reference/integrations/slack-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: Slack App
+title: App for Slack
 ---
 
 :::note Availability
@@ -8,19 +8,19 @@ title: Slack App
 
 :::
 
-The Slack App integration posts messages to a specified set of channels in your Slack workspace. The channels can be public or private, and can be specified on a per-flag basis by using [Slack tags](#tags).
+The App for Slack integration posts messages to a specified set of channels in your Slack workspace. The channels can be public or private, and can be specified on a per-flag basis by using [Slack tags](#tags).
 
 ## Installation {#installation}
 
-To install the Slack App integration, follow these steps:
+To install the App for Slack integration, follow these steps:
 
-1. Navigate to the *integrations* page in the Unleash admin UI (available at the URL `/integrations`) and select "configure" on the Slack App integration.
+1. Navigate to the *integrations* page in the Unleash admin UI (available at the URL `/integrations`) and select "configure" on the App for Slack integration.
 2. On the integration configuration form, use the "install & connect" button.
 3. A new tab will open, asking you to select the Slack workspace where you'd like to install the app.
-4. After successful installation of the Unleash Slack App in your chosen Slack workspace, you'll be automatically redirected to a page displaying a newly generated access token.
+4. After successful installation of the Unleash App for Slack in your chosen Slack workspace, you'll be automatically redirected to a page displaying a newly generated access token.
 5. Copy this access token and paste it into the `Access token` field within the integration settings.
 
-By default, the Unleash Slack App is granted access to public channels. If you want the app to post messages to private channels, you'll need to manually invite it to each of those channels.
+By default, the Unleash App for Slack is granted access to public channels. If you want the app to post messages to private channels, you'll need to manually invite it to each of those channels.
 
 ## Configuration {#configuration}
 
@@ -84,14 +84,14 @@ You can choose to trigger updates for the following events:
 
 #### Parameters {#parameters}
 
-The Unleash Slack App integration takes the following parameters.
+The Unleash App for Slack integration takes the following parameters.
 
-- **Access token** - This is the only required property. After successful installation of the Unleash Slack App in your chosen Slack workspace, you'll be automatically redirected to a page displaying a newly generated access token. You should copy this access token and paste it into this field.
+- **Access token** - This is the only required property. After successful installation of the Unleash App for Slack in your chosen Slack workspace, you'll be automatically redirected to a page displaying a newly generated access token. You should copy this access token and paste it into this field.
 - **Channels** - A comma-separated list of channels to post the configured events to. These channels are always notified, regardless of the event type or the presence of a Slack tag.
 
 ## Tags {#tags}
 
-Besides the configured channels, you can choose to notify other channels by tagging your feature flags with Slack-specific tags. For instance, if you want the Unleash Slack App to send notifications to the `#general` channel, add a Slack-type tag with the value "general" (or "#general"; both will work) to your flag. This will ensure that any configured events related to that feature flag will notify the tagged channel in addition to any channels configured on the integration-level.
+Besides the configured channels, you can choose to notify other channels by tagging your feature flags with Slack-specific tags. For instance, if you want the Unleash App for Slack to send notifications to the `#general` channel, add a Slack-type tag with the value "general" (or "#general"; both will work) to your flag. This will ensure that any configured events related to that feature flag will notify the tagged channel in addition to any channels configured on the integration-level.
 
 To exclusively use tags for determining notification channels, you can leave the "channels" field blank in the integration configuration. Since you can have multiple configurations for the integration, you're free to mix and match settings to meet your precise needs. Before posting a message, all channels for that event, both configured and tagged, are combined and duplicates are removed.
 

--- a/website/docs/reference/integrations/slack.md
+++ b/website/docs/reference/integrations/slack.md
@@ -5,7 +5,7 @@ title: Slack (deprecated)
 
 :::caution Deprecation notice
 
-This Slack integration is deprecated and will be removed in a future release. We recommend using the new [Slack App](./slack-app) integration instead.
+This Slack integration is deprecated and will be removed in a future release. We recommend using the new [App for Slack](./slack-app) integration instead.
 
 :::
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3640/update-unleashs-integration-and-docs-accordingly

Updates "Slack App" to "App for Slack" to satisfy Slack Marketplace requirements.

This is a follow up to:
- https://github.com/Unleash/unleash-slack-app/pull/7
- https://github.com/Unleash/unleash-slack-app/pull/9
- https://github.com/Unleash/unleash-slack-app/pull/10