### PR TITLE
chore: replace hand-crafted schemas with orval-generated schemas

### DIFF
--- a/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOf.ts
+++ b/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOf.ts
@@ -23,6 +23,6 @@ export type ChangeRequestSearchItemSchemaOneOf = {
     segments: string[];
     /** The current state of the change request. */
     state: ChangeRequestSearchItemSchemaOneOfState;
-    /** Title of the change request. */
-    title: string;
+    /** Title of the change request. Only present if a custom title is set for this change request. */
+    title?: string;
 };

--- a/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfCreatedBy.ts
+++ b/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfCreatedBy.ts
@@ -10,12 +10,8 @@
 export type ChangeRequestSearchItemSchemaOneOfCreatedBy = {
     /** Unique identifier of the user. */
     id: number;
-    /**
-     * Avatar image URL for the user.
-     */
+    /** Avatar image URL for the user. */
     imageUrl?: string;
-    /**
-     * Username of the user.
-     */
+    /** Username of the user. */
     username?: string;
 };

--- a/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfFour.ts
+++ b/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfFour.ts
@@ -25,6 +25,6 @@ export type ChangeRequestSearchItemSchemaOneOfFour = {
     segments: string[];
     /** The current state of the change request. */
     state: ChangeRequestSearchItemSchemaOneOfFourState;
-    /** Title of the change request. */
-    title: string;
+    /** Title of the change request. Only present if a custom title is set for this change request. */
+    title?: string;
 };

--- a/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfFourCreatedBy.ts
+++ b/frontend/src/openapi/models/changeRequestSearchItemSchemaOneOfFourCreatedBy.ts
@@ -10,12 +10,8 @@
 export type ChangeRequestSearchItemSchemaOneOfFourCreatedBy = {
     /** Unique identifier of the user. */
     id: number;
-    /**
-     * Avatar image URL for the user.
-     */
+    /** Avatar image URL for the user. */
     imageUrl?: string;
-    /**
-     * Username of the user.
-     */
+    /** Username of the user. */
     username?: string;
 };


### PR DESCRIPTION
They're mostly the same content, however, so nothing much should change. The `optional` title is already handled in the UI.