### PR TITLE
chore: remove uuid from the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
     "ts-toolbelt": "^9.6.0",
     "type-is": "^2.0.0",
     "ulidx": "^2.4.1",
-    "unleash-client": "^6.8.0-beta.0",
-    "uuid": "^11.0.0"
+    "unleash-client": "^6.8.0-beta.0"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "10.1.1",
@@ -161,7 +160,6 @@
     "@types/stoppable": "1.1.3",
     "@types/supertest": "6.0.3",
     "@types/type-is": "1.6.7",
-    "@types/uuid": "9.0.8",
     "@vitest/coverage-v8": "^3.1.3",
     "@vitest/ui": "^3.1.3",
     "concurrently": "^9.0.0",

--- a/src/lib/db/feature-environment-store.ts
+++ b/src/lib/db/feature-environment-store.ts
@@ -8,9 +8,9 @@ import metricsHelper from '../util/metrics-helper.js';
 import { DB_TIME } from '../metric-events.js';
 import type { IFeatureEnvironment, IVariant } from '../types/model.js';
 import NotFoundError from '../error/notfound-error.js';
-import { v4 as uuidv4 } from 'uuid';
 import type { Db } from './db.js';
 import type { IUnleashConfig } from '../types/index.js';
+import { randomId } from '../util/index.js';
 
 const T = {
     featureEnvs: 'feature_environments',
@@ -495,7 +495,7 @@ export class FeatureEnvironmentStore implements IFeatureEnvironmentStore {
             const clonedStrategyRows = sourceFeatureStrategies.map(
                 (featureStrategy) => ({
                     ...featureStrategy,
-                    id: uuidv4(),
+                    id: randomId(),
                     environment: destinationEnvironment,
                     parameters: JSON.stringify(featureStrategy.parameters),
                     constraints: JSON.stringify(featureStrategy.constraints),

--- a/src/lib/error/unleash-error.ts
+++ b/src/lib/error/unleash-error.ts
@@ -1,5 +1,5 @@
-import { v4 as uuidV4 } from 'uuid';
 import type { FromSchema } from 'json-schema-to-ts';
+import { randomId } from '../util/random-id.js';
 
 export const UnleashApiErrorTypes = [
     'ContentTypeError',
@@ -48,7 +48,7 @@ export abstract class UnleashError extends Error {
 
     constructor(message: string, name?: string) {
         super();
-        this.id = uuidV4();
+        this.id = randomId();
         this.name = name || this.constructor.name;
         super.message = message;
     }

--- a/src/lib/features/dependent-features/dependent.features.e2e.test.ts
+++ b/src/lib/features/dependent-features/dependent.features.e2e.test.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import dbInit, {
     type ITestDb,
 } from '../../../test/e2e/helpers/database-init.js';
@@ -13,7 +12,7 @@ import {
     FEATURE_DEPENDENCY_ADDED,
     FEATURE_DEPENDENCY_REMOVED,
 } from '../../events/index.js';
-import { DEFAULT_ENV } from '../../util/index.js';
+import { DEFAULT_ENV, randomId } from '../../util/index.js';
 import type { IEventStore } from '../../server-impl.js';
 
 let app: IUnleashTest;
@@ -169,9 +168,9 @@ const checkDependenciesExist = async (expectedCode = 200) => {
 };
 
 test('should add and delete feature dependencies', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
-    const child2 = uuidv4();
+    const parent = randomId();
+    const child = randomId();
+    const child2 = randomId();
     await app.createFeature(parent);
     await app.createFeature(child);
     await app.createFeature(child2);
@@ -209,10 +208,10 @@ test('should add and delete feature dependencies', async () => {
 });
 
 test('should sort potential parent features alphabetically', async () => {
-    const parent1 = `a${uuidv4()}`;
-    const parent2 = `c${uuidv4()}`;
-    const parent3 = `b${uuidv4()}`;
-    const child = uuidv4();
+    const parent1 = `a${randomId()}`;
+    const parent2 = `c${randomId()}`;
+    const parent3 = `b${randomId()}`;
+    const child = randomId();
     await app.createFeature(parent1);
     await app.createFeature(parent2);
     await app.createFeature(parent3);
@@ -223,7 +222,7 @@ test('should sort potential parent features alphabetically', async () => {
 });
 
 test('should sort potential parent variants', async () => {
-    const parent = uuidv4();
+    const parent = randomId();
     await app.createFeature(parent);
     await addFeatureEnvironmentVariant(parent, 'e');
     await addStrategyVariants(parent, ['c', 'a', 'd']);
@@ -235,9 +234,9 @@ test('should sort potential parent variants', async () => {
 });
 
 test('should not allow to add grandparent', async () => {
-    const grandparent = uuidv4();
-    const parent = uuidv4();
-    const child = uuidv4();
+    const grandparent = randomId();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(grandparent);
     await app.createFeature(parent);
     await app.createFeature(child);
@@ -255,9 +254,9 @@ test('should not allow to add grandparent', async () => {
 });
 
 test('should not allow to add grandchild', async () => {
-    const grandparent = uuidv4();
-    const parent = uuidv4();
-    const child = uuidv4();
+    const grandparent = randomId();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(grandparent);
     await app.createFeature(parent);
     await app.createFeature(child);
@@ -276,8 +275,8 @@ test('should not allow to add grandchild', async () => {
 });
 
 test('should not allow to add non-existent parent dependency', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(child);
 
     await addFeatureDependency(
@@ -290,8 +289,8 @@ test('should not allow to add non-existent parent dependency', async () => {
 });
 
 test('should not allow to add archived parent dependency', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(child);
     await app.createFeature(parent);
     await app.archiveFeature(parent);
@@ -306,8 +305,8 @@ test('should not allow to add archived parent dependency', async () => {
 });
 
 test('should check if any dependencies exist', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(child);
     await app.createFeature(parent);
 
@@ -323,7 +322,7 @@ test('should check if any dependencies exist', async () => {
 });
 
 test('should not allow to add dependency to self', async () => {
-    const parent = uuidv4();
+    const parent = randomId();
     await app.createFeature(parent);
 
     await addFeatureDependency(
@@ -336,8 +335,8 @@ test('should not allow to add dependency to self', async () => {
 });
 
 test('should not allow to add dependency to feature from another project', async () => {
-    const child = uuidv4();
-    const parent = uuidv4();
+    const child = randomId();
+    const parent = randomId();
     await app.createFeature(parent);
     await createProject('another-project');
     await app.createFeature(child, 'another-project');
@@ -351,8 +350,8 @@ test('should not allow to add dependency to feature from another project', async
     );
 });
 test('should create feature-dependency-removed when archiving and has dependency', async () => {
-    const child = uuidv4();
-    const parent = uuidv4();
+    const child = randomId();
+    const parent = randomId();
     await app.createFeature(parent);
     await app.createFeature(child);
 
@@ -369,8 +368,8 @@ test('should create feature-dependency-removed when archiving and has dependency
 });
 
 test('should not create feature-dependency-removed when archiving and no dependency', async () => {
-    const child = uuidv4();
-    const parent = uuidv4();
+    const child = randomId();
+    const parent = randomId();
     await app.createFeature(parent);
     await app.createFeature(child);
 

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -1,6 +1,5 @@
 import { Knex } from 'knex';
 import type EventEmitter from 'events';
-import { v4 as uuidv4 } from 'uuid';
 import metricsHelper from '../../util/metrics-helper.js';
 import { DB_TIME } from '../../metric-events.js';
 import type { Logger, LogProvider } from '../../logger.js';
@@ -24,6 +23,7 @@ import {
     ensureStringValue,
     generateImageUrl,
     mapValues,
+    randomId,
 } from '../../util/index.js';
 import type { IFeatureProjectUserParams } from './feature-toggle-controller.js';
 import type { Db } from '../../db/db.js';
@@ -238,7 +238,7 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
                 strategyConfig.environment,
             ));
         const strategyRow = mapInput({
-            id: uuidv4(),
+            id: randomId(),
             ...strategyConfig,
             sortOrder,
         });

--- a/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggles.e2e.test.ts
@@ -19,7 +19,6 @@ import ApiUser from '../../../types/api-user.js';
 import { ApiTokenType, type IApiToken } from '../../../types/model.js';
 import IncompatibleProjectError from '../../../error/incompatible-project-error.js';
 import { type IStrategyConfig, RoleName } from '../../../types/model.js';
-import { v4 as uuidv4 } from 'uuid';
 import type supertest from 'supertest';
 import { randomId } from '../../../util/random-id.js';
 import { DEFAULT_PROJECT, TEST_AUDIT_USER } from '../../../types/index.js';
@@ -202,8 +201,8 @@ test('Trying to add a strategy configuration to environment not connected to fla
 });
 
 test('should list dependencies and children', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.addDependency(child, parent);
@@ -228,8 +227,8 @@ test('should list dependencies and children', async () => {
 });
 
 test('should not allow to change project with dependencies', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.addDependency(child, parent);
@@ -259,8 +258,8 @@ test('should not allow to change project with dependencies', async () => {
 });
 
 test('Should not allow to archive/delete feature with children', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.addDependency(child, parent);
@@ -282,8 +281,8 @@ test('Should not allow to archive/delete feature with children', async () => {
 });
 
 test('Should allow to archive/delete feature with children if no orphans are left', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
+    const parent = randomId();
+    const child = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.addDependency(child, parent);
@@ -296,9 +295,9 @@ test('Should allow to archive/delete feature with children if no orphans are lef
 });
 
 test('Should not allow to archive/delete feature when orphans are left', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
-    const orphan = uuidv4();
+    const parent = randomId();
+    const child = randomId();
+    const orphan = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.createFeature(orphan, 'default');
@@ -317,9 +316,9 @@ test('Should not allow to archive/delete feature when orphans are left', async (
 });
 
 test('should clone feature with parent dependencies', async () => {
-    const parent = uuidv4();
-    const child = uuidv4();
-    const childClone = uuidv4();
+    const parent = randomId();
+    const child = randomId();
+    const childClone = randomId();
     await app.createFeature(parent, 'default');
     await app.createFeature(child, 'default');
     await app.addDependency(child, parent);
@@ -2419,7 +2418,7 @@ test('Can create flag with impression data on different project', async () => {
 });
 
 test('should handle strategy variants', async () => {
-    const feature = { name: uuidv4(), impressionData: false };
+    const feature = { name: randomId(), impressionData: false };
     await app.createFeature(feature.name);
 
     const strategyWithInvalidVariant = {
@@ -2494,14 +2493,14 @@ test('should handle strategy variants', async () => {
 
 test('should reject invalid constraint values for multi-valued constraints', async () => {
     const project = await db.stores.projectStore.create({
-        id: uuidv4(),
-        name: uuidv4(),
+        id: randomId(),
+        name: randomId(),
         description: '',
         mode: 'open',
     });
 
     const flag = await db.stores.featureToggleStore.create(project.id, {
-        name: uuidv4(),
+        name: randomId(),
         impressionData: true,
         createdByUserId: 9999,
     });
@@ -2542,14 +2541,14 @@ test('should reject invalid constraint values for multi-valued constraints', asy
 
 test('should add default constraint values for single-valued constraints', async () => {
     const project = await db.stores.projectStore.create({
-        id: uuidv4(),
-        name: uuidv4(),
+        id: randomId(),
+        name: randomId(),
         description: '',
         mode: 'open',
     });
 
     const flag = await db.stores.featureToggleStore.create(project.id, {
-        name: uuidv4(),
+        name: randomId(),
         impressionData: true,
         createdByUserId: 9999,
     });
@@ -2603,14 +2602,14 @@ test('should add default constraint values for single-valued constraints', async
 
 test('should allow long parameter values', async () => {
     const project = await db.stores.projectStore.create({
-        id: uuidv4(),
-        name: uuidv4(),
-        description: uuidv4(),
+        id: randomId(),
+        name: randomId(),
+        description: randomId(),
         mode: 'open',
     });
 
     const flag = await db.stores.featureToggleStore.create(project.id, {
-        name: uuidv4(),
+        name: randomId(),
         createdByUserId: 9999,
     });
 
@@ -2628,7 +2627,7 @@ test('should allow long parameter values', async () => {
 });
 
 test('should change strategy sort order when payload is valid', async () => {
-    const flag = { name: uuidv4(), impressionData: false };
+    const flag = { name: randomId(), impressionData: false };
     await app.request
         .post('/api/admin/projects/default/features')
         .send({
@@ -2696,7 +2695,7 @@ test('should change strategy sort order when payload is valid', async () => {
 });
 
 test('should reject set sort order request when payload is invalid', async () => {
-    const flag = { name: uuidv4(), impressionData: false };
+    const flag = { name: randomId(), impressionData: false };
 
     await app.request
         .post(
@@ -2714,7 +2713,7 @@ test('should reject set sort order request when payload is invalid', async () =>
 });
 
 test('should return strategies in correct order when new strategies are added', async () => {
-    const flag = { name: uuidv4(), impressionData: false };
+    const flag = { name: randomId(), impressionData: false };
     await app.request
         .post('/api/admin/projects/default/features')
         .send({
@@ -2835,7 +2834,7 @@ test('should return strategies in correct order when new strategies are added', 
 });
 
 test('should create a strategy with segments', async () => {
-    const feature = { name: uuidv4(), impressionData: false };
+    const feature = { name: randomId(), impressionData: false };
     await app.createFeature(feature.name);
     const segment = await createSegment('segmentOne');
     const { body: strategyOne } = await createStrategy(feature.name, {
@@ -2883,7 +2882,7 @@ test('should create a strategy with segments', async () => {
 });
 
 test('should add multiple segments to a strategy', async () => {
-    const feature = { name: uuidv4(), impressionData: false };
+    const feature = { name: randomId(), impressionData: false };
     await app.createFeature(feature.name);
     const segment = await createSegment('seg1');
     const segmentTwo = await createSegment('seg2');
@@ -3063,7 +3062,7 @@ test('Should batch stale features', async () => {
 });
 
 test('should return disabled strategies', async () => {
-    const flag = { name: uuidv4(), impressionData: false };
+    const flag = { name: randomId(), impressionData: false };
     await app.request
         .post('/api/admin/projects/default/features')
         .send({
@@ -3107,7 +3106,7 @@ test('should return disabled strategies', async () => {
 });
 
 test('should disable strategies in place', async () => {
-    const flag = { name: uuidv4(), impressionData: false };
+    const flag = { name: randomId(), impressionData: false };
     await app.request
         .post('/api/admin/projects/default/features')
         .send({
@@ -3458,7 +3457,7 @@ test('Updating feature strategy sort-order should trigger a an event', async () 
 });
 
 test('should not be allowed to create with invalid strategy type name', async () => {
-    const feature = { name: uuidv4(), impressionData: false };
+    const feature = { name: randomId(), impressionData: false };
     await app.createFeature(feature.name);
     await createStrategy(
         feature.name,
@@ -3473,7 +3472,7 @@ test('should not be allowed to create with invalid strategy type name', async ()
 });
 
 test('should not be allowed to update with invalid strategy type name', async () => {
-    const feature = { name: uuidv4(), impressionData: false };
+    const feature = { name: randomId(), impressionData: false };
     await app.createFeature(feature.name);
     const { body: strategyOne } = await createStrategy(feature.name, {
         name: 'default',

--- a/src/lib/util/random-id.test.ts
+++ b/src/lib/util/random-id.test.ts
@@ -1,0 +1,9 @@
+import { randomId } from './random-id.js';
+
+test('randomId returns a valid UUID', () => {
+    const id = randomId();
+    console.log(id);
+    expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+});

--- a/src/lib/util/random-id.ts
+++ b/src/lib/util/random-id.ts
@@ -1,5 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 
 export const randomId = (): string => {
-    return uuidv4();
+    return randomUUID();
 };

--- a/src/migrations/20210218090213-generate-server-identifier.js
+++ b/src/migrations/20210218090213-generate-server-identifier.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 
 exports.up = function (db, cb) {
-    const instanceId = uuidv4();
+    const instanceId = randomUUID();
     db.runSql(
         `
     INSERT INTO settings(name, content) VALUES ('instanceInfo', json_build_object('id', '${instanceId}'));

--- a/src/migrations/20210615115226-migrate-strategies-to-feature-strategies.js
+++ b/src/migrations/20210615115226-migrate-strategies-to-feature-strategies.js
@@ -1,4 +1,4 @@
-const { v4: uuid } = require('uuid');
+const { randomUUID } = require('crypto');
 
 exports.up = function (db, cb) {
     db.runSql(
@@ -15,7 +15,7 @@ exports.up = function (db, cb) {
                         `INSERT INTO feature_strategies(id, feature_name, project_name, strategy_name, parameters, constraints)
                                 VALUES (?, ?, ?, ?, ?, ?)`,
                         [
-                            uuid(),
+                            randomUUID(),
                             feature.name,
                             feature.project,
                             strategy.name,

--- a/src/test/e2e/api/admin/context.e2e.test.ts
+++ b/src/test/e2e/api/admin/context.e2e.test.ts
@@ -1,11 +1,10 @@
 import dbInit, { type ITestDb } from '../../helpers/database-init.js';
-import { v4 as uuidv4 } from 'uuid';
 import {
     type IUnleashTest,
     setupAppWithCustomConfig,
 } from '../../helpers/test-helper.js';
 import getLogger from '../../../fixtures/no-logger.js';
-import { DEFAULT_ENV } from '../../../../lib/server-impl.js';
+import { DEFAULT_ENV, randomId } from '../../../../lib/server-impl.js';
 
 let db: ITestDb;
 let app: IUnleashTest;
@@ -183,7 +182,7 @@ test('should delete context field', async () => {
 
 test('should not delete a context field that is in use by active flags', async () => {
     const context = 'appName';
-    const feature = uuidv4();
+    const feature = randomId();
     await app.request
         .post('/api/admin/projects/default/features')
         .send({

--- a/src/test/e2e/api/admin/user-admin.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-admin.e2e.test.ts
@@ -20,11 +20,10 @@ import { randomId } from '../../../../lib/util/random-id.js';
 import { omitKeys } from '../../../../lib/util/omit-keys.js';
 import type { ISessionStore } from '../../../../lib/types/stores/session-store.js';
 import type { IUnleashStores } from '../../../../lib/types/index.js';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { createDb } from '../../../../lib/db/db-pool.js';
 import { migrateDb } from '../../../../migrator.js';
 import { createTestConfig } from '../../../config/test-config.js';
-import { v4 as uuidv4 } from 'uuid';
 import { getDbConfig } from '../../../../lib/server-impl.js';
 
 let stores: IUnleashStores;
@@ -39,7 +38,7 @@ let editorRole: IRole;
 let adminRole: IRole;
 
 describe('Users created without an event are amended', () => {
-    const testDbName = `migration_test_${uuidv4().replace(/-/g, '')}`;
+    const testDbName = `migration_test_${randomUUID().replace(/-/g, '')}`;
     const dbConnConfig = getDbConfig();
     beforeAll(async () => {
         // create a new empty database for this test

--- a/src/test/e2e/helpers/database-init.ts
+++ b/src/test/e2e/helpers/database-init.ts
@@ -13,7 +13,7 @@ import type {
 import postgresPkg from 'pg';
 const { Client } = postgresPkg;
 import type { Knex } from 'knex';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 // require('db-migrate-shared').log.silence(false);
 
@@ -39,7 +39,7 @@ export default async function init(
     getLogger: LogProvider = noLoggerProvider,
     configOverride: Partial<IUnleashOptions & DBTestOptions> = {},
 ): Promise<ITestDb> {
-    const testDbName = `${testDbPrefix}${uuidv4().replace(/-/g, '')}`;
+    const testDbName = `${testDbPrefix}${randomUUID().replace(/-/g, '')}`;
     const testDBTemplateName = process.env.TEST_DB_TEMPLATE_NAME;
     const config = createTestConfig({
         db: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,13 +1706,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:9.0.8":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
-  languageName: node
-  linkType: hard
-
 "@vitest/coverage-v8@npm:^3.1.3":
   version: 3.1.3
   resolution: "@vitest/coverage-v8@npm:3.1.3"
@@ -7594,7 +7587,6 @@ __metadata:
     "@types/stoppable": "npm:1.1.3"
     "@types/supertest": "npm:6.0.3"
     "@types/type-is": "npm:1.6.7"
-    "@types/uuid": "npm:9.0.8"
     "@vitest/coverage-v8": "npm:^3.1.3"
     "@vitest/ui": "npm:^3.1.3"
     "@wesleytodd/openapi": "npm:^1.1.0"
@@ -7675,7 +7667,6 @@ __metadata:
     typescript: "npm:5.8.3"
     ulidx: "npm:^2.4.1"
     unleash-client: "npm:^6.8.0-beta.0"
-    uuid: "npm:^11.0.0"
     vite-node: "npm:^3.1.3"
     vitest: "npm:^3.1.3"
     wait-on: "npm:^8.0.0"
@@ -7728,15 +7719,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backend only of: https://github.com/Unleash/unleash/pull/10806

## About the changes
This PR drops the uuid package from node modules and replaces it with standard randomUUID usage that is available from 14.17 onwards, and we have a minimum requirement of node 20 at Unleash.

[Node.js crypto](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)
[Web crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)

Co-Authored-By: @AnastasiyaHladina 