### PR TITLE
chore: remove privateProjectMiddlewareMove flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -88,7 +88,6 @@ export type UiFlags = {
     gtmReleaseManagement?: boolean;
     projectContextFields?: boolean;
     readOnlyUsersUI?: boolean;
-    privateProjectMiddlewareMove?: boolean;
     datePickerRangeConstraints?: boolean;
     regexConstraintOperator?: boolean;
     signupDialog?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -70,7 +70,6 @@ export type IFlagKey =
     | 'projectContextFields'
     | 'readOnlyUsers'
     | 'readOnlyUsersUI'
-    | 'privateProjectMiddlewareMove'
     | 'remoteMcpServer'
     | 'datePickerRangeConstraints'
     | 'regexConstraintOperator'
@@ -316,10 +315,6 @@ const flags: IFlags = {
     ),
     readOnlyUsersUI: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_READ_ONLY_USERS_UI,
-        false,
-    ),
-    privateProjectMiddlewareMove: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_PRIVATE_PROJECT_MIDDLEWARE_MOVE,
         false,
     ),
     remoteMcpServer: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,7 +58,6 @@ process.nextTick(async () => {
                         projectContextFields: true,
                         readOnlyUsers: true,
                         readOnlyUsersUI: true,
-                        privateProjectMiddlewareMove: true,
                         datePickerRangeConstraints: true,
                         regexConstraintOperator: true,
                         updateMilestoneStrategy: true,


### PR DESCRIPTION
What it says on the tin. All usages exist only in enterprise (https://github.com/bricks-software/unleash-enterprise/pull/824), so that should be merged first.