### PR TITLE
fix: Only show "not enough data" text when there isn't enough data.

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveChart.tsx
@@ -139,6 +139,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
     }, [creationVsArchivedChart, theme]);
 
     const useGraphCover = notEnoughData || isLoading;
+    const showNotEnoughDataText = notEnoughData && !isLoading;
     const data = useGraphCover ? placeholderData : aggregateOrProjectData;
 
     const options = useMemo(
@@ -229,7 +230,7 @@ export const CreationArchiveChart: FC<ICreationArchiveChartProps> = ({
             <CreationArchiveRatioTooltip tooltip={tooltip} />
             {useGraphCover ? (
                 <GraphCover>
-                    {notEnoughData ? <NotEnoughData /> : isLoading}
+                    {showNotEnoughDataText ? <NotEnoughData /> : isLoading}
                 </GraphCover>
             ) : null}
         </>


### PR DESCRIPTION
The previous implementation had a small bug where it would show "not enough data" even if the graph was loading. This commit fixes that.

While working, I thought that maybe we should keep the current data while we're fetching new data instead of adding a cover, but all the other graphs use a cover when loading, so I've not made any changes to that effect.

