### PR TITLE
fix: health to technical debt on projects list

### DIFF
--- a/frontend/src/component/project/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/ProjectCard.tsx
@@ -29,6 +29,7 @@ export const ProjectCard = ({
     name,
     featureCount,
     health,
+    technicalDebt,
     memberCount = 0,
     id,
     mode,
@@ -71,7 +72,7 @@ export const ProjectCard = ({
                     </StyledProjectCardContent>
                     <StyledProjectCardContent>
                         <div data-loading>
-                            <strong>{health}%</strong> health
+                            <strong>{technicalDebt}%</strong> technical debt
                         </div>
                         <div data-loading>
                             <ProjectLastSeen date={lastReportedFlagUsage} />

--- a/frontend/src/component/project/ProjectList/ProjectsListTable/ProjectsListTable.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectsListTable/ProjectsListTable.tsx
@@ -80,12 +80,12 @@ export const ProjectsListTable = ({ projects }: ProjectsListTableProps) => {
                 width: 90,
             },
             {
-                Header: 'Health',
-                accessor: 'health',
+                Header: 'Technical debt',
+                accessor: 'technicalDebt',
                 Cell: ({ value }: { value: number }) => (
                     <TextCell>{value}%</TextCell>
                 ),
-                width: 70,
+                width: 130,
             },
             {
                 Header: 'Last seen',

--- a/src/lib/features/project/project-owners-read-model.test.ts
+++ b/src/lib/features/project/project-owners-read-model.test.ts
@@ -14,6 +14,7 @@ const mockProjectData = (name: string): ProjectForUi => ({
     memberCount: 0,
     mode: 'open' as const,
     health: 100,
+    technicalDebt: 0,
     createdAt: new Date(),
     favorite: false,
     lastReportedFlagUsage: null,

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -6,6 +6,7 @@ export type ProjectForUi = {
     name: string;
     description?: string;
     health: number;
+    technicalDebt: number;
     createdAt: Date;
     mode: ProjectMode;
     memberCount: number;

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -21,6 +21,7 @@ const mapProjectForUi = (row): ProjectForUi => {
         id: row.id,
         description: row.description,
         health: row.health,
+        technicalDebt: 100 - (row.health || 0),
         favorite: row.favorite,
         featureCount: Number(row.number_of_features) || 0,
         memberCount: Number(row.number_of_users) || 0,

--- a/src/lib/features/project/projects.e2e.test.ts
+++ b/src/lib/features/project/projects.e2e.test.ts
@@ -91,3 +91,16 @@ test('response for project overview should include feature type counts', async (
         ],
     });
 });
+
+test('response should include technical debt field', async () => {
+    const { body } = await app.request
+        .get('/api/admin/projects')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0]).toHaveProperty('technicalDebt');
+    expect(typeof body.projects[0].technicalDebt).toBe('number');
+    expect(body.projects[0].technicalDebt).toBeGreaterThanOrEqual(0);
+    expect(body.projects[0].technicalDebt).toBeLessThanOrEqual(100);
+});


### PR DESCRIPTION
CC @nunogois, we're shifting from 'health' to 'technical debt' in all UI

<img width="703" height="465" alt="image" src="https://github.com/user-attachments/assets/6dac3b38-9dc4-4ca1-97a3-5d8a0eb808ba" />
