### PR TITLE
feat: apply strategy suggestion directly when clicked

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -1,5 +1,5 @@
 import { type DragEventHandler, type RefObject, useRef } from 'react';
-import { styled, useMediaQuery, useTheme } from '@mui/material';
+import { useMediaQuery, useTheme } from '@mui/material';
 import type { IFeatureEnvironment } from 'interfaces/featureToggle';
 import type { IFeatureStrategy } from 'interfaces/strategy';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
@@ -15,14 +15,6 @@ import MenuStrategyRemove from './StrategyItem/MenuStrategyRemove/MenuStrategyRe
 import { Link } from 'react-router-dom';
 import { UPDATE_FEATURE_STRATEGY } from '@server/types/permissions';
 import { StrategyDraggableItem } from './StrategyDraggableItem.tsx';
-
-const StyledPermissionIconButton = styled(PermissionIconButton)(
-    ({ theme }) => ({
-        borderRadius: theme.spacing(0.5),
-        fontSize: theme.fontSizes.smallBody,
-        padding: theme.spacing(1),
-    }),
-);
 
 type ProjectEnvironmentStrategyDraggableItemProps = {
     strategy: IFeatureStrategy;
@@ -111,7 +103,7 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
                             strategy={strategy}
                         />
                     ) : null}
-                    <StyledPermissionIconButton
+                    <PermissionIconButton
                         permission={UPDATE_FEATURE_STRATEGY}
                         environmentId={environmentName}
                         projectId={projectId}
@@ -123,8 +115,7 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
                         data-testid={`STRATEGY_EDIT-${strategy.name}`}
                     >
                         <Edit />
-                        &nbsp;Edit strategy
-                    </StyledPermissionIconButton>
+                    </PermissionIconButton>
                     <MenuStrategyRemove
                         projectId={projectId}
                         featureId={featureId}


### PR DESCRIPTION
Applies the strategy suggestion directly when clicked. Also changes the strategy edit button to have text 'Edit strategy'.