### PR TITLE
Remove uses of one of / use operator checks instead

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFilterItem.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsModal/ProjectActionsForm/ProjectActionsFormStep/ProjectActionsFormStepSource/ProjectActionsFilterItem.tsx
@@ -11,13 +11,13 @@ import Input from 'component/common/Input/Input';
 import { ProjectActionsFormItem } from '../ProjectActionsFormItem.tsx';
 import {
     inOperators,
+    isStringOperator,
     numOperators,
     type Operator,
     semVerOperators,
     stringOperators,
 } from 'constants/operators';
 import { useEffect, useState } from 'react';
-import { oneOf } from 'utils/oneOf';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { CaseSensitiveButton } from './StyledToggleButton/CaseSensitiveButton/CaseSensitiveButton.tsx';
 import { InvertedOperatorButton } from './StyledToggleButton/InvertedOperatorButton/InvertedOperatorButton.tsx';
@@ -169,7 +169,7 @@ export const ProjectActionsFilterItem = ({
     }, [value, error]);
 
     useEffect(() => {
-        if (oneOf(stringOperators, operator)) {
+        if (isStringOperator(operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);
@@ -177,7 +177,7 @@ export const ProjectActionsFilterItem = ({
     }, [operator]);
 
     const onOperatorChange = (operator: Operator) => {
-        if (oneOf(stringOperators, operator)) {
+        if (isStringOperator(operator)) {
             setShowCaseSensitiveButton(true);
         } else {
             setShowCaseSensitiveButton(false);

--- a/frontend/src/hooks/useChangeRequestInReviewWarning.tsx
+++ b/frontend/src/hooks/useChangeRequestInReviewWarning.tsx
@@ -1,5 +1,4 @@
 import { Alert } from '@mui/material';
-import { oneOf } from 'utils/oneOf';
 import type { ChangeRequestType } from '../component/changeRequest/changeRequest.types';
 
 export const useChangeRequestInReviewWarning = (
@@ -11,7 +10,7 @@ export const useChangeRequestInReviewWarning = (
         return draft.some(
             (changeRequest) =>
                 changeRequest.environment === environment &&
-                oneOf(['In review', 'Approved'], changeRequest.state),
+                ['In review', 'Approved'].includes(changeRequest.state),
         );
     };
 

--- a/frontend/src/utils/cleanConstraint.ts
+++ b/frontend/src/utils/cleanConstraint.ts
@@ -1,13 +1,12 @@
-import { singleValueOperators } from 'constants/operators';
 import type { IConstraint } from 'interfaces/strategy';
-import { oneOf } from 'utils/oneOf';
 import produce from 'immer';
+import { isSingleValueOperator } from 'constants/operators';
 
 export const cleanConstraint = (
     constraint: Readonly<IConstraint>,
 ): IConstraint => {
     return produce(constraint, (draft) => {
-        if (oneOf(singleValueOperators, constraint.operator)) {
+        if (isSingleValueOperator(constraint.operator)) {
             delete draft.values;
         } else {
             delete draft.value;

--- a/frontend/src/utils/oneOf.ts
+++ b/frontend/src/utils/oneOf.ts
@@ -1,3 +1,0 @@
-export const oneOf = (values: string[], match: string) => {
-    return values.some((value) => value === match);
-};

--- a/frontend/src/utils/operatorsForContext.ts
+++ b/frontend/src/utils/operatorsForContext.ts
@@ -1,23 +1,22 @@
 import {
     allOperators,
-    dateOperators,
+    isDateOperator,
     type Operator,
 } from 'constants/operators';
-import { oneOf } from 'utils/oneOf';
 
 export const CURRENT_TIME_CONTEXT_FIELD = 'currentTime';
 
 export const operatorsForContext = (contextName: string): Operator[] => {
     return allOperators.filter((operator) => {
         if (
-            oneOf(dateOperators, operator) &&
+            isDateOperator(operator) &&
             contextName !== CURRENT_TIME_CONTEXT_FIELD
         ) {
             return false;
         }
 
         if (
-            !oneOf(dateOperators, operator) &&
+            !isDateOperator(operator) &&
             contextName === CURRENT_TIME_CONTEXT_FIELD
         ) {
             return false;


### PR DESCRIPTION
Updates a few remaining places where we check constraint operators with the new constraint operator checks. Additionally, because there was only one remaining place where we used the `oneOf` function, I replaced it with a normal `includes` check and deleted the `oneOf` util. From what I can tell, there's no need to have that utility function; it doesn't provide much benefit over using the language built-ins 🤷🏼 