### PR TITLE
Chore: remove aria-current; group buttons

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.styles.tsx
@@ -7,7 +7,7 @@ export const makeStyledChip = (ariaControlTarget: string) =>
         padding: theme.spacing(0.5),
         fontSize: theme.typography.body2.fontSize,
         height: 'auto',
-        '&[aria-current="true"]': {
+        '&[data-selected="true"]': {
             backgroundColor: theme.palette.secondary.light,
             fontWeight: 'bold',
             borderColor: theme.palette.primary.main,
@@ -28,10 +28,10 @@ export const makeStyledChip = (ariaControlTarget: string) =>
             borderBottomRightRadius: theme.shape.borderRadius,
         },
 
-        '&:not(&[aria-current="true"], :last-of-type)': {
+        '&:not(&[data-selected="true"], :last-of-type)': {
             borderRightWidth: 0,
         },
-        '[aria-current="true"] + &': {
+        '[data-selected="true"] + &': {
             borderLeftWidth: 0,
         },
 

--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/StateFilterChips.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/StateFilterChips.tsx
@@ -33,13 +33,13 @@ export const StateFilterChips: FC<FilterChipsProps> = ({
         <StyledContainer>
             <StyledChip
                 label={'Open'}
-                aria-current={activeStateFilter === 'open'}
+                data-selected={activeStateFilter === 'open'}
                 onClick={handleStateFilterChange('open')}
                 title={'Show open change requests'}
             />
             <StyledChip
                 label={'Closed'}
-                aria-current={activeStateFilter === 'closed'}
+                data-selected={activeStateFilter === 'closed'}
                 onClick={handleStateFilterChange('closed')}
                 title={'Show closed change requests'}
             />

--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/UserFilterChips.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/UserFilterChips.tsx
@@ -67,13 +67,13 @@ export const UserFilterChips: FC<UserFilterChipsProps> = ({
         <StyledContainer>
             <StyledChip
                 label={'Created'}
-                aria-current={activeUserFilter === 'created'}
+                data-selected={activeUserFilter === 'created'}
                 onClick={handleUserFilterChange('created')}
                 title={'Show change requests created by you'}
             />
             <StyledChip
                 label={'Approval Requested'}
-                aria-current={activeUserFilter === 'approval requested'}
+                data-selected={activeUserFilter === 'approval requested'}
                 onClick={handleUserFilterChange('approval requested')}
                 title={'Show change requests requesting your approval'}
             />


### PR DESCRIPTION
After some more consideration and reading, I don't think `aria-current` is the right attribute here. Additionally, `aria-pressed` and `aria-selected` are also not appropriate here. I can't find a suitable alternative, so I'm falling back to the first rule of aria: if you don't know what to do: don't do anything.

As such, I'm falling back to regular html data attributes.