### PR TITLE
chore: running e2e:oss

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "fmt:check": "biome check src --error-on-warnings",
     "ts:check": "tsc",
     "e2e": "yarn run cypress open --config baseUrl='http://localhost:3000' --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
-    "e2e:oss": "yarn --cwd frontend run cypress run --spec \"cypress/oss/**/*.spec.ts\" --config baseUrl=\"http://localhost:${EXPOSED_PORT:-4242}\" --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
+    "e2e:oss": "yarn run cypress run --spec \"cypress/oss/**/*.spec.ts\" --config baseUrl=\"http://localhost:${EXPOSED_PORT:-4242}\" --env AUTH_USER=admin,AUTH_PASSWORD=unleash4all",
     "gen:api": "orval --config orval.config.ts",
     "gen:api:demo": "UNLEASH_OPENAPI_URL=https://app.unleash-hosted.com/demo/docs/openapi.json yarn run gen:api",
     "gen:api:sandbox": "UNLEASH_OPENAPI_URL=https://sandbox.getunleash.io/demo2/docs/openapi.json yarn run gen:api",


### PR DESCRIPTION
I'm not sure if we're even using it. The only place that seems to be calling it is a Makefile in test-migrations. 

Still, it's already in the frontend directory so it just returns an error when called. 

```
test-migrations % make test
Running tests against 4242...
Internal Error: spawn /Users/kkula/.nvm/versions/node/v22.22.0/bin/node ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
make: *** [test] Error 1
```

context: https://github.com/Unleash/unleash/pull/5645