### PR TITLE
fix: clone environments

### DIFF
--- a/src/lib/features/release-plans/release-plan-store.ts
+++ b/src/lib/features/release-plans/release-plan-store.ts
@@ -366,4 +366,32 @@ export class ReleasePlanStore extends CRUDStore<
         endTimer();
         return present;
     }
+
+    async getByEnvironmentAndProjects(
+        environment: string,
+        projects: string[],
+    ): Promise<ReleasePlan[]> {
+        const endTimer = this.timer('getByEnvironmentAndProjects');
+        const rows = await this.db(`${this.tableName} AS rpd`)
+            .join('features AS f', 'f.name', 'rpd.feature_name')
+            .where('rpd.discriminator', 'plan')
+            .andWhere('rpd.environment', environment)
+            .whereIn('f.project', projects)
+            .leftJoin(
+                'milestones AS mi',
+                'mi.release_plan_definition_id',
+                'rpd.id',
+            )
+            .leftJoin('milestone_strategies AS ms', 'ms.milestone_id', 'mi.id')
+            .leftJoin(
+                'milestone_strategy_segments AS mss',
+                'mss.milestone_strategy_id',
+                'ms.id',
+            )
+            .orderBy('mi.sort_order', 'asc')
+            .orderBy('ms.sort_order', 'asc')
+            .select(selectColumns);
+        endTimer();
+        return processReleasePlanRows(rows);
+    }
 }

--- a/src/lib/types/stores/feature-environment-store.ts
+++ b/src/lib/types/stores/feature-environment-store.ts
@@ -68,6 +68,7 @@ export interface IFeatureEnvironmentStore
     cloneStrategies(
         sourceEnvironment: string,
         destinationEnvironment: string,
+        projects: string[],
     ): Promise<void>;
     addVariantsToFeatureEnvironment(
         featureName: string,

--- a/src/test/e2e/stores/feature-environment-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-environment-store.e2e.test.ts
@@ -165,7 +165,9 @@ test('Copying strategies also copies strategy variants', async () => {
     });
     await featureEnvironmentStore.connectProject('clone-2', 'default');
 
-    await featureEnvironmentStore.cloneStrategies(envName, 'clone-2');
+    await featureEnvironmentStore.cloneStrategies(envName, 'clone-2', [
+        'default',
+    ]);
 
     const clonedStrategy =
         await featureStrategiesStore.getStrategiesForFeatureEnv(


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3932/cloned-environments-enable-disabled-strategies-unexpectedly

Cloning environments didn't work as expected. This fixes a few of issues:
 - Disabled strategies remain disabled after cloning
 - All strategy properties are cloned (including e.g. title)
 - Strategy cloning respects the selected projects
 - Release plans and their milestones are now correctly cloned