### PR TITLE
chore: fix bug where we track signup-dialog even if dialog is not shown

### DIFF
--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -238,8 +238,10 @@ export const SignupDialog = () => {
     const safeStep = Math.min(step, steps.length - 1);
     const currentStep = steps[safeStep];
 
+    const isVisible = signupRequired && steps.length > 0 && currentStep;
+
     useEffect(() => {
-        if (currentStep?.title) {
+        if (isVisible && currentStep?.title) {
             trackEvent('signup-dialog', {
                 props: {
                     eventType: 'view',
@@ -247,9 +249,9 @@ export const SignupDialog = () => {
                 },
             });
         }
-    }, [currentStep?.title, trackEvent]);
+    }, [isVisible, currentStep?.title, trackEvent]);
 
-    if (!signupRequired || steps.length === 0 || !currentStep) return null;
+    if (!isVisible) return null;
 
     const StepContent = currentStep.content;
 


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-192/fix-dont-track-signup-dialog-views-unless-its-actually-visible

Fixes a bug where we are tracking signup-dialog Plausible events even if the dialog is not shown.