### PR TITLE
chore: emit CLIENT_METRICS event after sifting

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
@@ -113,7 +113,7 @@ test('process metrics properly even when some names are not url friendly, filter
     );
 
     // only toggle with a bad name gets filtered out
-    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).not.toHaveBeenCalled();
     expect(lastSeenService.updateLastSeen).not.toHaveBeenCalled();
 });
 

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -251,6 +251,7 @@ export default class ClientMetricsServiceV2 {
             ...siftedMetrics,
         ]);
         this.lastSeenService.updateLastSeen(siftedMetrics);
+        this.config.eventBus.emit(CLIENT_METRICS, siftedMetrics);
     }
 
     async registerImpactMetrics(impactMetrics: Metric[]) {
@@ -300,7 +301,6 @@ export default class ClientMetricsServiceV2 {
 
         if (clientMetrics.length) {
             await this.registerBulkMetrics(clientMetrics);
-            this.config.eventBus.emit(CLIENT_METRICS, clientMetrics);
         }
     }
 

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -23,7 +23,6 @@ import {
     customMetricsSchema,
 } from '../shared/schema.js';
 import type { IClientMetricsEnv } from '../client-metrics/client-metrics-store-v2-type.js';
-import { CLIENT_METRICS } from '../../../events/index.js';
 import type { CustomMetricsSchema } from '../../../openapi/spec/custom-metrics-schema.js';
 import type { StoredCustomMetric } from '../custom/custom-metrics-store.js';
 import type { CustomMetricsService } from '../custom/custom-metrics-service.js';
@@ -276,7 +275,6 @@ export default class ClientMetricsController extends Controller {
                     promises.push(
                         this.metricsV2.registerBulkMetrics(filteredData),
                     );
-                    this.config.eventBus.emit(CLIENT_METRICS, data);
                 }
 
                 if (


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3705/only-emit-client-metrics-after-sifting-metrics

Only emits the `CLIENT_METRICS` event after metric sifting.

This ensures the event is emitted only for valid metrics tied to known flags, instead of all flags included in the metrics payload.

See: https://github.com/Unleash/unleash/pull/10375#discussion_r2218974109