### PR TITLE
chore: check also role type when checking admin role

### DIFF
--- a/src/lib/features/access/access-read-model.ts
+++ b/src/lib/features/access/access-read-model.ts
@@ -2,6 +2,7 @@ import {
     ADMIN_TOKEN_USER,
     type IAccessStore,
     type IUnleashStores,
+    RoleType,
     SYSTEM_USER_ID,
 } from '../../types/index.js';
 import type { IAccessReadModel } from './access-read-model-type.js';
@@ -22,7 +23,9 @@ export class AccessReadModel implements IAccessReadModel {
         }
         const roles = await this.store.getRolesForUserId(userId);
         return roles.some(
-            (role) => role.name.toLowerCase() === ADMIN.toLowerCase(),
+            (role) =>
+                role.name.toLowerCase() === ADMIN.toLowerCase() &&
+                role.type === RoleType.ROOT,
         );
     }
 }

--- a/src/lib/services/access-service.test.ts
+++ b/src/lib/services/access-service.test.ts
@@ -357,15 +357,14 @@ test('should return true if user has admin role', async () => {
 
     const userId = 1;
     let calledWithSameId = false;
-    // @ts-expect-error role is missing the project. Should admin have a project?
-    const role: IRoleWithProject = {
+    const role: IRole = {
         id: userId,
         name: 'ADMIN',
-        type: 'custom',
+        type: 'root',
     };
     accessStore.getRolesForUserId = (id: number) => {
         calledWithSameId = id === userId;
-        return Promise.resolve([role]);
+        return Promise.resolve([role as IRoleWithProject]);
     };
 
     const result = await accessReadModel.isRootAdmin(userId);


### PR DESCRIPTION
## About the changes
After relaxing our constraints (https://github.com/Unleash/unleash/pull/11178), we've identified this piece of code, which is checking for the role name. 

Although we currently validate that the role name is unique at the code level, that might change in the future or be a source of confusion. Just to be on the safe side if someone creates an Admin custom role, we're now validating also the role type.