### PR TITLE
chore: make env variables override option variables

### DIFF
--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -1,4 +1,9 @@
-import { createConfig, resolveIsOss } from './create-config.js';
+import {
+    createConfig,
+    mergeExperimentalOptions,
+    resolveIsOss,
+} from './create-config.js';
+import type { IExternalFlagResolver } from './server-impl.js';
 import { ApiTokenType } from './types/model.js';
 
 beforeEach(() => {
@@ -536,6 +541,31 @@ test('create config should be idempotent in terms of tokens', async () => {
         createConfig(config).authentication.initApiTokens.length,
     );
     expect(config.authentication.initApiTokens).toHaveLength(5);
+});
+
+test('env vars should take precedence over arg-supplied flags', () => {
+    expect(
+        mergeExperimentalOptions({
+            flags: {
+                messageBanner: {
+                    enabled: true,
+                    name: 'env-option',
+                },
+            },
+            externalResolver: {} as IExternalFlagResolver,
+        })({
+            experimental: {
+                flags: {
+                    messageBanner: {
+                        enabled: false,
+                        name: 'arg-option',
+                    },
+                },
+            },
+        }),
+    ).toMatchObject({
+        flags: { messageBanner: { enabled: true, name: 'env-option' } },
+    });
 });
 
 describe('isOSS', () => {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -44,10 +44,7 @@ import {
     parseEnvVarNumber,
     parseEnvVarStrings,
 } from './util/parseEnvVar.js';
-import {
-    defaultExperimentalOptions,
-    type IExperimentalOptions,
-} from './types/experimental.js';
+import { defaultExperimentalOptions } from './types/experimental.js';
 import {
     DEFAULT_SEGMENT_VALUES_LIMIT,
     DEFAULT_STRATEGY_SEGMENTS_LIMIT,
@@ -73,16 +70,18 @@ function mergeAll<T>(objects: Partial<T>[]): T {
     return merge.all<T>(objects.filter((i) => i));
 }
 
-function loadExperimental(options: IUnleashOptions): IExperimentalOptions {
-    return {
-        ...defaultExperimentalOptions,
-        ...options.experimental,
+export const mergeExperimentalOptions =
+    (envOptions: typeof defaultExperimentalOptions) =>
+    (argOptions: IUnleashOptions) => ({
+        ...argOptions.experimental,
+        ...envOptions,
         flags: {
-            ...defaultExperimentalOptions.flags,
-            ...options.experimental?.flags,
+            ...argOptions.experimental?.flags,
+            ...envOptions.flags,
         },
-    };
-}
+    });
+
+const loadExperimental = mergeExperimentalOptions(defaultExperimentalOptions);
 
 const defaultClientCachingOptions: IClientCachingOption = {
     enabled: true,


### PR DESCRIPTION
If you start Unleash with conflicting flag variables in the environment and the supplied Unleash options, then the env variables should take precedence.

