### PR TITLE
chore: Add a cover for when we don't have enough data to show the chart

### DIFF
--- a/frontend/src/component/insights/GraphCover.tsx
+++ b/frontend/src/component/insights/GraphCover.tsx
@@ -1,0 +1,32 @@
+import { styled } from '@mui/material';
+import type { FC, PropsWithChildren } from 'react';
+
+const StyledCover = styled('div')(({ theme }) => ({
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    zIndex: theme.zIndex.appBar,
+    '&::before': {
+        zIndex: theme.zIndex.fab,
+        content: '""',
+        position: 'absolute',
+        inset: 0,
+        backgroundColor: theme.palette.background.paper,
+        opacity: 0.8,
+    },
+}));
+
+const StyledCoverContent = styled('div')(({ theme }) => ({
+    zIndex: theme.zIndex.modal,
+    margin: 'auto',
+    color: theme.palette.text.secondary,
+    textAlign: 'center',
+}));
+
+export const GraphCover: FC<PropsWithChildren> = ({ children }) => {
+    return (
+        <StyledCover>
+            <StyledCoverContent>{children}</StyledCoverContent>
+        </StyledCover>
+    );
+};

--- a/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
+++ b/frontend/src/component/insights/components/LineChart/LineChartComponent.tsx
@@ -26,31 +26,10 @@ import { styled } from '@mui/material';
 import { createOptions } from './createChartOptions.ts';
 import merge from 'deepmerge';
 import { customHighlightPlugin } from 'component/common/Chart/customHighlightPlugin.ts';
+import { GraphCover } from 'component/insights/GraphCover.tsx';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     position: 'relative',
-}));
-
-const StyledCover = styled('div')(({ theme }) => ({
-    position: 'absolute',
-    inset: 0,
-    display: 'flex',
-    zIndex: theme.zIndex.appBar,
-    '&::before': {
-        zIndex: theme.zIndex.fab,
-        content: '""',
-        position: 'absolute',
-        inset: 0,
-        backgroundColor: theme.palette.background.paper,
-        opacity: 0.8,
-    },
-}));
-
-const StyledCoverContent = styled('div')(({ theme }) => ({
-    zIndex: theme.zIndex.modal,
-    margin: 'auto',
-    color: theme.palette.text.secondary,
-    textAlign: 'center',
 }));
 
 function mergeAll<T>(objects: Partial<T>[]): T {
@@ -113,11 +92,7 @@ const LineChartComponent: FC<{
                     )
                 }
                 elseShow={
-                    <StyledCover>
-                        <StyledCoverContent>
-                            {cover !== true ? cover : ' '}
-                        </StyledCoverContent>
-                    </StyledCover>
+                    <GraphCover>{cover !== true ? cover : ' '}</GraphCover>
                 }
             />
         </StyledContainer>

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -2,7 +2,7 @@ import 'chartjs-adapter-date-fns';
 import { type FC, useMemo, useState } from 'react';
 import type { InstanceInsightsSchema } from 'openapi';
 import { useProjectChartData } from 'component/insights/hooks/useProjectChartData';
-import { styled, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material';
 import type { GroupedDataByProject } from 'component/insights/hooks/useGroupedProjectTrends';
 import {
     CategoryScale,
@@ -26,6 +26,7 @@ import { customHighlightPlugin } from 'component/common/Chart/customHighlightPlu
 import { NotEnoughData } from 'component/insights/components/LineChart/LineChart.tsx';
 import { placeholderData } from './placeholderData.ts';
 import { Bar } from 'react-chartjs-2';
+import { GraphCover } from 'component/insights/GraphCover.tsx';
 
 ChartJS.register(
     CategoryScale,
@@ -45,28 +46,6 @@ interface ICreationArchiveChartProps {
     >;
     isLoading?: boolean;
 }
-
-const StyledCover = styled('div')(({ theme }) => ({
-    position: 'absolute',
-    inset: 0,
-    display: 'flex',
-    zIndex: theme.zIndex.appBar,
-    '&::before': {
-        zIndex: theme.zIndex.fab,
-        content: '""',
-        position: 'absolute',
-        inset: 0,
-        backgroundColor: theme.palette.background.paper,
-        opacity: 0.8,
-    },
-}));
-
-const StyledCoverContent = styled('div')(({ theme }) => ({
-    zIndex: theme.zIndex.modal,
-    margin: 'auto',
-    color: theme.palette.text.secondary,
-    textAlign: 'center',
-}));
 
 export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
     creationArchiveTrends,
@@ -231,7 +210,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                 },
             },
         }),
-        [theme, locationSettings, setTooltip],
+        [theme, locationSettings, setTooltip, useGraphCover],
     );
 
     return (
@@ -249,11 +228,9 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
             />
             <CreationArchiveRatioTooltip tooltip={tooltip} />
             {useGraphCover ? (
-                <StyledCover>
-                    <StyledCoverContent>
-                        {notEnoughData ? <NotEnoughData /> : isLoading}
-                    </StyledCoverContent>
-                </StyledCover>
+                <GraphCover>
+                    {notEnoughData ? <NotEnoughData /> : isLoading}
+                </GraphCover>
             ) : null}
         </>
     );

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -21,11 +21,11 @@ import type { TooltipState } from 'component/insights/components/LineChart/Chart
 import type { WeekData, RawWeekData } from './types.ts';
 import { createTooltip } from 'component/insights/components/LineChart/createTooltip.ts';
 import { CreationArchiveRatioTooltip } from './CreationArchiveRatioTooltip.tsx';
-import { Chart } from 'react-chartjs-2';
 import { getDateFnsLocale } from '../../getDateFnsLocale.ts';
 import { customHighlightPlugin } from 'component/common/Chart/customHighlightPlugin.ts';
 import { NotEnoughData } from 'component/insights/components/LineChart/LineChart.tsx';
-import { usePlaceholderData } from 'component/insights/hooks/usePlaceholderData.ts';
+import { placeholderData } from './placeholderData.ts';
+import { Bar } from 'react-chartjs-2';
 
 ChartJS.register(
     CategoryScale,
@@ -74,7 +74,6 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
 }) => {
     const creationVsArchivedChart = useProjectChartData(creationArchiveTrends);
     const theme = useTheme();
-    const placeholderData = usePlaceholderData();
     const { locationSettings } = useLocationSettings();
     const [tooltip, setTooltip] = useState<null | TooltipState>(null);
 
@@ -213,7 +212,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
                         display: false,
                     },
                     ticks: {
-                        source: 'data',
+                        source: 'data' as const,
                         display: !useGraphCover,
                     },
                 },
@@ -237,8 +236,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
 
     return (
         <>
-            <Chart
-                type='bar'
+            <Bar
                 data={data}
                 options={options}
                 height={100}

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/placeholderData.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/placeholderData.ts
@@ -1,0 +1,63 @@
+import type { ChartData } from 'chart.js';
+import type { WeekData } from './types.ts';
+
+const data = [
+    {
+        archivedFlags: 3,
+        totalCreatedFlags: 4,
+        archivePercentage: 75,
+        week: '2025-30',
+        date: '2025-07-27T01:00:00.000Z',
+    },
+    {
+        archivedFlags: 7,
+        totalCreatedFlags: 3,
+        archivePercentage: 140,
+        week: '2025-31',
+        date: '2025-08-03T01:00:00.000Z',
+    },
+    {
+        archivedFlags: 2,
+        totalCreatedFlags: 3,
+        archivePercentage: 50,
+        week: '2025-32',
+        date: '2025-08-10T01:00:00.000Z',
+    },
+    {
+        archivedFlags: 2,
+        totalCreatedFlags: 6,
+        archivePercentage: 25,
+        week: '2025-33',
+        date: '2025-08-17T00:40:40.606Z',
+    },
+    {
+        archivedFlags: 4,
+        totalCreatedFlags: 9,
+        archivePercentage: 66.66666666666666,
+        week: '2025-34',
+        date: '2025-08-24T00:29:19.583Z',
+    },
+];
+
+export const placeholderData: ChartData<any, WeekData[]> = {
+    datasets: [
+        {
+            label: 'Flags archived',
+            data,
+            parsing: {
+                yAxisKey: 'archivedFlags',
+                xAxisKey: 'date',
+            },
+            order: 1,
+        },
+        {
+            label: 'Flags created',
+            data,
+            parsing: {
+                yAxisKey: 'totalCreatedFlags',
+                xAxisKey: 'date',
+            },
+            order: 2,
+        },
+    ],
+};


### PR DESCRIPTION
Adds a cover to the archived vs created flag chart if we don't have enough data or if the data is loading. Follows the pattern established in the other analytics charts.

Because the values for a placeholder bar chart are different than for a placeholder line chart, I've added in actual placeholder values. This also makes the gives the chart in question two bars per category, even in the placeholder data, which matches nicely with the actual graph.

Before:
<img width="2272" height="974" alt="image" src="https://github.com/user-attachments/assets/3336717f-acc8-4d23-a208-138259d6d3c7" />


After: 
<img width="1131" height="487" alt="image" src="https://github.com/user-attachments/assets/5189e323-c636-4089-b4eb-30b231b09b8b" />

In context with the other charts: 
<img width="1392" height="1744" alt="image" src="https://github.com/user-attachments/assets/7809669c-dae8-496b-b89b-0913fab85c17" />

