### PR TITLE
chore: add seat_type col to users table

### DIFF
--- a/src/migrations/20260106164443-users-seat-type.js
+++ b/src/migrations/20260106164443-users-seat-type.js
@@ -1,6 +1,6 @@
 exports.up = function (db, cb) {
     db.runSql(
-        `ALTER TABLE users ADD COLUMN IF NOT EXISTS seat_type TEXT NOT NULL DEFAULT 'Regular';`,
+        `ALTER TABLE users ADD COLUMN IF NOT EXISTS seat_type TEXT;`,
         cb,
     );
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4087/add-new-seattype-text-column-to-the-users-table

Adds a new `seat_type` column to the users table.

This will allow us to optimize the way we handle special seat users (i.e. RO) instead of having to always calculate them on the fly.