### PR TITLE
fix: missing strategy name in editing release plan strategies

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/LegacyReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/LegacyReleasePlanTemplateAddStrategyForm.tsx
@@ -125,7 +125,10 @@ export const LegacyReleasePlanTemplateAddStrategyForm = ({
     onAddUpdateStrategy,
     editMode,
 }: IReleasePlanTemplateAddStrategyFormProps) => {
-    const [currentStrategy, setCurrentStrategy] = useState(strategy);
+    const [currentStrategy, setCurrentStrategy] = useState({
+        ...strategy,
+        name: strategy.name || strategy.strategyName || '',
+    });
     const [activeTab, setActiveTab] = useState(0);
     const { segments: allSegments } = useSegments();
     const { segments: assignableSegments = [] } = useAssignableSegments();

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/ReleasePlanTemplateAddStrategyForm.tsx
@@ -125,7 +125,10 @@ const _NewReleasePlanTemplateAddStrategyForm = ({
     onAddUpdateStrategy,
     editMode,
 }: IReleasePlanTemplateAddStrategyFormProps) => {
-    const [currentStrategy, setCurrentStrategy] = useState(strategy);
+    const [currentStrategy, setCurrentStrategy] = useState({
+        ...strategy,
+        name: strategy.name || strategy.strategyName || '',
+    });
     const [activeTab, setActiveTab] = useState(0);
     const { segments: allSegments } = useSegments();
     const { segments: assignableSegments = [] } = useAssignableSegments();


### PR DESCRIPTION
When editing release plan strategies, the `strategyName` would be set, but not the `name`. This caused strategies to be rendered as `GeneralStrategy` instead of `GradualRollout`. This fix ensures that it's populated when we initialize the form.

The reason this started failing now is that https://github.com/Unleash/unleash/pull/11385 switched it to using the one from the feature strat form, but failed to account for this.

But the good news is that the UI is tolerant enough to still be pretty useful.

Before fix:
<img width="1001" height="821" alt="image" src="https://github.com/user-attachments/assets/c89aa85b-df0b-449d-b909-3b3bb44689af" />


After fix:
<img width="1005" height="667" alt="image" src="https://github.com/user-attachments/assets/0fe40311-80a3-4fdd-a31d-e5380a98501a" />
