### PR TITLE
fix: don't call location hook conditionally in CR badge

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestStatusBadge.tsx
@@ -25,6 +25,7 @@ const DraftBadge: VFC = () => <Badge color='warning'>Draft</Badge>;
 export const ChangeRequestStatusBadge: VFC<IChangeRequestStatusBadgeProps> = ({
     changeRequest,
 }) => {
+    const { locationSettings } = useLocationSettings();
     if (!changeRequest) {
         return null;
     }
@@ -60,7 +61,6 @@ export const ChangeRequestStatusBadge: VFC<IChangeRequestStatusBadgeProps> = ({
             );
         case 'Scheduled': {
             const { schedule } = changeRequest;
-            const { locationSettings } = useLocationSettings();
             const scheduledAt = new Date(schedule.scheduledAt).toLocaleString(
                 locationSettings.locale,
             );


### PR DESCRIPTION
Fixes a bug where I added a conditional hook call in https://github.com/Unleash/unleash/pull/10651.
