### PR TITLE
chore: accept partial MilestoneStrategyConfig updates

### DIFF
--- a/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
@@ -2,6 +2,7 @@ import type {
     IAuditUser,
     IUnleashConfig,
     MilestoneStrategyConfig,
+    MilestoneStrategyConfigUpdate,
 } from '../../types/index.js';
 import type { IUser } from '../../types/user.js';
 import type { Logger } from '../../logger.js';
@@ -41,7 +42,7 @@ export class ReleasePlanMilestoneStrategyService {
 
     async updateStrategy(
         id: string,
-        strategy: Partial<MilestoneStrategyConfig>,
+        strategy: Partial<MilestoneStrategyConfigUpdate>,
         context: MilestoneStrategyContext,
         auditUser: IAuditUser,
         user?: IUser,

--- a/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
@@ -3,7 +3,7 @@ import type { ReleasePlanMilestoneStrategy } from './release-plan-milestone-stra
 import { CRUDStore, type CrudStoreConfig } from '../../db/crud/crud-store.js';
 import type { Row } from '../../db/crud/row-type.js';
 import type { Db } from '../../db/db.js';
-import type { MilestoneStrategyConfig } from '../../types/index.js';
+import type { MilestoneStrategyConfigUpdate } from '../../types/index.js';
 import type { Store } from '../../types/stores/store.js';
 const TABLE = 'milestone_strategies';
 
@@ -22,7 +22,7 @@ export interface IReleasePlanMilestoneStrategyStore
     ): Promise<ReleasePlanMilestoneStrategy>;
     upsert(
         id: string,
-        updates: Partial<MilestoneStrategyConfig>,
+        updates: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy>;
     deleteStrategiesForMilestone(milestoneId: string): Promise<void>;
 }
@@ -54,12 +54,11 @@ const toRow = (item: ReleasePlanMilestoneStrategyWriteModel) => {
     };
 };
 
-const toUpdateRow = (item: Partial<MilestoneStrategyConfig>) => {
+const toUpdateRow = (item: Partial<MilestoneStrategyConfigUpdate>) => {
     return {
         milestone_id: item.milestoneId,
         sort_order: item.sortOrder,
         title: item.title,
-        strategy_name: item.strategyName,
         parameters: item.parameters ?? {},
         constraints: JSON.stringify(item.constraints ?? []),
         variants: JSON.stringify(item.variants ?? []),
@@ -98,7 +97,7 @@ export class ReleasePlanMilestoneStrategyStore
 
     private async updateStrategy(
         strategyId: string,
-        { segments, ...strategy }: Partial<MilestoneStrategyConfig>,
+        { segments, ...strategy }: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy> {
         const rows = await this.db(this.tableName)
             .where({ id: strategyId })
@@ -109,7 +108,7 @@ export class ReleasePlanMilestoneStrategyStore
 
     async upsert(
         strategyId: string,
-        { segments, ...strategy }: Partial<MilestoneStrategyConfig>,
+        { segments, ...strategy }: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy> {
         const releasePlanMilestoneStrategy = await this.updateStrategy(
             strategyId,

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -44,6 +44,11 @@ export type MilestoneStrategyConfig = Omit<IStrategyConfig, 'name'> & {
     strategyName: string;
 };
 
+export type MilestoneStrategyConfigUpdate = Omit<
+    MilestoneStrategyConfig,
+    'strategyName'
+>;
+
 export interface IFeatureStrategy {
     id: string;
     featureName: string;

--- a/src/test/fixtures/fake-release-plan-milestone-strategy-store.ts
+++ b/src/test/fixtures/fake-release-plan-milestone-strategy-store.ts
@@ -1,6 +1,6 @@
 import type { ReleasePlanMilestoneStrategy } from '../../lib/features/release-plans/release-plan-milestone-strategy.js';
 import type { IReleasePlanMilestoneStrategyStore } from '../../lib/features/release-plans/release-plan-milestone-strategy-store.js';
-import type { MilestoneStrategyConfig } from '../../lib/types/model.js';
+import type { MilestoneStrategyConfigUpdate } from '../../lib/types/model.js';
 
 export class FakeReleasePlanMilestoneStrategyStore
     implements IReleasePlanMilestoneStrategyStore
@@ -32,7 +32,7 @@ export class FakeReleasePlanMilestoneStrategyStore
 
     async upsert(
         _strategyId: string,
-        _strategy: Partial<MilestoneStrategyConfig>,
+        _strategy: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy> {
         return {} as ReleasePlanMilestoneStrategy;
     }


### PR DESCRIPTION
Makes `updateStrategy` and the related store methods accept partial updates (this way we can also avoid updating `strategyName`).