### PR TITLE
feat: rebrand sdk tokens and sdk types

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Find your preferred SDK in [our list of official SDKs](#unleash-sdks) and import
 
 If you use the docker compose file from the previous step, here's the configuration details you'll need to get going:
 
-- For front-end SDKs, use:
+- For frontend SDKs, use:
   - URL: `http://localhost:4242/api/frontend/`
   - `clientKey`: `default:development.unleash-insecure-frontend-api-token`
-- For Backend SDKs, use:
+- For backend SDKs, use:
   - Unleash API URL: `http://localhost:4242/api/`
   - API token: `default:development.unleash-insecure-api-token`
 
@@ -145,7 +145,7 @@ Check out [the CONTRIBUTING.md file](./CONTRIBUTING.md) for contribution guideli
 - Out-of-the-box integrations with popular tools ([Slack](https://docs.getunleash.io/addons/slack), [Microsoft Teams](https://docs.getunleash.io/addons/teams), [Datadog](https://docs.getunleash.io/addons/datadog)) + integrate with anything with [webhooks](https://docs.getunleash.io/addons/webhook)
 - [Insights for managing technical debt](https://docs.getunleash.io/reference/technical-debt) and [stale flags](https://docs.getunleash.io/reference/technical-debt#stale-and-potentially-stale-flags)
 - API-first: _everything_ can be automated. No exceptions.
-- [12 official client SDKs](https://docs.getunleash.io/reference/sdks#official-sdks), and 10 [community-contributed client SDKs](https://docs.getunleash.io/reference/sdks#community-sdks)
+- [12 official SDKs](https://docs.getunleash.io/reference/sdks#official-sdks), and 10 [community-contributed SDKs](https://docs.getunleash.io/reference/sdks#community-sdks)
 - Run it via Docker with the [official Docker image](https://hub.docker.com/r/unleashorg/unleash-server) or as a pure Node.js application
 
 ### Security and performance
@@ -154,7 +154,7 @@ Check out [the CONTRIBUTING.md file](./CONTRIBUTING.md) for contribution guideli
 - [Audit logs](https://docs.getunleash.io/advanced/audit_log)
 - Enforce [OWASP's secure headers](https://owasp.org/www-project-secure-headers/) via the strict HTTPS-only mode
 - Flexible hosting options: host it on premise or in the cloud (_any_ cloud)
-- Scale with [Unleash Edge](https://docs.getunleash.io/reference/unleash-edge) independently of the Unleash server to support any number of front-end clients without overloading your Unleash instance
+- Scale with [Unleash Edge](https://docs.getunleash.io/reference/unleash-edge) independently of the Unleash server to support any number of frontend clients without overloading your Unleash instance
 
 ### Looking for more features?
 
@@ -183,7 +183,7 @@ Read more in the [_system overview_ section of the Unleash documentation](https:
 
 To connect your application to Unleash you'll need to use a client SDK for your programming language.
 
-**Official Backend SDKs:**
+**Official backend SDKs:**
 
 - [Go SDK](https://docs.getunleash.io/reference/sdks/go)
 - [Java SDK](https://docs.getunleash.io/reference/sdks/java)
@@ -194,9 +194,9 @@ To connect your application to Unleash you'll need to use a client SDK for your 
 - [Rust SDK](https://github.com/unleash/unleash-client-rust)
 - [.NET SDK](https://docs.getunleash.io/reference/sdks/dotnet)
 
-**Official front-end SDKs:**
+**Official frontend SDKs:**
 
-The front-end SDKs connect via [Unleash Edge](https://docs.getunleash.io/reference/unleash-edge) in order to ensure privacy, scalability and security.
+The frontend SDKs connect via [Unleash Edge](https://docs.getunleash.io/reference/unleash-edge) in order to ensure privacy, scalability and security.
 
 - [Android Proxy SDK](https://docs.getunleash.io/reference/sdks/android-proxy)
 - [Flutter Proxy SDK](https://docs.getunleash.io/reference/sdks/flutter)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you use the docker compose file from the previous step, here's the configurat
 - For front-end SDKs, use:
   - URL: `http://localhost:4242/api/frontend/`
   - `clientKey`: `default:development.unleash-insecure-frontend-api-token`
-- For server-side SDKs, use:
+- For Backend SDKs, use:
   - Unleash API URL: `http://localhost:4242/api/`
   - API token: `default:development.unleash-insecure-api-token`
 
@@ -183,7 +183,7 @@ Read more in the [_system overview_ section of the Unleash documentation](https:
 
 To connect your application to Unleash you'll need to use a client SDK for your programming language.
 
-**Official server-side SDKs:**
+**Official Backend SDKs:**
 
 - [Go SDK](https://docs.getunleash.io/reference/sdks/go)
 - [Java SDK](https://docs.getunleash.io/reference/sdks/java)

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -23,16 +23,16 @@ export const useApiTokenForm = (project?: string) => {
     const apiTokenTypes: SelectOption[] = [
         {
             key: TokenType.CLIENT,
-            label: `Server-side SDK (${TokenType.CLIENT})`,
-            title: 'Connect server-side SDK or Unleash Proxy/Edge',
+            label: 'Backend SDK',
+            title: 'Creates a backend token to connect a backend SDK or Unleash Edge',
             enabled:
                 useHasRootAccess(CREATE_CLIENT_API_TOKEN) ||
                 hasCreateProjectTokenPermission,
         },
         {
             key: TokenType.FRONTEND,
-            label: `Client-side SDK (${TokenType.FRONTEND})`,
-            title: 'Connect web and mobile SDK directly to Unleash',
+            label: 'Frontend SDK',
+            title: 'Creates a frontend token to connect from a frontend SDK',
             enabled:
                 useHasRootAccess(CREATE_FRONTEND_API_TOKEN) ||
                 hasCreateProjectTokenPermission,

--- a/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
+++ b/frontend/src/component/admin/apiToken/ApiTokenForm/useApiTokenForm.ts
@@ -32,7 +32,7 @@ export const useApiTokenForm = (project?: string) => {
         {
             key: TokenType.FRONTEND,
             label: 'Frontend SDK',
-            title: 'Creates a frontend token to connect from a frontend SDK',
+            title: 'Creates a frontend token to connect a frontend SDK',
             enabled:
                 useHasRootAccess(CREATE_FRONTEND_API_TOKEN) ||
                 hasCreateProjectTokenPermission,

--- a/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
+++ b/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
@@ -125,7 +125,7 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
             loading={loadingCreateToken}
             title={pageTitle}
             modal={modal}
-            description='Unleash SDKs use API tokens to authenticate to the Unleash API. Backend SDKs need a backend token, which allows them to fetch feature flag configurations and post usage metrics.'
+            description='Unleash SDKs use API tokens to authenticate with the Unleash API. An SDK must be configured with a token of the corresponding type, so they can fetch feature flags and post usage metrics.'
             documentationLink='https://docs.getunleash.io/reference/api-tokens-and-client-keys'
             documentationLinkLabel='API tokens documentation'
             formatApiCode={formatApiCode}

--- a/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
+++ b/frontend/src/component/admin/apiToken/CreateApiToken/CreateApiToken.tsx
@@ -125,7 +125,7 @@ export const CreateApiToken = ({ modal = false }: ICreateApiTokenProps) => {
             loading={loadingCreateToken}
             title={pageTitle}
             modal={modal}
-            description="Unleash SDKs use API tokens to authenticate to the Unleash API. Client SDKs need a token with 'client privileges', which allows them to fetch feature flag configurations and post usage metrics."
+            description='Unleash SDKs use API tokens to authenticate to the Unleash API. Backend SDKs need a backend token, which allows them to fetch feature flag configurations and post usage metrics.'
             documentationLink='https://docs.getunleash.io/reference/api-tokens-and-client-keys'
             documentationLinkLabel='API tokens documentation'
             formatApiCode={formatApiCode}

--- a/frontend/src/component/common/ApiTokenTable/useApiTokenTable.tsx
+++ b/frontend/src/component/common/ApiTokenTable/useApiTokenTable.tsx
@@ -142,12 +142,12 @@ const tokenDescriptions: {
     [index: string]: { label: string; title: string };
 } = {
     client: {
-        label: 'CLIENT',
-        title: 'Connect server-side SDK or Unleash Proxy/Edge',
+        label: 'BACKEND',
+        title: 'Connect backend SDK or Unleash Edge',
     },
     frontend: {
         label: 'FRONTEND',
-        title: 'Connect web and mobile SDK',
+        title: 'Connect frontend SDK',
     },
     admin: {
         label: 'ADMIN',

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -334,10 +334,9 @@ export const EnvironmentCloneModal = ({
                             </FormControl>
                             <StyledInlineContainer>
                                 <StyledInputSecondaryDescription>
-                                    A new Server-side SDK (CLIENT) API token
-                                    will be generated for the cloned
-                                    environment, so you can get started right
-                                    away.
+                                    A new backend SDK API token will be
+                                    generated for the cloned environment, so you
+                                    can get started right away.
                                 </StyledInputSecondaryDescription>
                                 <ConditionallyRender
                                     condition={

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentActionCell/EnvironmentCloneModal/EnvironmentCloneModal.tsx
@@ -334,9 +334,9 @@ export const EnvironmentCloneModal = ({
                             </FormControl>
                             <StyledInlineContainer>
                                 <StyledInputSecondaryDescription>
-                                    A new backend SDK API token will be
-                                    generated for the cloned environment, so you
-                                    can get started right away.
+                                    A new backend API token will be generated
+                                    for the cloned environment, so you can get
+                                    started right away.
                                 </StyledInputSecondaryDescription>
                                 <ConditionallyRender
                                     condition={

--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
@@ -225,9 +225,9 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                                     target='_blank'
                                     rel='noopener noreferrer'
                                 >
-                                    Unleash frontend API
+                                    Unleash Frontend API
                                 </a>
-                                , but not to the regular Unleash client API.
+                                , but not to the regular Unleash Client API.
                             </Typography>
                         </Box>
                         <StyledCardsGrid small>

--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
@@ -175,10 +175,10 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                     <StyledSdksGroup>
                         <Box>
                             <Typography component='h4' variant='h4'>
-                                Server-side SDKs
+                                Backend SDKs
                             </Typography>
                             <Typography variant='body2' color='text.secondary'>
-                                Server-side clients run on your server and
+                                Backend clients run on your server and
                                 communicate directly with your Unleash instance.
                             </Typography>
                         </Box>

--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/AvailableIntegrations.tsx
@@ -208,10 +208,10 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                     <StyledSdksGroup>
                         <Box>
                             <Typography component='h4' variant='h4'>
-                                Client-side SDKs
+                                Frontend SDKs
                             </Typography>
                             <Typography variant='body2' color='text.secondary'>
-                                Client-side SDKs can connect to the{' '}
+                                Frontend SDKs can connect to the{' '}
                                 <a
                                     href='https://docs.getunleash.io/reference/unleash-edge'
                                     target='_blank'
@@ -225,7 +225,7 @@ export const AvailableIntegrations: VFC<IAvailableIntegrationsProps> = ({
                                     target='_blank'
                                     rel='noopener noreferrer'
                                 >
-                                    Unleash front-end API
+                                    Unleash frontend API
                                 </a>
                                 , but not to the regular Unleash client API.
                             </Typography>

--- a/src/lib/openapi/spec/bulk-registration-schema.ts
+++ b/src/lib/openapi/spec/bulk-registration-schema.ts
@@ -5,7 +5,7 @@ export const bulkRegistrationSchema = {
     $id: '#/components/schemas/bulkRegistrationSchema',
     type: 'object',
     required: ['appName', 'instanceId', 'environment'],
-    description: `An application registration. Defines the format POSTed by our server-side SDKs when they're starting up`,
+    description: `An application registration. Defines the format POSTed by our backend SDKs when they're starting up`,
     properties: {
         connectVia: {
             type: 'array',

--- a/src/lib/openapi/spec/client-features-schema.ts
+++ b/src/lib/openapi/spec/client-features-schema.ts
@@ -16,7 +16,7 @@ export const clientFeaturesSchema = {
     type: 'object',
     required: ['version', 'features'],
     description:
-        'Configuration data for Backend SDKs for evaluating feature flags.',
+        'Configuration data for backend SDKs for evaluating feature flags.',
     properties: {
         version: {
             type: 'number',

--- a/src/lib/openapi/spec/client-features-schema.ts
+++ b/src/lib/openapi/spec/client-features-schema.ts
@@ -16,7 +16,7 @@ export const clientFeaturesSchema = {
     type: 'object',
     required: ['version', 'features'],
     description:
-        'Configuration data for server-side SDKs for evaluating feature flags.',
+        'Configuration data for Backend SDKs for evaluating feature flags.',
     properties: {
         version: {
             type: 'number',

--- a/src/lib/openapi/spec/resource-limits-schema.ts
+++ b/src/lib/openapi/spec/resource-limits-schema.ts
@@ -98,7 +98,7 @@ export const resourceLimitsSchema = {
             minimum: 0,
             example: 2000,
             description:
-                'The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.',
+                'The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to backend and frontend SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.',
         },
         projects: {
             type: 'integer',

--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -37,7 +37,7 @@ const OPENAPI_TAGS = [
     {
         name: 'Client',
         description:
-            'Endpoints for [Unleash server-side clients](https://docs.getunleash.io/reference/sdks).',
+            'Endpoints for [Unleash backend clients](https://docs.getunleash.io/reference/sdks).',
     },
     {
         name: 'Context',


### PR DESCRIPTION
## About the changes
Rebrand SDK tokens and SDK types to make it easier to onboard and use:

**Backend SDK Token**: Intended for server-side SDKs. It can be used to access:

- The Client Features API (/api/client/features) for fetching all flag configurations for local evaluation.
- The Frontend API (/api/frontend) for remote evaluation.

**Frontend SDK Token**: Intended for client-side/frontend SDKs. It is restricted and can only be used to access:

- The Frontend API (/api/frontend) for remote evaluation.