### PR TITLE
Chore: Use step size of 1 for created vs archived.

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -178,6 +178,9 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                         display: true,
                         text: 'Number of flags',
                     },
+                    ticks: {
+                        stepSize: 1,
+                    },
                 },
             },
         }),


### PR DESCRIPTION
You can't archive half a flag.

Closes 1-4034.