### PR TITLE
chore: export default metrics register

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -190,6 +190,7 @@ import ProjectStore from './features/project/project-store.js';
 import type { ReleasePlanMilestoneWriteModel } from './features/release-plans/release-plan-milestone.js';
 import { FakeChangeRequestAccessReadModel } from './features/change-request-access-service/fake-change-request-access-read-model.js';
 import { fakeImpactMetricsResolver } from '../test/fixtures/fake-impact-metrics.js';
+import { register as defaultMetricsRegister } from 'prom-client';
 
 export async function initialServiceSetup(
     { authentication }: Pick<IUnleashConfig, 'authentication'>,
@@ -503,6 +504,7 @@ export {
     impactRegister,
     EnvironmentStore,
     ProjectStore,
+    defaultMetricsRegister,
 };
 
 export type {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4035/avoid-prom-client-dependency-in-enterprise-cloud

This exports the default metrics register so consumers can tap into it if needed.