### PR TITLE
Add .vite to biome's ignore lists (formatting and linting)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -77,7 +77,8 @@
       "coverage",
       "CHANGELOG.md",
       "./package.json",
-      "./frontend/package.json"
+      "./frontend/package.json",
+      ".vite"
     ]
   },
   "organizeImports": {
@@ -101,7 +102,8 @@
       "website/global.js",
       ".docusaurus",
       "./package.json",
-      "./frontend/package.json"
+      "./frontend/package.json",
+      ".vite"
     ],
     "indentWidth": 4
   },

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
@@ -1,7 +1,6 @@
 import type { IChangeRequestReorderStrategy } from '../../../../changeRequest.types';
 import type { ReactNode } from 'react';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
-import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
 import { Box, styled } from '@mui/material';
 import { EnvironmentStrategyOrderDiff } from './EnvironmentStrategyOrderDiff.tsx';
 import { StrategyExecution } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution';


### PR DESCRIPTION
Also fixes an auto-fixable issue reported by biome.