### PR TITLE
fix: truncate breadcrumb path name with super long project name

### DIFF
--- a/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
@@ -100,9 +100,13 @@ const BreadcrumbNav = () => {
                                         ? project.name
                                         : path;
                                     const lastItem = index === paths.length - 1;
+                                    const tooltipTitle =
+                                        isProjectPath && pathName.length > 25
+                                            ? pathName
+                                            : undefined;
                                     if (lastItem) {
                                         return (
-                                            <Tooltip title={pathName} arrow>
+                                            <Tooltip title={tooltipTitle} arrow>
                                                 <StyledCurrentPage key={path}>
                                                     {pathName}
                                                 </StyledCurrentPage>
@@ -121,7 +125,7 @@ const BreadcrumbNav = () => {
                                     });
 
                                     return (
-                                        <Tooltip title={pathName} arrow>
+                                        <Tooltip title={tooltipTitle} arrow>
                                             <StyledLink key={path} to={link}>
                                                 {pathName}
                                             </StyledLink>


### PR DESCRIPTION
After changing the project breadcrumbs to include the project name instead of ID, if the project name is super long the whole page looks broken. 
This PR:
- truncates each breadcrumb path name if too long;
- shows a tooltip with the full project name in project paths if the name is too long.


## Before 
<img width="800" height="524" alt="Screenshot 2026-01-12 at 14 59 43" src="https://github.com/user-attachments/assets/aa80731d-49dd-40b1-90cb-2d6daf0d2ba3" />
<img width="800" height="524" alt="Screenshot 2026-01-12 at 14 59 50" src="https://github.com/user-attachments/assets/7bca8643-fb67-4fee-b547-f646b3b8cb94" />

## After 
<img width="800" height="396" alt="Screenshot 2026-01-12 at 15 16 08" src="https://github.com/user-attachments/assets/9999a7e7-3b55-48af-af6d-367f62c023da" />

<img width="800" height="268" alt="Screenshot 2026-01-12 at 15 16 11" src="https://github.com/user-attachments/assets/227229f2-8632-4d78-b90f-7e63f38a458e" />
