### PR TITLE
chore: add newStrategyModal flag

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -21,6 +21,7 @@ import { formatUnknownError } from 'utils/formatUnknownError';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ReleasePlanReviewDialog } from '../../FeatureView/FeatureOverview/ReleasePlan/ReleasePlanReviewDialog.tsx';
 import { FeatureStrategyMenuCards } from './FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 interface IFeatureStrategyMenuProps {
     label: string;
@@ -160,32 +161,13 @@ export const FeatureStrategyMenu = ({
 
     return (
         <StyledStrategyMenu onClick={(event) => event.stopPropagation()}>
-            <>
-                {displayReleasePlanButton ? (
-                    <PermissionButton
-                        data-testid='ADD_TEMPLATE_BUTTON'
-                        permission={CREATE_FEATURE_STRATEGY}
-                        projectId={projectId}
-                        environmentId={environmentId}
-                        onClick={openReleasePlans}
-                        aria-labelledby={dialogId}
-                        variant='outlined'
-                        sx={{ minWidth: matchWidth ? '282px' : 'auto' }}
-                        disabled={Boolean(disableReason)}
-                        tooltipProps={{
-                            title: disableReason ? disableReason : undefined,
-                        }}
-                    >
-                        Use template
-                    </PermissionButton>
-                ) : null}
-
+            {newStrategyModalEnabled ? (
                 <PermissionButton
                     data-testid='ADD_STRATEGY_BUTTON'
                     permission={CREATE_FEATURE_STRATEGY}
                     projectId={projectId}
                     environmentId={environmentId}
-                    onClick={openDefaultStrategyCreationModal}
+                    onClick={openMoreStrategies}
                     aria-labelledby={dialogId}
                     variant={variant}
                     sx={{ minWidth: matchWidth ? '282px' : 'auto' }}
@@ -194,26 +176,66 @@ export const FeatureStrategyMenu = ({
                         title: disableReason ? disableReason : undefined,
                     }}
                 >
-                    {label}
+                    Add strategy
                 </PermissionButton>
+            ) : (
+                <>
+                    {displayReleasePlanButton ? (
+                        <PermissionButton
+                            data-testid='ADD_TEMPLATE_BUTTON'
+                            permission={CREATE_FEATURE_STRATEGY}
+                            projectId={projectId}
+                            environmentId={environmentId}
+                            onClick={openReleasePlans}
+                            aria-labelledby={dialogId}
+                            variant='outlined'
+                            sx={{ minWidth: matchWidth ? '282px' : 'auto' }}
+                            disabled={Boolean(disableReason)}
+                            tooltipProps={{
+                                title: disableReason
+                                    ? disableReason
+                                    : undefined,
+                            }}
+                        >
+                            Use template
+                        </PermissionButton>
+                    ) : null}
 
-                <StyledAdditionalMenuButton
-                    permission={CREATE_FEATURE_STRATEGY}
-                    projectId={projectId}
-                    environmentId={environmentId}
-                    onClick={openMoreStrategies}
-                    variant='outlined'
-                    hideLockIcon
-                    disabled={Boolean(disableReason)}
-                    tooltipProps={{
-                        title: disableReason
-                            ? disableReason
-                            : 'More strategies',
-                    }}
-                >
-                    <MoreVert />
-                </StyledAdditionalMenuButton>
-            </>
+                    <PermissionButton
+                        data-testid='ADD_STRATEGY_BUTTON'
+                        permission={CREATE_FEATURE_STRATEGY}
+                        projectId={projectId}
+                        environmentId={environmentId}
+                        onClick={openDefaultStrategyCreationModal}
+                        aria-labelledby={dialogId}
+                        variant={variant}
+                        sx={{ minWidth: matchWidth ? '282px' : 'auto' }}
+                        disabled={Boolean(disableReason)}
+                        tooltipProps={{
+                            title: disableReason ? disableReason : undefined,
+                        }}
+                    >
+                        {label}
+                    </PermissionButton>
+
+                    <StyledAdditionalMenuButton
+                        permission={CREATE_FEATURE_STRATEGY}
+                        projectId={projectId}
+                        environmentId={environmentId}
+                        onClick={openMoreStrategies}
+                        variant='outlined'
+                        hideLockIcon
+                        disabled={Boolean(disableReason)}
+                        tooltipProps={{
+                            title: disableReason
+                                ? disableReason
+                                : 'More strategies',
+                        }}
+                    >
+                        <MoreVert />
+                    </StyledAdditionalMenuButton>
+                </>
+            )}
             <Dialog
                 open={isStrategyMenuDialogOpen}
                 onClose={onClose}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -6,7 +6,7 @@ import PermissionButton, {
 } from 'component/common/PermissionButton/PermissionButton';
 import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
 import { Dialog, styled } from '@mui/material';
-import { FeatureStrategyMenuCards } from './FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx';
+import { LegacyFeatureStrategyMenuCards } from './LegacyFeatureStrategyMenuCards/LegacyFeatureStrategyMenuCards.tsx';
 import { formatCreateStrategyPath } from '../FeatureStrategyCreate/FeatureStrategyCreate.tsx';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
@@ -20,6 +20,7 @@ import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ReleasePlanReviewDialog } from '../../FeatureView/FeatureOverview/ReleasePlan/ReleasePlanReviewDialog.tsx';
+import { FeatureStrategyMenuCards } from './FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx';
 
 interface IFeatureStrategyMenuProps {
     label: string;
@@ -77,6 +78,7 @@ export const FeatureStrategyMenu = ({
     const { isEnterprise } = useUiConfig();
     const displayReleasePlanButton = isEnterprise();
     const crProtected = isChangeRequestConfigured(environmentId);
+    const newStrategyModalEnabled = useUiFlag('newStrategyModal');
 
     const onClose = () => {
         setIsStrategyMenuDialogOpen(false);
@@ -222,22 +224,41 @@ export const FeatureStrategyMenu = ({
                     },
                 }}
             >
-                <FeatureStrategyMenuCards
-                    projectId={projectId}
-                    featureId={featureId}
-                    environmentId={environmentId}
-                    onlyReleasePlans={onlyReleasePlans}
-                    onAddReleasePlan={(template) => {
-                        setSelectedTemplate(template);
-                        addReleasePlan(template);
-                    }}
-                    onReviewReleasePlan={(template) => {
-                        setSelectedTemplate(template);
-                        setAddReleasePlanOpen(true);
-                        onClose();
-                    }}
-                    onClose={onClose}
-                />
+                {newStrategyModalEnabled ? (
+                    <FeatureStrategyMenuCards
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={environmentId}
+                        onlyReleasePlans={onlyReleasePlans}
+                        onAddReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            addReleasePlan(template);
+                        }}
+                        onReviewReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            setAddReleasePlanOpen(true);
+                            onClose();
+                        }}
+                        onClose={onClose}
+                    />
+                ) : (
+                    <LegacyFeatureStrategyMenuCards
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={environmentId}
+                        onlyReleasePlans={onlyReleasePlans}
+                        onAddReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            addReleasePlan(template);
+                        }}
+                        onReviewReleasePlan={(template) => {
+                            setSelectedTemplate(template);
+                            setAddReleasePlanOpen(true);
+                            onClose();
+                        }}
+                        onClose={onClose}
+                    />
+                )}
             </Dialog>
             {selectedTemplate && (
                 <ReleasePlanReviewDialog

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/LegacyFeatureStrategyMenuCards/LegacyFeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/LegacyFeatureStrategyMenuCards/LegacyFeatureStrategyMenuCards.tsx
@@ -113,7 +113,7 @@ const ClickableBoldText = styled(Link)(({ theme }) => ({
     },
 }));
 
-export const FeatureStrategyMenuCards = ({
+export const LegacyFeatureStrategyMenuCards = ({
     projectId,
     featureId,
     environmentId,
@@ -204,7 +204,9 @@ export const FeatureStrategyMenuCards = ({
     return (
         <GridContainer>
             <TitleRow>
-                <TitleText variant='h2'>Add strategy</TitleText>
+                <TitleText variant='h2'>
+                    {onlyReleasePlans ? 'Select template' : 'Add configuration'}
+                </TitleText>
                 <IconButton
                     size='small'
                     onClick={onClose}

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -87,6 +87,7 @@ export type UiFlags = {
     customMetrics?: boolean;
     impactMetrics?: boolean;
     lifecycleGraphs?: boolean;
+    newStrategyModal?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -57,7 +57,8 @@ export type IFlagKey =
     | 'lifecycleGraphs'
     | 'etagByEnv'
     | 'fetchMode'
-    | 'optimizeLifecycle';
+    | 'optimizeLifecycle'
+    | 'newStrategyModal';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -263,6 +264,10 @@ const flags: IFlags = {
             false,
         ),
     },
+    newStrategyModal: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_STRATEGY_MODAL,
+        false,
+    ),
 };
 
 export const defaultExperimentalOptions: IExperimentalOptions = {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -53,6 +53,7 @@ process.nextTick(async () => {
                         customMetrics: true,
                         impactMetrics: true,
                         lifecycleGraphs: true,
+                        newStrategyModal: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3865/add-newstrategymodal-feature-flag

Adds `newStrategyModal` feature flag.

The approach here is to duplicate the existing `FeatureStrategyMenuCards` into a `LegacyFeatureStrategyMenuCards`. We'll continue working on the `FeatureStrategyMenuCards` component while leaving `LegacyFeatureStrategyMenuCards` untouched. Once we're done with the implementation and remove the flag we can drop the legacy file.

I think it's easier to reduce our add strategy buttons to a single one right away (like we did with the `addConfiguration` flag in https://github.com/Unleash/unleash/pull/10420). This allows us to focus on the end result instead of having to implement things like "clicking the 'add release template' button should show the modal filtered to only release templates".

<img width="735" height="126" alt="image" src="https://github.com/user-attachments/assets/6d10fab2-d091-40f3-9c36-05a6f28f7dda" />

<img width="995" height="742" alt="image" src="https://github.com/user-attachments/assets/a0fb9366-89b5-44e1-a684-47ee30d6d36c" />