### PR TITLE
[CI]: Cancel CI runs that become obsolete

### DIFF
--- a/.github/workflows/build_doc_prs.yaml
+++ b/.github/workflows/build_doc_prs.yaml
@@ -5,6 +5,11 @@ on:
     paths:
       - website/**
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: build # temporary solution to trick branch protection rules

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,11 @@ name: Dependency review
 on:
   pull_request:
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/e2e.frontend.yaml
+++ b/.github/workflows/e2e.frontend.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     # paths:
     #   - 'frontend/**'
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## About the changes
Currently, if a PR is open and a push happens, the **e2e:frontend** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

### Example
Here is an example of the behaviour described above: the commit `b1b2e61` triggered [this](https://github.com/Unleash/unleash/actions/runs/14493085673/) workflow run, and shortly after the commit `9997fe1`, that happened on top of the first commit, triggered [this](https://github.com/Unleash/unleash/actions/runs/14493089012/) workflow. Both workflows ran till the end, spending approximately 8 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~8 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **2 CPU hours** over the last few months.

The same holds for these workflow(s) as well: Dependency review, PR -> Build Docs.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch
