### PR TITLE
fix: don't use project-based context API unless the flag is enabled

### DIFF
--- a/frontend/src/hooks/api/getters/useUnleashContext/useUnleashContext.ts
+++ b/frontend/src/hooks/api/getters/useUnleashContext/useUnleashContext.ts
@@ -2,6 +2,7 @@ import useSWR, { type SWRConfiguration } from 'swr';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler.js';
 import type { IUnleashContextDefinition } from 'interfaces/context';
+import { useUiFlag } from 'hooks/useUiFlag.js';
 
 export interface IUnleashContextOutput {
     context: IUnleashContextDefinition[];
@@ -37,7 +38,9 @@ const useUnleashContext = (
         revalidateIfStale: true,
     },
 ): IUnleashContextOutput => {
-    const uri = uriFromQuery(query);
+    const useProjectContext = useUiFlag('projectContextFields');
+
+    const uri = useProjectContext ? uriFromQuery(query) : `api/admin/context`;
 
     const fetcher = () => {
         const path = formatApiPath(uri);


### PR DESCRIPTION
Fixes an issue where, if the flag was not enabled, the user would not be able to add any context fields to project-specific resources, such as strategies.

The url formatting should have been behind a flag, so that it would only use the project API if the flag was active, but it was, unfortunately overlooked.

If the flag was enabled, however, this would've worked as expected.

Before:
<img width="903" height="550" alt="image" src="https://github.com/user-attachments/assets/c2da6dbe-2b6b-4696-a1f6-9ba0e2b81496" />


After:
<img width="884" height="657" alt="image" src="https://github.com/user-attachments/assets/742c61ff-2972-4182-9187-e6ce08dd460c" />
