### PR TITLE
chore: add application_created event type

### DIFF
--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -24,7 +24,11 @@ import type { IClientMetricsStoreV2 } from '../client-metrics/client-metrics-sto
 import { clientMetricsSchema } from '../shared/schema.js';
 import type { PartialSome } from '../../../types/partial.js';
 import type { IPrivateProjectChecker } from '../../private-project/privateProjectCheckerType.js';
-import { type IFlagResolver, SYSTEM_USER } from '../../../types/index.js';
+import {
+    type ApplicationCreatedEvent,
+    type IFlagResolver,
+    SYSTEM_USER,
+} from '../../../types/index.js';
 import { ALL_PROJECTS, parseStrictSemVer } from '../../../util/index.js';
 import type { Logger } from '../../../logger.js';
 import { findOutdatedSDKs, isOutdatedSdk } from './findOutdatedSdks.js';
@@ -148,13 +152,15 @@ export default class ClientInstanceService {
             const appsToAnnounce =
                 await this.clientApplicationsStore.setUnannouncedToAnnounced();
             if (appsToAnnounce.length > 0) {
-                const events = appsToAnnounce.map((app) => ({
-                    type: APPLICATION_CREATED,
-                    createdBy: app.createdBy || SYSTEM_USER.username!,
-                    data: app,
-                    createdByUserId: app.createdByUserId || SYSTEM_USER.id,
-                    ip: '', // TODO: fix this, how do we get the ip from the client? This comes from a row in the DB
-                }));
+                const events: ApplicationCreatedEvent[] = appsToAnnounce.map(
+                    (app) => ({
+                        type: APPLICATION_CREATED,
+                        createdBy: app.createdBy || SYSTEM_USER.username!,
+                        data: app,
+                        createdByUserId: app.createdByUserId || SYSTEM_USER.id,
+                        ip: '', // TODO: fix this, how do we get the ip from the client? This comes from a row in the DB
+                    }),
+                );
                 await this.eventStore.batchStore(events);
             }
         }

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -120,8 +120,10 @@ import {
     FEATURE_LINK_REMOVED,
     FEATURE_LINK_UPDATED,
     FEATURE_LINK_ADDED,
+    APPLICATION_CREATED,
 } from '../events/index.js';
 import type { ITag } from '../tags/index.js';
+import type { IClientApplication } from './stores/client-applications-store.js';
 
 export class BaseEvent implements IBaseEvent {
     readonly type: IEventType;
@@ -1913,6 +1915,17 @@ export class ReleasePlanMilestoneStartedEvent extends BaseEvent {
         this.featureName = eventData.featureName;
         this.environment = eventData.environment;
         this.preData = eventData.preData;
+        this.data = eventData.data;
+    }
+}
+
+export class ApplicationCreatedEvent extends BaseEvent {
+    readonly data: IClientApplication;
+    constructor(eventData: {
+        data: IClientApplication;
+        auditUser: IAuditUser;
+    }) {
+        super(APPLICATION_CREATED, eventData.auditUser);
         this.data = eventData.data;
     }
 }


### PR DESCRIPTION
This is primarily to facilitate reading and processing these events in the payg cloud section of Unleash. We only emit these in one place, so I added the types in there.
