### PR TITLE
chore: add new standardized fetcher

### DIFF
--- a/frontend/src/hooks/api/getters/useApiGetter/useApiGetter.ts
+++ b/frontend/src/hooks/api/getters/useApiGetter/useApiGetter.ts
@@ -33,3 +33,8 @@ export const fetcher = (path: string, errorTarget: string) => {
         .then(handleErrorResponses(errorTarget))
         .then((res) => res.json());
 };
+
+export const createFetcher =
+    ({ url, errorTarget }: { url: string; errorTarget: string }) =>
+    () =>
+        fetcher(url, errorTarget);


### PR DESCRIPTION
Adds a new `createFetcher` function that's exposed from `useApiGetter`.

Much like in https://github.com/Unleash/unleash/pull/6541, I'm tired of having to manually redeclare the fetcher in each and every fetching hook, especially when it's always the exact same. As such, I'd like to create a shared standard.

... But that didn't work the last time. Presumably because existing uses weren't updated. I'd suggest that if we do this, then we should update all existing hooks so that the next time someone copies an existing fetch hook, they get the new fetcher instead of the old one.

Additionally, this `createFetcher` function has two improvements on the existing `fetcher` function:
1. It takes the path and errorTarget as part of an object instead of positional parameters. Because both params are of type string, it's possible to mix up the order, so I think it makes sense to enforce the object here.
2. Returns a function that returns the fetcher instead of returning the fetcher directly. All the places in the code where we use the `fetcher` function, we use it as `() => fetcher(args)`. If it's always gonna be a function, why don't we just do that directly?

## Follow-up work: 

Replace all existing usages of `const fetcher =` and the other `fetcher` function, such that we can standardize this.
