### PR TITLE
fix: limit reset when no pagination bar

### DIFF
--- a/frontend/src/component/common/Table/PaginationBar/PaginationBar.tsx
+++ b/frontend/src/component/common/Table/PaginationBar/PaginationBar.tsx
@@ -1,5 +1,4 @@
 import type React from 'react';
-import { useEffect } from 'react';
 import { Box, Typography, Button, styled } from '@mui/material';
 import { ConditionallyRender } from '../../ConditionallyRender/ConditionallyRender.tsx';
 import { ReactComponent as ArrowRight } from 'assets/icons/arrowRight.svg';
@@ -61,12 +60,6 @@ export const PaginationBar: React.FC<PaginationBarProps> = ({
     fetchNextPage,
     setPageLimit,
 }) => {
-    useEffect(() => {
-        if (![25, 50, 75, 100].includes(pageSize)) {
-            setPageLimit(25);
-        }
-    }, [pageSize]);
-
     const itemRange =
         totalItems !== undefined && pageSize && totalItems > 1
             ? `${pageIndex * pageSize + 1}-${Math.min(

--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -51,6 +51,19 @@ export const usePersistentTableState = <T extends QueryParamConfigMap>(
         return reorderObject(tableState, [...searchParams.keys()]);
     }, [searchParams, tableState, reorderObject]);
 
+    useEffect(() => {
+        if (
+            tableState.limit &&
+            ![25, 50, 75, 100].includes(tableState.limit as number)
+        ) {
+            setTableStateInternal((prevState) => ({
+                ...prevState,
+                limit: 25,
+                offset: 0, // Reset offset when changing limit
+            }));
+        }
+    }, [tableState.limit, setTableStateInternal]);
+
     type SetTableStateInternalParam = Parameters<
         typeof setTableStateInternal
     >[0];


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Allow only predefined pagination limits even when no pagination bar.
Previously we were enforcing page limit only when pagination bar was enabled.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
