### PR TITLE
chore: change from "change requests" to "open" in project change request tabs

### DIFF
--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
@@ -104,7 +104,7 @@ export const ChangeRequestsTabs = ({
 
     const tabs = [
         {
-            title: 'Change requests',
+            title: 'Open',
             data: openChangeRequests,
             type: 'open' as const,
         },


### PR DESCRIPTION
For some reason, the two change request tabs are called "Change Requests" and "Closed", instead of "Open" and "Closed".

I suspect this may be an error, but this fixes it. 

Before:
<img width="383" height="176" alt="image" src="https://github.com/user-attachments/assets/faf95827-f384-4187-bc0b-f32b8fbbef41" />

After:
<img width="372" height="166" alt="image" src="https://github.com/user-attachments/assets/67528024-7783-42e3-b014-bad4f7bc871b" />
