### PR TITLE
chore: adds a way to get a measure of distinct counts of types of sdk filters

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -36,6 +36,7 @@ import type { ClientFeatureToggleService } from './client-feature-toggle-service
 import {
     CLIENT_FEATURES_MEMORY,
     CLIENT_METRICS_NAMEPREFIX,
+    CLIENT_METRICS_PROJECT,
     CLIENT_METRICS_TAGS,
 } from '../../internals.js';
 import isEqual from 'lodash.isequal';
@@ -279,16 +280,24 @@ export default class FeatureController extends Controller {
             return {};
         }
 
-        if (namePrefix) {
-            this.eventBus.emit(CLIENT_METRICS_NAMEPREFIX);
-        }
-
-        if (tag) {
-            this.eventBus.emit(CLIENT_METRICS_TAGS);
-        }
-
         const tagQuery = this.paramToArray(tag);
         const projectQuery = this.paramToArray(project);
+
+        if (namePrefix) {
+            this.eventBus.emit(CLIENT_METRICS_NAMEPREFIX, { namePrefix });
+        }
+
+        if (tagQuery?.length) {
+            this.eventBus.emit(CLIENT_METRICS_TAGS, {
+                tags: tagQuery.map(String),
+            });
+        }
+
+        if (projectQuery?.length) {
+            this.eventBus.emit(CLIENT_METRICS_PROJECT, {
+                projects: projectQuery.map(String),
+            });
+        }
         const query = await querySchema.validateAsync({
             tag: tagQuery,
             project: projectQuery,

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -17,6 +17,7 @@ const REQUEST_ORIGIN = 'request_origin' as const;
 const ADDON_EVENTS_HANDLED = 'addon-event-handled' as const;
 const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
 const CLIENT_METRICS_TAGS = 'client-api-tags';
+const CLIENT_METRICS_PROJECT = 'client-api-project';
 const CLIENT_FEATURES_MEMORY = 'client_features_memory';
 const CLIENT_DELTA_MEMORY = 'client_delta_memory';
 const CLIENT_REGISTERED = 'client_registered';
@@ -38,6 +39,7 @@ type MetricEvent =
     | typeof REQUEST_ORIGIN
     | typeof CLIENT_METRICS_NAMEPREFIX
     | typeof CLIENT_METRICS_TAGS
+    | typeof CLIENT_METRICS_PROJECT
     | typeof CLIENT_FEATURES_MEMORY
     | typeof CLIENT_DELTA_MEMORY;
 
@@ -47,9 +49,24 @@ type RequestOriginEventPayload = {
     source?: string;
 };
 
+type ClientMetricsNamePrefixPayload = {
+    namePrefix: string;
+};
+
+type ClientMetricsTagsPayload = {
+    tags: string[];
+};
+
+type ClientMetricsProjectPayload = {
+    projects: string[];
+};
+
 type MetricEventPayloads = {
     [key: string]: unknown;
     [REQUEST_ORIGIN]: RequestOriginEventPayload;
+    [CLIENT_METRICS_NAMEPREFIX]: ClientMetricsNamePrefixPayload;
+    [CLIENT_METRICS_TAGS]: ClientMetricsTagsPayload;
+    [CLIENT_METRICS_PROJECT]: ClientMetricsProjectPayload;
 };
 
 type MetricEventPayload<T extends MetricEvent> = MetricEventPayloads[T];
@@ -90,6 +107,7 @@ export {
     ADDON_EVENTS_HANDLED,
     CLIENT_METRICS_NAMEPREFIX,
     CLIENT_METRICS_TAGS,
+    CLIENT_METRICS_PROJECT,
     CLIENT_FEATURES_MEMORY,
     CLIENT_DELTA_MEMORY,
     CLIENT_REGISTERED,


### PR DESCRIPTION
Adds a way to get counts for number of distinct usages of namePrefix, tag and project filters that are used in the wild. Hoping this gives us some insight into whether or not we can deprecate this in the wild.

Hyperloglog use here should give us within a few percent accuracy for a tradeoff of just over a 1kb per node. Seems fine to me. Data will be a bit janky because gauges work weird across nodes but it will give us within (number of nodes)* (returned count) and (returned count) level of accuracy, which is enough to make a decision here