### PR TITLE
chore: add new NewInUnleashItems file

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashItems.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashItems.tsx
@@ -1,0 +1,44 @@
+import { styled } from '@mui/material';
+import { formatAssetPath } from 'utils/formatPath';
+import ReleaseTemplatePreviewImage from 'assets/img/releaseTemplatePreview.png';
+
+const StyledImg = styled('img')(() => ({
+    maxWidth: '100%',
+}));
+
+export type NewInUnleashItem = {
+    label: string;
+    summary: string;
+    longDescription?: string;
+    preview: React.ReactNode;
+    filter: {
+        flag?: string;
+        enterpriseOnly?: boolean;
+        versionLowerThan: string;
+    };
+    appLink?: string;
+    docsLink?: string;
+    beta: boolean;
+    modal?: boolean;
+};
+
+export const newInUnleashItems: NewInUnleashItem[] = [
+    {
+        label: 'Release templates',
+        summary: 'Faster and safer rollouts with release management',
+        preview: (
+            <StyledImg
+                src={formatAssetPath(ReleaseTemplatePreviewImage)}
+                alt='Release templates preview'
+            />
+        ),
+        appLink: '/release-templates',
+        docsLink: 'https://docs.getunleash.io/reference/release-templates',
+        filter: {
+            enterpriseOnly: true,
+            versionLowerThan: '7.4.0',
+        },
+        beta: false,
+        modal: true,
+    },
+];


### PR DESCRIPTION
Adds a NewInUnleashItems file. This file will supplant the list of items coded into the existing `NewInUnleash.tsx`. Because we can use links instead of onClick navigation handlers for app navigation, we also don't need it to be stateful. If there is a need for this later, we can add it in then.

The file also exports a type for the items.

Also, removes the previous items (lifecycle 2.0, and signals and actions) from the list (or rather: doesn't port them over) because they're out of date now anyway.