### PR TITLE
add `crDiffView` to Unleash

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -90,6 +90,7 @@ export type UiFlags = {
     createFlagDialogCache?: boolean;
     healthToTechDebt?: boolean;
     improvedJsonDiff?: boolean;
+    crDiffView?: boolean;
     changeRequestApproverEmails?: boolean;
 };
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -61,6 +61,7 @@ export type IFlagKey =
     | 'impactMetrics'
     | 'createFlagDialogCache'
     | 'improvedJsonDiff'
+    | 'crDiffView'
     | 'changeRequestApproverEmails';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -280,6 +281,10 @@ const flags: IFlags = {
     ),
     improvedJsonDiff: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_IMPROVED_JSON_DIFF,
+        false,
+    ),
+    crDiffView: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_CR_DIFF_VIEW,
         false,
     ),
     impactMetrics: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,7 @@ process.nextTick(async () => {
                         lifecycleMetrics: true,
                         improvedJsonDiff: true,
                         impactMetrics: true,
+                        crDiffView: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
This change adds the `crDiffView` flag to Unleash, potentially enabling the new JSON diff tab in change request changes instead of the "view json diff" hover functionality.
