### PR TITLE
feat: do not propagate scheduledAt when environment paused

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/milestoneStatusUtils.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/milestoneStatusUtils.ts
@@ -27,11 +27,13 @@ export const calculateMilestoneStatus = (
         return { type: 'completed', progression };
     }
 
-    const scheduledAt = calculateMilestoneStartTime(
-        allMilestones,
-        milestone.id,
-        activeMilestoneId,
-    );
+    const scheduledAt = environmentIsDisabled
+        ? null
+        : calculateMilestoneStartTime(
+              allMilestones,
+              milestone.id,
+              activeMilestoneId,
+          );
 
     return {
         type: 'not-started',


### PR DESCRIPTION
We will not calculate and pass in scheduledAt time, **because it is semantically also correct, when environment is disabled, there is no schedule time.**

Now in disabled state

<img width="1417" height="1229" alt="Screenshot from 2026-01-02 11-32-38" src="https://github.com/user-attachments/assets/036196dd-377a-4f6b-b667-2a4ff2b8a51e" />

In enabled state

<img width="1417" height="1229" alt="Screenshot from 2026-01-02 11-32-42" src="https://github.com/user-attachments/assets/d28014c5-7a25-43e5-a0b6-acce2c773f2b" />
