### PR TITLE
chore: Support border collapsing for an arbitrary number of filters

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
@@ -28,13 +28,11 @@ export const makeStyledChip = (ariaControlTarget: string) =>
             borderBottomRightRadius: theme.shape.borderRadius,
         },
 
-        '&:not(&[aria-current="true"])': {
-            '&:not(&:first-of-type)': {
-                borderLeftWidth: 0,
-            },
-            '&:not(&:last-of-type)': {
-                borderRightWidth: 0,
-            },
+        '&:not(&[aria-current="true"], :last-of-type)': {
+            borderRightWidth: 0,
+        },
+        '[aria-current="true"] + &': {
+            borderLeftWidth: 0,
         },
 
         '& .MuiChip-label': {


### PR DESCRIPTION
Allows using an arbitrary number of styled chips with successful border collapsing.

Before:
<img width="682" height="126" alt="image" src="https://github.com/user-attachments/assets/80d66a5a-e0d7-461f-9be4-4a75579a7ff2" />

<img width="634" height="134" alt="image" src="https://github.com/user-attachments/assets/5d42be62-c4db-49a2-8c36-6f941f742f5f" />


After:
<img width="647" height="166" alt="image" src="https://github.com/user-attachments/assets/43a2fcf8-2a56-41a3-ad84-381a6adfc947" />

<img width="641" height="131" alt="image" src="https://github.com/user-attachments/assets/cb38bae1-77e0-4c8b-b12f-4e4fa8250a34" />
