### PR TITLE
chore: revert back to 7.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unleash-server",
   "type": "module",
   "description": "Unleash is an enterprise ready feature flag service. It provides different strategies for handling feature flags.",
-  "version": "7.4.0",
+  "version": "7.3.0",
   "keywords": [
     "unleash",
     "feature flag",


### PR DESCRIPTION
Reverts back to 7.3.0 so we can re-attempt the release.