### PR TITLE
Revert "chore: removes an unused `after` image (#11054)"

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -68,6 +68,22 @@ html[data-theme="light"] {
     --unleash-color-footer-icon: #657a80;
 }
 
+main:after {
+    background-image: url("/img/mountain-texture.png");
+    position: fixed;
+    display: block;
+    z-index: 0;
+    bottom: 0px;
+    right: 0px;
+    width: 350px;
+    aspect-ratio: 652 / 905;
+    background-size: cover;
+    pointer-events: none;
+    user-select: none;
+    background-repeat: no-repeat;
+    content: "";
+}
+
 html[data-theme="dark"] {
     --ifm-color-primary-lightest: #d1d1ff;
     --ifm-color-primary-lighter: #c9c9ff;


### PR DESCRIPTION
This reverts commit 246c898da369620b9bee82e4ae090ca444b9dc02.

Turns out this was in the docs and not in the product. No wonder I couldn't see it.