### PR TITLE
feat: make generalselect component also accept option groups

### DIFF
--- a/frontend/src/component/common/GeneralSelect/GeneralSelect.tsx
+++ b/frontend/src/component/common/GeneralSelect/GeneralSelect.tsx
@@ -117,14 +117,14 @@ function GeneralSelect<T extends string = string>({
                 {...rest}
             >
                 {isSelectOptionGroup(options)
-                    ? options?.flatMap((group, index) => {
+                    ? options.flatMap((group) => {
                           return [
                               <ListSubheader key={group.groupHeader}>
                                   {group.groupHeader}
                               </ListSubheader>,
-                          ].concat(group.options?.map(toMenuItem));
+                          ].concat(group.options.map(toMenuItem));
                       })
-                    : options?.map(toMenuItem)}
+                    : options.map(toMenuItem)}
             </Select>
         </StyledFormControl>
     );


### PR DESCRIPTION
Updates the general select component to accept option groups instead of just flat options. If an option group is presented, it will unwrap the options and use ListSubheader component as [shown in the MUI docs](https://v5.mui.com/material-ui/react-select/#grouping).

Existing uses of this component should not be affected.