### PR TITLE
feat: add a suggestion banner at the bottom of empty feature-environments

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -138,7 +138,6 @@ const MetadataChip = ({
 };
 
 const DEFAULT_STRATEGY: Omit<IFeatureStrategy, 'id'> = {
-    id: '',
     name: 'flexibleRollout',
     disabled: false,
     constraints: [],

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader.tsx
@@ -137,7 +137,7 @@ const MetadataChip = ({
     return <StyledStrategyCount>{text}</StyledStrategyCount>;
 };
 
-const DEFAULT_STRATEGY: IFeatureStrategy = {
+const DEFAULT_STRATEGY: Omit<IFeatureStrategy, 'id'> = {
     id: '',
     name: 'flexibleRollout',
     disabled: false,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentStrategySuggestion/EnvironmentStrategySuggestion.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentStrategySuggestion/EnvironmentStrategySuggestion.tsx
@@ -1,0 +1,116 @@
+import { Box, styled } from '@mui/material';
+import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
+import { Link, useNavigate } from 'react-router-dom';
+import { StrategyExecution } from '../../EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.js';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton.js';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker.js';
+import { formatCreateStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.js';
+import { UPDATE_FEATURE } from '@server/types/permissions.js';
+import type { IFeatureStrategy } from 'interfaces/strategy.js';
+
+const StyledSuggestion = styled('div')(({ theme }) => ({
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0.5, 3),
+    marginRight: theme.spacing(-6),
+    background: theme.palette.secondary.light,
+    borderBottomLeftRadius: theme.shape.borderRadiusLarge,
+    borderBottomRightRadius: theme.shape.borderRadiusLarge,
+    color: theme.palette.primary.main,
+    fontSize: theme.fontSizes.smallerBody,
+}));
+
+const StyledBold = styled('b')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const StyledSpan = styled('span')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    textDecoration: 'underline',
+}));
+
+const TooltipHeader = styled('div')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const TooltipDescription = styled('div')(({ theme }) => ({
+    fontSize: theme.fontSizes.smallerBody,
+    paddingBottom: theme.spacing(1.5),
+}));
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(1.5),
+}));
+
+type DefaultStrategySuggestionProps = {
+    projectId: string;
+    featureId: string;
+    environmentId: string;
+    strategy: Omit<IFeatureStrategy, 'id'>;
+};
+
+export const EnvironmentStrategySuggestion = ({
+    projectId,
+    featureId,
+    environmentId,
+    strategy,
+}: DefaultStrategySuggestionProps) => {
+    const { trackEvent } = usePlausibleTracker();
+    const navigate = useNavigate();
+    const editDefaultStrategyPath = `/projects/${projectId}/settings/default-strategy`;
+    const createStrategyPath = formatCreateStrategyPath(
+        projectId,
+        featureId,
+        environmentId,
+        'flexibleRollout',
+        true,
+    );
+
+    const openStrategyCreationModal = () => {
+        trackEvent('strategy-add', {
+            props: {
+                buttonTitle: 'flexibleRollout',
+            },
+        });
+        navigate(createStrategyPath);
+    };
+
+    return (
+        <StyledSuggestion>
+            <StyledBold>Suggestion:</StyledBold>
+            &nbsp;Add the&nbsp;
+            <HtmlTooltip
+                title={
+                    <StyledBox>
+                        <TooltipHeader>Default strategy</TooltipHeader>
+                        <TooltipDescription>
+                            Defined per project, per environment&nbsp;
+                            <Link
+                                to={editDefaultStrategyPath}
+                                title='Project default strategies'
+                            >
+                                here
+                            </Link>
+                        </TooltipDescription>
+                        <StrategyExecution strategy={strategy} />
+                    </StyledBox>
+                }
+                maxWidth='200'
+                arrow
+            >
+                <StyledSpan>default strategy</StyledSpan>
+            </HtmlTooltip>
+            &nbsp;for this project&nbsp;
+            <PermissionButton
+                size='small'
+                permission={UPDATE_FEATURE}
+                projectId={projectId}
+                variant='text'
+                onClick={() => openStrategyCreationModal()}
+            >
+                Apply
+            </PermissionButton>
+        </StyledSuggestion>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentStrategySuggestion/EnvironmentStrategySuggestion.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentStrategySuggestion/EnvironmentStrategySuggestion.tsx
@@ -13,7 +13,6 @@ const StyledSuggestion = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     padding: theme.spacing(0.5, 3),
-    marginRight: theme.spacing(-6),
     background: theme.palette.secondary.light,
     borderBottomLeftRadius: theme.shape.borderRadiusLarge,
     borderBottomRightRadius: theme.shape.borderRadiusLarge,
@@ -68,7 +67,7 @@ export const EnvironmentStrategySuggestion = ({
     );
 
     const openStrategyCreationModal = () => {
-        trackEvent('strategy-add', {
+        trackEvent('suggestion-strategy-add', {
             props: {
                 buttonTitle: 'flexibleRollout',
             },

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/LegacyEnvironmentHeader/LegacyEnvironmentHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/LegacyEnvironmentHeader/LegacyEnvironmentHeader.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type FC, type PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import {
     AccordionSummary,
     type AccordionSummaryProps,
@@ -7,16 +7,12 @@ import {
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { Truncator } from 'component/common/Truncator/Truncator';
 import { useId } from 'hooks/useId';
-import { EnvironmentStrategySuggestion } from './EnvironmentStrategySuggestion/EnvironmentStrategySuggestion.js';
-import type { IFeatureStrategy } from 'interfaces/strategy';
-import { useProjectEnvironments } from 'hooks/api/getters/useProjectEnvironments/useProjectEnvironments';
 
 const StyledAccordionSummary = styled(AccordionSummary, {
-    shouldForwardProp: (prop) => prop !== 'expandable' && prop !== 'empty',
+    shouldForwardProp: (prop) => prop !== 'expandable',
 })<{
     expandable?: boolean;
-    empty?: boolean;
-}>(({ theme, expandable, empty }) => ({
+}>(({ theme, expandable }) => ({
     boxShadow: 'none',
     padding: theme.spacing(0.5, 3, 0.5, 2),
     display: 'flex',
@@ -31,26 +27,9 @@ const StyledAccordionSummary = styled(AccordionSummary, {
     ':focus-within': {
         background: 'none',
     },
-    ...(empty && {
-        padding: 0,
-        alignItems: 'normal',
-        '.MuiAccordionSummary-content': {
-            marginBottom: '0px',
-            paddingBottom: '0px',
-            flexDirection: 'column',
-        },
-
-        '.MuiAccordionSummary-expandIconWrapper': {
-            width: '0px',
-        },
-    }),
 }));
 
-const StyledHeader = styled('header', {
-    shouldForwardProp: (prop) => prop !== 'empty',
-})<{
-    empty?: boolean;
-}>(({ theme, empty }) => ({
+const StyledHeader = styled('header')(({ theme }) => ({
     display: 'flex',
     columnGap: theme.spacing(1),
     paddingRight: theme.spacing(1),
@@ -58,9 +37,6 @@ const StyledHeader = styled('header', {
     color: theme.palette.text.primary,
     alignItems: 'center',
     minHeight: theme.spacing(8),
-    ...(empty && {
-        padding: theme.spacing(0, 8, 0, 2),
-    }),
 }));
 
 const StyledHeaderTitle = styled('hgroup')(({ theme }) => ({
@@ -103,12 +79,9 @@ type EnvironmentMetadata = {
 };
 
 type EnvironmentHeaderProps = {
-    projectId: string;
-    featureId: string;
     environmentId: string;
     expandable?: boolean;
     environmentMetadata?: EnvironmentMetadata;
-    hasActivations?: boolean;
 } & AccordionSummaryProps;
 
 const MetadataChip = ({
@@ -137,54 +110,19 @@ const MetadataChip = ({
     return <StyledStrategyCount>{text}</StyledStrategyCount>;
 };
 
-const DEFAULT_STRATEGY: IFeatureStrategy = {
-    id: '',
-    name: 'flexibleRollout',
-    disabled: false,
-    constraints: [],
-    title: '',
-    parameters: {
-        rollout: '100',
-        stickiness: 'default',
-        groupId: '',
-    },
-};
-
 export const environmentAccordionSummaryClassName =
     'environment-accordion-summary';
 
-export const EnvironmentHeader: FC<
+export const LegacyEnvironmentHeader: FC<
     PropsWithChildren<EnvironmentHeaderProps>
 > = ({
-    projectId,
-    featureId,
     environmentId,
     children,
     expandable = true,
     environmentMetadata,
-    hasActivations = false,
     ...props
 }) => {
     const id = useId();
-    const { environments } = useProjectEnvironments(projectId);
-    const defaultStrategy = environments.find(
-        (env) => env.name === environmentId,
-    )?.defaultStrategy;
-
-    const strategy: Omit<IFeatureStrategy, 'id'> = useMemo(() => {
-        const baseDefaultStrategy = {
-            ...DEFAULT_STRATEGY,
-            ...defaultStrategy,
-        };
-        return {
-            ...baseDefaultStrategy,
-            disabled: false,
-            constraints: baseDefaultStrategy.constraints ?? [],
-            title: baseDefaultStrategy.title ?? '',
-            parameters: baseDefaultStrategy.parameters ?? {},
-        };
-    }, [JSON.stringify(defaultStrategy)]);
-
     return (
         <StyledAccordionSummary
             {...props}
@@ -198,9 +136,8 @@ export const EnvironmentHeader: FC<
             expandable={expandable}
             tabIndex={expandable ? 0 : -1}
             className={environmentAccordionSummaryClassName}
-            empty={!hasActivations}
         >
-            <StyledHeader empty={!hasActivations} data-loading>
+            <StyledHeader data-loading>
                 <StyledHeaderTitle>
                     <StyledHeaderTitleLabel>Environment</StyledHeaderTitleLabel>
                     <StyledTruncator component='h2'>
@@ -212,14 +149,6 @@ export const EnvironmentHeader: FC<
                 </StyledHeaderTitle>
                 {children}
             </StyledHeader>
-            {!hasActivations && (
-                <EnvironmentStrategySuggestion
-                    projectId={projectId}
-                    featureId={featureId}
-                    environmentId={environmentId}
-                    strategy={strategy}
-                />
-            )}
         </StyledAccordionSummary>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment.tsx
@@ -6,17 +6,17 @@ import type {
 import { FeatureStrategyMenu } from 'component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu';
 import { FEATURE_ENVIRONMENT_ACCORDION } from 'utils/testIds';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { UpgradeChangeRequests } from './UpgradeChangeRequests/UpgradeChangeRequests.tsx';
+import { UpgradeChangeRequests } from '../UpgradeChangeRequests/UpgradeChangeRequests.tsx';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import {
     environmentAccordionSummaryClassName,
-    EnvironmentHeader,
-} from './EnvironmentHeader/EnvironmentHeader.tsx';
-import FeatureOverviewEnvironmentMetrics from './EnvironmentHeader/FeatureOverviewEnvironmentMetrics/FeatureOverviewEnvironmentMetrics.tsx';
-import { FeatureOverviewEnvironmentToggle } from './EnvironmentHeader/FeatureOverviewEnvironmentToggle/FeatureOverviewEnvironmentToggle.tsx';
+    LegacyEnvironmentHeader,
+} from '../EnvironmentHeader/LegacyEnvironmentHeader/LegacyEnvironmentHeader.tsx';
+import FeatureOverviewEnvironmentMetrics from '../EnvironmentHeader/FeatureOverviewEnvironmentMetrics/FeatureOverviewEnvironmentMetrics.tsx';
+import { FeatureOverviewEnvironmentToggle } from '../EnvironmentHeader/FeatureOverviewEnvironmentToggle/FeatureOverviewEnvironmentToggle.tsx';
 import { useState } from 'react';
 import type { IReleasePlan } from 'interfaces/releasePlans';
-import { EnvironmentAccordionBody } from './EnvironmentAccordionBody/EnvironmentAccordionBody.tsx';
+import { EnvironmentAccordionBody } from '../EnvironmentAccordionBody/EnvironmentAccordionBody.tsx';
 import { Box } from '@mui/material';
 import { ReleaseTemplatesFeedback } from 'component/feature/FeatureStrategy/FeatureStrategyMenu/ReleaseTemplatesFeedback/ReleaseTemplatesFeedback';
 
@@ -29,8 +29,6 @@ const StyledFeatureOverviewEnvironment = styled('div')(({ theme }) => ({
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
     boxShadow: 'none',
     background: 'none',
-    borderRadius: theme.shape.borderRadiusLarge,
-
     [`&:has(.${environmentAccordionSummaryClassName}:focus-visible)`]: {
         background: theme.palette.table.headerHover,
     },
@@ -65,7 +63,7 @@ type FeatureOverviewEnvironmentProps = {
     onToggleEnvOpen?: (isOpen: boolean) => void;
 };
 
-export const FeatureOverviewEnvironment = ({
+export const LegacyFeatureOverviewEnvironment = ({
     environment,
     metrics = { yes: 0, no: 0 },
     otherEnvironments = [],
@@ -93,16 +91,13 @@ export const FeatureOverviewEnvironment = ({
                     setIsOpen(state);
                 }}
             >
-                <EnvironmentHeader
+                <LegacyEnvironmentHeader
                     environmentMetadata={{
                         strategyCount: environment.strategies?.length ?? 0,
                         releasePlanCount: environment.releasePlans?.length ?? 0,
                     }}
                     environmentId={environment.name}
-                    projectId={projectId}
-                    featureId={featureId}
                     expandable={hasActivations}
-                    hasActivations={hasActivations}
                 >
                     <FeatureOverviewEnvironmentToggle
                         environment={environment}
@@ -120,7 +115,7 @@ export const FeatureOverviewEnvironment = ({
                             environmentMetric={metrics}
                         />
                     )}
-                </EnvironmentHeader>
+                </LegacyEnvironmentHeader>
                 <NewStyledAccordionDetails>
                     <StyledEnvironmentAccordionContainer>
                         <EnvironmentAccordionBody

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironments.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironments.tsx
@@ -1,10 +1,12 @@
 import type { ComponentProps, FC } from 'react';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
+import { LegacyFeatureOverviewEnvironment } from './FeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment/LegacyFeatureOverviewEnvironment.tsx';
 import { FeatureOverviewEnvironment } from './FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
 import { getFeatureMetrics } from 'utils/getFeatureMetrics';
 import { useReleasePlans } from 'hooks/api/getters/useReleasePlans/useReleasePlans';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 type FeatureOverviewEnvironmentsProps = {
     hiddenEnvironments?: string[];
@@ -12,7 +14,7 @@ type FeatureOverviewEnvironmentsProps = {
 };
 
 const FeatureOverviewWithReleasePlans: FC<
-    ComponentProps<typeof FeatureOverviewEnvironment>
+    ComponentProps<typeof LegacyFeatureOverviewEnvironment>
 > = ({ environment, ...props }) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -21,9 +23,20 @@ const FeatureOverviewWithReleasePlans: FC<
         featureId,
         environment?.name,
     );
+    const envAddStrategySuggestionEnabled = useUiFlag(
+        'envAddStrategySuggestion',
+    );
+    if (envAddStrategySuggestionEnabled) {
+        return (
+            <FeatureOverviewEnvironment
+                {...props}
+                environment={{ ...environment, releasePlans }}
+            />
+        );
+    }
 
     return (
-        <FeatureOverviewEnvironment
+        <LegacyFeatureOverviewEnvironment
             {...props}
             environment={{ ...environment, releasePlans }}
         />

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironment.tsx
@@ -2,7 +2,7 @@ import { Accordion, AccordionDetails, styled } from '@mui/material';
 import { PROJECT_ENVIRONMENT_ACCORDION } from 'utils/testIds';
 import type { ProjectEnvironmentType } from '../../../../../../interfaces/environments.ts';
 import { ProjectEnvironmentDefaultStrategy } from './ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx';
-import { EnvironmentHeader } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/EnvironmentHeader';
+import { LegacyEnvironmentHeader } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/LegacyEnvironmentHeader/LegacyEnvironmentHeader';
 
 interface IProjectEnvironmentProps {
     environment: ProjectEnvironmentType;
@@ -35,7 +35,10 @@ export const ProjectEnvironment = ({
                 onChange={(e) => e.stopPropagation()}
                 data-testid={`${PROJECT_ENVIRONMENT_ACCORDION}_${name}`}
             >
-                <EnvironmentHeader environmentId={name} expandable={false} />
+                <LegacyEnvironmentHeader
+                    environmentId={name}
+                    expandable={false}
+                />
                 <StyledAccordionDetails>
                     <ProjectEnvironmentDefaultStrategy
                         environment={environment}

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -41,6 +41,7 @@ export type CustomEvents =
     | 'context-usage'
     | 'segment-usage'
     | 'strategy-add'
+    | 'suggestion-strategy-add'
     | 'playground'
     | 'feature-type-edit'
     | 'strategy-variants'

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -89,6 +89,7 @@ export type UiFlags = {
     newStrategyModal?: boolean;
     globalChangeRequestList?: boolean;
     flagsUiFilterRefactor?: boolean;
+    envAddStrategySuggestion?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -61,7 +61,8 @@ export type IFlagKey =
     | 'newStrategyModal'
     | 'globalChangeRequestList'
     | 'newUiConfigService'
-    | 'flagsUiFilterRefactor';
+    | 'flagsUiFilterRefactor'
+    | 'envAddStrategySuggestion';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -281,6 +282,10 @@ const flags: IFlags = {
     ),
     flagsUiFilterRefactor: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FLAGS_UI_FILTER_REFACTOR,
+        false,
+    ),
+    envAddStrategySuggestion: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ENV_ADD_STRATEGY_SUGGESTION,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -57,6 +57,7 @@ process.nextTick(async () => {
                         globalChangeRequestList: true,
                         newUiConfigService: true,
                         flagsUiFilterRefactor: true,
+                        envAddStrategySuggestion: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
This adds a default-strategy suggestion banner to the bottom of empty feature environments (envs without strategies)

<img width="1166" height="312" alt="image" src="https://github.com/user-attachments/assets/2d028eaf-e455-4e70-a129-6e25e4df81d0" />
