### PR TITLE
 chore: add privateProjectMiddlewareMove flag to Unleash

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -93,6 +93,7 @@ export type UiFlags = {
     gtmReleaseManagement?: boolean;
     projectContextFields?: boolean;
     readOnlyUsersUI?: boolean;
+    privateProjectMiddlewareMove?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -68,7 +68,8 @@ export type IFlagKey =
     | 'gtmReleaseManagement'
     | 'projectContextFields'
     | 'readOnlyUsers'
-    | 'readOnlyUsersUI';
+    | 'readOnlyUsersUI'
+    | 'privateProjectMiddlewareMove';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -303,6 +304,10 @@ const flags: IFlags = {
     ),
     readOnlyUsersUI: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_READ_ONLY_USERS_UI,
+        false,
+    ),
+    privateProjectMiddlewareMove: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_PRIVATE_PROJECT_MIDDLEWARE_MOVE,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,6 +58,7 @@ process.nextTick(async () => {
                         projectContextFields: true,
                         readOnlyUsers: true,
                         readOnlyUsersUI: true,
+                        privateProjectMiddlewareMove: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
 Facilitates a fix for private project leakage in enterprise (https://github.com/bricks-software/unleash-enterprise/pull/762)

