### PR TITLE
fix: don't unselect selected path in configure menu when clicking it again

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ConfigurationAccordion.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ConfigurationAccordion.tsx
@@ -10,7 +10,7 @@ type ConfigurationAccordionProps = {
     mode: NavigationMode;
     setMode;
     activeItem?: string;
-    onClick?: () => void;
+    onClick?: (activeItemPath: string) => void;
 };
 
 export const ConfigurationAccordion: FC<ConfigurationAccordionProps> = ({
@@ -46,12 +46,12 @@ export const ConfigurationAccordion: FC<ConfigurationAccordionProps> = ({
         }
     };
 
-    const onItemClick = () => {
+    const onItemClick = (activeItemPath: string) => {
         if (temporarilyExpanded) {
             setTemporarilyExpanded(false);
             setMode('mini');
         }
-        onClick?.();
+        onClick?.(activeItemPath);
     };
 
     return (

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
@@ -81,7 +81,7 @@ export const PrimaryNavigationList: FC<{
                 mode={mode}
                 setMode={setMode}
                 activeItem={activeItem}
-                onClick={() => onClick('configure')}
+                onClick={onClick}
             />
         </List>
     );


### PR DESCRIPTION
This fixes a bug where if you re-clicked the current path you were on in the configure sub-menu, it would unselect the item, even though if that's where you were still at.

The reason is that the onClick handler was pre-populated with the text `configure`. (However, the children were calling onClick with their own paths). I'm not really sure why this even worked in the first place.

Anyway, now the types have been changed and I've removed the application of the "configure" string as the active item.

First click (same both before and after):
<img width="285" height="181" alt="image" src="https://github.com/user-attachments/assets/c13142ef-8ef8-4a9d-8719-68dcb16db7f0" />


Before (second click):
<img width="303" height="220" alt="image" src="https://github.com/user-attachments/assets/6b576a91-2f1e-48f5-b8fe-9b1364c8987e" />

After (second click):
<img width="286" height="190" alt="image" src="https://github.com/user-attachments/assets/72434401-414c-43e4-b5bf-7c972bb99b7a" />
