### PR TITLE
feat: now next text is not visible for progression

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -122,7 +122,8 @@ export const ReleasePlanMilestone = ({
     const [expanded, setExpanded] = useState(false);
     const hasAutomation = Boolean(automationSection);
     const isPreviousMilestonePaused =
-        previousMilestoneStatus?.type === 'paused' || previousMilestoneStatus?.progression === 'paused';
+        previousMilestoneStatus?.type === 'paused' ||
+        previousMilestoneStatus?.progression === 'paused';
 
     if (!milestone.strategies.length) {
         return (


### PR DESCRIPTION
Before
<img width="861" height="1085" alt="Screenshot from 2025-12-01 14-45-00" src="https://github.com/user-attachments/assets/0998279a-a680-41f2-858b-74aef1a0c49b" />
After
<img width="838" height="851" alt="Screenshot from 2025-12-01 14-44-45" src="https://github.com/user-attachments/assets/9b9318b2-5922-4df5-a090-ba2e8b94a284" />
