### PR TITLE
chore: update view more templates button design

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCard/FeatureStrategyMenuCard.tsx
@@ -21,9 +21,7 @@ const StyledCard = styled('div', {
 })<{ isDefault?: boolean }>(({ theme, isDefault }) => ({
     display: 'flex',
     alignItems: 'center',
-    width: '100%',
     height: theme.spacing(10),
-    maxWidth: '30rem',
     padding: theme.spacing(2),
     backgroundColor: theme.palette.background.elevation1,
     color: 'inherit',

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
@@ -74,12 +74,15 @@ const StyledNoTemplatesDescription = styled('p')(({ theme }) => ({
     color: theme.palette.text.secondary,
 }));
 
-const StyledViewAllTemplates = styled(Box)({
+const StyledViewMoreButton = styled(Button)(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    height: '100%',
-});
+    height: theme.spacing(10),
+    padding: theme.spacing(2),
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.spacing(1),
+}));
 
 const StyledLink = styled(RouterLink)({
     textDecoration: 'none',
@@ -174,17 +177,13 @@ export const FeatureStrategyMenuCardsReleaseTemplates = ({
                     ))}
                     {slicedTemplates.length < templates.length &&
                         templates.length > RELEASE_TEMPLATE_DISPLAY_LIMIT && (
-                            <StyledViewAllTemplates>
-                                <Button
-                                    variant='text'
-                                    size='small'
-                                    onClick={() =>
-                                        setFilter('releaseTemplates')
-                                    }
-                                >
-                                    View all available templates
-                                </Button>
-                            </StyledViewAllTemplates>
+                            <StyledViewMoreButton
+                                variant='text'
+                                size='small'
+                                onClick={() => setFilter('releaseTemplates')}
+                            >
+                                View more templates
+                            </StyledViewMoreButton>
                         )}
                 </FeatureStrategyMenuCardsSection>
             )}


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3898/update-the-design-of-the-view-more-button

Updates the design of the "view more templates" button in the new "add strategy" modal.

<img width="925" height="221" alt="image" src="https://github.com/user-attachments/assets/2a790828-aac5-4c56-bbac-bcb254dc6049" />