### PR TITLE
feat: safeguard form 3 variants

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -34,7 +34,7 @@ import type {
 } from 'openapi';
 import { ProgressionChange } from './ProgressionChange.tsx';
 import { ConsolidatedProgressionChanges } from './ConsolidatedProgressionChanges.tsx';
-import { SafeguardForm } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm';
+import { SafeguardFormChangeRequestView } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm';
 import { ReadonlySafeguardDisplay } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/ReadonlySafeguardDisplay';
 import { formatUnknownError } from 'utils/formatUnknownError.ts';
 import { omitIfDefined } from 'utils/omitFields';
@@ -181,7 +181,7 @@ const ChangeSafeguard: FC<{
                 {readonly ? (
                     <ReadonlySafeguardDisplay safeguard={safeguard} />
                 ) : (
-                    <SafeguardForm
+                    <SafeguardFormChangeRequestView
                         onSubmit={onSubmit}
                         onDelete={
                             safeguardId
@@ -191,7 +191,6 @@ const ChangeSafeguard: FC<{
                         onCancel={() => {}}
                         safeguard={safeguard}
                         environment={environmentName}
-                        skipConfirmation={true}
                     />
                 )}
             </TabPanel>
@@ -262,7 +261,7 @@ const DeleteSafeguard: FC<{
                 {readonly ? (
                     <ReadonlySafeguardDisplay safeguard={safeguard} />
                 ) : (
-                    <SafeguardForm
+                    <SafeguardFormChangeRequestView
                         onSubmit={onSubmit}
                         onDelete={
                             safeguard?.id
@@ -272,7 +271,6 @@ const DeleteSafeguard: FC<{
                         onCancel={() => {}}
                         safeguard={safeguard}
                         environment={environmentName}
-                        skipConfirmation={true}
                     />
                 )}
             </TabPanel>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlan.tsx
@@ -456,6 +456,7 @@ export const ReleasePlan = ({
                     type: 'success',
                     text: 'Added to draft',
                 });
+                onAutomationChange?.();
             } catch (error: unknown) {
                 setToastApiError(formatUnknownError(error));
             }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Explicitly capture different form modes:
* SafeguardFormDirect (no confirmation dialog on save, keep local changes on save until HTTP refreshes everything)
* SafeguardFormWithChangeRequests (change request confirmation dialog on save, discard changes on save after adding to a shopping cart)
* SafeguardFormChangeRequestView (no confirmation dialog inside a shopping cart, keep changes on save until HTTP refreshed everything)
<img width="1008" height="172" alt="Screenshot 2025-12-01 at 12 01 32" src="https://github.com/user-attachments/assets/232cd19f-41af-480b-b001-589468d0cdd5" />

Important decisions:
* every form variant gets an explicit component instead of one component with boolean/status properties
* extract each part of the component behavior in a custom hook


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
