### PR TITLE
chore: bump slack/web-api dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "schema:update": "node ./.husky/update-openapi-spec-list.js"
   },
   "dependencies": {
-    "@slack/web-api": "^7.9.1",
+    "@slack/web-api": "^7.10.0",
     "@wesleytodd/openapi": "^1.1.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,23 +1173,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@slack/web-api@npm:^7.9.1":
-  version: 7.9.3
-  resolution: "@slack/web-api@npm:7.9.3"
+"@slack/web-api@npm:^7.10.0":
+  version: 7.10.0
+  resolution: "@slack/web-api@npm:7.10.0"
   dependencies:
     "@slack/logger": "npm:^4.0.0"
     "@slack/types": "npm:^2.9.0"
     "@types/node": "npm:>=18.0.0"
     "@types/retry": "npm:0.12.0"
-    axios: "npm:^1.8.3"
+    axios: "npm:^1.11.0"
     eventemitter3: "npm:^5.0.1"
-    form-data: "npm:^4.0.0"
+    form-data: "npm:^4.0.4"
     is-electron: "npm:2.2.2"
     is-stream: "npm:^2"
     p-queue: "npm:^6"
     p-retry: "npm:^4"
     retry: "npm:^0.13.1"
-  checksum: 10c0/a08342156683abe6cd05659c6a51eeb782adcd7f418df43ad212501f0d0da77c6caf57785491a7f024116499e1819da589b803622318454b8abe6b375ba1d8c0
+  checksum: 10c0/663273891187eea9041c6cc64bbd736a4925674b4c3c6fc5905368c24a590a47daa84037c802e00fcadb2b92bf12929095736db5c4b14f02993ec7dc724ab22e
   languageName: node
   linkType: hard
 
@@ -2075,7 +2075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.11.0, axios@npm:^1.8.3":
+"axios@npm:^1.11.0":
   version: 1.12.2
   resolution: "axios@npm:1.12.2"
   dependencies:
@@ -7570,7 +7570,7 @@ __metadata:
     "@biomejs/biome": "npm:^1.9.4"
     "@cyclonedx/yarn-plugin-cyclonedx": "npm:^2.0.0"
     "@fast-check/vitest": "npm:^0.2.1"
-    "@slack/web-api": "npm:^7.9.1"
+    "@slack/web-api": "npm:^7.10.0"
     "@swc/core": "npm:1.11.31"
     "@types/bcryptjs": "npm:2.4.6"
     "@types/cors": "npm:2.8.19"


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3894/bump-slackweb-api-to-7100

Bumps `@slack/web-api` dependency to `^7.10.0`.

Ran a few manual tests just to be sure, and everything seems to be working as intended.