### PR TITLE
fix MaxListenersExceededWarning in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "exports": "./dist/lib/server-impl.js",
   "scripts": {
-    "ci": "yarn lint:fix && yarn build:backend && yarn test",
+    "ci": "yarn lint:fix && yarn build:backend --logLevel=error && yarn test --reporter=dot",
     "start": "TZ=UTC node ./dist/server.js",
     "copy-templates": "copyfiles-fixed -u 1 src/mailtemplates/**/* dist/",
     "build:backend": "tsc --pretty && copyfiles-fixed -u 2 src/migrations/package.json dist/migrations",
@@ -63,6 +63,7 @@
     "test:coverage": "PORT=4243 vitest run --coverage --outputFile=\"coverage/report.json\"",
     "test:updateSnapshot": "PORT=4243 vitest run -u",
     "test:ui": "vitest --ui",
+    "test:trace": "NODE_OPTIONS=--trace-warnings yarn test --no-file-parallelism",
     "seed:setup": "ts-node src/test/e2e/seed/segment.seed.ts",
     "seed:serve": "UNLEASH_DATABASE_NAME=unleash_test UNLEASH_DATABASE_SCHEMA=seed yarn run start:dev",
     "clean": "del-cli --force dist",

--- a/src/lib/features/frontend-api/createFrontendApiService.ts
+++ b/src/lib/features/frontend-api/createFrontendApiService.ts
@@ -57,6 +57,9 @@ export const createFakeFrontendApiService = (
     configurationRevisionService: ConfigurationRevisionService,
     clientInstanceService: ClientInstanceService,
 ): FrontendApiService => {
+    // MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 200 UPDATE_REVISION listeners added to [ConfigurationRevisionService]. MaxListeners is 199. Use emitter.setMaxListeners() to increase limit
+    configurationRevisionService.setMaxListeners(200);
+
     const segmentReadModel = new FakeSegmentReadModel();
     const settingStore = new FakeSettingStore();
     const eventService = createFakeEventsService(config);

--- a/src/lib/middleware/response-time-metrics.test.ts
+++ b/src/lib/middleware/response-time-metrics.test.ts
@@ -45,6 +45,10 @@ describe('responseTimeMetrics new behavior', () => {
         getAppCountSnapshot: vi.fn() as () => number | undefined,
     };
     const eventBus = new EventEmitter();
+    afterEach(() => {
+        // (node:16735) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 request_time listeners added to [EventEmitter]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
+        eventBus.removeAllListeners();
+    });
 
     test('uses baseUrl and route path to report metrics with flag enabled, but no res.locals.route', async () => {
         let timeInfo: any;


### PR DESCRIPTION
## `yarn test` will print a buch of warnings: 

### 11 listeners
```
(node:16735) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 request_time listeners added to [EventEmitter]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

### 200 listeners
and a second one where after experimenting the number is around 200

```
// MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 200 UPDATE_REVISION listeners added to [ConfigurationRevisionService]. MaxListeners is 199. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

###  Testing 

```
yarn test | grep MaxListenersExceededWarning
```

## About the changes

* clean listeners in test to fix the 11 listeners warning
* The other one is caused by `configurationRevisionService` that's a singleton in tests. Increasing the number of connections in `createFakeFrontendApiService` seems like a least intrusive option. 
* Some small tweaks to `yarn ci` that probably only I use so please ignore. 

Closes #

### Important files


## Discussion points

* It might be a good idea to increase limit from 200 to some higher number like 300 so the warning won't show up next time we add a test... 
* But, the other option is to take a little more time to think if we can somehow get rid of the singleton in tests to prevent this from happening. 
