### PR TITLE
fix: allow the SDK metrics API to ingest null variants

### DIFF
--- a/src/lib/features/metrics/shared/schema.test.ts
+++ b/src/lib/features/metrics/shared/schema.test.ts
@@ -103,3 +103,23 @@ test('clientMetricsSchema should use instanceId', () => {
 
     expect(value.instanceId).toBe('some');
 });
+
+test('clientMetricsSchema should accept null variants and default to empty object', () => {
+    const { error, value } = clientMetricsSchema.validate({
+        appName: 'test',
+        bucket: {
+            start: Date.now(),
+            stop: Date.now(),
+            toggles: {
+                Demo: {
+                    yes: 1,
+                    no: 2,
+                    variants: null,
+                },
+            },
+        },
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.bucket.toggles.Demo.variants).toEqual({});
+});

--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -7,7 +7,11 @@ const countSchema = joi
     .keys({
         yes: joi.number().min(0).empty('').default(0),
         no: joi.number().min(0).empty('').default(0),
-        variants: joi.object().pattern(joi.string(), joi.number().min(0)),
+        variants: joi
+            .object()
+            .pattern(joi.string(), joi.number().min(0))
+            .empty(null)
+            .default({}),
     });
 
 // validated type from client-metrics-schema.ts with default values
@@ -45,7 +49,11 @@ export const clientMetricsEnvSchema = joi
         yes: joi.number().default(0),
         no: joi.number().default(0),
         timestamp: joi.date(),
-        variants: joi.object().pattern(joi.string(), joi.number().min(0)),
+        variants: joi
+            .object()
+            .pattern(joi.string(), joi.number().min(0))
+            .empty(null)
+            .default({}),
     });
 export const clientMetricsEnvBulkSchema = joi
     .array()

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -115,6 +115,7 @@ export const clientMetricsSchema = {
                                 description:
                                     'An object describing how many times each variant was returned. Variant names are used as properties, and the number of times they were exposed is the corresponding value (i.e. `{ [variantName]: number }`).',
                                 type: 'object',
+                                nullable: true,
                                 additionalProperties: {
                                     type: 'integer',
                                     minimum: 0,


### PR DESCRIPTION
This patches the validation on ingesting client metrics to allow for ingesting null variant buckets - these are then transformed into empty objects, which was what was previously expected.

This shouldn't affect existing downstream users but allows the API to be more tolerant in cases where the intent is unambiguous.

We keep breaking this in our SDKs by mistake and this really, really shouldn't cause an error