### PR TITLE
feat: Block inverted regex on backend

### DIFF
--- a/src/lib/features/constraints/constraints-read-model.test.ts
+++ b/src/lib/features/constraints/constraints-read-model.test.ts
@@ -254,6 +254,23 @@ describe('ConstraintsReadModel - validateConstraints', () => {
                 readModel.validateConstraints(constraints),
             ).rejects.toThrow();
         });
+
+        test('rejects inverted REGEX constraint', async () => {
+            const { readModel } = createReadModel();
+            const constraints: IConstraint[] = [
+                {
+                    contextName: 'someField',
+                    operator: 'REGEX',
+                    value: '^test.*$',
+                    values: [],
+                    inverted: true,
+                },
+            ];
+
+            await expect(
+                readModel.validateConstraints(constraints),
+            ).rejects.toThrow('REGEX operator cannot be inverted.');
+        });
     });
 
     describe('legal values validation', () => {

--- a/src/lib/features/constraints/constraints-read-model.ts
+++ b/src/lib/features/constraints/constraints-read-model.ts
@@ -61,7 +61,7 @@ export class ConstraintsReadModel implements IConstraintsReadModel {
         }
 
         if (operator === REGEX) {
-            validateRegex(constraint.value);
+            validateRegex(constraint.value, constraint.inverted);
         }
 
         if (await this.contextFieldStore.exists(constraint.contextName)) {

--- a/src/lib/util/validators/constraint-types.test.ts
+++ b/src/lib/util/validators/constraint-types.test.ts
@@ -147,3 +147,26 @@ test('regex validation should accept a valid regex', () => {
 
     expect(() => validateRegex(goodRegex)).not.toThrow();
 });
+
+test('regex validation should throw when inverted is true', () => {
+    const goodRegex = '^[a-zA-Z0-9]+$';
+    expect.assertions(1);
+
+    try {
+        validateRegex(goodRegex, true);
+    } catch (e) {
+        expect(e.message).toContain('REGEX operator cannot be inverted.');
+    }
+});
+
+test('regex validation should not throw when inverted is false', () => {
+    const goodRegex = '^[a-zA-Z0-9]+$';
+
+    expect(() => validateRegex(goodRegex, false)).not.toThrow();
+});
+
+test('regex validation should not throw when inverted is undefined', () => {
+    const goodRegex = '^[a-zA-Z0-9]+$';
+
+    expect(() => validateRegex(goodRegex, undefined)).not.toThrow();
+});

--- a/src/lib/util/validators/constraint-types.ts
+++ b/src/lib/util/validators/constraint-types.ts
@@ -28,7 +28,7 @@ export const validateSemver = (value: unknown): void => {
     }
 };
 
-export const validateRegex = (value: unknown): void => {
+export const validateRegex = (value: unknown, inverted?: unknown): void => {
     if (typeof value !== 'string') {
         throw new BadDataError(
             `the provided value is not a valid regex string.`,
@@ -41,6 +41,10 @@ export const validateRegex = (value: unknown): void => {
         throw new BadDataError(
             `the provided value is not a valid regex string. Error: ${e.message}`,
         );
+    }
+
+    if (inverted === true) {
+        throw new BadDataError(`REGEX operator cannot be inverted.`);
     }
 };
 


### PR DESCRIPTION


## About the changes

To make UX simpler we've decided to disable `inverted: true` for REGEX operator until customers explicitly ask for it. In our testing making sense of regex matching and inversion at the same time was leading to some really unexpected behaviors. 

Closes 2-4238


### Important files


## Discussion points

