### PR TITLE
Chore: Vertically center change request quick filters

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
@@ -54,7 +54,7 @@ export const Wrapper = styled(Box)(({ theme }) => ({
     display: 'flex',
     justifyContent: 'flex-start',
     flexFlow: 'row wrap',
-    padding: theme.spacing(1.5, 3, 0, 3),
+    paddingInline: theme.spacing(3),
     minHeight: theme.spacing(7),
     gap: theme.spacing(2),
 }));


### PR DESCRIPTION
Removes top padding that pushes the filters down.

Before:
<img width="683" height="260" alt="image" src="https://github.com/user-attachments/assets/9eb43413-b988-435f-8ca0-8ee2e5e03a87" />


After:
<img width="553" height="244" alt="image" src="https://github.com/user-attachments/assets/b1ed623c-f154-43d8-ab31-cc0df374fb19" />
