### PR TITLE
chore: add strategyFormConsolidation flag to Unleash

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -92,6 +92,7 @@ export type UiFlags = {
     regexConstraintOperator?: boolean;
     signupDialog?: boolean;
     updateMilestoneStrategy?: boolean;
+    strategyFormConsolidation?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -74,6 +74,7 @@ export type IFlagKey =
     | 'datePickerRangeConstraints'
     | 'regexConstraintOperator'
     | 'signupDialog'
+    | 'strategyFormConsolidation'
     | 'updateMilestoneStrategy';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -333,6 +334,10 @@ const flags: IFlags = {
     ),
     updateMilestoneStrategy: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_UPDATE_MILESTONE_STRATEGY,
+        false,
+    ),
+    strategyFormConsolidation: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_STRATEGY_FORM_CONSOLIDATION,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -62,6 +62,7 @@ process.nextTick(async () => {
                         datePickerRangeConstraints: true,
                         regexConstraintOperator: true,
                         updateMilestoneStrategy: true,
+                        strategyFormConsolidation: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
To let us add non-trivial component changes behind a flag. In first instance, to gate the merged component that's being introduced in https://github.com/Unleash/unleash/pull/11376.