### PR TITLE
chore: add quick filters to add strategy modal

### DIFF
--- a/frontend/src/component/common/QuickFilters/QuickFilters.tsx
+++ b/frontend/src/component/common/QuickFilters/QuickFilters.tsx
@@ -1,0 +1,54 @@
+import { Box, Chip, styled } from '@mui/material';
+
+const StyledChip = styled(Chip, {
+    shouldForwardProp: (prop) => prop !== 'isActive',
+})<{
+    isActive?: boolean;
+}>(({ theme, isActive = false }) => ({
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(0.5),
+    fontSize: theme.fontSizes.smallerBody,
+    height: 'auto',
+    ...(isActive && {
+        backgroundColor: theme.palette.secondary.light,
+        fontWeight: 'bold',
+        borderColor: theme.palette.primary.main,
+        color: theme.palette.primary.main,
+    }),
+    ':focus-visible': {
+        outline: `1px solid ${theme.palette.primary.main}`,
+        borderColor: theme.palette.primary.main,
+    },
+}));
+
+const StyledContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+}));
+
+interface IQuickFiltersProps<T> {
+    filters: Array<{ label: string; value: T }>;
+    value: T;
+    onChange: (value: T) => void;
+}
+
+export const QuickFilters = <T extends string | null>({
+    filters,
+    value: currentValue,
+    onChange,
+}: IQuickFiltersProps<T>) => (
+    <StyledContainer>
+        {filters.map(({ label, value }) => (
+            <StyledChip
+                key={label}
+                data-loading
+                label={label}
+                variant='outlined'
+                isActive={value === currentValue}
+                onClick={() => onChange(value)}
+            />
+        ))}
+    </StyledContainer>
+);

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -251,7 +251,6 @@ export const FeatureStrategyMenu = ({
                         projectId={projectId}
                         featureId={featureId}
                         environmentId={environmentId}
-                        onlyReleasePlans={onlyReleasePlans}
                         onAddReleasePlan={(template) => {
                             setSelectedTemplate(template);
                             addReleasePlan(template);

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
@@ -1,0 +1,143 @@
+import { useReleasePlanTemplates } from 'hooks/api/getters/useReleasePlanTemplates/useReleasePlanTemplates';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import FactCheckOutlinedIcon from '@mui/icons-material/FactCheckOutlined';
+import { FeatureReleasePlanCard } from '../FeatureReleasePlanCard/FeatureReleasePlanCard.tsx';
+import type { IReleasePlanTemplate } from 'interfaces/releasePlans.ts';
+import { Box, Button, styled, Typography } from '@mui/material';
+import type { StrategyFilterValue } from './FeatureStrategyMenuCards.tsx';
+import type { Dispatch, SetStateAction } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+    FeatureStrategyMenuCardsSection,
+    StyledStrategyModalSectionHeader,
+} from './FeatureStrategyMenuCardsSection.tsx';
+
+const RELEASE_TEMPLATE_DISPLAY_LIMIT = 5;
+
+const StyledIcon = styled('span')(({ theme }) => ({
+    width: theme.spacing(3),
+    '& > svg': {
+        fill: theme.palette.primary.main,
+        width: theme.spacing(2.25),
+        height: theme.spacing(2.25),
+    },
+    display: 'flex',
+    alignItems: 'center',
+}));
+
+const StyledNoTemplatesContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    backgroundColor: theme.palette.neutral.light,
+    borderRadius: theme.shape.borderRadiusMedium,
+    padding: theme.spacing(3),
+    width: 'auto',
+}));
+
+const StyledNoTemplatesTitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.caption.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    marginBottom: theme.spacing(1),
+    display: 'flex',
+    alignItems: 'center',
+}));
+
+const StyledNoTemplatesDescription = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledViewAllTemplates = styled(Box)({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+});
+
+const StyledLink = styled(RouterLink)({
+    textDecoration: 'none',
+    '&:hover': {
+        textDecoration: 'underline',
+    },
+});
+
+interface IFeatureStrategyMenuCardsReleaseTemplatesProps {
+    onAddReleasePlan: (template: IReleasePlanTemplate) => void;
+    onReviewReleasePlan: (template: IReleasePlanTemplate) => void;
+    filter: StrategyFilterValue;
+    setFilter: Dispatch<SetStateAction<StrategyFilterValue>>;
+}
+
+export const FeatureStrategyMenuCardsReleaseTemplates = ({
+    onAddReleasePlan,
+    onReviewReleasePlan,
+    filter,
+    setFilter,
+}: IFeatureStrategyMenuCardsReleaseTemplatesProps) => {
+    const { isEnterprise } = useUiConfig();
+    const { templates } = useReleasePlanTemplates();
+
+    if (!isEnterprise()) {
+        return null;
+    }
+
+    const slicedTemplates =
+        filter === 'releaseTemplates'
+            ? templates
+            : templates.slice(0, RELEASE_TEMPLATE_DISPLAY_LIMIT);
+
+    return (
+        <Box>
+            <StyledStrategyModalSectionHeader>
+                <Typography color='inherit' variant='body2'>
+                    Release templates
+                </Typography>
+            </StyledStrategyModalSectionHeader>
+            {!templates.length ? (
+                <StyledNoTemplatesContainer>
+                    <StyledNoTemplatesTitle>
+                        <StyledIcon>
+                            <FactCheckOutlinedIcon />
+                        </StyledIcon>
+                        Create your own release templates
+                    </StyledNoTemplatesTitle>
+                    <StyledNoTemplatesDescription>
+                        Standardize your rollouts and save time by reusing
+                        predefined strategies. Find release templates in the
+                        side menu under{' '}
+                        <StyledLink to='/release-templates'>
+                            Configure &gt; Release templates
+                        </StyledLink>
+                    </StyledNoTemplatesDescription>
+                </StyledNoTemplatesContainer>
+            ) : (
+                <FeatureStrategyMenuCardsSection>
+                    {slicedTemplates.map((template) => (
+                        <FeatureReleasePlanCard
+                            key={template.id}
+                            template={template}
+                            onClick={() => onAddReleasePlan(template)}
+                            onPreviewClick={() => onReviewReleasePlan(template)}
+                        />
+                    ))}
+                    {slicedTemplates.length < templates.length &&
+                        templates.length > RELEASE_TEMPLATE_DISPLAY_LIMIT && (
+                            <StyledViewAllTemplates>
+                                <Button
+                                    variant='text'
+                                    size='small'
+                                    onClick={() =>
+                                        setFilter('releaseTemplates')
+                                    }
+                                >
+                                    View all available templates
+                                </Button>
+                            </StyledViewAllTemplates>
+                        )}
+                </FeatureStrategyMenuCardsSection>
+            )}
+        </Box>
+    );
+};

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsSection.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsSection.tsx
@@ -1,0 +1,40 @@
+import { Box, styled, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
+
+export const StyledStrategyModalSectionHeader = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
+    width: '100%',
+}));
+
+const StyledStrategyModalSectionGrid = styled(Box)(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: theme.spacing(2),
+    width: '100%',
+}));
+
+interface IFeatureStrategyMenuCardsSectionProps {
+    title?: string;
+    children: ReactNode;
+}
+
+export const FeatureStrategyMenuCardsSection = ({
+    title,
+    children,
+}: IFeatureStrategyMenuCardsSectionProps) => (
+    <Box>
+        {title && (
+            <StyledStrategyModalSectionHeader>
+                <Typography color='inherit' variant='body2'>
+                    {title}
+                </Typography>
+            </StyledStrategyModalSectionHeader>
+        )}
+        <StyledStrategyModalSectionGrid>
+            {children}
+        </StyledStrategyModalSectionGrid>
+    </Box>
+);


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3868/add-strategy-filters-at-the-top

Adds quick filters to our "add strategy" modal.

`FeatureStrategyMenuCards.tsx` was getting increasingly complex, so this includes some refactoring.

My quick filters implementation was generic enough that I added `QuickFilters.tsx` as a common component, maybe we can reuse it in the future.

<img width="991" height="663" alt="image" src="https://github.com/user-attachments/assets/352b6d2d-c975-4cb1-9799-163dfb153ccb" />

<img width="985" height="358" alt="image" src="https://github.com/user-attachments/assets/a7d20dab-2774-409f-8940-f0d1a980b819" />
