### PR TITLE
chore: add link to versioning info in admin widget

### DIFF
--- a/frontend/src/component/admin/AdminHome.tsx
+++ b/frontend/src/component/admin/AdminHome.tsx
@@ -14,7 +14,7 @@ import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { formatAssetPath } from 'utils/formatPath';
 import easyToDeploy from 'assets/img/easyToDeploy.png';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { EnterpriseEdgeDismissibleAlert } from './enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx';
 
 const UI_SWITCH_WIDGET_RATIO_BREAKPOINT = 1505;
@@ -152,7 +152,7 @@ const StyledHelpContainer = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledHelpLink = styled('a')(({ theme }) => ({
+const StyledHelpLink = styled(Link)(({ theme }) => ({
     color: theme.palette.common.white,
     textDecoration: 'underline !important',
     fontSize: theme.typography.body2.fontSize,
@@ -209,7 +209,7 @@ const InstanceWidget = ({
             </StyledParagraph>
             <StyledHelpContainer>
                 <StyledHelpLink
-                    href='https://docs.getunleash.io/availability#versioning'
+                    to='https://docs.getunleash.io/availability#versioning'
                     target='_blank'
                     rel='noopener noreferrer'
                 >


### PR DESCRIPTION
In order to bring more transparency about how versioning works in Unleash, this adds a link to the relative docs in the admin dashboard. 

https://linear.app/unleash/issue/CJUX-348/version-link-in-admin-dashboard

What it looks like in different viewports:

<img width="592" height="398" alt="Screenshot 2026-01-09 at 20 59 22" src="https://github.com/user-attachments/assets/245aa2bd-c276-4c6b-ab43-c8d5395393b5" />
<img width="1101" height="297" alt="Screenshot 2026-01-09 at 20 59 37" src="https://github.com/user-attachments/assets/5fb21c13-185a-44e2-9804-822744517aa4" />
<img width="515" height="331" alt="Screenshot 2026-01-09 at 21 00 12" src="https://github.com/user-attachments/assets/4d351fe3-35da-4441-bde3-a5f11725d1b4" />

