### PR TITLE
Can switch to enterprise billing for now?

### DIFF
--- a/frontend/src/component/admin/billing/Billing.tsx
+++ b/frontend/src/component/admin/billing/Billing.tsx
@@ -35,8 +35,7 @@ export const Billing = () => {
         uiConfig: { billing },
     } = useUiConfig();
 
-    const eligibleForDetailedBilling =
-        billing === 'pay-as-you-go' || billing === 'enterprise-consumption';
+    const eligibleForDetailedBilling = billing === 'enterprise-consumption';
 
     useEffect(() => {
         const hardRefresh = async () => {


### PR DESCRIPTION
I'm not really sure about this change, but following the @nunogois suggestion I started looking at code that uses

```
const { instancePrices } = useInstancePrices();
```

 instead of 
```    const {
        planPrice,
        planCurrency,
        loading: invoicesLoading,
    } = useDetailedInvoices();
```

This is the smallest change that gives us that. 

- [ ] I have no idea how to simulate invoices
- [ ] Should I check if invoices are shown in the same way after this change? 
- [ ] I'm not sure why this is not $75 per user billed monthly as in production. Do we charge by seat? 

## Prev

<img width="984" height="483" alt="Screenshot 2026-03-09 at 16 55 31" src="https://github.com/user-attachments/assets/0565f985-d182-43eb-8797-08e1fc1bc72d" />


## This PR

<img width="1843" height="930" alt="Screenshot 2026-03-09 at 16 54 25" src="https://github.com/user-attachments/assets/7ec661e2-4bc3-474c-9a85-fd614079bb38" />
