### PR TITLE
chore: show release templates in license info in the UI

### DIFF
--- a/frontend/src/component/admin/license/License.tsx
+++ b/frontend/src/component/admin/license/License.tsx
@@ -105,6 +105,14 @@ export const License = () => {
                             </StyledDataCollectionPropertyRow>
                             <StyledDataCollectionPropertyRow>
                                 <StyledPropertyName>
+                                    Release templates
+                                </StyledPropertyName>
+                                <StyledPropertyDetails>
+                                    {license.releaseTemplates}
+                                </StyledPropertyDetails>
+                            </StyledDataCollectionPropertyRow>
+                            <StyledDataCollectionPropertyRow>
+                                <StyledPropertyName>
                                     Expire at
                                 </StyledPropertyName>
                                 <StyledPropertyDetails>

--- a/frontend/src/hooks/api/getters/useLicense/useLicense.ts
+++ b/frontend/src/hooks/api/getters/useLicense/useLicense.ts
@@ -25,6 +25,7 @@ export interface License {
         instanceName: string;
         plan: string;
         seats: number;
+        releaseTemplates: number;
         expireAt: Date;
     };
     loading: boolean;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3823/show-release-templates-in-license-info-in-ui

Shows release templates in license info in the UI.

<img width="1173" height="687" alt="image" src="https://github.com/user-attachments/assets/b93cb510-282d-4027-bd39-2269ec138cc6" />
