### PR TITLE
fix: allow external flag resolver to override false experiments with variants in getAll

### DIFF
--- a/src/lib/util/flag-resolver.ts
+++ b/src/lib/util/flag-resolver.ts
@@ -27,10 +27,17 @@ export default class FlagResolver implements IFlagResolver {
             const flag = flags[flagName];
             if (typeof flag === 'boolean') {
                 if (!flag) {
-                    flags[flagName] = this.externalResolver.isEnabled(
+                    const variant = this.externalResolver.getVariant(
                         flagName,
                         context,
                     );
+                    if (variant.enabled) {
+                        flags[flagName] = variant;
+                    } else {
+                        flags[flagName] =
+                            variant.feature_enabled ??
+                            this.externalResolver.isEnabled(flagName, context);
+                    }
                 }
             } else {
                 if (!flag?.enabled) {


### PR DESCRIPTION
Fixes a bug / uncovered edge case in the flag resolver in Unleash:
If a local experiment was defined as false (the typical default value), then that flag could only ever be returned as a boolean from the `ui-config` endpoint. In other words, even if the external resolver has a variant for that flag, the UI would never get the variant.

The fix is to not just check `isEnabled` for false flags, but instead:
- use `getVariant`
- then check `variant.enabled` (in which case we have a variant and can return it)
- else check `variant.feature_enabled`, falling back to `isEnabled` only if `feature_enabled` is null/undefined.

