### PR TITLE
remove (optional) project from payload body

### DIFF
--- a/src/lib/openapi/spec/context-field-schema.ts
+++ b/src/lib/openapi/spec/context-field-schema.ts
@@ -63,11 +63,6 @@ export const contextFieldSchema = {
                 $ref: '#/components/schemas/legalValueSchema',
             },
         },
-        project: {
-            description: 'The id of the project this context field belongs to',
-            type: 'string',
-            example: 'project123',
-        },
     },
     components: {
         schemas: {


### PR DESCRIPTION
Removes the project payload from the context field schema. This optional property would only have been returned in the get endpoints (and only if there was a project tied to a context field).