### PR TITLE
fix: force ordering of hydration events in delta api

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/delta-cache.ts
+++ b/src/lib/features/client-feature-toggles/delta/delta-cache.ts
@@ -97,5 +97,22 @@ export class DeltaCache {
             }
             this.hydrationEvent.eventId = appliedEvent.eventId;
         }
+        // small perf hit here but this is a cold path and this is absolutely critical to ensure
+        // that down stream Edge instances receive the data in predictable orders because that
+        // affects how they calculate their etags
+        this.sortHydrationEvent();
+    }
+
+    private sortHydrationEvent(): void {
+        this.hydrationEvent.features.sort((a, b) =>
+            a.name.localeCompare(b.name),
+        );
+        this.hydrationEvent.segments.sort((a, b) => {
+            const byName = a.name.localeCompare(b.name);
+            if (byName !== 0) {
+                return byName;
+            }
+            return a.id - b.id;
+        });
     }
 }


### PR DESCRIPTION
This fixes an issue that's both very subtle and very expensive. Strap in, gonna learn you a thing

**The discrepancy**

Currently the sliding window of deltas is built in one of two ways. Either an initial hydration event that's built from the database and uses ordering determined by db queries (in segment's case, order by name), or by a series of mutations of that window, which are maintained by appending or deleting events chronologically. This means that initial hydration can have a different ordering from long running hydration

**The revenge of infrastructure**

Unleash nodes can be restarted for whatever reason, so we can never depend on a given Unleash node to have the same ordering of deltas as any other node. We also run Unleash behind an LB so we also cannot guarantee which instance a downstream instance will connect to

**The consequence**

Edge calculates etags on a bit level representation of the client features response. This means that any Edge node that receives a client feature response with different ordering will calculate etags in a different way.  If Edge node A is talking to Unleash node A and Edge node B is talking to Unleash node B, there's no guarantee that both of these Edge nodes will return the same etag. If those nodes are behind a LB (which they are for our setup). Connecting SDKs will receive differing etags from both of those Edge nodes

**The fix**

We just sort both these collections. Order doesn't matter so long as its predictable