### PR TITLE
chore: fix signup-related dialog zIndex

### DIFF
--- a/frontend/src/component/personalDashboard/WelcomeDialog.tsx
+++ b/frontend/src/component/personalDashboard/WelcomeDialog.tsx
@@ -8,6 +8,7 @@ import { ScreenReaderOnly } from '../common/ScreenReaderOnly/ScreenReaderOnly.ts
 import { formatAssetPath } from 'utils/formatPath';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
+    zIndex: theme.zIndex.modal + 1,
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
         width: '65vw',

--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -28,6 +28,7 @@ const StyledUnleashLogo = styled(UnleashLogo)({
 });
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
+    zIndex: theme.zIndex.modal + 2,
     '.MuiBackdrop-root': {
         backdropFilter: 'blur(8px)',
     },


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-126/dont-show-release-management-dialog-on-top-of-key-concepts

Ensures signup-related dialogs zIndex make sense: welcome dialog above other dialogs, signup dialog above the welcome one.