### PR TITLE
chore: bulk add instances once every 10 seconds

### DIFF
--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -89,7 +89,7 @@ export const scheduleServices = (
 
     schedulerService.schedule(
         clientInstanceService.bulkAdd.bind(clientInstanceService),
-        secondsToMilliseconds(5),
+        secondsToMilliseconds(10),
         'bulkAddInstances',
     );
 


### PR DESCRIPTION
This is most executed method by far and almost always hits db layer. We should make it less frequent.