### PR TITLE
chore: update strategy cards background color

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -25,6 +25,7 @@ const StyledCard = styled('div', {
     height: theme.spacing(10),
     maxWidth: '30rem',
     padding: theme.spacing(2),
+    backgroundColor: theme.palette.background.elevation1,
     color: 'inherit',
     textDecoration: 'inherit',
     lineHeight: 1.25,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3895/update-cards-background-color

Updates the strategy cards background color to match the designs.

<img width="985" height="569" alt="image" src="https://github.com/user-attachments/assets/6b6e1dd3-b811-4841-8858-4046f3c79717" />