### PR TITLE
feat: change "archived" flags filter placement on project flags list

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -119,7 +119,7 @@ const LinkToggle = styled('button')(({ theme }) => ({
 }));
 
 export const ProjectFeatureToggles = ({
-    environments: passedEnvironments,
+    environments: availableEnvironments,
 }: ProjectFeatureTogglesProps) => {
     const { trackEvent } = usePlausibleTracker();
     const projectId = useRequiredPathParam('projectId');
@@ -218,7 +218,7 @@ export const ProjectFeatureToggles = ({
             setTableState({ archived: { operator: 'IS', values: ['true'] } });
         }
     };
-    const environments = showArchived ? [] : passedEnvironments;
+    const environments = showArchived ? [] : availableEnvironments;
 
     const columns = useMemo(
         () => [

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -558,7 +558,6 @@ export const ProjectFeatureToggles = ({
                                     <LinkToggle
                                         type='button'
                                         onClick={toggleArchived}
-                                        aria-pressed={showArchived}
                                     >
                                         {showArchived
                                             ? 'View active flags'

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { type FC, type ReactNode, useState } from 'react';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import useLoading from 'hooks/useLoading';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
@@ -12,11 +12,19 @@ type ProjectFeatureTogglesHeaderProps = {
     isLoading?: boolean;
     totalItems?: number;
     environmentsToExport?: string[];
+    actions?: ReactNode;
+    title?: string;
 };
 
 export const ProjectFeatureTogglesHeader: FC<
     ProjectFeatureTogglesHeaderProps
-> = ({ isLoading, totalItems, environmentsToExport }) => {
+> = ({
+    isLoading,
+    totalItems,
+    environmentsToExport,
+    actions,
+    title = 'Feature flags',
+}) => {
     const projectId = useRequiredPathParam('projectId');
     const headerLoadingRef = useLoading(isLoading || false);
     const [showExportDialog, setShowExportDialog] = useState(false);
@@ -24,11 +32,12 @@ export const ProjectFeatureTogglesHeader: FC<
     return (
         <Box ref={headerLoadingRef} aria-busy={isLoading} aria-live='polite'>
             <PageHeader
-                titleElement={`Feature flags ${
+                titleElement={`${title} ${
                     totalItems !== undefined ? `(${totalItems})` : ''
                 }`}
                 actions={
                     <>
+                        {actions}
                         <Tooltip title='Export all project flags' arrow>
                             <IconButton
                                 data-loading

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -120,14 +120,18 @@ export const ProjectOverviewFilters: FC<ProjectOverviewFiltersProps> = ({
                 singularOperators: ['IS', 'IS_NOT'],
                 pluralOperators: ['IS_ANY_OF', 'IS_NONE_OF'],
             },
-            {
-                label: 'Show only archived',
-                icon: 'inventory',
-                options: [{ label: 'True', value: 'true' }],
-                filterKey: 'archived',
-                singularOperators: ['IS'],
-                pluralOperators: ['IS_ANY_OF'],
-            },
+            ...(!flagsUiFilterRefactorEnabled
+                ? [
+                      {
+                          label: 'Show only archived',
+                          icon: 'inventory',
+                          options: [{ label: 'True', value: 'true' }],
+                          filterKey: 'archived',
+                          singularOperators: ['IS'],
+                          pluralOperators: ['IS_ANY_OF'],
+                      } satisfies IFilterItem,
+                  ]
+                : []),
         ];
 
         setAvailableFilters(availableFilters);


### PR DESCRIPTION
Archived flags link will now it will show up on the right side, next to import/export, which makes it more in line with flags overview.

<img width="418" height="203" alt="image" src="https://github.com/user-attachments/assets/5f60a0d6-329c-4692-82c7-7f508f60ea0d" />
