### PR TITLE
chore: show Modified in draft badge for updateMilestoneStrategy CR

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestDraftStatusBadge.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestStatusBadge/ChangeRequestDraftStatusBadge.tsx
@@ -11,6 +11,7 @@ export const ChangeRequestDraftStatusBadge = ({
 }) => {
     switch (changeAction) {
         case 'updateStrategy':
+        case 'updateMilestoneStrategy':
             return (
                 <Badge color='warning' sx={sx}>
                     Modified in draft

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/useStrategyChangesFromRequest.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/useStrategyChangesFromRequest.tsx
@@ -32,7 +32,8 @@ export const useStrategyChangesFromRequest = (
         const change = feature?.changes.find((change) => {
             if (
                 change.action === 'updateStrategy' ||
-                change.action === 'deleteStrategy'
+                change.action === 'deleteStrategy' ||
+                change.action === 'updateMilestoneStrategy'
             ) {
                 return change.payload.id === strategyId;
             }


### PR DESCRIPTION
Shows the "Modified in draft" badge for update milestone strategy change requests (the same way we do for regular feature strategy updates CRs). 

<img width="1148" height="634" alt="Screenshot 2026-03-05 at 18 05 14" src="https://github.com/user-attachments/assets/39af7624-f02b-45be-ad3e-400036e0de94" />
