### PR TITLE
chore: sync read only users total to auth-app

### DIFF
--- a/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
+++ b/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
@@ -13,9 +13,11 @@ import { useInstanceStats } from 'hooks/api/getters/useInstanceStats/useInstance
 import { formatApiPath } from '../../../../utils/formatPath.ts';
 import { PageContent } from '../../../common/PageContent/PageContent.tsx';
 import { PageHeader } from '../../../common/PageHeader/PageHeader.tsx';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 export const InstanceStats: FC = () => {
     const { stats } = useInstanceStats();
+    const readOnlyUsersUIEnabled = useUiFlag('readOnlyUsersUI');
 
     let versionTitle: string;
     let version: string | undefined;
@@ -72,6 +74,13 @@ export const InstanceStats: FC = () => {
             { title: 'SAML enabled', value: stats?.SAMLenabled ? 'Yes' : 'No' },
             { title: 'OIDC enabled', value: stats?.OIDCenabled ? 'Yes' : 'No' },
         );
+
+        if (readOnlyUsersUIEnabled) {
+            rows.push({
+                title: 'ReadOnly users',
+                value: stats?.readOnlyUsers,
+            });
+        }
     }
 
     return (

--- a/frontend/src/openapi/models/instanceAdminStatsSchema.ts
+++ b/frontend/src/openapi/models/instanceAdminStatsSchema.ts
@@ -86,6 +86,11 @@ export interface InstanceAdminStatsSchema {
      */
     projects?: number;
     /**
+     * The number of ReadOnly users in this instance
+     * @minimum 0
+     */
+    readOnlyUsers?: number;
+    /**
      * The number of release plans in this instance
      * @minimum 0
      */

--- a/src/lib/openapi/spec/instance-admin-stats-schema.ts
+++ b/src/lib/openapi/spec/instance-admin-stats-schema.ts
@@ -298,6 +298,12 @@ export const instanceAdminStatsSchema = {
                 '2024-10': 0.45,
             },
         },
+        readOnlyUsers: {
+            type: 'integer',
+            minimum: 0,
+            example: 1,
+            description: 'The number of ReadOnly users in this instance',
+        },
         sum: {
             type: 'string',
             description:

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -130,6 +130,7 @@ class InstanceAdminController extends Controller {
                 '2022-07': 2.567,
                 '2022-08': 2.789,
             },
+            readOnlyUsers: 4,
         };
     }
 

--- a/src/lib/services/version-service.test.ts
+++ b/src/lib/services/version-service.test.ts
@@ -46,6 +46,7 @@ const fakeTelemetryData = {
     releaseTemplates: 2,
     releasePlans: 4,
     edgeInstanceUsage: {},
+    readOnlyUsers: 2,
 };
 
 test('yields current versions', async () => {

--- a/src/lib/services/version-service.ts
+++ b/src/lib/services/version-service.ts
@@ -56,6 +56,7 @@ export interface IFeatureUsageInfo {
     releaseTemplates: number;
     releasePlans: number;
     edgeInstanceUsage?: EdgeInstanceUsage;
+    readOnlyUsers?: number;
 }
 
 export interface IInstanceInfo {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4097/sync-read-only-users-total-to-auth-app

Adds read only users total to instance stats, so it is synced with auth-app.