### PR TITLE
chore: limit requested approver count to 10

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRequestedApprovers/ChangeRequestRequestedApprovers.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRequestedApprovers/ChangeRequestRequestedApprovers.tsx
@@ -158,6 +158,7 @@ export const ChangeRequestAddRequestedApprovers: FC<{
 }> = ({ changeRequest, saveClicked, existingReviewers }) => {
     const theme = useTheme();
     const [reviewers, setReviewers] = useState<AvailableReviewerSchema[]>([]);
+    const allReviewers = [...existingReviewers, ...reviewers];
     const { reviewers: fetchedReviewers, loading: isLoading } =
         useAvailableChangeRequestReviewers(
             changeRequest.project,
@@ -207,6 +208,13 @@ export const ChangeRequestAddRequestedApprovers: FC<{
                 options={availableReviewers}
                 renderOption={renderOption}
                 filterOptions={filterOptions}
+                freeSolo={allReviewers.length >= 10 ? false : undefined}
+                getOptionDisabled={(options) => {
+                    return (
+                        allReviewers.length >= 10 &&
+                        !reviewers.find((opt) => opt.id === options.id)
+                    );
+                }}
                 isOptionEqualToValue={(option, value) => option.id === value.id}
                 getOptionLabel={(option: AvailableReviewerSchema) =>
                     option.email || option.name || option.username || ''

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/DraftChangeRequestActions/DraftChangeRequestActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/DraftChangeRequestActions/DraftChangeRequestActions.tsx
@@ -147,6 +147,13 @@ export const DraftChangeRequestActions: FC<{
                 options={availableReviewers}
                 renderOption={renderOption}
                 filterOptions={filterOptions}
+                freeSolo={reviewers.length >= 10 ? false : undefined}
+                getOptionDisabled={(options) => {
+                    return (
+                        reviewers.length >= 10 &&
+                        !reviewers.find((opt) => opt.id === options.id)
+                    );
+                }}
                 isOptionEqualToValue={(option, value) => option.id === value.id}
                 getOptionLabel={(option: AvailableReviewerSchema) =>
                     option.email || option.name || option.username || ''


### PR DESCRIPTION
This limits the amount of approvers that can be requested to 10 in the frontend, backend is already implemented for this

![Skjermbilde 2025-07-02 kl  15 53 46](https://github.com/user-attachments/assets/9e23ece8-2a28-4df3-b9f3-52ef3a1f2487)
![Skjermbilde 2025-07-02 kl  15 53 21](https://github.com/user-attachments/assets/e29cf832-ebfd-429a-bf94-6bc6fa781a70)
![Skjermbilde 2025-07-02 kl  15 53 10](https://github.com/user-attachments/assets/f9dd6154-757e-4076-a142-7c0a1e72c0df)
