### PR TITLE
fix: flaky delete stale session

### DIFF
--- a/src/test/e2e/services/session-service.e2e.test.ts
+++ b/src/test/e2e/services/session-service.e2e.test.ts
@@ -114,6 +114,7 @@ test('Can delete session by sid', async () => {
 
 test('Can delete stale sessions', async () => {
     await sessionService.insertSession(newSession);
+    await new Promise((resolve) => setTimeout(resolve, 100)); // Ensure a different createdAt
     await sessionService.insertSession({ ...newSession, sid: 'new' });
 
     const sessionsToKeep = 1;


### PR DESCRIPTION
When deleting stale sessions, we sort them by createdAt. If both sessions are created with the same createdAt, there's a chance we get a different sort order and we end up with the wrong order: https://github.com/Unleash/unleash/actions/runs/16438565746/job/46453700977

I think adding 100ms between inserts should be enough (1ms should do, but this gives me more confidence and doesn't hurt that much)