### PR TITLE
chore: remove tags that were deprecated and unused

### DIFF
--- a/src/lib/openapi/util/api-operation.ts
+++ b/src/lib/openapi/util/api-operation.ts
@@ -1,16 +1,7 @@
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiTag } from './openapi-tags.js';
 
-type DeprecatedOpenAPITag =
-    // Deprecated tag names. Please use a tag from the OpenAPITag type instead.
-    //
-    // These tag names were the original ones we used for OpenAPI, but they
-    // turned out to be too generic and/or didn't match the new tag naming
-    // schema. Because we require our operations to have one of a predefined set
-    // of values, it would be breaking change to remove them completely.
-    'client' | 'other' | 'auth' | 'admin';
-
-export interface ApiOperation<Tag = OpenApiTag | DeprecatedOpenAPITag>
+export interface ApiOperation<Tag = OpenApiTag>
     extends Omit<OpenAPIV3.OperationObject, 'tags'> {
     operationId: string;
     tags: [Tag];


### PR DESCRIPTION
Minor cleanup. If there's no build issue, we're all good