### PR TITLE
Remove the red coloration of deleted strategy change boxes

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -73,6 +73,7 @@ const InlineList = styled('ul')(({ theme }) => ({
 
 const ChangeInnerBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(3),
+    // todo: remove with flag crDiffView
     '&:has(.delete-strategy-information-wrapper)': {
         backgroundColor: theme.palette.error.light,
     },

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -141,7 +141,7 @@ const DeleteStrategy: FC<{
 
     return (
         <>
-            <ChangeItemCreateEditDeleteWrapper className='delete-strategy-information-wrapper'>
+            <ChangeItemCreateEditDeleteWrapper>
                 <ChangeItemInfo>
                     <Typography
                         sx={(theme) => ({


### PR DESCRIPTION
We don't want deleted strategies to have the red background color anymore with the new change/diff view. As such, we can remove it in the new component and add a todo to delete the css for it after it's gone.

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/083cbcac-5df9-47cd-bd78-2501c3bbf64e" />
