### PR TITLE
chore: information message when you have no connected edge enterprise instances

### DIFF
--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
@@ -176,7 +176,10 @@ export const NetworkConnectedEdges = () => {
                 <br />• Full observability into your Edge instances
                 <br />
                 <br />
-                Interested in getting started? Contact us
+                Interested in getting started?{' '}
+                <a href={`mailto:sales@getunleash.io?subject=Enterprise Edge`}>
+                    Contact us
+                </a>
             </Alert>
         );
 


### PR DESCRIPTION
Just some sugar so you know what's up when you don't have Enterprise Edge instances, what you can do about it and why you should (pay us)

<img width="1698" height="708" alt="image" src="https://github.com/user-attachments/assets/f644bb2a-01d5-4888-a5ca-491187b1e2ce" />
