### PR TITLE
fix: audit scim user deleted events

### DIFF
--- a/src/lib/features/users/user-store.ts
+++ b/src/lib/features/users/user-store.ts
@@ -290,8 +290,12 @@ export class UserStore implements IUserStore {
         await this.activeUsers().del();
     }
 
-    async deleteScimUsers(): Promise<void> {
-        await this.db(TABLE).whereNotNull('scim_id').del();
+    async deleteScimUsers(): Promise<User[]> {
+        const rows = await this.db(TABLE)
+            .whereNotNull('scim_id')
+            .del()
+            .returning(USER_COLUMNS);
+        return rows.map(rowToUser);
     }
 
     async count(): Promise<number> {

--- a/src/lib/types/stores/user-store.ts
+++ b/src/lib/types/stores/user-store.ts
@@ -46,5 +46,5 @@ export interface IUserStore extends Store<IUser, number> {
     count(): Promise<number>;
     countRecentlyDeleted(): Promise<number>;
     countServiceAccounts(): Promise<number>;
-    deleteScimUsers(): Promise<void>;
+    deleteScimUsers(): Promise<IUser[]>;
 }

--- a/src/test/fixtures/fake-user-store.ts
+++ b/src/test/fixtures/fake-user-store.ts
@@ -159,7 +159,7 @@ class UserStoreMock implements IUserStore {
         return Promise.resolve(undefined);
     }
 
-    deleteScimUsers(): Promise<void> {
+    deleteScimUsers(): Promise<User[]> {
         throw new Error('Method not implemented.');
     }
 


### PR DESCRIPTION
SCIM users deleted in bulk are not captured in the event log. We just add an event like this:
![image](https://github.com/user-attachments/assets/2d7078b2-61d6-475e-8151-63b5b5ed7449)

This prevents partial user sync because we don't get an event when the user was deleted.