### PR TITLE
chore: signup dialog account details

### DIFF
--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -5,6 +5,7 @@ import { ThemeMode } from '../../common/ThemeMode/ThemeMode.tsx';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus.ts';
 import { type ComponentType, useState } from 'react';
 import { SignupDialogSetPassword } from './SignupDialogSetPassword/SignupDialogSetPassword.tsx';
+import { SignupDialogAccountDetails } from './SignupDialogAccountDetails.tsx';
 
 const StyledUnleashLogoWhite = styled(UnleashLogoWhite)({
     height: '56px',
@@ -107,6 +108,11 @@ const steps: SignupStep[] = [
         title: 'Set password',
         description: `Create a secure password, and you're good to go!`,
         content: SignupDialogSetPassword,
+    },
+    {
+        title: 'Set up your account',
+        description: 'Tell us a few more details to get started.',
+        content: SignupDialogAccountDetails,
     },
 ];
 

--- a/frontend/src/component/signup/SignupDialog/SignupDialogAccountDetails.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogAccountDetails.tsx
@@ -1,0 +1,171 @@
+import {
+    Autocomplete,
+    Checkbox,
+    FormControlLabel,
+    styled,
+    TextField,
+} from '@mui/material';
+import {
+    StyledSignupDialogButton,
+    StyledSignupDialogField,
+    StyledSignupDialogLabel,
+    type SignupStepContent,
+} from './SignupDialog';
+
+const StyledRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: theme.spacing(2),
+    width: '100%',
+}));
+
+const StyledTextFieldWithHelperText = styled(TextField)(({ theme }) => ({
+    '& .MuiFormHelperText-root': {
+        marginLeft: 0,
+        marginTop: theme.spacing(1),
+    },
+}));
+
+const StyledCheckboxContainer = styled('div')(({ theme }) => ({
+    '& .MuiFormControlLabel-label': {
+        fontWeight: theme.typography.fontWeightBold,
+    },
+}));
+
+export const SignupDialogAccountDetails: SignupStepContent = ({
+    data,
+    setData,
+    onNext,
+}) => {
+    const isValidForm =
+        data.firstName.trim() !== '' &&
+        data.lastName.trim() !== '' &&
+        data.companyRole.trim() !== '' &&
+        data.companyName.trim() !== '';
+
+    return (
+        <>
+            <StyledRow>
+                <StyledSignupDialogField>
+                    <StyledSignupDialogLabel>
+                        First name
+                    </StyledSignupDialogLabel>
+                    <TextField
+                        variant='outlined'
+                        placeholder='First name'
+                        name='given-name'
+                        autoComplete='given-name'
+                        value={data.firstName}
+                        onChange={(e) =>
+                            setData((prev) => ({
+                                ...prev,
+                                firstName: e.target.value,
+                            }))
+                        }
+                    />
+                </StyledSignupDialogField>
+                <StyledSignupDialogField>
+                    <StyledSignupDialogLabel>Last name</StyledSignupDialogLabel>
+                    <TextField
+                        variant='outlined'
+                        placeholder='Last name'
+                        name='family-name'
+                        autoComplete='family-name'
+                        value={data.lastName}
+                        onChange={(e) =>
+                            setData((prev) => ({
+                                ...prev,
+                                lastName: e.target.value,
+                            }))
+                        }
+                    />
+                </StyledSignupDialogField>
+            </StyledRow>
+            <StyledSignupDialogField>
+                <StyledSignupDialogLabel>
+                    What's your role?
+                </StyledSignupDialogLabel>
+                <Autocomplete
+                    openOnFocus
+                    value={data.companyRole}
+                    onChange={(_, role) =>
+                        setData((prev) => ({
+                            ...prev,
+                            companyRole: role || '',
+                        }))
+                    }
+                    options={[
+                        'Developer',
+                        'DevOps',
+                        'Engineering manager',
+                        'Product manager',
+                        'Other',
+                    ]}
+                    renderInput={(params) => (
+                        <StyledTextFieldWithHelperText
+                            {...params}
+                            placeholder='Please select'
+                            helperText='We use this to customize your onboarding'
+                        />
+                    )}
+                />
+            </StyledSignupDialogField>
+            <StyledSignupDialogField>
+                <StyledSignupDialogLabel>Company name</StyledSignupDialogLabel>
+                <StyledTextFieldWithHelperText
+                    variant='outlined'
+                    placeholder='Company name'
+                    helperText='This is displayed when people join your workspace'
+                    name='organization'
+                    autoComplete='organization'
+                    value={data.companyName}
+                    onChange={(e) =>
+                        setData((prev) => ({
+                            ...prev,
+                            companyName: e.target.value,
+                        }))
+                    }
+                />
+            </StyledSignupDialogField>
+            <StyledCheckboxContainer>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={data.companyIsNA}
+                            onChange={() =>
+                                setData((prev) => ({
+                                    ...prev,
+                                    companyIsNA: !prev.companyIsNA,
+                                }))
+                            }
+                            color='primary'
+                        />
+                    }
+                    label='My company is based in North America'
+                />
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={data.emailSubscription}
+                            onChange={() =>
+                                setData((prev) => ({
+                                    ...prev,
+                                    emailSubscription: !prev.emailSubscription,
+                                }))
+                            }
+                            color='primary'
+                        />
+                    }
+                    label='I would like to receive product updates by email'
+                />
+            </StyledCheckboxContainer>
+            <StyledSignupDialogButton
+                variant='contained'
+                onClick={onNext}
+                disabled={!isValidForm}
+            >
+                Next
+            </StyledSignupDialogButton>
+        </>
+    );
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-70/signup-dialog-step-2-account-details

Adds the second step of the signup dialog: account details.

<img width="624" height="801" alt="image" src="https://github.com/user-attachments/assets/7fb23f3b-eac7-41ed-bcfa-af64a3e70bd4" />

<img width="675" height="835" alt="image" src="https://github.com/user-attachments/assets/846e6a80-af9f-4aa9-8254-45e9f758ca68" />
