### PR TITLE
fix: should be allowed to change strategy

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -899,17 +899,11 @@ export class FeatureToggleService {
         const existingSegments = await this.segmentService.getByStrategy(id);
 
         if (existingStrategy.id === id) {
-            console.log(
-                `Updating strategy ${id} for feature ${featureName} in environment ${environment}: ${JSON.stringify(updates)}`,
-            );
             const standardizedUpdates = await this.standardizeStrategyConfig(
                 projectId,
                 featureName,
                 { ...updates, name: updates.name! },
                 existingStrategy,
-            );
-            console.log(
-                `Standardized updates: ${JSON.stringify(standardizedUpdates)}`,
             );
             const strategy = await this.featureStrategiesStore.updateStrategy(
                 id,

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -698,8 +698,8 @@ export class FeatureToggleService {
         strategyConfig: Unsaved<IStrategyConfig>,
         existing?: IFeatureStrategy,
     ): Promise<
-        { strategyName: string } & Pick<
-            Partial<IFeatureStrategy>,
+        { name: string } & Pick<
+            Partial<IStrategyConfig>,
             | 'title'
             | 'disabled'
             | 'variants'
@@ -731,7 +731,7 @@ export class FeatureToggleService {
         }
 
         return {
-            strategyName: name,
+            name,
             title,
             disabled,
             sortOrder,
@@ -770,6 +770,7 @@ export class FeatureToggleService {
             const newFeatureStrategy =
                 await this.featureStrategiesStore.createStrategyFeatureEnv({
                     ...standardizedConfig,
+                    strategyName: standardizedConfig.name,
                     constraints: standardizedConfig.constraints || [],
                     variants: standardizedConfig.variants || [],
                     parameters: standardizedConfig.parameters || {},
@@ -898,11 +899,17 @@ export class FeatureToggleService {
         const existingSegments = await this.segmentService.getByStrategy(id);
 
         if (existingStrategy.id === id) {
+            console.log(
+                `Updating strategy ${id} for feature ${featureName} in environment ${environment}: ${JSON.stringify(updates)}`,
+            );
             const standardizedUpdates = await this.standardizeStrategyConfig(
                 projectId,
                 featureName,
                 { ...updates, name: updates.name! },
                 existingStrategy,
+            );
+            console.log(
+                `Standardized updates: ${JSON.stringify(standardizedUpdates)}`,
             );
             const strategy = await this.featureStrategiesStore.updateStrategy(
                 id,

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -136,13 +136,18 @@ test('Should be able to update existing strategy configuration', async () => {
     expect(createdConfig.name).toEqual('default');
     const updatedConfig = await service.updateStrategy(
         createdConfig.id,
-        { parameters: { b2b: 'true' } },
+        { name: 'flexibleRollout', parameters: { b2b: 'true' } },
         { projectId, featureName, environment: DEFAULT_ENV },
         TEST_AUDIT_USER,
     );
     expect(createdConfig.id).toEqual(updatedConfig.id);
+    expect(updatedConfig.name).toEqual('flexibleRollout');
     expect(updatedConfig.parameters).toEqual({
         b2b: 'true',
+        // flexible rollout default parameters
+        rollout: '100',
+        groupId: featureName,
+        stickiness: 'default',
     });
 });
 


### PR DESCRIPTION
## About the changes
Previous PR: https://github.com/Unleash/unleash/pull/10439 introduced a bug not allowing to update the strategy name

Because there was no test covering this, it was only caught later on integration.

This PR modifies a test to also validate the change of strategy and fixes the problem