### PR TITLE
feat: add change request table filter buttons

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters.tsx
@@ -1,0 +1,82 @@
+import { Box, Chip, styled } from '@mui/material';
+import { useState, type FC } from 'react';
+
+const StyledChip = styled(Chip)(({ theme }) => ({
+    borderRadius: `${theme.shape.borderRadius}px`,
+    padding: theme.spacing(0.5),
+    fontSize: theme.typography.body2.fontSize,
+    height: 'auto',
+    '&[aria-current="true"]': {
+        backgroundColor: theme.palette.secondary.light,
+        fontWeight: 'bold',
+        borderColor: theme.palette.primary.main,
+        color: theme.palette.primary.main,
+    },
+    ':focus-visible': {
+        outline: `1px solid ${theme.palette.primary.main}`,
+        borderColor: theme.palette.primary.main,
+    },
+}));
+
+export type ChangeRequestQuickFilter = 'Created' | 'Approval Requested';
+
+interface IChangeRequestFiltersProps {
+    ariaControlTarget: string;
+    initialSelection?: ChangeRequestQuickFilter;
+    onSelectionChange: (selection: ChangeRequestQuickFilter) => void;
+}
+
+const Wrapper = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'flex-start',
+    padding: theme.spacing(1.5, 3, 0, 3),
+    minHeight: theme.spacing(7),
+    gap: theme.spacing(2),
+}));
+
+const StyledContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+}));
+
+export const ChangeRequestFilters: FC<IChangeRequestFiltersProps> = ({
+    onSelectionChange,
+    initialSelection,
+    ariaControlTarget,
+}) => {
+    const [selected, setSelected] = useState<ChangeRequestQuickFilter>(
+        initialSelection || 'Created',
+    );
+    const handleSelectionChange = (value: ChangeRequestQuickFilter) => () => {
+        if (value === selected) {
+            return;
+        }
+        setSelected(value);
+        onSelectionChange(value);
+    };
+
+    return (
+        <Wrapper>
+            <StyledContainer>
+                <StyledChip
+                    label={'Created'}
+                    variant='outlined'
+                    aria-current={selected === 'Created'}
+                    aria-controls={ariaControlTarget}
+                    onClick={handleSelectionChange('Created')}
+                    title={'Show change requests created by you'}
+                />
+                <StyledChip
+                    label={'Approval Requested'}
+                    variant='outlined'
+                    aria-current={selected === 'Approval Requested'}
+                    aria-controls={ariaControlTarget}
+                    onClick={handleSelectionChange('Approval Requested')}
+                    title={'Show change requests requesting your approval'}
+                />
+            </StyledContainer>
+        </Wrapper>
+    );
+};


### PR DESCRIPTION
Adds filter buttons for filtering between "CRs created by me" and "CRs where I've been requested as an approver".

The current implementation is fairly simplistic and the buttons are not connected to the actual table state directly (instead being set up with their own simple state and onChange hooks), but it covers the simple scenario. I want to defer a more complex solution until we know we need it and until we know exactly what we need. The implementation is based on the lifecycle filters that we have on the project flags page.

The current logic is such that: when you land on the page, there's no query params in the URL, but the data fetch applies `createdBy:IS<your user>`. If you switch to "approval requested" (and back again), the URL will reflect this.

For reference, the github workflow works like this, where each URL has a set of default filters, e.g.:
- `/pulls`: `is:open is:pr assignee:thomasheartman archived:false`
- `/pulls/review-requested`: `is:open is:pr review-requested:thomasheartman archived:false`

But if you change the default filters or add new ones, the URL will update to `pulls?<query-string>` (e.g. `/pulls?q=is%3Aopen+is%3Apr+review-requested%3Athomasheartman+archived%3Atrue`)

So this takes a similar approach, but better suited to the way we do tables in general.

Rendered:

<img width="1816" height="791" alt="image" src="https://github.com/user-attachments/assets/60935900-488d-4ca9-b110-39f3568a08a6" />

<img width="1855" height="329" alt="image" src="https://github.com/user-attachments/assets/5e865a2e-8fdc-41ab-ba38-bbe6776d04ad" />
