### PR TITLE
fix: don't overwrite `seenClients` in instance-service; merge if same client appears again

### DIFF
--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -34,7 +34,7 @@ const mapRow = (row) => ({
 const mapToDb = (client) => ({
     app_name: client.appName,
     instance_id: client.instanceId,
-    sdk_version: client.sdkVersion,
+    sdk_version: client.sdkVersion || '',
     sdk_type: client.sdkType,
     client_ip: client.clientIp,
     last_seen: client.lastSeen || 'now()',
@@ -75,11 +75,10 @@ export default class ClientInstanceStore implements IClientInstanceStore {
         const stopTimer = this.metricTimer('bulkUpsert');
 
         const rows = instances.map(mapToDb);
-
         await this.db(TABLE)
             .insert(rows)
             .onConflict(['app_name', 'instance_id', 'environment'])
-            .merge(['last_seen', 'client_ip']);
+            .merge();
 
         stopTimer();
     }

--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -74,16 +74,12 @@ export default class ClientInstanceStore implements IClientInstanceStore {
     async bulkUpsert(instances: INewClientInstance[]): Promise<void> {
         const stopTimer = this.metricTimer('bulkUpsert');
 
-        const rows = instances.map((i) =>
-            Object.fromEntries(
-                Object.entries(mapToDb(i)).filter(([, v]) => v !== undefined),
-            ),
-        );
+        const rows = instances.map(mapToDb);
 
         await this.db(TABLE)
             .insert(rows)
             .onConflict(['app_name', 'instance_id', 'environment'])
-            .merge();
+            .merge(['last_seen', 'client_ip']);
 
         stopTimer();
     }

--- a/src/lib/db/client-instance-store.ts
+++ b/src/lib/db/client-instance-store.ts
@@ -34,7 +34,7 @@ const mapRow = (row) => ({
 const mapToDb = (client) => ({
     app_name: client.appName,
     instance_id: client.instanceId,
-    sdk_version: client.sdkVersion || '',
+    sdk_version: client.sdkVersion,
     sdk_type: client.sdkType,
     client_ip: client.clientIp,
     last_seen: client.lastSeen || 'now()',
@@ -74,7 +74,12 @@ export default class ClientInstanceStore implements IClientInstanceStore {
     async bulkUpsert(instances: INewClientInstance[]): Promise<void> {
         const stopTimer = this.metricTimer('bulkUpsert');
 
-        const rows = instances.map(mapToDb);
+        const rows = instances.map((i) =>
+            Object.fromEntries(
+                Object.entries(mapToDb(i)).filter(([, v]) => v !== undefined),
+            ),
+        );
+
         await this.db(TABLE)
             .insert(rows)
             .onConflict(['app_name', 'instance_id', 'environment'])

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -21,8 +21,6 @@ import type {
 import { clientRegisterSchema } from '../shared/schema.js';
 
 import type { IClientMetricsStoreV2 } from '../client-metrics/client-metrics-store-v2-type.js';
-import { clientMetricsSchema } from '../shared/schema.js';
-import type { PartialSome } from '../../../types/partial.js';
 import type { IPrivateProjectChecker } from '../../private-project/privateProjectCheckerType.js';
 import {
     type ApplicationCreatedEvent,
@@ -35,6 +33,7 @@ import { findOutdatedSDKs, isOutdatedSdk } from './findOutdatedSdks.js';
 import type { OutdatedSdksSchema } from '../../../openapi/spec/outdated-sdks-schema.js';
 import { CLIENT_REGISTERED } from '../../../metric-events.js';
 import { NotFoundError } from '../../../error/index.js';
+import type { ClientMetricsSchema, PartialSome } from '../../../server-impl.js';
 
 type ClientData = IClientApp & { lastSeen?: Date };
 
@@ -110,15 +109,16 @@ export default class ClientInstanceService {
     };
 
     public async registerInstance(
-        data: PartialSome<IClientApp, 'instanceId'>,
+        data: Pick<
+            ClientMetricsSchema,
+            'appName' | 'instanceId' | 'environment'
+        >,
         clientIp: string,
     ): Promise<void> {
-        const value = await clientMetricsSchema.validateAsync(data);
-
         this.updateSeenClient({
-            appName: value.appName,
-            instanceId: value.instanceId,
-            environment: value.environment,
+            appName: data.appName,
+            instanceId: data.instanceId ?? 'default',
+            environment: data.environment,
             clientIp: clientIp,
         });
     }

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -35,14 +35,12 @@ import { CLIENT_REGISTERED } from '../../../metric-events.js';
 import { NotFoundError } from '../../../error/index.js';
 import type { ClientMetricsSchema, PartialSome } from '../../../server-impl.js';
 
-type ClientData = IClientApp & { lastSeen?: Date };
-
 export default class ClientInstanceService {
     apps = {};
 
     logger: Logger;
 
-    seenClients: Record<string, ClientData> = {};
+    seenClients: Record<string, IClientApp> = {};
 
     private clientMetricsStoreV2: IClientMetricsStoreV2;
 
@@ -100,7 +98,7 @@ export default class ClientInstanceService {
         );
     }
 
-    private updateSeenClient = (data: ClientData) => {
+    private updateSeenClient = (data: IClientApp) => {
         const current = this.seenClients[this.clientKey(data)];
         this.seenClients[this.clientKey(data)] = {
             ...current,

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -28,6 +28,7 @@ import type { CustomMetricsSchema } from '../../../openapi/spec/custom-metrics-s
 import type { StoredCustomMetric } from '../custom/custom-metrics-store.js';
 import type { CustomMetricsService } from '../custom/custom-metrics-service.js';
 import type { MetricsTranslator } from '../impact/metrics-translator.js';
+import type { ClientMetricsSchema } from '../../../server-impl.js';
 
 export default class ClientMetricsController extends Controller {
     logger: Logger;
@@ -147,7 +148,10 @@ export default class ClientMetricsController extends Controller {
         // Note: Custom metrics GET endpoints are now handled by the admin API
     }
 
-    async registerMetrics(req: IAuthRequest, res: Response): Promise<void> {
+    async registerMetrics(
+        req: IAuthRequest<ClientMetricsSchema>,
+        res: Response,
+    ): Promise<void> {
         if (this.config.flagResolver.isEnabled('disableMetrics')) {
             res.status(204).end();
         } else {

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -27,7 +27,10 @@ import { CLIENT_METRICS } from '../../../events/index.js';
 import type { CustomMetricsSchema } from '../../../openapi/spec/custom-metrics-schema.js';
 import type { StoredCustomMetric } from '../custom/custom-metrics-store.js';
 import type { CustomMetricsService } from '../custom/custom-metrics-service.js';
-import type { MetricsTranslator } from '../impact/metrics-translator.js';
+import type {
+    Metric,
+    MetricsTranslator,
+} from '../impact/metrics-translator.js';
 import type { ClientMetricsSchema } from '../../../server-impl.js';
 
 export default class ClientMetricsController extends Controller {
@@ -149,7 +152,7 @@ export default class ClientMetricsController extends Controller {
     }
 
     async registerMetrics(
-        req: IAuthRequest<ClientMetricsSchema>,
+        req: IAuthRequest<void, void, ClientMetricsSchema>,
         res: Response,
     ): Promise<void> {
         if (this.config.flagResolver.isEnabled('disableMetrics')) {
@@ -173,7 +176,9 @@ export default class ClientMetricsController extends Controller {
                     this.flagResolver.isEnabled('impactMetrics') &&
                     impactMetrics
                 ) {
-                    await this.metricsV2.registerImpactMetrics(impactMetrics);
+                    await this.metricsV2.registerImpactMetrics(
+                        impactMetrics as Metric[],
+                    );
                 }
 
                 res.getHeaderNames().forEach((header) =>

--- a/src/lib/openapi/spec/create-application-schema.ts
+++ b/src/lib/openapi/spec/create-application-schema.ts
@@ -6,13 +6,16 @@ export const createApplicationSchema = {
     description: 'Reported application information from Unleash SDKs',
     properties: {
         appName: {
-            description: 'Name of the application',
+            deprecated: true,
+            description:
+                'Deprecated: Name of the application. This property is ignored. The app name is taken from the URL instead.',
             type: 'string',
             example: 'accounting',
         },
         sdkVersion: {
+            deprecated: true,
             description:
-                'Which SDK and version the application reporting uses. Typically represented as `<identifier>:<version>`',
+                'Deprecated: Which SDK and version the application reporting uses. Typically represented as `<identifier>:<version>`. This is not used in the client_applications db table.',
             type: 'string',
             example: 'unleash-client-java:8.0.0',
         },

--- a/src/lib/openapi/spec/create-application-schema.ts
+++ b/src/lib/openapi/spec/create-application-schema.ts
@@ -5,20 +5,6 @@ export const createApplicationSchema = {
     type: 'object',
     description: 'Reported application information from Unleash SDKs',
     properties: {
-        appName: {
-            deprecated: true,
-            description:
-                'Deprecated: Name of the application. This property is ignored. The app name is taken from the URL instead.',
-            type: 'string',
-            example: 'accounting',
-        },
-        sdkVersion: {
-            deprecated: true,
-            description:
-                'Deprecated: Which SDK and version the application reporting uses. Typically represented as `<identifier>:<version>`. This is not used in the client_applications db table.',
-            type: 'string',
-            example: 'unleash-client-java:8.0.0',
-        },
         strategies: {
             description:
                 'Which [strategies](https://docs.getunleash.io/topics/the-anatomy-of-unleash#activation-strategies) the application has loaded. Useful when trying to figure out if your [custom strategy](https://docs.getunleash.io/reference/custom-activation-strategies) has been loaded in the SDK',

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -555,6 +555,7 @@ export interface IClientApp {
     yggdrasilVersion?: string;
     specVersion?: string;
     sdkType?: 'frontend' | 'backend' | null;
+    sdkVersion?: string;
 }
 
 export interface IAppFeature {

--- a/src/test/e2e/api/admin/applications.e2e.test.ts
+++ b/src/test/e2e/api/admin/applications.e2e.test.ts
@@ -85,6 +85,7 @@ beforeEach(async () => {
         db.stores.featureToggleStore.deleteAll(),
         db.stores.clientApplicationsStore.deleteAll(),
     ]);
+    app.services.clientInstanceService.seenClients = {};
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Fixes a bug where `registerInstance` and `register{Frontend|Backend}Client` would overwrite each other's data in the instance service, leading to the bulk update being made with partial data, often missing SDK version. There's a different issue in the actual store that causes sdk version and type to be overwritten when it's updated (because we don't use `setLastSeen` anymore), but I'll handle that in a different PR.

This PR adds tests for the changes I've made. Additionally, I've made these semi-related bonus changes:
- In registerInstance, don't expect a partial `IClientApp`. We used to validate that it was actual a metrics object instead. Instead, update the signature to expect the actual properties we need from the cilent metrics schema and set a default for instanceId the way Joi did.
- In `metrics.ts`, use the `ClientMetricsSchema` type in the function signature, so that the request body is correctly typed in the function (instead of being `any`).
- Delete two unused properties from the`createApplicationSchema`. They would get ignored and were never used as far as I can tell. (`appName` is taken from the URL, and applications don't store `sdkVersion` information).
- Add `sdkVersion` to `IClientApp` because it's used in instance service.

I've been very confused about all the weird type shenanigans we do in the instance service (expecting `IClientApp`, then validating with a different Joi schema etc). I think this makes it a little bit better and updates the bits I'm touching, but I'm happy to take input if you disagree.