### PR TITLE
Regex constaint validation  on frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,6 +163,7 @@
   "dependencies": {
     "chartjs-plugin-datalabels": "^2.2.0",
     "json-2-csv": "^5.5.5",
-    "json-diff-react": "^1.0.1"
+    "json-diff-react": "^1.0.1",
+    "re2js": "^1.2.2"
   }
 }

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintOperatorSelect.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintOperatorSelect.tsx
@@ -105,12 +105,7 @@ export const ConstraintOperatorSelect = ({
 
     const operators = isRegexOperatorEnabled
         ? options
-        : options.filter((operator) => {
-              if (isRegexOperator(operator)) {
-                  return false;
-              }
-              return true;
-          });
+        : options.filter((operator) => !isRegexOperator(operator));
 
     return (
         <FormControl variant='standard' size='small' hiddenLabel>

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-validator.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-validator.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import { allOperators } from 'constants/operators';
+import { constraintValidator } from './constraint-validator';
+
+describe('constraintValidator', () => {
+    describe('number operator', () => {
+        const validate = constraintValidator('NUM_EQ');
+
+        test('accepts valid numbers', () => {
+            expect(validate('123')).toEqual([true, '']);
+            expect(validate('0')).toEqual([true, '']);
+            expect(validate('-1')).toEqual([true, '']);
+            expect(validate('3.14')).toEqual([true, '']);
+        });
+
+        test('rejects non-numeric strings', () => {
+            const [valid] = validate('abc');
+            expect(valid).toBe(false);
+        });
+
+        test('gives a hint when comma is used as decimal separator', () => {
+            const [valid, message] = validate('3,14');
+            expect(valid).toBe(false);
+            expect(message).toContain('Comma');
+        });
+    });
+
+    describe('semver operator', () => {
+        const validate = constraintValidator('SEMVER_EQ');
+
+        test('accepts valid semver', () => {
+            expect(validate('1.2.3')).toEqual([true, '']);
+            expect(validate('0.0.1')).toEqual([true, '']);
+        });
+
+        test('rejects invalid semver', () => {
+            const [valid] = validate('not-semver');
+            expect(valid).toBe(false);
+        });
+
+        test('rejects unclean semver', () => {
+            const [valid] = validate('v1.2.3');
+            expect(valid).toBe(false);
+        });
+    });
+
+    describe('date operator', () => {
+        const validate = constraintValidator('DATE_AFTER');
+
+        test('accepts valid ISO dates', () => {
+            expect(validate('2024-01-15T00:00:00Z')).toEqual([true, '']);
+            expect(validate('2024-06-01')).toEqual([true, '']);
+        });
+
+        test('rejects invalid dates', () => {
+            const [valid] = validate('not-a-date');
+            expect(valid).toBe(false);
+        });
+    });
+
+    describe('regex operator', () => {
+        const validate = constraintValidator('REGEX');
+
+        test('accepts valid regex', () => {
+            expect(validate('^foo.*bar$')).toEqual([true, '']);
+            expect(validate('[a-z]+')).toEqual([true, '']);
+        });
+
+        test('rejects invalid regex', () => {
+            const [valid, message] = validate('[invalid');
+            expect(valid).toBe(false);
+            expect(message).toMatch(/Value must be a valid RE2 regex\. Error/);
+
+            // This assertion is a bit brittle, but it ensures that the error message from the RE2 parser is included in the final message
+            expect(message).toBe(
+                'Value must be a valid RE2 regex. Error parsing regexp: missing closing ]: `[invalid`',
+            );
+        });
+    });
+
+    describe('string list operator (default)', () => {
+        const validate = constraintValidator('IN');
+
+        test('accepts string values', () => {
+            expect(validate('hello', 'world')).toEqual([true, '']);
+        });
+    });
+
+    test('every operator has a validator', () => {
+        for (const operator of allOperators) {
+            const validator = constraintValidator(operator);
+            expect(validator, `missing validator for ${operator}`).toBeTypeOf(
+                'function',
+            );
+        }
+    });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8712,6 +8712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"re2js@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "re2js@npm:1.2.2"
+  checksum: 10c0/423b058c205cb35b5d89b401268f0587798d33cefe94e43863c428b9bd0eb993102658201b52ffd13338e657a8e81d4a99a2de11d43a71303ad155065d8ea95c
+  languageName: node
+  linkType: hard
+
 "react-activity-calendar@npm:^2.7.11":
   version: 2.7.12
   resolution: "react-activity-calendar@npm:2.7.12"
@@ -10629,6 +10636,7 @@ __metadata:
     pkginfo: "npm:0.4.1"
     plausible-tracker: "npm:0.3.9"
     prop-types: "npm:15.8.1"
+    re2js: "npm:^1.2.2"
     react: "npm:18.3.1"
     react-archer: "npm:4.4.0"
     react-chartjs-2: "npm:4.3.1"


### PR DESCRIPTION
## About the changes

Basic validation

<img width="299" height="208" alt="Zrzut ekranu 2026-02-19 o 14 39 36" src="https://github.com/user-attachments/assets/369cef54-425d-4fc9-a952-34adc9e68168" />

Closes 
https://linear.app/unleash/issue/2-4196/add-frontend-validation-of-regex
and 
https://linear.app/unleash/issue/2-4206/check-regex-context-fields-legal-values-of-type-regex

This will also disable invalid regexes in legal values: 

<img width="773" height="359" alt="Zrzut ekranu 2026-02-19 o 14 39 14" src="https://github.com/user-attachments/assets/9b7d9dec-b6b0-470b-afc3-c368ff0ad535" />


### Important files

Tests are generated

Take a look at this one: https://github.com/Unleash/unleash/pull/11366/changes#r2828081081

## Discussion points

