### PR TITLE
chore: disable browser autocomplete on commandbar

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -317,6 +317,7 @@ export const CommandBar = () => {
                     inputProps={{
                         'data-testid': SEARCH_INPUT,
                     }}
+                    autoComplete='off'
                     value={value}
                     onChange={(e) => onSearchChange(e.target.value)}
                     onFocus={() => {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3819/disable-browser-autocomplete-on-our-command-bar

Disables browser autocomplete on our CommandBar:

### Before

<img width="424" height="352" alt="image" src="https://github.com/user-attachments/assets/597bbb9f-6391-4bb9-9f80-4fa80cb5c00c" />

### After

<img width="421" height="351" alt="image" src="https://github.com/user-attachments/assets/ef5409b2-5cfd-4780-b33c-63a8f740feda" />