### PR TITLE
chore: clear unknown flags every 24h instead of every 7d

### DIFF
--- a/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
@@ -22,9 +22,15 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(3),
 }));
 
+const StyledAlertContent = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+}));
+
 const StyledUl = styled('ul')(({ theme }) => ({
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
 }));
 
 export const UnknownFlagsTable = () => {
@@ -142,29 +148,40 @@ export const UnknownFlagsTable = () => {
             }
         >
             <StyledAlert severity='info'>
-                <p>
-                    <strong>Unknown flags</strong> are feature flags that your
-                    SDKs tried to evaluate but which Unleash doesn't recognize.
-                    Tracking them helps you catch typos, remove outdated flags,
-                    and keep your code and configuration in sync. These can
-                    include:
-                </p>
+                <StyledAlertContent>
+                    <p>
+                        <strong>Unknown flags</strong> are feature flags that
+                        your SDKs tried to evaluate but which Unleash doesn't
+                        recognize. Tracking them helps you catch typos, remove
+                        outdated flags, and keep your code and configuration in
+                        sync. These can include:
+                    </p>
 
-                <StyledUl>
-                    <li>
-                        <b>Missing flags</b>: typos or flags referenced in code
-                        that don't exist in Unleash.
-                    </li>
-                    <li>
-                        <b>Invalid flags</b>: flags with malformed or unexpected
-                        names, unsupported by Unleash.
-                    </li>
-                </StyledUl>
+                    <StyledUl>
+                        <li>
+                            <b>Missing flags</b>: typos or flags referenced in
+                            code that don't exist in Unleash.
+                        </li>
+                        <li>
+                            <b>Invalid flags</b>: flags with malformed or
+                            unexpected names, unsupported by Unleash.
+                        </li>
+                    </StyledUl>
 
-                <p>
-                    We display up to 1,000 unknown flag reports from the last 7
-                    days. Older flags are automatically pruned.
-                </p>
+                    <p>
+                        Each row in the table represents an{' '}
+                        <strong>unknown flag report</strong>, which is a unique
+                        combination of <em>flag name</em>, <em>application</em>,
+                        and <em>environment</em>. The same flag name may appear
+                        multiple times if it's been seen in different
+                        applications or environments.
+                    </p>
+
+                    <p>
+                        We display up to 1,000 unknown flag reports from the
+                        last 24 hours. Older reports are automatically pruned.
+                    </p>
+                </StyledAlertContent>
             </StyledAlert>
 
             <SearchHighlightProvider value={getSearchText(searchValue)}>
@@ -181,14 +198,14 @@ export const UnknownFlagsTable = () => {
                         condition={searchValue?.length > 0}
                         show={
                             <TablePlaceholder>
-                                No unknown flags found matching &ldquo;
+                                No unknown flag reports found matching &ldquo;
                                 {searchValue}
                                 &rdquo;
                             </TablePlaceholder>
                         }
                         elseShow={
                             <TablePlaceholder>
-                                No unknown flags reported in the last 7 days.
+                                No unknown flags reported in the last 24 hours.
                             </TablePlaceholder>
                         }
                     />

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
@@ -43,9 +43,9 @@ export default class UnknownFlagsController extends Controller {
                 openApiService.validPath({
                     operationId: 'getUnknownFlags',
                     tags: ['Unstable'],
-                    summary: 'Get latest reported unknown flag names',
+                    summary: 'Get unknown flag reports',
                     description:
-                        'Returns a list of unknown flag reports from the last 7 days, if any. Maximum of 1000.',
+                        'Returns a list of unknown flag reports from the last 24 hours, if any. Maximum of 1000.',
                     responses: {
                         200: createResponseSchema('unknownFlagsResponseSchema'),
                     },

--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -203,8 +203,8 @@ export const scheduleServices = (
     );
 
     schedulerService.schedule(
-        unknownFlagsService.clear.bind(unknownFlagsService, 24 * 7),
-        hoursToMilliseconds(24),
+        unknownFlagsService.clear.bind(unknownFlagsService, 24),
+        hoursToMilliseconds(6),
         'clearUnknownFlags',
     );
 };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -761,7 +761,7 @@ export function registerPrometheusMetrics(
 
     const unknownFlagsGauge = createGauge({
         name: 'unknown_flags',
-        help: 'Number of unknown flags reported in the last 24 hours, if any. Maximum of 10.',
+        help: 'Number of unknown flags reported in the last 24 hours, if any. Maximum of 1000.',
     });
 
     // register event listeners

--- a/src/lib/openapi/spec/unknown-flag-schema.ts
+++ b/src/lib/openapi/spec/unknown-flag-schema.ts
@@ -5,7 +5,7 @@ export const unknownFlagSchema = {
     type: 'object',
     additionalProperties: false,
     required: ['name', 'appName', 'seenAt', 'environment'],
-    description: 'An unknown flag that has been reported by the system',
+    description: 'An unknown flag report',
     properties: {
         name: {
             type: 'string',

--- a/src/lib/openapi/spec/unknown-flags-response-schema.ts
+++ b/src/lib/openapi/spec/unknown-flags-response-schema.ts
@@ -6,8 +6,7 @@ export const unknownFlagsResponseSchema = {
     type: 'object',
     additionalProperties: false,
     required: ['unknownFlags'],
-    description:
-        'A list of unknown flags that have been reported by the system',
+    description: 'A list of unknown flag reports',
     properties: {
         unknownFlags: {
             description: 'The list of recently reported unknown flags.',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3738/clear-unknown-flags-every-24h-instead-of-every-7d

Clears unknown flags every 24h instead of every 7d.

This ensures the list stays more relevant by removing stale entries sooner, allowing users to focus on actively reported unknown flags.

Also includes small improvements, including a new paragraph on the unknown flags page that better explains the concept of unknown flag reports.