### PR TITLE
chore: change release_plans to release-plans in endpoints/hooks

### DIFF
--- a/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
+++ b/frontend/src/hooks/api/actions/useReleasePlansApi/useReleasePlansApi.ts
@@ -12,7 +12,7 @@ export const useReleasePlansApi = () => {
         environment: string,
     ): Promise<void> => {
         const requestId = 'addReleasePlanToFeature';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans`;
         const req = createRequest(
             path,
             {
@@ -32,7 +32,7 @@ export const useReleasePlansApi = () => {
         releasePlanId: string,
     ): Promise<void> => {
         const requestId = 'removeReleasePlanFromFeature';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans/${releasePlanId}`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans/${releasePlanId}`;
         const req = createRequest(path, { method: 'DELETE' }, requestId);
 
         await makeRequest(req.caller, req.id);
@@ -46,7 +46,7 @@ export const useReleasePlansApi = () => {
         milestoneId: string,
     ): Promise<void> => {
         const requestId = 'startReleasePlanMilestone';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans/${releasePlanId}/milestones/${milestoneId}/start`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans/${releasePlanId}/milestones/${milestoneId}/start`;
         const req = createRequest(path, { method: 'POST' }, requestId);
 
         await makeRequest(req.caller, req.id);

--- a/frontend/src/hooks/api/actions/useSafeguardsApi/useSafeguardsApi.ts
+++ b/frontend/src/hooks/api/actions/useSafeguardsApi/useSafeguardsApi.ts
@@ -29,7 +29,7 @@ export const useSafeguardsApi = () => {
         body,
     }: CreateSafeguardParams): Promise<void> => {
         const requestId = 'createOrUpdateSafeguard';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans/${planId}/safeguards`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans/${planId}/safeguards`;
         const req = createRequest(
             path,
             {
@@ -49,7 +49,7 @@ export const useSafeguardsApi = () => {
         planId,
     }: DeleteSafeguardParams): Promise<void> => {
         const requestId = 'deleteSafeguard';
-        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans/${planId}/safeguards`;
+        const path = `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans/${planId}/safeguards`;
         const req = createRequest(
             path,
             {

--- a/frontend/src/hooks/api/getters/useReleasePlans/useReleasePlans.ts
+++ b/frontend/src/hooks/api/getters/useReleasePlans/useReleasePlans.ts
@@ -23,7 +23,7 @@ export const useReleasePlans = (
         isEnterprise() && Boolean(environment) && !featureReleasePlansEnabled,
         DEFAULT_DATA,
         formatApiPath(
-            `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release_plans`,
+            `api/admin/projects/${projectId}/features/${featureName}/environments/${environment}/release-plans`,
         ),
         fetcher,
     );


### PR DESCRIPTION
This changes the _ in release_plans used in release plans endpoints and their hooks to a -