### PR TITLE
fix: pagination limit and placeholder

### DIFF
--- a/frontend/src/component/common/Table/PaginationBar/PaginationBar.tsx
+++ b/frontend/src/component/common/Table/PaginationBar/PaginationBar.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { useEffect } from 'react';
 import { Box, Typography, Button, styled } from '@mui/material';
 import { ConditionallyRender } from '../../ConditionallyRender/ConditionallyRender.tsx';
 import { ReactComponent as ArrowRight } from 'assets/icons/arrowRight.svg';
@@ -60,6 +61,12 @@ export const PaginationBar: React.FC<PaginationBarProps> = ({
     fetchNextPage,
     setPageLimit,
 }) => {
+    useEffect(() => {
+        if (![25, 50, 75, 100].includes(pageSize)) {
+            setPageLimit(25);
+        }
+    }, [pageSize]);
+
     const itemRange =
         totalItems !== undefined && pageSize && totalItems > 1
             ? `${pageIndex * pageSize + 1}-${Math.min(

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -151,7 +151,7 @@ export const ProjectFeatureToggles = ({
         setShowFeatureDeleteDialogue,
     } = useRowActions(refetch, projectId, trackArchiveAction);
 
-    const isPlaceholder = Boolean(initialLoad || (loading && total));
+    const isPlaceholder = Boolean(initialLoad || loading);
 
     const [onboardingFlow, setOnboardingFlow] = useLocalStorageState<
         'visible' | 'closed'


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

* make sure that only page limit available in the UI can be selected and choose 25 otherwise. This will solve a problem when someone has bookmarked URL with limit=1 or has this value in local storage
* make sure that when paginating to next pages we see loading placeholder instead of "No feature flags available"

This is what we have now when changin a page on slow connection
<img width="867" height="366" alt="Screenshot 2025-08-25 at 16 13 18" src="https://github.com/user-attachments/assets/9d2a6c0d-ae17-4c8a-adc3-509263a47fbb" />


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

Another issue when paginating is that total count drops to 0 for a short period. I know we had a cache component for this but it doesn't seem to be working anymore.
<img width="892" height="528" alt="Screenshot 2025-08-25 at 16 13 23" src="https://github.com/user-attachments/assets/1c980d4a-72ed-44d5-8cc7-5f6d565e2ed2" />
