### PR TITLE
chore: better username support in signup set password

### DIFF
--- a/frontend/src/component/signup/SignupDialog/SignupDialogSetPassword/SignupDialogSetPassword.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogSetPassword/SignupDialogSetPassword.tsx
@@ -23,6 +23,7 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
         fontSize: theme.typography.body1.fontSize,
         lineHeight: 1.1,
         border: 'none',
+        outline: 'none',
         background: 'transparent',
         width: '100%',
         color: 'inherit',
@@ -37,22 +38,24 @@ export const SignupDialogSetPassword: SignupStepContent = ({
 }) => {
     const { user } = useAuthUser();
     const [isValidPassword, setIsValidPassword] = useState(false);
+    const emailOrUsername = user?.email || user?.username;
 
     return (
         <>
-            {user?.email && (
+            {emailOrUsername && (
                 <StyledSignupDialogField>
                     <StyledSignupDialogLabel>
-                        Verified email
+                        {user.email ? 'Verified email' : 'Username'}
                     </StyledSignupDialogLabel>
                     <StyledBadge color='success' icon={<CheckCircle />}>
                         <input
-                            type='email'
-                            id='email'
-                            name='email'
-                            autoComplete='email'
-                            value={user.email}
-                            disabled
+                            type={user.email ? 'email' : 'text'}
+                            id={user.email ? 'email' : 'username'}
+                            name={user.email ? 'email' : 'username'}
+                            autoComplete={user.email ? 'email' : 'username'}
+                            value={emailOrUsername}
+                            readOnly
+                            tabIndex={-1}
                         />
                     </StyledBadge>
                 </StyledSignupDialogField>


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-81/support-edge-cases-like-username-instead-of-email-in-the-signup

This improves the support of some edge cases in the signup dialog, like setting a password for users without email (e.g. admin).

Doesn't mean we'll need it right away, but it's a quick win so it doesn't break if we decide to do it in the future.

Also include some improvements to password manager detection.

<img width="644" height="627" alt="image" src="https://github.com/user-attachments/assets/45014bda-e0f6-4097-8f58-1da8dff90bdb" />
