### PR TITLE
Show change request stage timestamps in UI

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -349,7 +349,13 @@ export const ChangeRequestOverview: FC = () => {
             <ChangeRequestHeader changeRequest={changeRequest} />
             <ChangeRequestBody>
                 <StyledAsideBox>
-                    <ChangeRequestTimeline {...timelineProps} />
+                    <ChangeRequestTimeline
+                        {...timelineProps}
+                        timestamps={
+                            //@ts-expect-error This hasn't been put on the model yet
+                            changeRequest.stateTransitionTimestamps || {}
+                        }
+                    />
                     <ConditionallyRender
                         condition={approversEnabled}
                         show={

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -351,10 +351,7 @@ export const ChangeRequestOverview: FC = () => {
                 <StyledAsideBox>
                     <ChangeRequestTimeline
                         {...timelineProps}
-                        timestamps={
-                            //@ts-expect-error This hasn't been put on the model yet
-                            changeRequest.stateTransitionTimestamps || {}
-                        }
+                        timestamps={changeRequest.stateTransitionTimestamps}
                     />
                     <ConditionallyRender
                         condition={approversEnabled}

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.test.tsx
@@ -111,60 +111,63 @@ test('returns success for stages other than Rejected in Rejected state', () => {
 
 describe('changeRequestScheduleProps', () => {
     test('returns correct props for a pending schedule', () => {
+        const date = new Date();
         const schedule = {
-            scheduledAt: new Date().toISOString(),
+            scheduledAt: date.toISOString(),
             status: 'pending' as const,
         };
 
-        const time = 'some time string';
-
-        const { title, subtitle, color, reason } = getScheduleProps(
-            schedule,
-            time,
-        );
+        const { title, subtitle, color, reason } = getScheduleProps(schedule);
         expect(title).toBe('Scheduled');
-        expect(subtitle).toBe(`for ${time}`);
         expect(color).toBe('warning');
         expect(reason).toBeNull();
+
+        render(subtitle);
+        screen.getByText('for');
+        const timeElement = screen.getByRole('time');
+        const datetime = timeElement.getAttribute('datetime');
+        expect(new Date(datetime || 1)).toEqual(date);
     });
 
     test('returns correct props for a failed schedule', () => {
+        const date = new Date();
         const schedule = {
-            scheduledAt: new Date().toISOString(),
+            scheduledAt: date.toISOString(),
             status: 'failed' as const,
             reason: 'reason',
             failureReason: 'failure reason',
         };
 
-        const time = 'some time string';
-
-        const { title, subtitle, color, reason } = getScheduleProps(
-            schedule,
-            time,
-        );
+        const { title, subtitle, color, reason } = getScheduleProps(schedule);
         expect(title).toBe('Schedule failed');
-        expect(subtitle).toBe(`at ${time}`);
         expect(color).toBe('error');
         expect(reason).toBeTruthy();
+
+        render(subtitle);
+        screen.getByText('at');
+        const timeElement = screen.getByRole('time');
+        const datetime = timeElement.getAttribute('datetime');
+        expect(new Date(datetime || 1)).toEqual(date);
     });
 
     test('returns correct props for a suspended schedule', () => {
+        const date = new Date();
         const schedule = {
-            scheduledAt: new Date().toISOString(),
+            scheduledAt: date.toISOString(),
             status: 'suspended' as const,
             reason: 'reason',
         };
 
-        const time = 'some time string';
-
-        const { title, subtitle, color, reason } = getScheduleProps(
-            schedule,
-            time,
-        );
+        const { title, subtitle, color, reason } = getScheduleProps(schedule);
         expect(title).toBe('Schedule suspended');
-        expect(subtitle).toBe(`was ${time}`);
         expect(color).toBe('grey');
         expect(reason).toBeTruthy();
+
+        render(subtitle);
+        screen.getByText('was');
+        const timeElement = screen.getByRole('time');
+        const datetime = timeElement.getAttribute('datetime');
+        expect(new Date(datetime || 1)).toEqual(date);
     });
 });
 

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -13,8 +13,7 @@ import type {
 import { HtmlTooltip } from '../../../common/HtmlTooltip/HtmlTooltip.tsx';
 import ErrorIcon from '@mui/icons-material/Error';
 import { useLocationSettings } from 'hooks/useLocationSettings';
-import { formatDateYMDHM } from 'utils/formatDate';
-import type { ReactNode } from 'react-markdown/lib/react-markdown';
+import { formatDateYMDHM } from 'utils/formatDate.ts';
 
 export type ISuggestChangeTimelineProps = {
     timestamps?: Record<ChangeRequestState, string>;
@@ -111,9 +110,10 @@ export const ChangeRequestTimeline: FC<ISuggestChangeTimelineProps> = ({
             <StyledBox>
                 <StyledTimeline>
                     {data.map((title, index) => {
-                        const timestampComponent = timestamps?.[title] ? (
-                            <Timestamp timestamp={timestamps?.[title]} />
-                        ) : undefined;
+                        const timestampComponent =
+                            index <= activeIndex && timestamps?.[title] ? (
+                                <Timestamp timestamp={timestamps?.[title]} />
+                            ) : undefined;
 
                         if (schedule && title === 'Scheduled') {
                             return (

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import { Box, Paper, styled, Typography } from '@mui/material';
 import Timeline from '@mui/lab/Timeline';
 import MuiTimelineItem, { timelineItemClasses } from '@mui/lab/TimelineItem';

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -19,6 +19,7 @@ type BaseChangeRequest = {
     rejections: IChangeRequestApproval[];
     comments: IChangeRequestComment[];
     conflict?: string;
+    stateTransitionTimestamps?: Partial<Record<ChangeRequestState, string>>; // todo(timestampsInChangeRequestTimeline): make sure this matches the model and what we return from the API
 };
 
 export type UnscheduledChangeRequest = BaseChangeRequest & {


### PR DESCRIPTION
Adds a timestamp for each state we have time (and that isn't a state downstream from the current state) in the CR timeline.

<img width="437" height="318" alt="image" src="https://github.com/user-attachments/assets/a499e73f-c506-46a0-8d1a-7e4eb5ec4f7d" />

The timestamp respects the user's preferred locale and uses the `time` element.

I've used the current name of the API payload's timestamps as it stands on the enterprise main branch for now. This name is not set in any schemas yet, so it is likely to change. Because it's not currently exposed to any users, that will not cause any issues. Name suggestions are welcome if you have them.

We only show timestamps for states up to and including the current state. Timestamps for downstream states (such as "approved" if you're in the "in review" state), will not be shown, even if they exist in the payload. (There are some decisions to make on whether to include these in the payload at all or not.)

There's no flags in this PR. They're not necessary If the API payload doesn't contain the timestamp, we just don't render the timestamp, and the timeline looks the way it always did:
<img width="447" height="399" alt="image" src="https://github.com/user-attachments/assets/0062393a-190c-4099-bc16-29f9da82e7ea" />


## Bonus work

In the `ChangeRequestTimeline.tsx` file, I've made a few extra changes:
- `createTimelineItem` and `createScheduledTimelineItem` have become normal React components (`TimelineItem` and `ScheduledTimelineItem`) and are being called as such (in accordance with [React recommendations](https://react.dev/reference/rules/react-calls-components-and-hooks#never-call-component-functions-directly)).
- I've updated the subtitles for schedules to also use the time element, to improve HTML structure.

## Outstanding work

There's a few things that still need to be sorted out (primarily with UX). Mainly about how we handle scheduled items, which already have time information. For now, it looks like this:

<img width="426" height="394" alt="image" src="https://github.com/user-attachments/assets/4bfc4ca2-c738-4954-9251-8d063143371e" />

<img width="700" height="246" alt="image" src="https://github.com/user-attachments/assets/fe688b08-c5c8-40f8-a9d0-fe455e44665f" />
