### PR TITLE
chore: add user seatType property

### DIFF
--- a/src/lib/features/users/user-store.ts
+++ b/src/lib/features/users/user-store.ts
@@ -24,6 +24,7 @@ export const USER_COLUMNS_PUBLIC = [
     'seen_at',
     'is_service',
     'scim_id',
+    'seat_type',
 ];
 
 const USER_COLUMNS = [...USER_COLUMNS_PUBLIC, 'login_attempts', 'created_at'];
@@ -59,6 +60,7 @@ const rowToUser = (row) => {
         createdAt: row.created_at,
         isService: row.is_service,
         scimId: row.scim_id,
+        seatType: row.seat_type,
     });
 };
 

--- a/src/lib/openapi/spec/user-schema.ts
+++ b/src/lib/openapi/spec/user-schema.ts
@@ -1,5 +1,6 @@
 import type { FromSchema } from 'json-schema-to-ts';
 import { AccountTypes } from '../../events/index.js';
+import { SeatTypes } from '../../types/user.js';
 
 export const userSchema = {
     $id: '#/components/schemas/userSchema',
@@ -91,6 +92,13 @@ export const userSchema = {
             type: 'string',
             nullable: true,
             example: '01HTMEXAMPLESCIMID7SWWGHN6',
+        },
+        seatType: {
+            description: 'The seat type of this user',
+            type: 'string',
+            nullable: true,
+            enum: SeatTypes,
+            example: 'Regular',
         },
         activeSessions: {
             description: 'Count of active browser sessions for this user',

--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -5,6 +5,9 @@ import type { AccountTypes } from '../events/index.js';
 
 type AccountType = (typeof AccountTypes)[number];
 
+export const SeatTypes = ['Regular', 'ReadOnly'] as const;
+type SeatType = (typeof SeatTypes)[number];
+
 export interface UserData {
     id: number;
     name?: string;
@@ -16,6 +19,7 @@ export interface UserData {
     createdAt?: Date;
     isService?: boolean;
     scimId?: string;
+    seatType?: SeatType;
 }
 
 export interface IUser {
@@ -32,6 +36,7 @@ export interface IUser {
     imageUrl?: string;
     accountType?: AccountType;
     scimId?: string;
+    seatType?: SeatType;
     deletedSessions?: number;
     activeSessions?: number;
 }
@@ -76,6 +81,8 @@ export class User implements IUser {
 
     scimId?: string;
 
+    seatType?: SeatType = 'Regular';
+
     constructor({
         id,
         name,
@@ -87,6 +94,7 @@ export class User implements IUser {
         createdAt,
         isService,
         scimId,
+        seatType,
     }: UserData) {
         if (!id) {
             throw new ValidationError('Id is required', [], undefined);
@@ -102,6 +110,7 @@ export class User implements IUser {
         this.createdAt = createdAt;
         this.accountType = isService ? 'Service Account' : 'User';
         this.scimId = scimId;
+        this.seatType = seatType || 'Regular';
     }
 
     generateImageUrl(): string {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4090/add-the-seattype-property-to-the-users-entity-exposing-it-in-the-api

Adds the `seatType` user property, exposing it through the API when the `readOnlyUsersUI` flag is enabled.