### PR TITLE
chore: add a delayed evaluation of UI flags

### DIFF
--- a/frontend/src/hooks/useUiFlag.ts
+++ b/frontend/src/hooks/useUiFlag.ts
@@ -1,9 +1,17 @@
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
-type flags = ReturnType<typeof useUiConfig>['uiConfig']['flags'];
+type Flags = ReturnType<typeof useUiConfig>['uiConfig']['flags'];
+export type Flag = keyof Flags;
 
-export const useUiFlag = <K extends keyof flags>(flag: K) => {
+export const useDelayedUiFlagEvaluation = (): (<K extends Flag>(
+    flag: K,
+) => NonNullable<Flags[K]> | false) => {
     const { uiConfig } = useUiConfig();
 
-    return uiConfig?.flags?.[flag] || false;
+    return (flag) => uiConfig?.flags?.[flag] || false;
+};
+
+export const useUiFlag = <K extends Flag>(flag: K) => {
+    const evaluate = useDelayedUiFlagEvaluation();
+    return evaluate(flag);
 };


### PR DESCRIPTION
Adds a new hook for UI flag evaluation that returns an evaluation function.

This solves a frequent pain point where we can't check if a flag is enabled conditionally (e.g. if we don't know if we have a flag yet) because it's implemented as a hook.

The new implementation uses the same evaluation as the old one, but returns the eval function after calling the hook, thereby circumventing the issue and allowing you to eval a flag anywhere in the function body.
