### PR TITLE
feat: dynamic text field length milestone time

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionTimeInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionTimeInput.tsx
@@ -59,6 +59,7 @@ export const MilestoneProgressionTimeInput = ({
                 }}
                 sx={{
                     width: `max(60px, ${String(timeValue).length + 8}ch)`,
+                    maxWidth: '300px',
                 }}
                 size='small'
                 disabled={disabled}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Field starts small
<img width="599" height="171" alt="Screenshot 2025-12-11 at 15 24 42" src="https://github.com/user-attachments/assets/f68cd941-0264-4722-a4e0-97e7f1ae9317" />

Then grows with content until 300px
<img width="758" height="187" alt="Screenshot 2025-12-11 at 15 24 37" src="https://github.com/user-attachments/assets/095bb628-e62b-4b8e-b643-9c2a1838c91c" />

I tried other solutions but it's the cleanest one I found so far

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
