### PR TITLE
add db migration

### DIFF
--- a/src/migrations/20251210144308-add-project-column-to-context-fields.js
+++ b/src/migrations/20251210144308-add-project-column-to-context-fields.js
@@ -1,0 +1,13 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE context_fields ADD COLUMN project varchar(255) REFERENCES projects(id) ON DELETE CASCADE;`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE context_fields DROP COLUMN IF EXISTS project;`,
+        cb,
+    );
+};


### PR DESCRIPTION
Adds DB migration to add "project" column to context fields. The column is nullable, an fk to the projects table, and if a project is deleted, so is that project's context field.

Closes 1-4382

## Discuss:
Is cascading deletion of the context field the right thing to do? 