### PR TITLE
feat: warning when empty segment

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentList.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentList.test.tsx
@@ -17,28 +17,13 @@ const createMockSegment = (
 });
 
 describe('FeatureStrategySegmentList', () => {
-    test('should not render when segments array is empty', () => {
-        render(
-            <FeatureStrategySegmentList segments={[]} setSegments={() => {}} />,
-        );
-
-        expect(screen.queryByText('Selected Segments')).not.toBeInTheDocument();
-    });
-
-    test('should render segments with constraints without warning', () => {
+    test('should not show warning when segment has constraints', () => {
         const segments: ISegment[] = [
             createMockSegment(1, 'Segment with constraints', [
                 {
                     contextName: 'userId',
                     operator: 'IN',
                     values: ['user1', 'user2'],
-                },
-            ]),
-            createMockSegment(2, 'Another segment', [
-                {
-                    contextName: 'email',
-                    operator: 'IN',
-                    values: ['test@example.com'],
                 },
             ]),
         ];
@@ -54,35 +39,12 @@ describe('FeatureStrategySegmentList', () => {
         expect(
             screen.getByText('Segment with constraints'),
         ).toBeInTheDocument();
-        expect(screen.getByText('Another segment')).toBeInTheDocument();
         expect(
             screen.queryByText(/You are adding an empty segment/i),
         ).not.toBeInTheDocument();
     });
 
-    test('should show warning when a segment has no constraints', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Empty segment', []),
-        ];
-
-        render(
-            <FeatureStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(screen.getByText('Selected Segments')).toBeInTheDocument();
-        expect(screen.getByText('Empty segment')).toBeInTheDocument();
-        expect(
-            screen.getByText(/You are adding an empty segment/i),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/This will activate this feature for ALL USERS/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should show warning with segment name when segment has no constraints', () => {
+    test('should show warning when segment has no constraints', () => {
         const segments: ISegment[] = [
             createMockSegment(1, 'pre-access-demo-accounts', []),
         ];
@@ -96,83 +58,8 @@ describe('FeatureStrategySegmentList', () => {
 
         expect(screen.getByText('Selected Segments')).toBeInTheDocument();
         expect(
-            screen.getByText(/You are adding an empty segment/i),
+            screen.getByText('pre-access-demo-accounts'),
         ).toBeInTheDocument();
-        const warningElements = screen.getAllByText(
-            /pre-access-demo-accounts/i,
-        );
-        expect(warningElements.length).toBeGreaterThan(0);
-    });
-
-    test('should show plural warning when multiple empty segments are added', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Empty segment 1', []),
-            createMockSegment(2, 'Empty segment 2', []),
-        ];
-
-        render(
-            <FeatureStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(screen.getByText('Selected Segments')).toBeInTheDocument();
-        expect(
-            screen.getByText(/You are adding an empty segments/i),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/Empty segment 1, Empty segment 2/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should show warning only for empty segments, not segments with constraints', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Segment with constraints', [
-                {
-                    contextName: 'userId',
-                    operator: 'IN',
-                    values: ['user1'],
-                },
-            ]),
-            createMockSegment(2, 'Empty segment', []),
-        ];
-
-        render(
-            <FeatureStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(
-            screen.getByText('Segment with constraints'),
-        ).toBeInTheDocument();
-        const emptySegmentElements = screen.getAllByText(/Empty segment/i);
-        expect(emptySegmentElements.length).toBeGreaterThan(0);
-        expect(
-            screen.getByText(/You are adding an empty segment/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should handle segment with no constraints property', () => {
-        const segments: Partial<ISegment>[] = [
-            {
-                id: 1,
-                name: 'Segment without constraints',
-                description: 'Test',
-                createdAt: '2023-01-01T00:00:00Z',
-                createdBy: 'test-user',
-            } as ISegment,
-        ];
-
-        render(
-            <FeatureStrategySegmentList
-                segments={segments as ISegment[]}
-                setSegments={() => {}}
-            />,
-        );
-
         expect(
             screen.getByText(/You are adding an empty segment/i),
         ).toBeInTheDocument();

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentList.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegmentList.tsx
@@ -55,13 +55,10 @@ export const FeatureStrategySegmentList = ({
         return null;
     }
 
-    const hasEmptySegments = segments.some(
-        (segment) => !segment.constraints || segment.constraints.length === 0,
-    );
-
     const emptySegments = segments.filter(
         (segment) => !segment.constraints || segment.constraints.length === 0,
     );
+    const hasEmptySegments = emptySegments.length > 0;
 
     return (
         <>

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegmentList.test.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegmentList.test.tsx
@@ -17,31 +17,13 @@ const createMockSegment = (
 });
 
 describe('MilestoneStrategySegmentList', () => {
-    test('should not render when segments array is empty', () => {
-        render(
-            <MilestoneStrategySegmentList
-                segments={[]}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(screen.queryByText('Selected Segments')).not.toBeInTheDocument();
-    });
-
-    test('should render segments with constraints without warning', () => {
+    test('should not show warning when segment has constraints', () => {
         const segments: ISegment[] = [
             createMockSegment(1, 'Segment with constraints', [
                 {
                     contextName: 'userId',
                     operator: 'IN',
                     values: ['user1', 'user2'],
-                },
-            ]),
-            createMockSegment(2, 'Another segment', [
-                {
-                    contextName: 'email',
-                    operator: 'IN',
-                    values: ['test@example.com'],
                 },
             ]),
         ];
@@ -57,35 +39,12 @@ describe('MilestoneStrategySegmentList', () => {
         expect(
             screen.getByText('Segment with constraints'),
         ).toBeInTheDocument();
-        expect(screen.getByText('Another segment')).toBeInTheDocument();
         expect(
             screen.queryByText(/You are adding an empty segment/i),
         ).not.toBeInTheDocument();
     });
 
-    test('should show warning when a segment has no constraints', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Empty segment', []),
-        ];
-
-        render(
-            <MilestoneStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(screen.getByText('Selected Segments')).toBeInTheDocument();
-        expect(screen.getByText('Empty segment')).toBeInTheDocument();
-        expect(
-            screen.getByText(/You are adding an empty segment/i),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/This will activate this feature for ALL USERS/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should show warning with segment name when segment has no constraints', () => {
+    test('should show warning when segment has no constraints', () => {
         const segments: ISegment[] = [
             createMockSegment(1, 'pre-access-demo-accounts', []),
         ];
@@ -99,83 +58,8 @@ describe('MilestoneStrategySegmentList', () => {
 
         expect(screen.getByText('Selected Segments')).toBeInTheDocument();
         expect(
-            screen.getByText(/You are adding an empty segment/i),
+            screen.getByText('pre-access-demo-accounts'),
         ).toBeInTheDocument();
-        const warningElements = screen.getAllByText(
-            /pre-access-demo-accounts/i,
-        );
-        expect(warningElements.length).toBeGreaterThan(0);
-    });
-
-    test('should show plural warning when multiple empty segments are added', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Empty segment 1', []),
-            createMockSegment(2, 'Empty segment 2', []),
-        ];
-
-        render(
-            <MilestoneStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(screen.getByText('Selected Segments')).toBeInTheDocument();
-        expect(
-            screen.getByText(/You are adding an empty segments/i),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/Empty segment 1, Empty segment 2/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should show warning only for empty segments, not segments with constraints', () => {
-        const segments: ISegment[] = [
-            createMockSegment(1, 'Segment with constraints', [
-                {
-                    contextName: 'userId',
-                    operator: 'IN',
-                    values: ['user1'],
-                },
-            ]),
-            createMockSegment(2, 'Empty segment', []),
-        ];
-
-        render(
-            <MilestoneStrategySegmentList
-                segments={segments}
-                setSegments={() => {}}
-            />,
-        );
-
-        expect(
-            screen.getByText('Segment with constraints'),
-        ).toBeInTheDocument();
-        const emptySegmentElements = screen.getAllByText(/Empty segment/i);
-        expect(emptySegmentElements.length).toBeGreaterThan(0);
-        expect(
-            screen.getByText(/You are adding an empty segment/i),
-        ).toBeInTheDocument();
-    });
-
-    test('should handle segment with no constraints property', () => {
-        const segments: Partial<ISegment>[] = [
-            {
-                id: 1,
-                name: 'Segment without constraints',
-                description: 'Test',
-                createdAt: '2023-01-01T00:00:00Z',
-                createdBy: 'test-user',
-            } as ISegment,
-        ];
-
-        render(
-            <MilestoneStrategySegmentList
-                segments={segments as ISegment[]}
-                setSegments={() => {}}
-            />,
-        );
-
         expect(
             screen.getByText(/You are adding an empty segment/i),
         ).toBeInTheDocument();

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegmentList.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegmentList.tsx
@@ -50,13 +50,10 @@ export const MilestoneStrategySegmentList = ({
         return null;
     }
 
-    const hasEmptySegments = segments.some(
-        (segment) => !segment.constraints || segment.constraints.length === 0,
-    );
-
     const emptySegments = segments.filter(
         (segment) => !segment.constraints || segment.constraints.length === 0,
     );
+    const hasEmptySegments = emptySegments.length > 0;
 
     return (
         <>


### PR DESCRIPTION
Decisions made:

1. If there are other constraints and segments, **the warning still appears**, because I still think it's a misconfiguration. Adding an empty segment should not be done unless it’s really necessary, as it can be dangerous.

<img width="1016" height="996" alt="Screenshot from 2025-10-27 13-57-56" src="https://github.com/user-attachments/assets/c595a52b-a3bd-4c7f-ad8e-a908591dc09f" />
