### PR TITLE
chore: Etag log and code improvements

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -373,7 +373,7 @@ export default class FeatureController extends Controller {
             this.logger.info(
                 `[etag] for query ${JSON.stringify(
                     query,
-                )} is "${queryHash}:${revisionId}" (revision id query with env ${etagByEnvEnabled ? query.environment : undefined})`,
+                )} is "${queryHash}:${revisionId}" query by env enabled? ${etagByEnvEnabled ? 'yes' : 'no'}. Querying with env ${etagByEnvEnabled ? query.environment : undefined})`,
             );
         }
         const etagVariant = this.flagResolver.getVariant('etagVariant');

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -99,15 +99,14 @@ export default class ConfigurationRevisionService extends EventEmitter {
             this.revisionId,
         );
         if (this.revisionId !== revisionId) {
+            const knownEnvironments = [...this.maxRevisionId.keys()];
             this.logger.debug(
-                `Updating feature configuration with new revision Id ${revisionId} and all envs: ${Object.keys(this.maxRevisionId).join(', ')}`,
+                `Updating feature configuration with new revision Id ${revisionId} and all envs: ${knownEnvironments.join(', ')}`,
             );
             await Promise.allSettled(
-                this.maxRevisionId
-                    .keys()
-                    .map((environment) =>
-                        this.updateMaxEnvironmentRevisionId(environment),
-                    ),
+                knownEnvironments.map((environment) =>
+                    this.updateMaxEnvironmentRevisionId(environment),
+                ),
             );
             this.revisionId = revisionId;
             if (emit) {

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -77,15 +77,14 @@ export default class ConfigurationRevisionService extends EventEmitter {
             maxRevId,
             environment,
         );
+        if (this.flagResolver.isEnabled('debugEtag')) {
+            this.logger.info(
+                `[etag] Computed ETag for environment ${environment}: ${actualMax} previous was ${maxRevId}`,
+            );
+        }
         if (maxRevId < actualMax) {
             this.maxRevisionId.set(environment, actualMax);
             maxRevId = actualMax;
-        }
-
-        if (this.flagResolver.isEnabled('debugEtag')) {
-            this.logger.info(
-                `[etag] Computed ETag for environment ${environment}: ${actualMax} stored as "${this.maxRevisionId.get(environment)}"`,
-            );
         }
 
         return maxRevId;
@@ -100,15 +99,9 @@ export default class ConfigurationRevisionService extends EventEmitter {
             this.revisionId,
         );
         if (this.revisionId !== revisionId) {
-            if (this.flagResolver.isEnabled('debugEtag')) {
-                this.logger.info(
-                    `[etag] Updating feature configuration with new revision Id ${revisionId} and all envs: ${Object.keys(this.maxRevisionId).join(', ')}`,
-                );
-            } else {
-                this.logger.debug(
-                    `Updating feature configuration with new revision Id ${revisionId} and all envs: ${Object.keys(this.maxRevisionId).join(', ')}`,
-                );
-            }
+            this.logger.debug(
+                `Updating feature configuration with new revision Id ${revisionId} and all envs: ${Object.keys(this.maxRevisionId).join(', ')}`,
+            );
             await Promise.allSettled(
                 this.maxRevisionId
                     .keys()


### PR DESCRIPTION
This is a follow-up on the comments in https://github.com/Unleash/unleash/pull/10512

Mostly using get and set when accessing the Map