### PR TITLE
chore: new add strategy modal design

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -49,7 +49,7 @@ const StyledSectionHeader = styled(Box)(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    marginBottom: theme.spacing(1),
+    marginBottom: theme.spacing(0.5),
     width: '100%',
 }));
 

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -12,7 +12,7 @@ import { HelpIcon } from 'component/common/HelpIcon/HelpIcon.tsx';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview.ts';
 import { useState } from 'react';
 
-const RELEASE_TEMPLATE_LIMIT = 5;
+const RELEASE_TEMPLATE_DISPLAY_LIMIT = 5;
 
 const StyledContainer = styled(Box)(() => ({
     width: '100%',
@@ -166,7 +166,7 @@ export const FeatureStrategyMenuCards = ({
 
         const slicedTemplates = seeAllReleaseTemplates
             ? templates
-            : templates.slice(0, RELEASE_TEMPLATE_LIMIT);
+            : templates.slice(0, RELEASE_TEMPLATE_DISPLAY_LIMIT);
 
         return (
             <Box>
@@ -205,7 +205,8 @@ export const FeatureStrategyMenuCards = ({
                             />
                         ))}
                         {slicedTemplates.length < templates.length &&
-                            templates.length > RELEASE_TEMPLATE_LIMIT && (
+                            templates.length >
+                                RELEASE_TEMPLATE_DISPLAY_LIMIT && (
                                 <StyledViewAllTemplates>
                                     <Button
                                         variant='text'


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3870/new-modal-design

New "add strategy" modal base design.

We're still missing a few details, like the new card design and the filters at the top, but those will come in follow-up PRs.

### New layout

<img width="986" height="597" alt="image" src="https://github.com/user-attachments/assets/2bc83117-97a8-4b59-a187-73ef9a7d0469" />

### Default strategy tooltip, with a link to the default strategy settings

<img width="326" height="119" alt="image" src="https://github.com/user-attachments/assets/45da60cb-088b-4b6e-bead-f9ef13a2540b" />

### Default strategy with a custom title

<img width="318" height="163" alt="image" src="https://github.com/user-attachments/assets/9c9862db-f21d-409f-8dc1-63673f00ba2e" />
