### PR TITLE
chore: keep command bar visible in smaller viewports

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -78,11 +78,12 @@ const Header = () => {
     const { onSetThemeMode, themeMode } = useThemeMode();
     const theme = useTheme();
 
-    const smallScreen = useMediaQuery(theme.breakpoints.down('lg'));
+    const mediumScreen = useMediaQuery(theme.breakpoints.down('lg'));
+    const smallScreen = useMediaQuery(theme.breakpoints.down('md'));
     const [openDrawer, setOpenDrawer] = useState(false);
     const toggleDrawer = () => setOpenDrawer((prev) => !prev);
 
-    if (smallScreen) {
+    if (mediumScreen) {
         return (
             <HeaderComponent position='static'>
                 <ContainerComponent>
@@ -101,6 +102,7 @@ const Header = () => {
                     </Tooltip>
                     <DrawerMenu open={openDrawer} toggleDrawer={toggleDrawer} />
                     <StyledUserContainer>
+                        {!smallScreen && <CommandBar />}
                         <UserProfile />
                     </StyledUserContainer>
                 </ContainerComponent>


### PR DESCRIPTION
Since there is plenty of space in the header even in smaller viewports, the command bar stays visible on medium screens (smaller than 'lg') and disappears on small screens (smaller than 'md'). 


https://github.com/user-attachments/assets/3e246eae-e301-4772-9f24-8acb774f5e8e

With a super long user name:


https://github.com/user-attachments/assets/07e92904-40d4-4d9f-915e-3491ea001d4a


