### PR TITLE
fix: fall back to count === 0 if undefined / don't show "0 of undefined"

### DIFF
--- a/frontend/src/component/common/LifecycleFilters/LifecycleFilters.tsx
+++ b/frontend/src/component/common/LifecycleFilters/LifecycleFilters.tsx
@@ -84,7 +84,7 @@ export const LifecycleFilters = ({
                         : allFlagsCount || undefined;
                     const dynamicLabel =
                         isActive && Number.isInteger(total)
-                            ? `${label} (${total === count ? total : `${total} of ${count}`})`
+                            ? `${label} (${total === (count ?? 0) ? total : `${total} of ${count}`})`
                             : `${label}${count !== undefined ? ` (${count})` : ''}`;
 
                     const handleClick = () =>


### PR DESCRIPTION
If the total number of flag is undefined, we've previously shown "0 of undefined". However, I don't think that's sensible. Instead, we should show "0".

Before:
<img width="386" height="114" alt="image" src="https://github.com/user-attachments/assets/5da61c05-16d2-4722-9874-63c1d011884b" />

After:
<img width="224" height="103" alt="image" src="https://github.com/user-attachments/assets/c6c0711b-f3ce-45e3-8302-bfe9377112a8" />
