### PR TITLE
chore: replace update_project permission with update_project_context for project context actions

### DIFF
--- a/frontend/src/component/context/ContextList/AddContextButton.tsx
+++ b/frontend/src/component/context/ContextList/AddContextButton.tsx
@@ -8,7 +8,7 @@ import type { FC } from 'react';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 import {
     CREATE_CONTEXT_FIELD,
-    UPDATE_PROJECT,
+    UPDATE_PROJECT_CONTEXT,
 } from '@server/types/permissions.ts';
 
 type IAddContextButtonProps = {};
@@ -27,7 +27,7 @@ export const AddContextButton: FC<IAddContextButtonProps> = () => {
             condition={smallScreen}
             show={
                 <PermissionIconButton
-                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                     projectId={projectId}
                     onClick={() => navigate(createLocation)}
                     size='large'
@@ -38,7 +38,7 @@ export const AddContextButton: FC<IAddContextButtonProps> = () => {
             }
             elseShow={
                 <PermissionButton
-                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                     projectId={projectId}
                     onClick={() => navigate(createLocation)}
                     color='primary'

--- a/frontend/src/component/context/ContextList/ContextActionsCell.tsx
+++ b/frontend/src/component/context/ContextList/ContextActionsCell.tsx
@@ -8,7 +8,7 @@ import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 import {
     DELETE_CONTEXT_FIELD,
     UPDATE_CONTEXT_FIELD,
-    UPDATE_PROJECT,
+    UPDATE_PROJECT_CONTEXT,
 } from '@server/types/permissions.ts';
 
 interface IContextActionsCellProps {
@@ -31,7 +31,7 @@ export const ContextActionsCell: FC<IContextActionsCellProps> = ({
     return (
         <ActionCell>
             <PermissionIconButton
-                permission={[UPDATE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                permission={[UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                 projectId={projectId}
                 onClick={() => navigate(updateLocation)}
                 data-loading
@@ -43,7 +43,7 @@ export const ContextActionsCell: FC<IContextActionsCellProps> = ({
                 <Edit />
             </PermissionIconButton>
             <PermissionIconButton
-                permission={[DELETE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                permission={[DELETE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                 projectId={projectId}
                 onClick={onDelete}
                 data-loading

--- a/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
+++ b/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
@@ -9,7 +9,7 @@ import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashCon
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
-import { UPDATE_PROJECT } from '@server/types/permissions.ts';
+import { UPDATE_PROJECT_CONTEXT } from '@server/types/permissions.ts';
 
 interface ICreateContextProps {
     onSubmit: () => void;
@@ -105,7 +105,7 @@ export const CreateUnleashContext = ({
             >
                 <CreateButton
                     name='context'
-                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                    permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                     projectId={projectId}
                 />
             </ContextForm>

--- a/frontend/src/component/context/EditContext/EditContext.tsx
+++ b/frontend/src/component/context/EditContext/EditContext.tsx
@@ -14,7 +14,7 @@ import { useContextForm } from '../hooks/useContextForm.ts';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { GO_BACK } from 'constants/navigate';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
-import { UPDATE_PROJECT } from '@server/types/permissions.ts';
+import { UPDATE_PROJECT_CONTEXT } from '@server/types/permissions.ts';
 
 type EditContextProps = {
     modal?: boolean;
@@ -117,7 +117,7 @@ export const EditContext: FC<EditContextProps> = ({ modal }) => {
                 clearErrors={clearErrors}
             >
                 <UpdateButton
-                    permission={[UPDATE_CONTEXT_FIELD, UPDATE_PROJECT]}
+                    permission={[UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                     projectId={projectId}
                 />
             </ContextForm>

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -7,7 +7,7 @@ import {
     UPDATE_CONTEXT_FIELD,
     DELETE_CONTEXT_FIELD,
     NONE,
-    UPDATE_PROJECT,
+    UPDATE_PROJECT_CONTEXT,
 } from '../../types/permissions.js';
 import type { IUnleashConfig } from '../../types/option.js';
 import type { IUnleashServices } from '../../services/index.js';
@@ -149,7 +149,7 @@ export class ContextController extends Controller {
             method: 'post',
             path: prefix,
             handler: this.createContextField,
-            permission: [CREATE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [CREATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
@@ -174,7 +174,7 @@ export class ContextController extends Controller {
             method: 'put',
             path: `${prefix}/:contextField`,
             handler: this.updateContextField,
-            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
@@ -196,7 +196,7 @@ export class ContextController extends Controller {
             method: 'post',
             path: `${prefix}/:contextField/legal-values`,
             handler: this.updateLegalValue,
-            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
@@ -220,7 +220,7 @@ export class ContextController extends Controller {
             path: `${prefix}/:contextField/legal-values/:legalValue`,
             handler: this.deleteLegalValue,
             acceptAnyContentType: true,
-            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
@@ -243,7 +243,7 @@ export class ContextController extends Controller {
             path: `${prefix}/:contextField`,
             handler: this.deleteContextField,
             acceptAnyContentType: true,
-            permission: [DELETE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [DELETE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],
@@ -263,7 +263,7 @@ export class ContextController extends Controller {
             method: 'post',
             path: `${prefix}/validate`,
             handler: this.validateContextFieldName,
-            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT],
+            permission: [UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT],
             middleware: [
                 openApiService.validPath({
                     tags: ['Context'],


### PR DESCRIPTION
Updates the context edit actions in the UI to use the new permission instead of the old update_project.

I have verified manually that this works. Tests will be added in a later PR.

Merging this one is safe because:
- project permissions are only checked if the api endpoint called has a project id in its path. As such, there is no chance the update_project permission will interfere with the existing API.
- The new API is behind a flag and is not available unless the flag is on. Likewise, the project-specific context field list ils also not shown unless the flag is on.

Closes 1-4423
