### PR TITLE
fix: use universal id extract for feature search

### DIFF
--- a/src/lib/features/feature-search/feature-search-controller.ts
+++ b/src/lib/features/feature-search/feature-search-controller.ts
@@ -25,7 +25,7 @@ import {
     featureSearchQueryParameters,
 } from '../../openapi/spec/feature-search-query-parameters.js';
 import { normalizeQueryParams } from './search-utils.js';
-import { anonymise } from '../../util/index.js';
+import { anonymise, extractUserId } from '../../util/index.js';
 
 type FeatureSearchServices = Pick<
     IUnleashServices,
@@ -110,7 +110,7 @@ export default class FeatureSearchController extends Controller {
             sortBy,
             lastSeenAt,
         } = req.query;
-        const userId = req.user.id;
+        const userId = extractUserId(req);
         const {
             normalizedQuery,
             normalizedSortOrder,


### PR DESCRIPTION
We have suspicion that id is undefined, and db query failed do to it.