### PR TITLE
chore: add interactiveDemoKillSwitch to experimental

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -19,6 +19,7 @@ export type IFlagKey =
     | 'personalAccessTokensKillSwitch'
     | 'migrationLock'
     | 'demo'
+    | 'interactiveDemoKillSwitch'
     | 'advancedPlayground'
     | 'filterInvalidClientMetrics'
     | 'disableMetrics'
@@ -112,6 +113,10 @@ const flags: IFlags = {
     ),
     migrationLock: parseEnvVarBoolean(process.env.MIGRATION_LOCK, true),
     demo: parseEnvVarBoolean(process.env.UNLEASH_DEMO, false),
+    interactiveDemoKillSwitch: parseEnvVarBoolean(
+        process.env.UNLEASH_INTERACTIVE_DEMO_KILL_SWITCH,
+        false,
+    ),
     filterInvalidClientMetrics: parseEnvVarBoolean(
         process.env.FILTER_INVALID_CLIENT_METRICS,
         false,


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-130/add-interactivedemokillswitch-that-controls-whether-the-demo-includes

It seems that, in order to get this flag in `uiConfig` in its evaluated state, we need to add it to the list of flags in `experimental`.

Follow-up to: https://github.com/Unleash/unleash/pull/11391