### PR TITLE
fix: invalid metrics should not crash

### DIFF
--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -297,9 +297,10 @@ export default class ClientMetricsController extends Controller {
                         'Some bulkMetrics tasks failed',
                         rejected.map((r) => r.reason?.message || r.reason),
                     );
+                    res.status(400).end();
+                } else {
+                    res.status(202).end();
                 }
-
-                res.status(202).end();
             } catch (e) {
                 const results = await Promise.allSettled(promises);
                 const rejected = results.filter(


### PR DESCRIPTION
## About the changes
Properly awaits all submitted promises, preventing the node's main process from seeing rejected & unawaited promises.

What's going on?
- The bulk metrics handler pushes `registerBackendClient` promises into promises.
- The next step (`clientMetricsEnvBulkSchema.validateAsync`) throws for invalid metrics (e.g., `appName: null`), so we jump to catch and return 400.
- Because the code never reaches `Promise.all(...)`, the previously spawned promises are never awaited. Node later detects the rejected `registerBackendClient` promise as an **unhandled rejection** and crashes the process. If that promise hadn’t been rejected, there’d be no crash, but with invalid input, it does reject.
- **Fix:** always await the spawned tasks (using `Promise.allSettled`) so every rejection is observed, even when validation later throws.
