### PR TITLE
chore: allow bulk metrics with empty flag names

### DIFF
--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -39,7 +39,7 @@ export const clientMetricsEnvSchema = joi
     .object()
     .options({ stripUnknown: true })
     .keys({
-        featureName: joi.string().required(),
+        featureName: joi.string().required().allow(''),
         environment: joi.string().required(),
         appName: joi.string().required(),
         yes: joi.number().default(0),


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3695/allow-empty-flag-names-to-be-reported-in-bulk-metrics

Accepts metrics with empty flag names in the `/api/client/metrics/bulk` endpoint.

When testing unknown flags through Edge, which uses the `/bulk` endpoint, we noticed that there's a slight difference in validation behavior compared to the regular metrics endpoint. While the regular endpoint allows empty flag names, this one does not.

We can argue that we don't care about empty flag names in the first place, which is true, but this inconsistency between the metric endpoints can be confusing, and it also means that a single empty flag name evaluation would break metrics being reported for that entire Edge instance, for example.

This way we still accept it, just like we currently do if we point to Unleash directly instead of going through Edge.

**Note**: We noticed that, due to the slightly different logic branch, the bulk metrics endpoint does not report unknown flags. We'll take a look at this at a later point.