### PR TITLE
fix: hide change request items that are already consolidated

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -70,6 +70,9 @@ const InlineList = styled('ul')(({ theme }) => ({
 
 const ChangeInnerBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(3),
+    '&:empty': {
+        display: 'none',
+    },
 }));
 
 export const FeatureChange: FC<{

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -1,15 +1,16 @@
-import { useRef, useState, type FC, type ReactNode } from 'react';
+import { type FC, type ReactNode, useRef, useState } from 'react';
 import { styled, Typography } from '@mui/material';
 import type {
     ChangeRequestState,
     IChangeRequestAddReleasePlan,
-    IChangeRequestDeleteReleasePlan,
-    IChangeRequestStartMilestone,
     IChangeRequestChangeMilestoneProgression,
-    IChangeRequestDeleteMilestoneProgression,
     IChangeRequestChangeSafeguard,
+    IChangeRequestDeleteMilestoneProgression,
+    IChangeRequestDeleteReleasePlan,
     IChangeRequestDeleteSafeguard,
+    IChangeRequestFeature,
     IChangeRequestResumeMilestoneProgression,
+    IChangeRequestStartMilestone,
 } from 'component/changeRequest/changeRequest.types';
 import { useReleasePlanPreview } from 'hooks/useReleasePlanPreview';
 import { useFeatureReleasePlans } from 'hooks/api/getters/useFeatureReleasePlans/useFeatureReleasePlans';
@@ -33,7 +34,6 @@ import type {
     ChangeMilestoneProgressionSchema,
     CreateSafeguardSchema,
 } from 'openapi';
-import { ProgressionChange } from './ProgressionChange.tsx';
 import { ConsolidatedProgressionChanges } from './ConsolidatedProgressionChanges.tsx';
 import { SafeguardFormChangeRequestView } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm';
 import { ReadonlySafeguardDisplay } from 'component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/ReadonlySafeguardDisplay';
@@ -459,7 +459,7 @@ export const ReleasePlanChange: FC<{
     featureName: string;
     projectId: string;
     changeRequestState: ChangeRequestState;
-    feature?: any; // Optional feature object for consolidated progression changes
+    feature?: IChangeRequestFeature; // Optional feature object for consolidated progression changes
     onRefetch?: () => void;
 }> = ({
     actions,
@@ -665,20 +665,6 @@ export const ReleasePlanChange: FC<{
                     onSubmit={changeSafeguardSubmit}
                     onDelete={deleteSafeguardSubmit}
                     actions={actions}
-                />
-            )}
-            {change.action === 'changeMilestoneProgression' && (
-                <ProgressionChange
-                    change={change}
-                    currentReleasePlan={currentReleasePlan}
-                    actions={actions}
-                    changeRequestState={changeRequestState}
-                    onUpdateChangeRequestSubmit={
-                        changeMilestoneProgressionSubmit
-                    }
-                    onDeleteChangeRequestSubmit={
-                        deleteMilestonProgressionSubmit
-                    }
                 />
             )}
         </>


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Before (each milestone progression change we consolidate in UI was getting own space)
<img width="1092" height="470" alt="Screenshot 2025-12-08 at 14 37 58" src="https://github.com/user-attachments/assets/3b39f997-0d16-42b8-a16f-15a8b8278ce9" />

After
<img width="1081" height="480" alt="Screenshot 2025-12-08 at 14 38 06" src="https://github.com/user-attachments/assets/b5c57209-1fe5-4774-ad72-cb4a843cb63b" />

There's still some border left but it's better than spaced elements. 

Even better long term solution would be to collapse everything upfront but it's too much work for now

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
