### PR TITLE
chore: remove unused `route.route` property + rename function

### DIFF
--- a/frontend/src/component/admin/useAdminRoutes.ts
+++ b/frontend/src/component/admin/useAdminRoutes.ts
@@ -2,7 +2,7 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { adminRoutes } from './adminRoutes.js';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
 import { filterRoutesByPlanData } from './filterRoutesByPlanData.js';
-import { filterByConfig, mapRouteLink } from 'component/common/util';
+import { filterByConfig, normalizeRoutePath } from 'component/common/util';
 
 export const useAdminRoutes = () => {
     const { uiConfig, isPro, isEnterprise } = useUiConfig();
@@ -28,5 +28,5 @@ export const useAdminRoutes = () => {
                 billing: isBilling,
             }),
         )
-        .map(mapRouteLink);
+        .map(normalizeRoutePath);
 };

--- a/frontend/src/component/commandBar/CommandPageSuggestions.tsx
+++ b/frontend/src/component/commandBar/CommandPageSuggestions.tsx
@@ -19,7 +19,7 @@ interface IPageSuggestionItem {
 
 const toListItemData = (
     items: string[],
-    routes: Record<string, { path: string; route: string; title: string }>,
+    routes: Record<string, { path: string; title: string }>,
 ): IPageSuggestionItem[] => {
     return items.map((item) => {
         return {
@@ -44,7 +44,7 @@ export const CommandPageSuggestions = ({
     routes,
     onClick,
 }: {
-    routes: Record<string, { path: string; route: string; title: string }>;
+    routes: Record<string, { path: string; title: string }>;
     onClick: () => void;
 }) => {
     const { trackEvent } = usePlausibleTracker();

--- a/frontend/src/component/commandBar/CommandQuickSuggestions.tsx
+++ b/frontend/src/component/commandBar/CommandQuickSuggestions.tsx
@@ -11,7 +11,7 @@ import {
 
 const toListItemButton = (
     item: LastViewedPage,
-    routes: Record<string, { path: string; route: string; title: string }>,
+    routes: Record<string, { path: string; title: string }>,
     index: number,
     onClick: () => void,
 ) => {
@@ -55,7 +55,7 @@ export const CommandQuickSuggestions = ({
     onClick,
 }: {
     onClick: () => void;
-    routes: Record<string, { path: string; route: string; title: string }>;
+    routes: Record<string, { path: string; title: string }>;
 }) => {
     const { lastVisited } = useRecentlyVisited();
     const buttons = lastVisited.map((item, index) =>

--- a/frontend/src/component/commandBar/useCommandBarRoutes.ts
+++ b/frontend/src/component/commandBar/useCommandBarRoutes.ts
@@ -5,7 +5,6 @@ import { useMemo } from 'react';
 
 interface IPageRouteInfo {
     path: string;
-    route: string;
     title: string;
     searchText: string;
 }
@@ -37,7 +36,6 @@ export const useCommandBarRoutes = () => {
             const title = getRouteTitle(route);
             allRoutes[route.path] = {
                 path: route.path,
-                route: route.route,
                 title: title,
                 searchText: getSearchText(route, title),
             };

--- a/frontend/src/component/common/util.ts
+++ b/frontend/src/component/common/util.ts
@@ -40,10 +40,11 @@ export const scrollToTop = () => {
     window.scrollTo(0, 0);
 };
 
-export const mapRouteLink = (route: INavigationMenuItem) => ({
+export const normalizeRoutePath = (
+    route: INavigationMenuItem,
+): INavigationMenuItem => ({
     ...route,
     path: route.path.replace('/*', ''),
-    route: route.path,
 });
 
 export const trim = (value: string): string => {

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/useRoutes.ts
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/useRoutes.ts
@@ -1,7 +1,7 @@
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { getNavRoutes, getPrimaryRoutes } from 'component/menu/routes';
 import { useAdminRoutes } from 'component/admin/useAdminRoutes';
-import { filterByConfig, mapRouteLink } from 'component/common/util';
+import { filterByConfig, normalizeRoutePath } from 'component/common/util';
 import {
     filterRoutesByPlanData,
     type PlanData,
@@ -24,7 +24,7 @@ const filterRoutes = (
                 billing,
             }),
         )
-        .map(mapRouteLink);
+        .map(normalizeRoutePath);
 };
 
 export const useRoutes = () => {


### PR DESCRIPTION
This removes the `route.route` property that was previously set within the `mapRouteLink` function.

This property never existed on the `INavigationMenuItem` interface, so the fact that it was assigned to was only allowed because the function return type was implicit.

Further, this property seems to have never been used. There's some references to the `route` property in the command bar code, but the `route` property is never accessed there either.

As such, I think it makes sense to remove it. Additionally, because the `mapRouteLink` function doesn't add any new properties, I thought it made sense to rename it to `normalizeRoutePath`, as that is what it does (removes the literal string `/*` from the route path).
