### PR TITLE
fix: open regex editing when value resets

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.test.tsx
@@ -1,0 +1,65 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { describe, expect, test, vi } from 'vitest';
+import { EditableConstraint } from './EditableConstraint';
+import type { IConstraint } from 'interfaces/strategy';
+
+const server = testServerSetup();
+
+const setupApi = () => {
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: {
+            regexConstraintOperator: true,
+        },
+    });
+    testServerRoute(server, '/api/admin/context', [{ name: 'appName' }]);
+};
+
+describe('EditableConstraint', () => {
+    describe('REGEX constraint with an existing valid value', () => {
+        test('opens the regex editor when operator changes away from and back to REGEX', async () => {
+            setupApi();
+
+            const constraint: IConstraint = {
+                contextName: 'appName',
+                operator: 'REGEX',
+                value: '[abc]+',
+            };
+
+            render(
+                <EditableConstraint
+                    constraint={constraint}
+                    onDelete={vi.fn()}
+                    onUpdate={vi.fn()}
+                />,
+            );
+
+            // Wait for component to render; editor should be closed (value exists)
+            await screen.findByText('[abc]+');
+            expect(
+                screen.queryByTestId('CONSTRAINT_VALUES_INPUT'),
+            ).not.toBeInTheDocument();
+
+            // Change operator away from REGEX (this clears the value)
+            fireEvent.mouseDown(
+                screen.getByRole('combobox', { name: /operator/i }),
+            );
+            fireEvent.click(
+                await screen.findByRole('option', { name: /is one of/i }),
+            );
+
+            // Change operator back to REGEX
+            fireEvent.mouseDown(
+                screen.getByRole('combobox', { name: /operator/i }),
+            );
+            fireEvent.click(
+                await screen.findByRole('option', { name: /matches regex/i }),
+            );
+
+            // The editor should open automatically because the value was
+            // cleared when the operator changed.
+            await screen.findByTestId('CONSTRAINT_VALUES_INPUT');
+        });
+    });
+});

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
@@ -6,7 +6,7 @@ import {
     isStringOperator,
     type Operator,
 } from 'constants/operators';
-import { useCallback, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { operatorsForContext } from 'utils/operatorsForContext';
 import { ConstraintOperatorSelect } from './ConstraintOperatorSelect.tsx';
 import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
@@ -33,6 +33,7 @@ import {
     isNumberConstraint,
     isRegexConstraint,
     isSemVerConstraint,
+    isSingleValueConstraint,
 } from './useEditableConstraint/editable-constraint-type.ts';
 import type { ConstraintValidationResult } from './useEditableConstraint/constraint-validator.ts';
 import { useUiFlag } from 'hooks/useUiFlag.ts';
@@ -287,11 +288,6 @@ export const EditableConstraint: FC<Props> = ({
     onUpdate,
 }) => {
     const groupContextFieldOptionsByType = useUiFlag('projectContextFields');
-
-    const editingShouldBeOpenByDefaultForNewConstraints = !constraint.value;
-    const [editingOpen, setEditingOpen] = useState(
-        editingShouldBeOpenByDefaultForNewConstraints,
-    );
     const {
         constraint: localConstraint,
         updateConstraint,
@@ -299,6 +295,17 @@ export const EditableConstraint: FC<Props> = ({
         legalValueData,
         invertedDisabled,
     } = useEditableConstraint(constraint, onUpdate);
+    const editingShouldBeOpen =
+        isSingleValueConstraint(localConstraint) &&
+        isRegexConstraint(localConstraint) &&
+        !localConstraint.value;
+    const [editingOpen, setEditingOpen] = useState(editingShouldBeOpen);
+    useEffect(() => {
+        // open the editor when regex value is empty,
+        // even if it was closed before by the user
+        if (editingShouldBeOpen) setEditingOpen(true);
+    }, [editingShouldBeOpen]);
+
     const addValues = useCallback(
         (value: string | string[]) =>
             updateConstraint({ type: 'add value(s)', payload: value }),


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4247/when-regex-is-empty-editing-should-be-open

1. set up a regex
1. close editing
1. change operator
1. change operator back to regex
1. Notice that editing is closed even when the value is empty. Editing should be open. 

Added a unit test for this as it's a little tricky to remember about. 