### PR TITLE
fix: only load ga and gtm in production

### DIFF
--- a/website/src/components/VideoContent.jsx
+++ b/website/src/components/VideoContent.jsx
@@ -39,7 +39,7 @@ const LazyVideo = ({ url, title = 'YouTube video player' }) => {
                     className={styles.thumbnailImage}
                     src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
                     alt={`${title} thumbnail`}
-                    fetchPriority='high'
+                    fetchpriority='high'
                 />
                 <div className={styles.playButton}>
                     <svg

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -8,6 +8,11 @@ export default function Root({ children }: { children: React.ReactNode }) {
         }
 
         const loadGoogleAnalytics = () => {
+            // Skip Google Analytics in development
+            if (process.env.NODE_ENV === 'development') {
+                return;
+            }
+
             if (
                 window.gtag ||
                 document.querySelector('script[src*="googletagmanager"]')
@@ -33,6 +38,11 @@ export default function Root({ children }: { children: React.ReactNode }) {
         };
 
         const loadGoogleTagManager = () => {
+            // Skip GTM in development
+            if (process.env.NODE_ENV === 'development') {
+                return;
+            }
+
             if (
                 window.google_tag_manager ||
                 document.querySelector(


### PR DESCRIPTION
CookieYes was throwing an uncaught error triggered by GA and GTM scripts. We don't want analytics to run in development anyway, so I disabled them in these environments.