### PR TITLE
fix: don't clear "implicit" filters when updating table state outside quick filters

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequestFilters/ChangeRequestFilters.tsx
@@ -12,7 +12,7 @@ export const ChangeRequestFilters: FC<ChangeRequestFiltersProps> = ({
     ariaControlTarget,
 }) => {
     const updateTableState = (update: Partial<TableState>) => {
-        setTableState({ ...tableState, ...update, offset: 0 });
+        setTableState({ ...update, offset: 0 });
     };
 
     const StyledChip = makeStyledChip(ariaControlTarget);

--- a/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequests/ChangeRequests.tsx
@@ -23,7 +23,7 @@ import { styles as themeStyles } from 'component/common';
 import { ChangeRequestFilters } from './ChangeRequestFilters/ChangeRequestFilters.js';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser.js';
 import type { IUser } from 'interfaces/user.js';
-import { stateConfig } from './ChangeRequests.types.js';
+import { stateConfig, type TableState } from './ChangeRequests.types.js';
 
 const columnHelper = createColumnHelper<ChangeRequestSearchItemSchema>();
 
@@ -57,7 +57,7 @@ const ChangeRequestsInner = ({ user }: { user: IUser }) => {
 
     const initialState = shouldApplyDefaults ? defaultTableState(user) : {};
 
-    const [tableState, setTableState] = useQueryParams(stateConfig, {
+    const [tableState, setTableStateRaw] = useQueryParams(stateConfig, {
         updateType: 'replaceIn',
     });
 
@@ -67,6 +67,13 @@ const ChangeRequestsInner = ({ user }: { user: IUser }) => {
               ...initialState,
           }
         : tableState;
+
+    const setTableState = (newState: Partial<TableState>) => {
+        setTableStateRaw({
+            ...effectiveTableState,
+            ...newState,
+        });
+    };
 
     const {
         changeRequests: data,


### PR DESCRIPTION
Fixes bug that would only occur if the first thing you do (when there's no url query params) on the page is to try to change the sort order or change the number of results per page.

In those cases, the table state would be replaced with only the new state from the sorting/page limit (and probably page).

In more specific terms: if you're on the page with no query params, then that means that you're seeing your open change requests.

But if you tried to change the sorting, say, then the "state" and "createdBy" filters would be cleared, and you would end up showing "all change requests ever".

The fix is to spread the implicit table state into the new state before updating the actual state, such that implicit filters become explicit when that happens.

## Implicit filters?

So why do we have implicit filters? Partly aesthetic, partly because that's how it works on github (github.com/pulls), and partly because that makes it easier to share with coworkers. You just need to go to the change requests page and copy the url. With no query params, they'll see their own results instead of yours.
