### PR TITLE
fix: search user shema should point to the right schema

### DIFF
--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -235,7 +235,7 @@ export default class UserAdminController extends Controller {
                         },
                     ],
                     responses: {
-                        200: createResponseSchema('usersSchema'),
+                        200: createResponseSchema('usersSearchSchema'),
                         ...getStandardResponses(401),
                     },
                 }),
@@ -531,11 +531,12 @@ export default class UserAdminController extends Controller {
         if (this.flagResolver.isEnabled('anonymiseEventLog')) {
             users = this.anonymiseUsers(users);
         }
+        const response = users.map(({ isAPI, ...u }) => u);
         this.openApiService.respondWithValidation(
             200,
             res,
             usersSearchSchema.$id,
-            serializeDates(users.map(({ isAPI, ...u }) => u)),
+            serializeDates(response),
         );
     }
 


### PR DESCRIPTION
GET /api/admin/user-admin/search is pointing at the wrong schema.

- In user-admin.ts line 238:238, the route declares: `200: createResponseSchema('usersSchema')`
- `usersSchema` is an object with users and rootRoles (see users-schema.ts:5).
- But the actual handler returns an array and validates against `usersSearchSchema`.

So the generated OpenAPI is reflecting the route declaration (usersSchema), not the runtime response validation schema used in respondWithValidation. This is a route-docs/schema mismatch (likely a typo)


Currently:
```
$ curl -sS "http://localhost:4242/api/admin/user-admin/search?q=me@getunleash.io" \
    -H "Authorization: REDACTED" \
    -H "Accept: application/json" | jq .
[
  {
    "accountType": "User",
    "id": 10,
    "name": "me@getunleash.io",
    "email": "me@getunleash.io",
    "imageUrl": "https://gravatar.com/avatar/9a19208a504dc2d84faff6ded2452e814c3e85e308975a3dbdac51ac26f755ca?s=42&d=retro&r=g",
    "seenAt": null,
    "scimId": null
  }
]
```