### PR TITLE
Update `stateTransitions` property in UI to match new API prop

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestOverview.tsx
@@ -351,7 +351,7 @@ export const ChangeRequestOverview: FC = () => {
                 <StyledAsideBox>
                     <ChangeRequestTimeline
                         {...timelineProps}
-                        timestamps={changeRequest.stateTransitionTimestamps}
+                        timestamps={changeRequest.stateTimestamps}
                     />
                     <ConditionallyRender
                         condition={approversEnabled}

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestTimeline/ChangeRequestTimeline.tsx
@@ -24,7 +24,7 @@ import {
 } from './change-request-timeline-steps.ts';
 
 export type ISuggestChangeTimelineProps = {
-    timestamps?: ChangeRequestType['stateTransitionTimestamps']; // todo: update with flag `timestampsInChangeRequestTimeline`
+    timestamps?: ChangeRequestType['stateTimestamps'];
 } & (
     | {
           state: Exclude<ChangeRequestState, 'Scheduled'>;

--- a/frontend/src/component/changeRequest/changeRequest.types.ts
+++ b/frontend/src/component/changeRequest/changeRequest.types.ts
@@ -19,7 +19,7 @@ type BaseChangeRequest = {
     rejections: IChangeRequestApproval[];
     comments: IChangeRequestComment[];
     conflict?: string;
-    stateTransitionTimestamps?: Partial<Record<ChangeRequestState, string>>; // todo(timestampsInChangeRequestTimeline): make sure this matches the model and what we return from the API
+    stateTimestamps?: Partial<Record<ChangeRequestState, string>>;
 };
 
 export type UnscheduledChangeRequest = BaseChangeRequest & {


### PR DESCRIPTION
We renamed the property returned from the API, so we also need to update the UI.