### PR TITLE
chore: delete unused code

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyType/FeatureStrategyType.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyType/FeatureStrategyType.tsx
@@ -2,7 +2,6 @@ import type { IStrategy, StrategyFormState } from 'interfaces/strategy';
 import DefaultStrategy from 'component/feature/StrategyTypes/DefaultStrategy/DefaultStrategy';
 import FlexibleStrategy from 'component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy';
 import GeneralStrategy from 'component/feature/StrategyTypes/GeneralStrategy/GeneralStrategy';
-import { useAssignableUnleashContext } from 'hooks/api/getters/useUnleashContext/useAssignableUnleashContext';
 import produce from 'immer';
 import type React from 'react';
 import type { IFormErrors } from 'hooks/useFormErrors';
@@ -24,8 +23,6 @@ export const FeatureStrategyType = <T extends StrategyFormState>({
     validateParameter,
     errors,
 }: IFeatureStrategyTypeProps<T>) => {
-    const { context } = useAssignableUnleashContext();
-
     const updateParameter = (name: string, value: string) => {
         setStrategy(
             produce((draft) => {
@@ -42,7 +39,6 @@ export const FeatureStrategyType = <T extends StrategyFormState>({
         case 'flexibleRollout':
             return (
                 <FlexibleStrategy
-                    context={context}
                     parameters={strategy.parameters ?? {}}
                     updateParameter={updateParameter}
                     editable={hasAccess}

--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.test.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.test.tsx
@@ -36,7 +36,6 @@ test('manipulates the rollout slider', async () => {
                         <FlexibleStrategy
                             parameters={parameters}
                             updateParameter={updateParameter}
-                            context={{}}
                             editable={true}
                         />
                     }
@@ -76,7 +75,6 @@ test('if stickiness or groupId not present, fill it with defaults', async () => 
                             rollout: '50',
                         }}
                         updateParameter={updateParameter}
-                        context={{}}
                         editable={true}
                     />
                 }
@@ -111,7 +109,6 @@ test('displays groupId error', async () => {
                             _parameter: string,
                             _value: string,
                         ) => {}}
-                        context={{}}
                         editable={true}
                         errors={
                             {

--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/FlexibleStrategy.tsx
@@ -22,7 +22,6 @@ import type { IFormErrors } from 'hooks/useFormErrors';
 interface IFlexibleStrategyProps {
     parameters: IFeatureStrategyParameters;
     updateParameter: (field: string, value: string) => void;
-    context: any;
     editable: boolean;
     errors?: IFormErrors;
 }


### PR DESCRIPTION
There's more changes to come, but there's a lot to untangle, so we can at least start with this pretty innocuous step: remove a parameter that isn't used anywhere.