### PR TITLE
add newInUnleash operational boolean/variant flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     safeguards?: boolean;
     oidcPkceSupport?: boolean;
     extendedUsageMetrics?: boolean;
+    newInUnleash?: boolean | Variant;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -65,6 +65,7 @@ export type IFlagKey =
     | 'featureReleasePlans'
     | 'plausibleMetrics'
     | 'safeguards'
+    | 'newInUnleash'
     | 'oidcPkceSupport';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -288,6 +289,10 @@ const flags: IFlags = {
     ),
     oidcPkceSupport: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_OIDC_PKCE_SUPPORT,
+        false,
+    ),
+    newInUnleash: parseEnvVarBooleanOrStringVariant(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_IN_UNLEASH,
         false,
     ),
 };


### PR DESCRIPTION
Adds the `newInUnleash` flag to the interfaces and config as a boolean / Variant flag (similar to the recent update to maintenance mode).