### PR TITLE
chore: adjust add strategy modal height

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -248,6 +248,7 @@ export const FeatureStrategyMenu = ({
                 PaperProps={{
                     sx: {
                         borderRadius: '12px',
+                        height: newStrategyModalEnabled ? '100%' : 'auto',
                     },
                 }}
             >

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCards.tsx
@@ -45,7 +45,7 @@ const StyledContainer = styled(Box)(() => ({
 
 const StyledScrollableContent = styled(Box)(({ theme }) => ({
     width: theme.breakpoints.values.md,
-    height: theme.spacing(52),
+    height: '100%',
     overflowY: 'auto',
     padding: theme.spacing(4),
     paddingTop: theme.spacing(2),

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanReviewDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanReviewDialog.tsx
@@ -19,12 +19,13 @@ import CloseIcon from '@mui/icons-material/Close';
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
+        height: '100%',
     },
 }));
 
 const StyledScrollableContent = styled(Box)(({ theme }) => ({
     width: theme.breakpoints.values.md,
-    minHeight: '318px',
+    height: '100%',
     overflowY: 'auto',
     display: 'flex',
     flexDirection: 'column',


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3893/set-a-minimum-height-in-the-release-template-preview-dialog

Adjusts the "add strategy" and "release template preview" modal heights, ensuring better visual consistency between them.