### PR TITLE
chore: add alert about release plans when cloning flag

### DIFF
--- a/frontend/src/component/feature/CopyFeature/CopyFeature.tsx
+++ b/frontend/src/component/feature/CopyFeature/CopyFeature.tsx
@@ -78,7 +78,7 @@ export const CopyFeatureToggle = () => {
     const navigate = useNavigate();
     const { isChangeRequestConfiguredInAnyEnv } =
         useChangeRequestsEnabled(projectId);
-    const hasReleasePlan = feature.environments.some((env) =>
+    const hasReleasePlan = feature.environments?.some((env) =>
         Boolean(env.releasePlans?.length),
     );
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3966/cloning-a-feature-will-not-clone-release-plans

Adds an alert when cloning a feature flag with a release plan.

Requires the `featureReleasePlans` feature flag.

<img width="1162" height="568" alt="image" src="https://github.com/user-attachments/assets/325db586-14b9-4ce4-9d7c-6f680017c6ac" />
