### PR TITLE
Update chart colors to increase contrasts between the A series.

### DIFF
--- a/frontend/src/themes/dark-theme.ts
+++ b/frontend/src/themes/dark-theme.ts
@@ -221,10 +221,9 @@ const theme = {
          */
         charts: {
             A1: '#6C65E5',
-            A2: '#8C87EB',
-            A3: '#ADA9F1',
-            A4: '#CECCF6',
-            A5: '#F1F0FC',
+            A2: '#9D98EE',
+            A3: '#CECCF6',
+            A4: '#F1F0FC',
             B1: '#1791AE',
             C1: '#DF416E',
             D1: '#D76500',

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -277,10 +277,9 @@ const theme = {
          */
         charts: {
             A1: '#6C65E5',
-            A2: '#8C87EB',
-            A3: '#ADA9F1',
-            A4: '#CECCF6',
-            A5: '#F1F0FC',
+            A2: '#9D98EE',
+            A3: '#CECCF6',
+            A4: '#F1F0FC',
             B1: '#1791AE',
             C1: '#DF416E',
             D1: '#D76500',

--- a/frontend/src/themes/themeTypes.ts
+++ b/frontend/src/themes/themeTypes.ts
@@ -142,7 +142,6 @@ declare module '@mui/material/styles' {
             A2: string;
             A3: string;
             A4: string;
-            A5: string;
             B1: string;
             C1: string;
             D1: string;


### PR DESCRIPTION
Makes it easier to tell the difference between a1 and a2 in particular.

Before: 
<img width="1468" height="499" alt="image" src="https://github.com/user-attachments/assets/a77c4e61-33c1-4c87-8b39-f9919122137d" />

After:
<img width="1384" height="486" alt="image" src="https://github.com/user-attachments/assets/b35e856a-e6d3-44b4-adea-dfeb15bcdfcc" />
