### PR TITLE
chore: disable "sortable" column headers for change requests table

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
@@ -85,6 +85,7 @@ const ChangeRequestsInner = ({ user }: { user: IUser }) => {
                 header: 'Title',
                 meta: { width: '35%' },
                 cell: GlobalChangeRequestTitleCell,
+                enableSorting: false,
             }),
             columnHelper.accessor('features', {
                 header: 'Updated feature flags',
@@ -117,11 +118,13 @@ const ChangeRequestsInner = ({ user }: { user: IUser }) => {
             columnHelper.accessor('createdAt', {
                 header: 'Submitted',
                 meta: { width: '5%' },
+                enableSorting: false,
                 cell: ({ getValue }) => <TimeAgoCell value={getValue()} />,
             }),
             columnHelper.accessor('environment', {
                 header: 'Environment',
                 meta: { width: '10%' },
+                enableSorting: false,
                 cell: ({ getValue }) => (
                     <HighlightCell maxTitleLines={1} value={getValue()} />
                 ),
@@ -129,6 +132,7 @@ const ChangeRequestsInner = ({ user }: { user: IUser }) => {
             columnHelper.accessor('state', {
                 header: 'Status',
                 meta: { width: '10%' },
+                enableSorting: false,
                 cell: ({ getValue, row }) => (
                     <ChangeRequestStatusCell value={getValue()} row={row} />
                 ),


### PR DESCRIPTION
Makes all columns in the change requests table unsortable. The API doesn't support sorting yet and it's not entirely clear that we want it at the moment. As such, make it so that the column headers aren't interactable to make it less misleading.
