### PR TITLE
chore: add Release Templates OpenAPI tag

### DIFF
--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -116,6 +116,11 @@ const OPENAPI_TAGS = [
         description:
             'Create, update, and delete [Unleash Public Signup tokens](https://docs.getunleash.io/reference/public-signup-tokens).',
     },
+    {
+        name: 'Release Templates',
+        description:
+            'API for managing [release templates](https://docs.getunleash.io/reference/release-templates).',
+    },
     { name: 'Search', description: 'Search for features.' },
     {
         name: 'Segments',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3813/make-sure-we-promote-api-to-ga

Adds a new "Release Templates" OpenAPI tag.