### PR TITLE
Set a max width on the CR sidebar instead of a min width.

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/ChangeRequestSidebar.tsx
@@ -22,7 +22,7 @@ interface IChangeRequestSidebarProps {
 const StyledPageContent = styled(PageContent)(({ theme }) => ({
     height: '100vh',
     overflow: 'auto',
-    minWidth: '50vw',
+    maxWidth: 'max(40vw, 1000px)',
     padding: theme.spacing(6),
     [theme.breakpoints.down('md')]: {
         padding: theme.spacing(4, 2),


### PR DESCRIPTION
The max width is set to `max(40vw, 1000px)`, so that if you're on a very wide window, then it'll take up at most 40% of the horizontal space. Once your window is smaller than 2500px, however, the sidebar will stop shrinking and stay at 1000px (or as close to that as the window allows). It'll keep shrinking with the window size.

This came up because in certain cases, such as if you have a release template with a long description, the modal would just keep growing until it took up 98% of the window width.

I have not set a min width for now. I don't think there is any need for it, but if we find there is, we can add it back later.

Before:
![image](https://github.com/user-attachments/assets/815b014b-765f-4670-8724-dc70a71b3c17)


After: 
![image](https://github.com/user-attachments/assets/d2b59410-0907-4606-81b3-8103dfbcb44c)
