### PR TITLE
Add timestampsInChangeRequestTimeline flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     crDiffView?: boolean;
     changeRequestApproverEmails?: boolean;
     eventGrouping?: boolean;
+    timestampsInChangeRequestTimeline?: boolean;
     reportUnknownFlags?: boolean;
 };
 

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -63,6 +63,7 @@ export type IFlagKey =
     | 'paygTrialEvents'
     | 'eventGrouping'
     | 'paygInstanceStatsEvents'
+    | 'timestampsInChangeRequestTimeline'
     | 'lifecycleGraphs';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -289,6 +290,10 @@ const flags: IFlags = {
     ),
     paygInstanceStatsEvents: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PAYG_INSTANCE_STATS_EVENTS,
+        false,
+    ),
+    timestampsInChangeRequestTimeline: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_TIMESTAMPS_IN_CHANGE_REQUEST_TIMELINE,
         false,
     ),
     lifecycleGraphs: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -59,6 +59,7 @@ process.nextTick(async () => {
                         crDiffView: true,
                         eventGrouping: true,
                         paygTrialEvents: true,
+                        timestampsInChangeRequestTimeline: true,
                         lifecycleGraphs: true,
                     },
                 },


### PR DESCRIPTION
Adds flag to OSS for the new timestamps in CR timeline capability.

We might not need them in the UI, but might as well add it in case.