### PR TITLE
chore: use id-token write and npm_config_provenance in npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,8 @@
 name: 'Publish to npm'
+
+permissions:
+  id-token: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4082/fix-npm-publish-in-unleash-releaseyaml

Uses `NPM_CONFIG_PROVENANCE` in npm publish.