### PR TITLE
chore: don't mount a separate router for the conditional middleware

### DIFF
--- a/src/lib/middleware/conditional-middleware.ts
+++ b/src/lib/middleware/conditional-middleware.ts
@@ -4,15 +4,11 @@ export const conditionalMiddleware = (
     condition: () => boolean,
     middleware: RequestHandler,
 ): RequestHandler => {
-    const router = Router();
-
-    router.use((req, res, next) => {
+    return (req, res, next) => {
         if (condition()) {
             middleware(req, res, next);
         } else {
             next();
         }
-    });
-
-    return router;
+    };
 };


### PR DESCRIPTION
Discovered in https://github.com/bricks-software/unleash-enterprise/pull/762, there's an issue with using fake timers and the old implementation of the condititonal middleware.

By changing the implementation to not use a Router, but instead just a plain function, we can avoid the issue with fake timers.

## AI explanation

According to Claude:

The issue is the interaction between **`vi.useFakeTimers()`** and **Express `Router`**.

When Vitest (or Jest) fake timers are active, they replace the global `setTimeout`, `setInterval`, `setImmediate`, and related functions with mocked versions that only advance when you explicitly tell them to (e.g., `vi.advanceTimersByTime`).

### Why the Router causes a hang

Express's `Router` internally uses **asynchronous scheduling** — specifically `setImmediate` or `process.nextTick` in certain code paths for dispatching requests through its middleware stack. When you wrap your middleware in a `Router`:

```typescript
const router = Router();
router.use((req, res, next) => {
    // ...
});
return router;
```

The Router's internal dispatch mechanism may schedule work via `setImmediate`. With fake timers active, **that `setImmediate` never fires** because it's been replaced by a mock that waits for `vi.advanceTimersByTime()` or `vi.runAllTimers()`. The HTTP request enters the Router and never comes back — it just hangs.

### Why a plain function works

A plain handler function:

```typescript
return (req, res, next) => {
    if (condition()) {
        middleware(req, res, next);
    } else {
        next();
    }
};
```

...runs **synchronously inline** in the existing middleware chain. There's no sub-router dispatch, no `setImmediate`, nothing for fake timers to intercept. It just calls `next()` directly and everything proceeds.
