### PR TITLE
chore: add link to new demo walkthrough

### DIFF
--- a/frontend/src/component/demo/Demo.tsx
+++ b/frontend/src/component/demo/Demo.tsx
@@ -13,6 +13,7 @@ import theme from 'themes/theme';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useUiFlag } from 'hooks/useUiFlag.ts';
 import { useNavigate } from 'react-router-dom';
+import { DemoNotice } from './DemoNotice.tsx';
 
 const defaultProgress = {
     welcomeOpen: true,
@@ -91,15 +92,15 @@ export const Demo = ({ children }: IDemoProps): JSX.Element => {
                 step: 'welcome',
             },
         });
-
-        if (interactiveDemoKillSwitch) {
-            navigate(`/projects/${DEMO_PROJECT}?sort=name`);
-        }
     };
 
     const onWelcomeStart = () => {
         setWelcomeOpen(false);
-        onStart();
+        if (interactiveDemoKillSwitch) {
+            navigate(`/projects/${DEMO_PROJECT}?sort=name`);
+        } else {
+            onStart();
+        }
         trackEvent('demo-start');
     };
 
@@ -110,13 +111,21 @@ export const Demo = ({ children }: IDemoProps): JSX.Element => {
             <DemoBanner />
             {children}
             {interactiveDemoKillSwitch ? (
-                welcomeOpen && (
-                    <DemoDialogWelcome
-                        open={welcomeOpen}
-                        onClose={onWelcomeClose}
-                        onStart={onWelcomeStart}
+                <>
+                    {welcomeOpen && (
+                        <DemoDialogWelcome
+                            open={welcomeOpen}
+                            onClose={onWelcomeClose}
+                            onStart={onWelcomeStart}
+                        />
+                    )}
+                    <DemoNotice
+                        onClick={() => {
+                            setWelcomeOpen(true);
+                            trackEvent('demo-view-demo-link');
+                        }}
                     />
-                )
+                </>
             ) : (
                 <ConditionallyRender
                     condition={!isSmallScreen}

--- a/frontend/src/component/demo/DemoDialog/DemoDialog.tsx
+++ b/frontend/src/component/demo/DemoDialog/DemoDialog.tsx
@@ -11,7 +11,7 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusExtraLarge,
         maxWidth: theme.spacing(90),
-        padding: theme.spacing(7.5),
+        padding: theme.spacing(4),
         textAlign: 'center',
     },
     zIndex: theme.zIndex.snackbar,

--- a/frontend/src/component/demo/DemoDialog/DemoDialogWelcome/DemoDialogWelcome.tsx
+++ b/frontend/src/component/demo/DemoDialog/DemoDialogWelcome/DemoDialogWelcome.tsx
@@ -12,8 +12,8 @@ const StyledDemoPane = styled('div')(({ theme }) => ({
     alignItems: 'center',
     backgroundColor: theme.palette.neutral.light,
     borderRadius: theme.shape.borderRadiusLarge,
-    padding: theme.spacing(4),
-    margin: theme.spacing(4, 0),
+    padding: theme.spacing(2),
+    margin: theme.spacing(2, 0),
 }));
 
 const StyledScanMessage = styled(Typography)(({ theme }) => ({
@@ -28,8 +28,8 @@ const StyledQRCode = styled('img')(({ theme }) => ({
 }));
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
-    margin: theme.spacing(4, 0),
-    padding: theme.spacing(0, 4),
+    margin: theme.spacing(2, 0),
+    padding: theme.spacing(0, 2),
     width: '100%',
     color: theme.palette.text.secondary,
 }));
@@ -73,9 +73,30 @@ export const DemoDialogWelcome = ({
         <DemoDialog open={open} onClose={onClose} preventCloseOnBackdropClick>
             <DemoDialog.Header>Explore Unleash</DemoDialog.Header>
             <Typography color='textSecondary' sx={{ mt: 2 }}>
-                You can explore Unleash on your own, however for the best
-                experience it's recommended you follow our interactive demo. To
-                get started, you will need to open the demo website below.
+                {interactiveDemoKillSwitch ? (
+                    <>
+                        You can explore Unleash on your own, or follow our{' '}
+                        <StyledLink
+                            href='https://docs.getunleash.io/guides/demo-walkthrough'
+                            target='_blank'
+                            rel='noreferrer'
+                            onClick={() => {
+                                trackEvent('demo-open-walkthrough-guide');
+                            }}
+                        >
+                            demo walkthrough guide
+                        </StyledLink>{' '}
+                        alongside to get the most out of it. To get started, you
+                        will need to open the demo website below.
+                    </>
+                ) : (
+                    <>
+                        You can explore Unleash on your own, however for the
+                        best experience it's recommended you follow our
+                        interactive demo. To get started, you will need to open
+                        the demo website below.
+                    </>
+                )}
             </Typography>
             <StyledDemoPane>
                 <StyledScanMessage>
@@ -104,33 +125,53 @@ export const DemoDialogWelcome = ({
                 </Typography>
             </StyledDemoPane>
             {interactiveDemoKillSwitch && (
-                <Typography color='textSecondary' sx={{ mb: 4 }}>
-                    The demo website can be controlled using the flags in the
-                    demoApp project. You can find your userId on the demo page,
-                    so you can experiment with targeting rules and see the
-                    results in real time!
-                </Typography>
+                <>
+                    <Typography color='textSecondary' sx={{ mb: 1 }}>
+                        The demo website can be controlled using the flags in
+                        the demoApp project.
+                    </Typography>
+                    <Typography color='textSecondary' sx={{ mb: 2 }}>
+                        Need guidance?{' '}
+                        <StyledLink
+                            href='https://docs.getunleash.io/guides/demo-walkthrough'
+                            target='_blank'
+                            rel='noreferrer'
+                            onClick={() => {
+                                trackEvent('demo-open-walkthrough-guide');
+                            }}
+                        >
+                            Follow the demo walkthrough →
+                        </StyledLink>
+                    </Typography>
+                </>
             )}
             <StyledButtons>
-                <StyledButton
-                    variant={
-                        interactiveDemoKillSwitch ? 'contained' : 'outlined'
-                    }
-                    color='primary'
-                    onClick={onClose}
-                >
-                    Explore{' '}
-                    {interactiveDemoKillSwitch ? 'Unleash' : 'on your own'}
-                </StyledButton>
-                {!interactiveDemoKillSwitch && (
+                {interactiveDemoKillSwitch ? (
                     <StyledButton
                         variant='contained'
                         color='primary'
                         onClick={onStart}
-                        data-testid='DEMO_START_BUTTON'
                     >
-                        Go for a guided tour
+                        Explore Unleash
                     </StyledButton>
+                ) : (
+                    <>
+                        <StyledButton
+                            variant='outlined'
+                            color='primary'
+                            onClick={onClose}
+                        >
+                            Explore on your own
+                        </StyledButton>
+                        <StyledButton
+                            variant='contained'
+                            color='primary'
+                            onClick={onStart}
+                            data-testid='DEMO_START_BUTTON'
+                        >
+                            Go for a guided tour
+                        </StyledButton>
+                    </>
                 )}
             </StyledButtons>
         </DemoDialog>

--- a/frontend/src/component/demo/DemoNotice.tsx
+++ b/frontend/src/component/demo/DemoNotice.tsx
@@ -1,0 +1,56 @@
+import { Button, styled, Typography } from '@mui/material';
+import { ReactComponent as StarsIcon } from 'assets/img/stars.svg';
+
+const StyledNotice = styled(Button)(({ theme }) => ({
+    backgroundColor: theme.palette.web.main,
+    color: theme.palette.web.contrastText,
+    borderTopLeftRadius: theme.shape.borderRadiusLarge,
+    borderTopRightRadius: theme.shape.borderRadiusLarge,
+    position: 'fixed',
+    bottom: 0,
+    right: 0,
+    width: '100%',
+    maxWidth: theme.spacing(30),
+    height: theme.spacing(6),
+    zIndex: theme.zIndex.sticky,
+    boxShadow: theme.boxShadows.popup,
+    '&:hover': {
+        backgroundColor: theme.palette.web.main,
+        transition: 'filter ease-in-out 150ms',
+        filter: 'brightness(1.1)',
+    },
+}));
+
+const StyledStars = styled(StarsIcon)({
+    position: 'absolute',
+    left: 6,
+    top: -24,
+});
+
+const StyledStarsRight = styled(StarsIcon)({
+    position: 'absolute',
+    right: 6,
+    top: -24,
+    transform: 'scaleX(-1)',
+});
+
+const StyledTitle = styled('div')({
+    display: 'flex',
+    alignItems: 'center',
+});
+
+interface IDemoNoticeProps {
+    onClick?: () => void;
+}
+
+export const DemoNotice = ({ onClick }: IDemoNoticeProps) => {
+    return (
+        <StyledNotice onClick={onClick}>
+            <StyledStars />
+            <StyledTitle>
+                <Typography fontWeight='bold'>Unleash demo</Typography>
+            </StyledTitle>
+            <StyledStarsRight />
+        </StyledNotice>
+    );
+};

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -38,6 +38,7 @@ export type CustomEvents =
     | 'demo-start-topic'
     | 'demo-ask-questions'
     | 'demo-open-demo-web'
+    | 'demo-open-walkthrough-guide'
     | 'context-usage'
     | 'segment-usage'
     | 'strategy-add'


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-137/add-link-to-new-demo-docs

Adds a link to the new demo walkthrough when `interactiveDemoKillSwitch` is true, redesigns things a bit to accommodate this.

<img width="768" height="695" alt="image" src="https://github.com/user-attachments/assets/41eceaa8-af6d-48b2-9ddd-72134833f71d" />
<img width="291" height="114" alt="image" src="https://github.com/user-attachments/assets/0e550a51-cbd1-43e6-adad-9d080040e81a" />
