### PR TITLE
feat: skip safeguard cr confirmation dialogue

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -191,6 +191,7 @@ const ChangeSafeguard: FC<{
                         onCancel={() => {}}
                         safeguard={safeguard}
                         environment={environmentName}
+                        skipConfirmation={true}
                     />
                 )}
             </TabPanel>
@@ -271,6 +272,7 @@ const DeleteSafeguard: FC<{
                         onCancel={() => {}}
                         safeguard={safeguard}
                         environment={environmentName}
+                        skipConfirmation={true}
                     />
                 )}
             </TabPanel>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -51,6 +51,7 @@ interface ISafeguardFormProps {
     onDelete?: () => void;
     safeguard?: ISafeguard;
     environment: string;
+    skipConfirmation?: boolean;
 }
 
 const getInitialValues = (safeguard?: ISafeguard) => ({
@@ -87,6 +88,7 @@ export const SafeguardForm = ({
     onDelete,
     safeguard,
     environment,
+    skipConfirmation = false,
 }: ISafeguardFormProps) => {
     const { metricOptions, loading } = useImpactMetricsOptions();
     const projectId = useRequiredPathParam('projectId');
@@ -211,7 +213,7 @@ export const SafeguardForm = ({
             return;
         }
 
-        if (isChangeRequestConfigured(environment)) {
+        if (isChangeRequestConfigured(environment) && !skipConfirmation) {
             setDialogOpen(true);
             return;
         }


### PR DESCRIPTION
This follows the same pattern we use for release plans in cr.


<img width="1519" height="618" alt="image" src="https://github.com/user-attachments/assets/01ecbbd1-5991-4961-88ed-f3702f86dacf" />