### PR TITLE
chore: show edge instances in license info

### DIFF
--- a/frontend/src/component/admin/license/License.tsx
+++ b/frontend/src/component/admin/license/License.tsx
@@ -69,9 +69,9 @@ export const License = () => {
     };
 
     const resources = {
-        Seats: license.resources?.seats,
-        'Release templates': license.resources?.releaseTemplates,
-        'Edge instances': license.resources?.edgeInstances,
+        Seats: license.resources.seats,
+        'Release templates': license.resources.releaseTemplates,
+        'Edge instances': license.resources.edgeInstances,
     };
 
     return (

--- a/frontend/src/hooks/api/getters/useLicense/useLicense.ts
+++ b/frontend/src/hooks/api/getters/useLicense/useLicense.ts
@@ -63,7 +63,7 @@ export const useLicense = (): License => {
     );
 
     return {
-        license: { ...data },
+        license: data,
         loading: !error && !data,
         refetchLicense: () => mutate(),
         error,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3981/show-edge-instances-in-license-information-in-unleash

Show edge instances in license info.

Adapts to new logic, so resources are only shown if they are present.