### PR TITLE
fix: make sidebar fixed width again

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -38,8 +38,8 @@ export const StretchContainer = styled(Box, {
     gap: theme.spacing(2),
     zIndex: 1,
     overflowAnchor: 'none',
-    minWidth: mode === 'full' ? theme.spacing(32) : 'auto',
-    width: mode === 'full' ? theme.spacing(32) : 'auto',
+    minWidth: mode === 'full' ? theme.spacing(34) : 'auto',
+    width: mode === 'full' ? theme.spacing(34) : 'auto',
 }));
 
 const StyledLink = styled(Link)(({ theme }) => focusable(theme));


### PR DESCRIPTION
This PR reverts https://github.com/Unleash/unleash/pull/11037 and then increases the set sidebar width by 16px when it's expanded. 

The reason is that if the width is set to auto, then selecting the various sub-items of the "configure" route results in the sidebar width changing. I had a look, but couldn't figure out why. The strange thing is that shorter page names appear to cause wider sidebars.

For instance, here's release templates:
<img width="289" height="647" alt="image" src="https://github.com/user-attachments/assets/581e381e-4db4-47a3-b21a-f56220aea64c" />


Here's applications (look at the new in Unleash component):
<img width="330" height="652" alt="image" src="https://github.com/user-attachments/assets/fc812d40-bf40-4860-9a4e-0fa0275ed76e" />


I've increased the sidebar width a little bit, such that the submenu doesn't jump out of the main menu as described in #11037. It now looks like this for release plans with the new badge:

<img width="305" height="395" alt="image" src="https://github.com/user-attachments/assets/39f882e2-0489-44a4-be8a-74934202ccfc" />

Ideally, I'd like to find a better solution to this (by finding out what's causing the jumping), but there's more important issues to look at at the moment, and this will work fine.