### PR TITLE
fix: include horizontal truncation in Truncator

### DIFF
--- a/frontend/src/component/common/Truncator/Truncator.tsx
+++ b/frontend/src/component/common/Truncator/Truncator.tsx
@@ -51,7 +51,10 @@ export const Truncator = ({
 
     const checkTruncation = () => {
         if (ref.current) {
-            setIsTruncated(ref.current.scrollHeight > ref.current.offsetHeight);
+            setIsTruncated(
+                ref.current.scrollHeight > ref.current.offsetHeight ||
+                    ref.current.scrollWidth > ref.current.offsetWidth,
+            );
         }
     };
     useEffect(() => {


### PR DESCRIPTION
`checkTruncation`  in the `Truncator` component currently only detects vertical truncation, causing the tooltip to not be shown on horizontal truncation.
This adds horizontal truncation to the check.

## Before (e.g. if used in `BreadcrumbNav`)

<img width="836" height="141" alt="Screenshot 2026-01-12 at 16 22 09" src="https://github.com/user-attachments/assets/6e00fbf5-7471-4737-b2ea-a65e03a80f09" />

## After (e.g. if used in `BreadcrumbNav`)

<img width="838" height="180" alt="Screenshot 2026-01-12 at 16 22 16" src="https://github.com/user-attachments/assets/e17bbd8d-2d0e-470c-9892-e54c9dc5c08f" />
