### PR TITLE
chore: update release template preview dialog

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -19,6 +19,7 @@ import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePla
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { LegacyReleasePlanReviewDialog } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/LegacyReleasePlanReviewDialog.tsx';
 import { ReleasePlanReviewDialog } from '../../FeatureView/FeatureOverview/ReleasePlan/ReleasePlanReviewDialog.tsx';
 import {
     FeatureStrategyMenuCards,
@@ -288,23 +289,45 @@ export const FeatureStrategyMenu = ({
                 )}
             </Dialog>
             {selectedTemplate && (
-                <ReleasePlanReviewDialog
-                    open={addReleasePlanOpen}
-                    setOpen={(open) => {
-                        setAddReleasePlanOpen(open);
-                        if (!open) {
-                            setIsStrategyMenuDialogOpen(true);
-                        }
-                    }}
-                    onConfirm={() => {
-                        addReleasePlan(selectedTemplate);
-                    }}
-                    template={selectedTemplate}
-                    projectId={projectId}
-                    featureName={featureId}
-                    environment={environmentId}
-                    crProtected={crProtected}
-                />
+                <>
+                    {newStrategyModalEnabled ? (
+                        <ReleasePlanReviewDialog
+                            open={addReleasePlanOpen}
+                            setOpen={(open) => {
+                                setAddReleasePlanOpen(open);
+                                if (!open) {
+                                    setIsStrategyMenuDialogOpen(true);
+                                }
+                            }}
+                            onConfirm={() => {
+                                addReleasePlan(selectedTemplate);
+                            }}
+                            template={selectedTemplate}
+                            projectId={projectId}
+                            featureName={featureId}
+                            environment={environmentId}
+                            crProtected={crProtected}
+                        />
+                    ) : (
+                        <LegacyReleasePlanReviewDialog
+                            open={addReleasePlanOpen}
+                            setOpen={(open) => {
+                                setAddReleasePlanOpen(open);
+                                if (!open) {
+                                    setIsStrategyMenuDialogOpen(true);
+                                }
+                            }}
+                            onConfirm={() => {
+                                addReleasePlan(selectedTemplate);
+                            }}
+                            template={selectedTemplate}
+                            projectId={projectId}
+                            featureName={featureId}
+                            environment={environmentId}
+                            crProtected={crProtected}
+                        />
+                    )}
+                </>
             )}
         </StyledStrategyMenu>
     );

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -22,7 +22,7 @@ const StyledCard = styled('div', {
     display: 'flex',
     alignItems: 'center',
     width: '100%',
-    height: '100%',
+    height: theme.spacing(10),
     maxWidth: '30rem',
     padding: theme.spacing(2),
     color: 'inherit',

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/LegacyReleasePlanReviewDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/LegacyReleasePlanReviewDialog.tsx
@@ -8,6 +8,7 @@ import {
     Box,
     IconButton,
     Dialog,
+    DialogContent,
     DialogActions,
     Button,
 } from '@mui/material';
@@ -19,27 +20,38 @@ import CloseIcon from '@mui/icons-material/Close';
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
-        width: theme.breakpoints.values.md,
+        maxWidth: theme.spacing(85),
     },
-}));
-
-const StyledHeader = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: theme.spacing(4, 4, 2, 4),
-}));
-
-const StyledSubHeader = styled(Box)(({ theme }) => ({
-    padding: theme.spacing(0, 3, 3, 3),
-}));
-
-const StyledBackIcon = styled(ArrowBackIcon)(({ theme }) => ({
-    marginRight: theme.spacing(1),
 }));
 
 const StyledDialogActions = styled(DialogActions)(({ theme }) => ({
     padding: theme.spacing(2, 4, 4),
+}));
+
+const TopRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: theme.spacing(2),
+}));
+
+const BackButton = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+}));
+
+const StyledBackIcon = styled(ArrowBackIcon)(({ theme }) => ({
+    marginRight: theme.spacing(1),
+    color: theme.palette.primary.main,
+    display: 'flex',
+    alignSelf: 'center',
+}));
+
+const BackText = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightMedium,
+    display: 'flex',
+    alignItems: 'center',
+    lineHeight: 1,
 }));
 
 interface IReleasePlanAddDialogProps {
@@ -53,7 +65,7 @@ interface IReleasePlanAddDialogProps {
     crProtected?: boolean;
 }
 
-export const ReleasePlanReviewDialog = ({
+export const LegacyReleasePlanReviewDialog = ({
     open,
     setOpen,
     onConfirm,
@@ -87,50 +99,48 @@ export const ReleasePlanReviewDialog = ({
 
     return (
         <StyledDialog open={open} onClose={handleClose} fullWidth maxWidth='md'>
-            <StyledHeader>
-                <Typography variant='h2'>Add strategy</Typography>
-                <IconButton
-                    size='small'
-                    onClick={handleClose}
-                    edge='end'
-                    aria-label='close'
-                >
-                    <CloseIcon fontSize='small' />
-                </IconButton>
-            </StyledHeader>
-            <StyledSubHeader>
-                <Button variant='text' onClick={handleClose}>
-                    <StyledBackIcon />
-                    Go back
-                </Button>
-            </StyledSubHeader>
-            {activeReleasePlan && (
-                <Box sx={{ px: 4, pb: 2 }}>
-                    <Alert severity='error'>
+            <DialogContent>
+                <TopRow>
+                    <BackButton onClick={handleClose}>
+                        <StyledBackIcon />
+                        <BackText variant='body2' color='primary'>
+                            Go back
+                        </BackText>
+                    </BackButton>
+                    <IconButton
+                        size='small'
+                        onClick={handleClose}
+                        edge='end'
+                        aria-label='close'
+                    >
+                        <CloseIcon fontSize='small' />
+                    </IconButton>
+                </TopRow>
+
+                {activeReleasePlan && (
+                    <Alert severity='error' sx={{ mb: 1 }}>
                         This feature environment currently has{' '}
                         <strong>{activeReleasePlan.name}</strong> -{' '}
                         <strong>{activeReleasePlan.milestones[0].name}</strong>
                         {environmentEnabled ? ' running' : ' paused'}. Adding a
                         new release plan will replace the existing release plan.
                     </Alert>
-                </Box>
-            )}
-            <Box sx={{ px: 2 }}>
-                <ReleasePlan plan={planPreview} readonly />
-            </Box>
-            {crProtected && (
-                <Box sx={{ px: 4, pt: 1 }}>
-                    <Typography>
+                )}
+                <div>
+                    <ReleasePlan plan={planPreview} readonly />
+                </div>
+                {crProtected && (
+                    <Typography sx={{ mt: 4 }}>
                         <strong>Adding</strong> release template{' '}
                         <strong>{template?.name}</strong> to{' '}
                         <strong>{featureName}</strong> in{' '}
                         <strong>{environment}</strong>.
                     </Typography>
-                </Box>
-            )}
+                )}
+            </DialogContent>
             <StyledDialogActions>
                 <Button variant='contained' color='primary' onClick={onConfirm}>
-                    {crProtected ? 'Add suggestion to draft' : 'Apply template'}
+                    {crProtected ? 'Add suggestion to draft' : 'Use template'}
                 </Button>
             </StyledDialogActions>
         </StyledDialog>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3888/update-the-release-templates-preview-dialog-to-match-the-new-designs

Updates the release template preview dialog when using the new "add strategy" modal, so it better matches the new design.

Used the legacy file pattern to leave the previous modal component unchanged.

<img width="992" height="467" alt="image" src="https://github.com/user-attachments/assets/fd000822-c987-47be-b8a4-3f137e0291ec" />

<img width="979" height="576" alt="image" src="https://github.com/user-attachments/assets/02a27d5c-4480-4a49-88ae-0d573ff0f640" />
