### PR TITLE
chore: show connected edges for pro customers

### DIFF
--- a/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
+++ b/frontend/src/hooks/api/getters/useConnectedEdges/useConnectedEdges.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import useUiConfig from '../useUiConfig/useUiConfig.js';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler.js';
 import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR.js';
@@ -10,11 +9,10 @@ import { useUiFlag } from 'hooks/useUiFlag';
 const DEFAULT_DATA: ConnectedEdge[] = [];
 
 export const useConnectedEdges = (options?: SWRConfiguration) => {
-    const { isEnterprise } = useUiConfig();
     const edgeObservabilityEnabled = useUiFlag('edgeObservability');
 
     const { data, error, mutate } = useConditionalSWR<ConnectedEdge[]>(
-        isEnterprise() && edgeObservabilityEnabled,
+        edgeObservabilityEnabled,
         DEFAULT_DATA,
         formatApiPath('api/admin/metrics/edges'),
         fetcher,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4040/show-connected-edges-for-pro-customers

Show connected Edges for Pro customers.

This was previously filtered to Enterprise only instances.