### PR TITLE
fix: remove old archived flags tooltip

### DIFF
--- a/frontend/src/component/filter/AddFilterButton.tsx
+++ b/frontend/src/component/filter/AddFilterButton.tsx
@@ -8,19 +8,10 @@ import FilterList from '@mui/icons-material/FilterList';
 import { Box } from '@mui/system';
 import type { IFilterItem } from './Filters/Filters.tsx';
 import { FILTERS_MENU } from 'utils/testIds';
-import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
-import useSplashApi from 'hooks/api/actions/useSplashApi/useSplashApi';
-import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
-import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
-import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 
 const StyledButton = styled(Button)(({ theme }) => ({
     padding: theme.spacing(0, 1.25, 0, 1.25),
     height: theme.spacing(3.75),
-}));
-
-const StyledHtmlTooltip = styled(HtmlTooltip)(({ theme }) => ({
-    zIndex: theme.zIndex.drawer,
 }));
 
 const StyledIconContainer = styled(Box)(({ theme }) => ({
@@ -49,15 +40,7 @@ export const AddFilterButton = ({
     onSelectedOptionsChange,
     availableFilters,
 }: IAddFilterButtonProps) => {
-    const projectId = useOptionalPathParam('projectId');
-    const { user } = useAuthUser();
-    const { setSplashSeen } = useSplashApi();
-    const { splash } = useAuthSplash();
-
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-    const [archiveTooltipOpen, setArchiveTooltipOpen] = useState(
-        !splash?.simplifyProjectOverview,
-    );
 
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget);
@@ -71,58 +54,11 @@ export const AddFilterButton = ({
         handleClose();
     };
 
-    const isOldCustomer = (createdAt: string | undefined) => {
-        if (!createdAt) return false;
-        const cutoffDate = new Date('2024-11-08T00:00:00.000Z');
-        return new Date(createdAt) < cutoffDate;
-    };
-
-    const showArchiveTooltip = projectId && isOldCustomer(user?.createdAt);
-
-    const ArchiveTooltip = () => {
-        return (
-            <Box>
-                <Box>
-                    Archived flags are now accessible via the{' '}
-                    <b>Show only archived</b> filter option.
-                </Box>
-                <Box
-                    onClick={() => {
-                        setArchiveTooltipOpen(false);
-                        setSplashSeen('simplifyProjectOverview');
-                    }}
-                    sx={(theme) => ({
-                        color: theme.palette.primary.dark,
-                        cursor: 'pointer',
-                    })}
-                >
-                    Got it
-                </Box>
-            </Box>
-        );
-    };
     return (
         <div>
-            {showArchiveTooltip ? (
-                <StyledHtmlTooltip
-                    placement='right'
-                    arrow
-                    title={<ArchiveTooltip />}
-                    describeChild
-                    open={archiveTooltipOpen}
-                >
-                    <StyledButton
-                        onClick={handleClick}
-                        startIcon={<FilterList />}
-                    >
-                        Filter
-                    </StyledButton>
-                </StyledHtmlTooltip>
-            ) : (
-                <StyledButton onClick={handleClick} startIcon={<FilterList />}>
-                    Filter
-                </StyledButton>
-            )}
+            <StyledButton onClick={handleClick} startIcon={<FilterList />}>
+                Filter
+            </StyledButton>
 
             <Menu
                 id='simple-menu'


### PR DESCRIPTION
This tooltip isn't correct anymore. That option doesn't exist in the filters, and viewing archived flags is now done by the "view archived flags" button directly instead.

The tootlip in question:

<img width="910" height="518" alt="image" src="https://github.com/user-attachments/assets/61cc7177-5c47-46bc-a3f4-643d391dedbc" />