### PR TITLE
chore: separate sdk and edge consumption flags

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -795,7 +795,7 @@ export function registerPrometheusMetrics(
             config.flagResolver.impactMetrics?.incrementCounter(
                 REQUEST_COUNT,
                 1,
-                { flagNames: ['consumptionModel'], context: {} },
+                { flagNames: ['consumptionModelTrafficSdk'], context: {} },
             );
         },
     );

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -52,6 +52,8 @@ export type IFlagKey =
     | 'uniqueSdkTracking'
     | 'consumptionModel'
     | 'consumptionModelUI'
+    | 'consumptionModelTrafficSdk'
+    | 'consumptionModelTrafficEdge'
     | 'edgeObservability'
     | 'reportUnknownFlags'
     | 'lifecycleMetrics'
@@ -253,6 +255,14 @@ const flags: IFlags = {
     ),
     consumptionModelUI: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_CONSUMPTION_MODEL_UI,
+        false,
+    ),
+    consumptionModelTrafficSdk: parseEnvVarBoolean(
+        process.env.EXPERIMENTAL_CONSUMPTION_MODEL_TRAFFIC_SDK,
+        false,
+    ),
+    consumptionModelTrafficEdge: parseEnvVarBoolean(
+        process.env.EXPERIMENTAL_CONSUMPTION_MODEL_TRAFFIC_EDGE,
         false,
     ),
     edgeObservability: parseEnvVarBoolean(


### PR DESCRIPTION
We will separate sdk and edge traffic recording.