### PR TITLE
fix: render projects only as list past 500 projects

### DIFF
--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
@@ -32,6 +32,8 @@ const StyledContainer = styled('div')(({ theme }) => ({
     gap: theme.spacing(4),
 }));
 
+const projectCardDisplayLimit = 500;
+
 export const ProjectList = () => {
     const { projects, loading, error, refetch } = useProjects();
     const { isOss } = useUiConfig();
@@ -39,6 +41,16 @@ export const ProjectList = () => {
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
     const [state, setState] = useProjectsListState();
+
+    const forceListView = projects.length > projectCardDisplayLimit;
+    useEffect(() => {
+        if (forceListView && state.view !== 'list') {
+            setState({ view: 'list' });
+        }
+    }, [forceListView, state.view]);
+
+    const showViewToggleButton = !(isOss() || forceListView);
+    const safeView = forceListView ? 'list' : state.view;
 
     const myProfileProjects = new Set(useProfile().profile?.projects || []);
 
@@ -128,7 +140,7 @@ export const ProjectList = () => {
                                 helpText='Favorite projects, projects you own, and projects you are a member of'
                                 actions={
                                     <>
-                                        {!isOss() && (
+                                        {showViewToggleButton && (
                                             <ProjectsListViewToggle
                                                 view={state.view}
                                                 setView={(view) =>
@@ -151,7 +163,7 @@ export const ProjectList = () => {
                             </ProjectsListHeader>
                             <ProjectGroup
                                 loading={loading}
-                                view={state.view}
+                                view={safeView}
                                 projects={
                                     isOss()
                                         ? sortedProjects
@@ -167,7 +179,7 @@ export const ProjectList = () => {
                             </ProjectsListHeader>
                             <ProjectGroup
                                 loading={loading}
-                                view={state.view}
+                                view={safeView}
                                 projects={otherProjects}
                             />
                         </div>


### PR DESCRIPTION
When the project list gets very long, rendering the project cards takes too long (I had ~10s to render 3000) and the UI becomes unresponsive for that period of time.

Rendering the projects as a list instead mitigates that and renders fine, even at 3k projects.

This PR sets an upper limit for displaying cards (semi-arbitrarily to 500), after which it will force the UI to use the 'list' view and hide the toggle button. Additionally, if your query param is not `list`, it will update the query param.