### PR TITLE
add releaseplansschema (plural)

### DIFF
--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -176,6 +176,7 @@ export * from './record-ui-error-schema.js';
 export * from './release-plan-milestone-schema.js';
 export * from './release-plan-milestone-strategy-schema.js';
 export * from './release-plan-schema.js';
+export * from './release-plans-schema.js';
 export * from './release-plan-template-id-schema.js';
 export * from './release-plan-template-schema.js';
 export * from './requests-per-second-schema.js';

--- a/src/lib/openapi/spec/release-plans-schema.ts
+++ b/src/lib/openapi/spec/release-plans-schema.ts
@@ -1,0 +1,41 @@
+import type { FromSchema } from 'json-schema-to-ts';
+import { releasePlanSchema } from './release-plan-schema.js';
+import { releasePlanMilestoneSchema } from './release-plan-milestone-schema.js';
+import { releasePlanMilestoneStrategySchema } from './release-plan-milestone-strategy-schema.js';
+import { constraintSchema } from './constraint-schema.js';
+import { createFeatureStrategySchema } from './create-feature-strategy-schema.js';
+import { createStrategyVariantSchema } from './create-strategy-variant-schema.js';
+import { parametersSchema } from './parameters-schema.js';
+import { transitionConditionSchema } from './transition-condition-schema.js';
+import { safeguardSchema } from './safeguard-schema.js';
+import { metricQuerySchema } from './metric-query-schema.js';
+import { safeguardTriggerConditionSchema } from './safeguard-trigger-condition-schema.js';
+
+export const releasePlansSchema = {
+    $id: '#/components/schemas/releasePlansSchema',
+    description: 'A collection of release plans',
+    type: 'array',
+    items: {
+        $ref: '#/components/schemas/releasePlanSchema',
+    },
+    components: {
+        schemas: {
+            releasePlanSchema,
+            releasePlanMilestoneSchema,
+            releasePlanMilestoneStrategySchema,
+            createFeatureStrategySchema,
+            parametersSchema,
+            constraintSchema,
+            createStrategyVariantSchema,
+            transitionConditionSchema,
+            safeguardSchema,
+            metricQuerySchema,
+            safeguardTriggerConditionSchema,
+        },
+    },
+} as const;
+
+export type ReleasePlansSchema = FromSchema<
+    typeof releasePlansSchema,
+    { keepDefaultedPropertiesOptional: true }
+>;


### PR DESCRIPTION
We've been putting the wrong type in our enterprise endpoints. They list a single plan but there should be multiple.

https://github.com/bricks-software/unleash-enterprise/blob/0f342765a1b287aa6b00032790675c3b7dac14f3/src/release-plans/release-plan-controller.ts#L89