### PR TITLE
chore: update instance add scheduler to 20s from 10s

### DIFF
--- a/src/lib/features/scheduler/schedule-services.ts
+++ b/src/lib/features/scheduler/schedule-services.ts
@@ -89,7 +89,7 @@ export const scheduleServices = (
 
     schedulerService.schedule(
         clientInstanceService.bulkAdd.bind(clientInstanceService),
-        secondsToMilliseconds(10),
+        secondsToMilliseconds(20),
         'bulkAddInstances',
     );
 


### PR DESCRIPTION
This halves the frequency of `client_applications`  bulk upserts from each pod, which should reduce the amount of lock conflicts.