### PR TITLE
fix: now lifecycle trends will be added for flags that have official flag type

### DIFF
--- a/src/migrations/20250805152422-backfill-lifecycle-trends.js
+++ b/src/migrations/20250805152422-backfill-lifecycle-trends.js
@@ -30,6 +30,7 @@ exports.up = function (db, cb) {
                 FROM feature_lifecycles fl
                     JOIN features f ON f.name = fl.feature
                     JOIN projects p ON f.project = p.id
+                    JOIN feature_types ft ON ft.id = f.type
             ),
             latest_stage_on_week AS (
                 SELECT DISTINCT ON (fl.feature, wr.id)


### PR DESCRIPTION
We have instances that have fake flag types in features table. This ensures, we only count in flags have official types.