### PR TITLE
chore: make create feature flag button in unknown flags a text button

### DIFF
--- a/frontend/src/component/unknownFlags/UnknownFlagsActionsCell.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsActionsCell.tsx
@@ -36,7 +36,7 @@ export const UnknownFlagsActionsCell = ({
                     )
                 }
             >
-                Create feature flag
+                Create flag
             </PermissionButton>
         </StyledBox>
     );

--- a/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
@@ -122,7 +122,7 @@ export const UnknownFlagsTable = () => {
                         suggestedProject={suggestedProject}
                     />
                 ),
-                width: 160,
+                width: 120,
                 disableSortBy: true,
             },
             // Always hidden -- for search


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3835/make-create-feature-flag-a-variant=text-button-instead-of-an-icon

Makes "create feature flag" button in unknown flags a text button.

<img width="1130" height="480" alt="image" src="https://github.com/user-attachments/assets/2a5cb8f9-d0d1-486e-aaf9-cc02f39a2b6f" />