### PR TITLE
feat: allow 'instanceInfo' to be added to the version checker hook

### DIFF
--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -58,6 +58,12 @@ export interface IFeatureUsageInfo {
     edgeInstanceUsage?: EdgeInstanceUsage;
 }
 
+export type IInstanceInfo = Partial<{
+    customerPlan: string;
+    customerName: string;
+    clientId: string;
+}>;
+
 export default class VersionService {
     private logger: Logger;
 
@@ -131,6 +137,7 @@ export default class VersionService {
 
     async checkLatestVersion(
         telemetryDataProvider: () => Promise<IFeatureUsageInfo>,
+        instanceInfoProvider?: () => Promise<IInstanceInfo | undefined>,
     ): Promise<void> {
         const instanceId = await this.getInstanceId();
         this.logger.debug(
@@ -145,6 +152,10 @@ export default class VersionService {
 
                 if (this.telemetryEnabled) {
                     versionPayload.featureInfo = await telemetryDataProvider();
+                    const instanceInfo = await instanceInfoProvider?.();
+                    if (instanceInfo) {
+                        versionPayload.instanceInfo = instanceInfo;
+                    }
                 }
                 if (this.versionCheckUrl) {
                     const res = await ky.post(this.versionCheckUrl, {


### PR DESCRIPTION
Allows the `checkLatestVersion` function in the `VersionService` to accept an optional `instanceInfo` parameter. If provided, and if the promise returns a value that is truthy, then it will add `instanceInfo` to the versionPayload.

The license key may not contain a plan or a customer name, and while it definitely won't contain a client id, it has been requested that we report `self-hosted` as the client ID (will be handled in enterprise).

Adding a second, optional parameter seemed to be the most backwards compatible way of doing this rather than changing the established method / callback types.