### PR TITLE
chore: use `autoWidth` prop instead of `min-content` and css hacks

### DIFF
--- a/frontend/src/component/common/GeneralSelect/GeneralSelect.tsx
+++ b/frontend/src/component/common/GeneralSelect/GeneralSelect.tsx
@@ -85,13 +85,7 @@ function GeneralSelect<T extends string = string>({
                 label={visuallyHideLabel ? '' : label}
                 id={id}
                 value={value ?? ''}
-                MenuProps={{
-                    sx: {
-                        '.MuiPopover-paper.MuiMenu-paper': {
-                            width: 'min-content',
-                        },
-                    },
-                }}
+                autoWidth
                 IconComponent={KeyboardArrowDownOutlined}
                 labelId={labelId}
                 {...rest}


### PR DESCRIPTION
Replaces the `min-content` deep-reaching css override on the general select component with the `autoWidth` prop. This prop appears to solve the same issues that the min-content width was introduced to address, but also works better in other cases, such as for very narrow components.

The previous implementation was introduced in https://github.com/Unleash/unleash/pull/7591 to solve super long names breaking the dropdown in the flag project selector. The new behavior is slightly different, and I'd argue, better.

Before:
<img width="1613" height="1723" alt="image" src="https://github.com/user-attachments/assets/8daacaee-f0aa-4a99-ac94-c7610eee0aef" />

After:

<img width="1623" height="823" alt="image" src="https://github.com/user-attachments/assets/2a47211b-5988-4ca9-bf87-7a2078fd2d6f" />

This also paves the way for using context field groupings in the constraint selector:

With min-content:
<img width="210" height="961" alt="image" src="https://github.com/user-attachments/assets/9fb3ddee-0a8e-4afa-98cb-b70aa283d035" />


With auto-width:
<img width="254" height="752" alt="image" src="https://github.com/user-attachments/assets/b9a5c6de-2039-4199-a0aa-a9b36c055e5f" />
