### PR TITLE
chore: ignore CR events with feature name

### DIFF
--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -203,7 +203,8 @@ export class EventStore implements IEventStore {
                             .whereNotIn('type', [
                                 FEATURE_CREATED,
                                 FEATURE_TAGGED,
-                            ]),
+                            ])
+                            .whereNot('type', 'LIKE', 'change-%'),
                     )
                     .orWhereIn('type', [
                         SEGMENT_UPDATED,

--- a/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.optimal304.e2e.test.ts
@@ -6,6 +6,7 @@ import dbInit, { type ITestDb } from '../../helpers/database-init.js';
 import getLogger from '../../../fixtures/no-logger.js';
 import type User from '../../../../lib/types/user.js';
 import { TEST_AUDIT_USER } from '../../../../lib/types/index.js';
+import { CHANGE_REQUEST_CREATED } from '../../../../lib/events/index.js';
 // import { DEFAULT_ENV } from '../../../../lib/util/constants';
 
 const testUser = { name: 'test', id: -9999 } as User;
@@ -138,6 +139,14 @@ describe.each([
             ],
             TEST_AUDIT_USER,
         );
+
+        await app.services.eventService.storeEvent({
+            type: CHANGE_REQUEST_CREATED,
+            createdBy: testUser.email,
+            createdByUserId: testUser.id,
+            ip: '127.0.0.1',
+            featureName: `ch-on-feature-${apendix}`,
+        });
 
         shutdownHooks.push(async () => {
             await app.destroy();


### PR DESCRIPTION
## About the changes
This ignores Change Request event types when calculating the etag because Change Request events don't change data.

They were being included when the change request event contained a featureName. After this change, those should be excluded.