### PR TITLE
fix: Show 100% instead of Infinity% if you've not created any flags

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
@@ -49,7 +49,11 @@ export const CreationArchiveRatioTooltip: FC<
     const rawData = tooltip.dataPoints[0].raw as WeekData;
     const archivedCount = rawData.archivedFlags || 0;
     const createdCount = rawData.totalCreatedFlags || 0;
-    const ratio = Math.round((archivedCount / createdCount) * 100);
+
+    const ratio = Math.min(
+        Math.round((archivedCount / createdCount) * 100),
+        100,
+    );
 
     return (
         <ChartTooltipContainer tooltip={tooltip}>

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
@@ -50,10 +50,8 @@ export const CreationArchiveRatioTooltip: FC<
     const archivedCount = rawData.archivedFlags || 0;
     const createdCount = rawData.totalCreatedFlags || 0;
 
-    const ratio = Math.min(
-        Math.round((archivedCount / createdCount) * 100),
-        100,
-    );
+    const rawRatio = Math.round((archivedCount / createdCount) * 100);
+    const ratio = Number.isNaN(rawRatio) ? 100 : Math.min(rawRatio, 100);
 
     return (
         <ChartTooltipContainer tooltip={tooltip}>

--- a/frontend/src/component/insights/componentsStat/CreationArchiveStats/CreationArchiveStats.tsx
+++ b/frontend/src/component/insights/componentsStat/CreationArchiveStats/CreationArchiveStats.tsx
@@ -34,9 +34,8 @@ function getCurrentArchiveRatio(
         }
     });
 
-    return totalCreated > 0
-        ? Math.round((totalArchived / totalCreated) * 100)
-        : 0;
+    const rawRatio = Math.round((totalArchived / totalCreated) * 100);
+    return Number.isNaN(rawRatio) ? 100 : Math.min(rawRatio, 100);
 }
 
 const StyledRatioContainer = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
JS gives you positive infinity if you divide a positive number by 0, which isn't very helpful here. Instead, let's show 100%. If you divide 0 by 0, then you get NaN, which we also need to handle explicitly because it doesn't work with math.min.

Fixes 1-4033.