### PR TITLE
chore: one unknown flag per row

### DIFF
--- a/frontend/src/component/unknownFlags/UnknownFlagsLastEventCell.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsLastEventCell.tsx
@@ -11,7 +11,7 @@ interface IUnknownFlagsSeenInUnleashCellProps extends ITimeAgoCellProps {
     unknownFlag: UnknownFlag;
 }
 
-export const UnknownFlagsSeenInUnleashCell = ({
+export const UnknownFlagsLastEventCell = ({
     unknownFlag,
     ...props
 }: IUnknownFlagsSeenInUnleashCellProps) => {

--- a/frontend/src/component/unknownFlags/UnknownFlagsLastReportedCell.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsLastReportedCell.tsx
@@ -1,0 +1,128 @@
+import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
+import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
+import type { UnknownFlag } from './hooks/useUnknownFlags.js';
+import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
+import { formatDateYMDHMS } from 'utils/formatDate.js';
+import { useLocationSettings } from 'hooks/useLocationSettings.js';
+import { styled } from '@mui/material';
+import { Highlighter } from 'component/common/Highlighter/Highlighter.js';
+import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext.js';
+
+const REPORT_APP_LIMIT = 20;
+const REPORT_ENV_LIMIT = 10;
+
+const StyledTooltip = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+}));
+
+const StyledReport = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    '& > ul': {
+        padding: theme.spacing(0, 3),
+        margin: 0,
+    },
+}));
+
+interface IUnknownFlagsLastReportedCellProps {
+    row: { original: UnknownFlag };
+}
+
+const UnknownFlagsLastReportedCellTooltip = ({
+    unknownFlag,
+    searchQuery,
+}: { unknownFlag: UnknownFlag; searchQuery: string }) => {
+    const { locationSettings } = useLocationSettings();
+    const lastReported = formatDateYMDHMS(
+        unknownFlag.lastSeenAt,
+        locationSettings.locale,
+    );
+
+    return (
+        <StyledTooltip>
+            Last reported: {lastReported}
+            {unknownFlag.reports
+                .slice(0, REPORT_APP_LIMIT)
+                .map(({ appName, environments }) => (
+                    <StyledReport key={appName}>
+                        <b>
+                            <Highlighter search={searchQuery}>
+                                {appName}
+                            </Highlighter>
+                        </b>
+                        <ul>
+                            {environments
+                                .slice(0, REPORT_ENV_LIMIT)
+                                .map(({ environment, seenAt }) => (
+                                    <li key={environment}>
+                                        <Highlighter search={searchQuery}>
+                                            {environment}
+                                        </Highlighter>
+                                        :{' '}
+                                        {formatDateYMDHMS(
+                                            seenAt,
+                                            locationSettings.locale,
+                                        )}
+                                    </li>
+                                ))}
+                            {environments.length > REPORT_ENV_LIMIT && (
+                                <li>
+                                    and {environments.length - REPORT_ENV_LIMIT}{' '}
+                                    more
+                                </li>
+                            )}
+                        </ul>
+                    </StyledReport>
+                ))}
+            {unknownFlag.reports.length > REPORT_APP_LIMIT && (
+                <span>
+                    and {unknownFlag.reports.length - REPORT_APP_LIMIT} more
+                </span>
+            )}
+        </StyledTooltip>
+    );
+};
+
+export const UnknownFlagsLastReportedCell = ({
+    row,
+}: IUnknownFlagsLastReportedCellProps) => {
+    const { original: unknownFlag } = row;
+    const { searchQuery } = useSearchHighlightContext();
+
+    const searchableAppNames = Array.from(
+        new Set(
+            unknownFlag.reports.map((report) => report.appName.toLowerCase()),
+        ),
+    ).join('\n');
+    const searchableEnvironments = Array.from(
+        new Set(
+            unknownFlag.reports.flatMap((report) =>
+                report.environments.map((env) => env.environment.toLowerCase()),
+            ),
+        ),
+    ).join('\n');
+
+    return (
+        <TextCell>
+            <TooltipLink
+                tooltip={
+                    <UnknownFlagsLastReportedCellTooltip
+                        unknownFlag={unknownFlag}
+                        searchQuery={searchQuery}
+                    />
+                }
+                highlighted={
+                    searchQuery.length > 0 &&
+                    (searchableAppNames.includes(searchQuery.toLowerCase()) ||
+                        searchableEnvironments.includes(
+                            searchQuery.toLowerCase(),
+                        ))
+                }
+            >
+                <TimeAgo date={unknownFlag.lastSeenAt} />
+            </TooltipLink>
+        </TextCell>
+    );
+};

--- a/frontend/src/component/unknownFlags/hooks/useUnknownFlags.ts
+++ b/frontend/src/component/unknownFlags/hooks/useUnknownFlags.ts
@@ -5,12 +5,21 @@ import { useConditionalSWR } from 'hooks/api/getters/useConditionalSWR/useCondit
 import handleErrorResponses from 'hooks/api/getters/httpErrorResponseHandler';
 import type { SWRConfiguration } from 'swr';
 
+type UnknownFlagEnvReport = {
+    environment: string;
+    seenAt: Date;
+};
+
+type UnknownFlagAppReport = {
+    appName: string;
+    environments: UnknownFlagEnvReport[];
+};
+
 export type UnknownFlag = {
     name: string;
-    appName: string;
-    seenAt: Date;
-    environment: string;
-    lastEventAt: Date;
+    lastSeenAt: Date;
+    lastEventAt?: Date;
+    reports: UnknownFlagAppReport[];
 };
 
 type UnknownFlagsResponse = {

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -32,7 +32,7 @@ import {
     MetricsTranslator,
 } from '../impact/metrics-translator.js';
 import { impactRegister } from '../impact/impact-register.js';
-import type { UnknownFlag } from '../unknown-flags/unknown-flags-store.js';
+import type { UnknownFlagReport } from '../unknown-flags/unknown-flags-store.js';
 
 export default class ClientMetricsServiceV2 {
     private config: IUnleashConfig;
@@ -209,14 +209,14 @@ export default class ClientMetricsServiceV2 {
             `Got ${toggleNames.length} metrics (${invalidCount > 0 ? `${invalidCount} invalid` : 'all valid'}).`,
         );
 
-        const unknownFlags: UnknownFlag[] = [];
+        const unknownFlags: UnknownFlagReport[] = [];
         for (const [featureName, group] of metricsByToggle) {
             if (unknownSet.has(featureName)) {
                 for (const m of group) {
                     unknownFlags.push({
                         name: featureName,
                         appName: m.appName,
-                        seenAt: m.timestamp,
+                        lastSeenAt: m.timestamp,
                         environment: m.environment,
                     });
                 }

--- a/src/lib/features/metrics/unknown-flags/fake-unknown-flags-store.ts
+++ b/src/lib/features/metrics/unknown-flags/fake-unknown-flags-store.ts
@@ -1,25 +1,67 @@
 import type {
     IUnknownFlagsStore,
     UnknownFlag,
+    UnknownFlagReport,
     QueryParams,
 } from './unknown-flags-store.js';
 
 export class FakeUnknownFlagsStore implements IUnknownFlagsStore {
-    private unknownFlagMap = new Map<string, UnknownFlag>();
+    private unknownFlagMap = new Map<string, UnknownFlagReport>();
 
-    private getKey(flag: UnknownFlag): string {
+    private getKey(flag: UnknownFlagReport): string {
         return `${flag.name}:${flag.appName}:${flag.environment}`;
     }
 
-    async insert(flags: UnknownFlag[]): Promise<void> {
+    async insert(flags: UnknownFlagReport[]): Promise<void> {
         this.unknownFlagMap.clear();
         for (const flag of flags) {
             this.unknownFlagMap.set(this.getKey(flag), flag);
         }
     }
 
+    private groupFlags(flags: UnknownFlagReport[]): UnknownFlag[] {
+        const byName = new Map<string, Map<string, Map<string, Date>>>();
+
+        for (const f of flags) {
+            const apps =
+                byName.get(f.name) ?? new Map<string, Map<string, Date>>();
+            const envs = apps.get(f.appName) ?? new Map<string, Date>();
+            const prev = envs.get(f.environment);
+            if (!prev || f.lastSeenAt > prev)
+                envs.set(f.environment, f.lastSeenAt);
+            apps.set(f.appName, envs);
+            byName.set(f.name, apps);
+        }
+
+        const out: UnknownFlag[] = [];
+        for (const [name, appsMap] of byName) {
+            let lastSeenAt: Date | null = null;
+
+            const reports = Array.from(appsMap.entries()).map(
+                ([appName, envMap]) => {
+                    const environments = Array.from(envMap.entries()).map(
+                        ([environment, seenAt]) => {
+                            if (!lastSeenAt || seenAt > lastSeenAt)
+                                lastSeenAt = seenAt;
+                            return { environment, seenAt };
+                        },
+                    );
+                    return { appName, environments };
+                },
+            );
+
+            out.push({
+                name,
+                lastSeenAt: lastSeenAt ?? new Date(0),
+                reports,
+            });
+        }
+        return out;
+    }
+
     async getAll({ limit, orderBy }: QueryParams = {}): Promise<UnknownFlag[]> {
-        const flags = Array.from(this.unknownFlagMap.values());
+        const flat = Array.from(this.unknownFlagMap.values());
+        const flags = this.groupFlags(flat);
         if (orderBy) {
             flags.sort((a, b) => {
                 for (const { column, order } of orderBy) {
@@ -36,7 +78,7 @@ export class FakeUnknownFlagsStore implements IUnknownFlagsStore {
     async clear(hoursAgo: number): Promise<void> {
         const cutoff = Date.now() - hoursAgo * 60 * 60 * 1000;
         for (const [key, flag] of this.unknownFlagMap.entries()) {
-            if (flag.seenAt.getTime() < cutoff) {
+            if (flag.lastSeenAt.getTime() < cutoff) {
                 this.unknownFlagMap.delete(key);
             }
         }

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-service.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-service.ts
@@ -5,7 +5,11 @@ import type {
     IUnleashConfig,
 } from '../../../types/index.js';
 import type { IUnleashStores } from '../../../types/index.js';
-import type { QueryParams, UnknownFlag } from './unknown-flags-store.js';
+import type {
+    QueryParams,
+    UnknownFlag,
+    UnknownFlagReport,
+} from './unknown-flags-store.js';
 
 export class UnknownFlagsService {
     private logger: Logger;
@@ -14,7 +18,7 @@ export class UnknownFlagsService {
 
     private unknownFlagsStore: IUnknownFlagsStore;
 
-    private unknownFlagsCache: Map<string, UnknownFlag>;
+    private unknownFlagsCache: Map<string, UnknownFlagReport>;
 
     constructor(
         { unknownFlagsStore }: Pick<IUnleashStores, 'unknownFlagsStore'>,
@@ -25,14 +29,14 @@ export class UnknownFlagsService {
         this.logger = config.getLogger(
             '/features/metrics/unknown-flags/unknown-flags-service.ts',
         );
-        this.unknownFlagsCache = new Map<string, UnknownFlag>();
+        this.unknownFlagsCache = new Map<string, UnknownFlagReport>();
     }
 
-    private getKey(flag: UnknownFlag) {
+    private getKey(flag: UnknownFlagReport) {
         return `${flag.name}:${flag.appName}:${flag.environment}`;
     }
 
-    register(unknownFlags: UnknownFlag[]) {
+    register(unknownFlags: UnknownFlagReport[]) {
         if (!this.flagResolver.isEnabled('reportUnknownFlags')) return;
         for (const flag of unknownFlags) {
             const key = this.getKey(flag);

--- a/src/lib/features/metrics/unknown-flags/unknown-flags.e2e.test.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags.e2e.test.ts
@@ -105,9 +105,18 @@ describe('should register unknown flags', () => {
         expect(unknownFlags).toHaveLength(1);
         expect(unknownFlags[0]).toMatchObject({
             name: 'unknown_flag',
-            environment: 'development',
-            appName: 'demo',
-            seenAt: expect.any(Date),
+            lastSeenAt: expect.any(Date),
+            reports: [
+                {
+                    appName: 'demo',
+                    environments: [
+                        {
+                            environment: 'development',
+                            seenAt: expect.any(Date),
+                        },
+                    ],
+                },
+            ],
         });
         expect(eventBus.emit).toHaveBeenCalledWith(
             CLIENT_METRICS,
@@ -167,9 +176,18 @@ describe('should register unknown flags', () => {
         expect(unknownFlags).toHaveLength(1);
         expect(unknownFlags[0]).toMatchObject({
             name: 'unknown_flag_bulk',
-            environment: 'development',
-            appName: 'demo',
-            seenAt: expect.any(Date),
+            lastSeenAt: expect.any(Date),
+            reports: [
+                {
+                    appName: 'demo',
+                    environments: [
+                        {
+                            environment: 'development',
+                            seenAt: expect.any(Date),
+                        },
+                    ],
+                },
+            ],
         });
         expect(eventBus.emit).toHaveBeenCalledWith(
             CLIENT_METRICS,
@@ -242,15 +260,35 @@ describe('should fetch unknown flags', () => {
         expect(res.body.unknownFlags).toEqual([
             expect.objectContaining({
                 name: 'unknown_flag_1',
-                environment: 'development',
-                appName: 'demo',
+                lastSeenAt: expect.any(String),
                 lastEventAt: null,
+                reports: [
+                    {
+                        appName: 'demo',
+                        environments: [
+                            {
+                                environment: 'development',
+                                seenAt: expect.any(String),
+                            },
+                        ],
+                    },
+                ],
             }),
             expect.objectContaining({
                 name: 'unknown_flag_2',
-                environment: 'development',
-                appName: 'demo',
+                lastSeenAt: expect.any(String),
                 lastEventAt: null,
+                reports: [
+                    {
+                        appName: 'demo',
+                        environments: [
+                            {
+                                environment: 'development',
+                                seenAt: expect.any(String),
+                            },
+                        ],
+                    },
+                ],
             }),
         ]);
     });
@@ -312,9 +350,18 @@ describe('should fetch unknown flags', () => {
         expect(res.body.unknownFlags).toEqual([
             expect.objectContaining({
                 name: 'unknown_flag_2',
-                environment: 'development',
-                appName: 'demo',
-                lastEventAt: null,
+                lastSeenAt: expect.any(String),
+                reports: [
+                    {
+                        appName: 'demo',
+                        environments: [
+                            {
+                                environment: 'development',
+                                seenAt: expect.any(String),
+                            },
+                        ],
+                    },
+                ],
             }),
         ]);
     });

--- a/src/lib/openapi/spec/unknown-flag-schema.ts
+++ b/src/lib/openapi/spec/unknown-flag-schema.ts
@@ -4,7 +4,7 @@ export const unknownFlagSchema = {
     $id: '#/components/schemas/unknownFlagSchema',
     type: 'object',
     additionalProperties: false,
-    required: ['name', 'appName', 'seenAt', 'environment'],
+    required: ['name', 'lastSeenAt'],
     description: 'An unknown flag report',
     properties: {
         name: {
@@ -12,24 +12,12 @@ export const unknownFlagSchema = {
             description: 'The name of the unknown flag.',
             example: 'my-unknown-flag',
         },
-        appName: {
-            type: 'string',
-            description:
-                'The name of the application that reported the unknown flag.',
-            example: 'my-app',
-        },
-        seenAt: {
+        lastSeenAt: {
             type: 'string',
             format: 'date-time',
             description:
-                'The date and time when the unknown flag was reported.',
+                'The date and time when the unknown flag was last reported.',
             example: '2023-10-01T12:00:00Z',
-        },
-        environment: {
-            type: 'string',
-            description:
-                'The environment in which the unknown flag was reported.',
-            example: 'production',
         },
         lastEventAt: {
             type: 'string',
@@ -38,6 +26,48 @@ export const unknownFlagSchema = {
                 'The date and time when the last event for the unknown flag name occurred, if any.',
             example: '2023-10-01T12:00:00Z',
             nullable: true,
+        },
+        reports: {
+            type: 'array',
+            description: 'The list of reports for this unknown flag.',
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['appName', 'environments'],
+                properties: {
+                    appName: {
+                        type: 'string',
+                        description:
+                            'The name of the application that reported the unknown flag.',
+                        example: 'my-app',
+                    },
+                    environments: {
+                        type: 'array',
+                        description:
+                            'The list of environments where this application reported the unknown flag.',
+                        items: {
+                            type: 'object',
+                            additionalProperties: false,
+                            required: ['environment', 'seenAt'],
+                            properties: {
+                                environment: {
+                                    type: 'string',
+                                    description:
+                                        'The environment in which the unknown flag was reported.',
+                                    example: 'production',
+                                },
+                                seenAt: {
+                                    type: 'string',
+                                    format: 'date-time',
+                                    description:
+                                        'The date and time when the unknown flag was last seen in this environment.',
+                                    example: '2023-10-01T12:00:00Z',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
     },
     components: {},


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3833/show-one-flag-name-per-row

Groups unknown flags by flag name, showing a single flag name per row. This greatly simplifies the way we show unknown flags.

Just to be safe, we're limiting the app names we're showing to 20, and environments per app name to 10.

Required some plumbing.

### Basic example
<img width="1350" height="866" alt="image" src="https://github.com/user-attachments/assets/ad8ee198-e5f8-45e4-8e3b-f2d8b7701cf9" />

### App name search example, with highlight

<img width="367" height="204" alt="image" src="https://github.com/user-attachments/assets/a1cc27ee-9ca1-4980-a3af-c08302c1d617" />
