### PR TITLE
chore: remove table row hover on Instance Stats

### DIFF
--- a/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
+++ b/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
@@ -99,7 +99,14 @@ export const InstanceStats: FC = () => {
                     </TableHead>
                     <TableBody>
                         {rows.map((row) => (
-                            <TableRow key={row.title}>
+                            <TableRow
+                                key={row.title}
+                                sx={{
+                                    '&:hover': {
+                                        backgroundColor: 'unset !important',
+                                    },
+                                }}
+                            >
                                 <TableCell component='th' scope='row'>
                                     <Box
                                         component='span'


### PR DESCRIPTION
Removes background color change on hover from `InstanceStats` table rows (since they are not interactive/clickable).

<img width="1043" height="458" alt="Screenshot 2026-03-09 at 15 55 57 (2)" src="https://github.com/user-attachments/assets/0945ed12-5519-4aec-b75f-7dd59c99e25e" />


