### PR TITLE
fix: move update approvers after cr change state

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
@@ -82,6 +82,11 @@ export const EnvironmentChangeRequest: FC<{
     const sendToReview = async (project: string) => {
         setDisabled(true);
         try {
+            await changeState(project, environmentChangeRequest.id, 'Draft', {
+                state: 'In review',
+                comment: commentText,
+            });
+
             if (reviewers && reviewers.length > 0) {
                 await updateRequestedApprovers(
                     project,
@@ -89,11 +94,6 @@ export const EnvironmentChangeRequest: FC<{
                     reviewers.map((reviewer) => reviewer.id),
                 );
             }
-
-            await changeState(project, environmentChangeRequest.id, 'Draft', {
-                state: 'In review',
-                comment: commentText,
-            });
         } catch (e) {
             setDisabled(false);
         }


### PR DESCRIPTION
This moves the updateRequestedApprovers call until after changing state to in review.
We do this to make sure the approvers updated event gets processed after the change request makes it into in review.

That paves the way for the other change request that removes the notification listener for state change on change request, which should take care of the double notifications issue