### PR TITLE
feat: use metric display name in impact charts

### DIFF
--- a/frontend/src/component/impact-metrics/ChartItem.tsx
+++ b/frontend/src/component/impact-metrics/ChartItem.tsx
@@ -16,7 +16,7 @@ const getConfigDescription = (config: ChartConfig): string => {
     const parts: string[] = [];
 
     if (config.selectedSeries) {
-        parts.push(`${config.selectedSeries}`);
+        parts.push(`${config.displayName}`);
     }
 
     parts.push(`last ${config.selectedRange}`);

--- a/frontend/src/component/impact-metrics/ChartItem.tsx
+++ b/frontend/src/component/impact-metrics/ChartItem.tsx
@@ -4,18 +4,18 @@ import Edit from '@mui/icons-material/Edit';
 import Delete from '@mui/icons-material/Delete';
 import DragHandle from '@mui/icons-material/DragHandle';
 import { ImpactMetricsChart } from './ImpactMetricsChart.tsx';
-import type { ChartConfig } from './types.ts';
+import type { ChartConfig, DisplayChartConfig } from './types.ts';
 
 export interface ChartItemProps {
-    config: ChartConfig;
+    config: DisplayChartConfig;
     onEdit: (config: ChartConfig) => void;
     onDelete: (id: string) => void;
 }
 
-const getConfigDescription = (config: ChartConfig): string => {
+const getConfigDescription = (config: DisplayChartConfig): string => {
     const parts: string[] = [];
 
-    if (config.selectedSeries) {
+    if (config.displayName) {
         parts.push(`${config.displayName}`);
     }
 

--- a/frontend/src/component/impact-metrics/types.ts
+++ b/frontend/src/component/impact-metrics/types.ts
@@ -1,6 +1,8 @@
 export type ChartConfig = {
     id: string;
-    selectedSeries: string;
+    selectedSeries: string; // e.g. unleash_counter_my_metric
+    type: 'counter' | 'gauge';
+    displayName: string; // e.g. my_metric with unleash_counter stripped
     selectedRange: 'hour' | 'day' | 'week' | 'month';
     beginAtZero: boolean;
     showRate: boolean;

--- a/frontend/src/component/impact-metrics/types.ts
+++ b/frontend/src/component/impact-metrics/types.ts
@@ -1,13 +1,16 @@
 export type ChartConfig = {
     id: string;
     selectedSeries: string; // e.g. unleash_counter_my_metric
-    type: 'counter' | 'gauge';
-    displayName: string; // e.g. my_metric with unleash_counter stripped
     selectedRange: 'hour' | 'day' | 'week' | 'month';
     beginAtZero: boolean;
     showRate: boolean;
     selectedLabels: Record<string, string[]>;
     title?: string;
+};
+
+export type DisplayChartConfig = ChartConfig & {
+    type: 'counter' | 'gauge';
+    displayName: string; // e.g. my_metric with unleash_counter stripped
 };
 
 export type LayoutItem = {
@@ -24,5 +27,10 @@ export type LayoutItem = {
 
 export type ImpactMetricsState = {
     charts: ChartConfig[];
+    layout: LayoutItem[];
+};
+
+export type DisplayImpactMetricsState = {
+    charts: DisplayChartConfig[];
     layout: LayoutItem[];
 };

--- a/frontend/src/hooks/api/getters/useImpactMetricsSettings/useImpactMetricsSettings.ts
+++ b/frontend/src/hooks/api/getters/useImpactMetricsSettings/useImpactMetricsSettings.ts
@@ -1,13 +1,13 @@
 import { fetcher, useApiGetter } from '../useApiGetter/useApiGetter.js';
 import { formatApiPath } from 'utils/formatPath';
-import type { ImpactMetricsState } from 'component/impact-metrics/types.ts';
+import type { DisplayImpactMetricsState } from 'component/impact-metrics/types.ts';
 
 export const useImpactMetricsSettings = () => {
     const PATH = `api/admin/impact-metrics/settings`;
-    const { data, refetch, loading, error } = useApiGetter<ImpactMetricsState>(
-        formatApiPath(PATH),
-        () => fetcher(formatApiPath(PATH), 'Impact metrics settings'),
-    );
+    const { data, refetch, loading, error } =
+        useApiGetter<DisplayImpactMetricsState>(formatApiPath(PATH), () =>
+            fetcher(formatApiPath(PATH), 'Impact metrics settings'),
+        );
 
     return {
         settings: data || { charts: [], layout: [] },


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Swap internal impl metric name for user provided name in the SDK
<img width="525" height="118" alt="Screenshot 2025-07-16 at 10 39 03" src="https://github.com/user-attachments/assets/62b35d7b-c729-42a6-a686-b218aa2ccbff" />

Details:
* ChartConfig type is used for writing new charts
* DisplayChartConfig is same as ChartConfig plus it has backend calculated human friendly display and metric type

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
