### PR TITLE
fix: correctly list legal values for project context fields

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/useEditableConstraint.tsx
@@ -24,6 +24,8 @@ import {
     getDeletedLegalValues,
     getInvalidLegalValues,
 } from './legal-value-functions.ts';
+import { useEffectiveProjectContext } from 'hooks/api/getters/useUnleashContext/useEffectiveProjectContext.ts';
+import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 
 const resolveContextDefinition = (
     context: IUnleashContextDefinition[],
@@ -70,7 +72,8 @@ export const useEditableConstraint = (
         onUpdate(toIConstraint(localConstraint));
     }, [constraintState]);
 
-    const { context } = useUnleashContext();
+    const projectId = useOptionalPathParam('projectId');
+    const { context } = useEffectiveProjectContext(projectId);
 
     const contextDefinition = useMemo(
         () => resolveContextDefinition(context, localConstraint.contextName),


### PR DESCRIPTION
Fixes the bug where project context fields wouldn't have their legal values picked up when assigning them. The issue was that this context call wasn't correctly set to be project specific.