### PR TITLE
chore: fix e2e tests after latest changes related to welcome dialog

### DIFF
--- a/frontend/cypress/support/UI.ts
+++ b/frontend/cypress/support/UI.ts
@@ -9,6 +9,17 @@ const ENTERPRISE = Boolean(Cypress.env('ENTERPRISE'));
 let strategyId: string | undefined;
 
 const disableActiveSplashScreens = () => {
+    cy.intercept('GET', '/api/admin/user', (req) => {
+        req.headers['cache-control'] = 'no-cache, no-store, must-revalidate';
+        req.on('response', (res) => {
+            if (res.body) {
+                res.body.splash = {
+                    ...res.body.splash,
+                    personalDashboardKeyConcepts: true,
+                };
+            }
+        });
+    });
     return cy.visit(`/splash/operators`);
 };
 
@@ -41,7 +52,9 @@ export const do_login = (
     // Wait for the login redirect to complete.
     cy.get("[data-testid='HEADER_USER_AVATAR']");
 
-    cy.get("[data-testid='CLOSE_SPLASH']").click({ multiple: true });
+    if (document.querySelector("[data-testid='CLOSE_SPLASH']")) {
+        cy.get("[data-testid='CLOSE_SPLASH']").click();
+    }
 
     return cy;
 };

--- a/frontend/src/component/personalDashboard/WelcomeDialog.tsx
+++ b/frontend/src/component/personalDashboard/WelcomeDialog.tsx
@@ -98,11 +98,7 @@ export const WelcomeDialog = () => {
                         environment.
                     </p>
                 </ScreenReaderOnly>
-                <Button
-                    variant='contained'
-                    data-testid='CLOSE_SPLASH'
-                    onClick={onClose}
-                >
+                <Button variant='contained' onClick={onClose}>
                     Got it, let's get started!
                 </Button>
             </ContentWrapper>


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4258/fix-e2e-tests-after-latest-changes-related-to-the-welcome-dialog

Fixes e2e tests after latest changes related to the welcome dialog.

Essentially this intercepts the `/api/admin/user` requests to inject `personalDashboardKeyConcepts: true`, marking the welcome dialog as seen, so it doesn't show up to block the elements our tests want to interact with.