### PR TITLE
chore: flag resolver default values

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -349,7 +349,7 @@ const flags: IFlags = {
     ),
     userTokenWithClientApiLogging: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_USERTOKEN_WITH_CLIENTAPI_LOGGING,
-        true,
+        false,
     ),
     featureEnvSafeguards: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FEATURE_ENV_SAFEGUARDS,

--- a/src/lib/util/flag-resolver.test.ts
+++ b/src/lib/util/flag-resolver.test.ts
@@ -70,6 +70,27 @@ test('should not use external resolver for enabled experiments', () => {
     expect(result.should_be_enabled).toBe(true);
 });
 
+test('enabled experiments should only be used as fallbacks', () => {
+    const externalResolver = {
+        isEnabled: () => {
+            return false;
+        },
+        getVariant: () => defaultVariant,
+        getStaticContext: () => ({}),
+    };
+
+    const config = {
+        flags: { celebrateUnleash: true, otherFlag: false },
+        externalResolver,
+    };
+
+    const resolver = new FlagResolver(config as IExperimentalOptions);
+
+    const enabled = resolver.isEnabled('celebrateUnleash');
+
+    expect(enabled).toBe(false);
+});
+
 test('should load experimental flags', () => {
     const externalResolver = {
         isEnabled: () => {


### PR DESCRIPTION
Adds a test that demonstrates default values for experiments doesn't get overridden by isEnabled checks against flagprovider when returning 'enabled'

We can set a default value in experimental.ts, example:

```typescript
celebrateUnleash: parseEnvVarBoolean(
    process.env.UNLEASH_EXPERIMENTAL_CELEBRATE_UNLEASH,
    false,
),
```
If the default value is 'truthy':

```typescript
celebrateUnleash: parseEnvVarBoolean(
    process.env.UNLEASH_EXPERIMENTAL_CELEBRATE_UNLEASH,
    true,
),
```
then we skip the flagprovider check and just return the result.
This seems to be the expectation, as we have tests that explicitly verifies this behavior.

But it isn't my expectation as a developer using this, I would expect this to work more like a kill-switch, we can turn it on by default, but if the flagprovider has the flag then whatever the flag state is will override the specified result in experimental.ts.

This means anything we set to true here can never be disabled by flipping a flag in Unleash, and will accidentally roll out anything new to all our hosted customers.

Use case in this scenario:

I want a feature to default to 'on' for Unleash OSS and self hosted users.
But I want to roll it out gradually to our hosted customers.
And I want to disable it quickly with a flag if I discover that needs to be done.