### PR TITLE
chore: don't crop template form name

### DIFF
--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
@@ -7,7 +7,7 @@ import { MilestoneList } from './MilestoneList/MilestoneList.tsx';
 import type { IExtendedMilestonePayload } from 'component/releases/hooks/useTemplateForm';
 
 const StyledInput = styled(Input)(({ theme }) => ({
-    maxWidth: theme.spacing(50),
+    width: '100%',
     fieldset: { border: 'none' },
     'label::first-letter': {
         textTransform: 'uppercase',
@@ -16,13 +16,7 @@ const StyledInput = styled(Input)(({ theme }) => ({
     padding: theme.spacing(0),
 }));
 
-const StyledDescriptionInput = styled(Input)(({ theme }) => ({
-    width: '100%',
-    fieldset: { border: 'none' },
-    'label::first-letter': {
-        textTransform: 'uppercase',
-    },
-    marginBottom: theme.spacing(2),
+const StyledDescriptionInput = styled(StyledInput)(({ theme }) => ({
     padding: theme.spacing(2, 5, 1, 1.75),
 }));
 


### PR DESCRIPTION
Makes the template form name input full width.

<img width="851" height="304" alt="Screenshot 2026-03-09 at 14 56 37" src="https://github.com/user-attachments/assets/8e4be224-a503-4b68-91aa-6199c818f52a" />

Closes # 1-14439

