### PR TITLE
feat: now it is possible to search events by group id

### DIFF
--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -73,6 +73,7 @@ export const useEventLogSearch = (
         type: FilterItemParam,
         environment: FilterItemParam,
         id: StringParam,
+        groupId: StringParam,
         ...extraParameters(logType),
     };
 

--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -222,6 +222,11 @@ export default class EventService {
             if (parsed) queryParams.push(parsed);
         }
 
+        if (params.groupId) {
+            const parsed = parseSearchOperatorValue('group_id', params.groupId);
+            if (parsed) queryParams.push(parsed);
+        }
+
         ['project', 'type', 'environment', 'id'].forEach((field) => {
             if (params[field]) {
                 const parsed = parseSearchOperatorValue(field, params[field]);

--- a/src/lib/openapi/spec/event-search-query-parameters.ts
+++ b/src/lib/openapi/spec/event-search-query-parameters.ts
@@ -23,6 +23,17 @@ export const eventSearchQueryParameters = [
         in: 'query',
     },
     {
+        name: 'groupId',
+        schema: {
+            type: 'string',
+            example: 'IS:123',
+            pattern: '^(IS|IS_ANY_OF):(.*?)(,([0-9]+))*$',
+        },
+        description:
+            'Filter by group ID using supported operators: IS, IS_ANY_OF.',
+        in: 'query',
+    },
+    {
         name: 'feature',
         schema: {
             type: 'string',

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -7,6 +7,7 @@ import type { IQueryParam } from '../../features/feature-toggle/types/feature-to
 
 export interface IEventSearchParams {
     id?: string;
+    groupId?: string;
     project?: string;
     query?: string;
     feature?: string;


### PR DESCRIPTION
Now when you put group ID as query param, it will filter based on transaction id.

I am not sure if its best naming, whether it should be groupId or transactionId, I will leave as group for now, but its simple change later.

![image](https://github.com/user-attachments/assets/e0caaf57-f93f-40ee-a332-d3aed249c4ca)
