### PR TITLE
chore: deprecate strategy name on ifeaturestrategy

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -195,7 +195,7 @@ export const MilestoneCard = ({
                 ...(milestone.strategies || []),
                 {
                     ...strategy,
-                    strategyName: strategy.strategyName,
+                    strategyName: strategy.name || strategy.strategyName,
                     sortOrder: milestone.strategies?.length || 0,
                 },
             ],

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/LegacyReleasePlanTemplateAddStrategyForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneStrategy/LegacyReleasePlanTemplateAddStrategyForm.tsx
@@ -133,7 +133,9 @@ export const LegacyReleasePlanTemplateAddStrategyForm = ({
     const { segments: allSegments } = useSegments();
     const { segments: assignableSegments = [] } = useAssignableSegments();
     const [segments, setSegments] = useState<ISegment[]>([]);
-    const { strategyDefinition } = useStrategy(strategy?.strategyName);
+    const { strategyDefinition } = useStrategy(
+        strategy?.name || strategy?.strategyName,
+    );
     const hasValidConstraints = useConstraintsValidation(strategy?.constraints);
     const errors = useFormErrors();
     const showVariants = Boolean(
@@ -225,6 +227,9 @@ export const LegacyReleasePlanTemplateAddStrategyForm = ({
         onAddUpdateStrategy(currentStrategy);
     };
 
+    const currentStrategyName =
+        currentStrategy.name || currentStrategy.strategyName || '';
+
     return (
         <FormTemplate
             modal
@@ -235,8 +240,8 @@ export const LegacyReleasePlanTemplateAddStrategyForm = ({
         >
             <StyledHeaderBox>
                 <StyledTitle>
-                    {formatStrategyName(currentStrategy.strategyName || '')}
-                    {currentStrategy.strategyName === 'flexibleRollout' && (
+                    {formatStrategyName(currentStrategyName)}
+                    {currentStrategyName === 'flexibleRollout' && (
                         <Badge color='success' sx={{ marginLeft: '1rem' }}>
                             {currentStrategy.parameters?.rollout}%
                         </Badge>

--- a/frontend/src/interfaces/strategy.ts
+++ b/frontend/src/interfaces/strategy.ts
@@ -4,6 +4,7 @@ import { constraintId } from 'constants/constraintId.js';
 
 export interface IFeatureStrategy {
     id: string;
+    /** @deprecated use {@link name} instead */ // todo(v8) remove this
     strategyName?: string;
     name: string;
     title?: string;

--- a/src/lib/openapi/spec/release-plan-milestone-strategy-schema.ts
+++ b/src/lib/openapi/spec/release-plan-milestone-strategy-schema.ts
@@ -10,7 +10,7 @@ export const releasePlanMilestoneStrategySchema = {
     description:
         'Schema representing the creation of a release plan milestone strategy.',
     type: 'object',
-    required: ['id', 'milestoneId', 'sortOrder', 'strategyName'],
+    required: ['id', 'milestoneId', 'sortOrder', 'strategyName'], // todo(v8) remove strategyName requirement; add `name` if not there
     properties: {
         id: {
             type: 'string',
@@ -27,7 +27,11 @@ export const releasePlanMilestoneStrategySchema = {
         },
         sortOrder: createFeatureStrategySchema.properties.sortOrder,
         title: createFeatureStrategySchema.properties.title,
-        strategyName: createFeatureStrategySchema.properties.name,
+        name: createFeatureStrategySchema.properties.name,
+        strategyName: {
+            ...createFeatureStrategySchema.properties.name,
+            deprecated: true,
+        },
         parameters: createFeatureStrategySchema.properties.parameters,
         constraints: createFeatureStrategySchema.properties.constraints,
         variants: createFeatureStrategySchema.properties.variants,


### PR DESCRIPTION
Prefer `name` to align with other uses of FeatureStrategy. Prepare for removing `strategyName` prop.