### PR TITLE
chore: renames "Change" tab to "View change" to align with "View diff".

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
@@ -109,7 +109,7 @@ export const EnvironmentStrategyExecutionOrder = ({
                         </NewChangeItemInfo>
                         <div>
                             <TabList>
-                                <Tab>Change</Tab>
+                                <Tab>View change</Tab>
                                 <Tab>View diff</Tab>
                             </TabList>
                             {actions}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -89,7 +89,7 @@ const StartMilestone: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>Change</Tab>
+                        <Tab>View change</Tab>
                         <Tab>View diff</Tab>
                     </TabList>
                     {actions}
@@ -202,7 +202,7 @@ const AddReleasePlan: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>Changes</Tab>
+                        <Tab>View change</Tab>
                         <Tab>View diff</Tab>
                     </TabList>
                     {actions}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
@@ -57,7 +57,7 @@ export const SegmentChangeDetails: FC<{
     const actionsWithTabs = (
         <ActionsContainer>
             <TabList>
-                <Tab>Change</Tab>
+                <Tab>View change</Tab>
                 <Tab>View diff</Tab>
             </TabList>
             {actions}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -316,7 +316,7 @@ export const StrategyChange: FC<{
     const actionsWithTabs = (
         <ActionsContainer>
             <TabList>
-                <Tab>Change</Tab>
+                <Tab>View change</Tab>
                 <Tab>View diff</Tab>
             </TabList>
             {actions}


### PR DESCRIPTION
There was some confusion whether the options were related or not. This is a quick and easy solution that may solve the problem. If it doesn't, we can make further changes later.

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/6b186b24-c4a7-491b-acbf-0e022a94493c" />
