### PR TITLE
feat: show rps only for counters

### DIFF
--- a/frontend/src/component/impact-metrics/ImpactMetricsControls/ImpactMetricsControls.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricsControls/ImpactMetricsControls.tsx
@@ -68,15 +68,19 @@ export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
                 label='Begin at zero'
             />
 
-            <FormControlLabel
-                control={
-                    <Checkbox
-                        checked={formData.showRate}
-                        onChange={(e) => actions.setShowRate(e.target.checked)}
-                    />
-                }
-                label='Show rate per second'
-            />
+            {formData.selectedSeries.startsWith('unleash_counter_') ? (
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={formData.showRate}
+                            onChange={(e) =>
+                                actions.setShowRate(e.target.checked)
+                            }
+                        />
+                    }
+                    label='Show rate per second'
+                />
+            ) : null}
         </Box>
         {availableLabels && (
             <LabelsFilter


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Include Show RPS checkbox only for counters as it doesn't make sense for gauges.
<img width="483" height="463" alt="Screenshot 2025-07-16 at 13 32 25" src="https://github.com/user-attachments/assets/8078af9f-b7bd-4e56-a539-0ff67964fe00" />

I am also planing another change to get rid of this boolean flag (booleans are usually a very poor modelling primitive).
What I want to have instead are unions for counters (total | rps) and gauges (sum | avg)

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
