### PR TITLE
chore: use license address instead of sales

### DIFF
--- a/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
+++ b/frontend/src/component/admin/network/NetworkConnectedEdges/NetworkConnectedEdges.tsx
@@ -177,7 +177,7 @@ export const NetworkConnectedEdges = () => {
                 <br />
                 <br />
                 Interested in getting started?{' '}
-                <a href={`mailto:sales@getunleash.io?subject=Enterprise Edge`}>
+                <a href='mailto:license@getunleash.io?subject=Enterprise Edge'>
                     Contact us
                 </a>
             </Alert>

--- a/website/docs/reference/integrations/jira-server-plugin-installation.md
+++ b/website/docs/reference/integrations/jira-server-plugin-installation.md
@@ -47,7 +47,7 @@ The [Jira server plugin is available in the Atlassian marketplace](https://marke
 
 You'll need to download the plugin and create a license key.
 
-If you have an Unleash enterprise license you're welcome to reach out to us at sales@getunleash.io for a free plugin license, otherwise you'll need to try the plugin for 30 days free or purchase a license through the marketplace.
+If you have an Unleash enterprise license you're welcome to reach out to us at license@getunleash.io for a free plugin license, otherwise you'll need to try the plugin for 30 days free or purchase a license through the marketplace.
 
 Once you've downloaded the plugin artifact, you'll need to follow the Manage apps link in Jira's administration menu.
 

--- a/website/docs/using-unleash/compliance/compliance-overview.mdx
+++ b/website/docs/using-unleash/compliance/compliance-overview.mdx
@@ -19,4 +19,4 @@ For a detailed overview of how [Unleash Enterprise](https://www.getunleash.io/pr
 - [ISO 27001](/using-unleash/compliance/iso27001)
 
 
-For information regarding any other frameworks, [reach out to us](mailto:sales@getunleash.io).
+For information regarding any other frameworks, [reach out to us](mailto:license@getunleash.io).

--- a/website/docs/using-unleash/deploy/license-keys.mdx
+++ b/website/docs/using-unleash/deploy/license-keys.mdx
@@ -52,7 +52,7 @@ If you are a new customer, your account representative will provide the required
 
 If you are an existing customer and are making changes to your agreement (changing seat count or the contract expiration), contact your account representative to obtain the required license key.
 
-Alternatively, you can reach out to sales@getunleash.io.
+Alternatively, you can reach out to license@getunleash.io.
 
 ## Check your current license
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4042/use-licensegetunleashio-instead-of-salesgetunleashio

Prefer `license@getunleash.io` over `sales@getunleash.io` for reach outs.