### PR TITLE
fix: show first date in archived to created chart

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -176,6 +176,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                     grid: {
                         display: false,
                     },
+                    ticks: { source: 'data' },
                 },
                 y: {
                     type: 'linear' as const,


### PR DESCRIPTION
Ensures that the first date of the data is also shown.

Before:
<img width="1144" height="441" alt="image" src="https://github.com/user-attachments/assets/33da968a-4f44-4ca9-825e-d19471cff00a" />


After:
<img width="1132" height="435" alt="image" src="https://github.com/user-attachments/assets/65d009d4-5bcb-40d0-abb6-05be81c9a361" />
