### PR TITLE
fix: sidebar overflow when displaying badges

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -24,9 +24,8 @@ import { useFlag } from '@unleash/proxy-client-react';
 import { useNewAdminMenu } from 'hooks/useNewAdminMenu';
 
 export const StretchContainer = styled(Box, {
-    shouldForwardProp: (propName) =>
-        propName !== 'mode' && propName !== 'admin',
-})<{ mode: string; admin: boolean }>(({ theme, mode, admin }) => ({
+    shouldForwardProp: (propName) => propName !== 'admin',
+})<{ admin: boolean }>(({ theme, admin }) => ({
     backgroundColor: admin
         ? theme.palette.background.application
         : theme.palette.background.paper,
@@ -38,8 +37,7 @@ export const StretchContainer = styled(Box, {
     gap: theme.spacing(2),
     zIndex: 1,
     overflowAnchor: 'none',
-    minWidth: mode === 'full' ? theme.spacing(32) : 'auto',
-    width: mode === 'full' ? theme.spacing(32) : 'auto',
+    width: 'auto',
 }));
 
 const StyledLink = styled(Link)(({ theme }) => focusable(theme));
@@ -94,7 +92,7 @@ export const NavigationSidebar: FC<{ NewInUnleash?: typeof NewInUnleash }> = ({
     }, [initialPathname]);
 
     return (
-        <StretchContainer mode={mode} admin={showOnlyAdminMenu}>
+        <StretchContainer admin={showOnlyAdminMenu}>
             <ConditionallyRender
                 condition={mode === 'full'}
                 show={


### PR DESCRIPTION
Fixes a bug where the sidebar accordion would overflow if one of the children had a badge. This was visible primarily in pro instances up until now, but will also be an issue with the new "new" badge.

Instead of basing the width and min-width on the "mode", we now set it to `auto` regardless.

This means that:
- When there's no badges, the sidebar will be slightly narrower than it is today, because it doesn't need all that space.
- When there *are* badges, it will be slightly wider.

The previous change to these width values was in https://github.com/Unleash/unleash/pull/8831 and was apparently to make it "easier to use on medium screen sizes".

While this change makes it slightly wider when there are badges, I think that's a worthwhile tradeoff to:
- not having the accordion body be wider than the rest of the menu
- not having badges have to be smooshed up against the text

There's no max width set, so technically you could force it super wide by having very long menu items, but I think that's an acceptable tradeoff that we can make. I also don't think it's very likely that we'll run into that issue and not notice.

Further, on narrow screens, the sidebar is replaced by a modal anyway, so it's not likely to be much of an issue, I think.

## Screenies

To show the changes, here are some screenies with widths:

### Before

The width is set to 256:

<img width="1270" height="1576" alt="image" src="https://github.com/user-attachments/assets/5c8f1d72-9f23-4ec9-8278-b2fe529680d4" />

But notice how the configure menu pops out when we've badges:
<img width="580" height="1538" alt="image" src="https://github.com/user-attachments/assets/9ebf4ff9-c11a-4716-a77f-0443d73dda90" />

This is the menu without badges. Still 256 px wide
<img width="554" height="1566" alt="image" src="https://github.com/user-attachments/assets/0a8ad895-3409-494e-9f32-644938545707" />


### After

The width is slightly narrower when there's no badges:
<img width="1280" height="1654" alt="image" src="https://github.com/user-attachments/assets/fdb792b6-c7be-408d-9e3b-a00c62794318" />

But slightly wider when there are badges to accommodate the extra elements.
<img width="1292" height="1552" alt="image" src="https://github.com/user-attachments/assets/e7437fa3-d747-44dc-9b0c-60e362c52833" />
