### PR TITLE
chore: update base image to node22.22-alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=22.21-alpine3.23
+ARG NODE_VERSION=22.22-alpine3.23
 
 FROM node:$NODE_VERSION AS builder
 


### PR DESCRIPTION
Resolves the [cve-2025-15467](https://access.redhat.com/security/cve/cve-2025-15467)
