### PR TITLE
chore: add flag enterpriseEdgeUI

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -93,6 +93,7 @@ export type UiFlags = {
     oidcPkceSupport?: boolean;
     extendedUsageMetrics?: boolean;
     newInUnleash?: boolean | Variant;
+    enterpriseEdgeUI?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -66,7 +66,8 @@ export type IFlagKey =
     | 'plausibleMetrics'
     | 'safeguards'
     | 'newInUnleash'
-    | 'oidcPkceSupport';
+    | 'oidcPkceSupport'
+    | 'enterpriseEdgeUI';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -293,6 +294,10 @@ const flags: IFlags = {
     ),
     newInUnleash: parseEnvVarBooleanOrStringVariant(
         process.env.UNLEASH_EXPERIMENTAL_NEW_IN_UNLEASH,
+        false,
+    ),
+    enterpriseEdgeUI: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ENTERPRISE_EDGE_UI,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -55,6 +55,7 @@ process.nextTick(async () => {
                         milestoneProgression: true,
                         featureReleasePlans: true,
                         safeguards: true,
+                        enterpriseEdgeUI: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4050/add-flag-for-new-enterprise-edge-ui-enterpriseedgeui

Adds a new flag for the new Enterprise Edge UI: `enterpriseEdgeUI`.