### PR TITLE
chore: promote unknown flags to a stable OpenAPI tag

### DIFF
--- a/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
@@ -42,8 +42,8 @@ export default class UnknownFlagsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     operationId: 'getUnknownFlags',
-                    tags: ['Unstable'],
-                    summary: 'Get unknown flag reports',
+                    tags: ['Unknown Flags'],
+                    summary: 'Get unknown flags',
                     description:
                         'Returns a list of unknown flag reports from the last 24 hours, if any. Maximum of 1000.',
                     responses: {

--- a/src/lib/openapi/util/openapi-tags.ts
+++ b/src/lib/openapi/util/openapi-tags.ts
@@ -147,6 +147,10 @@ const OPENAPI_TAGS = [
         description: 'API for information about telemetry collection',
     },
     {
+        name: 'Unknown Flags',
+        description: 'Endpoints related to unknown flags.',
+    },
+    {
         name: 'Unleash Edge',
         description:
             'Endpoints related to [Unleash Edge](https://docs.getunleash.io/reference/unleash-edge).',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3832/promote-api-to-a-stable-openapi-tag

Promotes the Unknown Flags API to a stable OpenAPI tag as we prepare for GA.