### PR TITLE
chore: Add flag for update milestone strategy

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -90,6 +90,7 @@ export type UiFlags = {
     privateProjectMiddlewareMove?: boolean;
     datePickerRangeConstraints?: boolean;
     signupDialog?: boolean;
+    updateMilestoneStrategy?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -72,7 +72,8 @@ export type IFlagKey =
     | 'privateProjectMiddlewareMove'
     | 'remoteMcpServer'
     | 'datePickerRangeConstraints'
-    | 'signupDialog';
+    | 'signupDialog'
+    | 'updateMilestoneStrategy';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -323,6 +324,10 @@ const flags: IFlags = {
     ),
     signupDialog: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_SIGNUP_DIALOG,
+        false,
+    ),
+    updateMilestoneStrategy: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_UPDATE_MILESTONE_STRATEGY,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -60,6 +60,7 @@ process.nextTick(async () => {
                         readOnlyUsersUI: true,
                         privateProjectMiddlewareMove: true,
                         datePickerRangeConstraints: true,
+                        updateMilestoneStrategy: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Adds a flag for the new update milestone strategy functionality (to be used in the endpoint and potentially the frontend as well). 