### PR TITLE
fix: translate alert observation window to metric range

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -1,4 +1,11 @@
-import { Button, FormControl, TextField, Box, styled } from '@mui/material';
+import {
+    Button,
+    FormControl,
+    TextField,
+    Box,
+    styled,
+    MenuItem,
+} from '@mui/material';
 import ShieldIcon from '@mui/icons-material/ShieldOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import type { FormEvent, ReactNode } from 'react';
@@ -480,7 +487,7 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                     </StyledTopRow>
                     <StyledTopRow sx={{ ml: 0.75 }}>
                         <StyledTopRow>
-                            <StyledLabel sx={{ ml: 2 }}>is</StyledLabel>
+                            <StyledLabel sx={{ ml: 2.5 }}>is</StyledLabel>
                             <FormControl variant='outlined' size='small'>
                                 <StyledSelect
                                     value={operator}
@@ -523,11 +530,17 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
 
                         <StyledTopRow>
                             <StyledLabel>over</StyledLabel>
+                            {/* Every range has an alert observation window equal to its step. Backend implies the step from the range */}
                             <RangeSelector
                                 value={timeRange}
                                 onChange={handleTimeRangeChange}
                                 label=''
-                            />
+                            >
+                                <MenuItem value='hour'>Last minute</MenuItem>
+                                <MenuItem value='day'>Last 15 minutes</MenuItem>
+                                <MenuItem value='week'>Last 3 hours</MenuItem>
+                                <MenuItem value='month'>Last day</MenuItem>
+                            </RangeSelector>
                         </StyledTopRow>
                     </StyledTopRow>
                 </SafeguardConfigurationSection>

--- a/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/ImpactMetricsControls.tsx
+++ b/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/ImpactMetricsControls.tsx
@@ -1,5 +1,11 @@
 import type { FC } from 'react';
-import { Box, Typography, FormControlLabel, Checkbox } from '@mui/material';
+import {
+    Box,
+    Typography,
+    FormControlLabel,
+    Checkbox,
+    MenuItem,
+} from '@mui/material';
 import type { ImpactMetricsSeries } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
 import { MetricSelector } from './SeriesSelector/MetricSelector.tsx';
 import { RangeSelector } from './RangeSelector/RangeSelector.tsx';
@@ -54,7 +60,12 @@ export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
                     <RangeSelector
                         value={formData.timeRange}
                         onChange={actions.setTimeRange}
-                    />
+                    >
+                        <MenuItem value='hour'>Last hour</MenuItem>
+                        <MenuItem value='day'>Last 24 hours</MenuItem>
+                        <MenuItem value='week'>Last 7 days</MenuItem>
+                        <MenuItem value='month'>Last 30 days</MenuItem>
+                    </RangeSelector>
                     <ModeSelector
                         value={formData.aggregationMode}
                         onChange={actions.setAggregationMode}

--- a/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/RangeSelector/RangeSelector.tsx
+++ b/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/RangeSelector/RangeSelector.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { FormControl, InputLabel, Select } from '@mui/material';
 
 export type TimeRange = 'hour' | 'day' | 'week' | 'month';
 
@@ -7,12 +7,14 @@ export type RangeSelectorProps = {
     value: TimeRange;
     onChange: (range: TimeRange) => void;
     label?: string;
+    children: React.ReactNode;
 };
 
 export const RangeSelector: FC<RangeSelectorProps> = ({
     value,
     onChange,
     label = 'Time',
+    children,
 }) => (
     <FormControl variant='outlined' size='small'>
         {label ? (
@@ -24,10 +26,7 @@ export const RangeSelector: FC<RangeSelectorProps> = ({
             onChange={(e) => onChange(e.target.value as TimeRange)}
             label={label}
         >
-            <MenuItem value='hour'>Last hour</MenuItem>
-            <MenuItem value='day'>Last 24 hours</MenuItem>
-            <MenuItem value='week'>Last 7 days</MenuItem>
-            <MenuItem value='month'>Last 30 days</MenuItem>
+            {children}
         </Select>
     </FormControl>
 );


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Range selector selects a total range for the impact metric used in the safeguard. However from the full impact metric only one last data point (equal to prometheus step value) is taken into account for safeguard triggering. That's why we show the observation step size (minute, 15 minutes, 3 hours or last day) corresponding to the time ranges (1h, 1d, 1w, 1month)
<img width="775" height="387" alt="Screenshot 2025-12-10 at 16 18 47" src="https://github.com/user-attachments/assets/dc6430e9-3ddf-4153-91e5-28bdfb9afe65" />



### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
For now we have a backend function that deduces the step size based on the range and it's fixes. We may need to relax this constraint in future and make both the range and the step size configurable to have fewer conventions.