### PR TITLE
chore: re-generate openapi

### DIFF
--- a/frontend/src/openapi/models/bulkRegistrationSchema.ts
+++ b/frontend/src/openapi/models/bulkRegistrationSchema.ts
@@ -8,7 +8,7 @@ import type { BulkRegistrationSchemaSdkType } from './bulkRegistrationSchemaSdkT
 import type { DateSchema } from './dateSchema.js';
 
 /**
- * An application registration. Defines the format POSTed by our server-side SDKs when they're starting up
+ * An application registration. Defines the format POSTed by our backend SDKs when they're starting up
  */
 export interface BulkRegistrationSchema {
     /** The name of the application that is evaluating toggles */

--- a/frontend/src/openapi/models/clientFeaturesSchema.ts
+++ b/frontend/src/openapi/models/clientFeaturesSchema.ts
@@ -8,7 +8,7 @@ import type { ClientFeaturesQuerySchema } from './clientFeaturesQuerySchema.js';
 import type { ClientSegmentSchema } from './clientSegmentSchema.js';
 
 /**
- * Configuration data for server-side SDKs for evaluating feature flags.
+ * Configuration data for backend SDKs for evaluating feature flags.
  */
 export interface ClientFeaturesSchema {
     /** A list of feature flags with their configuration */

--- a/frontend/src/openapi/models/edgeTokenSchema.ts
+++ b/frontend/src/openapi/models/edgeTokenSchema.ts
@@ -6,13 +6,13 @@
 import type { EdgeTokenSchemaType } from './edgeTokenSchemaType.js';
 
 /**
- * A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens) (used by proxy SDKs)
+ * A representation of a client token, limiting access to [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#backend-tokens) (used by serverside SDKs) or [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens) (used by proxy SDKs)
  */
 export interface EdgeTokenSchema {
     /** The list of projects this token has access to. If the token has access to specific projects they will be listed here. If the token has access to all projects it will be represented as [`*`] */
     projects: string[];
     /** The actual token value. [Unleash API tokens](https://docs.getunleash.io/reference/api-tokens-and-client-keys) are comprised of three parts. <project(s)>:<environment>.randomcharacters */
     token: string;
-    /** The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with */
+    /** The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#backend-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with */
     type: EdgeTokenSchemaType;
 }

--- a/frontend/src/openapi/models/edgeTokenSchemaType.ts
+++ b/frontend/src/openapi/models/edgeTokenSchemaType.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with
+ * The [API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys)'s **type**. Unleash supports three different types of API tokens ([ADMIN](https://docs.getunleash.io/reference/api-tokens-and-client-keys#admin-tokens), [CLIENT](https://docs.getunleash.io/reference/api-tokens-and-client-keys#backend-tokens), [FRONTEND](https://docs.getunleash.io/reference/api-tokens-and-client-keys#frontend-tokens)). They all have varying access, so when validating a token it's important to know what kind you're dealing with
  */
 export type EdgeTokenSchemaType =
     (typeof EdgeTokenSchemaType)[keyof typeof EdgeTokenSchemaType];

--- a/frontend/src/openapi/models/resourceLimitsSchema.ts
+++ b/frontend/src/openapi/models/resourceLimitsSchema.ts
@@ -17,7 +17,7 @@ export interface ResourceLimitsSchema {
     /** The maximum number of action set definitions per project allowed. */
     actionSetsPerProject: number;
     /**
-     * The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to server-side and client-side SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.
+     * The maximum number of SDK and admin API tokens you can have at the same time. This limit applies only to backend and frontend SDK tokens and to admin tokens. Personal access tokens are not subject to this limit. The limit applies to the total number of tokens across all projects in your organization.
      * @minimum 0
      */
     apiTokens: number;

--- a/frontend/src/openapi/models/unknownFlagSchema.ts
+++ b/frontend/src/openapi/models/unknownFlagSchema.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * An unknown flag that has been reported by the system
+ * An unknown flag report
  */
 export interface UnknownFlagSchema {
     /** The name of the application that reported the unknown flag. */

--- a/frontend/src/openapi/models/unknownFlagsResponseSchema.ts
+++ b/frontend/src/openapi/models/unknownFlagsResponseSchema.ts
@@ -6,7 +6,7 @@
 import type { UnknownFlagSchema } from './unknownFlagSchema.js';
 
 /**
- * A list of unknown flags that have been reported by the system
+ * A list of unknown flag reports
  */
 export interface UnknownFlagsResponseSchema {
     /** The list of recently reported unknown flags. */


### PR DESCRIPTION
Update documentation to replace 'server-side' with 'backend' in API schemas
