### PR TITLE
chore: fix interactiveDemoKillSwitch still showing steps

### DIFF
--- a/frontend/src/component/demo/Demo.tsx
+++ b/frontend/src/component/demo/Demo.tsx
@@ -109,12 +109,14 @@ export const Demo = ({ children }: IDemoProps): JSX.Element => {
         <>
             <DemoBanner />
             {children}
-            {interactiveDemoKillSwitch && welcomeOpen ? (
-                <DemoDialogWelcome
-                    open={welcomeOpen}
-                    onClose={onWelcomeClose}
-                    onStart={onWelcomeStart}
-                />
+            {interactiveDemoKillSwitch ? (
+                welcomeOpen && (
+                    <DemoDialogWelcome
+                        open={welcomeOpen}
+                        onClose={onWelcomeClose}
+                        onStart={onWelcomeStart}
+                    />
+                )
             ) : (
                 <ConditionallyRender
                     condition={!isSmallScreen}


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-135/fix-interactive-demo-kill-switch-should-not-show-interactive-steps

Fixes the `interactiveDemoKillSwitch` behavior by actually hiding (not rendering) the interactive steps if enabled, even when the dialog is closed.