### PR TITLE
feat: suggest default strategies with apply-link on empty feature envs

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
@@ -18,7 +18,7 @@ const StyledSuggestion = styled('div')(({ theme }) => ({
     borderBottomLeftRadius: theme.shape.borderRadiusLarge,
     borderBottomRightRadius: theme.shape.borderRadiusLarge,
     color: theme.palette.primary.main,
-    fontSize: theme.fontSizes.smallBody,
+    fontSize: theme.fontSizes.smallerBody,
 }));
 
 const StyledSpan = styled('span')(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
@@ -1,0 +1,120 @@
+import { Box, styled } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
+import type { IFeatureStrategy } from 'interfaces/strategy';
+import type { FC } from 'react';
+import { StrategyExecution } from '../../EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.js';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
+import { UPDATE_FEATURE } from '@server/types/permissions';
+import { formatCreateStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate';
+import { useNavigate } from 'react-router-dom';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker.js';
+
+const StyledSuggestion = styled('div')(({ theme }) => ({
+    padding: theme.spacing(0.25, 3),
+    width: '100%',
+    minHeight: theme.spacing(2),
+    background: theme.palette.secondary.light,
+    borderBottomLeftRadius: theme.shape.borderRadiusLarge,
+    borderBottomRightRadius: theme.shape.borderRadiusLarge,
+    color: theme.palette.primary.main,
+    fontSize: theme.fontSizes.smallBody,
+}));
+
+const StyledSpan = styled('span')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    textDecoration: 'underline',
+}));
+
+const StyledBold = styled('b')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const TooltipHeader = styled('div')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const TooltipDescription = styled('div')(({ theme }) => ({
+    fontSize: theme.fontSizes.smallerBody,
+    paddingBottom: theme.spacing(1.5),
+}));
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(1.5),
+    minWidth: theme.spacing(80),
+    maxWidth: theme.spacing(80),
+}));
+
+type DefaultStrategySuggestionProps = {
+    projectId: string;
+    featureId: string;
+    environmentId: string;
+    strategy: Omit<IFeatureStrategy, 'id'>;
+};
+
+export const DefaultStrategySuggestion: FC<DefaultStrategySuggestionProps> = ({
+    projectId,
+    featureId,
+    environmentId,
+    strategy,
+}) => {
+    const { trackEvent } = usePlausibleTracker();
+    const navigate = useNavigate();
+
+    const editDefaultStrategyPath = `/projects/${projectId}/settings/default-strategy`;
+
+    const createStrategyPath = formatCreateStrategyPath(
+        projectId,
+        featureId,
+        environmentId,
+        'flexibleRollout',
+        true,
+    );
+
+    const openStrategyCreationModal = () => {
+        trackEvent('strategy-add', {
+            props: {
+                buttonTitle: 'flexibleRollout',
+            },
+        });
+        navigate(createStrategyPath);
+    };
+
+    return (
+        <StyledSuggestion>
+            <StyledBold>Suggestion:</StyledBold>
+            &nbsp;Add the&nbsp;
+            <HtmlTooltip
+                title={
+                    <StyledBox>
+                        <TooltipHeader>Default strategy</TooltipHeader>
+                        <TooltipDescription>
+                            Defined per project, per environment&nbsp;
+                            <Link
+                                to={editDefaultStrategyPath}
+                                title='Project default strategies'
+                            >
+                                here
+                            </Link>
+                        </TooltipDescription>
+                        <StrategyExecution strategy={strategy} />
+                    </StyledBox>
+                }
+                maxWidth='200'
+                arrow
+            >
+                <StyledSpan>default strategy</StyledSpan>
+            </HtmlTooltip>
+            &nbsp;for this project&nbsp;
+            <PermissionButton
+                size='small'
+                permission={UPDATE_FEATURE}
+                projectId={projectId}
+                variant='text'
+                onClick={() => openStrategyCreationModal()}
+            >
+                Apply
+            </PermissionButton>
+        </StyledSuggestion>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/DefaultStrategySuggestion/DefaultStrategySuggestion.tsx
@@ -11,7 +11,9 @@ import { useNavigate } from 'react-router-dom';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker.js';
 
 const StyledSuggestion = styled('div')(({ theme }) => ({
-    padding: theme.spacing(0.25, 3),
+    padding: theme.spacing(0.5, 3),
+    display: 'flex',
+    alignItems: 'center',
     width: '100%',
     minHeight: theme.spacing(2),
     background: theme.palette.secondary.light,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -73,7 +73,6 @@ export const EmptyEnvironmentSection: FC<
     featureId,
     environmentId,
     children,
-    environmentMetadata,
     ...props
 }) => {
     const id = useId();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -73,7 +73,6 @@ export const EmptyEnvironmentSection: FC<
     featureId,
     environmentId,
     children,
-    ...props
 }) => {
     const id = useId();
     const { environments } = useProjectEnvironments(projectId);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -74,7 +74,6 @@ export const EmptyEnvironmentSection: FC<
     environmentId,
     children,
 }) => {
-    const id = useId();
     const { environments } = useProjectEnvironments(projectId);
     const defaultStrategy = environments.find(
         (env) => env.name === environmentId,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -16,7 +16,7 @@ const StyledContainer = styled('div')(({ theme }) => ({
 }));
 
 const StyledHeader = styled('div')(({ theme }) => ({
-    padding: theme.spacing(3, 2, 2, 2),
+    padding: theme.spacing(3, 8, 2, 2),
     display: 'flex',
     width: '100%',
 }));

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -73,7 +73,6 @@ export const EmptyEnvironmentSection: FC<
     featureId,
     environmentId,
     children,
-    expandable = true,
     environmentMetadata,
     ...props
 }) => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EmptyEnvironmentSection/EmptyEnvironmentSection.tsx
@@ -1,0 +1,119 @@
+import { useMemo, type FC, type PropsWithChildren } from 'react';
+import { styled } from '@mui/material';
+import { useId } from 'hooks/useId';
+import { Truncator } from 'component/common/Truncator/Truncator';
+import { useProjectEnvironments } from 'hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
+import type { IFeatureStrategy } from 'interfaces/strategy';
+import { DefaultStrategySuggestion } from './DefaultStrategySuggestion/DefaultStrategySuggestion.js';
+
+const StyledContainer = styled('div')(({ theme }) => ({
+    boxShadow: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    borderRadius: theme.shape.borderRadiusLarge,
+    pointerEvents: 'auto',
+    opacity: 1,
+}));
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    padding: theme.spacing(3, 2, 2, 2),
+    display: 'flex',
+    width: '100%',
+}));
+
+const StyledHeaderTitle = styled('hgroup')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'row wrap',
+    flex: 1,
+    columnGap: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
+}));
+
+const StyledHeaderTitleLabel = styled('p')(({ theme }) => ({
+    width: '100%',
+    fontSize: theme.fontSizes.smallerBody,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledTruncator = styled(Truncator)(({ theme }) => ({
+    fontSize: theme.typography.h2.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+}));
+
+const DEFAULT_STRATEGY: IFeatureStrategy = {
+    id: '',
+    name: 'flexibleRollout',
+    disabled: false,
+    constraints: [],
+    title: '',
+    parameters: {
+        rollout: '100',
+        stickiness: 'default',
+        groupId: '',
+    },
+};
+
+type EnvironmentMetadata = {
+    strategyCount: number;
+    releasePlanCount: number;
+};
+
+type EmptyEnvironmentSectionProps = {
+    projectId: string;
+    featureId: string;
+    environmentId: string;
+    expandable?: boolean;
+    environmentMetadata?: EnvironmentMetadata;
+};
+
+export const EmptyEnvironmentSection: FC<
+    PropsWithChildren<EmptyEnvironmentSectionProps>
+> = ({
+    projectId,
+    featureId,
+    environmentId,
+    children,
+    expandable = true,
+    environmentMetadata,
+    ...props
+}) => {
+    const id = useId();
+    const { environments } = useProjectEnvironments(projectId);
+    const defaultStrategy = environments.find(
+        (env) => env.name === environmentId,
+    )?.defaultStrategy;
+
+    const strategy: Omit<IFeatureStrategy, 'id'> = useMemo(() => {
+        const baseDefaultStrategy = {
+            ...DEFAULT_STRATEGY,
+            ...defaultStrategy,
+        };
+        return {
+            ...baseDefaultStrategy,
+            disabled: false,
+            constraints: baseDefaultStrategy.constraints ?? [],
+            title: baseDefaultStrategy.title ?? '',
+            parameters: baseDefaultStrategy.parameters ?? {},
+        };
+    }, [JSON.stringify(defaultStrategy)]);
+
+    return (
+        <StyledContainer>
+            <StyledHeader>
+                <StyledHeaderTitle>
+                    <StyledHeaderTitleLabel>Environment</StyledHeaderTitleLabel>
+                    <StyledTruncator component='h2'>
+                        {environmentId}
+                    </StyledTruncator>
+                </StyledHeaderTitle>
+                {children}
+            </StyledHeader>
+            <DefaultStrategySuggestion
+                projectId={projectId}
+                featureId={featureId}
+                environmentId={environmentId}
+                strategy={strategy}
+            />
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -19,6 +19,8 @@ import type { IReleasePlan } from 'interfaces/releasePlans';
 import { EnvironmentAccordionBody } from './EnvironmentAccordionBody/EnvironmentAccordionBody.tsx';
 import { Box } from '@mui/material';
 import { ReleaseTemplatesFeedback } from 'component/feature/FeatureStrategy/FeatureStrategyMenu/ReleaseTemplatesFeedback/ReleaseTemplatesFeedback';
+import { EmptyEnvironmentSection } from './EmptyEnvironmentSection/EmptyEnvironmentSection.tsx';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
     borderRadius: theme.shape.borderRadiusLarge,
@@ -73,11 +75,38 @@ export const FeatureOverviewEnvironment = ({
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
     const { isOss } = useUiConfig();
+    const envAddStrategySuggestionEnabled = useUiFlag(
+        'envAddStrategySuggestion',
+    );
     const hasActivations = Boolean(
         environment?.enabled ||
             (environment?.strategies && environment?.strategies.length > 0) ||
             (environment?.releasePlans && environment?.releasePlans.length > 0),
     );
+
+    if (!hasActivations && envAddStrategySuggestionEnabled) {
+        return (
+            <StyledFeatureOverviewEnvironment>
+                <EmptyEnvironmentSection
+                    environmentId={environment.name}
+                    projectId={projectId}
+                    featureId={featureId}
+                >
+                    <FeatureOverviewEnvironmentToggle
+                        environment={environment}
+                    />
+                    <FeatureStrategyMenu
+                        label='Add strategy'
+                        projectId={projectId}
+                        featureId={featureId}
+                        environmentId={environment.name}
+                        variant='outlined'
+                        size='small'
+                    />
+                </EmptyEnvironmentSection>
+            </StyledFeatureOverviewEnvironment>
+        );
+    }
 
     return (
         <StyledFeatureOverviewEnvironment>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -101,7 +101,6 @@ export const FeatureOverviewEnvironment = ({
                         featureId={featureId}
                         environmentId={environment.name}
                         variant='outlined'
-                        size='small'
                     />
                 </EmptyEnvironmentSection>
             </StyledFeatureOverviewEnvironment>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -89,6 +89,7 @@ export type UiFlags = {
     lifecycleGraphs?: boolean;
     newStrategyModal?: boolean;
     globalChangeRequestList?: boolean;
+    envAddStrategySuggestion?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -59,7 +59,8 @@ export type IFlagKey =
     | 'fetchMode'
     | 'optimizeLifecycle'
     | 'newStrategyModal'
-    | 'globalChangeRequestList';
+    | 'globalChangeRequestList'
+    | 'envAddStrategySuggestion';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -249,6 +250,10 @@ const flags: IFlags = {
     ),
     lifecycleGraphs: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_LIFECYCLE_GRAPHS,
+        false,
+    ),
+    envAddStrategySuggestion: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ADD_STRATEGY_SUGGESTION,
         false,
     ),
     streaming: {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -253,7 +253,7 @@ const flags: IFlags = {
         false,
     ),
     envAddStrategySuggestion: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_ADD_STRATEGY_SUGGESTION,
+        process.env.UNLEASH_EXPERIMENTAL_ENV_ADD_STRATEGY_SUGGESTION,
         false,
     ),
     streaming: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -55,6 +55,7 @@ process.nextTick(async () => {
                         lifecycleGraphs: true,
                         newStrategyModal: true,
                         globalChangeRequestList: true,
+                        envAddStrategySuggestion: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Implements a new environment card that shows a suggestion to add default strategy for empty feature environments

<img width="1203" height="655" alt="image" src="https://github.com/user-attachments/assets/46b66cb8-21d8-43cb-865d-c8ee6eb74aca" />
