### PR TITLE
feat: safeguard threshold input ux

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -1,10 +1,11 @@
 import { Button, FormControl, TextField, Box, styled } from '@mui/material';
 import ShieldIcon from '@mui/icons-material/Shield';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import type { ChangeEvent, FormEvent, KeyboardEvent, ReactNode } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useNumericStringInput } from 'hooks/useNumericStringInput';
 import { SafeguardChangeRequestDialog } from './SafeguardChangeRequestDialog.tsx';
 import { MiniMetricsChartWithTooltip } from './MiniMetricsChartWithTooltip.tsx';
 import {
@@ -398,39 +399,15 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
         (m) => m.name === metricName,
     )?.displayName;
 
-    const [thresholdInputValue, setThresholdInputValue] = useState(
-        threshold.toString(),
-    );
-
-    useEffect(() => {
-        setThresholdInputValue(threshold.toString());
-    }, [threshold]);
-
-    const handleThresholdInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const value = e.target.value;
-        setThresholdInputValue(value);
-        enterEditMode();
-    };
-
-    const handleThresholdInputBlur = () => {
-        if (thresholdInputValue === '') {
-            setThresholdInputValue(threshold.toString());
-            return;
-        }
-
-        const numValue = Number.parseFloat(thresholdInputValue);
-        if (!Number.isNaN(numValue)) {
-            handleThresholdChange(numValue);
-        } else {
-            setThresholdInputValue(threshold.toString());
-        }
-    };
-
-    const handleThresholdKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            handleThresholdInputBlur();
-        }
-    };
+    const {
+        inputValue: thresholdInputValue,
+        handleInputChange: handleThresholdInputChange,
+        handleInputBlur: handleThresholdInputBlur,
+        handleKeyDown: handleThresholdKeyDown,
+        handleFocus: handleThresholdFocus,
+    } = useNumericStringInput(threshold, handleThresholdChange, {
+        onEditStart: enterEditMode,
+    });
 
     return (
         <StyledFormContainer onSubmit={onSubmit} mode={mode}>
@@ -545,7 +522,7 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                                     }}
                                     value={thresholdInputValue}
                                     onChange={handleThresholdInputChange}
-                                    onFocus={enterEditMode}
+                                    onFocus={handleThresholdFocus}
                                     onBlur={handleThresholdInputBlur}
                                     onKeyDown={handleThresholdKeyDown}
                                     placeholder='Value'

--- a/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
+++ b/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import { ROLLOUT_SLIDER_ID } from 'utils/testIds';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
-import { useState, useEffect } from 'react';
+import { useNumericStringInput } from 'hooks/useNumericStringInput';
 
 const StyledSlider = withStyles(Slider, (theme) => ({
     root: {
@@ -117,34 +117,20 @@ const RolloutSlider = ({
     onChange,
     disabled = false,
 }: IRolloutSliderProps) => {
-    const [inputValue, setInputValue] = useState(value.toString());
-
-    useEffect(() => {
-        setInputValue(value.toString());
-    }, [value]);
-
-    const valuetext = (value: number) => `${value}%`;
-
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setInputValue(e.target.value);
-    };
-
-    const handleInputBlur = () => {
-        const numValue = Number.parseInt(inputValue, 10);
-        if (!Number.isNaN(numValue) && numValue >= 0 && numValue <= 100) {
+    // Bounds validation stays in component - hook only handles parsing
+    const handleValueChange = (numValue: number) => {
+        if (numValue >= 0 && numValue <= 100) {
             const event = new Event('input', { bubbles: true });
             onChange(event, numValue);
-        } else {
-            setInputValue(value.toString());
         }
     };
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            handleInputBlur();
-        }
-    };
+    const { inputValue, handleInputChange, handleInputBlur, handleKeyDown } =
+        useNumericStringInput(value, handleValueChange, {
+            parseMode: 'integer',
+        });
+
+    const valuetext = (value: number) => `${value}%`;
 
     return (
         <SliderWrapper>

--- a/frontend/src/hooks/useNumericStringInput.test.ts
+++ b/frontend/src/hooks/useNumericStringInput.test.ts
@@ -1,0 +1,96 @@
+import { renderHook, act } from '@testing-library/react';
+import { useNumericStringInput } from './useNumericStringInput.js';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { vi } from 'vitest';
+
+const changeEvent = (value: string) =>
+    ({ target: { value } }) as ChangeEvent<HTMLInputElement>;
+
+const keyEvent = (key: string) => ({ key }) as KeyboardEvent<HTMLInputElement>;
+
+describe('useNumericStringInput', () => {
+    test('initializes with value as string', () => {
+        const { result } = renderHook(() => useNumericStringInput(42, vi.fn()));
+
+        expect(result.current.inputValue).toBe('42');
+    });
+
+    test('allows empty input during editing', () => {
+        const { result } = renderHook(() => useNumericStringInput(10, vi.fn()));
+
+        act(() => result.current.handleInputChange(changeEvent('')));
+
+        expect(result.current.inputValue).toBe('');
+    });
+
+    test('commits valid value on blur', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useNumericStringInput(10, onChange),
+        );
+
+        act(() => result.current.handleInputChange(changeEvent('25')));
+        act(() => result.current.handleInputBlur());
+
+        expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    test('resets to original value when empty on blur', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useNumericStringInput(10, onChange),
+        );
+
+        act(() => result.current.handleInputChange(changeEvent('')));
+        act(() => result.current.handleInputBlur());
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(result.current.inputValue).toBe('10');
+    });
+
+    test('commits value on Enter key', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useNumericStringInput(10, onChange),
+        );
+
+        act(() => result.current.handleInputChange(changeEvent('25')));
+        act(() => result.current.handleKeyDown(keyEvent('Enter')));
+
+        expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    test('parses as integer when parseMode is integer', () => {
+        const onChange = vi.fn();
+        const { result } = renderHook(() =>
+            useNumericStringInput(10, onChange, { parseMode: 'integer' }),
+        );
+
+        act(() => result.current.handleInputChange(changeEvent('25.9')));
+        act(() => result.current.handleInputBlur());
+
+        expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    test('calls onEditStart on input change', () => {
+        const onEditStart = vi.fn();
+        const { result } = renderHook(() =>
+            useNumericStringInput(10, vi.fn(), { onEditStart }),
+        );
+
+        result.current.handleInputChange(changeEvent('25'));
+
+        expect(onEditStart).toHaveBeenCalled();
+    });
+
+    test('syncs with external value changes', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useNumericStringInput(value, vi.fn()),
+            { initialProps: { value: 10 } },
+        );
+
+        rerender({ value: 20 });
+
+        expect(result.current.inputValue).toBe('20');
+    });
+});

--- a/frontend/src/hooks/useNumericStringInput.ts
+++ b/frontend/src/hooks/useNumericStringInput.ts
@@ -1,0 +1,76 @@
+import {
+    useState,
+    useEffect,
+    type ChangeEvent,
+    type KeyboardEvent,
+} from 'react';
+
+type ParseMode = 'integer' | 'float';
+
+interface UseNumericStringInputOptions {
+    parseMode?: ParseMode;
+    onEditStart?: () => void;
+}
+
+interface UseNumericStringInputReturn {
+    inputValue: string;
+    handleInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    handleInputBlur: () => void;
+    handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+    handleFocus: () => void;
+}
+
+export const useNumericStringInput = (
+    value: number,
+    onChange: (value: number) => void,
+    options?: UseNumericStringInputOptions,
+): UseNumericStringInputReturn => {
+    const { parseMode = 'float', onEditStart } = options ?? {};
+
+    const [inputValue, setInputValue] = useState(value.toString());
+
+    useEffect(() => {
+        setInputValue(value.toString());
+    }, [value]);
+
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setInputValue(e.target.value);
+        onEditStart?.();
+    };
+
+    const handleInputBlur = () => {
+        if (inputValue === '') {
+            setInputValue(value.toString());
+            return;
+        }
+
+        const numValue =
+            parseMode === 'integer'
+                ? Number.parseInt(inputValue, 10)
+                : Number.parseFloat(inputValue);
+
+        if (!Number.isNaN(numValue)) {
+            onChange(numValue);
+        } else {
+            setInputValue(value.toString());
+        }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            handleInputBlur();
+        }
+    };
+
+    const handleFocus = () => {
+        onEditStart?.();
+    };
+
+    return {
+        inputValue,
+        handleInputChange,
+        handleInputBlur,
+        handleKeyDown,
+        handleFocus,
+    };
+};


### PR DESCRIPTION
Fixed threshold input UX by storing the input value as a string during editing, allowing users to clear the field completely with backspace. 

Threshold value converts to a number only on blur/Enter, matching the pattern used in `RolloutSlider` and preserving the number input type for proper numeric keyboard and spinner controls.

<img width="905" height="403" alt="image" src="https://github.com/user-attachments/assets/e07881d0-2fc3-4ed1-9c5d-108d72e7126d" />