### PR TITLE
Group playground context fields into global / project

### DIFF
--- a/frontend/src/component/common/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/component/common/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,4 @@
 import {
-    type CSSProperties,
     type FC,
     type MouseEventHandler,
     type ReactNode,

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -78,13 +78,13 @@ const createContextFieldOptions = (
     if (fields.project.length) {
         groups.push({
             groupHeader: 'Project context fields',
-            options: optList(fields.project)
+            options: optList(fields.project),
         });
     }
     if (fields.global.length) {
         groups.push({
             groupHeader: 'Global context fields',
-            options: optList(fields.global)
+            options: optList(fields.global),
         });
     }
 


### PR DESCRIPTION
Groups project fields in the playground context selector the same way as in the constraint editor. Uses a similar grouping mechanism as in the editable constraint, but simplifies it because there is no need to handle the "current context field", as this is not an editing operation. Also sorts the data by sortOrder.

Updates the playground component by using the shared general select component instead of a custom impl.

<img width="887" height="875" alt="image" src="https://github.com/user-attachments/assets/b9d30980-91ab-4eeb-a53c-2cfb9b502f83" />
