### PR TITLE
chore: remove deprecation warnings for custom strategies

### DIFF
--- a/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
+++ b/frontend/src/component/strategies/CreateStrategy/CreateStrategy.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import useToast from 'hooks/useToast';
 import FormTemplate from 'component/common/FormTemplate/FormTemplate';
@@ -11,25 +11,6 @@ import { formatUnknownError } from 'utils/formatUnknownError';
 import { CreateButton } from 'component/common/CreateButton/CreateButton';
 import { GO_BACK } from 'constants/navigate';
 import { CustomStrategyInfo } from '../CustomStrategyInfo/CustomStrategyInfo.tsx';
-import { Alert } from '@mui/material';
-
-const CreateStrategyDeprecationWarning = () => (
-    <Alert
-        severity='warning'
-        sx={(theme) => ({
-            marginBottom: theme.spacing(3),
-        })}
-    >
-        Custom strategies are deprecated and may be removed in a future major
-        release. We recommend using the predefined strategies like Gradual
-        rollout with{' '}
-        <Link to='https://docs.getunleash.io/reference/activation-strategies#constraints'>
-            {' '}
-            constraints
-        </Link>{' '}
-        instead of creating a custom strategy.
-    </Alert>
-);
 
 export const CreateStrategy = () => {
     const { setToastData, setToastApiError } = useToast();
@@ -94,7 +75,6 @@ export const CreateStrategy = () => {
             documentationLinkLabel='Custom strategies documentation'
             formatApiCode={formatApiCode}
         >
-            <CreateStrategyDeprecationWarning />
             <CustomStrategyInfo alert />
             <StrategyForm
                 errors={errors}

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -92,25 +92,6 @@ const Title: FC<{
     </StyledTitle>
 );
 
-const StrategyDeprecationWarning = () => (
-    <Alert severity='warning' sx={{ mb: 2 }}>
-        Custom strategies are deprecated and may be removed in a future major
-        version. We recommend not using custom strategies going forward and
-        instead using the gradual rollout strategy with{' '}
-        <Link
-            href={
-                'https://docs.getunleash.io/reference/activation-strategies#constraints'
-            }
-            target='_blank'
-            rel='noopener noreferrer'
-        >
-            constraints
-        </Link>
-        . If you have a need for custom strategies that you cannot support with
-        constraints, please reach out to us.
-    </Alert>
-);
-
 const RecommendationAlert = () => (
     <Alert severity='info' sx={{ mb: 2 }}>
         We recommend using gradual rollout. You can customize it with{' '}
@@ -550,7 +531,6 @@ export const StrategiesList = () => {
                         <span>Custom strategies</span>
                         <AddStrategyButton />
                     </StyledSubtitle>
-                    <StrategyDeprecationWarning />
                     <Table {...customGetTableProps()}>
                         <SortableTableHeader
                             headerGroups={customHeaderGroups}


### PR DESCRIPTION
These are considered undeprecated now and we should no longer warn in the UI