### PR TITLE
chore: remove unkonwn flags

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -9,7 +9,6 @@ export type IFlagKey =
     | 'anonymiseEventLog'
     | 'encryptEmails'
     | 'enableLicense'
-    | 'enableLicenseChecker'
     | 'responseTimeWithAppNameKillSwitch'
     | 'maintenanceMode'
     | 'messageBanner'
@@ -17,7 +16,6 @@ export type IFlagKey =
     | 'personalAccessTokensKillSwitch'
     | 'migrationLock'
     | 'demo'
-    | 'googleAuthEnabled'
     | 'advancedPlayground'
     | 'filterInvalidClientMetrics'
     | 'disableMetrics'
@@ -27,7 +25,6 @@ export type IFlagKey =
     | 'feedbackPosting'
     | 'extendedUsageMetrics'
     | 'feedbackComments'
-    | 'showInactiveUsers'
     | 'killScheduledChangeRequestCache'
     | 'estimateTrafficDataCost'
     | 'useMemoizedActiveTokens'
@@ -72,7 +69,6 @@ export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 const flags: IFlags = {
     anonymiseEventLog: false,
     enableLicense: false,
-    enableLicenseChecker: false,
     responseTimeWithAppNameKillSwitch: parseEnvVarBoolean(
         process.env.UNLEASH_RESPONSE_TIME_WITH_APP_NAME_KILL_SWITCH,
         false,
@@ -103,10 +99,6 @@ const flags: IFlags = {
     ),
     migrationLock: parseEnvVarBoolean(process.env.MIGRATION_LOCK, true),
     demo: parseEnvVarBoolean(process.env.UNLEASH_DEMO, false),
-    googleAuthEnabled: parseEnvVarBoolean(
-        process.env.GOOGLE_AUTH_ENABLED,
-        false,
-    ),
     filterInvalidClientMetrics: parseEnvVarBoolean(
         process.env.FILTER_INVALID_CLIENT_METRICS,
         false,
@@ -156,10 +148,6 @@ const flags: IFlags = {
                 '',
         },
     },
-    showInactiveUsers: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_SHOW_INACTIVE_USERS,
-        false,
-    ),
     useMemoizedActiveTokens: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_MEMOIZED_ACTIVE_TOKENS,
         false,


### PR DESCRIPTION
We're iterating over the keys of experimental and checking if they're enabled: https://github.com/Unleash/unleash/blob/e140ab63e1a730775f589ad1d07e70a6a9b6a3bc/src/lib/util/flag-resolver.ts#L26 which leads to this big list of unknown flags

This comes from our report:
<img width="1461" height="1042" alt="image" src="https://github.com/user-attachments/assets/9579f351-e5e9-42ad-a141-b5cde83a41b8" />

