### PR TITLE
chore: add Enterprise Edge group hosting badges

### DIFF
--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstances/EnterpriseEdgeInstances.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeInstances/EnterpriseEdgeInstances.tsx
@@ -163,7 +163,13 @@ const getGroupHosting = (instances: ConnectedEdge[]) => {
     if (instances.every((i) => i.hosting === 'enterprise-self-hosted')) {
         return { hostingLabel: 'Self-hosted', hostingColor: 'info' } as const;
     }
-    if (new Set(instances.map((i) => i.hosting)).size > 1) {
+    if (
+        instances.every(
+            (i) =>
+                i.hosting === 'hosted' ||
+                i.hosting === 'enterprise-self-hosted',
+        )
+    ) {
         return { hostingLabel: 'Hybrid', hostingColor: 'warning' } as const;
     }
     return { hostingLabel: 'Unknown', hostingColor: 'neutral' } as const;


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4059/add-enterprise-edge-instance-markers-for-hosted-and-self-hosted

Adds Enterprise Edge group hosting badges.

These are calculated based on the hosting value of their instances and can be one of:

 - **Cloud**: Every instance in this group is a cloud instance;
 - **Self-hosted**: Every instance in this group is a self-hosted instance;
 - **Hybrid**: Every instance in this group is either a cloud or self-hosted instance;
 - **Unknown**: None of the above;

<img width="1250" height="479" alt="image" src="https://github.com/user-attachments/assets/dfa69fec-e8f4-4f15-a036-157500f1dabc" />