### PR TITLE
fix: segment row id for modals

### DIFF
--- a/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
+++ b/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
@@ -80,6 +80,7 @@ export const SegmentTable = () => {
             defaultColumn: {
                 Cell: HighlightCell,
             },
+            getRowId: (row: any) => row.id,
         },
         useGlobalFilter,
         useSortBy,


### PR DESCRIPTION
Fixing the issue where modal with an active segment (for deletion) can change which segment it's listing if a new segment that is alphabetically earlier than the original segment