### PR TITLE
fix: constraints should not be null

### DIFF
--- a/src/migrations/20251002095623-not-null-constraints.js
+++ b/src/migrations/20251002095623-not-null-constraints.js
@@ -1,0 +1,19 @@
+exports.up = function (db) {
+    return db.runSql(`
+        UPDATE feature_strategies 
+        SET constraints = '[]'::jsonb 
+        WHERE constraints IS NULL;
+        
+        ALTER TABLE feature_strategies 
+        ALTER COLUMN constraints SET DEFAULT '[]'::jsonb,
+        ALTER COLUMN constraints SET NOT NULL;
+    `);
+};
+
+exports.down = function (db) {
+    return db.runSql(`
+        ALTER TABLE feature_strategies 
+        ALTER COLUMN constraints DROP DEFAULT,
+        ALTER COLUMN constraints DROP NOT NULL;
+    `);
+};


### PR DESCRIPTION
## About the changes
In our code, we're not expecting constraints to be null: https://github.com/search?q=repo%3AUnleash%2Funleash%20jsonb_array_elements(constraints)&type=code

It's unlikely to get a null value in constraints when using our API or UI, but there might be cases where this can happen, as we saw in our logs:
```
error: select "context_fields"."name", "context_fields"."description", "context_fields"."stickiness", "context_fields"."sort_order", "context_fields"."legal_values", "context_fields"."created_at", COUNT(DISTINCT CASE
                        WHEN features.archived_at IS NULL
                        THEN feature_strategies.project_name
                    END) AS used_in_projects, COUNT(DISTINCT CASE
                        WHEN features.archived_at IS NULL
                        THEN feature_strategies.feature_name
                    END) AS used_in_features from "context_fields" LEFT JOIN feature_strategies ON EXISTS (
                        SELECT 1
                        FROM jsonb_array_elements(feature_strategies.constraints) AS elem
                        WHERE elem ->> 'contextName' = context_fields.name
                      ) left join "features" on "features"."name" = "feature_strategies"."feature_name" group by "context_fields"."name", "context_fields"."description", "context_fields"."stickiness", "context_fields"."sort_order", "context_fields"."created_at" order by "name" asc - cannot extract elements from a scalar
```
which is likely due to: `jsonb_array_elements(feature_strategies.constraints)` with null constraints

For this reason, it seems reasonable to enforce the constraint at the database level.