### PR TITLE
fix(docs): Slack webhook URL documentation link

### DIFF
--- a/website/docs/reference/integrations/slack.md
+++ b/website/docs/reference/integrations/slack.md
@@ -20,7 +20,7 @@ This Slack integration is deprecated and will be removed in a future release. We
 :::
 
 
-The Slack integration allows Unleash to post Updates when a feature flag is updated. To set up Slack, you need to configure an incoming Slack webhook URL. You can follow [Sending messages using Incoming Webhooks](https://api.slack.com/incoming-webhooks) on how to do that. You can also choose to [create a slack app for Unleash](https://api.slack.com/apps), which will provide you with additional functionality to control how Unleash communicates messages on your Slack workspace.
+The Slack integration allows Unleash to post Updates when a feature flag is updated. To set up Slack, you need to configure an incoming Slack webhook URL. You can follow [Sending messages using Incoming Webhooks](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/) on how to do that. You can also choose to [create a slack app for Unleash](https://api.slack.com/apps), which will provide you with additional functionality to control how Unleash communicates messages on your Slack workspace.
 
 The Slack integration will perform a single retry if the HTTP POST against the Slack Webhook URL fails (either a 50x or network error). Duplicate events may happen. You should never assume events always comes in order.
 


### PR DESCRIPTION
Updated the Slack webhook URL documentation link to the latest Slack API documentation.

Fixes: #10731

https://api.slack.com/incoming-webhooks is redirected to https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/