### PR TITLE
Single source of operator types

### DIFF
--- a/frontend/src/constants/operators.ts
+++ b/frontend/src/constants/operators.ts
@@ -1,56 +1,44 @@
-export type Operator =
-    | 'NOT_IN'
-    | 'IN'
-    | 'STR_ENDS_WITH'
-    | 'STR_STARTS_WITH'
-    | 'STR_CONTAINS'
-    | 'NUM_EQ'
-    | 'NUM_GT'
-    | 'NUM_GTE'
-    | 'NUM_LT'
-    | 'NUM_LTE'
-    | 'DATE_AFTER'
-    | 'DATE_BEFORE'
-    | 'SEMVER_EQ'
-    | 'SEMVER_GT'
-    | 'SEMVER_LT'
-    | 'REGEX';
-
-export const NOT_IN = 'NOT_IN' as const;
-export const IN = 'IN' as const;
-export const STR_ENDS_WITH = 'STR_ENDS_WITH' as const;
-export const STR_STARTS_WITH = 'STR_STARTS_WITH' as const;
-export const STR_CONTAINS = 'STR_CONTAINS' as const;
-export const NUM_EQ = 'NUM_EQ' as const;
-export const NUM_GT = 'NUM_GT' as const;
-export const NUM_GTE = 'NUM_GTE' as const;
-export const NUM_LT = 'NUM_LT' as const;
-export const NUM_LTE = 'NUM_LTE' as const;
-export const DATE_AFTER = 'DATE_AFTER' as const;
-export const DATE_BEFORE = 'DATE_BEFORE' as const;
-export const SEMVER_EQ = 'SEMVER_EQ' as const;
-export const SEMVER_GT = 'SEMVER_GT' as const;
-export const SEMVER_LT = 'SEMVER_LT' as const;
-export const REGEX = 'REGEX' as const;
-
-export const allOperators: Operator[] = [
-    IN,
+export {
     NOT_IN,
-    STR_CONTAINS,
-    STR_STARTS_WITH,
+    IN,
     STR_ENDS_WITH,
+    STR_STARTS_WITH,
+    STR_CONTAINS,
     NUM_EQ,
     NUM_GT,
     NUM_GTE,
     NUM_LT,
     NUM_LTE,
-    DATE_BEFORE,
     DATE_AFTER,
+    DATE_BEFORE,
     SEMVER_EQ,
     SEMVER_GT,
     SEMVER_LT,
     REGEX,
-];
+} from '@server/util/constants';
+import {
+    ALL_OPERATORS,
+    NOT_IN,
+    IN,
+    STR_ENDS_WITH,
+    STR_STARTS_WITH,
+    STR_CONTAINS,
+    NUM_EQ,
+    NUM_GT,
+    NUM_GTE,
+    NUM_LT,
+    NUM_LTE,
+    DATE_AFTER,
+    DATE_BEFORE,
+    SEMVER_EQ,
+    SEMVER_GT,
+    SEMVER_LT,
+    REGEX,
+} from '@server/util/constants';
+
+export type Operator = (typeof ALL_OPERATORS)[number];
+
+export const allOperators = ALL_OPERATORS;
 
 const isOperator =
     <T extends string>(operators: T[]) =>

--- a/src/lib/features/playground/feature-evaluator/constraint.ts
+++ b/src/lib/features/playground/feature-evaluator/constraint.ts
@@ -2,6 +2,7 @@ import { gt as semverGt, lt as semverLt, eq as semverEq } from 'semver';
 import type { Context } from './context.js';
 import { resolveContextValue } from './helpers.js';
 import { RE2JS } from 're2js';
+import { ALL_OPERATORS } from '../../../util/constants.js';
 
 export interface Constraint {
     contextName: string;
@@ -12,25 +13,10 @@ export interface Constraint {
     caseInsensitive?: boolean;
 }
 
-// TODO: why is this different type?
-export enum Operator {
-    IN = 'IN',
-    NOT_IN = 'NOT_IN',
-    STR_ENDS_WITH = 'STR_ENDS_WITH',
-    STR_STARTS_WITH = 'STR_STARTS_WITH',
-    STR_CONTAINS = 'STR_CONTAINS',
-    NUM_EQ = 'NUM_EQ',
-    NUM_GT = 'NUM_GT',
-    NUM_GTE = 'NUM_GTE',
-    NUM_LT = 'NUM_LT',
-    NUM_LTE = 'NUM_LTE',
-    DATE_AFTER = 'DATE_AFTER',
-    DATE_BEFORE = 'DATE_BEFORE',
-    SEMVER_EQ = 'SEMVER_EQ',
-    SEMVER_GT = 'SEMVER_GT',
-    SEMVER_LT = 'SEMVER_LT',
-    REGEX = 'REGEX',
-}
+export type Operator = (typeof ALL_OPERATORS)[number];
+export const Operator = Object.fromEntries(
+    ALL_OPERATORS.map((op) => [op, op]),
+) as { [K in Operator]: K };
 
 export type OperatorImpl = (
     constraint: Constraint,

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -19,22 +19,22 @@ export const PROJECT_ROLE_TYPES = [PROJECT_ROLE_TYPE, CUSTOM_PROJECT_ROLE_TYPE];
 
 /* CONTEXT FIELD OPERATORS */
 
-export const NOT_IN = 'NOT_IN';
-export const IN = 'IN';
-export const STR_ENDS_WITH = 'STR_ENDS_WITH';
-export const STR_STARTS_WITH = 'STR_STARTS_WITH';
-export const STR_CONTAINS = 'STR_CONTAINS';
-export const NUM_EQ = 'NUM_EQ';
-export const NUM_GT = 'NUM_GT';
-export const NUM_GTE = 'NUM_GTE';
-export const NUM_LT = 'NUM_LT';
-export const NUM_LTE = 'NUM_LTE';
-export const DATE_AFTER = 'DATE_AFTER';
-export const DATE_BEFORE = 'DATE_BEFORE';
-export const SEMVER_EQ = 'SEMVER_EQ';
-export const SEMVER_GT = 'SEMVER_GT';
-export const SEMVER_LT = 'SEMVER_LT';
-export const REGEX = 'REGEX';
+export const NOT_IN = 'NOT_IN' as const;
+export const IN = 'IN' as const;
+export const STR_ENDS_WITH = 'STR_ENDS_WITH' as const;
+export const STR_STARTS_WITH = 'STR_STARTS_WITH' as const;
+export const STR_CONTAINS = 'STR_CONTAINS' as const;
+export const NUM_EQ = 'NUM_EQ' as const;
+export const NUM_GT = 'NUM_GT' as const;
+export const NUM_GTE = 'NUM_GTE' as const;
+export const NUM_LT = 'NUM_LT' as const;
+export const NUM_LTE = 'NUM_LTE' as const;
+export const DATE_AFTER = 'DATE_AFTER' as const;
+export const DATE_BEFORE = 'DATE_BEFORE' as const;
+export const SEMVER_EQ = 'SEMVER_EQ' as const;
+export const SEMVER_GT = 'SEMVER_GT' as const;
+export const SEMVER_LT = 'SEMVER_LT' as const;
+export const REGEX = 'REGEX' as const;
 
 export const ALL_OPERATORS = [
     NOT_IN,


### PR DESCRIPTION
## About the changes

### Important files


## Discussion points

Maybe it's better to keep them separate? 

I'm using `src/lib/util/constants.ts` in frontend and playground. 

Of course there is also a list in `unleash-client` that needs to be in sync with playground https://github.com/Unleash/unleash/actions/runs/22148875665/job/64034106151?pr=11339 


