### PR TITLE
chore: Add flag for datepickers invalid dates constraints

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -33,6 +33,7 @@ export interface IUiConfig {
     samlConfiguredThroughEnv?: boolean;
     maxSessionsCount?: number;
     unleashContext?: IMutableContext;
+    datePickerRangeConstraints?: boolean;
 }
 
 export type UiFlags = {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -69,7 +69,8 @@ export type IFlagKey =
     | 'projectContextFields'
     | 'readOnlyUsers'
     | 'readOnlyUsersUI'
-    | 'privateProjectMiddlewareMove';
+    | 'privateProjectMiddlewareMove'
+    | 'datePickerRangeConstraints';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -308,6 +309,10 @@ const flags: IFlags = {
     ),
     privateProjectMiddlewareMove: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PRIVATE_PROJECT_MIDDLEWARE_MOVE,
+        false,
+    ),
+    datePickerRangeConstraints: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_DATEPICKER_RANGE_CONSTRAINTS,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -59,6 +59,7 @@ process.nextTick(async () => {
                         readOnlyUsers: true,
                         readOnlyUsersUI: true,
                         privateProjectMiddlewareMove: true,
+                        datePickerRangeConstraints: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Adds a feature flag for the datepickers range constraints to be introduced in #11245, so we can test out the UX in sandbox before settling on a solution.
