### PR TITLE
chore: change token rate limit log to debug

### DIFF
--- a/src/lib/services/api-token-service.ts
+++ b/src/lib/services/api-token-service.ts
@@ -170,18 +170,14 @@ export class ApiTokenService {
                 }
                 stopCacheTimer();
             } else {
-                this.logger.debug(
-                    `Token ${secret.replace(
-                        /^([^.]*)\.(.{8}).*$/,
-                        '$1.$2...',
-                    )} rate limited until: ${this.queryAfter.get(secret)}`,
-if (Math.random() < 0.1) {
-    this.logger.debug(
-                    `Token ${secret.replace(
-                        /^([^.]*)\.(.{8}).*$/,
-                        '$1.$2...',
-                    )} rate limited until: ${this.queryAfter.get(secret)}`,
-}
+                if (Math.random() < 0.1) {
+                    this.logger.info(
+                        `Token ${secret.replace(
+                            /^([^.]*)\.(.{8}).*$/,
+                            '$1.$2...',
+                        )} rate limited until: ${this.queryAfter.get(secret)}`,
+                    );
+                }
             }
         }
         return token;


### PR DESCRIPTION
The token rate-limit logs at info level generate a lot of data that is not particularly useful during normal operations. 

I suggest we change the level to `debug`.