### PR TITLE
chore: allow project env strategy draggable item to be marked as read-only

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -36,6 +36,7 @@ type ProjectEnvironmentStrategyDraggableItemProps = {
     ) => DragEventHandler<HTMLDivElement>;
     onDragEnd?: () => void;
     featureId: string;
+    readonly?: boolean;
 };
 
 export const ProjectEnvironmentStrategyDraggableItem = ({
@@ -49,6 +50,7 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
     onDragOver,
     onDragEnd,
     featureId,
+    readonly,
 }: ProjectEnvironmentStrategyDraggableItemProps) => {
     const projectId = useRequiredPathParam('projectId');
     const strategyChangesFromRequest = useStrategyChangesFromRequest(
@@ -74,6 +76,39 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
 
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+    const EditControls: React.FC = () => (
+        <>
+            <PermissionIconButton
+                permission={UPDATE_FEATURE_STRATEGY}
+                environmentId={environmentName}
+                projectId={projectId}
+                component={Link}
+                to={editStrategyPath}
+                tooltipProps={{
+                    title: 'Edit strategy',
+                }}
+                data-testid={`STRATEGY_EDIT-${strategy.name}`}
+            >
+                <Edit />
+            </PermissionIconButton>
+            {otherEnvironments && otherEnvironments?.length > 0 ? (
+                <CopyStrategyIconMenu
+                    environmentId={environmentName}
+                    environments={otherEnvironments as string[]}
+                    strategy={strategy}
+                />
+            ) : null}
+            {scope === 'milestone' ? null : (
+                <MenuStrategyRemove
+                    projectId={projectId}
+                    featureId={featureId}
+                    environmentId={environmentName}
+                    strategy={strategy}
+                />
+            )}
+        </>
+    );
 
     return (
         <StrategyDraggableItem
@@ -101,34 +136,7 @@ export const ProjectEnvironmentStrategyDraggableItem = ({
                             ).map((scheduledChange) => scheduledChange.id)}
                         />
                     ) : null}
-                    <PermissionIconButton
-                        permission={UPDATE_FEATURE_STRATEGY}
-                        environmentId={environmentName}
-                        projectId={projectId}
-                        component={Link}
-                        to={editStrategyPath}
-                        tooltipProps={{
-                            title: 'Edit strategy',
-                        }}
-                        data-testid={`STRATEGY_EDIT-${strategy.name}`}
-                    >
-                        <Edit />
-                    </PermissionIconButton>
-                    {otherEnvironments && otherEnvironments?.length > 0 ? (
-                        <CopyStrategyIconMenu
-                            environmentId={environmentName}
-                            environments={otherEnvironments as string[]}
-                            strategy={strategy}
-                        />
-                    ) : null}
-                    {scope === 'milestone' ? null : (
-                        <MenuStrategyRemove
-                            projectId={projectId}
-                            featureId={featureId}
-                            environmentId={environmentName}
-                            strategy={strategy}
-                        />
-                    )}
+                    {readonly ? null : <EditControls />}
                 </>
             }
         />

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -239,6 +239,7 @@ export const ReleasePlanMilestone = ({
 
                                 {canEditStrategies ? (
                                     <ProjectEnvironmentStrategyDraggableItem
+                                        readonly={readonly}
                                         scope='milestone'
                                         featureId={featureId}
                                         strategy={{


### PR DESCRIPTION

When in read-only mode, the edit, copy, and delete controls are not rendered.

The only place that sets this as true at the moment is the release plan added/deleted change request view.

Before:
<img width="1212" height="1382" alt="image" src="https://github.com/user-attachments/assets/a73c5b7c-c14c-41b8-aa8d-8a190fa79edd" />


After:
<img width="1220" height="1286" alt="image" src="https://github.com/user-attachments/assets/ddfc205d-5ca2-47d8-b313-ce344278b7fe" />
