### PR TITLE
chore: make userId required for new context service method

### DIFF
--- a/src/lib/features/context/context-service.ts
+++ b/src/lib/features/context/context-service.ts
@@ -74,13 +74,13 @@ class ContextService {
     }
 
     async getContextFields({
+        include,
         projectId,
         userId,
-        include,
     }: {
-        projectId?: string;
-        userId?: number;
         include?: string;
+        projectId?: string;
+        userId: number;
     }): Promise<IContextField[]> {
         if (projectId) {
             if (include?.match(/^root$/i)) {
@@ -92,9 +92,6 @@ class ContextService {
 
         if (include?.match(/^project$/i)) {
             const allFields = await this.getAll();
-            if (!userId) {
-                return allFields;
-            }
 
             const accessibleProjects =
                 await this.privateProjectChecker.getUserAccessibleProjects(


### PR DESCRIPTION
Makes the user ID parameter required for the getContextFields method, as suggsted in https://github.com/Unleash/unleash/pull/11237#discussion_r2712944604. 

Also: sorts the object properties for readability.

Closes 1-4434