### PR TITLE
feat: give project owner UPDATE_PROJECT_CONTEXT permissions

### DIFF
--- a/src/migrations/20260115122651-project-owner-crud-project-context.js
+++ b/src/migrations/20260115122651-project-owner-crud-project-context.js
@@ -1,0 +1,19 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        SELECT assign_unleash_permission_to_role('UPDATE_PROJECT_CONTEXT', 'Owner');
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DELETE FROM role_permission
+        WHERE permission = 'UPDATE_PROJECT_CONTEXT'
+        AND role_id = (SELECT id from roles WHERE name = 'Owner' AND type = 'project' LIMIT 1);
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
Makes it so that project owners can manage project context fields without any additional permissions.
