### PR TITLE
chore: add flag paygInstanceStatsEvents

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -64,7 +64,8 @@ export type IFlagKey =
     | 'crDiffView'
     | 'changeRequestApproverEmails'
     | 'paygTrialEvents'
-    | 'eventGrouping';
+    | 'eventGrouping'
+    | 'paygInstanceStatsEvents';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -295,6 +296,10 @@ const flags: IFlags = {
     ),
     paygTrialEvents: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PAYG_TRIAL_EVENTS,
+        false,
+    ),
+    paygInstanceStatsEvents: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PAYG_INSTANCE_STATS_EVENTS,
         false,
     ),
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3697/add-flag-payginstancestatsevents

Adds a new flag: `paygInstanceStatsEvents`

This controls sending the daily PAYG instance stats events.