### PR TITLE
feat: enhance billing invoice components

### DIFF
--- a/frontend/src/component/admin/billing/BillingInvoices/BillingInvoice/BillingInvoiceRow/BillingInvoiceRow.tsx
+++ b/frontend/src/component/admin/billing/BillingInvoices/BillingInvoice/BillingInvoiceRow/BillingInvoiceRow.tsx
@@ -11,14 +11,6 @@ const StyledCellWithIndicator = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
-type BillingInvoiceRowProps = {
-    description: string;
-    quantity?: number;
-    amount?: number;
-    quota?: number;
-    usage?: number;
-};
-
 const StyledDescriptionCell = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
@@ -30,6 +22,10 @@ const StyledSubText = styled(Typography)(({ theme }) => ({
     fontSize: theme.typography.body2.fontSize,
 }));
 
+type BillingInvoiceRowProps = DetailedInvoicesLineSchema & {
+    showLimits?: boolean;
+};
+
 export const BillingInvoiceRow = ({
     quantity,
     consumption,
@@ -39,7 +35,8 @@ export const BillingInvoiceRow = ({
     totalAmount,
     startDate,
     endDate,
-}: DetailedInvoicesLineSchema) => {
+    showLimits,
+}: BillingInvoiceRowProps) => {
     const percentage =
         limit && limit > 0
             ? Math.min(100, Math.round(((consumption || 0) / limit) * 100))
@@ -68,11 +65,15 @@ export const BillingInvoiceRow = ({
                     </StyledSubText>
                 ) : null}
             </StyledDescriptionCell>
-            <StyledCellWithIndicator>
-                <ConsumptionIndicator percentage={percentage || 0} />
-                {limit !== undefined ? formatLargeNumbers(limit) : '–'}
-                {percentage !== undefined ? ` (${percentage}%)` : ''}
-            </StyledCellWithIndicator>
+            {showLimits ? (
+                <StyledCellWithIndicator>
+                    <ConsumptionIndicator percentage={percentage || 0} />
+                    {limit !== undefined ? formatLargeNumbers(limit) : '–'}
+                    {percentage !== undefined ? ` (${percentage}%)` : ''}
+                </StyledCellWithIndicator>
+            ) : (
+                <StyledCellWithIndicator />
+            )}
             <div>{quantity ? formatLargeNumbers(quantity) : '–'}</div>
             <StyledAmountCell>
                 {formatCurrency(totalAmount || 0, currency)}

--- a/frontend/src/component/admin/billing/BillingInvoices/BillingInvoices.tsx
+++ b/frontend/src/component/admin/billing/BillingInvoices/BillingInvoices.tsx
@@ -14,16 +14,17 @@ export const BillingInvoices: FC = () => {
     const { invoices, loading } = useDetailedInvoices();
 
     if (loading) {
-        return null;
+        return <StyledContainer />;
     }
 
     return (
         <StyledContainer>
             {invoices.length > 0 ? (
                 <>
-                    {invoices.map((invoice) => (
+                    {invoices.map((invoice, index) => (
                         <BillingInvoice
                             key={invoice.invoiceDate}
+                            defaultExpanded={index === 0}
                             {...invoice}
                         />
                     ))}


### PR DESCRIPTION
## About the changes
- Hide "included usage" column if an invoice doesn't have any items that have lines with `limit`
- Minor component types refactors
- Only open (extend accordion) for the first invoice on the list 