### PR TITLE
chore: improve openapi diff output

### DIFF
--- a/.github/workflows/openapi-diff.yaml
+++ b/.github/workflows/openapi-diff.yaml
@@ -1,5 +1,9 @@
 name: OpenAPI Diff
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:
@@ -123,7 +127,11 @@ jobs:
           docker run --rm -t -v $(pwd):/specs:ro tufin/oasdiff changelog --format markdown /specs/openapi-stable.json /specs/openapi-current.json > openapi-diff.txt || true
           # then output in a format that is useful when you go inside the job output
           docker run --rm -t -v $(pwd):/specs:ro tufin/oasdiff changelog --format githubactions /specs/openapi-stable.json /specs/openapi-current.json
+      - name: Show OpenAPI diff
+        if: github.event_name != 'pull_request'
+        run: cat openapi-diff.txt
       - name: Comment on PR with OpenAPI diff
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
This will output the comment of openapi diffs in proper markdown format.