### PR TITLE
chore: include segments in milestone strategy store get()

### DIFF
--- a/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-service.ts
@@ -9,7 +9,6 @@ import type { Logger } from '../../logger.js';
 import type { IReleasePlanMilestoneStrategyStore } from './release-plan-milestone-strategy-store.js';
 import type { FeatureToggleService } from '../feature-toggle/feature-toggle-service.js';
 import {
-    NotFoundError,
     PermissionError,
     SKIP_CHANGE_REQUEST,
     type IChangeRequestAccessReadModel,
@@ -94,12 +93,7 @@ export class ReleasePlanMilestoneStrategyService {
     ): Promise<ReleasePlanMilestoneStrategy> {
         const { projectId, environment, featureName } = context;
 
-        const existingStrategy = await this.milestoneStrategyStore.get(id);
-        if (!existingStrategy) {
-            throw new NotFoundError(
-                `Could not find milestone strategy with id=${id}`,
-            );
-        }
+        await this.milestoneStrategyStore.get(id); // Validate milestone strategy exists
 
         let isActive: boolean;
         try {

--- a/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
@@ -5,6 +5,8 @@ import type { Row } from '../../db/crud/row-type.js';
 import type { Db } from '../../db/db.js';
 import type { MilestoneStrategyConfigUpdate } from '../../types/index.js';
 import type { Store } from '../../types/stores/store.js';
+import NotFoundError from '../../error/notfound-error.js';
+
 const TABLE = 'milestone_strategies';
 
 export type ReleasePlanMilestoneStrategyWriteModel = Omit<
@@ -42,7 +44,7 @@ const fromRow = (row: any): ReleasePlanMilestoneStrategy => {
     };
 };
 
-const fromUpdateRow = (row: any): ReleasePlanMilestoneStrategy => {
+const fromDatabaseRow = (row: any): ReleasePlanMilestoneStrategy => {
     return {
         id: row.id,
         milestoneId: row.milestone_id,
@@ -95,6 +97,25 @@ export class ReleasePlanMilestoneStrategyStore
         super(TABLE, db, config);
     }
 
+    override async get(id: string): Promise<ReleasePlanMilestoneStrategy> {
+        const row = await this.db(TABLE).where({ id }).first();
+        if (!row) {
+            throw new NotFoundError(
+                `Milestone strategy with id ${id} not found`,
+            );
+        }
+        const strategy = fromDatabaseRow(row);
+
+        const segmentRows = await this.db('milestone_strategy_segments')
+            .where('milestone_strategy_id', id)
+            .select('segment_id');
+
+        return {
+            ...strategy,
+            segments: segmentRows.map((row: any) => row.segment_id),
+        };
+    }
+
     override async insert({
         segments,
         ...strategy
@@ -119,7 +140,7 @@ export class ReleasePlanMilestoneStrategyStore
             .where({ id: strategyId })
             .update(toUpdateRow(strategy))
             .returning('*');
-        return fromUpdateRow(rows[0]);
+        return fromDatabaseRow(rows[0]);
     }
 
     async upsert(


### PR DESCRIPTION
- Adds segments to the returned object of the release plan milestone strategy store `get()`;
- Throws `NotFoundError` from `get()` when strategy not found, matching `CRUDStore` pattern;
- Renames `fromUpdateRow` to `fromDatabaseRow` to clarify its purpose: the function transforms any row returned from the database (used in both `get()` and after updates), not just update operations. It handles rows that come back from database queries (where Knex already parses JSONB);
- Removes now unnecessary guard in `unprotectedUpdateStrategy` in the service.

Fixes # 1-4510