### PR TITLE
Spike: sync `feature_strategies` and `milestone_strategies` updates

### DIFF
--- a/SPIKE-plan-strategy-sync.md
+++ b/SPIKE-plan-strategy-sync.md
@@ -1,0 +1,110 @@
+# Spike: Release Plan Strategy Sync
+
+## Overview
+
+When a feature strategy is updated and it has a `milestoneId` (meaning it originated from a release plan), we need to sync the changes back to the corresponding `milestone_strategies` record to keep both tables in sync.
+
+## Data Model
+
+```
+milestone_strategies (definition)         feature_strategies (runtime)
+├── id (ULID) ─────────────────────────── id (same ID!)
+├── milestone_id                          ├── milestone_id
+├── strategy_name                         ├── strategy_name
+├── parameters                            ├── parameters
+├── constraints                           ├── constraints
+├── variants                              ├── variants
+├── title                                 ├── title
+└── sort_order                            └── sort_order
+
+milestone_strategy_segments               feature_strategy_segment
+├── milestone_strategy_id                 ├── feature_strategy_id
+└── segment_id                            └── segment_id
+```
+
+## Scenario Matrix
+
+| Scenario | feature_strategies | milestone_strategies | What happens |
+|----------|-------------------|---------------------|--------------|
+| Feature strategy found, no milestoneId | ✅ exists | N/A | Update feature_strategies only |
+| Feature strategy found, has milestoneId | ✅ exists | ✅ exists | Update both in transaction ✅ |
+| Feature strategy not found, milestone exists | ❌ missing | ✅ exists | Update milestone_strategies only ✅ |
+| Strategy not found anywhere | ❌ missing | ❌ missing | NotFoundError |
+
+### Scenario Details
+
+1. **Feature strategy without milestone** - Normal strategy, just update `feature_strategies`
+2. **Feature strategy with milestone** - Release plan strategy that's been activated, update both atomically
+3. **Milestone not activated yet** - Strategy only exists in `milestone_strategies`, update it directly
+4. **Not found anywhere** - Error case, strategy doesn't exist in either table
+
+## Change Request Flow
+
+When CRs are enabled and applied:
+1. User creates CR with `updateStrategy` action
+2. CR is approved
+3. `change-request-executor.ts` calls `featureToggleService.unprotectedUpdateStrategy()`
+4. Our sync logic runs - both tables updated in transaction
+5. `FEATURE_STRATEGY_UPDATE` event emitted
+6. Conflict detector handles any scheduled CR conflicts
+
+**No changes needed in unleash-enterprise** - the CR executor already calls `unprotectedUpdateStrategy()` which contains our sync logic.
+
+## Changes Made
+
+### unleash repo
+
+#### 1. [feature-toggle-strategies-store.ts](src/lib/features/feature-toggle/feature-toggle-strategies-store.ts)
+- Added `getDb()` method to expose database connection for transactions
+- Modified `updateStrategy()` to accept optional `trx` parameter
+
+#### 2. [feature-toggle-strategies-store-type.ts](src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts)
+- Updated interface with `getDb()` and optional `trx` on `updateStrategy()`
+
+#### 3. [release-plan-milestone-strategy-store.ts](src/lib/features/release-plans/release-plan-milestone-strategy-store.ts)
+- Added `updateWithSegments(strategyId, data, segmentIds, trx?)` method
+- Accepts optional transaction; creates new one if not provided
+
+#### 4. [feature-toggle-service.ts](src/lib/features/feature-toggle/feature-toggle-service.ts)
+- Added optional `ReleasePlanMilestoneStrategyStore` dependency
+- In `unprotectedUpdateStrategy`, when strategy has `milestoneId`:
+  - Uses `db.transaction()` to wrap both updates atomically
+
+#### 5. [createFeatureToggleService.ts](src/lib/features/feature-toggle/createFeatureToggleService.ts)
+- Creates and wires up `ReleasePlanMilestoneStrategyStore`
+
+#### 6. [fake-feature-strategies-store.ts](src/lib/features/feature-toggle/fakes/fake-feature-strategies-store.ts)
+- Added stub `getDb()` for interface compliance
+
+### unleash-enterprise repo
+
+**No changes needed** - existing CR flow calls `unprotectedUpdateStrategy()` which contains our sync logic.
+
+## Testing
+
+To test:
+1. Create a release plan with a strategy
+2. Activate the milestone (strategy copied to `feature_strategies`)
+3. Edit the strategy via the regular strategy edit endpoint
+4. Verify both `feature_strategies` and `milestone_strategies` have the updated values
+5. Verify both segments tables are in sync
+
+### CR Testing
+1. Enable change requests for an environment
+2. Create a release plan and activate milestone
+3. Create a CR to update the strategy
+4. Approve and apply the CR
+5. Verify both tables are updated
+
+## Notes
+
+- **Atomic updates**: Feature strategy and milestone strategy updates wrapped in single DB transaction
+- Feature strategy segments updated via segment service (outside transaction - future improvement)
+- CRs work automatically - they call `unprotectedUpdateStrategy` which has our sync logic
+- Conflict detection works - `FEATURE_STRATEGY_UPDATE` event triggers existing conflict detector
+
+## Future Work
+
+- Including feature_strategy_segment updates in the transaction
+- Flag to enable/disable milestone sync
+- Emit a different event type for milestone-only updates (currently no event emitted)

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategyEditForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestoneStrategyEditForm.tsx
@@ -1,0 +1,433 @@
+import {
+    Box,
+    Button,
+    styled,
+    Alert,
+    Tab,
+    Tabs,
+    Typography,
+    Divider,
+} from '@mui/material';
+import { Badge } from 'component/common/Badge/Badge';
+import FormTemplate from 'component/common/FormTemplate/FormTemplate';
+import type { IReleasePlanMilestoneStrategy } from 'interfaces/releasePlans';
+import type { ISegment } from 'interfaces/segment';
+import { useEffect, useState } from 'react';
+import { formatStrategyName } from 'utils/strategyNames';
+import { useStrategy } from 'hooks/api/getters/useStrategy/useStrategy';
+import { useFormErrors } from 'hooks/useFormErrors';
+import produce from 'immer';
+import { MilestoneStrategySegment } from 'component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategySegment';
+import { useConstraintsValidation } from 'hooks/api/getters/useConstraintsValidation/useConstraintsValidation';
+import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
+import { MilestoneStrategyTitle } from 'component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategyTitle';
+import { MilestoneStrategyConstraints } from 'component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategyConstraints';
+import { MilestoneStrategyVariants } from 'component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategyVariants';
+import { MilestoneStrategyType } from 'component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/MilestoneStrategyType';
+import { ConstraintSeparator } from 'component/common/ConstraintsList/ConstraintSeparator/ConstraintSeparator';
+import {
+    featureStrategyDocsLink,
+    featureStrategyDocsLinkLabel,
+    featureStrategyHelp,
+} from 'component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit';
+import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
+import useToast from 'hooks/useToast';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
+import { usePendingChangeRequests } from 'hooks/api/getters/usePendingChangeRequests/usePendingChangeRequests';
+
+const StyledCancelButton = styled(Button)(({ theme }) => ({
+    marginLeft: theme.spacing(3),
+}));
+
+const StyledButtonContainer = styled('div')(({ theme }) => ({
+    marginTop: 'auto',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+    paddingTop: theme.spacing(3),
+    paddingRight: theme.spacing(6),
+    paddingLeft: theme.spacing(6),
+    paddingBottom: theme.spacing(6),
+    backgroundColor: theme.palette.background.paper,
+    borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledHeaderBox = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingLeft: theme.spacing(6),
+    paddingRight: theme.spacing(6),
+    paddingTop: theme.spacing(2),
+}));
+
+const StyledTitle = styled('h1')(({ theme }) => ({
+    fontWeight: 'normal',
+    display: 'flex',
+    alignItems: 'center',
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+}));
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+    borderTop: `1px solid ${theme.palette.divider}`,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    paddingLeft: theme.spacing(6),
+    paddingRight: theme.spacing(6),
+    minHeight: '60px',
+}));
+
+const StyledTab = styled(Tab)(({ theme }) => ({
+    width: '100px',
+}));
+
+const StyledBadge = styled(Badge)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+}));
+
+const StyledContentDiv = styled('div')(({ theme }) => ({
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    padding: theme.spacing(6),
+    paddingBottom: theme.spacing(16),
+    paddingTop: theme.spacing(4),
+    overflow: 'auto',
+    height: '100%',
+}));
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    position: 'relative',
+    marginTop: theme.spacing(3.5),
+}));
+
+const StyledDivider = styled(Divider)(({ theme }) => ({
+    width: '100%',
+}));
+
+const StyledConstraintSeparator = styled(ConstraintSeparator)(({ theme }) => ({
+    top: '-10px',
+    left: '0',
+    transform: 'translateY(0)',
+}));
+
+const StyledStrategyIdBox = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.background.elevation1,
+    borderRadius: theme.shape.borderRadius,
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+}));
+
+interface IReleasePlanMilestoneStrategyEditFormProps {
+    onCancel: () => void;
+    strategy: IReleasePlanMilestoneStrategy;
+    projectId: string;
+    featureName: string;
+    environmentId: string;
+    onSuccess?: () => void;
+}
+
+export const ReleasePlanMilestoneStrategyEditForm = ({
+    onCancel,
+    strategy,
+    projectId,
+    featureName,
+    environmentId,
+    onSuccess,
+}: IReleasePlanMilestoneStrategyEditFormProps) => {
+    const [currentStrategy, setCurrentStrategy] =
+        useState<IReleasePlanMilestoneStrategy>(strategy);
+    const [activeTab, setActiveTab] = useState(0);
+    const { segments: allSegments } = useSegments();
+    const [segments, setSegments] = useState<ISegment[]>([]);
+    const strategyName = strategy?.strategyName || strategy?.name || '';
+    const { strategyDefinition } = useStrategy(strategyName);
+    const hasValidConstraints = useConstraintsValidation(strategy?.constraints);
+    const errors = useFormErrors();
+    const { updateStrategyOnFeature, loading } = useFeatureStrategyApi();
+    const { setToastData, setToastApiError } = useToast();
+    const { addChange } = useChangeRequestApi();
+    const { isChangeRequestConfigured } = useChangeRequestsEnabled(projectId);
+    const { refetch: refetchChangeRequests } =
+        usePendingChangeRequests(projectId);
+
+    const showVariants = Boolean(
+        currentStrategy?.parameters &&
+            'stickiness' in currentStrategy?.parameters,
+    );
+
+    const stickiness =
+        currentStrategy?.parameters &&
+        'stickiness' in currentStrategy?.parameters
+            ? String(currentStrategy.parameters.stickiness)
+            : 'default';
+
+    const segmentsMap = allSegments?.reduce(
+        (acc, segment) => {
+            acc[segment.id] = segment;
+            return acc;
+        },
+        {} as Record<number, ISegment>,
+    );
+
+    useEffect(() => {
+        if (segmentsMap && currentStrategy?.segments) {
+            const resolvedSegments = currentStrategy.segments
+                .map((segmentId) => {
+                    if (typeof segmentId === 'number') {
+                        return segmentsMap[segmentId];
+                    }
+                    return segmentsMap[Number(segmentId)];
+                })
+                .filter(Boolean) as ISegment[];
+            setSegments(resolvedSegments);
+        }
+    }, [allSegments]);
+
+    useEffect(() => {
+        setCurrentStrategy((prev) => ({
+            ...prev,
+            segments: segments.map((segment) => segment.id),
+        }));
+    }, [segments]);
+
+    useEffect(() => {
+        if (showVariants) {
+            setCurrentStrategy((prev) => ({
+                ...prev,
+                variants: (currentStrategy.variants || []).map((variant) => ({
+                    stickiness,
+                    name: variant.name,
+                    weight: variant.weight,
+                    payload: variant.payload,
+                    weightType: variant.weightType,
+                })),
+            }));
+        }
+    }, [stickiness]);
+
+    if (!strategy || !currentStrategy || !strategyDefinition) {
+        return null;
+    }
+
+    const handleChange = (_event: React.ChangeEvent<{}>, newValue: number) => {
+        setActiveTab(newValue);
+    };
+
+    const getTargetingCount = () => {
+        const constraintCount = currentStrategy?.constraints?.length || 0;
+        const segmentCount = segments?.length || 0;
+        return constraintCount + segmentCount;
+    };
+
+    const validateParameter = (_key: string, _value: string) => true;
+
+    const updateParameter = (name: string, value: string) => {
+        setCurrentStrategy(
+            produce((draft) => {
+                if (!draft) {
+                    return;
+                }
+                if (name === 'title') {
+                    draft.title = value;
+                    return;
+                }
+                draft.parameters = draft.parameters ?? {};
+                draft.parameters[name] = value;
+                validateParameter(name, value);
+            }),
+        );
+    };
+
+    const handleSave = async () => {
+        try {
+            const payload = {
+                name: currentStrategy.strategyName || currentStrategy.name,
+                title: currentStrategy.title || undefined,
+                constraints: currentStrategy.constraints || [],
+                parameters: currentStrategy.parameters || {},
+                variants: currentStrategy.variants || [],
+                segments: segments.map((segment) => segment.id),
+                disabled: false,
+            };
+
+            if (isChangeRequestConfigured(environmentId)) {
+                // Create a change request
+                await addChange(projectId, environmentId, {
+                    action: 'updateStrategy',
+                    feature: featureName,
+                    payload: { ...payload, id: strategy.id },
+                });
+                setToastData({
+                    text: 'Change added to draft',
+                    type: 'success',
+                });
+                refetchChangeRequests();
+            } else {
+                // Direct update
+                await updateStrategyOnFeature(
+                    projectId,
+                    featureName,
+                    environmentId,
+                    strategy.id,
+                    payload,
+                );
+                setToastData({
+                    text: 'Strategy updated successfully',
+                    type: 'success',
+                });
+            }
+
+            onSuccess?.();
+            onCancel();
+        } catch (error) {
+            setToastApiError(formatUnknownError(error));
+        }
+    };
+
+    return (
+        <FormTemplate
+            modal
+            disablePadding
+            description={featureStrategyHelp}
+            documentationLink={featureStrategyDocsLink}
+            documentationLinkLabel={featureStrategyDocsLinkLabel}
+        >
+            <StyledHeaderBox>
+                <StyledTitle>
+                    {formatStrategyName(strategyName)}
+                    {strategyName === 'flexibleRollout' && (
+                        <Badge color="success" sx={{ marginLeft: '1rem' }}>
+                            {currentStrategy.parameters?.rollout}%
+                        </Badge>
+                    )}
+                </StyledTitle>
+            </StyledHeaderBox>
+            <StyledTabs value={activeTab} onChange={handleChange}>
+                <StyledTab label="General" />
+                <Tab
+                    label={
+                        <Typography>
+                            Targeting
+                            <StyledBadge>{getTargetingCount()}</StyledBadge>
+                        </Typography>
+                    }
+                />
+                {showVariants && (
+                    <Tab
+                        label={
+                            <Typography>
+                                Variants
+                                <StyledBadge>
+                                    {currentStrategy?.variants?.length || 0}
+                                </StyledBadge>
+                            </Typography>
+                        }
+                    />
+                )}
+            </StyledTabs>
+            <StyledContentDiv>
+                {activeTab === 0 && (
+                    <>
+                        <MilestoneStrategyTitle
+                            title={currentStrategy.title || ''}
+                            setTitle={(title) =>
+                                updateParameter('title', title)
+                            }
+                        />
+
+                        <MilestoneStrategyType
+                            strategy={currentStrategy}
+                            strategyDefinition={strategyDefinition}
+                            parameters={currentStrategy.parameters}
+                            updateParameter={updateParameter}
+                            errors={errors}
+                        />
+
+                        <StyledStrategyIdBox>
+                            <strong>Strategy ID:</strong> {strategy.id}
+                            {strategy.milestoneId && (
+                                <>
+                                    {' '}
+                                    | <strong>Milestone ID:</strong>{' '}
+                                    {strategy.milestoneId}
+                                </>
+                            )}
+                        </StyledStrategyIdBox>
+                    </>
+                )}
+                {activeTab === 1 && (
+                    <>
+                        <Alert severity="info" sx={{ mb: 2 }} icon={false}>
+                            Segmentation and constraints allow you to set
+                            filters on your strategies, so that they will only
+                            be evaluated for users and applications that match
+                            the specified preconditions.
+                        </Alert>
+                        <MilestoneStrategySegment
+                            segments={segments}
+                            setSegments={setSegments}
+                        />
+                        <StyledBox>
+                            <StyledDivider />
+                            <StyledConstraintSeparator />
+                        </StyledBox>
+                        <MilestoneStrategyConstraints
+                            strategy={currentStrategy}
+                            setStrategy={
+                                setCurrentStrategy as React.Dispatch<
+                                    React.SetStateAction<
+                                        Omit<
+                                            IReleasePlanMilestoneStrategy,
+                                            'milestoneId'
+                                        >
+                                    >
+                                >
+                            }
+                        />
+                    </>
+                )}
+                {activeTab === 2 && showVariants && (
+                    <MilestoneStrategyVariants
+                        strategy={currentStrategy}
+                        setStrategy={
+                            setCurrentStrategy as React.Dispatch<
+                                React.SetStateAction<
+                                    Omit<
+                                        IReleasePlanMilestoneStrategy,
+                                        'milestoneId'
+                                    >
+                                >
+                            >
+                        }
+                    />
+                )}
+            </StyledContentDiv>
+            <StyledButtonContainer>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    type="submit"
+                    disabled={
+                        !hasValidConstraints || errors.hasFormErrors() || loading
+                    }
+                    onClick={handleSave}
+                >
+                    {loading
+                        ? 'Saving...'
+                        : isChangeRequestConfigured(environmentId)
+                          ? 'Add to change request'
+                          : 'Save changes'}
+                </Button>
+                <StyledCancelButton onClick={onCancel}>
+                    Cancel
+                </StyledCancelButton>
+            </StyledButtonContainer>
+        </FormTemplate>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/ReleasePlanMilestoneItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/ReleasePlanMilestoneItem.tsx
@@ -196,6 +196,8 @@ export const ReleasePlanMilestoneItem = ({
                 previousMilestoneStatus={previousMilestoneStatus}
                 projectId={projectId}
                 environmentId={environment}
+                featureName={featureName}
+                onStrategyUpdate={onUpdate}
             />
             <ConditionallyRender
                 condition={isNotLastMilestone}

--- a/src/lib/features/feature-toggle/createFeatureToggleService.ts
+++ b/src/lib/features/feature-toggle/createFeatureToggleService.ts
@@ -62,6 +62,7 @@ import {
     createFeatureLinkService,
 } from '../feature-links/createFeatureLinkService.js';
 import { ResourceLimitsService } from '../resource-limits/resource-limits-service.js';
+import { ReleasePlanMilestoneStrategyStore } from '../release-plans/release-plan-milestone-strategy-store.js';
 
 export const createFeatureToggleService = (
     db: Db,
@@ -135,6 +136,9 @@ export const createFeatureToggleService = (
 
     const resourceLimitsService = new ResourceLimitsService(config);
 
+    const releasePlanMilestoneStrategyStore =
+        new ReleasePlanMilestoneStrategyStore(db, { eventBus });
+
     const featureToggleService = new FeatureToggleService(
         {
             featureStrategiesStore,
@@ -159,6 +163,7 @@ export const createFeatureToggleService = (
             featureLinksReadModel,
             featureLinkService,
             resourceLimitsService,
+            releasePlanMilestoneStrategyStore,
         },
     );
     return featureToggleService;

--- a/src/lib/features/feature-toggle/fakes/fake-feature-strategies-store.ts
+++ b/src/lib/features/feature-toggle/fakes/fake-feature-strategies-store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
 import type {
     FeatureToggleWithEnvironment,
     IFeatureOverview,
@@ -27,6 +28,10 @@ export default class FakeFeatureStrategiesStore
     featureStrategies: IFeatureStrategy[] = [];
 
     featureToggles: FeatureToggle[] = [];
+
+    getDb(): Knex {
+        throw new Error('Not implemented in fake store');
+    }
 
     async createStrategyFeatureEnv(
         strategyConfig: Omit<IFeatureStrategy, 'id' | 'createdAt'>,

--- a/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-strategies-store.ts
@@ -175,6 +175,10 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
             });
     }
 
+    getDb(): Db {
+        return this.db;
+    }
+
     async delete(key: string): Promise<void> {
         await this.db(T.featureStrategies).where({ id: key }).del();
     }
@@ -804,9 +808,11 @@ class FeatureStrategiesStore implements IFeatureStrategiesStore {
     async updateStrategy(
         id: string,
         updates: Partial<IFeatureStrategy>,
+        trx?: Knex,
     ): Promise<IFeatureStrategy> {
+        const db = trx ?? this.db;
         const update = mapStrategyUpdate(updates);
-        const row = await this.db<IFeatureStrategiesTable>(T.featureStrategies)
+        const row = await db<IFeatureStrategiesTable>(T.featureStrategies)
             .where({ id })
             .update(update)
             .returning('*');

--- a/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
+++ b/src/lib/features/feature-toggle/types/feature-toggle-strategies-store-type.ts
@@ -1,3 +1,4 @@
+import type { Knex } from 'knex';
 import type {
     FeatureToggleWithEnvironment,
     IDependency,
@@ -63,6 +64,8 @@ export interface IQueryParam {
 
 export interface IFeatureStrategiesStore
     extends Store<IFeatureStrategy, string> {
+    getDb(): Knex;
+
     createStrategyFeatureEnv(
         strategyConfig: Omit<IFeatureStrategy, 'id' | 'createdAt'>,
     ): Promise<IFeatureStrategy>;
@@ -99,6 +102,7 @@ export interface IFeatureStrategiesStore
     updateStrategy(
         id: string,
         updates: Partial<IFeatureStrategy>,
+        trx?: Knex,
     ): Promise<IFeatureStrategy>;
 
     deleteConfigurationsForProjectAndEnvironment(


### PR DESCRIPTION
Spike for option 2 (see [here](https://linear.app/unleash/document/spike-release-plans-strategies-editing-8c0fedf0d561) at the bottom)

No changes needed in unleash-enterprise as far as I (and my friend Claude who did all the work) can tell, since conflict detection already works: the existing detector listens for FEATURE_STRATEGY_UPDATE events which we still emit.

UPDATE: we still need to emit FEATURE_STRATEGY_UPDATE when updating a plan strategy that hasn't been activated yet (copied over to feature strategies). But that just requires storing an event for milestone strategies updates AFAICT. So no changes needed in unleash-enterprise (unless I'm missing something). 