### PR TITLE
fix: ignore release plans in strategy diffing

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
+++ b/frontend/src/component/feature/FeatureStrategy/featureStrategy.utils.ts
@@ -13,5 +13,6 @@ export const comparisonModerator = (
         'no',
         'lifecycle',
         'collaborators',
+        'releasePlans',
     );
 };


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

On strategy page we're diffing feature which got releasePlans recently. Since we can't edit release plan from a strategy we can ignore this field for now.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
