### PR TITLE
chore: show seat type in users table

### DIFF
--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -61,6 +61,8 @@ const UsersList = () => {
     const showUserDeviceCount = useUiFlag('showUserDeviceCount');
     const showSSOUpgrade = isOss() && users.length > 3;
 
+    const showSeatTypes = isEnterprise() && useUiFlag('readOnlyUsersUI');
+
     const {
         settings: { enabled: scimEnabled },
     } = useScimSettings();
@@ -201,6 +203,14 @@ const UsersList = () => {
                 sortType: 'boolean',
             },
             {
+                id: 'seatType',
+                Header: 'Seat type',
+                accessor: 'seatType',
+                maxWidth: 100,
+                sortType: 'boolean',
+                Cell: TextCell,
+            },
+            {
                 Header: '',
                 id: 'Actions',
                 align: 'center',
@@ -239,17 +249,20 @@ const UsersList = () => {
                 searchable: true,
             },
         ],
-        [roles, navigate, isBillingUsers],
+        [roles, navigate, isBillingUsers, showSeatTypes],
     );
 
     const initialState = useMemo(() => {
         return {
             sortBy: [{ id: 'createdAt', desc: true }],
-            hiddenColumns: isBillingUsers
-                ? ['username', 'email']
-                : ['type', 'username', 'email'],
+            hiddenColumns: [
+                'username',
+                'email',
+                ...(isBillingUsers ? [] : ['type']),
+                ...(showSeatTypes ? [] : ['seatType']),
+            ],
         };
-    }, [isBillingUsers]);
+    }, [isBillingUsers, showSeatTypes]);
 
     const { data, getSearchText } = useSearch(
         columns,
@@ -280,6 +293,10 @@ const UsersList = () => {
             {
                 condition: !isBillingUsers || isSmallScreen,
                 columns: ['type'],
+            },
+            {
+                condition: !showSeatTypes || isSmallScreen,
+                columns: ['seatType'],
             },
             {
                 condition: isExtraSmallScreen,

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     newInUnleash?: boolean | Variant;
     gtmReleaseManagement?: boolean;
     projectContextFields?: boolean;
+    readOnlyUsersUI?: boolean;
 };
 
 export interface IVersionInfo {

--- a/frontend/src/interfaces/user.ts
+++ b/frontend/src/interfaces/user.ts
@@ -1,5 +1,7 @@
 export const AccountTypes = ['User', 'Service Account'] as const;
 export type AccountType = (typeof AccountTypes)[number];
+export const SeatTypes = ['Regular', 'ReadOnly'] as const;
+export type SeatType = (typeof SeatTypes)[number];
 
 export interface IUser {
     id: number;
@@ -19,6 +21,7 @@ export interface IUser {
     accountType?: AccountType;
     scimId?: string;
     activeSessions?: number;
+    seatType?: SeatType;
 }
 
 export interface IPermission {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4094/show-read-only-users-in-the-users-list

Shows seat type in the users table.

This is only visible to Enterprise users that have the `readOnlyUsersUI` flag enabled.

<img width="1470" height="494" alt="image" src="https://github.com/user-attachments/assets/aa905670-20a6-4be5-b558-6ddbcbb80b35" />
