### PR TITLE
fix: show longer legal values

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/LegalValuesSelector.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/LegalValuesSelector.tsx
@@ -16,8 +16,8 @@ import type { ILegalValue } from 'interfaces/context';
 import React from 'react';
 
 const StyledValuesContainer = styled('div')(({ theme }) => ({
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+    display: 'flex',
+    flexWrap: 'wrap',
     gap: theme.spacing(1),
     maxHeight: '378px',
     overflow: 'auto',


### PR DESCRIPTION
## Problem

Long legal values are hard to read. 

Approved by UX in https://linear.app/unleash/issue/2-4221/fix-rendering-of-long-legal-values#comment-c1fa4271


<img width="753" height="374" alt="Zrzut ekranu 2026-02-27 o 10 05 10" src="https://github.com/user-attachments/assets/867fb6e6-ff04-4b3a-8e1e-473e15669898" />


## About the changes
<img width="338" height="258" alt="Zrzut ekranu 2026-02-23 o 15 55 30" src="https://github.com/user-attachments/assets/8ef4ae72-cec5-41fd-b995-cbb4a0822063" />
<img width="864" height="337" alt="Zrzut ekranu 2026-02-23 o 15 52 08" src="https://github.com/user-attachments/assets/b516c1f8-9944-4b13-8430-b5e9b199dc7c" />
<img width="564" height="527" alt="Zrzut ekranu 2026-02-23 o 15 37 10" src="https://github.com/user-attachments/assets/51a1aea9-5309-4678-9dae-486a0bda360c" />



Closes 
* https://linear.app/unleash/issue/2-4221/fix-rendering-of-long-legal-values


### Important files


## Discussion points

