### PR TITLE
fix: feature link should return same id as it sends to db

### DIFF
--- a/src/lib/features/feature-links/feature-link-store.ts
+++ b/src/lib/features/feature-links/feature-link-store.ts
@@ -22,7 +22,7 @@ export class FeatureLinkStore
     async insert(item: Omit<IFeatureLink, 'id'>): Promise<IFeatureLink> {
         const id = ulid();
         const featureLink = {
-            id: ulid(),
+            id: id,
             feature_name: item.featureName,
             url: item.url,
             title: item.title,


### PR DESCRIPTION
During feature link creation, we should return same id as it sends to db.