### PR TITLE
feat: add CR support for milestone strategy update

### DIFF
--- a/src/lib/features/release-plans/createReleasePlanMilestoneStrategyService.ts
+++ b/src/lib/features/release-plans/createReleasePlanMilestoneStrategyService.ts
@@ -7,19 +7,29 @@ import {
     createFakeFeatureToggleService,
 } from '../feature-toggle/createFeatureToggleService.js';
 import { FakeReleasePlanMilestoneStrategyStore } from '../../../test/fixtures/fake-release-plan-milestone-strategy-store.js';
+import {
+    createChangeRequestAccessReadModel,
+    createFakeChangeRequestAccessService,
+} from '../change-request-access-service/createChangeRequestAccessReadModel.js';
 
 export const createReleasePlanMilestoneStrategyService = (
     db: Db,
     config: IUnleashConfig,
 ): ReleasePlanMilestoneStrategyService => {
-    const milestoneStrategyStore = new ReleasePlanMilestoneStrategyStore(db, {
-        eventBus: config.eventBus,
-    });
+    const releasePlanMilestoneStrategyStore =
+        new ReleasePlanMilestoneStrategyStore(db, {
+            eventBus: config.eventBus,
+        });
     const featureToggleService = createFeatureToggleService(db, config);
+    const changeRequestAccessReadModel = createChangeRequestAccessReadModel(
+        db,
+        config,
+    );
 
     return new ReleasePlanMilestoneStrategyService(
-        { milestoneStrategyStore },
+        { releasePlanMilestoneStrategyStore },
         { featureToggleService },
+        changeRequestAccessReadModel,
         config,
     );
 };
@@ -31,10 +41,12 @@ export const createFakeReleasePlanMilestoneStrategyService = (
     const { featureToggleService, projectStore } =
         createFakeFeatureToggleService(config);
 
+    const changeRequestAccessReadModel = createFakeChangeRequestAccessService();
     const releasePlanMilestoneStrategyService =
         new ReleasePlanMilestoneStrategyService(
-            { milestoneStrategyStore },
+            { releasePlanMilestoneStrategyStore: milestoneStrategyStore },
             { featureToggleService },
+            changeRequestAccessReadModel,
             config,
         );
 

--- a/src/lib/features/release-plans/release-plan-milestone-strategy-service.test.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-service.test.ts
@@ -6,7 +6,9 @@ import { DEFAULT_ENV } from '../../util/constants.js';
 import type { FeatureToggleService } from '../feature-toggle/feature-toggle-service.js';
 import type FakeProjectStore from '../../../test/fixtures/fake-project-store.js';
 import type { FakeReleasePlanMilestoneStrategyStore } from '../../../test/fixtures/fake-release-plan-milestone-strategy-store.js';
-import type { ReleasePlanMilestoneStrategyService } from './release-plan-milestone-strategy-service.js';
+import { ReleasePlanMilestoneStrategyService } from './release-plan-milestone-strategy-service.js';
+import { FakeChangeRequestAccessReadModel } from '../change-request-access-service/fake-change-request-access-read-model.js';
+import { SKIP_CHANGE_REQUEST } from '../../server-impl.js';
 
 const defaultContext = {
     projectId: 'default',
@@ -40,7 +42,7 @@ const createFeatureStrategy = async (milestoneStrategy) => {
     );
 };
 
-test('should also update feature strategy when present', async () => {
+test('also updates feature strategy when present', async () => {
     await projectStore.create({
         id: defaultContext.projectId,
         name: 'Default',
@@ -84,4 +86,28 @@ test('should also update feature strategy when present', async () => {
             parameters: expect.objectContaining({ rollout: '50' }),
         }),
     );
+});
+
+test('throws PermissionError when user cannot bypass change requests', async () => {
+    const config = createTestConfig();
+    const service = new ReleasePlanMilestoneStrategyService(
+        { releasePlanMilestoneStrategyStore: milestoneStrategyStore },
+        { featureToggleService },
+        new FakeChangeRequestAccessReadModel(false),
+        config,
+    );
+
+    await expect(
+        service.updateStrategy(
+            'some-id',
+            {
+                title: 'updated-title',
+                parameters: { rollout: '50' },
+                constraints: [],
+                variants: [],
+            },
+            defaultContext,
+            TEST_AUDIT_USER,
+        ),
+    ).rejects.toThrow(SKIP_CHANGE_REQUEST);
 });


### PR DESCRIPTION
Adds a check for change requests in the service and exposes `unprotectedUpdateStrategy` so that the CR executor can call it. 
Also calls `featureToggleService.unprotectedUpdateStrategy()` (instead of `featureToggleService.updateStrategy`) to avoid hitting a second CR guard. 