### PR TITLE
Fix: use locale string for change request time badge.

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
@@ -8,6 +8,7 @@ import Close from '@mui/icons-material/Close';
 import ErrorIcon from '@mui/icons-material/Error';
 import PauseCircle from '@mui/icons-material/PauseCircle';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
+import { useLocationSettings } from 'hooks/useLocationSettings';
 
 interface IChangeRequestStatusBadgeProps {
     changeRequest: ChangeRequestType | undefined;
@@ -59,7 +60,10 @@ export const ChangeRequestStatusBadge: VFC<IChangeRequestStatusBadgeProps> = ({
             );
         case 'Scheduled': {
             const { schedule } = changeRequest;
-            const scheduledAt = new Date(schedule.scheduledAt).toLocaleString();
+            const { locationSettings } = useLocationSettings();
+            const scheduledAt = new Date(schedule.scheduledAt).toLocaleString(
+                locationSettings.locale,
+            );
 
             const { color, icon, tooltipTitle } = (() => {
                 switch (schedule.status) {


### PR DESCRIPTION
Uses the user's preferred date / time formatting for the scheduled at time in CR schedule badges.

Before (en-US formatting):
<img width="291" height="58" alt="image" src="https://github.com/user-attachments/assets/edb04292-4678-4bfd-93a1-8fd2a3f01a1f" />

After (ja formatting):
<img width="308" height="106" alt="image" src="https://github.com/user-attachments/assets/9828355f-0c23-4b8f-bef3-a0173e92c306" />
