### PR TITLE
chore: cache projects response

### DIFF
--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -58,7 +58,7 @@ export class ProjectReadModel implements IProjectReadModel {
         this.db = db;
         this.timer = (action) =>
             metricsHelper.wrapTimer(eventBus, DB_TIME, {
-                store: 'project',
+                store: 'project-read-model',
                 action,
             });
         this.flagResolver = flagResolver;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -62,7 +62,8 @@ export type IFlagKey =
     | 'milestoneProgression'
     | 'featureReleasePlans'
     | 'plausibleMetrics'
-    | 'safeguards';
+    | 'safeguards'
+    | 'project-admin-cache';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 


### PR DESCRIPTION
## About the changes
This could backfire if our terraform integration might be expecting to see new data after creating a project... we'd need cache invalidation and that starts to feel like a lot of complexity...