### PR TITLE
 chore: Fix global change requests table scaling

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
@@ -45,6 +45,7 @@ const StyledPaginatedTable = styled(
 
     td: {
         verticalAlign: 'top',
+        maxWidth: '250px',
     },
 }));
 
@@ -105,7 +106,7 @@ const ChangeRequestsInner = () => {
             columnHelper.accessor('id', {
                 id: 'Title',
                 header: 'Title',
-                meta: { width: '300px' },
+                meta: { width: '35%' },
                 cell: GlobalChangeRequestTitleCell,
             }),
             columnHelper.accessor('features', {
@@ -134,20 +135,20 @@ const ChangeRequestsInner = () => {
             columnHelper.accessor('createdBy', {
                 id: 'By',
                 header: 'By',
-                meta: { width: '180px', align: 'left' },
+                meta: { width: '10%' },
                 enableSorting: false,
                 cell: ({ getValue }) => <AvatarCell value={getValue()} />,
             }),
             columnHelper.accessor('createdAt', {
                 id: 'Submitted',
                 header: 'Submitted',
-                meta: { width: '100px' },
+                meta: { width: '5%' },
                 cell: ({ getValue }) => <TimeAgoCell value={getValue()} />,
             }),
             columnHelper.accessor('environment', {
                 id: 'Environment',
                 header: 'Environment',
-                meta: { width: '100px' },
+                meta: { width: '10%' },
                 cell: ({ getValue }) => (
                     <HighlightCell maxTitleLines={1} value={getValue()} />
                 ),
@@ -155,7 +156,7 @@ const ChangeRequestsInner = () => {
             columnHelper.accessor('state', {
                 id: 'Status',
                 header: 'Status',
-                meta: { width: '170px' },
+                meta: { width: '10%' },
                 cell: ({ getValue, row }) => (
                     <ChangeRequestStatusCell value={getValue()} row={row} />
                 ),

--- a/frontend/src/component/changeRequest/ChangeRequests/GlobalChangeRequestTitleCell.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/GlobalChangeRequestTitleCell.tsx
@@ -57,7 +57,7 @@ export const GlobalChangeRequestTitleCell = ({
     const crPath = `${projectPath}/change-requests/${id}`;
 
     return (
-        <TextCell sx={{ minWidth: '300px' }}>
+        <TextCell>
             <LinkContainer>
                 <Truncator title={projectName}>
                     <BaseLink to={projectPath}>{projectName}</BaseLink>

--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/FeaturesCell.tsx
@@ -1,16 +1,15 @@
 import { Box, styled } from '@mui/material';
 import { Link } from 'react-router-dom';
-import type { VFC } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { TooltipLink } from 'component/common/TooltipLink/TooltipLink';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { Truncator } from 'component/common/Truncator/Truncator';
+import type { FC } from 'react';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
-    width: '300px',
     padding: theme.spacing(1, 0, 1, 2),
 }));
 
@@ -41,7 +40,7 @@ interface FeaturesCellProps {
     project: string;
 }
 
-export const FeaturesCell: VFC<FeaturesCellProps> = ({ value, project }) => {
+export const FeaturesCell: FC<FeaturesCellProps> = ({ value, project }) => {
     const { searchQuery } = useSearchHighlightContext();
     const featureNames = value?.map((feature: any) => feature.name);
     return (


### PR DESCRIPTION
Assigns more reasonable sizes and scaling to the change requests table. Once the window gets too narrow, it'll result in a horizontal overflow.


<img width="1527" height="498" alt="image" src="https://github.com/user-attachments/assets/a2697d51-fa6d-42c1-9b46-7e2d70a183d8" />

<img width="1269" height="492" alt="image" src="https://github.com/user-attachments/assets/f2d1c916-06dd-449e-8bb8-f3895457d975" />
<img width="1070" height="510" alt="image" src="https://github.com/user-attachments/assets/765f09f1-214f-46c9-a65b-3a7a2c71aeeb" />
<img width="967" height="503" alt="image" src="https://github.com/user-attachments/assets/ca3bd439-12b1-4438-9028-96d473ef6b29" />
<img width="896" height="507" alt="image" src="https://github.com/user-attachments/assets/e2b07de9-8100-466f-ac62-b9078e0bb060" />

