### PR TITLE
feat: start storing event group type and id

### DIFF
--- a/src/migrations/20250630114145-add-transaction-context-to-events.js
+++ b/src/migrations/20250630114145-add-transaction-context-to-events.js
@@ -1,0 +1,15 @@
+exports.up = function(db, cb) {
+  db.runSql(`
+    ALTER TABLE events 
+    ADD COLUMN IF NOT EXISTS group_type TEXT,
+    ADD COLUMN IF NOT EXISTS group_id TEXT;
+  `, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`
+    ALTER TABLE events 
+    DROP COLUMN IF EXISTS group_id,
+    DROP COLUMN IF EXISTS group_type;
+  `, cb);
+}; 


### PR DESCRIPTION
Simple 2 columns for event type and event id.

I thought about adding check for type, but decided to handle checking in backend code.

Currently the types will be

1. transaction
2. change-request

And ID is ulid