### PR TITLE
chore: remove unused project id prop

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -165,7 +165,6 @@ export const EditChange = ({
                 }
             >
                 <FeatureStrategyForm
-                    projectId={projectId}
                     feature={data}
                     strategy={strategy}
                     setStrategy={setStrategy}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -221,7 +221,6 @@ export const FeatureStrategyCreate = () => {
             }
         >
             <FeatureStrategyForm
-                projectId={projectId}
                 feature={data}
                 strategy={strategy}
                 setStrategy={setStrategy}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -296,7 +296,6 @@ export const FeatureStrategyEdit = () => {
             }
         >
             <FeatureStrategyForm
-                projectId={projectId}
                 feature={data}
                 strategy={strategy}
                 setStrategy={setStrategy}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyForm/FeatureStrategyForm.tsx
@@ -55,7 +55,6 @@ import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 interface IFeatureStrategyFormProps {
     feature: IFeatureToggle;
-    projectId: string;
     environmentId: string;
     permission: string;
     onSubmit: () => void;
@@ -163,7 +162,6 @@ const StyledConstraintSeparator = styled(ConstraintSeparator)({
 });
 
 export const FeatureStrategyForm = ({
-    projectId,
     feature,
     environmentId,
     permission,


### PR DESCRIPTION
The `projectId` prop for the feature strategy form is unused, so let's get rid of it.