### PR TITLE
feat: give project owner UPDATE_PROJECT_SEGMENT permissions

### DIFF
--- a/src/migrations/20260115122720-project-owner-crud-project-segment.js
+++ b/src/migrations/20260115122720-project-owner-crud-project-segment.js
@@ -1,0 +1,19 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        SELECT assign_unleash_permission_to_role('UPDATE_PROJECT_SEGMENT', 'Owner');
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DELETE FROM role_permission
+        WHERE permission = 'UPDATE_PROJECT_SEGMENT'
+        AND role_id = (SELECT id from roles WHERE name = 'Owner' AND type = 'project' LIMIT 1);
+        `,
+        cb,
+    );
+};


### PR DESCRIPTION
Makes it so that project owners can manage project segments without any additional permissions.

It appears to have been an oversight that this wasn't added to the project owner role previously.
