### PR TITLE
Change dashboard items icons to settings

### DIFF
--- a/frontend/src/component/personalDashboard/MyFlags.tsx
+++ b/frontend/src/component/personalDashboard/MyFlags.tsx
@@ -19,7 +19,7 @@ import {
     Typography,
     styled,
 } from '@mui/material';
-import LinkIcon from '@mui/icons-material/ArrowForward';
+import SettingsIcon from '@mui/icons-material/Settings';
 import React from 'react';
 import type { PersonalDashboardSchemaFlagsItem } from 'openapi';
 
@@ -76,7 +76,7 @@ const FlagListItem: FC<{
                         size='small'
                         sx={{ ml: 'auto' }}
                     >
-                        <LinkIcon titleAccess={flagLink} />
+                        <SettingsIcon titleAccess={`Go to flag ${flag.name}`} />
                     </IconButton>
                 </ListItemBox>
             </ListItemButton>

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -8,7 +8,7 @@ import {
     styled,
 } from '@mui/material';
 import { ProjectIcon } from '../common/ProjectIcon/ProjectIcon.tsx';
-import LinkIcon from '@mui/icons-material/ArrowForward';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { ProjectSetupComplete } from './ProjectSetupComplete.tsx';
 import { ConnectSDK, CreateFlag, ExistingFlag } from './ConnectSDK.tsx';
 import { LatestProjectEvents } from './LatestProjectEvents.tsx';
@@ -123,7 +123,9 @@ const ProjectListItem: FC<{
                             });
                         }}
                     >
-                        <LinkIcon titleAccess={`projects/${project.id}`} />
+                        <SettingsIcon
+                            titleAccess={`Go to project ${project.id}`}
+                        />
                     </IconButton>
                 </ListItemBox>
                 {selected ? <ActiveProjectDetails project={project} /> : null}


### PR DESCRIPTION
## About the changes

Change Icon form an arrow pointing to the right (what what exactly?) to a Settings icon that will better indicate that it's a link. 

It's not a perfect solution as we're pointing to the details and not exactly to settings of projects/flags, but IMHO. it's a lot easier to notice now. 

### How it looked like

<img width="912" height="376" alt="Zrzut ekranu 2026-02-12 o 15 39 23" src="https://github.com/user-attachments/assets/c02be736-e3f9-43d1-b68e-243e9e1a8887" />

### How it looks like with Settings icons

<img width="1874" height="895" alt="Zrzut ekranu 2026-02-12 o 15 30 23" src="https://github.com/user-attachments/assets/f60ff2c8-631a-4f30-bccb-b353cc6b70bb" />
<img width="1879" height="869" alt="Zrzut ekranu 2026-02-12 o 15 30 09" src="https://github.com/user-attachments/assets/40f8db36-12af-4a69-98df-d1426a45c7a6" />


Closes #

https://linear.app/unleash/issue/2-4165/change-favorite-projectsflags-icon-to-settings

## Discussion points


