### PR TITLE
chore: fix search results page in our docs

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -689,3 +689,12 @@ html[data-theme="dark"] .footer-separator {
 }
 
 /* end welcome page */
+
+/* search results page */
+
+.search-page-wrapper main {
+    flex-direction: column;
+    background-color: transparent;
+}
+
+/* end search results page */


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3982/fix-search-results-page-in-our-docs

Fixes the search results page in our docs.

### Before

<img width="1699" height="634" alt="image" src="https://github.com/user-attachments/assets/341c086c-7a1e-4d10-87c7-d24e8afa43d2" />

### After

<img width="1360" height="1261" alt="image" src="https://github.com/user-attachments/assets/4a74f2c5-6914-436b-96cf-8fa1691b84f4" />