### PR TITLE
chore: add unknown flag metric for unique flag names

### DIFF
--- a/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-store.ts
@@ -37,12 +37,16 @@ export type QueryParams = {
     }[];
 };
 
+type CountParams = {
+    unique?: boolean;
+};
+
 export interface IUnknownFlagsStore {
     insert(flags: UnknownFlagReport[]): Promise<void>;
     getAll(params?: QueryParams): Promise<UnknownFlag[]>;
     clear(hoursAgo: number): Promise<void>;
     deleteAll(): Promise<void>;
-    count(): Promise<number>;
+    count(params?: CountParams): Promise<number>;
 }
 
 export class UnknownFlagsStore implements IUnknownFlagsStore {
@@ -157,8 +161,12 @@ export class UnknownFlagsStore implements IUnknownFlagsStore {
         await this.db(TABLE).delete();
     }
 
-    async count(): Promise<number> {
-        const row = await this.db(TABLE).count('* as count').first();
+    async count({ unique }: CountParams = {}): Promise<number> {
+        const countQuery = unique
+            ? this.db(TABLE).countDistinct({ count: 'name' }).first()
+            : this.db(TABLE).count('* as count').first();
+
+        const row = await countQuery;
         return Number(row?.count ?? 0);
     }
 }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -761,7 +761,12 @@ export function registerPrometheusMetrics(
 
     const unknownFlagsGauge = createGauge({
         name: 'unknown_flags',
-        help: 'Number of unknown flags reported in the last 24 hours, if any. Maximum of 1000.',
+        help: 'Number of unknown flag reports (name + app + env) in the last 24 hours, if any.',
+    });
+
+    const unknownFlagsUniqueNamesGauge = createGauge({
+        name: 'unknown_flags_unique_names',
+        help: 'Number of unique unknown flag names reported in the last 24 hours, if any.',
     });
 
     // register event listeners
@@ -1230,6 +1235,11 @@ export function registerPrometheusMetrics(
                 const unknownFlags = await stores.unknownFlagsStore.count();
                 unknownFlagsGauge.reset();
                 unknownFlagsGauge.set(unknownFlags);
+
+                const unknownFlagsUniqueNames =
+                    await stores.unknownFlagsStore.count({ unique: true });
+                unknownFlagsUniqueNamesGauge.reset();
+                unknownFlagsUniqueNamesGauge.set(unknownFlagsUniqueNames);
             } catch (e) {}
         },
     };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3845/add-metric-for-unique-unknown-flag-names

Adds a new unknown flag metric for unique unknown flag names.

<img width="864" height="126" alt="image" src="https://github.com/user-attachments/assets/c20ce53e-eff3-4cda-af4b-f2c2aae8575c" />
