### PR TITLE
chore: override webkit autofill styling on login

### DIFF
--- a/frontend/src/component/common/PasswordField/PasswordField.tsx
+++ b/frontend/src/component/common/PasswordField/PasswordField.tsx
@@ -1,22 +1,9 @@
-import {
-    IconButton,
-    InputAdornment,
-    styled,
-    TextField,
-    type TextFieldProps,
-} from '@mui/material';
+import { IconButton, InputAdornment, type TextFieldProps } from '@mui/material';
+import { StyledAutofillTextField } from 'component/user/StyledAutofillTextField';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import type React from 'react';
 import { useState, type VFC } from 'react';
-
-const StyledTextField = styled(TextField)(({ theme }) => ({
-    '& input': {
-        boxShadow: `transparent 0px 0px 0px 1px inset, ${theme.palette.background.paper} 0px 0px 0px 100px inset`,
-        WebkitTextFillColor: theme.palette.text.primary,
-        caretColor: theme.palette.text.primary,
-    },
-}));
 
 const PasswordField: VFC<TextFieldProps> = ({ ...rest }) => {
     const [showPassword, setShowPassword] = useState(false);
@@ -35,7 +22,7 @@ const PasswordField: VFC<TextFieldProps> = ({ ...rest }) => {
     const iconTitle = 'Toggle password visibility';
 
     return (
-        <StyledTextField
+        <StyledAutofillTextField
             variant='outlined'
             size='small'
             type={showPassword ? 'text' : 'password'}

--- a/frontend/src/component/user/DeprecatedPasswordAuth.tsx
+++ b/frontend/src/component/user/DeprecatedPasswordAuth.tsx
@@ -1,5 +1,6 @@
 import { type FormEventHandler, useState, type VFC } from 'react';
-import { Button, styled, TextField } from '@mui/material';
+import { Button, styled } from '@mui/material';
+import { StyledAutofillTextField } from './StyledAutofillTextField.tsx';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useNavigate } from 'react-router';
 import useQueryParams from 'hooks/useQueryParams';
@@ -128,7 +129,7 @@ const DeprecatedPasswordAuth: VFC<IPasswordAuthProps> = ({
                         />
 
                         <StyledDiv>
-                            <TextField
+                            <StyledAutofillTextField
                                 label='Username or email'
                                 name='username'
                                 id='username'

--- a/frontend/src/component/user/HostedAuth.tsx
+++ b/frontend/src/component/user/HostedAuth.tsx
@@ -1,5 +1,6 @@
 import { type FormEventHandler, useState, type VFC } from 'react';
-import { Button, Grid, styled, TextField, Typography } from '@mui/material';
+import { Button, Grid, styled, Typography } from '@mui/material';
+import { StyledAutofillTextField } from './StyledAutofillTextField.tsx';
 import { useNavigate } from 'react-router';
 import useQueryParams from 'hooks/useQueryParams';
 import AuthOptions from './common/AuthOptions/AuthOptions.tsx';
@@ -34,14 +35,6 @@ const StyledButton = styled(Button)(({ theme }) => ({
     margin: theme.spacing(2, 'auto', 0, 'auto'),
     display: 'block',
     textAlign: 'center',
-}));
-
-const StyledTextField = styled(TextField)(({ theme }) => ({
-    '& input': {
-        boxShadow: `transparent 0px 0px 0px 1px inset, ${theme.palette.background.paper} 0px 0px 0px 100px inset`,
-        WebkitTextFillColor: theme.palette.text.primary,
-        caretColor: theme.palette.text.primary,
-    },
 }));
 
 const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
@@ -134,7 +127,7 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
                             {apiError}
                         </StyledTypography>
                         <StyledDiv>
-                            <StyledTextField
+                            <StyledAutofillTextField
                                 label='Username or email'
                                 name='username'
                                 id='username'

--- a/frontend/src/component/user/PasswordAuth.tsx
+++ b/frontend/src/component/user/PasswordAuth.tsx
@@ -1,24 +1,25 @@
-import { type FormEventHandler, useState, type VFC } from "react";
-import { Button, styled, TextField } from "@mui/material";
-import { ConditionallyRender } from "component/common/ConditionallyRender/ConditionallyRender";
-import { useNavigate } from "react-router";
-import useQueryParams from "hooks/useQueryParams";
-import AuthOptions from "./common/AuthOptions/AuthOptions.tsx";
-import OrDivider from "./common/OrDivider";
-import { Alert } from "@mui/material";
-import { LOGIN_BUTTON, LOGIN_EMAIL_ID, LOGIN_PASSWORD_ID } from "utils/testIds";
-import PasswordField from "component/common/PasswordField/PasswordField";
-import { useAuthApi } from "hooks/api/actions/useAuthApi/useAuthApi";
-import { useAuthUser } from "hooks/api/getters/useAuth/useAuthUser";
-import type { IAuthEndpointDetailsResponse } from "hooks/api/getters/useAuth/useAuthEndpoint";
+import { type FormEventHandler, useState, type VFC } from 'react';
+import { Button, styled } from '@mui/material';
+import { StyledAutofillTextField } from './StyledAutofillTextField.tsx';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useNavigate } from 'react-router';
+import useQueryParams from 'hooks/useQueryParams';
+import AuthOptions from './common/AuthOptions/AuthOptions.tsx';
+import OrDivider from './common/OrDivider';
+import { Alert } from '@mui/material';
+import { LOGIN_BUTTON, LOGIN_EMAIL_ID, LOGIN_PASSWORD_ID } from 'utils/testIds';
+import PasswordField from 'component/common/PasswordField/PasswordField';
+import { useAuthApi } from 'hooks/api/actions/useAuthApi/useAuthApi';
+import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+import type { IAuthEndpointDetailsResponse } from 'hooks/api/getters/useAuth/useAuthEndpoint';
 import {
     AuthenticationError,
     BadRequestError,
     NotFoundError,
-} from "utils/apiUtils";
-import useToast from "hooks/useToast";
-import { useFlag } from "@unleash/proxy-client-react";
-import DeprecatedPasswordAuth from "./DeprecatedPasswordAuth";
+} from 'utils/apiUtils';
+import useToast from 'hooks/useToast';
+import { useFlag } from '@unleash/proxy-client-react';
+import DeprecatedPasswordAuth from './DeprecatedPasswordAuth';
 
 interface IPasswordAuthProps {
     authDetails: IAuthEndpointDetailsResponse;
@@ -30,23 +31,15 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(1),
 }));
 
-const StyledDiv = styled("div")(({ theme }) => ({
-    display: "flex",
-    flexDirection: "column",
+const StyledDiv = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
     gap: theme.spacing(3),
 }));
 
 const StyledButton = styled(Button)({
-    width: "100%",
+    width: '100%',
 });
-
-const StyledTextField = styled(TextField)(({ theme }) => ({
-    "&&& input": {
-        boxShadow: `transparent 0px 0px 0px 1px inset, ${theme.palette.background.paper} 0px 0px 0px 100px inset`,
-        WebkitTextFillColor: theme.palette.text.primary,
-        caretColor: theme.palette.text.primary,
-    },
-}));
 
 const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
     authDetails,
@@ -55,8 +48,8 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
     const navigate = useNavigate();
     const { refetchUser } = useAuthUser();
     const params = useQueryParams();
-    const [username, setUsername] = useState(params.get("email") || "");
-    const [password, setPassword] = useState("");
+    const [username, setUsername] = useState(params.get('email') || '');
+    const [password, setPassword] = useState('');
     const { passwordAuth } = useAuthApi();
     const [errors, setErrors] = useState<{
         usernameError?: string;
@@ -71,13 +64,13 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
         if (!username) {
             setErrors((prev) => ({
                 ...prev,
-                usernameError: "This is a required field",
+                usernameError: 'This is a required field',
             }));
         }
         if (!password) {
             setErrors((prev) => ({
                 ...prev,
-                passwordError: "This is a required field",
+                passwordError: 'This is a required field',
             }));
         }
 
@@ -93,7 +86,7 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
             );
             if (data.deletedSessions && data.activeSessions) {
                 setToastData({
-                    type: "success",
+                    type: 'success',
                     text: `Maximum session limit of ${data.activeSessions} reached`,
                 });
             }
@@ -107,17 +100,17 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
             ) {
                 setErrors((prev) => ({
                     ...prev,
-                    apiError: "Invalid login details",
+                    apiError: 'Invalid login details',
                 }));
-                setPassword("");
-                setUsername("");
+                setPassword('');
+                setUsername('');
             } else if (error instanceof AuthenticationError) {
                 setErrors({
-                    apiError: "Invalid password and username combination.",
+                    apiError: 'Invalid password and username combination.',
                 });
             } else {
                 setErrors({
-                    apiError: "Unknown error while trying to authenticate.",
+                    apiError: 'Unknown error while trying to authenticate.',
                 });
             }
         }
@@ -134,47 +127,47 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
                         <ConditionallyRender
                             condition={Boolean(apiError)}
                             show={
-                                <StyledAlert severity="error">
+                                <StyledAlert severity='error'>
                                     {apiError}
                                 </StyledAlert>
                             }
                         />
 
                         <StyledDiv>
-                            <StyledTextField
-                                label="Email"
-                                name="username"
-                                id="username"
-                                type="text"
+                            <StyledAutofillTextField
+                                label='Email'
+                                name='username'
+                                id='username'
+                                type='text'
                                 onChange={(evt) =>
                                     setUsername(evt.target.value)
                                 }
                                 value={username}
                                 error={Boolean(usernameError)}
                                 helperText={usernameError}
-                                autoComplete="username"
+                                autoComplete='username'
                                 data-testid={LOGIN_EMAIL_ID}
-                                variant="outlined"
-                                size="small"
+                                variant='outlined'
+                                size='small'
                                 autoFocus
                             />
                             <PasswordField
-                                label="Password"
+                                label='Password'
                                 onChange={(evt) =>
                                     setPassword(evt.target.value)
                                 }
-                                name="password"
-                                id="password"
+                                name='password'
+                                id='password'
                                 value={password}
                                 error={Boolean(passwordError)}
                                 helperText={passwordError}
-                                autoComplete="off"
+                                autoComplete='off'
                                 data-testid={LOGIN_PASSWORD_ID}
                             />
                             <StyledButton
-                                variant="contained"
-                                color="primary"
-                                type="submit"
+                                variant='contained'
+                                color='primary'
+                                type='submit'
                                 data-testid={LOGIN_BUTTON}
                             >
                                 Sign in
@@ -209,7 +202,7 @@ const NewPasswordAuth: VFC<IPasswordAuthProps> = ({
 };
 
 const PasswordAuth: VFC<IPasswordAuthProps> = (props) => {
-    const newLogin = useFlag("newLogin");
+    const newLogin = useFlag('newLogin');
     if (newLogin) {
         return <NewPasswordAuth {...props} />;
     }

--- a/frontend/src/component/user/StyledAutofillTextField.tsx
+++ b/frontend/src/component/user/StyledAutofillTextField.tsx
@@ -1,0 +1,9 @@
+import { styled, TextField } from '@mui/material';
+
+export const StyledAutofillTextField = styled(TextField)(({ theme }) => ({
+    '&&& input': {
+        boxShadow: `transparent 0px 0px 0px 1px inset, ${theme.palette.background.paper} 0px 0px 0px 100px inset`,
+        WebkitTextFillColor: theme.palette.text.primary,
+        caretColor: theme.palette.text.primary,
+    },
+}));


### PR DESCRIPTION
Adds custom styling for autofilled inputs to `PasswordField`, `PasswordAuth` and `HostedAuth`.

## About the changes
Webkit-autofill inputs use browser defaults that override custom CSS. As a result, on the log in form in dark mode, the email/username and password inputs background was auto set to white. Using nested `box-shadow` with inset spread allows us to override that.
Thank you @nunogois for the suggested solution! 💖 

Closes # 1-4437

## Discussion points

~~I'm repeating this `StyledTextField` in three places instead of exporting it somewhere and reusing as I can't seem to find that pattern elsewhere in the code and I'm not sure where that shared styled component should live. But I'm also happy to extract it in a separate file if you think it's better.~~ broke out the styled component into `StyledAutofillTextField`

Before: 

https://github.com/user-attachments/assets/96ed0d2b-8d20-4167-8ffe-177f9ca015c9

After: 

https://github.com/user-attachments/assets/ebb4fcdf-44e4-45d4-9d7e-1d591675cd4c


