### PR TITLE
chore: unknown flags with environment

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -244,14 +244,17 @@ export default class ClientMetricsServiceV2 {
             this.config.eventBus.emit(CLIENT_REGISTER, heartbeatEvent);
         }
 
+        const environment = value.environment ?? 'default';
+
         if (unknownToggleNames.length > 0) {
             const unknownFlags = unknownToggleNames.map((name) => ({
                 name,
                 appName: value.appName,
                 seenAt: value.bucket.stop,
+                environment,
             }));
             this.logger.info(
-                `Registering ${unknownFlags.length} unknown flags from ${value.appName}, i.e.: ${unknownFlags
+                `Registering ${unknownFlags.length} unknown flags from ${value.appName} in the ${environment} environment. Some of the unknown flag names include: ${unknownFlags
                     .slice(0, 10)
                     .map((f) => f.name)
                     .join(', ')}`,
@@ -264,7 +267,7 @@ export default class ClientMetricsServiceV2 {
                 (name) => ({
                     featureName: name,
                     appName: value.appName,
-                    environment: value.environment ?? 'default',
+                    environment,
                     timestamp: value.bucket.stop, //we might need to approximate between start/stop...
                     yes: value.bucket.toggles[name].yes ?? 0,
                     no: value.bucket.toggles[name].no ?? 0,

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
@@ -45,7 +45,7 @@ export default class UnknownFlagsController extends Controller {
                     tags: ['Unstable'],
                     summary: 'Get latest reported unknown flag names',
                     description:
-                        'Returns a list of unknown flag names reported in the last 24 hours, if any. Maximum of 10.',
+                        'Returns a list of unknown flag reports from the last 2 hours, if any. Maximum of 100.',
                     responses: {
                         200: createResponseSchema('unknownFlagsResponseSchema'),
                     },
@@ -61,8 +61,7 @@ export default class UnknownFlagsController extends Controller {
         if (!this.flagResolver.isEnabled('reportUnknownFlags')) {
             throw new NotFoundError();
         }
-        const unknownFlags =
-            await this.unknownFlagsService.getGroupedUnknownFlags();
+        const unknownFlags = await this.unknownFlagsService.getAll();
 
         this.openApiService.respondWithValidation(
             200,

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
@@ -7,6 +7,7 @@ export type UnknownFlag = {
     name: string;
     appName: string;
     seenAt: Date;
+    environment: string;
 };
 
 export interface IUnknownFlagsStore {
@@ -32,10 +33,11 @@ export class UnknownFlagsStore implements IUnknownFlagsStore {
                     name: flag.name,
                     app_name: flag.appName,
                     seen_at: flag.seenAt,
+                    environment: flag.environment,
                 }));
                 await tx(TABLE)
                     .insert(rows)
-                    .onConflict(['name', 'app_name'])
+                    .onConflict(['name', 'app_name', 'environment'])
                     .merge(['seen_at']);
             }
         });
@@ -43,13 +45,13 @@ export class UnknownFlagsStore implements IUnknownFlagsStore {
 
     async getAll(): Promise<UnknownFlag[]> {
         const rows = await this.db(TABLE)
-            .select('name', 'app_name', 'seen_at')
-            .orderBy('seen_at', 'desc')
+            .select('name', 'app_name', 'seen_at', 'environment')
             .limit(MAX_UNKNOWN_FLAGS);
         return rows.map((row) => ({
             name: row.name,
             appName: row.app_name,
             seenAt: new Date(row.seen_at),
+            environment: row.environment,
         }));
     }
 

--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -203,8 +203,8 @@ export const scheduleServices = (
     );
 
     schedulerService.schedule(
-        unknownFlagsService.clear.bind(unknownFlagsService, 24),
-        hoursToMilliseconds(24),
+        unknownFlagsService.clear.bind(unknownFlagsService, 2),
+        hoursToMilliseconds(2),
         'clearUnknownFlags',
     );
 };

--- a/src/lib/openapi/spec/unknown-flag-schema.ts
+++ b/src/lib/openapi/spec/unknown-flag-schema.ts
@@ -4,7 +4,7 @@ export const unknownFlagSchema = {
     $id: '#/components/schemas/unknownFlagSchema',
     type: 'object',
     additionalProperties: false,
-    required: ['name', 'reportedBy'],
+    required: ['name', 'appName', 'seenAt', 'environment'],
     description: 'An unknown flag that has been reported by the system',
     properties: {
         name: {
@@ -12,30 +12,24 @@ export const unknownFlagSchema = {
             description: 'The name of the unknown flag.',
             example: 'my-unknown-flag',
         },
-        reportedBy: {
+        appName: {
+            type: 'string',
             description:
-                'Details about the application that reported the unknown flag.',
-            type: 'array',
-            items: {
-                type: 'object',
-                additionalProperties: false,
-                required: ['appName', 'seenAt'],
-                properties: {
-                    appName: {
-                        type: 'string',
-                        description:
-                            'The name of the application that reported the unknown flag.',
-                        example: 'my-app',
-                    },
-                    seenAt: {
-                        type: 'string',
-                        format: 'date-time',
-                        description:
-                            'The date and time when the unknown flag was reported.',
-                        example: '2023-10-01T12:00:00Z',
-                    },
-                },
-            },
+                'The name of the application that reported the unknown flag.',
+            example: 'my-app',
+        },
+        seenAt: {
+            type: 'string',
+            format: 'date-time',
+            description:
+                'The date and time when the unknown flag was reported.',
+            example: '2023-10-01T12:00:00Z',
+        },
+        environment: {
+            type: 'string',
+            description:
+                'The environment in which the unknown flag was reported.',
+            example: 'production',
         },
     },
     components: {},

--- a/src/migrations/20250707153020-unknown-flags-environment.js
+++ b/src/migrations/20250707153020-unknown-flags-environment.js
@@ -1,0 +1,17 @@
+exports.up = function(db, cb) {
+  db.runSql(`
+    ALTER TABLE unknown_flags
+      ADD COLUMN IF NOT EXISTS environment TEXT NOT NULL DEFAULT 'default',
+      DROP CONSTRAINT unknown_flags_pkey,
+      ADD PRIMARY KEY (name, app_name, environment);
+  `, cb);
+};
+
+exports.down = function(db, cb) {
+  db.runSql(`
+    ALTER TABLE unknown_flags
+      DROP CONSTRAINT unknown_flags_pkey,
+      ADD PRIMARY KEY (name, app_name),
+      DROP COLUMN IF EXISTS environment;
+  `, cb);
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3681/add-environment-to-unknown-flag-reports

This does a few things:
 - Adds environment to our unknown flag reports
 - Increases our max unknown flag reports from 10 to 100
 - Flattens our response (easier to get started with and display in a table, we can later decide if we want to group this data)

<img width="496" alt="image" src="https://github.com/user-attachments/assets/11350639-9f7f-4011-8b39-b135c820ca21" />
