### PR TITLE
fix: add missing createdAt field to store insert

### DIFF
--- a/src/lib/features/release-plans/release-plan-template-store.test.ts
+++ b/src/lib/features/release-plans/release-plan-template-store.test.ts
@@ -1,0 +1,31 @@
+import { createTestConfig } from '../../../test/config/test-config.js';
+import { ReleasePlanTemplateStore } from './release-plan-template-store.js';
+import dbInit, {
+    type ITestDb,
+} from '../../../test/e2e/helpers/database-init.js';
+
+let db: ITestDb;
+const config = createTestConfig();
+
+beforeAll(async () => {
+    db = await dbInit('release_plan_template_store_serial', config.getLogger);
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+test('insert returns createdAt from the database', async () => {
+    const store = new ReleasePlanTemplateStore(db.rawDatabase, config);
+    const template = await store.insert({
+        name: 'test-template',
+        description: 'a test template',
+        discriminator: 'template',
+        createdByUserId: 1,
+    });
+
+    expect(template.id).toBeDefined();
+    expect(template.createdAt).toBeDefined();
+    expect(template.createdAt).toBeInstanceOf(Date);
+    expect(template.name).toBe('test-template');
+});

--- a/src/lib/features/release-plans/release-plan-template-store.ts
+++ b/src/lib/features/release-plans/release-plan-template-store.ts
@@ -193,9 +193,9 @@ export class ReleasePlanTemplateStore extends CRUDStore<
         const endTimer = this.timer('insert');
         const row = this.toRow(item);
         row.id = ulid();
-        await this.db(TABLE).insert(row);
+        const [inserted] = await this.db(TABLE).insert(row).returning('*');
         endTimer();
-        return fromRow(row);
+        return fromRow(inserted);
     }
 
     async archive(id: string): Promise<void> {


### PR DESCRIPTION
fixes a bug where the store wouldn't return a createdAt field from the insert method, even though the type said it was definitely there.

