### PR TITLE
chore: include disabled when getting active feature strategies

### DIFF
--- a/src/lib/features/release-plans/release-plan-store.ts
+++ b/src/lib/features/release-plans/release-plan-store.ts
@@ -307,6 +307,7 @@ export class ReleasePlanStore extends CRUDStore<
                 'parameters',
                 'variants',
                 'constraints',
+                'disabled',
             )
             .from('feature_strategies')
             .whereRaw(


### PR DESCRIPTION
When milestone strategies are activated (synced to `feature_strategies` table),  the `getActiveStrategiesForPlan`() method now properly includes the 'disabled'  field in the returned data.