### PR TITLE
feat: allow test operation for patch

### DIFF
--- a/src/lib/openapi/spec/patch-schema.ts
+++ b/src/lib/openapi/spec/patch-schema.ts
@@ -14,7 +14,7 @@ export const patchSchema = {
         },
         op: {
             type: 'string',
-            enum: ['add', 'remove', 'replace', 'copy', 'move'],
+            enum: ['add', 'remove', 'replace', 'copy', 'move', 'test'],
             description: 'The kind of operation to perform',
             example: 'replace',
         },


### PR DESCRIPTION
## About the changes
This would allow users to add test statements to protect from concurrent modifications. From https://github.com/orgs/Unleash/discussions/10707#discussioncomment-14602784

E.g.
If you had this feature flag configuration
```
{
  "name": "flexibleRollout",
  "constraints": [
    {
      "contextName": "a",
      "operator": "IN",
      "values": [
        "100", "200", "300", "400", "500"
      ],
      "caseInsensitive": false,
      "inverted": false
    }
  ],
  "parameters": {
    "rollout": "100",
    "stickiness": "default",
    "groupId": "api-access"
  },
  "variants": [],
  "segments": [
    122
  ],
  "disabled": false
}
```

And you'd like to remove the value 300 from the constraints, you'd have to first get the current values and then PATCH the strategy with the following body:
```
[{ "op": "remove", "path": "/constraints/0/values/2" }]
```

This could fail in case of concurrent modifications (e.g. if someone removed the value "100", then the index to remove "300" will no longer be 2).

With the test operation, you'd be able to add a protection mechanism to validate that the value at index 2 is still 300:
```
[
    { "op": "test", "path": "/constraints/0/values/2", "value": "300" },
    { "op": "remove", "path": "/constraints/0/values/2" }
]
```
If the test fails, the remove operation will not be applied.

I've tested this locally and works as expected:
1. If the value is still 300, it will remove it
2. The operation will fail if the value is no longer 300 because of another change.