### PR TITLE
chore: AI flag cleanup better support advanced flag names

### DIFF
--- a/.github/workflows/ai-flag-cleanup-pr.yml
+++ b/.github/workflows/ai-flag-cleanup-pr.yml
@@ -87,7 +87,8 @@ jobs:
         run: |
           TITLE="${{ fromJson(steps.get_issue.outputs.result).title }}"
 
-          if [[ "$TITLE" =~ Flag[[:space:]]([[:alnum:]\-\._\!\~\*\'\(\)]+)[[:space:]]marked ]]; then
+          if [[ $TITLE =~ Flag[[:space:]]+([^[:space:]]+)[[:space:]]+marked ]]; then
+            FLAG="${BASH_REMATCH[1]}"
             echo "flag-name=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           else
             MSG="Could not extract flag name from title: $TITLE"


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3709/improve-support-for-advanced-flag-names-in-ai-flag-cleanup

Improves support for advanced flag names in AI flag cleanup.

This is something I noticed when it tried to run against https://github.com/Unleash/unleash/issues/10395 — The dot (.) broke the previous logic.