### PR TITLE
chore: welcome dialog not showing on 'view key concepts'

### DIFF
--- a/frontend/src/component/personalDashboard/WelcomeDialogProvider.tsx
+++ b/frontend/src/component/personalDashboard/WelcomeDialogProvider.tsx
@@ -37,7 +37,7 @@ export const WelcomeDialogProvider = ({
         if (splash?.personalDashboardKeyConcepts && welcomeDialog === 'open') {
             setWelcomeDialog('closed');
         }
-    }, [splash?.personalDashboardKeyConcepts, setWelcomeDialog]);
+    }, [splash?.personalDashboardKeyConcepts]);
 
     const onClose = () => {
         setSplashSeen('personalDashboardKeyConcepts');


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-160/fix-welcome-key-concepts-dialog-not-showing-up-when-pressing-view-key

Fix a bug where the welcome (key concepts) dialog did not show up when pressing the "view key concepts" button in the dashboard.