### PR TITLE
feat: split milestone paused with progression paused

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/MilestoneListRenderer.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/MilestoneListRenderer.tsx
@@ -39,7 +39,7 @@ const MilestoneListRendererCore = ({
 }: MilestoneListRendererCoreProps) => {
     const status: MilestoneStatus = {
         type: 'not-started',
-        progressions: 'active',
+        progression: 'active',
     };
 
     return (

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -109,7 +109,7 @@ interface IReleasePlanMilestoneProps {
 
 export const ReleasePlanMilestone = ({
     milestone,
-    status = { type: 'not-started', progressions: 'active' },
+    status = { type: 'not-started', progression: 'active' },
     onStartMilestone,
     readonly,
     automationSection,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStatus.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStatus.tsx
@@ -10,11 +10,11 @@ export type MilestoneStatus =
     | {
           type: 'not-started';
           scheduledAt?: Date;
-          progressions: MilestoneProgressionStatus;
+          progression: MilestoneProgressionStatus;
       }
-    | { type: 'active'; progressions: MilestoneProgressionStatus }
-    | { type: 'paused'; progressions: MilestoneProgressionStatus }
-    | { type: 'completed'; progressions: MilestoneProgressionStatus };
+    | { type: 'active'; progression: MilestoneProgressionStatus }
+    | { type: 'paused'; progression: MilestoneProgressionStatus }
+    | { type: 'completed'; progression: MilestoneProgressionStatus };
 
 const BaseStatusButton = styled('button')<{ disabled?: boolean }>(
     ({ theme, disabled }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/MilestoneAutomation.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/MilestoneAutomation.tsx
@@ -59,7 +59,7 @@ export const MilestoneAutomation = ({
         <Badge color='error'>Deleted in draft</Badge>
     ) : hasPendingChange ? (
         <Badge color='warning'>Modified in draft</Badge>
-    ) : status?.progressions === 'paused' ? (
+    ) : status?.progression === 'paused' ? (
         <Badge color='error' icon={<WarningAmber fontSize='small' />}>
             Paused
         </Badge>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/milestoneStatusUtils.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/milestoneStatusUtils.ts
@@ -13,18 +13,18 @@ export const calculateMilestoneStatus = (
     environmentIsDisabled: boolean | undefined,
     allMilestones: IReleasePlanMilestone[],
 ): MilestoneStatus => {
-    const progressions: MilestoneProgressionStatus = milestone.pausedAt
+    const progression: MilestoneProgressionStatus = milestone.pausedAt
         ? 'paused'
         : 'active';
 
     if (milestone.id === activeMilestoneId) {
         return environmentIsDisabled
-            ? { type: 'paused', progressions }
-            : { type: 'active', progressions };
+            ? { type: 'paused', progression }
+            : { type: 'active', progression };
     }
 
     if (index < activeIndex) {
-        return { type: 'completed', progressions };
+        return { type: 'completed', progression };
     }
 
     const scheduledAt = calculateMilestoneStartTime(
@@ -36,6 +36,6 @@ export const calculateMilestoneStatus = (
     return {
         type: 'not-started',
         scheduledAt: scheduledAt || undefined,
-        progressions,
+        progression,
     };
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/hooks/useMilestoneProgressionInfo.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/hooks/useMilestoneProgressionInfo.ts
@@ -11,7 +11,7 @@ export const useMilestoneProgressionInfo = (
     if (
         !status ||
         status.type !== 'active' ||
-        status.progressions === 'paused'
+        status.progression === 'paused'
     ) {
         return null;
     }


### PR DESCRIPTION
Split milestone paused with progression paused. **This fixes the issue that milestone seems paused, but actually progressions are paused.**

Before
<img width="1392" height="1181" alt="Screenshot from 2025-11-24 10-28-11" src="https://github.com/user-attachments/assets/33ad0d26-1368-44e8-a665-4ce117de6e9b" />

After
<img width="1402" height="1165" alt="Screenshot from 2025-11-24 10-27-52" src="https://github.com/user-attachments/assets/70bbc9ab-35e2-4abf-9a95-a0884165d914" />
