### PR TITLE
chore: better logging of failed tokens

### DIFF
--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -171,7 +171,7 @@ export class ApiTokenService {
                 stopCacheTimer();
             } else {
                 this.logger.info(
-                    `Not allowed to query this token until: ${this.queryAfter.get(
+                    `Token ${secret.replace(/(.*\.....).*/, '$1...')} rate limited until: ${this.queryAfter.get(
                         secret,
                     )}`,
                 );

--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -171,9 +171,10 @@ export class ApiTokenService {
                 stopCacheTimer();
             } else {
                 this.logger.info(
-                    `Token ${secret.replace(/(.*\.....).*/, '$1...')} rate limited until: ${this.queryAfter.get(
-                        secret,
-                    )}`,
+                    `Token ${secret.replace(
+                        /^([^.]*)\.(.{8}).*$/,
+                        '$1.$2...',
+                    )} rate limited until: ${this.queryAfter.get(secret)}`,
                 );
             }
         }


### PR DESCRIPTION
When querying invalid tokens we might catch them for a while to reduce database load. Being able to identify the token can help understanding what's going on or the client using that token

Log looks like:
```
[INFO] /services/api-token-service.ts - Token default:development.3ef3... rate limited until: Tue Jul 29 2025 09:53:47 GMT+0000 (Coordinated Universal Time)
```