### PR TITLE
feat: make create/edit project context show up in correct category

### DIFF
--- a/src/lib/types/permissions.ts
+++ b/src/lib/types/permissions.ts
@@ -188,6 +188,7 @@ export const PROJECT_PERMISSIONS_STRUCTURE: ProjectPermissionCategory[] = [
             [DELETE_FEATURE_STRATEGY],
             [UPDATE_FEATURE_ENVIRONMENT],
             [UPDATE_FEATURE_ENVIRONMENT_VARIANTS],
+            [UPDATE_PROJECT_CONTEXT],
             [UPDATE_PROJECT_SEGMENT],
         ],
     },


### PR DESCRIPTION
Moves the update project context permission into the right section of the project permissions.

Before:
<img width="1140" height="1191" alt="image" src="https://github.com/user-attachments/assets/004fecaf-f909-4686-8913-ed106c81b297" />

After: 
<img width="1159" height="1212" alt="image" src="https://github.com/user-attachments/assets/34b707f9-f1e1-490c-bfb0-c4414e71ac50" />
