### PR TITLE
Fix broken markdown link in api-overview doc.

### DIFF
--- a/website/docs/api-overview.mdx
+++ b/website/docs/api-overview.mdx
@@ -16,7 +16,7 @@ Unleash provides a set of APIs to give you full programmatic control over your f
 |---------------|---------|---|
 | **Client API** | Server-side SDKs | Fetch feature flag configurations. |
 | **Frontend API** | Client-side SDKs | Fetch enabled feature flags for a specific [Unleash Context](/reference/unleash-context). |
-| **Admin API** | [Admin UI(/understanding-unleash/unleash-overview#the-unleash-admin-ui), internal tooling, and third-party [integrations](/reference/integrations) | Access and manage all resources within Unleash, such as context, environments, events, metrics, and users. |
+| **Admin API** | [Admin UI](/understanding-unleash/unleash-overview#the-unleash-admin-ui), internal tooling, and third-party [integrations](/reference/integrations) | Access and manage all resources within Unleash, such as context, environments, events, metrics, and users. |
 
 ## API authentication and tokens
 
@@ -63,4 +63,3 @@ You can access the specification from your Unleash instance at the following pat
 - **Raw JSON specification**: `/docs/openapi.json`
 
 For detailed guides on each API, please refer to the full reference documentation.
-


### PR DESCRIPTION
It was missing a closing `]`.
