### PR TITLE
docs: clarify `archived` query param syntax for `api/admin/search/features`

### DIFF
--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -163,9 +163,10 @@ export const featureSearchQueryParameters = [
         schema: {
             type: 'string',
             example: 'IS:true',
+            pattern: '^IS:(true|false)$',
         },
         description:
-            'Whether to get results for archived feature flags or active feature flags. If `true`, Unleash will return only archived flags. If `false`, it will return only active flags.',
+            'Whether to get results for archived feature flags or active feature flags. If `IS:true`, Unleash will return only archived flags. If `IS:false`, it will return only active flags.',
         in: 'query',
     },
     {


### PR DESCRIPTION
## About the changes
This PR updates the [Search and filter features](https://docs.getunleash.io/reference/api/unleash/search-features) doc to clearly indicate `IS:` query syntax requirement for `archived` query param. 
