### PR TITLE
fix: avoid querying for project overviews if we don't have a project

### DIFF
--- a/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/frontend/src/component/common/BreadcrumbNav/BreadcrumbNav.tsx
@@ -4,7 +4,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import AccessContext from 'contexts/AccessContext';
 import { useContext } from 'react';
 import { styled } from '@mui/material';
-import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import { useConditionalProjectOverview } from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
 import { Truncator } from '../Truncator/Truncator';
 
@@ -39,7 +39,7 @@ const BreadcrumbNav = () => {
     const location = useLocation();
 
     const projectId = useOptionalPathParam('projectId');
-    const { project } = useProjectOverview(projectId || '');
+    const { project } = useConditionalProjectOverview(projectId);
 
     let paths = location.pathname
         .split('/')

--- a/frontend/src/hooks/api/getters/useProjectOverview/useProjectOverview.ts
+++ b/frontend/src/hooks/api/getters/useProjectOverview/useProjectOverview.ts
@@ -31,6 +31,13 @@ const fallbackProject: ProjectOverviewSchema = {
 };
 
 const useProjectOverview = (id: string, options: SWRConfiguration = {}) => {
+    return useConditionalProjectOverview(id, options);
+};
+
+export const useConditionalProjectOverview = (
+    id: string = '',
+    options: SWRConfiguration = {},
+) => {
     const { KEY, fetcher } = getProjectOverviewFetcher(id);
     const { data, error, mutate } = useConditionalSWR<ProjectOverviewSchema>(
         !!id,


### PR DESCRIPTION
Fixes an issue where we were seeing repeated calls to `api/admin/projects/overview`. Because that project doesn't exist, we were getting 404s.

The issue appears to have originated in https://github.com/Unleash/unleash/pull/11201 due to passing an empty string as the project id to the project overview fetcher. 

Because we use breadcrumbs on other pages too (such as context / segment creation screen), we can't move the breadcrumbs. Instead, I've introduced a "useConditionalProjectOverview" hook, which allows you to call it without a project id, in which case it's a no-op.