### PR TITLE
chore: exclude signup dialog from special scenarios

### DIFF
--- a/frontend/src/component/signup/hooks/useSignup.ts
+++ b/frontend/src/component/signup/hooks/useSignup.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from 'hooks/api/getters/httpErrorResponseHandler';
 import type { SWRConfiguration } from 'swr';
@@ -6,6 +5,7 @@ import { useConditionalSWR } from 'hooks/api/getters/useConditionalSWR/useCondit
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
+import { useAuthEndpoint } from 'hooks/api/getters/useAuth/useAuthEndpoint';
 
 export type SignupData = {
     shouldSetPassword?: boolean;
@@ -23,38 +23,49 @@ export const useSignup = (options?: SWRConfiguration) => {
         isEnterprise,
         uiConfig: { billing },
     } = useUiConfig();
+    const { data: authData } = useAuthEndpoint();
     const { instanceStatus } = useInstanceStatus();
-    const isPAYG = isEnterprise() && billing === 'pay-as-you-go';
     const signupDialogEnabled = useUiFlag('signupDialog');
 
-    const { data, error, mutate } = useConditionalSWR<SignupData | undefined>(
-        isPAYG && signupDialogEnabled,
+    const isPAYG = isEnterprise() && billing === 'pay-as-you-go';
+    const shouldFetch = isPAYG && signupDialogEnabled;
+
+    const {
+        data: signupData,
+        error,
+        mutate,
+    } = useConditionalSWR<SignupData | undefined>(
+        shouldFetch,
         undefined,
         formatApiPath(ENDPOINT),
         fetcher,
         options,
     );
 
-    return useMemo(
-        () => ({
-            signupData: data,
-            signupRequired: Boolean(
-                instanceStatus?.ucaSignup &&
-                    data &&
-                    (data.shouldSetPassword ||
-                        !data.companyRole ||
-                        !data.companyName),
-            ),
-            loading: !error && !data,
-            refetch: () => mutate(),
-            error,
-        }),
-        [data, instanceStatus?.ucaSignup, error, mutate],
-    );
+    const loading = shouldFetch && !error && !signupData;
+
+    const isUCASignup = instanceStatus?.ucaSignup;
+    const isUnleashUser =
+        authData &&
+        'user' in authData &&
+        authData.user?.email?.toLowerCase().endsWith('@getunleash.io');
+    const dataIncomplete =
+        signupData &&
+        (signupData.shouldSetPassword ||
+            !signupData.companyRole ||
+            !signupData.companyName);
+    const signupRequired = isUCASignup && !isUnleashUser && dataIncomplete;
+
+    return {
+        signupData,
+        signupRequired,
+        loading,
+        refetch: mutate,
+        error,
+    };
 };
 
-const fetcher = (path: string) => {
-    return fetch(path)
+const fetcher = (path: string) =>
+    fetch(path)
         .then(handleErrorResponses('Signup'))
         .then((res) => res.json());
-};


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-172/fix-auth-app-special-admin-should-not-need-to-fill-up-signup-form

Adapts the signup logic so the dialog does not show up for some special scenarios, like internal users with `@getunleash.io` emails.

Also refactored and tried simplifying a few things here.