### PR TITLE
chore: Export IClientInstance from `server-impl`.

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -185,6 +185,7 @@ import type { RequestHandler } from 'express';
 import { UPDATE_REVISION } from './features/feature-toggle/configuration-revision-service.js';
 import type { IFeatureUsageInfo } from './services/version-service.js';
 import { defineImpactMetrics } from './features/metrics/impact/define-impact-metrics.js';
+import type { IClientInstance } from './types/stores/client-instance-store.js';
 
 export async function initialServiceSetup(
     { authentication }: Pick<IUnleashConfig, 'authentication'>,
@@ -549,6 +550,7 @@ export type {
     QueryOverride,
     IUserPermission,
     IFeatureUsageInfo,
+    IClientInstance,
 };
 export * from './openapi/index.js';
 export * from './types/index.js';


### PR DESCRIPTION
This type wasn't available in enterprise, so I'm adding it to serer-impl to make it available.

I was a little unsure whether this would be an implementation detail that we shouldn't expose in server-impl, but comparing it with the other things we export (`applyGenericQueryParams`, `flattenPayload`, `basePaginationParameters`), that seems to be fine. I'm guessing this isn't the main public export? Or it is, and we just don't care 🤷
