### PR TITLE
chore: regex should never not be inverted

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
@@ -16,6 +16,7 @@ import {
     type EditableMultiValueConstraint,
     type EditableSingleValueConstraint,
     isMultiValueConstraint,
+    invertedToggleDisabled,
 } from './editable-constraint-type.js';
 import { difference, union } from './set-functions.js';
 
@@ -162,7 +163,7 @@ export const constraintReducer = (
             return addValue(action.payload);
         }
         case 'toggle inverted operator':
-            if (isRegexOperator(state.operator)) {
+            if (invertedToggleDisabled(state)) {
                 return state;
             }
             return { ...state, inverted: !state.inverted };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/editable-constraint-type.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/editable-constraint-type.test.ts
@@ -1,6 +1,7 @@
 import { createEmptyConstraint } from 'utils/createEmptyConstraint';
 import { fromIConstraint, toIConstraint } from './editable-constraint-type.ts';
 import { constraintId } from 'constants/constraintId';
+import { REGEX } from 'constants/operators';
 import type { IConstraint } from 'interfaces/strategy.ts';
 
 test('mapping to and from retains the constraint id', () => {
@@ -29,4 +30,16 @@ test('mapping from an empty constraint removes redundant value / values', () => 
 
     const transformed = toIConstraint(fromIConstraint(constraint));
     expect(transformed).not.toHaveProperty('value');
+});
+
+test('if we have in DB REGEX constraint with inverted flag our UI has to reset it', () => {
+    const constraint: IConstraint = {
+        contextName: 'appName',
+        operator: REGEX,
+        value: 'some-pattern',
+        inverted: true,
+    };
+
+    // REGEX does not support inversion; reset on load to avoid impossible state
+    expect(fromIConstraint(constraint).inverted).toBe(false);
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/editable-constraint-type.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/editable-constraint-type.ts
@@ -80,6 +80,10 @@ export const isRegexConstraint = (
 ): constraint is EditableRegexConstraint =>
     isRegexOperator(constraint.operator);
 
+export const invertedToggleDisabled = (
+    constraint: Pick<EditableConstraint, 'operator'>,
+) => isRegexOperator(constraint.operator);
+
 export const fromIConstraint = (
     constraint: IConstraint,
 ): EditableConstraint => {
@@ -90,6 +94,7 @@ export const fromIConstraint = (
             ...rest,
             operator,
             value: value ?? '',
+            ...(invertedToggleDisabled({ operator }) && { inverted: false }),
         };
     } else {
         return {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/useEditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/useEditableConstraint.tsx
@@ -3,6 +3,7 @@ import type { IConstraint } from 'interfaces/strategy';
 import {
     type EditableConstraint,
     fromIConstraint,
+    invertedToggleDisabled,
     isMultiValueConstraint,
     isSingleValueConstraint,
     toIConstraint,
@@ -15,7 +16,6 @@ import {
     constraintReducer,
     type ConstraintUpdateAction,
 } from './constraint-reducer.ts';
-import { isRegexOperator } from 'constants/operators';
 import {
     constraintValidator,
     type ConstraintValidationResult,
@@ -143,11 +143,13 @@ export const useEditableConstraint = (
           }
         : undefined;
 
+    const invertedDisabled = invertedToggleDisabled(localConstraint);
+
     return {
         updateConstraint,
         constraint: localConstraint,
         validator,
         legalValueData,
-        invertedDisabled: isRegexOperator(localConstraint.operator),
+        invertedDisabled,
     } as EditableConstraintState;
 };


### PR DESCRIPTION

## About the changes

While testing I once got to a state when inverted was set while on REGEX operator. This should be invalid state so it seems it was a leftover in DB from time when we didn't have that limitation. 

Unfortunately it made it impossible do do anything with the constraint other than delete it. 
Maybe that's fine, but it looked broken...

So here I assume that any such data was not intentional and is not used in production by any customer (feature flag is still disabled). 
Our backend won't allow it to be saved back in that state either. 
Every time we notice it we silently fix it. 

