### PR TITLE
chore: deprecate update feature strategy name

### DIFF
--- a/src/lib/openapi/spec/update-feature-strategy-schema.ts
+++ b/src/lib/openapi/spec/update-feature-strategy-schema.ts
@@ -9,7 +9,9 @@ export const updateFeatureStrategySchema = {
     properties: {
         name: {
             type: 'string',
-            description: 'The name of the strategy type',
+            description:
+                "The name of the strategy type. This property is deprecated and the ability to change a strategy's type will be removed in a future release.",
+            deprecated: true,
         },
         sortOrder: {
             type: 'number',


### PR DESCRIPTION
Deprecates the `name` property on `update-feature-strategy-schema`. We shouldn't allow updating a strategy's type after its creation, so this deprecates the property in preparation for removal.