### PR TITLE
chore: mount project-level context API unconditionally

### DIFF
--- a/src/lib/features/project/project-controller.ts
+++ b/src/lib/features/project/project-controller.ts
@@ -211,13 +211,10 @@ export default class ProjectController extends Controller {
         this.use('/', new ProjectStatusController(config, services).router);
         this.use('/', new FeatureLifecycleController(config, services).router);
         this.use('/', new FeatureLinkController(config, services).router);
-
-        if (this.flagResolver.isEnabled('projectContextFields')) {
-            this.use(
-                '/',
-                new ContextController(config, services, 'project').router,
-            );
-        }
+        this.use(
+            '/',
+            new ContextController(config, services, 'project').router,
+        );
     }
 
     async getProjects(


### PR DESCRIPTION
The mounting was originally wrapped in a flag check, but this means that the flag has to be enabled at startup for the routes to get mounted. This, in turn, means that if you enable the flag after startup, the Ui will start trying to call the project-level API, but not get any results because the routes are not mounted.

The API is still marked as beta, so this can be rolled back if we want to.
