### PR TITLE
chore: enable the exact same change components as normal update strategies

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -13,7 +13,6 @@ import type {
 } from 'component/changeRequest/changeRequest.types';
 import { useCurrentStrategy } from './hooks/useCurrentStrategy.ts';
 import { Badge } from 'component/common/Badge/Badge';
-import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { flexRow } from 'themes/themeStyles';
 import { EnvironmentVariantsTable } from 'component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable';
 import { ChangeOverwriteWarning } from './ChangeOverwriteWarning/ChangeOverwriteWarning.tsx';
@@ -173,14 +172,10 @@ const UpdateStrategy: FC<{
             />
             <ChangeItemWrapper>
                 <ChangeItemInfo>
-                    {change.action === 'updateMilestoneStrategy' ? (
-                        <Action>Editing strategy</Action>
-                    ) : (
-                        <EditHeader
-                            wasDisabled={currentStrategy?.disabled}
-                            willBeDisabled={change.payload?.disabled}
-                        />
-                    )}
+                    <EditHeader
+                        wasDisabled={currentStrategy?.disabled}
+                        willBeDisabled={change.payload?.disabled}
+                    />
                     <NameWithChangeInfo
                         newName={change.payload.title}
                         previousName={previousTitle}
@@ -188,27 +183,20 @@ const UpdateStrategy: FC<{
                 </ChangeItemInfo>
                 {actions}
             </ChangeItemWrapper>
-            {change.action === 'updateStrategy' && (
-                <ConditionallyRender
-                    condition={
-                        change.payload?.disabled !== currentStrategy?.disabled
-                    }
-                    show={
-                        <Typography
-                            sx={{
-                                marginTop: (theme) => theme.spacing(2),
-                                marginBottom: (theme) => theme.spacing(2),
-                                ...flexRow,
-                                gap: (theme) => theme.spacing(1),
-                            }}
-                        >
-                            This strategy will be{' '}
-                            <DisabledEnabledState
-                                disabled={change.payload?.disabled || false}
-                            />
-                        </Typography>
-                    }
-                />
+            {change.payload?.disabled !== currentStrategy?.disabled && (
+                <Typography
+                    sx={{
+                        marginTop: (theme) => theme.spacing(2),
+                        marginBottom: (theme) => theme.spacing(2),
+                        ...flexRow,
+                        gap: (theme) => theme.spacing(1),
+                    }}
+                >
+                    This strategy will be{' '}
+                    <DisabledEnabledState
+                        disabled={change.payload?.disabled || false}
+                    />
+                </Typography>
             )}
 
             <TabPanel>


### PR DESCRIPTION
Removes any special treatment of milestone strategies in the change request change item. Milestone strategies can also be disabled, so might as well allow showing the same kind of content for that.

