### PR TITLE
fix: decouple project environment strategy draggable item from required featureid in path

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/MilestoneListRenderer.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/MilestoneListRenderer.tsx
@@ -111,6 +111,7 @@ const MilestoneListRendererCore = ({
                 return (
                     <div key={milestone.id}>
                         <ReleasePlanMilestone
+                            featureId={plan.featureName}
                             readonly={readonly}
                             milestone={milestone}
                             environmentId={plan.environment}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -158,6 +158,7 @@ const StartMilestone: FC<{
                     readonly
                     milestone={newMilestone}
                     environmentId={releasePlan.environment}
+                    featureId={releasePlan.featureName}
                 />
             </TabPanel>
             <TabPanel variant='diff'>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -243,6 +243,7 @@ export const EnvironmentAccordionBody = ({
 
                                 <ProjectEnvironmentStrategyDraggableItem
                                     strategy={strategy}
+                                    featureId={featureId}
                                     index={index + pageIndex * pageSize}
                                     environmentName={featureEnvironment.name}
                                     otherEnvironments={otherEnvironments}
@@ -259,6 +260,7 @@ export const EnvironmentAccordionBody = ({
                                 ) : null}
 
                                 <ProjectEnvironmentStrategyDraggableItem
+                                    featureId={featureId}
                                     strategy={strategy}
                                     index={index}
                                     environmentName={featureEnvironment.name}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -35,6 +35,7 @@ type ProjectEnvironmentStrategyDraggableItemProps = {
         index: number,
     ) => DragEventHandler<HTMLDivElement>;
     onDragEnd?: () => void;
+    featureId: string;
 };
 
 export const ProjectEnvironmentStrategyDraggableItem = ({
@@ -47,9 +48,9 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
     onDragStartRef,
     onDragOver,
     onDragEnd,
+    featureId,
 }: ProjectEnvironmentStrategyDraggableItemProps) => {
     const projectId = useRequiredPathParam('projectId');
-    const featureId = useRequiredPathParam('featureId');
     const strategyChangesFromRequest = useStrategyChangesFromRequest(
         projectId,
         featureId,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.test.tsx
@@ -204,7 +204,7 @@ beforeEach(() => {
     setupOtherServerRoutes();
 });
 
-const Component = () => {
+const Component = ({ featureId = 'feature1' }) => {
     return (
         <>
             <Routes>
@@ -212,6 +212,7 @@ const Component = () => {
                     path={'/projects/:projectId/features/:featureId'}
                     element={
                         <ProjectEnvironmentStrategyDraggableItem
+                            featureId={featureId}
                             strategy={strategy}
                             environmentName={'production'}
                             index={1}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -109,6 +109,7 @@ interface IReleasePlanMilestoneProps {
     previousMilestoneStatus?: MilestoneStatus;
     projectId?: string;
     environmentId: string;
+    featureId: string;
 }
 
 export const ReleasePlanMilestone = ({
@@ -120,6 +121,7 @@ export const ReleasePlanMilestone = ({
     previousMilestoneStatus,
     projectId,
     environmentId,
+    featureId,
 }: IReleasePlanMilestoneProps) => {
     const [expanded, setExpanded] = useState(false);
     const canEditStrategies = useUiFlag('updateMilestoneStrategy');
@@ -238,6 +240,7 @@ export const ReleasePlanMilestone = ({
                                 {canEditStrategies ? (
                                     <ProjectEnvironmentStrategyDraggableItem
                                         scope='milestone'
+                                        featureId={featureId}
                                         strategy={{
                                             ...strategy,
                                             name:

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/ReleasePlanMilestoneItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestoneItem/ReleasePlanMilestoneItem.tsx
@@ -188,6 +188,7 @@ export const ReleasePlanMilestoneItem = ({
     return (
         <div key={milestone.id}>
             <ReleasePlanMilestone
+                featureId={featureName}
                 readonly={readonly}
                 milestone={milestone}
                 status={status}


### PR DESCRIPTION
This hard requirement was causing breakage in change requests which added / removed release plans:

<img width="3900" height="1472" alt="image" src="https://github.com/user-attachments/assets/c3bc38f5-b6df-409c-afb5-99a79e08c073" />

Because the only places this component is used, we already have the feature name on a level above, we can simply pass it down to the component instead of requiring it in the path.