### PR TITLE
fix: remove console log from tests

### DIFF
--- a/src/lib/addons/webhook.test.ts
+++ b/src/lib/addons/webhook.test.ts
@@ -72,7 +72,6 @@ describe('Webhook integration', () => {
             .post('/')
             .matchHeader('Content-Type', 'application/json')
             .reply(200, (uri, body) => {
-                console.log(`uri: ${uri} body: ${body}`);
                 callCount++;
                 callBody = body;
                 return { ok: true, status: 200 };

--- a/src/test/e2e/services/playground-service.test.ts
+++ b/src/test/e2e/services/playground-service.test.ts
@@ -204,10 +204,6 @@ describe('the playground service (e2e)', () => {
         segments?: SegmentSchema[];
     }): Promise<PlaygroundFeatureEvaluationResult[]> => {
         await seedDatabaseForPlaygroundTest(db, features, env, segments);
-
-        //     const activeSegments = await db.stores.segmentStore.getAllFeatureStrategySegments()
-        // console.log("active segments db seeding", activeSegments)
-
         const projects = '*';
 
         const serviceFeatures = await service.evaluateQuery(


### PR DESCRIPTION
One thing that can make tests fail is console.out, as it produces IO.