### PR TITLE
chore: replace deprecated `getDefaultVariant` with `defaultVariant`

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -1,6 +1,6 @@
 import { PayloadType, type Variant } from 'unleash-client';
 import { parseEnvVarBoolean } from '../util/index.js';
-import { getDefaultVariant } from 'unleash-client/lib/variant.js';
+import { defaultVariant } from 'unleash-client/lib/variant.js';
 import type { MetricFlagContext } from 'unleash-client/lib/impact-metrics/metric-types.js';
 import type { Context } from '../features/playground/feature-evaluator/index.js';
 
@@ -288,7 +288,7 @@ export const defaultExperimentalOptions: IExperimentalOptions = {
     flags,
     externalResolver: {
         isEnabled: (): boolean => false,
-        getVariant: () => getDefaultVariant(),
+        getVariant: () => defaultVariant,
         getStaticContext: () => ({}),
     },
 };

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../types/experimental.js';
 import FlagResolver, { getVariantValue } from './flag-resolver.js';
 import type { IExperimentalOptions } from '../types/experimental.js';
-import { getDefaultVariant } from 'unleash-client/lib/variant.js';
+import { defaultVariant } from 'unleash-client/lib/variant.js';
 
 test('should produce empty exposed flags', () => {
     const resolver = new FlagResolver(defaultExperimentalOptions);
@@ -34,7 +34,7 @@ test('should use external resolver for dynamic flags', () => {
                 return true;
             }
         },
-        getVariant: () => getDefaultVariant(),
+        getVariant: () => defaultVariant,
         getStaticContext: () => ({}),
     };
 
@@ -55,7 +55,7 @@ test('should not use external resolver for enabled experiments', () => {
         isEnabled: () => {
             return false;
         },
-        getVariant: () => getDefaultVariant(),
+        getVariant: () => defaultVariant,
         getStaticContext: () => ({}),
     };
 
@@ -76,7 +76,7 @@ test('should load experimental flags', () => {
         isEnabled: () => {
             return false;
         },
-        getVariant: () => getDefaultVariant(),
+        getVariant: () => defaultVariant,
         getStaticContext: () => ({}),
     };
 
@@ -98,7 +98,7 @@ test('should load experimental flags from external provider', () => {
                 return true;
             }
         },
-        getVariant: () => getDefaultVariant(),
+        getVariant: () => defaultVariant,
         getStaticContext: () => ({}),
     };
 
@@ -129,7 +129,7 @@ test('should support variant flags', () => {
             if (name === 'extraFlag') {
                 return variant;
             }
-            return getDefaultVariant();
+            return defaultVariant;
         },
         getStaticContext: () => ({}),
     };
@@ -142,10 +142,10 @@ test('should support variant flags', () => {
     const resolver = new FlagResolver(config as IExperimentalOptions);
 
     expect(resolver.getVariant('someFlag' as IFlagKey)).toStrictEqual(
-        getDefaultVariant(),
+        defaultVariant,
     );
     expect(resolver.getVariant('otherFlag' as IFlagKey)).toStrictEqual(
-        getDefaultVariant(),
+        defaultVariant,
     );
     expect(resolver.getVariant('extraFlag' as IFlagKey)).toStrictEqual(variant);
 });
@@ -199,7 +199,7 @@ test('should call external resolver getVariant when not overridden to be true, e
             if (name === 'variantFlag') {
                 return variant;
             }
-            return getDefaultVariant();
+            return defaultVariant;
         },
         getStaticContext: () => ({}),
     };
@@ -241,7 +241,7 @@ test('should call external resolver getStaticContext ', () => {
             if (name === 'variantFlag') {
                 return variant;
             }
-            return getDefaultVariant();
+            return defaultVariant;
         },
         getStaticContext: () => {
             return { properties: { clientId: 'red' } };

--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -8,7 +8,7 @@ import type {
     IFlagKey,
     IImpactMetricsResolver,
 } from '../types/experimental.js';
-import { getDefaultVariant } from 'unleash-client/lib/variant.js';
+import { defaultVariant } from 'unleash-client/lib/variant.js';
 
 export default class FlagResolver implements IFlagResolver {
     private experiments: IFlags;
@@ -57,7 +57,7 @@ export default class FlagResolver implements IFlagResolver {
     getVariant(expName: IFlagKey, context?: IFlagContext): Variant {
         const exp = this.experiments[expName];
         if (exp) {
-            if (typeof exp === 'boolean') return getDefaultVariant();
+            if (typeof exp === 'boolean') return defaultVariant;
             else if (exp.enabled) return exp;
         }
         return this.externalResolver.getVariant(expName, context);


### PR DESCRIPTION
Updates the flag resolver and other references to the unleash client's deprecated `getDefaultVariant` to instead point to the `defaultVariant` property instead, as described by the deprecation notice:

https://github.com/Unleash/unleash-node-sdk/blob/46bf068d2698ca4a09743505c823eca52d549e89/src/variant.ts#L55-L60
