### PR TITLE
fix: flag resolver isEnabled for variant configs

### DIFF
--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -49,7 +49,7 @@ export default class FlagResolver implements IFlagResolver {
         const exp = this.experiments[expName];
         if (exp) {
             if (typeof exp === 'boolean') return exp;
-            else return exp.enabled;
+            else if (exp.enabled) return exp.enabled;
         }
         return this.externalResolver.isEnabled(expName, context);
     }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Internal flag resolver was not allowing to use external flag resolver when experimental flag was configured with an object config.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
