### PR TITLE
fix: context field link in project context list takes you to flags list

### DIFF
--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -82,7 +82,7 @@ const ContextList: FC = () => {
                     },
                 }: any) => {
                     const editUrl = projectId
-                        ? `/projects/${projectId}/context/${name}`
+                        ? `/projects/${projectId}/settings/context-fields/edit/${name}`
                         : `/context/edit/${name}`;
 
                     return (


### PR DESCRIPTION
Fixes an incorrect edit url for project context list. 