### PR TITLE
Fix broken architecture diagram link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If you're looking for one of the following features, please take a look at our [
 
 ## Architecture
 
-<img src="./website/static/img/unleash-architecture-edge.png" title="Unleash System Overview" />
+<img src="./website/static/img/unleash-architecture.png" title="Unleash System Overview" />
 
 Read more in the [_system overview_ section of the Unleash documentation](https://docs.getunleash.io/get-started/unleash-overview#system-overview).
 


### PR DESCRIPTION
### Overview
Fixed the architecture diagram image link in the root README.

### Issue
The README references to `website/static/img/unleash-architecture-edge.png` and which returns 404.

### Solution
Point the README to `website/static/img/unleash-architecture.png` (referenced from the documentation's system overview section)


First contribution! Happy to fix small paper cuts like this :)