### PR TITLE
chore: update update-strategy-schema

### DIFF
--- a/src/lib/openapi/spec/update-feature-strategy-schema.ts
+++ b/src/lib/openapi/spec/update-feature-strategy-schema.ts
@@ -37,6 +37,21 @@ export const updateFeatureStrategySchema = {
             example: false,
             nullable: true,
         },
+        variants: {
+            type: 'array',
+            description: 'Strategy level variants',
+            items: {
+                $ref: '#/components/schemas/strategyVariantSchema',
+            },
+        },
+        segments: {
+            type: 'array',
+            description: 'A list of segment ids attached to the strategy',
+            example: [1, 2],
+            items: {
+                type: 'number',
+            },
+        },
         parameters: {
             $ref: '#/components/schemas/parametersSchema',
         },


### PR DESCRIPTION
Looks like we'd forgotten to add in strategy variants and segments. Because the API is lenient with its input, however, it just accepted it without telling us.
