### PR TITLE
fix: tear down also event handlers in addon service

### DIFF
--- a/src/lib/features/events/event-service.ts
+++ b/src/lib/features/events/event-service.ts
@@ -110,6 +110,13 @@ export default class EventService {
         return this.eventStore.on(eventName, listener);
     }
 
+    off(
+        eventName: string | symbol,
+        listener: (...args: any[]) => void,
+    ): EventEmitter {
+        return this.eventStore.off(eventName, listener);
+    }
+
     private async enhanceEventsWithTags(
         events: IBaseEvent[],
     ): Promise<IBaseEvent[]> {

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -137,47 +137,34 @@ export default class AddonService {
     handleEvent(eventName: string): (event: IEvent) => void {
         const { addonProviders } = this;
         return (event) => {
-            this.fetchAddonConfigs()
-                .then((addonInstances) => {
-                    addonInstances
-                        .filter((addon) => addon.events.includes(eventName))
-                        .filter(
-                            (addon) =>
-                                !event.project ||
-                                !addon.projects ||
-                                addon.projects.length === 0 ||
-                                addon.projects[0] === WILDCARD_OPTION ||
-                                addon.projects.includes(event.project),
-                        )
-                        .filter(
-                            (addon) =>
-                                !event.environment ||
-                                !addon.environments ||
-                                addon.environments.length === 0 ||
-                                addon.environments[0] === WILDCARD_OPTION ||
-                                addon.environments.includes(event.environment),
-                        )
-                        .filter((addon) => addonProviders[addon.provider])
-                        .forEach((addon) =>
-                            addonProviders[addon.provider].handleEvent(
-                                event,
-                                addon.parameters,
-                                addon.id,
-                            ),
-                        );
-                })
-                .catch((error) => {
-                    if (error.message === 'aborted') {
-                        this.logger.debug(
-                            `Addon event handling aborted during shutdown for event ${eventName}`,
-                        );
-                    } else {
-                        this.logger.warn(
-                            `Failed to handle addon event ${eventName}:`,
-                            error,
-                        );
-                    }
-                });
+            this.fetchAddonConfigs().then((addonInstances) => {
+                addonInstances
+                    .filter((addon) => addon.events.includes(eventName))
+                    .filter(
+                        (addon) =>
+                            !event.project ||
+                            !addon.projects ||
+                            addon.projects.length === 0 ||
+                            addon.projects[0] === WILDCARD_OPTION ||
+                            addon.projects.includes(event.project),
+                    )
+                    .filter(
+                        (addon) =>
+                            !event.environment ||
+                            !addon.environments ||
+                            addon.environments.length === 0 ||
+                            addon.environments[0] === WILDCARD_OPTION ||
+                            addon.environments.includes(event.environment),
+                    )
+                    .filter((addon) => addonProviders[addon.provider])
+                    .forEach((addon) =>
+                        addonProviders[addon.provider].handleEvent(
+                            event,
+                            addon.parameters,
+                            addon.id,
+                        ),
+                    );
+            });
         };
     }
 

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -367,7 +367,6 @@ export default class AddonService {
     }
 
     destroy(): void {
-        // Clean up event handlers first to prevent race conditions during teardown
         this.eventHandlers.forEach((handler, eventName) => {
             try {
                 this.eventService.off(eventName, handler);
@@ -380,7 +379,6 @@ export default class AddonService {
         });
         this.eventHandlers.clear();
 
-        // Then destroy addon providers
         Object.values(this.addonProviders).forEach((addon) =>
             addon.destroy?.(),
         );


### PR DESCRIPTION
This is attempt to fix tests, as I caught this service failing in the stacktrace.

Basically the event handlers were not cleaned up during stop.

1. Test ends → stopUnleash() is called
2. services.addonService.destroy() called → but this only destroyed addon providers, not event handlers
3. await db.destroy() called → destroys database connection pool
4. Event comes in → triggers handleEvent → calls fetchAddonConfigs() → tries to query destroyed database
5. Database query fails with "Error: aborted"
6. Node.js catches this → db-migrate's fatal handler → process.exit(1)