### PR TITLE
feat: histogram impact metric ingestion

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -259,7 +259,7 @@ export default class ClientMetricsServiceV2 {
             this.impactMetricsTranslator.translateMetrics(value);
         } catch (e) {
             // impact metrics should not affect other metrics on failure
-            this.logger.warn(e);
+            this.logger.warn('Impact metrics registration failed:', e);
         }
     }
 

--- a/src/lib/features/metrics/impact/batch-histogram.ts
+++ b/src/lib/features/metrics/impact/batch-histogram.ts
@@ -15,6 +15,7 @@ export class BatchHistogram {
     private name: string;
     private help: string;
     private registry: Registry;
+    public labelNames: string[] = [];
 
     // Store accumulated data for each label combination
     private store: Map<
@@ -65,7 +66,7 @@ export class BatchHistogram {
 
     private createLabelKey(labels: Record<string, string | number>): string {
         const sortedKeys = Object.keys(labels).sort();
-        return sortedKeys.map((key) => `${key}:${labels[key]}`).join(',');
+        return JSON.stringify(sortedKeys.map((key) => [key, labels[key]]));
     }
 
     reset(): void {
@@ -78,10 +79,12 @@ export class BatchHistogram {
         for (const [labelKey, data] of this.store) {
             const labels: Record<string, string | number> = {};
             if (labelKey) {
-                labelKey.split(',').forEach((pair) => {
-                    const [key, value] = pair.split(':');
-                    labels[key] = value;
-                });
+                const parsedLabels = JSON.parse(labelKey);
+                parsedLabels.forEach(
+                    ([key, value]: [string, string | number]) => {
+                        labels[key] = value;
+                    },
+                );
             }
 
             for (const [le, cumulativeCount] of Array.from(

--- a/src/lib/features/metrics/impact/batch-histogram.ts
+++ b/src/lib/features/metrics/impact/batch-histogram.ts
@@ -31,10 +31,12 @@ export class BatchHistogram {
         name: string;
         help: string;
         registry: Registry;
+        labelNames?: string[];
     }) {
         this.name = config.name;
         this.help = config.help;
         this.registry = config.registry;
+        this.labelNames = config.labelNames || [];
 
         this.registry.registerMetric(this as any);
     }

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -180,7 +180,6 @@ test('should store histogram metrics with batch data', async () => {
             name: 'response_time',
             help: 'Response time histogram',
             type: 'histogram',
-            buckets: [1],
             samples: [
                 {
                     labels: { foo: 'bar' },
@@ -200,7 +199,6 @@ test('should store histogram metrics with batch data', async () => {
             name: 'response_time',
             help: 'Response time histogram',
             type: 'histogram',
-            buckets: [1],
             samples: [
                 {
                     labels: { foo: 'bar' },

--- a/src/lib/features/metrics/impact/metrics-translator.test.ts
+++ b/src/lib/features/metrics/impact/metrics-translator.test.ts
@@ -193,6 +193,22 @@ describe('MetricsTranslator', () => {
                     },
                 ],
             },
+            {
+                name: 'histogram_with_labels',
+                help: 'histogram with labels',
+                type: 'histogram' as const,
+                samples: [
+                    {
+                        labels: { service: 'api' },
+                        count: 5,
+                        sum: 2.5,
+                        buckets: [
+                            { le: 1, count: 3 },
+                            { le: '+Inf' as const, count: 5 },
+                        ],
+                    },
+                ],
+            },
         ];
 
         const result1 = await translator.translateAndSerializeMetrics(metrics1);
@@ -201,6 +217,9 @@ describe('MetricsTranslator', () => {
         );
         expect(result1).toContain(
             'unleash_gauge_gauge_with_labels{unleash_env="prod",unleash_origin="sdk"} 10',
+        );
+        expect(result1).toContain(
+            'unleash_histogram_histogram_with_labels_count{unleash_origin="sdk",unleash_service="api"} 5',
         );
 
         const metrics2 = [
@@ -226,6 +245,23 @@ describe('MetricsTranslator', () => {
                     },
                 ],
             },
+            {
+                name: 'histogram_with_labels',
+                help: 'histogram with labels',
+                type: 'histogram' as const,
+                buckets: [1],
+                samples: [
+                    {
+                        labels: { service: 'api', region: 'us-east' }, // Added a new label
+                        count: 3,
+                        sum: 1.8,
+                        buckets: [
+                            { le: 1, count: 2 },
+                            { le: '+Inf' as const, count: 3 },
+                        ],
+                    },
+                ],
+            },
         ];
 
         const result2 = await translator.translateAndSerializeMetrics(metrics2);
@@ -235,6 +271,12 @@ describe('MetricsTranslator', () => {
         );
         expect(result2).toContain(
             'unleash_gauge_gauge_with_labels{unleash_env="prod",unleash_region="us-east",unleash_origin="sdk"} 20',
+        );
+        expect(result2).toContain(
+            'unleash_histogram_histogram_with_labels_count{unleash_origin="sdk",unleash_region="us-east",unleash_service="api"} 3',
+        );
+        expect(result2).not.toContain(
+            'unleash_histogram_histogram_with_labels_count{unleash_origin="sdk",unleash_service="api"} 5',
         );
     });
 });

--- a/src/lib/features/metrics/impact/metrics-translator.ts
+++ b/src/lib/features/metrics/impact/metrics-translator.ts
@@ -174,6 +174,7 @@ export class MetricsTranslator {
                         name: prefixedName,
                         help: metric.help,
                         registry: this.registry,
+                        labelNames,
                     });
                 } else {
                     histogram = existingMetric as BatchHistogram;
@@ -183,6 +184,7 @@ export class MetricsTranslator {
                     name: prefixedName,
                     help: metric.help,
                     registry: this.registry,
+                    labelNames,
                 });
             }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Extends the impact metrics ingestion to support histograms, enabling SDKs to send pre-aggregated histogram data to Unleash.

  Key Changes

  - MetricsTranslator enhancements: Added histogram translation with proper label management and registry reuse pattern (consistent with counters/gauges)
  - Schema validation: Extended Joi schemas to validate histogram samples including support for +Inf bucket boundaries
  - Label encoding fix: Switched from string concatenation to JSON encoding for label keys to safely handle special characters (colons, URLs)


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
