### PR TITLE
chore: investigate knex timeout errors

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -247,7 +247,7 @@ const defaultDbOptions: WithOptional<IDBOption, 'user' | 'password' | 'host'> =
         acquireConnectionTimeout: secondsToMilliseconds(30),
         pool: {
             min: parseEnvVarNumber(process.env.DATABASE_POOL_MIN, 0),
-            max: parseEnvVarNumber(process.env.DATABASE_POOL_MAX, 4),
+            max: parseEnvVarNumber(process.env.DATABASE_POOL_MAX, 1),
             idleTimeoutMillis: parseEnvVarNumber(
                 process.env.DATABASE_POOL_IDLE_TIMEOUT_MS,
                 secondsToMilliseconds(30),

--- a/src/lib/db/db-pool.ts
+++ b/src/lib/db/db-pool.ts
@@ -8,7 +8,8 @@ export function createDb({
     getLogger,
 }: Pick<IUnleashConfig, 'db' | 'getLogger'>): Knex {
     const logger = getLogger('db-pool.js');
-    return knex({
+
+    const k = knex({
         client: 'pg',
         version: db.version,
         connection: {
@@ -24,4 +25,29 @@ export function createDb({
             error: (msg) => logger.error(msg),
         },
     });
+
+    const pool = k.client?.pool;
+    if (pool?.on) {
+        const logStats = () => {
+            logger.debug(
+                `pool used=${pool.numUsed()} free=${pool.numFree()} ` +
+                    `pendingCreates=${pool.numPendingCreates()} pendingAcquires=${pool.numPendingAcquires()}`,
+            );
+        };
+
+        pool.on('createSuccess', logStats);
+        pool.on('destroySuccess', logStats);
+        pool.on('acquireSuccess', logStats);
+        pool.on('release', logStats);
+        pool.on('createFail', (e: unknown) =>
+            logger.warn(`pool createFail: ${String(e)}`),
+        );
+        pool.on('acquireFail', (e: unknown) =>
+            logger.warn(`pool acquireFail: ${String(e)}`),
+        );
+    } else {
+        logger.warn('knex client pool not available to attach listeners');
+    }
+
+    return k;
 }


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4018/investigate-knex-timeout-errors-due-to-db-connection-pool-exhaustion

These changes help us investigate Knex timeout errors due to DB connection pool exhaustion.

**Note**: This PR should not be merged, at least not in its initial state.