### PR TITLE
refactor: split the stat card widget into its own component

### DIFF
--- a/frontend/src/component/insights/componentsStat/CreationArchiveStats/CreationArchiveStats.tsx
+++ b/frontend/src/component/insights/componentsStat/CreationArchiveStats/CreationArchiveStats.tsx
@@ -1,47 +1,8 @@
 import type { FC } from 'react';
-import { Box, Typography, styled } from '@mui/material';
-import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
-import InfoOutlined from '@mui/icons-material/InfoOutlined';
-import Lightbulb from '@mui/icons-material/LightbulbOutlined';
-import { StatsExplanation } from 'component/insights/InsightsCharts.styles';
 import type { GroupedDataByProject } from 'component/insights/hooks/useGroupedProjectTrends';
 import type { InstanceInsightsSchema } from 'openapi';
-import { Link } from 'react-router-dom';
 import { calculateArchiveRatio } from './calculateArchiveRatio.ts';
-
-const StyledRatioContainer = styled(Box)(({ theme }) => ({
-    backgroundColor: theme.palette.background.elevation1,
-    borderRadius: theme.spacing(2),
-    padding: theme.spacing(2),
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-}));
-
-const StyledPercentageRow = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-}));
-
-const StyledRatioTypography = styled(Typography)(({ theme }) => ({
-    color: theme.palette.primary.main,
-    fontSize: theme.spacing(2.5),
-    fontWeight: 'bold',
-}));
-
-const StyledInfoIcon = styled(InfoOutlined)(({ theme }) => ({
-    color: theme.palette.text.secondary,
-}));
-
-const StyledLink = styled(Link)(({ theme }) => ({
-    color: theme.palette.primary.main,
-    textDecoration: 'none',
-    '&:hover': {
-        textDecoration: 'underline',
-    },
-    fontSize: theme.spacing(1.75),
-}));
+import { StatCard } from '../shared/StatCard.tsx';
 
 interface CreationArchiveStatsProps {
     groupedCreationArchiveData: GroupedDataByProject<
@@ -57,26 +18,16 @@ export const CreationArchiveStats: FC<CreationArchiveStatsProps> = ({
     const averageRatio = calculateArchiveRatio(groupedCreationArchiveData);
 
     return (
-        <>
-            <StyledRatioContainer>
-                <StyledPercentageRow>
-                    <StyledRatioTypography>
-                        {isLoading ? '...' : averageRatio}
-                    </StyledRatioTypography>
-                    <HelpIcon tooltip='Ratio of archived flags to created flags in the selected period'>
-                        <StyledInfoIcon />
-                    </HelpIcon>
-                </StyledPercentageRow>
-                <Typography variant='body2'>Average ratio</Typography>
-            </StyledRatioContainer>
-            <StatsExplanation>
-                <Lightbulb color='primary' />
-                Do you create more flags than you archive? Or do you have good
-                process for cleaning up?
-            </StatsExplanation>
-            <StyledLink to='/search?lifecycle=IS:completed'>
-                View flags in cleanup stage
-            </StyledLink>
-        </>
+        <StatCard
+            value={averageRatio}
+            label='Average ratio'
+            tooltip='Ratio of archived flags to created flags in the selected period'
+            explanation='Do you create more flags than you archive? Or do you have good process for cleaning up?'
+            link={{
+                to: '/search?lifecycle=IS:completed',
+                text: 'View flags in cleanup stage',
+            }}
+            isLoading={isLoading}
+        />
     );
 };

--- a/frontend/src/component/insights/componentsStat/shared/StatCard.tsx
+++ b/frontend/src/component/insights/componentsStat/shared/StatCard.tsx
@@ -1,0 +1,83 @@
+import type { FC, ReactNode } from 'react';
+import { Box, Typography, styled } from '@mui/material';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
+import Lightbulb from '@mui/icons-material/LightbulbOutlined';
+import { StatsExplanation } from 'component/insights/InsightsCharts.styles';
+import { Link } from 'react-router-dom';
+
+const StyledRatioContainer = styled(Box)(({ theme }) => ({
+    backgroundColor: theme.palette.background.elevation1,
+    borderRadius: theme.spacing(2),
+    padding: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+}));
+
+const StyledPercentageRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+}));
+
+const StyledRatioTypography = styled(Typography)(({ theme }) => ({
+    color: theme.palette.primary.main,
+    fontSize: theme.spacing(2.5),
+    fontWeight: 'bold',
+}));
+
+const StyledInfoIcon = styled(InfoOutlined)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+}));
+
+const StyledLink = styled(Link)(({ theme }) => ({
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    '&:hover': {
+        textDecoration: 'underline',
+    },
+    fontSize: theme.spacing(1.75),
+}));
+
+interface StatCardProps {
+    value: string | number;
+    label: string;
+    tooltip: string;
+    explanation: ReactNode;
+    link?: {
+        to: string;
+        text: string;
+    };
+    isLoading?: boolean;
+}
+
+export const StatCard: FC<StatCardProps> = ({
+    value,
+    label,
+    tooltip,
+    explanation,
+    link,
+    isLoading,
+}) => {
+    return (
+        <>
+            <StyledRatioContainer>
+                <StyledPercentageRow>
+                    <StyledRatioTypography>
+                        {isLoading ? '...' : value}
+                    </StyledRatioTypography>
+                    <HelpIcon tooltip={tooltip}>
+                        <StyledInfoIcon />
+                    </HelpIcon>
+                </StyledPercentageRow>
+                <Typography variant='body2'>{label}</Typography>
+            </StyledRatioContainer>
+            <StatsExplanation>
+                <Lightbulb color='primary' />
+                {explanation}
+            </StatsExplanation>
+            {link && <StyledLink to={link.to}>{link.text}</StyledLink>}
+        </>
+    );
+};


### PR DESCRIPTION
Prepares it for being shared between the new flags in production and the archived to created ration sections.

The card in question is this one: 
<img width="310" height="177" alt="image" src="https://github.com/user-attachments/assets/66549601-36cd-4ccc-b175-79bd049ed1d4" />
