### PR TITLE
chore: don't fail if array is not ordered properly

### DIFF
--- a/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
+++ b/src/lib/features/feature-lifecycle/feature-lifecycle.e2e.test.ts
@@ -254,9 +254,12 @@ test('should not backfill for existing lifecycle', async () => {
     await featureLifecycleStore.backfill();
 
     const { body } = await getFeatureLifecycle('my_feature_e');
-    expect(body).toEqual([
-        { stage: 'initial', enteredStageAt: expect.any(String) },
-        { stage: 'pre-live', enteredStageAt: expect.any(String) },
-        { stage: 'live', enteredStageAt: expect.any(String) },
-    ]);
+    expect(body).toEqual(
+        expect.arrayContaining([
+            { stage: 'initial', enteredStageAt: expect.any(String) },
+            { stage: 'pre-live', enteredStageAt: expect.any(String) },
+            { stage: 'live', enteredStageAt: expect.any(String) },
+        ]),
+    );
+    expect(body).toHaveLength(3);
 });


### PR DESCRIPTION
Spotted it here: https://github.com/Unleash/unleash/actions/runs/16443263365/job/46468801248
<img width="928" height="584" alt="image" src="https://github.com/user-attachments/assets/5e430b91-2664-4a79-9f13-cf6da4640046" />

where the sort order is different.