### PR TITLE
test: add extra test to ensure we don't return a disabled variant

### DIFF
--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -271,6 +271,26 @@ test('should fall back to isEnabled if variant.feature_enabled is not defined in
     expect(flags.flag).toStrictEqual(true);
 });
 
+test("should return the the flag's enabled state (instead of the disabled variant) if the variant is disabled and the experimental definition is a boolean", () => {
+    const variant = defaultVariant;
+
+    const externalResolver = {
+        isEnabled: () => false,
+        getVariant: () => variant,
+        getStaticContext: () => ({}),
+    };
+
+    const config = {
+        flags: { flag: false },
+        externalResolver,
+    };
+
+    const resolver = new FlagResolver(config as IExperimentalOptions);
+    const flags = resolver.getAll() as typeof config.flags;
+
+    expect(flags.flag).toStrictEqual(false);
+});
+
 test('should call external resolver getStaticContext ', () => {
     const variant = {
         enabled: true,


### PR DESCRIPTION
Adds a test to ensure that the `getAll` method of the flag resolver doesn't return the disabled variant if a flag is defined as a boolean in the settings. 

We have some places in the UI where we check `if (uiConfig.flags.<flagname>) {...}`. If one of these flags were suddenly returned as the disabled variant instead of `false`, then it'd be impossible to turn it off. 

As such, to maintain backwards compatibility and adhere to the principle of least surprise, I'd like to add this test to ensure this doesn't change going forward. 