### PR TITLE
fix: notFlag logic in route

### DIFF
--- a/frontend/src/component/common/util.ts
+++ b/frontend/src/component/common/util.ts
@@ -11,15 +11,14 @@ import { formatDateYMD } from '../../utils/formatDate.js';
  */
 export const filterByConfig =
     (config: IUiConfig) => (r: INavigationMenuItem) => {
-        if (r.notFlag) {
-            const flags = config.flags as unknown as Record<string, boolean>;
+        const flags = config.flags as unknown as Record<string, boolean>;
 
-            return !(flags[r.notFlag] === true);
+        if (r.notFlag && flags[r.notFlag] === true) {
+            return false;
         }
 
         if (r.flag) {
             // Check if the route's `flag` is enabled in IUiConfig.flags.
-            const flags = config.flags as unknown as Record<string, boolean>;
             return Boolean(flags[r.flag]);
         }
 


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4060/fix-route-notflag-logic

This fixes a regression introduced in https://github.com/Unleash/unleash/pull/11063, where a `notFlag` would always take precedence if present in the route configuration, even when the flag was disabled.

What we actually want is for `notFlag` to take precedence **only when it is set and its flag evaluates to true**. In other words: if a route defines a `notFlag` and that feature flag is enabled, the route should be filtered out. Otherwise, the remaining checks should still apply.