### PR TITLE
fix: cherry-pick OSS export-fixes from main

### DIFF
--- a/src/lib/db/feature-environment-store.test.ts
+++ b/src/lib/db/feature-environment-store.test.ts
@@ -1,0 +1,35 @@
+import dbInit, { type ITestDb } from '../../test/e2e/helpers/database-init.js';
+import getLogger from '../../test/fixtures/no-logger.js';
+import { SYSTEM_USER_ID } from '../server-impl.js';
+
+let db: ITestDb;
+
+beforeAll(async () => {
+    db = await dbInit('feature_environment_store', getLogger, { isOss: true });
+    getLogger.setMuteError(true);
+});
+
+afterAll(async () => {
+    if (db) {
+        await db.destroy();
+    }
+    getLogger.setMuteError(false);
+});
+
+test('getAllByFeatures returns correct enabled state', async () => {
+    await db.stores.featureToggleStore.create('default', {
+        name: 'test-toggle',
+        createdByUserId: SYSTEM_USER_ID,
+    });
+    await db.stores.featureEnvironmentStore.addEnvironmentToFeature(
+        'test-toggle',
+        'development',
+        false,
+    );
+    const featureEnvs =
+        await db.stores.featureEnvironmentStore.getAllByFeatures(
+            ['test-toggle'],
+            'development',
+        );
+    expect(featureEnvs[0].enabled).toBe(false);
+});

--- a/src/lib/db/feature-environment-store.ts
+++ b/src/lib/db/feature-environment-store.ts
@@ -124,6 +124,13 @@ export class FeatureEnvironmentStore implements IFeatureEnvironmentStore {
                     'default',
                     'development',
                     'production',
+                ])
+                .select([
+                    'feature_name',
+                    'environment',
+                    'variants',
+                    'last_seen_at',
+                    `${T.featureEnvs}.enabled`,
                 ]);
         }
         return queryBuilder;


### PR DESCRIPTION
This cherry-picks the export fixes for OSS from main so we can release OSS 7.2.1