### PR TITLE
Simplify created numbers (don't show count by flag type) and update colors

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveTooltip.tsx
@@ -41,29 +41,11 @@ export const CreationArchiveTooltip: FC<CreationArchiveTooltipProps> = ({
 
     const rawData = createdFlagDataPoints[0]?.raw as WeekData;
 
-    if (!rawData?.createdFlagsByType) {
-        return null;
-    }
-
     const flagTypeNames = createdFlagDataPoints.map(
         (point) => point.dataset.label || '',
     );
 
     const flagTypeColors = getFlagTypeColors(theme);
-
-    const flagTypeEntries = Object.entries(rawData.createdFlagsByType)
-        .filter(([, count]) => (count as number) > 0)
-        .map(([flagType, count], index) => ({
-            type: flagType,
-            count: count as number,
-            color:
-                flagTypeColors[flagTypeNames.indexOf(flagType)] ||
-                flagTypeColors[index % flagTypeColors.length],
-        }));
-
-    if (flagTypeEntries.length === 0) {
-        return null;
-    }
 
     return (
         <ChartTooltipContainer tooltip={tooltip}>
@@ -77,19 +59,18 @@ export const CreationArchiveTooltip: FC<CreationArchiveTooltipProps> = ({
                     Flag type
                 </Typography>
 
-                {flagTypeEntries.map(({ type, count, color }) => (
-                    <StyledFlagTypeItem key={type}>
-                        <Typography variant='body2' component='span'>
-                            <Typography sx={{ color }} component='span'>
-                                {'● '}
-                            </Typography>
-                            {type.charAt(0).toUpperCase() + type.slice(1)}
-                        </Typography>
-                        <Typography variant='body2' component='span'>
-                            {count}
-                        </Typography>
-                    </StyledFlagTypeItem>
-                ))}
+                <Typography variant='body2' component='span'>
+                    <Typography
+                        sx={{ color: flagTypeColors[0] }}
+                        component='span'
+                    >
+                        {'● '}
+                    </Typography>
+                    Total created:
+                </Typography>
+                <Typography variant='body2' component='span'>
+                    {rawData.totalCreatedFlags}
+                </Typography>
             </StyledTooltipItemContainer>
         </ChartTooltipContainer>
     );

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/flagTypeColors.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/flagTypeColors.ts
@@ -1,3 +1,4 @@
+// todo (lifecycleGraphs): delete this file
 import type { Theme } from '@mui/material';
 
 export const getFlagTypeColors = (theme: Theme) => [

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/types.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/types.ts
@@ -1,7 +1,6 @@
 export type WeekData = {
     archivedFlags: number;
     totalCreatedFlags: number;
-    createdFlagsByType: Record<string, number>;
     archivePercentage: number;
     week: string;
     date?: string;


### PR DESCRIPTION
Simplifies the data we show for the archive vs creation chart by not showing the created count by flag type. Instead, all we show is the total.

Also, in doing this, updates the colors we use for the bars (to A1, and A2). The contrast is a little low between A1 and A2, so we should look at that before taking this into production.

The created tooltip colors are wrong, but we'll need to update the tooltip in a later PR, so not tackling that now.

Before:
<img width="1115" height="456" alt="image" src="https://github.com/user-attachments/assets/13626295-1aa5-42be-b8dd-cea9912effe0" />
<img width="564" height="311" alt="image" src="https://github.com/user-attachments/assets/7a02eec0-e018-49fd-8b1f-92aa3376a6cc" />



After: 
<img width="1179" height="481" alt="image" src="https://github.com/user-attachments/assets/1ba6584a-d7e2-4ae4-81ec-38260c1f0e07" />

<img width="420" height="159" alt="image" src="https://github.com/user-attachments/assets/e4433c32-eaa4-41d2-a5ef-af84a9725c30" />

Closes 1-4018, 1-4013, 1-4014
