### PR TITLE
chore: add verbose logs to AWS IAM auth logic, add DB access checker

### DIFF
--- a/src/lib/db/aws-iam.ts
+++ b/src/lib/db/aws-iam.ts
@@ -16,7 +16,12 @@ export const getDBPasswordResolver = (db: IDBOption): PasswordResolver => {
             port: db.port,
             username: db.user,
         });
-        return async () => signer.getAuthToken();
+        return async () => {
+            console.log('[AWS RDS SIGNER] Getting token...');
+            const token = await signer.getAuthToken();
+            console.log(`[AWS RDS SIGNER] Got token: ${token}`);
+            return token;
+        };
     }
 
     return async () => db.password;

--- a/src/lib/db/aws-iam.ts
+++ b/src/lib/db/aws-iam.ts
@@ -19,7 +19,7 @@ export const getDBPasswordResolver = (db: IDBOption): PasswordResolver => {
         return async () => {
             console.log('[AWS RDS SIGNER] Getting token...');
             const token = await signer.getAuthToken();
-            console.log(`[AWS RDS SIGNER] Got token: ${token}`);
+            console.log(`[AWS RDS SIGNER] Got token!`);
             return token;
         };
     }

--- a/src/lib/db/db-access-checker.ts
+++ b/src/lib/db/db-access-checker.ts
@@ -1,0 +1,33 @@
+import { Client } from 'pg';
+import type { IDBOption, Logger } from '../server-impl.js';
+import { getDBPassword } from './aws-iam.js';
+
+export const dbAccessChecker = async (db: IDBOption, logger: Logger) => {
+    if (!db.awsIamAuth) return;
+
+    logger.info(
+        'Using AWS IAM authentication for database connection. Checking DB access...',
+    );
+
+    const password = await getDBPassword(db);
+
+    const client = new Client({
+        host: db.host,
+        port: db.port,
+        user: db.user,
+        database: db.database,
+        password,
+        statement_timeout: 10_000,
+        connectionTimeoutMillis: 10_000,
+    });
+    try {
+        await client.connect();
+        await client.query('SELECT 1');
+        logger.info('DB auth/connection successful');
+    } catch (e: any) {
+        const code = e?.code ?? 'unknown';
+        throw new Error(`DB auth/connection failed (pg code: ${code})`);
+    } finally {
+        await client.end().catch(() => {});
+    }
+};

--- a/src/lib/db/db-pool.ts
+++ b/src/lib/db/db-pool.ts
@@ -9,13 +9,6 @@ export function createDb({
     getLogger,
 }: Pick<IUnleashConfig, 'db' | 'getLogger'>): Knex {
     const logger = getLogger('db-pool.js');
-
-    if (db.awsIamAuth) {
-        logger.info(
-            `createDb: iam=${Boolean(db.awsIamAuth)} host=${db.host} port=${db.port} db=${db.database} user=${db.user} ssl=${Boolean(db.ssl)}`,
-        );
-    }
-
     return knex({
         client: 'pg',
         version: db.version,

--- a/src/lib/db/db-pool.ts
+++ b/src/lib/db/db-pool.ts
@@ -9,6 +9,13 @@ export function createDb({
     getLogger,
 }: Pick<IUnleashConfig, 'db' | 'getLogger'>): Knex {
     const logger = getLogger('db-pool.js');
+
+    if (db.awsIamAuth) {
+        logger.info(
+            `createDb: iam=${Boolean(db.awsIamAuth)} host=${db.host} port=${db.port} db=${db.database} user=${db.user} ssl=${Boolean(db.ssl)}`,
+        );
+    }
+
     return knex({
         client: 'pg',
         version: db.version,

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -186,6 +186,7 @@ import { UPDATE_REVISION } from './features/feature-toggle/configuration-revisio
 import type { IFeatureUsageInfo } from './services/version-service.js';
 import { defineImpactMetrics } from './features/metrics/impact/define-impact-metrics.js';
 import type { IClientInstance } from './types/stores/client-instance-store.js';
+import { dbAccessChecker } from './db/db-access-checker.js';
 
 export async function initialServiceSetup(
     { authentication }: Pick<IUnleashConfig, 'authentication'>,
@@ -335,6 +336,10 @@ async function start(
 ): Promise<IUnleash> {
     const config = createConfig(opts);
     const logger = config.getLogger('server-impl.js');
+
+    if (config.db.awsIamAuth) {
+        await dbAccessChecker(config.db, logger);
+    }
 
     try {
         if (config.db.disableMigration) {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3874/add-verbose-logs-to-aws-iam-auth-logic-including-a-db-access-checker

Adds verbose logs to our new AWS IAM DB auth logic. Also adds a DB access checker that runs before our migrator and fails fast in case something is wrong with DB access.

This should not affect the regular auth path.