### PR TITLE
chore: add migration for new `disabled` column in milestone_strategies

### DIFF
--- a/src/migrations/20260303132225-add-milestone-strategies-disabled.js
+++ b/src/migrations/20260303132225-add-milestone-strategies-disabled.js
@@ -1,0 +1,13 @@
+exports.up = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE milestone_strategies ADD COLUMN IF NOT EXISTS disabled BOOLEAN DEFAULT false;`,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `ALTER TABLE milestone_strategies DROP COLUMN IF EXISTS disabled;`,
+        cb,
+    );
+};


### PR DESCRIPTION
Adds new `disabled` column to `milestone_strategies` (equivalent to `disabled` in `feature_strategies`).