### PR TITLE
chore: rollback hashing of release-plans and templates

### DIFF
--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -703,7 +703,7 @@ export class InstanceStatsService {
             .reduce((a, b) => a + b, 0);
 
         const sum = sha256(
-            `${instanceStats.instanceId}${instanceStats.users}${instanceStats.featureToggles}${totalProjects}${instanceStats.roles}${instanceStats.groups}${instanceStats.environments}${instanceStats.segments}${instanceStats.releaseTemplates}${instanceStats.releasePlans}`,
+            `${instanceStats.instanceId}${instanceStats.users}${instanceStats.featureToggles}${totalProjects}${instanceStats.roles}${instanceStats.groups}${instanceStats.environments}${instanceStats.segments}`,
         );
         return { ...instanceStats, sum, projects: totalProjects };
     }

--- a/src/test/e2e/api/admin/instance-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/instance-admin.e2e.test.ts
@@ -124,7 +124,7 @@ test('should return signed instance statistics', async () => {
         .expect((res) => {
             expect(res.body.instanceId).toBe('test-static');
             expect(res.body.sum).toBe(
-                'a5fd70e5ba5dfa02644404d4d075cb7f783487f607fbc00e8e4bc0aef41fd81a',
+                'd9bac94bba7afa20d98f0a9d54a84b79a6668f8103b8f89db85d05d38e84f519',
             );
         });
 });


### PR DESCRIPTION
Rolls back hashing of the newly added releasePlans and releaseTemplates fields