### PR TITLE
Add entrypoint script to only migrate and exit gracefully

### DIFF
--- a/src/migrate-only.ts
+++ b/src/migrate-only.ts
@@ -1,0 +1,17 @@
+import { createConfig } from './lib/create-config.js';
+import { migrateDb } from './migrator.js';
+
+async function runMigrations() {
+  try {
+      console.log('Starting database migrations...');
+      const config = createConfig({});
+      await migrateDb(config);
+      console.log('Migrations completed successfully!');
+      process.exit(0);
+  } catch (error) {
+      console.error('Migration failed:', error);
+      process.exit(1);
+  }
+}
+
+runMigrations();


### PR DESCRIPTION
## About the changes

With the introduction of PG IAM authentication, it is not possible to rely on the raw db-migrate utility to have a task that simply migrates the database and doesn't attempt to start the unleash server.

This PR proposes to introduce a new entrypoint script to launch migrations and exit gracefully, while supporting among other things PG IAM auth.

