### PR TITLE
fix: allow flag resolver to handle get variant flag enabled better

### DIFF
--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -49,7 +49,7 @@ export default class FlagResolver implements IFlagResolver {
         const exp = this.experiments[expName];
         if (exp) {
             if (typeof exp === 'boolean') return exp;
-            else if (exp.enabled) return exp.enabled;
+            else if (exp.enabled || exp.feature_enabled) return true;
         }
         return this.externalResolver.isEnabled(expName, context);
     }


### PR DESCRIPTION
Fixes an edge case in the flag resolver, where if you call `isEnabled` for a variant flag, but the flag returns a disabled (or default) variant (but its feature is enabled), then the flag should still be "enabled" if `feature_enabled` is true.