### PR TITLE
fix: hide enable strategy dialog when there are release plans

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/FeatureOverviewEnvironmentToggle/FeatureOverviewEnvironmentToggle.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentHeader/FeatureOverviewEnvironmentToggle/FeatureOverviewEnvironmentToggle.tsx
@@ -23,12 +23,17 @@ export const FeatureOverviewEnvironmentToggle = ({
 }: FeatureOverviewEnvironmentToggleProps) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
-    const { refetchFeature } = useFeature(projectId, featureId);
+    const { feature, refetchFeature } = useFeature(projectId, featureId);
 
     const { isChangeRequestConfigured } = useChangeRequestsEnabled(projectId);
 
     const { onToggle: onFeatureToggle, modals: featureToggleModals } =
         useFeatureToggleSwitch(projectId);
+
+    const hasReleasePlans = Boolean(
+        feature.environments.find((env) => env.name === name)?.releasePlans
+            ?.length,
+    );
 
     const onToggle = (newState: boolean, onRollback: () => void) =>
         onFeatureToggle(newState, {
@@ -40,6 +45,7 @@ export const FeatureOverviewEnvironmentToggle = ({
             hasEnabledStrategies: strategies.some(
                 (strategy) => !strategy.disabled,
             ),
+            hasReleasePlans,
             isChangeRequestEnabled: isChangeRequestConfigured(name),
             onRollback,
             onSuccess: refetchFeature,

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/FeatureToggleCell/FeatureToggleCell.tsx
@@ -65,6 +65,7 @@ const FeatureToggleCellComponent = ({
             environmentName: environment?.name || '',
             environmentType: environment?.type,
             hasStrategies: environment?.hasStrategies,
+            hasReleasePlans: Boolean(environment?.releasePlans?.length),
             hasEnabledStrategies: environment?.hasEnabledStrategies,
             isChangeRequestEnabled,
             onRollback,

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.types.ts
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.types.ts
@@ -12,6 +12,7 @@ export type ListItemType = Pick<
             type: string;
             hasStrategies: boolean;
             hasEnabledStrategies: boolean;
+            hasReleasePlans: boolean;
         };
     };
     someEnabledEnvironmentHasVariants: boolean;

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/FeatureToggleSwitch.types.ts
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/FeatureToggleSwitch.types.ts
@@ -6,6 +6,7 @@ export type OnFeatureToggleSwitchArgs = {
     environmentName: string;
     environmentType?: string;
     hasStrategies?: boolean;
+    hasReleasePlans?: boolean;
     hasEnabledStrategies?: boolean;
     isChangeRequestEnabled?: boolean;
     onRollback?: () => void;

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/createFeatureToggleCell.tsx
@@ -59,6 +59,7 @@ const FeatureToggleCellComponent = ({
             environmentType: environment?.type,
             hasStrategies: environment?.hasStrategies,
             hasEnabledStrategies: environment?.hasEnabledStrategies,
+            hasReleasePlans: environment?.hasReleasePlans,
             isChangeRequestEnabled,
             onRollback,
             onSuccess: refetch,

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/FeatureToggleSwitch/useFeatureToggleSwitch.tsx
@@ -102,7 +102,8 @@ export const useFeatureToggleSwitch: UseFeatureToggleSwitchType = (
                 if (
                     newState === false ||
                     !config.hasStrategies ||
-                    config.hasEnabledStrategies
+                    config.hasEnabledStrategies ||
+                    config.hasReleasePlans
                 ) {
                     return next();
                 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3953/fix-enable-environment-modal-when-there-are-release-plans

Prevents the "environment needs at least one enabled strategy" dialog from showing up if you have added a release plan.

This relies on the new `featureReleasePlans` feature flag.

PS: Maybe we should revisit this dialog in the future. We don't usually see it, and maybe it should trigger the new "add strategy" modal?

<img width="684" height="399" alt="image" src="https://github.com/user-attachments/assets/2f8213db-22b4-4618-b8e2-15eca096d465" />
