### PR TITLE
feat: enable "edit change" item in cr item for milestone strategies

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeActions.tsx
@@ -4,6 +4,7 @@ import type {
     ChangeRequestType,
     IChange,
     IChangeRequestAddStrategy,
+    IChangeRequestUpdateMilestoneStrategy,
     IChangeRequestUpdateStrategy,
 } from 'component/changeRequest/changeRequest.types';
 import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
@@ -48,7 +49,9 @@ const useShowActions = (changeRequest: ChangeRequestType, change: IChange) => {
 
     const showEdit =
         showActions &&
-        ['addStrategy', 'updateStrategy'].includes(change.action);
+        ['addStrategy', 'updateStrategy', 'updateMilestoneStrategy'].includes(
+            change.action,
+        );
 
     const showDiscard = showActions && changesCount(changeRequest) > 1;
 
@@ -163,6 +166,7 @@ export const ChangeActions: FC<{
                                                 change as
                                                     | IChangeRequestAddStrategy
                                                     | IChangeRequestUpdateStrategy
+                                                    | IChangeRequestUpdateMilestoneStrategy
                                             }
                                             environment={
                                                 changeRequest.environment

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -11,12 +11,17 @@ import { useCollaborateData } from 'hooks/useCollaborateData';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
 import { useChangeRequestsEnabled } from 'hooks/useChangeRequestsEnabled';
-import { useChangeRequestApi } from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
+import {
+    type IChangeSchema,
+    useChangeRequestApi,
+} from 'hooks/api/actions/useChangeRequestApi/useChangeRequestApi';
 import { comparisonModerator } from 'component/feature/FeatureStrategy/featureStrategy.utils';
 import type {
     ChangeRequestAddStrategy,
     ChangeRequestEditStrategy,
+    ChangeRequestUpdateMilestoneStrategy,
     IChangeRequestAddStrategy,
+    IChangeRequestUpdateMilestoneStrategy,
     IChangeRequestUpdateStrategy,
 } from 'component/changeRequest/changeRequest.types';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
@@ -27,7 +32,10 @@ import { useUiFlag } from 'hooks/useUiFlag.ts';
 import { LegacyEditChange } from './LegacyEditChange.tsx';
 
 interface IEditChangeProps {
-    change: IChangeRequestAddStrategy | IChangeRequestUpdateStrategy;
+    change:
+        | IChangeRequestAddStrategy
+        | IChangeRequestUpdateStrategy
+        | IChangeRequestUpdateMilestoneStrategy;
     changeRequestId: number;
     featureId: string;
     environment: string;
@@ -37,7 +45,10 @@ interface IEditChangeProps {
 }
 
 const addIdSymbolToConstraints = (
-    strategy?: ChangeRequestAddStrategy | ChangeRequestEditStrategy,
+    strategy?:
+        | ChangeRequestAddStrategy
+        | ChangeRequestEditStrategy
+        | ChangeRequestUpdateMilestoneStrategy,
 ) => {
     if (!strategy) return;
 
@@ -98,13 +109,14 @@ const NewEditChange = ({
         }
     }, [feature]);
 
+    const payload: IChangeSchema = {
+        action: change.action,
+        feature: featureId,
+        payload: strategy,
+    };
     const onInternalSubmit = async () => {
         try {
-            await editChange(projectId, changeRequestId, change.id, {
-                action: strategy.id ? 'updateStrategy' : 'addStrategy',
-                feature: featureId,
-                payload: strategy,
-            });
+            await editChange(projectId, changeRequestId, change.id, payload);
             onSubmit();
             setToastData({
                 text: 'Change updated',
@@ -137,7 +149,7 @@ const NewEditChange = ({
                         projectId,
                         changeRequestId,
                         change.id,
-                        strategy,
+                        payload,
                         unleashUrl,
                     )
                 }
@@ -176,7 +188,7 @@ export const formatUpdateStrategyApiCode = (
     projectId: string,
     changeRequestId: number,
     changeId: number,
-    strategy: Partial<IFeatureStrategy>,
+    strategy: IChangeSchema,
     unleashUrl?: string,
 ): string => {
     if (!unleashUrl) {

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/LegacyEditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/LegacyEditChange.tsx
@@ -18,7 +18,9 @@ import { comparisonModerator } from 'component/feature/FeatureStrategy/featureSt
 import type {
     ChangeRequestAddStrategy,
     ChangeRequestEditStrategy,
+    ChangeRequestUpdateMilestoneStrategy,
     IChangeRequestAddStrategy,
+    IChangeRequestUpdateMilestoneStrategy,
     IChangeRequestUpdateStrategy,
 } from 'component/changeRequest/changeRequest.types';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
@@ -29,7 +31,10 @@ import { constraintId } from 'constants/constraintId.ts';
 import { apiPayloadConstraintReplacer } from 'utils/api-payload-constraint-replacer.ts';
 
 interface IEditChangeProps {
-    change: IChangeRequestAddStrategy | IChangeRequestUpdateStrategy;
+    change:
+        | IChangeRequestAddStrategy
+        | IChangeRequestUpdateStrategy
+        | IChangeRequestUpdateMilestoneStrategy;
     changeRequestId: number;
     featureId: string;
     environment: string;
@@ -39,7 +44,10 @@ interface IEditChangeProps {
 }
 
 const addIdSymbolToConstraints = (
-    strategy?: ChangeRequestAddStrategy | ChangeRequestEditStrategy,
+    strategy?:
+        | ChangeRequestAddStrategy
+        | ChangeRequestEditStrategy
+        | ChangeRequestUpdateMilestoneStrategy,
 ) => {
     if (!strategy) return;
 
@@ -75,10 +83,6 @@ export const LegacyEditChange = ({
 
     const [segments, setSegments] = useState<ISegment[]>(strategySegments);
 
-    const strategyDefinition = {
-        parameters: change.payload.parameters,
-        name: change.payload.name,
-    };
     const { setToastData, setToastApiError } = useToast();
     const errors = useFormErrors();
     const { uiConfig } = useUiConfig();
@@ -133,10 +137,6 @@ export const LegacyEditChange = ({
             setToastApiError(formatUnknownError(error));
         }
     };
-
-    if (!strategyDefinition) {
-        return null;
-    }
 
     if (!data) return null;
 


### PR DESCRIPTION
Enables the "edit change" for milestone strategy updates in crs.

<img width="1495" height="308" alt="image" src="https://github.com/user-attachments/assets/28d3e475-9c11-49ac-8d21-23dabfdd7d4a" />

The "discard change" is only shown when there's multiple changes in one request:

<img width="1499" height="526" alt="image" src="https://github.com/user-attachments/assets/6748877e-2742-47fb-8e8a-4b70b8c06637" />

Closes 1-4502.
