### PR TITLE
fix: check that userVersion is defined before comparing to etag

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -316,7 +316,7 @@ export default class FeatureController extends Controller {
 
         res.setHeader('ETag', etag);
 
-        if (etag === userVersion) {
+        if (userVersion !== undefined && etag === userVersion) {
             res.status(304);
             res.getHeaderNames().forEach((header) => {
                 res.removeHeader(header);


### PR DESCRIPTION
This one's been annoying me a bit.

If we start up Edge and connect to the delta endpoint without a if-none-match header, we still get a 304 from an instance without toggles (since `undefined === undefined`). This is obviously wrong, so this PR adds verification that if-none-match  is not undefined before comparing to etag.
