### PR TITLE
chore: do not assume seat type

### DIFF
--- a/src/lib/types/user.ts
+++ b/src/lib/types/user.ts
@@ -81,7 +81,7 @@ export class User implements IUser {
 
     scimId?: string;
 
-    seatType?: SeatType = 'Regular';
+    seatType?: SeatType;
 
     constructor({
         id,


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4111/we-should-not-assume-seattype-=-regular-by-default

We should not assume a default 'Regular' seat type for our user entity.

It may be useful to differentiate between actual Regular users and users that have not been processed yet.