### PR TITLE
fix: make key concepts dialog background blurry

### DIFF
--- a/frontend/src/component/personalDashboard/WelcomeDialog.tsx
+++ b/frontend/src/component/personalDashboard/WelcomeDialog.tsx
@@ -8,6 +8,9 @@ import { formatAssetPath } from 'utils/formatPath';
 import { useWelcomeDialogContext } from './WelcomeDialogContext.tsx';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
+    '.MuiBackdrop-root': {
+        backdropFilter: 'blur(8px)',
+    },
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
         width: '65vw',


### PR DESCRIPTION
## About the changes

Closes https://linear.app/unleash/issue/SA-127/make-key-concepts-dialog-background-blurry


### Important files


## Discussion points

<img width="1284" height="913" alt="Screenshot 2026-03-09 at 10 43 54" src="https://github.com/user-attachments/assets/46cf38e2-d1bf-4d75-b2f8-08de6483b6e7" />
