### PR TITLE
Add PAYG trial events flag to Unleash

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -63,6 +63,7 @@ export type IFlagKey =
     | 'improvedJsonDiff'
     | 'crDiffView'
     | 'changeRequestApproverEmails'
+    | 'paygTrialEvents'
     | 'eventGrouping';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -294,6 +295,10 @@ const flags: IFlags = {
     ),
     eventGrouping: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_EVENT_GROUPING,
+        false,
+    ),
+    paygTrialEvents: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PAYG_TRIAL_EVENTS,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,6 +58,7 @@ process.nextTick(async () => {
                         impactMetrics: true,
                         crDiffView: true,
                         eventGrouping: true,
+                        paygTrialEvents: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Pretty much what it says on the tin: add PAYG trial events flag to control the upcoming trial events