### PR TITLE
chore: decrease log level of acquire job lock

### DIFF
--- a/src/lib/features/scheduler/job-service.ts
+++ b/src/lib/features/scheduler/job-service.ts
@@ -33,7 +33,7 @@ export class JobService {
 
             if (acquired) {
                 const { name, bucket } = acquired;
-                this.logger.info(
+                this.logger.debug(
                     `Acquired job lock for ${name} from >= ${subMinutes(
                         bucket,
                         bucketSizeInMinutes,


### PR DESCRIPTION
This was done in order to debug the functionality, now it serves no purpose