### PR TITLE
fix: week range for lifecycle backfill

### DIFF
--- a/src/migrations/20250813125755-backfill-lifecycle-trends-fix.js
+++ b/src/migrations/20250813125755-backfill-lifecycle-trends-fix.js
@@ -1,0 +1,96 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+            DELETE FROM lifecycle_trends;
+
+            WITH current_sunday AS (
+                SELECT date_trunc('day', now() AT TIME ZONE 'UTC')
+                           - ((extract(dow from date_trunc('day', now() AT TIME ZONE 'UTC'))::int + 7) % 7) * INTERVAL '1 day' AS sunday_date
+                ),
+            week_ranges AS (
+            SELECT
+                to_char(week_start, 'YYYY') || '-' ||
+                lpad((floor(extract(epoch from (week_start - (
+                date_trunc('year', week_start)
+                - extract(dow from date_trunc('year', week_start))::int * INTERVAL '1 day'
+                ))) / 604800) + 1)::text, 2, '0') AS id,
+                week_start,
+                week_start + INTERVAL '7 days' AS week_end,
+                week_start + INTERVAL '7 days' + INTERVAL '1 hour' AS created_at
+            FROM current_sunday,
+                generate_series(
+                sunday_date - INTERVAL '52 weeks',
+                sunday_date - INTERVAL '1 week',
+                INTERVAL '1 week'
+                ) AS week_start
+            ),
+            feature_data AS (
+                SELECT
+                    fl.created_at AT TIME ZONE 'UTC' AS lifecycle_time,
+                    fl.stage,
+                    f.type AS flag_type,
+                    f.project,
+                    fl.feature
+                FROM feature_lifecycles fl
+                    JOIN features f ON f.name = fl.feature
+                    JOIN projects p ON f.project = p.id
+                    JOIN feature_types ft ON ft.id = f.type
+            ),
+            latest_stage_on_week AS (
+                SELECT DISTINCT ON (fl.feature, wr.id)
+                    wr.id AS week_id,
+                    fl.feature,
+                    fl.stage AS stage_on_week,
+                    fl.created_at
+                FROM week_ranges wr
+                    JOIN feature_lifecycles fl ON fl.created_at <= wr.week_end
+                ORDER BY wr.id, fl.feature, fl.created_at DESC
+            ),
+            weekly_counts AS (
+                SELECT
+                    wr.id,
+                    wr.created_at,
+                    fd.stage,
+                    fd.flag_type,
+                    fd.project,
+                    COUNT(DISTINCT CASE WHEN fd.lifecycle_time >= wr.week_start AND fd.lifecycle_time < wr.week_end THEN fd.feature END) AS new_flags_this_week,
+                    COUNT(DISTINCT CASE WHEN fd.lifecycle_time < wr.week_start
+                        AND lsbw.feature IS NOT NULL
+                        AND lsbw.stage_on_week = fd.stage
+                            THEN fd.feature
+                        END) AS flags_older_than_week
+                FROM week_ranges wr
+                    JOIN feature_data fd ON fd.lifecycle_time < wr.week_end
+                    LEFT JOIN latest_stage_on_week lsbw ON lsbw.feature = fd.feature AND lsbw.week_id = wr.id
+                GROUP BY wr.id, wr.created_at, fd.stage, fd.flag_type, fd.project
+            )
+            INSERT INTO lifecycle_trends (
+                id,
+                stage,
+                flag_type,
+                project,
+                flags_older_than_week,
+                new_flags_this_week,
+                created_at
+            )
+            SELECT
+                id,
+                stage,
+                flag_type,
+                project,
+                flags_older_than_week,
+                new_flags_this_week,
+                created_at
+            FROM weekly_counts
+            ORDER BY id, project, flag_type, stage;
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        ``,
+        cb,
+    );
+};


### PR DESCRIPTION
It is using almost same logic as https://github.com/Unleash/unleash/pull/10476, but week range is correct.