### PR TITLE
feat: batch week data if the shown time span is greater than 12 weeks.

### DIFF
--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/CreationArchiveRatioTooltip.tsx
@@ -44,6 +44,7 @@ interface CreationArchiveRatioTooltipProps {
 }
 
 const Timestamp = styled('span')(({ theme }) => ({
+    whiteSpace: 'nowrap',
     fontSize: theme.typography.body2.fontSize,
     color: theme.palette.text.secondary,
 }));

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/batchWeekData.test.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/batchWeekData.test.ts
@@ -1,0 +1,79 @@
+import { batchWeekData } from './batchWeekData.ts';
+
+it('handles empty input', () => {
+    expect(batchWeekData([])).toEqual([]);
+});
+
+it('handles a single data point', () => {
+    const input = {
+        archivedFlags: 5,
+        totalCreatedFlags: 1,
+        archivePercentage: 500,
+        week: '50',
+        date: '2022-01-01',
+    };
+    expect(batchWeekData([input])).toStrictEqual([
+        {
+            archivedFlags: 5,
+            totalCreatedFlags: 1,
+            archivePercentage: 500,
+            date: input.date,
+            endDate: input.date,
+        },
+    ]);
+});
+it('batches by 4, starting from the first entry', () => {
+    const input = [
+        {
+            archivedFlags: 1,
+            totalCreatedFlags: 1,
+            archivePercentage: 100,
+            week: '50',
+            date: '2022-01-01',
+        },
+        {
+            archivedFlags: 5,
+            totalCreatedFlags: 1,
+            archivePercentage: 500,
+            week: '50',
+            date: '2022-02-02',
+        },
+        {
+            archivedFlags: 3,
+            totalCreatedFlags: 0,
+            archivePercentage: 0,
+            week: '50',
+            date: '2022-03-03',
+        },
+        {
+            archivedFlags: 3,
+            totalCreatedFlags: 4,
+            archivePercentage: 75,
+            week: '50',
+            date: '2022-04-04',
+        },
+        {
+            archivedFlags: 3,
+            totalCreatedFlags: 2,
+            archivePercentage: 150,
+            week: '50',
+            date: '2022-05-05',
+        },
+    ];
+    expect(batchWeekData(input)).toStrictEqual([
+        {
+            archivedFlags: 12,
+            totalCreatedFlags: 6,
+            archivePercentage: 200,
+            date: '2022-01-01',
+            endDate: '2022-04-04',
+        },
+        {
+            archivedFlags: 3,
+            totalCreatedFlags: 2,
+            archivePercentage: 150,
+            date: '2022-05-05',
+            endDate: '2022-05-05',
+        },
+    ]);
+});

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/batchWeekData.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/batchWeekData.ts
@@ -1,0 +1,29 @@
+import type { BatchedWeekData, WeekData } from './types.ts';
+
+const batchSize = 4;
+
+export const batchWeekData = (weeks: WeekData[]): BatchedWeekData[] =>
+    weeks.reduce((acc, curr, index) => {
+        const currentAggregatedIndex = Math.floor(index / batchSize);
+
+        const data = acc[currentAggregatedIndex];
+
+        if (data) {
+            data.totalCreatedFlags += curr.totalCreatedFlags;
+            data.archivedFlags += curr.archivedFlags;
+
+            data.archivePercentage =
+                data.totalCreatedFlags > 0
+                    ? (data.archivedFlags / data.totalCreatedFlags) * 100
+                    : 0;
+
+            data.endDate = curr.date;
+        } else {
+            const { week: _, ...shared } = curr;
+            acc[currentAggregatedIndex] = {
+                ...shared,
+                endDate: curr.date,
+            };
+        }
+        return acc;
+    }, [] as BatchedWeekData[]);

--- a/frontend/src/component/insights/componentsChart/CreationArchiveChart/types.ts
+++ b/frontend/src/component/insights/componentsChart/CreationArchiveChart/types.ts
@@ -3,7 +3,7 @@ export type WeekData = {
     totalCreatedFlags: number;
     archivePercentage: number;
     week: string;
-    date?: string;
+    date: string;
 };
 
 export type RawWeekData = {
@@ -11,4 +11,8 @@ export type RawWeekData = {
     createdFlags: Record<string, number>;
     week: string;
     date: string;
+};
+
+export type BatchedWeekData = Omit<WeekData, 'week'> & {
+    endDate: string;
 };

--- a/frontend/src/component/insights/hooks/useInsightsData.ts
+++ b/frontend/src/component/insights/hooks/useInsightsData.ts
@@ -12,18 +12,9 @@ export const useInsightsData = (
     const allMetricsDatapoints = useAllDatapoints(
         instanceInsights.metricsSummaryTrends,
     );
+
     const projectsData = useFilteredTrends(
         instanceInsights.projectFlagTrends,
-        projects,
-    );
-
-    const lifecycleData = useFilteredTrends(
-        instanceInsights.lifecycleTrends,
-        projects,
-    );
-
-    const creationArchiveData = useFilteredTrends(
-        instanceInsights.creationArchiveTrends,
         projects,
     );
 
@@ -37,8 +28,16 @@ export const useInsightsData = (
 
     const summary = useFilteredFlagsSummary(projectsData);
 
+    const lifecycleData = useFilteredTrends(
+        instanceInsights.lifecycleTrends,
+        projects,
+    );
     const groupedLifecycleData = useGroupedProjectTrends(lifecycleData);
 
+    const creationArchiveData = useFilteredTrends(
+        instanceInsights.creationArchiveTrends,
+        projects,
+    );
     const groupedCreationArchiveData =
         useGroupedProjectTrends(creationArchiveData);
 

--- a/frontend/src/component/insights/sections/PerformanceInsights.tsx
+++ b/frontend/src/component/insights/sections/PerformanceInsights.tsx
@@ -71,13 +71,6 @@ export const PerformanceInsights: FC = () => {
     const lastFlagTrend = flagTrends[flagTrends.length - 1];
     const flagsTotal = lastFlagTrend?.total ?? 0;
 
-    function getFlagsPerUser(flagsTotal: number, usersTotal: number) {
-        const flagsPerUserCalculation = flagsTotal / usersTotal;
-        return Number.isNaN(flagsPerUserCalculation)
-            ? 'N/A'
-            : flagsPerUserCalculation.toFixed(2);
-    }
-
     const isLifecycleGraphsEnabled = useUiFlag('lifecycleGraphs');
 
     return (


### PR DESCRIPTION
Implements batching of data points in the archived:created chart: when there's 12 or more weeks of data, batch data into batches of 4 weeks at a time. When we batch data, we also switch the labeling to be month-based and auto-generated (cf the inline comment with more details).

<img width="798" height="317" alt="image" src="https://github.com/user-attachments/assets/068ee528-a6d6-4aaf-ac81-c729c2c813d1" />


The current implementation batches into groups of 4 weeks, but this can easily be parameterized to support arbitrary batch sizes.

Because of the batching, we also now need to adjust the tooltip title in those cases. This is handled by a callback.
