### PR TITLE
Add metadata to quickstart

### DIFF
--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -7,6 +7,12 @@ import Tabs from '@theme/Tabs';
 
 import TabItem from '@theme/TabItem';
 
+import Head from '@docusaurus/Head';
+
+<Head>
+  <meta name="search_priority" content="3" />
+</Head>
+
 The easiest way to get started with Unleash is through a [cloud-hosted free trial](https://www.getunleash.io/plans/enterprise-payg). This gives you a ready-to-use instance, so you can explore all Unleash features without any local setup.
 
 In this guide, you'll:


### PR DESCRIPTION
Test Algolia config with a search_priority property in page metadata