### PR TITLE
fix: export ReleasePlanMilestoneStrategyStore for enterprise usage

### DIFF
--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -58,7 +58,10 @@ import type { IUniqueConnectionReadModel } from '../features/unique-connection/u
 import { ReleasePlanStore } from '../features/release-plans/release-plan-store.js';
 import { ReleasePlanTemplateStore } from '../features/release-plans/release-plan-template-store.js';
 import { ReleasePlanMilestoneStore } from '../features/release-plans/release-plan-milestone-store.js';
-import type { IReleasePlanMilestoneStrategyStore } from '../features/release-plans/release-plan-milestone-strategy-store.js';
+import {
+    type IReleasePlanMilestoneStrategyStore,
+    ReleasePlanMilestoneStrategyStore,
+} from '../features/release-plans/release-plan-milestone-strategy-store.js';
 import type { IFeatureLinkStore } from '../features/feature-links/feature-link-store-type.js';
 import type { IUnknownFlagsStore } from '../features/metrics/unknown-flags/unknown-flags-store.js';
 import type { IFeatureLinksReadModel } from '../features/feature-links/feature-links-read-model-type.js';
@@ -193,6 +196,7 @@ export {
     ReleasePlanTemplateStore,
     ReleasePlanMilestoneStore,
     type IReleasePlanMilestoneStrategyStore,
+    ReleasePlanMilestoneStrategyStore,
     type IFeatureLinkStore,
     type IUnknownFlagsStore,
     type IFeatureLinksReadModel,


### PR DESCRIPTION
Only exporting the store interface was breaking unleash-enterprise which consumes `ReleasePlanMilestoneStrategyStore`.

Fixes bug introduced by #11319 