### PR TITLE
chore: remove null handling from batch data function

### DIFF
--- a/frontend/src/component/insights/componentsChart/batchData.test.ts
+++ b/frontend/src/component/insights/componentsChart/batchData.test.ts
@@ -13,38 +13,3 @@ it('batches by 4, starting from the first entry', () => {
         ),
     ).toStrictEqual([50, 23]);
 });
-
-describe('null entry handling', () => {
-    it('creates a new entry from the next item, if the accumulated is null', () => {
-        const input = [null, 9];
-        const result = batchData<number, number>({
-            merge: (x, y) => x * y,
-            map: Math.sqrt,
-        })(input);
-        expect(result).toStrictEqual([3]);
-    });
-    it('merges the accumulated entry with the next item if they are both present', () => {
-        const input = [4, 9];
-        const result = batchData<number, number>({
-            merge: (x, y) => x + y,
-            map: (x) => x,
-        })(input);
-        expect(result).toStrictEqual([13]);
-    });
-    it('it returns null if both the accumulated and the next item are null', () => {
-        const input = [null, null];
-        const result = batchData<number, number>({
-            merge: (x, y) => x + y,
-            map: (x) => x,
-        })(input);
-        expect(result).toStrictEqual([null]);
-    });
-    it('it returns the accumulated entry if the next item is null', () => {
-        const input = [7, null];
-        const result = batchData<number, number>({
-            merge: (x, y) => x * y,
-            map: (x) => x,
-        })(input);
-        expect(result).toStrictEqual([7]);
-    });
-});

--- a/frontend/src/component/insights/componentsChart/batchData.ts
+++ b/frontend/src/component/insights/componentsChart/batchData.ts
@@ -6,33 +6,22 @@ export type BatchDataOptions<T, TBatched> = {
     batchSize?: number;
 };
 
-const nullOrUndefined = (value: any): value is null | undefined =>
-    value === null || value === undefined;
-
 export const batchData =
     <T, TBatched>({
         merge,
         map,
         batchSize = defaultBatchSize,
     }: BatchDataOptions<T, TBatched>) =>
-    (xs: (T | null)[]): (TBatched | null)[] =>
-        xs.reduce(
-            (acc, curr, index) => {
-                const currentAggregatedIndex = Math.floor(index / batchSize);
-                const data = acc[currentAggregatedIndex];
+    (xs: T[]): TBatched[] =>
+        xs.reduce((acc, curr, index) => {
+            const currentAggregatedIndex = Math.floor(index / batchSize);
+            const data = acc[currentAggregatedIndex];
 
-                const hasData = !nullOrUndefined(data);
-                const hasCurr = curr !== null;
+            if (data) {
+                acc[currentAggregatedIndex] = merge(data, curr);
+            } else {
+                acc[currentAggregatedIndex] = map(curr);
+            }
 
-                if (!hasData && !hasCurr) {
-                    acc[currentAggregatedIndex] = null;
-                } else if (hasData && hasCurr) {
-                    acc[currentAggregatedIndex] = merge(data, curr);
-                } else if (!hasData && hasCurr) {
-                    acc[currentAggregatedIndex] = map(curr);
-                }
-
-                return acc;
-            },
-            [] as (TBatched | null)[],
-        );
+            return acc;
+        }, [] as TBatched[]);


### PR DESCRIPTION
This null handling isn't necessary anymore, as the data is never null, so we can remove the added complexity.
