### PR TITLE
chore: fix location of created context fields

### DIFF
--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -350,7 +350,7 @@ export class ContextController extends Controller {
             res,
             contextFieldSchema.$id,
             serializeDates(result),
-            { location: `context/${result.name}` },
+            { location: `context/${result.name}` }, // todo: this will also be incorrect if it's project based (easy to fix) 
         );
     }
 


### PR DESCRIPTION
Because we return the location of the created context fields, we need to also use the prefix for this.

Or maybe not. Because it's a relative url, it'll probably still work.