### PR TITLE
feat: group id clickable in event search

### DIFF
--- a/frontend/src/component/events/EventCard/EventCard.tsx
+++ b/frontend/src/component/events/EventCard/EventCard.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { styled } from '@mui/material';
 import type { EventSchema } from 'openapi';
 import { useUiFlag } from 'hooks/useUiFlag';
+import { useLocation } from 'react-router-dom';
 
 interface IEventCardProps {
     entry: EventSchema;
@@ -74,17 +75,41 @@ export const StyledCodeSection = styled('div')(({ theme }) => ({
 const EventCard = ({ entry }: IEventCardProps) => {
     const { locationSettings } = useLocationSettings();
     const eventGroupingEnabled = useUiFlag('eventGrouping');
+    const location = useLocation();
 
     const createdAtFormatted = formatDateYMDHMS(
         entry.createdAt,
         locationSettings.locale,
     );
 
+    const getGroupIdLink = () => {
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('groupId', `IS:${entry.groupId}`);
+        return `${location.pathname}?${searchParams.toString()}`;
+    };
+
     return (
         <StyledContainerListItem>
             <dl>
                 <StyledDefinitionTerm>Event id:</StyledDefinitionTerm>
                 <dd>{entry.id}</dd>
+                <ConditionallyRender
+                    condition={
+                        !eventGroupingEnabled && entry.groupId !== undefined
+                    }
+                    show={
+                        <>
+                            <StyledDefinitionTerm>
+                                Transaction id:
+                            </StyledDefinitionTerm>
+                            <dd>
+                                <Link to={getGroupIdLink()}>
+                                    {entry.groupId}
+                                </Link>
+                            </dd>
+                        </>
+                    }
+                />
                 <StyledDefinitionTerm>Changed at:</StyledDefinitionTerm>
                 <dd>{createdAtFormatted}</dd>
                 <StyledDefinitionTerm>Event:</StyledDefinitionTerm>

--- a/frontend/src/component/events/EventLog/EventLogFilters.tsx
+++ b/frontend/src/component/events/EventLog/EventLogFilters.tsx
@@ -11,6 +11,7 @@ import type { ProjectSchema } from 'openapi';
 import { useEventCreators } from 'hooks/api/getters/useEventCreators/useEventCreators';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { useLocation } from 'react-router-dom';
+import { FilterItemParam } from 'utils/serializeQueryParams';
 
 export const useEventLogFilters = (
     projects: ProjectSchema[],
@@ -58,12 +59,18 @@ export const useEventLogFilters = (
 
         const groupIdOptions =
             hasGroupId && groupIdValue
-                ? [
-                      {
-                          label: groupIdValue.replace(/^IS:/, ''), // Remove IS: prefix for display
-                          value: groupIdValue,
-                      },
-                  ]
+                ? (() => {
+                      const parsedGroupId =
+                          FilterItemParam.decode(groupIdValue);
+                      return parsedGroupId
+                          ? [
+                                {
+                                    label: parsedGroupId.values[0],
+                                    value: parsedGroupId.values[0],
+                                },
+                            ]
+                          : [];
+                  })()
                 : [];
 
         const availableFilters: IFilterItem[] = [
@@ -107,7 +114,7 @@ export const useEventLogFilters = (
                 ? ([
                       {
                           label: 'Group ID',
-                          icon: 'link',
+                          icon: 'group',
                           options: groupIdOptions,
                           filterKey: 'groupId',
                           singularOperators: ['IS'],

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -73,7 +73,7 @@ export const useEventLogSearch = (
         type: FilterItemParam,
         environment: FilterItemParam,
         id: StringParam,
-        groupId: StringParam,
+        groupId: FilterItemParam,
         ...extraParameters(logType),
     };
 

--- a/frontend/src/component/filter/FilterItem/FilterItem.tsx
+++ b/frontend/src/component/filter/FilterItem/FilterItem.tsx
@@ -131,6 +131,7 @@ export const FilterItem: FC<IFilterItemProps> = ({
             );
             onChange({ operator: currentOperator, values: newOptions });
         } else {
+            console.log('woggle');
             const newOptions = [
                 ...(selectedOptions ?? []),
                 (
@@ -140,6 +141,11 @@ export const FilterItem: FC<IFilterItemProps> = ({
                     }
                 ).value,
             ];
+            console.log(
+                { operator: currentOperator, values: newOptions },
+                selectedOptions,
+                value,
+            );
             onChange({ operator: currentOperator, values: newOptions });
         }
     };

--- a/frontend/src/openapi/models/eventSchema.ts
+++ b/frontend/src/openapi/models/eventSchema.ts
@@ -47,6 +47,10 @@ export interface EventSchema {
      */
     ip?: string | null;
     /**
+     * The event group ID.
+     */
+    groupId?: string;
+    /**
      * The concise, human-readable name of the event.
      * @nullable
      */


### PR DESCRIPTION
Now when pressing the group id, the query params get updated.
Also the FilterItem appears and it is possible to discard the group id selection through it.

![image](https://github.com/user-attachments/assets/89d82f40-621b-4b0c-a440-01e50f929ca2)

