### PR TITLE
Remove ratio graph & column to the right

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -25,7 +25,6 @@ import {
 } from 'component/insights/components/LineChart/ChartTooltip/ChartTooltip';
 import { createTooltip } from 'component/insights/components/LineChart/createTooltip';
 import { CreationArchiveTooltip } from './CreationArchiveTooltip.tsx';
-import { CreationArchiveRatioTooltip } from './CreationArchiveRatioTooltip.tsx';
 import { getFlagTypeColors } from './flagTypeColors.ts';
 import type { WeekData, RawWeekData } from './types.ts';
 
@@ -153,19 +152,6 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                     order: 2,
                 },
                 ...flagTypeDatasets,
-                {
-                    label: 'Flags archived / Flags created',
-                    data: weeks,
-                    borderColor: theme.palette.primary.light,
-                    backgroundColor: theme.palette.primary.light,
-                    type: 'line' as const,
-                    parsing: {
-                        yAxisKey: 'archivePercentage',
-                        xAxisKey: 'date',
-                    },
-                    yAxisID: 'y1',
-                    order: 1,
-                },
             ],
             flagTypeNames,
         };
@@ -256,38 +242,15 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                                 text: 'Number of flags',
                             },
                         },
-                        y1: {
-                            type: 'linear',
-                            display: true,
-                            position: 'right',
-                            beginAtZero: true,
-                            title: {
-                                display: true,
-                                text: 'Ratio',
-                            },
-                            grid: {
-                                drawOnChartArea: false,
-                            },
-                            ticks: {
-                                callback: (value) => `${value}%`,
-                            },
-                        },
                     },
                 }}
                 height={100}
                 width={250}
             />
             {tooltip?.dataPoints?.some(
-                (point) =>
-                    point.dataset.label !== 'Archived flags' &&
-                    point.dataset.label !== 'Flags archived / Flags created',
+                (point) => point.dataset.label !== 'Archived flags',
             ) ? (
                 <CreationArchiveTooltip tooltip={tooltip} />
-            ) : tooltip?.dataPoints?.some(
-                  (point) =>
-                      point.dataset.label === 'Flags archived / Flags created',
-              ) ? (
-                <CreationArchiveRatioTooltip tooltip={tooltip} />
             ) : (
                 <ChartTooltip tooltip={tooltip} />
             )}


### PR DESCRIPTION
This PR removes the flags archived / flags created trend line as well as the right-hand column.

Before:
<img width="1107" height="459" alt="image" src="https://github.com/user-attachments/assets/f6bcbef0-7b71-44c1-b8a0-db5ebaff01ed" />


After:
<img width="1128" height="450" alt="image" src="https://github.com/user-attachments/assets/e55bd335-cc8c-4b88-8e3c-dafecf134742" />

I'm not deleting the tooltip yet, because I think we'll want to re-use that for the group tooltip.
