### PR TITLE
chore: use Truncator in breadcrumbs

### DIFF
--- a/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
@@ -4,7 +4,6 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import AccessContext from 'contexts/AccessContext';
 import { useContext } from 'react';
 import { styled } from '@mui/material';
-import { textTruncated } from 'themes/themeStyles';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
 import { Truncator } from '../Truncator/Truncator';
@@ -24,9 +23,8 @@ const StyledBreadcrumbs = styled(Breadcrumbs)({
 });
 
 const StyledCurrentPage = styled('span')(({ theme }) => ({
-    ...textTruncated,
     fontWeight: theme.typography.fontWeightBold,
-    maxWidth: theme.spacing(50),
+    maxWidth: theme.spacing(25),
     display: 'block',
 }));
 


### PR DESCRIPTION
Following up on [this comment](https://github.com/Unleash/unleash/pull/11217#pullrequestreview-3651021468) from #11217: this uses `Truncator` in breadcrumbs.

## Before

<img width="836" height="141" alt="Screenshot 2026-01-12 at 16 22 09" src="https://github.com/user-attachments/assets/6e00fbf5-7471-4737-b2ea-a65e03a80f09" />

## After

<img width="838" height="180" alt="Screenshot 2026-01-12 at 16 22 16" src="https://github.com/user-attachments/assets/e17bbd8d-2d0e-470c-9892-e54c9dc5c08f" />

