### PR TITLE
fix: update legend display logic

### DIFF
--- a/frontend/src/component/impact-metrics/ImpactMetricsChart.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricsChart.tsx
@@ -90,6 +90,9 @@ export const ImpactMetricsChart: FC<ImpactMetricsChartProps> = ({
             description=''
         />
     );
+
+    const hasManyLabels = Object.keys(selectedLabels).length > 0;
+
     const cover = notEnoughData ? placeholder : isLoading;
 
     const chartOptions = shouldShowPlaceholder
@@ -132,7 +135,9 @@ export const ImpactMetricsChart: FC<ImpactMetricsChartProps> = ({
               },
               plugins: {
                   legend: {
-                      display: timeSeriesData && timeSeriesData.length > 1,
+                      display:
+                          timeSeriesData &&
+                          (hasManyLabels || timeSeriesData.length > 1),
                       position: 'bottom' as const,
                       labels: {
                           usePointStyle: true,


### PR DESCRIPTION
## About the changes
When grouping by multiple labels, chart label should always be visible. Even if returned data only has 1 series