### PR TITLE
docs: add FAQs to 11 principles page

### DIFF
--- a/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
+++ b/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
@@ -302,15 +302,15 @@ The key is to keep flags short-lived. Test both code paths while the flag is act
 #### What are the best feature flag management tools or libraries that support your tech stack?
 Unleash provides [extensive SDK support](/reference/sdks) across diverse tech stacks, including server-side languages like Node.js, Java, Go, PHP, Python, Ruby, Rust, .NET as well as frontend frameworks such as React, JavaScript, Vue, iOS, and Android.
 
-In addition, the community maintains SDKs for other languages and frameworks, such as: Elixir, Clojure, Dart/Flutter, Haskell, Kotlin (server-side), Scala, ColdFusion, and more.
+In addition, the community maintains SDKs for other languages and frameworks, such as Elixir, Clojure, Dart/Flutter, Haskell, Kotlin, Scala, ColdFusion, and more.
 
-This broad support means you can use the same feature flagging system across backend services, frontend apps, and mobile clients. Other tools exist, but Unleash combines open source flexibility that you can scale from a small team to thousands of developers for any use case.
+This broad support means you can use the same feature flagging system across backend services, frontend apps, and mobile clients. Other tools exist, but Unleash comes with open-source flexibility and helps you scale from a small team to thousands of developers for any use case.
 
-#### What is the ideal way to add implementation switch or feature flags in code?
+#### What is the ideal way to add an implementation switch or feature flags in code?
 Evaluate feature flags at the highest level and once per request. Keep the branching or conditional logic simple. Use logging for visibility and remove the flag quickly once it's served its purpose. With Unleash SDKs, you also get local caching and server-side evaluation for performance and security.
 
 #### What are good feature flag tools/libraries that support Go?
-Unleash provides a robust [Go SDK](/reference/sdks/go) for implementing feature flags. Other notable open-source options include Go Feature Flag, which is written in Go, and Flagr, also a Go-based microservice for feature flagging.
+Unleash provides a robust [Go SDK](/reference/sdks/go) for implementing feature flags. Other notable open-source options include [Go Feature Flag](https://gofeatureflag.org/), which is written in Go, and [Flagr](https://openflagr.github.io/flagr/#/), also a Go-based microservice for feature flagging.
 
 #### How do you deal with the exponential complexity from multiple feature flags?
 Complexity comes from keeping too many flags active at once and spreading evaluations throughout the code. The best way to manage this is to keep flags short-lived with clear ownership and a planned end date, then remove them once the rollout is complete. Evaluate each flag once at the highest practical level and pass the result down, so behavior stays consistent. In a microservices setup, perform the evaluation at the edge and propagate the result through the request. Centralize flag names and use a wrapper service around the SDK to handle logging, defaults, and consistency. Finally, archive flags after removal to maintain history without adding clutter.

--- a/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
+++ b/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
@@ -297,7 +297,7 @@ Set an expiration date and assign an owner when you create the flag. Track clean
 Organize flags into [projects and environments](/feature-flag-tutorials/use-cases/organize-feature-flags), enforce unique names, and keep payloads small by using [segments](/reference/segments) instead of large targeting lists. Apply [access control](/reference/rbac) and [change requests](/reference/change-requests) for your production environments and use [audit logs](/reference/events) for visibility. A management platform like Unleash provides these features out of the box, making it easier to scale.
 
 #### How do you mitigate the risk of introducing bugs or technical debt due to unused or stale feature flags?
-The key is to keep flags short-lived. Test both code paths while the flag is active, and remove the flag and old path once the rollout finishes. Archive stale flags for audit purposes. In Unleash, lifecycle states help you identify and clean up unused flags.
+The key is to keep flags short-lived. Test both code paths while the flag is active, and remove the flag and old path once the rollout finishes. Archive stale flags for audit purposes. In Unleash, lifecycle stages help you identify and clean up unused flags.
 
 #### What are the best feature flag management tools or libraries that support your tech stack?
 Unleash provides [extensive SDK support](/reference/sdks) across diverse tech stacks, including server-side languages like Node.js, Java, Go, PHP, Python, Ruby, Rust, .NET as well as frontend frameworks such as React, JavaScript, Vue, iOS, and Android.

--- a/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
+++ b/website/docs/topics/feature-flags/feature-flag-best-practices.mdx
@@ -267,3 +267,52 @@ To learn more about Unleash architecture and implementation basics, check out th
 An introduction to Unleash Edge product and its scaling capabilities:
 
 <VideoContent videoUrls={["https://www.youtube.com/embed/6uIdF-yByWs?si=kk5OGb-1nVfea06B"]}/>
+
+## Frequently asked questions (FAQs)
+This FAQ section addresses common questions about using feature flags effectively and managing them at scale.
+
+#### What approaches or patterns can improve code maintainability and readability when adding feature flags?
+Keep flags short-lived and localize the logic. Evaluate a flag once per request and pass the result down instead of re-checking it in multiple places. Use a small wrapper or abstraction layer around your SDK calls, and delete the flag and old code path as soon as the rollout finishes. See [Managing feature flags in code](/feature-flag-tutorials/use-cases/manage-feature-flags-in-code) for more recommendations. 
+
+#### What are the benefits of assigning an index to each feature flag and storing it centrally?
+
+Teams sometimes think in terms of assigning numeric IDs or indices to feature flags. In practice, this isn't necessary. What really matters is centralized management and unique, descriptive names. A central feature flag service, like Unleash, ensures consistent definitions across systems, makes flags easy to find, and prevents accidental reuse. Unique names provide the same benefits an index would, but in a more human-readable and scalable way.
+
+#### How can configuration files be used for basic feature flag implementation?
+You can store on/off values in a config file, and your app will read them at startup. But that's closer to static configuration than true feature flagging. Real feature flags are evaluated at runtime with SDKs that fetch updates dynamically. Tools like Unleash provide runtime control, instant rollbacks, and gradual rollouts that config files can't.
+
+#### How do you manage feature flags without turning your code into spaghetti?
+Evaluate feature flags once per request and pass the results down, rather than checking the same flag everywhere. Keep the if/else branching simple, use wrappers or helpers to hide SDK details, and remove flags as soon as they're no longer needed. See [Managing feature flags in code](/feature-flag-tutorials/use-cases/manage-feature-flags-in-code) for more recommendations. 
+
+#### What strategies do you use to avoid cluttering your codebase with feature flags?
+Treat feature flags like technical debt. Give them owners, set expiration dates, and add cleanup tasks to your backlog. Archive old flags after removal so you keep an audit trail. Lifecycle states and other automation in Unleash make the cleanup process much easier.
+
+#### When should you use feature flags versus feature branches?
+Use feature branches to isolate development work before it's ready for production. Use feature flags to control exposure after code is deployed: for progressive rollouts, experiments, or kill switches. Many teams combine trunk-based development with flags to reduce merge conflicts while still having control in production.
+
+#### How do you ensure timely removal of feature flags after a feature is fully released?
+Set an expiration date and assign an owner when you create the flag. Track cleanup like any other piece of technical debt, and use automation and tooling to surface and clean up stale flags.
+
+#### What tools or practices help manage multiple feature flags effectively in a large project?
+Organize flags into [projects and environments](/feature-flag-tutorials/use-cases/organize-feature-flags), enforce unique names, and keep payloads small by using [segments](/reference/segments) instead of large targeting lists. Apply [access control](/reference/rbac) and [change requests](/reference/change-requests) for your production environments and use [audit logs](/reference/events) for visibility. A management platform like Unleash provides these features out of the box, making it easier to scale.
+
+#### How do you mitigate the risk of introducing bugs or technical debt due to unused or stale feature flags?
+The key is to keep flags short-lived. Test both code paths while the flag is active, and remove the flag and old path once the rollout finishes. Archive stale flags for audit purposes. In Unleash, lifecycle states help you identify and clean up unused flags.
+
+#### What are the best feature flag management tools or libraries that support your tech stack?
+Unleash provides [extensive SDK support](/reference/sdks) across diverse tech stacks, including server-side languages like Node.js, Java, Go, PHP, Python, Ruby, Rust, .NET as well as frontend frameworks such as React, JavaScript, Vue, iOS, and Android.
+
+In addition, the community maintains SDKs for other languages and frameworks, such as: Elixir, Clojure, Dart/Flutter, Haskell, Kotlin (server-side), Scala, ColdFusion, and more.
+
+This broad support means you can use the same feature flagging system across backend services, frontend apps, and mobile clients. Other tools exist, but Unleash combines open source flexibility that you can scale from a small team to thousands of developers for any use case.
+
+#### What is the ideal way to add implementation switch or feature flags in code?
+Evaluate feature flags at the highest level and once per request. Keep the branching or conditional logic simple. Use logging for visibility and remove the flag quickly once it's served its purpose. With Unleash SDKs, you also get local caching and server-side evaluation for performance and security.
+
+#### What are good feature flag tools/libraries that support Go?
+Unleash provides a robust [Go SDK](/reference/sdks/go) for implementing feature flags. Other notable open-source options include Go Feature Flag, which is written in Go, and Flagr, also a Go-based microservice for feature flagging.
+
+#### How do you deal with the exponential complexity from multiple feature flags?
+Complexity comes from keeping too many flags active at once and spreading evaluations throughout the code. The best way to manage this is to keep flags short-lived with clear ownership and a planned end date, then remove them once the rollout is complete. Evaluate each flag once at the highest practical level and pass the result down, so behavior stays consistent. In a microservices setup, perform the evaluation at the edge and propagate the result through the request. Centralize flag names and use a wrapper service around the SDK to handle logging, defaults, and consistency. Finally, archive flags after removal to maintain history without adding clutter.
+
+See [Managing feature flags in code](/feature-flag-tutorials/use-cases/manage-feature-flags-in-code) for more recommendations. 


### PR DESCRIPTION
We've run an AI workflow to find frequently asked questions around feature flagging on community forums.

This change adds these FAQs at the bottom of our 11 principles page to help with discoverability and LLM search.

Preview: https://unleash-docs-git-docs-add-faqs-to-11-principles-unleash-team.vercel.app/topics/feature-flags/feature-flag-best-practices#frequently-asked-questions-faqs