### PR TITLE
chore: improve tracking in signup dialog

### DIFF
--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -6,7 +6,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import { type ComponentType, useEffect, useState } from 'react';
+import { type ComponentType, useState } from 'react';
 import { SignupDialogSetPassword } from './SignupDialogSetPassword/SignupDialogSetPassword.tsx';
 import { SignupDialogAccountDetails } from './SignupDialogAccountDetails.tsx';
 import { SignupDialogInviteOthers } from './SignupDialogInviteOthers.tsx';
@@ -172,7 +172,7 @@ export type SignupStepContent = ComponentType<{
     data: SubmitSignupData;
     setData: React.Dispatch<React.SetStateAction<SubmitSignupData>>;
     onBack?: () => void;
-    onNext: () => void;
+    onNext: (eventType?: string) => void;
     signupData?: SignupData;
     isSubmitting?: boolean;
 }>;
@@ -240,17 +240,6 @@ export const SignupDialog = () => {
 
     const isVisible = signupRequired && steps.length > 0 && currentStep;
 
-    useEffect(() => {
-        if (isVisible && currentStep?.title) {
-            trackEvent('signup-dialog', {
-                props: {
-                    eventType: 'view',
-                    step: currentStep.title,
-                },
-            });
-        }
-    }, [isVisible, currentStep?.title, trackEvent]);
-
     if (!isVisible) return null;
 
     const StepContent = currentStep.content;
@@ -261,34 +250,25 @@ export const SignupDialog = () => {
         setStep(safeStep - 1);
     };
 
-    const onNext = async () => {
+    const onNext = async (eventType = 'next') => {
         if (isSubmitting) return;
 
-        if (safeStep < steps.length - 1) {
-            let eventType = 'next';
-            if (currentStep.title === 'Invite your team') {
-                eventType = data.inviteEmails.length ? 'invite' : 'later';
-            }
-            trackEvent('signup-dialog', {
-                props: {
-                    eventType,
-                    step: currentStep.title,
-                },
-            });
+        trackEvent('signup-dialog', {
+            props: {
+                eventType,
+                step: currentStep.title,
+                ...(eventType === 'invite' && {
+                    totalInvitedEmails: data.inviteEmails.length,
+                }),
+            },
+        });
 
+        if (safeStep < steps.length - 1) {
             setStep(safeStep + 1);
             return;
         }
 
         try {
-            trackEvent('signup-dialog', {
-                props: {
-                    eventType: 'complete',
-                    step: currentStep.title,
-                    totalInvitedEmails: data.inviteEmails.length,
-                },
-            });
-
             setIsSubmitting(true);
             await submitSignupData(data);
             refetch();

--- a/frontend/src/component/signup/SignupDialog/SignupDialogAccountDetails.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogAccountDetails.tsx
@@ -142,7 +142,7 @@ export const SignupDialogAccountDetails: SignupStepContent = ({
             </StyledCheckboxContainer>
             <StyledSignupDialogButton
                 variant='contained'
-                onClick={onNext}
+                onClick={() => onNext()}
                 disabled={!isValidForm}
             >
                 Next

--- a/frontend/src/component/signup/SignupDialog/SignupDialogComplete.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogComplete.tsx
@@ -52,7 +52,7 @@ export const SignupDialogComplete: SignupStepContent = ({
             </StyledHeader>
             <Button
                 variant='contained'
-                onClick={onNext}
+                onClick={() => onNext('complete')}
                 disabled={isSubmitting}
             >
                 Start using Unleash

--- a/frontend/src/component/signup/SignupDialog/SignupDialogInviteOthers.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogInviteOthers.tsx
@@ -72,12 +72,12 @@ export const SignupDialogInviteOthers: SignupStepContent = ({
 
     const onLater = () => {
         setInviteEmails([]);
-        onNext();
+        onNext('later');
     };
 
     const onInvite = () => {
         addEmailsFromRaw(trimmedInput);
-        onNext();
+        onNext('invite');
     };
 
     return (

--- a/frontend/src/component/signup/SignupDialog/SignupDialogSetPassword/SignupDialogSetPassword.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogSetPassword/SignupDialogSetPassword.tsx
@@ -82,7 +82,7 @@ export const SignupDialogSetPassword: SignupStepContent = ({
             />
             <StyledSignupDialogButton
                 variant='contained'
-                onClick={onNext}
+                onClick={() => onNext()}
                 disabled={!isValidPassword}
             >
                 Next


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-194/improve-plausible-tracking-in-signup-dialog

Improves tracking in signup dialog:
- Only track `invite` if the user actually presses "invite";
- Move `totalInvitedEmails` to the "invite" eventType;
- Stop tracking eventType `view`;