### PR TITLE
fix: only show assignable segments in recently used segments

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/FeatureStrategySegment.tsx
@@ -10,6 +10,7 @@ import { useSegmentLimits } from 'hooks/api/getters/useSegmentLimits/useSegmentL
 import { Box, styled, Typography } from '@mui/material';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { RecentlyUsedSegments } from './RecentlyUsedSegments/RecentlyUsedSegments.tsx';
+import { useRecentlyUsedSegments } from './RecentlyUsedSegments/useRecentlyUsedSegments.ts';
 
 interface IFeatureStrategySegmentProps {
     segments: ISegment[];
@@ -30,6 +31,12 @@ export const FeatureStrategySegment = ({
     availableSegments,
 }: IFeatureStrategySegmentProps) => {
     const { strategySegmentsLimit } = useSegmentLimits();
+    const { items: recentlyUsedSegmentIds } = useRecentlyUsedSegments();
+    const availableRecentlyUsedSegments = availableSegments.filter(
+        (segment) =>
+            recentlyUsedSegmentIds.includes(segment.id) &&
+            !selectedSegments.find((selected) => selected.id === segment.id),
+    );
 
     const atStrategySegmentsLimit: boolean = Boolean(
         strategySegmentsLimit &&
@@ -94,10 +101,12 @@ export const FeatureStrategySegment = ({
                 segments={selectedSegments}
                 setSegments={setSelectedSegments}
             />
-            <RecentlyUsedSegments
-                setSegments={setSelectedSegments}
-                segments={selectedSegments}
-            />
+            {availableRecentlyUsedSegments.length > 0 ? (
+                <RecentlyUsedSegments
+                    setSegments={setSelectedSegments}
+                    segments={availableRecentlyUsedSegments}
+                />
+            ) : null}
         </>
     );
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/RecentlyUsedSegments/RecentlyUsedSegments.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategySegment/RecentlyUsedSegments/RecentlyUsedSegments.tsx
@@ -1,12 +1,10 @@
 import { styled, Typography } from '@mui/material';
-import { useRecentlyUsedSegments } from './useRecentlyUsedSegments.ts';
 import type { ISegment } from 'interfaces/segment';
 import { RecentlyUsedSegmentChip } from './RecentlyUsedSegmentChip.tsx';
-import { useAssignableSegments } from 'hooks/api/getters/useSegments/useAssignableSegments.ts';
 
 type RecentlyUsedSegmentsProps = {
-    setSegments?: React.Dispatch<React.SetStateAction<ISegment[]>>;
-    segments?: ISegment[];
+    setSegments: React.Dispatch<React.SetStateAction<ISegment[]>>;
+    segments: ISegment[];
 };
 
 const StyledContainer = styled('div')(({ theme }) => ({
@@ -27,35 +25,13 @@ const StyledSegmentsContainer = styled('div')(({ theme }) => ({
 
 export const RecentlyUsedSegments = ({
     setSegments,
-    segments = [],
+    segments,
 }: RecentlyUsedSegmentsProps) => {
-    const { items: recentlyUsedSegmentIds } = useRecentlyUsedSegments();
-    const { segments: assignableSegments } = useAssignableSegments();
-    if (
-        recentlyUsedSegmentIds.length === 0 ||
-        !setSegments ||
-        !assignableSegments
-    ) {
-        return null;
-    }
-
-    const segmentObjects = recentlyUsedSegmentIds
-        .map((id) => assignableSegments.find((segment) => segment.id === id))
-        .filter((segment) => segment !== undefined) as ISegment[];
-
-    const nonSelectedRecentSegments = segmentObjects.filter(
-        (segment) => !segments.some((selected) => selected.id === segment.id),
-    );
-
-    if (nonSelectedRecentSegments.length === 0) {
-        return null;
-    }
-
     return (
         <StyledContainer>
             <StyledHeader>Recently used segments</StyledHeader>
             <StyledSegmentsContainer>
-                {nonSelectedRecentSegments.map((segment) => (
+                {segments.map((segment) => (
                     <RecentlyUsedSegmentChip
                         key={segment.id}
                         segment={segment}


### PR DESCRIPTION
Previously, the recently used segments were not filtered in any way, meaning that they might show you a project segment belonging to a different project than the one you're working in. 

This fix uses the new `useAssignableSegments` hook to give you only root-level segments in root contexts and root and project-level segments (for the current project) in project contexts.

closes 1-4468
