### PR TITLE
chore: Update from "toggles" to "flags"

### DIFF
--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
@@ -84,7 +84,7 @@ export const FeaturesCell: VFC<FeaturesCellProps> = ({ value, project }) => {
                             </StyledTooltipContainer>
                         }
                     >
-                        {featureNames?.length} toggles
+                        {featureNames?.length} flags
                     </TooltipLink>
                 }
             />


### PR DESCRIPTION
Updates the features cell text when you have lots of flags affected.

Looks like we missed this one in a previous renaming attempt.

Before:
<img width="245" height="154" alt="image" src="https://github.com/user-attachments/assets/922334f4-a0f1-4dee-9d14-3c9b3f77f32c" />

After:
<img width="275" height="170" alt="image" src="https://github.com/user-attachments/assets/7fa0f454-e695-46aa-918b-c22b97e94187" />