### PR TITLE
Update unleash.github.io link (integrations)

### DIFF
--- a/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationForm.tsx
@@ -276,7 +276,7 @@ export const IntegrationForm: FC<IntegrationFormProps> = ({
         name,
         displayName,
         description,
-        documentationUrl = 'https://unleash.github.io/docs/addons',
+        documentationUrl = 'https://docs.getunleash.io/reference/integrations',
         installation,
         alerts,
     } = provider ? provider : ({} as Partial<AddonTypeSchema>);


### PR DESCRIPTION

## About the changes
unleash.github.io doesn't exist anymore, so I'm updating the domain to docs.getunleash.io

FYI @melindafekete 