### PR TITLE
chore: update colors for new in Unleah toast / add palette.inverse

### DIFF
--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashToast.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashToast.tsx
@@ -36,8 +36,8 @@ const StyledIcon = styled(NewReleases)(({ theme }) => ({
 }));
 
 const NewInUnleashBody = styled('article')(({ theme }) => ({
-    backgroundColor: theme.palette.common.black,
-    color: theme.palette.common.white,
+    backgroundColor: theme.palette.inverse.main,
+    color: theme.palette.inverse.contrastText,
     padding: theme.spacing(1.5),
     borderRadius: theme.shape.borderRadiusLarge,
     position: 'relative',

--- a/frontend/src/themes/dark-theme.ts
+++ b/frontend/src/themes/dark-theme.ts
@@ -230,6 +230,11 @@ const theme = {
             E1: '#68A611',
             series: colors.chartSeries,
         },
+
+        inverse: {
+            main: '#EEEEFC',
+            contrastText: colors.grey[900],
+        },
     },
 } as const;
 

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -286,6 +286,11 @@ const theme = {
             E1: '#68A611',
             series: colors.chartSeries,
         },
+
+        inverse: {
+            main: '#222130',
+            contrastText: '#EEEEFC',
+        },
     },
 } as const;
 

--- a/frontend/src/themes/themeTypes.ts
+++ b/frontend/src/themes/themeTypes.ts
@@ -148,6 +148,11 @@ declare module '@mui/material/styles' {
             E1: string;
             series: string[];
         };
+
+        inverse: {
+            main: string;
+            contrastText: string;
+        };
     }
     interface Theme extends CustomTheme {}
     interface ThemeOptions extends CustomTheme {}


### PR DESCRIPTION
Adds a new `palette.inverse` property to the theme and uses it for the New in Unleash toast.

Toast with new colors in light mode:
<img width="626" height="222" alt="image" src="https://github.com/user-attachments/assets/2264dd00-117b-493f-8ce7-ff1a173d622d" />

Dark mode:
<img width="710" height="264" alt="image" src="https://github.com/user-attachments/assets/14b27bc3-f516-46fc-9422-db08a7112f4f" />
