### PR TITLE
feat: add include query param to context api to allow different combinations

### DIFF
--- a/src/lib/features/context/context-service.ts
+++ b/src/lib/features/context/context-service.ts
@@ -64,6 +64,15 @@ class ContextService {
         return allFields.filter((field) => field.project === projectId);
     }
 
+    async getAssignableFieldsForProject(
+        projectId: string,
+    ): Promise<IContextField[]> {
+        const allFields = await this.contextFieldStore.getAll();
+        return allFields.filter(
+            (field) => field.project === projectId || !field.project,
+        );
+    }
+
     async getContextField(name: string): Promise<IContextField> {
         const field = await this.contextFieldStore.get(name);
         if (field === undefined) {

--- a/src/lib/openapi/spec/context-query-parameters.ts
+++ b/src/lib/openapi/spec/context-query-parameters.ts
@@ -1,0 +1,18 @@
+import type { FromQueryParams } from 'unleash-server';
+
+export const contextQueryParameters = [
+    {
+        name: 'include',
+        schema: {
+            type: 'string',
+            example: 'project',
+        },
+        description:
+            'Whether the response should include project-specific or root context fields in addition to the fields in the default response. When querying the root context API, `include=project` will yield a response that includes all project-specific context fields in addition to all root context fields. Conversely, when querying a project-specific context API, using `include=root` will yield a response that includes all root context fields in addition to the project-specific context fields. The other combinations have no effect, because the responses already include those fields.',
+        in: 'query',
+    },
+] as const;
+
+export type ContextQueryParameters = Partial<
+    FromQueryParams<typeof contextQueryParameters>
+>;


### PR DESCRIPTION
Lets the context API return:
- all context fields
- only root context fields
- only fields belonging to a queried project
- all "assignable" fields within a project (project-specific + root)

Uses an "include" query parameter to control this. The parameter can either be "project" or "root", e.g. "GET api/admin/context?include=project". 

Including "project" on the root level, will give all root fields AND all project-specific fields (for all projects).
Likewise, including "root" on the project level will give the project-specific fields for that project and all root fields.

Without the includes, the top-level context API only returns root fields, and the project level API only returns project fields.

Tests to be added in a later PR.

## Root vs global

As [described in the docs](https://docs.getunleash.io/concepts#the-root-level), Unleash calls the top level the "root level". The root level includes things like users, tokens, roles, and **context fields**. As such, I think that the include keyword should be `root` instead of `global`.