### PR TITLE
chore: add enterprise edge page

### DIFF
--- a/frontend/src/component/admin/Admin.tsx
+++ b/frontend/src/component/admin/Admin.tsx
@@ -19,6 +19,11 @@ import NotFound from 'component/common/NotFound/NotFound';
 import { Banners } from './banners/Banners.tsx';
 import { License } from './license/License.tsx';
 import { AdminHome } from './AdminHome.tsx';
+import { lazy } from 'react';
+
+const EnterpriseEdge = lazy(
+    () => import('./enterprise-edge/EnterpriseEdge.tsx'),
+);
 
 export const Admin = () => {
     return (
@@ -34,6 +39,7 @@ export const Admin = () => {
                 <Route path='groups/*' element={<GroupsAdmin />} />
                 <Route path='roles/*' element={<Roles />} />
                 <Route path='instance' element={<InstanceAdmin />} />
+                <Route path='enterprise-edge' element={<EnterpriseEdge />} />
                 <Route path='network/*' element={<Network />} />
                 <Route path='maintenance' element={<MaintenanceAdmin />} />
                 <Route path='banners' element={<Banners />} />

--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -117,6 +117,14 @@ export const adminRoutes: INavigationMenuItem[] = [
         group: 'sso',
     },
 
+    // Enterprise Edge
+    {
+        path: '/admin/enterprise-edge',
+        title: 'Enterprise Edge',
+        menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
+        flag: 'enterpriseEdgeUI',
+    },
+
     // Network
     {
         path: '/admin/network',
@@ -136,6 +144,7 @@ export const adminRoutes: INavigationMenuItem[] = [
         menu: { adminSettings: true, mode: ['pro', 'enterprise'] },
         group: 'network',
         flag: 'edgeObservability',
+        notFlag: 'enterpriseEdgeUI',
     },
     {
         path: '/admin/network/backend-connections',

--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdge.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdge.tsx
@@ -1,0 +1,251 @@
+import { usePageTitle } from 'hooks/usePageTitle';
+import { ArcherContainer, ArcherElement } from 'react-archer';
+import { Alert, Typography, styled, useTheme } from '@mui/material';
+import { unknownify } from 'utils/unknownify';
+import { useMemo } from 'react';
+import { ReactComponent as LogoIcon } from 'assets/icons/logoBg.svg';
+import { ReactComponent as LogoIconWhite } from 'assets/icons/logoWhiteBg.svg';
+import { ThemeMode } from 'component/common/ThemeMode/ThemeMode';
+import { useConnectedEdges } from 'hooks/api/getters/useConnectedEdges/useConnectedEdges';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+import { EnterpriseEdgeInstance } from './EnterpriseEdgeInstance/EnterpriseEdgeInstance.tsx';
+import { PageContent } from 'component/common/PageContent/PageContent.tsx';
+
+const UNLEASH = 'Unleash';
+
+const StyledUnleashLevel = styled('div')(({ theme }) => ({
+    marginBottom: theme.spacing(18),
+    display: 'flex',
+    justifyContent: 'center',
+}));
+
+const StyledEdgeLevel = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    gap: theme.spacing(4),
+    flexWrap: 'wrap',
+    marginTop: theme.spacing(2),
+}));
+
+const StyledNode = styled('div')(({ theme }) => ({
+    borderRadius: theme.shape.borderRadiusMedium,
+    border: `1px solid ${theme.palette.secondary.border}`,
+    backgroundColor: theme.palette.secondary.light,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: theme.spacing(1.5),
+    zIndex: 1,
+    marginTop: theme.spacing(1),
+    '& > svg': {
+        width: theme.spacing(9),
+        height: theme.spacing(9),
+    },
+}));
+
+const StyledGroup = styled(StyledNode)({
+    backgroundColor: 'transparent',
+});
+
+const StyledNodeHeader = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.fontWeight.bold,
+}));
+
+const StyledNodeDescription = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallerBody,
+    color: theme.palette.text.secondary,
+}));
+
+type AppNameGroup = {
+    appName: string;
+    instances: ConnectedEdge[];
+    groupTargets: Set<string>;
+    level: number;
+};
+
+const createGroups = (edges: ConnectedEdge[]): Map<string, AppNameGroup> =>
+    edges.reduce((groups, edge) => {
+        if (!groups.has(edge.appName)) {
+            groups.set(edge.appName, {
+                appName: edge.appName,
+                instances: [],
+                groupTargets: new Set(),
+                level: 0,
+            });
+        }
+        groups.get(edge.appName)!.instances.push(edge);
+        return groups;
+    }, new Map<string, AppNameGroup>());
+
+const computeGroupLevels = (
+    groups: Map<string, AppNameGroup>,
+): Map<number, AppNameGroup[]> => {
+    const memo = new Map<string, number>();
+
+    const getLevel = (group: AppNameGroup): number => {
+        if (memo.has(group.appName)) return memo.get(group.appName)!;
+        let level = 0;
+        group.groupTargets.forEach((target) => {
+            if (target !== UNLEASH) {
+                const targetGroup = groups.get(target);
+                if (targetGroup) {
+                    level = Math.max(level, getLevel(targetGroup) + 1);
+                }
+            }
+        });
+        memo.set(group.appName, level);
+        return level;
+    };
+
+    groups.forEach((group) => {
+        group.level = getLevel(group);
+    });
+
+    const levelsMap = new Map<number, AppNameGroup[]>();
+    groups.forEach((group) => {
+        const levelGroups = levelsMap.get(group.level) || [];
+        levelGroups.push(group);
+        levelsMap.set(group.level, levelGroups);
+    });
+    return levelsMap;
+};
+
+const processEdges = (edges: ConnectedEdge[]): Map<number, AppNameGroup[]> => {
+    const groups = createGroups(edges);
+    const instanceIdToId = new Map<string, string>();
+    const idToAppName = new Map<string, string>();
+
+    groups.forEach((group) => {
+        group.instances = group.instances
+            .sort((a, b) => a.instanceId.localeCompare(b.instanceId))
+            .map((instance, index) => {
+                const id = `${group.appName}-${index + 1}`;
+                instanceIdToId.set(instance.instanceId, id);
+                idToAppName.set(id, group.appName);
+                return { ...instance, id };
+            });
+    });
+
+    groups.forEach((group) => {
+        group.instances = group.instances.map((instance) => ({
+            ...instance,
+            connectedVia: instance.connectedVia
+                ? instanceIdToId.get(instance.connectedVia) ||
+                  instance.connectedVia
+                : UNLEASH,
+        }));
+        const targets = new Set<string>();
+        group.instances.forEach((instance) => {
+            if (!instance.connectedVia || instance.connectedVia === UNLEASH) {
+                targets.add(UNLEASH);
+            } else {
+                const targetApp = idToAppName.get(instance.connectedVia);
+                if (targetApp && targetApp !== group.appName) {
+                    targets.add(targetApp);
+                }
+            }
+        });
+        group.groupTargets = targets;
+    });
+
+    return computeGroupLevels(groups);
+};
+
+export const EnterpriseEdge = () => {
+    usePageTitle('Enterprise Edge');
+    const theme = useTheme();
+    const { connectedEdges } = useConnectedEdges({ refreshInterval: 30_000 });
+
+    const edgeLevels = useMemo(
+        () => processEdges(connectedEdges),
+        [connectedEdges],
+    );
+    const levels = Array.from(edgeLevels.keys()).sort((a, b) => a - b);
+
+    if (edgeLevels.size === 0)
+        return (
+            <PageContent header='Enterprise Edge'>
+                <Alert severity='info'>
+                    <strong>No Enterprise Edge instances connected</strong>
+                    <br />
+                    <br />
+                    Unlock deeper visibility into your Edge network and enable
+                    high-performance streaming for your SDKs.
+                    <br />
+                    <br />
+                    Enterprise Edge gives you:
+                    <br />• Real-time SDK updates through the streaming API
+                    <br />• Full observability into your Edge instances
+                    <br />
+                    <br />
+                    Interested in getting started?{' '}
+                    <a href='mailto:license@getunleash.io?subject=Enterprise Edge'>
+                        Contact us
+                    </a>
+                </Alert>
+            </PageContent>
+        );
+
+    return (
+        <PageContent header='Enterprise Edge'>
+            <ArcherContainer
+                strokeColor={theme.palette.text.primary}
+                endShape={{ arrow: { arrowLength: 4, arrowThickness: 4 } }}
+            >
+                <StyledUnleashLevel>
+                    <ArcherElement id={UNLEASH}>
+                        <StyledNode>
+                            <ThemeMode
+                                darkmode={<LogoIconWhite />}
+                                lightmode={<LogoIcon />}
+                            />
+                            <Typography sx={{ mt: 1 }}>{UNLEASH}</Typography>
+                        </StyledNode>
+                    </ArcherElement>
+                </StyledUnleashLevel>
+                {levels.map((level) => (
+                    <StyledEdgeLevel key={level}>
+                        {edgeLevels
+                            .get(level)
+                            ?.map(({ appName, groupTargets, instances }) => (
+                                <ArcherElement
+                                    key={appName}
+                                    id={appName}
+                                    relations={Array.from(groupTargets).map(
+                                        (target) => ({
+                                            targetId: target,
+                                            targetAnchor: 'bottom',
+                                            sourceAnchor: 'top',
+                                            style: {
+                                                strokeColor:
+                                                    theme.palette.secondary
+                                                        .border,
+                                            },
+                                        }),
+                                    )}
+                                >
+                                    <StyledGroup>
+                                        <StyledNodeHeader>
+                                            {unknownify(appName)}
+                                        </StyledNodeHeader>
+                                        <StyledNodeDescription>
+                                            {instances.length} instance
+                                            {instances.length !== 1 && 's'}
+                                        </StyledNodeDescription>
+                                        {instances.map((instance) => (
+                                            <EnterpriseEdgeInstance
+                                                key={instance.instanceId}
+                                                instance={instance}
+                                            />
+                                        ))}
+                                    </StyledGroup>
+                                </ArcherElement>
+                            ))}
+                    </StyledEdgeLevel>
+                ))}
+            </ArcherContainer>
+        </PageContent>
+    );
+};
+
+export default EnterpriseEdge;

--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstance/EnterpriseEdgeInstance.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstance/EnterpriseEdgeInstance.tsx
@@ -1,0 +1,268 @@
+import { useLocationSettings } from 'hooks/useLocationSettings';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+import CircleIcon from '@mui/icons-material/Circle';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import { formatDateYMDHMS } from 'utils/formatDate';
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    styled,
+    Tooltip,
+} from '@mui/material';
+import { Badge } from 'component/common/Badge/Badge';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import { EnterpriseEdgeInstanceLatency } from './EnterpriseEdgeInstanceLatency.tsx';
+
+const StyledInstance = styled('div')(({ theme }) => ({
+    width: '100%',
+    borderRadius: theme.shape.borderRadiusMedium,
+    border: '1px solid',
+    borderColor: theme.palette.secondary.border,
+    backgroundColor: theme.palette.secondary.light,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: 0,
+    zIndex: 1,
+    marginTop: theme.spacing(1),
+}));
+
+const StyledAccordion = styled(Accordion)({
+    width: '100%',
+    background: 'transparent',
+    boxShadow: 'none',
+});
+
+const StyledAccordionSummary = styled(AccordionSummary, {
+    shouldForwardProp: (prop) => prop !== 'connectionStatus',
+})<{ connectionStatus: InstanceConnectionStatus }>(
+    ({ theme, connectionStatus }) => ({
+        fontSize: theme.fontSizes.smallBody,
+        padding: theme.spacing(1),
+        minHeight: theme.spacing(3),
+        '& .MuiAccordionSummary-content': {
+            alignItems: 'center',
+            gap: theme.spacing(1),
+            margin: 0,
+            '&.Mui-expanded': {
+                margin: 0,
+            },
+            '& svg': {
+                fontSize: theme.fontSizes.mainHeader,
+                color:
+                    connectionStatus === 'Stale'
+                        ? theme.palette.warning.main
+                        : connectionStatus === 'Disconnected'
+                          ? theme.palette.error.main
+                          : theme.palette.success.main,
+            },
+        },
+    }),
+);
+
+const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    fontSize: theme.fontSizes.smallerBody,
+    gap: theme.spacing(2),
+}));
+
+const StyledDetailRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    '& > span': {
+        display: 'flex',
+        alignItems: 'center',
+    },
+}));
+
+const StyledBadge = styled(Badge)(({ theme }) => ({
+    padding: theme.spacing(0, 1),
+}));
+
+const getHosting = ({
+    hosting,
+}: ConnectedEdge): 'Cloud' | 'Self-hosted' | 'Unknown' => {
+    switch (hosting) {
+        case 'hosted':
+            return 'Cloud';
+        case 'enterprise-self-hosted':
+            return 'Self-hosted';
+        default:
+            return hosting ? `Unknown: ${hosting}` : 'Unknown';
+    }
+};
+
+const getConnectionStatus = ({
+    reportedAt,
+}: ConnectedEdge): InstanceConnectionStatus => {
+    const reportedTime = new Date(reportedAt).getTime();
+    const reportedSecondsAgo = (Date.now() - reportedTime) / 1000;
+
+    if (reportedSecondsAgo > 360) return 'Disconnected';
+    if (reportedSecondsAgo > 180) return 'Stale';
+
+    return 'Connected';
+};
+
+const getCPUPercentage = ({
+    started,
+    reportedAt,
+    cpuUsage,
+}: ConnectedEdge): string => {
+    const cpuUsageSeconds = Number(cpuUsage);
+    if (!cpuUsageSeconds) return 'No usage';
+
+    const startedTimestamp = new Date(started).getTime();
+    const reportedTimestamp = new Date(reportedAt).getTime();
+
+    const totalRuntimeSeconds = (reportedTimestamp - startedTimestamp) / 1000;
+    if (totalRuntimeSeconds === 0) return 'No usage';
+
+    return `${((cpuUsageSeconds / totalRuntimeSeconds) * 100).toFixed(2)} %`;
+};
+
+const getMemory = ({ memoryUsage }: ConnectedEdge): string => {
+    if (!memoryUsage) return 'No usage';
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let size = memoryUsage;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+    }
+
+    return `${size.toFixed(2)} ${units[unitIndex]}`;
+};
+
+type InstanceConnectionStatus = 'Connected' | 'Stale' | 'Disconnected';
+
+interface IEnterpriseEdgeInstanceProps {
+    instance: ConnectedEdge;
+}
+
+export const EnterpriseEdgeInstance = ({
+    instance,
+}: IEnterpriseEdgeInstanceProps) => {
+    const { locationSettings } = useLocationSettings();
+
+    const connectionStatus = getConnectionStatus(instance);
+    const start = formatDateYMDHMS(instance.started, locationSettings?.locale);
+    const lastReport = formatDateYMDHMS(
+        instance.reportedAt,
+        locationSettings?.locale,
+    );
+    const cpuPercentage = getCPUPercentage(instance);
+    const memory = getMemory(instance);
+    const archWarning = cpuPercentage === 'No usage' &&
+        memory === 'No usage' && (
+            <p>Resource metrics are only available when running on Linux.</p>
+        );
+
+    return (
+        <StyledInstance>
+            <StyledAccordion>
+                <StyledAccordionSummary
+                    expandIcon={<ExpandMore />}
+                    connectionStatus={connectionStatus}
+                >
+                    <Tooltip
+                        arrow
+                        title={`${connectionStatus}. Last reported: ${lastReport}`}
+                    >
+                        <CircleIcon />
+                    </Tooltip>
+                    {instance.id || instance.instanceId}
+                </StyledAccordionSummary>
+                <StyledAccordionDetails>
+                    <StyledDetailRow>
+                        <strong>ID</strong>
+                        <span>{instance.instanceId}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Upstream server</strong>
+                        <span>{instance.connectedVia || 'Unleash'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Region</strong>
+                        <span>{instance.region || 'Unknown'}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Hosting</strong>
+                        <span>{getHosting(instance)}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Version</strong>
+                        <span>{instance.edgeVersion}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Status</strong>
+                        <StyledBadge
+                            color={
+                                connectionStatus === 'Disconnected'
+                                    ? 'error'
+                                    : connectionStatus === 'Stale'
+                                      ? 'warning'
+                                      : 'success'
+                            }
+                        >
+                            {connectionStatus}
+                        </StyledBadge>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Start</strong>
+                        <span>{start}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Last report</strong>
+                        <span>{lastReport}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>CPU</strong>
+                        <span>
+                            {cpuPercentage}{' '}
+                            <HelpIcon
+                                tooltip={
+                                    <>
+                                        <p>
+                                            CPU average usage since instance
+                                            started.
+                                        </p>
+                                        {archWarning}
+                                    </>
+                                }
+                                size='16px'
+                            />
+                        </span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Memory</strong>
+                        <span>
+                            {memory}{' '}
+                            <HelpIcon
+                                tooltip={
+                                    <>
+                                        <p>Current memory usage.</p>
+                                        {archWarning}
+                                    </>
+                                }
+                                size='16px'
+                            />
+                        </span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <strong>Stream clients</strong>
+                        <span>{instance.connectedStreamingClients}</span>
+                    </StyledDetailRow>
+                    <StyledDetailRow>
+                        <EnterpriseEdgeInstanceLatency instance={instance} />
+                    </StyledDetailRow>
+                </StyledAccordionDetails>
+            </StyledAccordion>
+        </StyledInstance>
+    );
+};

--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstance/EnterpriseEdgeInstanceLatency.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstance/EnterpriseEdgeInstanceLatency.tsx
@@ -1,0 +1,102 @@
+import { styled } from '@mui/material';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import type { ConnectedEdge } from 'interfaces/connectedEdge';
+
+const StyledTable = styled('table')(({ theme }) => ({
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: theme.fontSizes.smallerBody,
+    '& > thead': {
+        borderBottom: `1px solid ${theme.palette.text.primary}`,
+    },
+    '& tr': {
+        textAlign: 'right',
+        '& > th:first-of-type, td:first-of-type': {
+            textAlign: 'left',
+        },
+    },
+}));
+
+const StyledSectionHeader = styled('tr')(({ theme }) => ({
+    fontWeight: theme.fontWeight.bold,
+    '&&& > td': {
+        paddingTop: theme.spacing(1),
+        '& > div': {
+            display: 'flex',
+            alignItems: 'center',
+        },
+    },
+}));
+
+interface IEnterpriseEdgeInstanceLatencyProps {
+    instance: ConnectedEdge;
+}
+
+export const EnterpriseEdgeInstanceLatency = ({
+    instance,
+}: IEnterpriseEdgeInstanceLatencyProps) => {
+    return (
+        <StyledTable>
+            <thead>
+                <tr>
+                    <th>Latency (ms)</th>
+                    <th>Avg</th>
+                    <th>p99</th>
+                </tr>
+            </thead>
+            <tbody>
+                <StyledSectionHeader>
+                    <td colSpan={3}>
+                        <div>
+                            Upstream{' '}
+                            <HelpIcon
+                                tooltip={
+                                    'Latency measured for requests sent from this Edge instance to the configured upstream, i.e. Unleash or another Edge instance.'
+                                }
+                                size='16px'
+                            />
+                        </div>
+                    </td>
+                </StyledSectionHeader>
+                <tr>
+                    <td>Client Features</td>
+                    <td>{instance.upstreamFeaturesAverageLatencyMs}</td>
+                    <td>{instance.upstreamFeaturesP99LatencyMs}</td>
+                </tr>
+                <tr>
+                    <td>Metrics</td>
+                    <td>{instance.upstreamMetricsAverageLatencyMs}</td>
+                    <td>{instance.upstreamMetricsP99LatencyMs}</td>
+                </tr>
+                <tr>
+                    <td>Edge</td>
+                    <td>{instance.upstreamEdgeAverageLatencyMs}</td>
+                    <td>{instance.upstreamEdgeP99LatencyMs}</td>
+                </tr>
+                <StyledSectionHeader>
+                    <td colSpan={3}>
+                        <div>
+                            Downstream{' '}
+                            <HelpIcon
+                                tooltip={
+                                    'Latency measured when serving requests from clients, i.e. SDKs or other Edge instances.'
+                                }
+                                size='16px'
+                            />
+                        </div>
+                    </td>
+                </StyledSectionHeader>
+                <tr>
+                    <td>Client Features</td>
+                    <td>{instance.clientFeaturesAverageLatencyMs}</td>
+                    <td>{instance.clientFeaturesP99LatencyMs}</td>
+                </tr>
+                <tr>
+                    <td>Frontend</td>
+                    <td>{instance.frontendApiAverageLatencyMs}</td>
+                    <td>{instance.frontendApiP99LatencyMs}</td>
+                </tr>
+            </tbody>
+        </StyledTable>
+    );
+};

--- a/frontend/src/component/admin/network/Network.tsx
+++ b/frontend/src/component/admin/network/Network.tsx
@@ -1,7 +1,7 @@
 import { lazy } from 'react';
 
 import { Tab, Tabs } from '@mui/material';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { TabLink } from 'component/common/TabNav/TabLink';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { useUiFlag } from 'hooks/useUiFlag';
@@ -62,12 +62,15 @@ export const Network = () => {
     const { pathname } = useLocation();
     const edgeObservabilityEnabled = useUiFlag('edgeObservability');
     const consumptionModelEnabled = useUiFlag('consumptionModelUI');
+    const enterpriseEdgeUIEnabled = useUiFlag('enterpriseEdgeUI');
     const allTabs = consumptionModelEnabled
         ? [...tabs, ...consumptionModelTabs]
         : [...tabs, ...seatModelTabs];
 
     const filteredTabs = allTabs.filter(
-        ({ label }) => label !== 'Connected Edges' || edgeObservabilityEnabled,
+        ({ label }) =>
+            label !== 'Connected Edges' ||
+            (edgeObservabilityEnabled && !enterpriseEdgeUIEnabled),
     );
 
     return (
@@ -103,7 +106,16 @@ export const Network = () => {
                     {edgeObservabilityEnabled && (
                         <Route
                             path='connected-edges'
-                            element={<NetworkConnectedEdges />}
+                            element={
+                                enterpriseEdgeUIEnabled ? (
+                                    <Navigate
+                                        to='/admin/enterprise-edge'
+                                        replace
+                                    />
+                                ) : (
+                                    <NetworkConnectedEdges />
+                                )
+                            }
                         />
                     )}
                     <Route

--- a/frontend/src/component/common/util.ts
+++ b/frontend/src/component/common/util.ts
@@ -11,16 +11,16 @@ import { formatDateYMD } from '../../utils/formatDate.js';
  */
 export const filterByConfig =
     (config: IUiConfig) => (r: INavigationMenuItem) => {
-        if (r.flag) {
-            // Check if the route's `flag` is enabled in IUiConfig.flags.
-            const flags = config.flags as unknown as Record<string, boolean>;
-            return Boolean(flags[r.flag]);
-        }
-
         if (r.notFlag) {
             const flags = config.flags as unknown as Record<string, boolean>;
 
             return !(flags[r.notFlag] === true);
+        }
+
+        if (r.flag) {
+            // Check if the route's `flag` is enabled in IUiConfig.flags.
+            const flags = config.flags as unknown as Record<string, boolean>;
+            return Boolean(flags[r.flag]);
         }
 
         if (r.configFlag) {

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
@@ -6,6 +6,7 @@ import BillingIcon from '@mui/icons-material/CreditCardOutlined';
 import PeopleOutlineRoundedIcon from '@mui/icons-material/PeopleOutlineRounded';
 import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
 import SingleSignOnIcon from '@mui/icons-material/AssignmentOutlined';
+import LanguageIcon from '@mui/icons-material/Language';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import EmptyIcon from '@mui/icons-material/CheckBoxOutlineBlankOutlined';
@@ -17,6 +18,7 @@ const icons: Record<string, typeof SvgIcon> = {
     '/admin/service-accounts': LaptopIcon,
     access: KeyRoundedIcon,
     sso: SingleSignOnIcon,
+    '/admin/enterprise-edge': LanguageIcon,
     network: HubOutlinedIcon,
     instance: BuildOutlinedIcon,
     '/admin/billing': BillingIcon,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4051/add-new-enterprise-edge-page

Adds a new **Enterprise Edge** page behind the `enterpriseEdgeUI` flag.

This also removes the **Connected Edges** page and sets up a redirect.

The new components are essentially a copy of the Connected Edges components. We can clean up the old ones once we remove the flag.

<img width="1475" height="612" alt="image" src="https://github.com/user-attachments/assets/876be96c-66a8-4e3e-911d-006fc2574563" />