### PR TITLE
task: Added name and email of requester to track down spammers

### DIFF
--- a/src/mailtemplates/requested-cr-approval/requested-cr-approval.html.mustache
+++ b/src/mailtemplates/requested-cr-approval/requested-cr-approval.html.mustache
@@ -340,7 +340,7 @@
                             <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateBody">
                                 <tr>
                                     <td valign="top" class="bodyContent" mc:edit="body_content">
-                                        <h1>You have been added to review {{{ changeRequestTitle }}}</h1>
+                                        <h1>You have been added to review {{{ changeRequestTitle }}} by {{{ requesterName }}} ({{{ requesterEmail }}}) </h1>
                                         <p>Click <a class="changeRequestLink" href="{{{ changeRequestLink }}}" target="_blank" rel="noopener noreferrer">{{{changeRequestLink}}}</a> to review it</p>
                                     </td>
                                 </tr>

--- a/src/mailtemplates/requested-cr-approval/requested-cr-approval.plain.mustache
+++ b/src/mailtemplates/requested-cr-approval/requested-cr-approval.plain.mustache
@@ -1,3 +1,3 @@
-You have been added to review {{{ changeRequestTitle }}}
+You have been added to review {{{ changeRequestTitle }}} by {{{ requesterName }}} ({{{ requesterEmail }}})
 
 Follow the link: {{{ changeRequestLink }}} to review it.


### PR DESCRIPTION
As the title says. This adds name and email of requester to CR approval mails. This will hopefully have users complain to their coworkers rather than Unleash if they get too many mails.