### PR TITLE
fix: when adding new milestone progression, prevent default form submit

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionForm.tsx
@@ -50,7 +50,9 @@ export const MilestoneProgressionForm = ({
         status,
     );
 
-    const handleSubmit = async () => {
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+
         if (!form.validate()) {
             return;
         }


### PR DESCRIPTION
Fixed form submitting the form and reloading page.