### PR TITLE
chore: swap edit and copy strategy button order

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -96,13 +96,6 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
                             ).map((scheduledChange) => scheduledChange.id)}
                         />
                     ) : null}
-                    {otherEnvironments && otherEnvironments?.length > 0 ? (
-                        <CopyStrategyIconMenu
-                            environmentId={environmentName}
-                            environments={otherEnvironments as string[]}
-                            strategy={strategy}
-                        />
-                    ) : null}
                     <PermissionIconButton
                         permission={UPDATE_FEATURE_STRATEGY}
                         environmentId={environmentName}
@@ -116,6 +109,13 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
                     >
                         <Edit />
                     </PermissionIconButton>
+                    {otherEnvironments && otherEnvironments?.length > 0 ? (
+                        <CopyStrategyIconMenu
+                            environmentId={environmentName}
+                            environments={otherEnvironments as string[]}
+                            strategy={strategy}
+                        />
+                    ) : null}
                     <MenuStrategyRemove
                         projectId={projectId}
                         featureId={featureId}


### PR DESCRIPTION
Swaps the order of edit strategy and copy strategy

From:
<img width="211" height="85" alt="image" src="https://github.com/user-attachments/assets/2e4df369-051f-4f2d-a2e6-6ea30de0c71a" />


To:
<img width="193" height="75" alt="image" src="https://github.com/user-attachments/assets/cc47a840-8afb-4e80-89e0-a8bb51521c50" />
