### PR TITLE
fix: remove unusable button from navigation sidebar accordion

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
@@ -210,6 +210,8 @@ export const MenuListAccordion: FC<{
                         sx={listItemButtonStyle}
                         selected={active && mode === 'mini'}
                         disableRipple
+                        tabIndex={-1}
+                        component='span'
                         role={undefined}
                     >
                         {mode === 'mini' ? (


### PR DESCRIPTION
For some reason, there's two nested buttons here, where only the outer one is interactable. It doesn't matter much for mouse interactions, but for keyboard interactions, they're both focusable (which is strange) and the inner one doesn't do anything.

As such, this PR:
- removes it from the navigation tree (tabindex -1)
- changes the component to be a span instead of a button.

It keeps the role=undefined to override the default role="button" that MUI sets on it.

The double button was also visible when the inner one had focus (the overflow in the image is a different issue, though):
<img width="542" height="182" alt="image" src="https://github.com/user-attachments/assets/2942033d-09ee-4806-a2de-a5e6a6680a35" />
