### PR TITLE
Chore: return `ReleasePlanMilestoneStrategy` instead of `MilestoneStrategyConfig` from update methods

### DIFF
--- a/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
@@ -1,9 +1,9 @@
 import type {
     IAuditUser,
     IUnleashConfig,
-    MilestoneStrategyConfig,
     MilestoneStrategyConfigUpdate,
 } from '../../types/index.js';
+import type { ReleasePlanMilestoneStrategy } from './release-plan-milestone-strategy.js';
 import type { IUser } from '../../types/user.js';
 import type { Logger } from '../../logger.js';
 import type { IReleasePlanMilestoneStrategyStore } from './release-plan-milestone-strategy-store.js';
@@ -53,7 +53,7 @@ export class ReleasePlanMilestoneStrategyService {
         context: MilestoneStrategyContext,
         auditUser: IAuditUser,
         user?: IUser,
-    ): Promise<MilestoneStrategyConfig> {
+    ): Promise<ReleasePlanMilestoneStrategy> {
         await this.stopWhenChangeRequestsEnabled(
             context.projectId,
             context.environment,
@@ -91,7 +91,7 @@ export class ReleasePlanMilestoneStrategyService {
         context: MilestoneStrategyContext,
         auditUser: IAuditUser,
         user?: IUser,
-    ): Promise<MilestoneStrategyConfig> {
+    ): Promise<ReleasePlanMilestoneStrategy> {
         const { projectId, environment, featureName } = context;
 
         const existingStrategy = await this.milestoneStrategyStore.get(id);

--- a/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
@@ -72,7 +72,6 @@ const toRow = (item: ReleasePlanMilestoneStrategyWriteModel) => {
 
 const toUpdateRow = (item: Partial<MilestoneStrategyConfigUpdate>) => {
     return {
-        milestone_id: item.milestoneId,
         sort_order: item.sortOrder,
         title: item.title,
         parameters: item.parameters ?? {},

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -40,13 +40,9 @@ export interface IStrategyConfig {
     disabled?: boolean | null;
 }
 
-export type MilestoneStrategyConfig = Omit<IStrategyConfig, 'name'> & {
-    strategyName: string;
-};
-
 export type MilestoneStrategyConfigUpdate = Omit<
-    MilestoneStrategyConfig,
-    'strategyName'
+    IStrategyConfig,
+    'name' | 'milestoneId'
 >;
 
 export interface IFeatureStrategy {


### PR DESCRIPTION
Because `MilestoneStrategyConfig` has `id` marked as optional, but it's always there (and should always be there) when updating a milestone strategy. (because a strategy can't not have an id)