### PR TITLE
feat: now impact metrics charts are limited to 20

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureImpactMetrics.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureImpactMetrics.tsx
@@ -130,8 +130,7 @@ export const FeatureImpactMetrics: FC = () => {
     );
 
     const maxChartsReached = impactMetrics.configs.length >= 20;
-    const isDisabled =
-        metadataLoading || !!metadataError || maxChartsReached;
+    const isDisabled = metadataLoading || !!metadataError || maxChartsReached;
 
     return (
         <PageContent>

--- a/frontend/src/component/impact-metrics/ImpactMetrics.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetrics.tsx
@@ -1,6 +1,6 @@
 import { type FC, useMemo } from 'react';
 import { useState, useCallback } from 'react';
-import { Typography, Button, Paper, styled, Box, Tooltip } from '@mui/material';
+import { Typography, Button, Paper, styled, Box } from '@mui/material';
 import Add from '@mui/icons-material/Add';
 import { PageHeader } from 'component/common/PageHeader/PageHeader.tsx';
 import { useImpactMetricsOptions } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';


### PR DESCRIPTION
<img width="2300" height="625" alt="image" src="https://github.com/user-attachments/assets/b36eae15-2a09-411b-a65d-972a801d2d02" />
