### PR TITLE
fix: disable sticky positioning for LicenseBanner to fix visual bug

### DIFF
--- a/frontend/src/component/banners/internalBanners/LicenseBanner.tsx
+++ b/frontend/src/component/banners/internalBanners/LicenseBanner.tsx
@@ -20,7 +20,7 @@ export const LicenseBanner = () => {
                     licenseInfo.message ||
                     'You have an invalid Unleash license.',
                 variant: 'error' as BannerVariant,
-                sticky: true,
+                sticky: false,
             };
 
             return <Banner key={banner.message} banner={banner} />;
@@ -29,7 +29,7 @@ export const LicenseBanner = () => {
                 const banner = {
                     message: licenseInfo.message,
                     variant: mapToVariant(licenseInfo.messageType),
-                    sticky: true,
+                    sticky: false,
                 };
                 return <Banner key={banner.message} banner={banner} />;
             }


### PR DESCRIPTION
## Summary
Fixes a visual bug with the LicenseBanner by changing `sticky` from `true` to `false` for both the invalid license and license warning message banner variants.

The sticky positioning was causing layout/display issues, and disabling it resolves the visual bug.

Made with [Cursor](https://cursor.com)