### PR TITLE
feat: PostgreSQL lock contention on client_applications bulk upsert

### DIFF
--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -806,6 +806,14 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
 
     const edgeClientSecret =
         options.edgeClientSecret ?? process.env.EDGE_CLIENT_SECRET;
+
+    const clientApplicationSeenAtUpdateIntervalSeconds =
+        options.clientApplicationSeenAtUpdateIntervalSeconds ??
+        parseEnvVarNumber(
+            process.env.CLIENT_APP_SEEN_TTL_SECONDS,
+            0,
+        );
+
     return {
         db,
         session,
@@ -854,5 +862,6 @@ export function createConfig(options: IUnleashOptions): IUnleashConfig {
         checkDbOnReady,
         edgeMasterKey,
         edgeClientSecret,
+        clientApplicationSeenAtUpdateIntervalSeconds,
     };
 }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -93,6 +93,7 @@ export const createStores = (
             eventBus,
             getLogger,
             config.flagResolver,
+            config.clientApplicationSeenAtUpdateIntervalSeconds,
         ),
         clientInstanceStore: new ClientInstanceStore(db, eventBus, getLogger),
         clientMetricsStoreV2: new ClientMetricsStoreV2(

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -185,6 +185,7 @@ export interface IUnleashOptions {
     checkDbOnReady?: boolean;
     edgeMasterKey?: string;
     edgeClientSecret?: string;
+    clientApplicationSeenAtUpdateIntervalSeconds?: number;
 }
 
 export interface IEmailOption {
@@ -315,4 +316,5 @@ export interface IUnleashConfig {
     checkDbOnReady?: boolean;
     edgeMasterKey?: string;
     edgeClientSecret?: string;
+    clientApplicationSeenAtUpdateIntervalSeconds: number;
 }


### PR DESCRIPTION
## About the changes

Reduces PostgreSQL lock contention on the `client_applications` table caused by
concurrent `INSERT … ON CONFLICT (app_name) DO UPDATE` writes during high-concurrency
events (rollouts, HPA scale-ups, mass restarts with 20+ pods).

**Root cause:** `bulkAdd()` fires every 10 s on every pod. With N pods all flushing at
the same time, N concurrent upserts queue behind each other on the same row locks,
producing `wait_event = 'transactionid'` waits of 25–47 s in PostgreSQL.

**Fix:** A new opt-in environment variable `CLIENT_APP_SEEN_TTL_SECONDS` adds a `WHERE`
condition to the `ON CONFLICT DO UPDATE` in `ClientApplicationsStore.bulkUpsert()`:

```sql
ON CONFLICT (app_name) DO UPDATE SET
    updated_at = EXCLUDED.updated_at,
    seen_at    = EXCLUDED.seen_at
WHERE client_applications.seen_at < EXCLUDED.seen_at - interval '<N> seconds'
```

When the condition is false (the row was already updated within the window), PostgreSQL
skips the write and releases the row lock almost immediately instead of queuing all pods
behind each other.

| `CLIENT_APP_SEEN_TTL_SECONDS` | Behaviour |
|---|---|
| not set / `0` (default) | Original behaviour — always updates `seen_at` |
| `60` | Only updates if the row is older than 60 s |
| `300` | Only updates if the row is older than 5 min |

Closes #

### Important files

| File | Why it matters |
|---|---|
| `src/lib/db/client-applications-store.ts` | Core fix — conditional `WHERE` in `bulkUpsert()` |
| `src/lib/create-config.ts` | Reads `CLIENT_APP_SEEN_TTL_SECONDS`, default `0` |
| `src/lib/types/option.ts` | Adds `clientApplicationSeenAtUpdateIntervalSeconds` to `IUnleashOptions` / `IUnleashConfig` |
| `src/lib/db/index.ts` | Passes the new config value to `ClientApplicationsStore` |

## Discussion points

- **Default is `0` (disabled)** — no behaviour change for existing deployments. Operators
  affected by lock contention opt in by setting the env var.
- **Recommended starting value:** `60` (1 min). The `bulkAdd` scheduler runs every 10 s,
  so a 60 s window reduces actual DB writes by ~6× per pod and ~120× with 20 pods.
- **`seen_at` precision:** the field is used only for the 30-day inactivity cleanup
  (`removeInactiveApplications`), so a 1–5 min lag has no functional impact.
- **`upsert()` (single-app path) is unchanged** — the threshold only applies to the
  high-frequency bulk path.
