### PR TITLE
fix: Revert recent context field changes

### DIFF
--- a/frontend/src/component/context/ContextForm/ContextForm.tsx
+++ b/frontend/src/component/context/ContextForm/ContextForm.tsx
@@ -262,9 +262,7 @@ export const ContextForm: React.FC<IContextForm> = ({
                     />
                     <Typography>{stickiness ? 'On' : 'Off'}</Typography>
                 </StyledSwitchContainer>
-                {mode === 'Edit' ? (
-                    <ContextFieldUsage contextName={contextName} />
-                ) : null}
+                <ContextFieldUsage contextName={contextName} />
             </div>
             <StyledButtonContainer>
                 {children}

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -33,15 +33,9 @@ const ContextList: FC = () => {
     const projectContextFieldsEnabled = useUiFlag('projectContextFields');
     const [showDelDialogue, setShowDelDialogue] = useState(false);
     const [name, setName] = useState<string>();
-    const { context, refetchUnleashContext, loading } = useUnleashContext(
-        undefined,
-        projectId,
-    );
-    const { removeContext } = useContextsApi(projectId);
+    const { context, refetchUnleashContext, loading } = useUnleashContext();
+    const { removeContext } = useContextsApi();
     const { setToastData, setToastApiError } = useToast();
-    const editUrl = projectId
-        ? `/projects/${projectId}/context/${name}`
-        : `/context/edit/${name}`;
 
     const data = useMemo(() => {
         if (loading) {
@@ -51,7 +45,14 @@ const ContextList: FC = () => {
             });
         }
 
-        return context
+        const filteredContextFields =
+            projectId && projectContextFieldsEnabled
+                ? // @ts-expect-error project doesn't exist yet; todo: fix with flag projectContextFields
+                  context.filter((c) => c.project === projectId)
+                : // @ts-expect-error project doesn't exist yet; todo: fix with flag projectContextFields
+                  context.filter((c) => !c.project);
+
+        return filteredContextFields
             .map(
                 ({
                     name,
@@ -88,7 +89,7 @@ const ContextList: FC = () => {
                 }: any) => (
                     <LinkCell
                         title={name}
-                        to={editUrl}
+                        to={`/context/edit/${name}`}
                         subtitle={description}
                     />
                 ),

--- a/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
+++ b/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
@@ -40,8 +40,8 @@ export const CreateUnleashContext = ({
         setErrors,
         errors,
     } = useContextForm({ initialProject: projectId });
-    const { createContext, loading } = useContextsApi(projectId);
-    const { refetchUnleashContext } = useUnleashContext(undefined, projectId);
+    const { createContext, loading } = useContextsApi();
+    const { refetchUnleashContext } = useUnleashContext();
 
     const handleSubmit = async (e: Event) => {
         e.preventDefault();
@@ -64,12 +64,8 @@ export const CreateUnleashContext = ({
         }
     };
 
-    const postTarget = projectId
-        ? `/api/admin/projects/${projectId}/context`
-        : '/api/admin/context';
-
     const formatApiCode = () => {
-        return `curl --location --request POST '${uiConfig.unleashUrl}${postTarget}' \\
+        return `curl --location --request POST '${uiConfig.unleashUrl}/api/admin/context' \\
 --header 'Authorization: INSERT_API_KEY' \\
 --header 'Content-Type: application/json' \\
 --data-raw '${JSON.stringify(getContextPayload(), undefined, 2)}'`;

--- a/frontend/src/component/context/EditContext/EditContext.tsx
+++ b/frontend/src/component/context/EditContext/EditContext.tsx
@@ -29,8 +29,8 @@ export const EditContext: FC<EditContextProps> = ({ modal }) => {
     const { setToastData, setToastApiError } = useToast();
     const projectId = useOptionalPathParam('projectId');
     const name = useRequiredPathParam('name');
-    const { context, refetch } = useContext({ name, project: projectId });
-    const { updateContext, loading } = useContextsApi(projectId);
+    const { context, refetch } = useContext(name);
+    const { updateContext, loading } = useContextsApi();
     const navigate = useNavigate();
     const {
         contextName,
@@ -53,13 +53,10 @@ export const EditContext: FC<EditContextProps> = ({ modal }) => {
         initialProject: projectId,
     });
 
-    const apiUrl = projectId
-        ? `/projects/${projectId}/api/admin/context/${name}`
-        : `/api/admin/context/${name}`;
     const formatApiCode = () => {
         return `curl --location --request PUT '${
             uiConfig.unleashUrl
-        }${apiUrl}' \\
+        }/api/admin/context/${name}' \\
 --header 'Authorization: INSERT_API_KEY' \\
 --header 'Content-Type: application/json' \\
 --data-raw '${JSON.stringify(getContextPayload(), undefined, 2)}'`;
@@ -68,8 +65,8 @@ export const EditContext: FC<EditContextProps> = ({ modal }) => {
     const handleSubmit = async (e: Event) => {
         e.preventDefault();
         const payload = getContextPayload();
-        const navigationTarget = projectId
-            ? `/projects/${projectId}/settings/context-fields`
+        const navigationTarget = payload.project
+            ? `/projects/${payload.project}/settings/context-fields`
             : '/context';
 
         try {

--- a/frontend/src/component/context/hooks/useContextForm.ts
+++ b/frontend/src/component/context/hooks/useContextForm.ts
@@ -24,7 +24,7 @@ export const useContextForm = ({
     const [stickiness, setStickiness] = useState(initialStickiness);
     const [project, setProject] = useState(initialProject);
     const [errors, setErrors] = useState({});
-    const { validateContextName } = useContextsApi(project);
+    const { validateContextName } = useContextsApi();
 
     useEffect(() => {
         setContextName(initialContextName);
@@ -49,6 +49,7 @@ export const useContextForm = ({
             description: contextDesc,
             legalValues,
             stickiness,
+            project,
         };
     };
 

--- a/frontend/src/hooks/api/actions/useContextsApi/useContextsApi.ts
+++ b/frontend/src/hooks/api/actions/useContextsApi/useContextsApi.ts
@@ -1,13 +1,11 @@
 import useAPI from '../useApi/useApi.js';
 
-const useContextsApi = (projectId?: string) => {
+const useContextsApi = () => {
     const { makeRequest, createRequest, errors, loading } = useAPI({
         propagateErrors: true,
     });
 
-    const URI = projectId
-        ? `api/admin/projects/${projectId}/context`
-        : 'api/admin/context';
+    const URI = 'api/admin/context';
 
     const validateContextName = async (name: string) => {
         const path = `${URI}/validate`;

--- a/frontend/src/hooks/api/getters/useContext/useContext.ts
+++ b/frontend/src/hooks/api/getters/useContext/useContext.ts
@@ -3,21 +3,9 @@ import { useState, useEffect } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler.js';
 
-type ContextInfo = {
-    name: string;
-    project?: string;
-};
-
-const useContext = (
-    { name, project }: ContextInfo,
-    options: SWRConfiguration = {},
-) => {
-    const uri = project
-        ? `api/admin/projects/${project}/context/${name}`
-        : `api/admin/context/${name}`;
-
+const useContext = (name: string, options: SWRConfiguration = {}) => {
     const fetcher = async () => {
-        const path = formatApiPath(uri);
+        const path = formatApiPath(`api/admin/context/${name}`);
         return fetch(path, {
             method: 'GET',
         })
@@ -25,7 +13,7 @@ const useContext = (
             .then((res) => res.json());
     };
 
-    const FEATURE_CACHE_KEY = uri;
+    const FEATURE_CACHE_KEY = `api/admin/context/${name}`;
 
     const { data, error } = useSWR(FEATURE_CACHE_KEY, fetcher, {
         ...options,

--- a/frontend/src/hooks/api/getters/useUnleashContext/useUnleashContext.ts
+++ b/frontend/src/hooks/api/getters/useUnleashContext/useUnleashContext.ts
@@ -16,14 +16,9 @@ const useUnleashContext = (
         revalidateOnReconnect: true,
         revalidateIfStale: true,
     },
-    projectId?: string,
 ): IUnleashContextOutput => {
-    const uri = projectId
-        ? formatApiPath(`api/admin/projects/${projectId}/context`)
-        : formatApiPath(`api/admin/context`);
-
     const fetcher = () => {
-        const path = formatApiPath(uri);
+        const path = formatApiPath(`api/admin/context`);
         return fetch(path, {
             method: 'GET',
         })
@@ -31,7 +26,7 @@ const useUnleashContext = (
             .then((res) => res.json());
     };
 
-    const CONTEXT_CACHE_KEY = uri;
+    const CONTEXT_CACHE_KEY = 'api/admin/context';
 
     const { data, mutate, error, isValidating } = useSWR(
         CONTEXT_CACHE_KEY,

--- a/src/lib/features/context/context-service.ts
+++ b/src/lib/features/context/context-service.ts
@@ -54,16 +54,6 @@ class ContextService {
         return this.contextFieldStore.getAll();
     }
 
-    async getAllWithoutProject(): Promise<IContextField[]> {
-        const allFields = await this.contextFieldStore.getAll();
-        return allFields.filter((field) => !field.project);
-    }
-
-    async getAllForProject(projectId: string): Promise<IContextField[]> {
-        const allFields = await this.contextFieldStore.getAll();
-        return allFields.filter((field) => field.project === projectId);
-    }
-
     async getContextField(name: string): Promise<IContextField> {
         const field = await this.contextFieldStore.get(name);
         if (field === undefined) {

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -41,7 +41,6 @@ import type { CreateContextFieldSchema } from '../../openapi/spec/create-context
 import { extractUserIdFromUser } from '../../util/index.js';
 import type { LegalValueSchema } from '../../openapi/index.js';
 import type { WithTransactional } from '../../db/transaction.js';
-import type { IFlagResolver } from '../../types/index.js';
 
 interface ContextParam {
     contextField: string;
@@ -59,8 +58,6 @@ export class ContextController extends Controller {
 
     private openApiService: OpenApiService;
 
-    private flagResolver: IFlagResolver;
-
     constructor(
         config: IUnleashConfig,
         {
@@ -77,7 +74,6 @@ export class ContextController extends Controller {
         this.transactionalContextService = transactionalContextService;
         const prefix = mode === 'global' ? '' : '/:projectId/context';
         const beta = mode === 'project';
-        this.flagResolver = config.flagResolver;
 
         this.route({
             method: 'get',
@@ -285,27 +281,14 @@ export class ContextController extends Controller {
     }
 
     async getContextFields(
-        req: Request<{ projectId?: string }>,
+        _req: Request,
         res: Response<ContextFieldsSchema>,
     ): Promise<void> {
-        if (this.flagResolver.isEnabled('projectContextFields')) {
-            const { projectId } = req.params;
-            const getContextFields = projectId
-                ? this.transactionalContextService.getAllForProject(projectId)
-                : this.transactionalContextService.getAllWithoutProject();
-
-            res.status(200)
-                .json(serializeDates(await getContextFields))
-                .end();
-        } else {
-            res.status(200)
-                .json(
-                    serializeDates(
-                        await this.transactionalContextService.getAll(),
-                    ),
-                )
-                .end();
-        }
+        res.status(200)
+            .json(
+                serializeDates(await this.transactionalContextService.getAll()),
+            )
+            .end();
     }
 
     async getContextField(


### PR DESCRIPTION
This reverts the following commits:
- 62314aa66: fix: don't attempt to get fetch strategies for new context fields on every key stroke (#11152)
- 7369977b2: chore: update the UI to use project-based context endpoints when on a project endpoint (#11153)
- 4ef205066: make context field fetch differentiate based on project ID (#11151)

These changes are being reverted to address issues with the context field implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes #

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
