### PR TITLE
refactor: billing trial formatting to use YMD format

### DIFF
--- a/frontend/src/component/admin/billing/TrialUpsell/TrialUpsell.test.tsx
+++ b/frontend/src/component/admin/billing/TrialUpsell/TrialUpsell.test.tsx
@@ -60,7 +60,7 @@ describe('TrialUpsell', () => {
             screen.getByRole('button', { name: /upgrade now/i }),
         ).toBeInTheDocument();
         expect(
-            screen.getByText(/Your trial expires on March 19/),
+            screen.getByText(/Your trial expires on 03\/19\/2026/),
         ).toBeInTheDocument();
         expect(
             screen.getByText('Trusted by enterprises like'),

--- a/frontend/src/component/admin/billing/TrialUpsell/TrialUpsell.tsx
+++ b/frontend/src/component/admin/billing/TrialUpsell/TrialUpsell.tsx
@@ -13,7 +13,7 @@ import { ReactComponent as SamsungLogo } from 'assets/logos/samsung.svg';
 import { ReactComponent as LloydsLogo } from 'assets/logos/lloyds.svg';
 import { trialHasExpired } from 'utils/instanceTrial';
 import { parseISO } from 'date-fns';
-import { formatDateDM } from 'utils/formatDate';
+import { formatDateYMD } from 'utils/formatDate';
 import { useLocationSettings } from 'hooks/useLocationSettings';
 
 const StyledBillingInformation = styled('div')(({ theme }) => ({
@@ -63,7 +63,7 @@ const StyledLogoList = styled('div')(({ theme }) => ({
 const formatTrialExpiry = (locale: string, trialExpiry?: string): string => {
     if (!trialExpiry) return '';
 
-    return formatDateDM(parseISO(trialExpiry), locale);
+    return formatDateYMD(parseISO(trialExpiry), locale);
 };
 
 export const TrialUpsell = () => {

--- a/frontend/src/utils/formatDate.test.ts
+++ b/frontend/src/utils/formatDate.test.ts
@@ -1,11 +1,4 @@
-import { formatDateYMD, formatDateDM } from 'utils/formatDate';
-
-test('formatDateDM', () => {
-    const date = new Date('2026-03-19T23:59:59.999Z');
-    expect(formatDateDM(date, 'en-US')).toEqual('March 19');
-    expect(formatDateDM(date, 'en-US', 'America/New_York')).toEqual('March 19');
-    expect(formatDateDM(date, 'en-US', 'Australia/Sydney')).toEqual('March 20');
-});
+import { formatDateYMD } from 'utils/formatDate';
 
 test('formatDateYMD', () => {
     const date = new Date('2026-03-19T23:59:59.999Z');
@@ -16,4 +9,5 @@ test('formatDateYMD', () => {
     expect(formatDateYMD(date, 'en-US', 'Australia/Sydney')).toEqual(
         '03/20/2026',
     );
+    expect(formatDateYMD(date, 'pl-PL', 'UTC')).toEqual('19.03.2026');
 });

--- a/frontend/src/utils/formatDate.ts
+++ b/frontend/src/utils/formatDate.ts
@@ -40,18 +40,6 @@ export const formatDateYMD = (
     });
 };
 
-export const formatDateDM = (
-    date: number | string | Date,
-    locale: string,
-    timeZone?: string,
-): string => {
-    return new Date(date).toLocaleString(locale, {
-        day: 'numeric',
-        month: 'long',
-        timeZone,
-    });
-};
-
 export const formatDateHM = (
     date: number | string | Date,
     locale: string,


### PR DESCRIPTION

<img width="594" height="96" alt="Screenshot 2026-03-11 at 16 03 38" src="https://github.com/user-attachments/assets/db072db8-d7e2-47ea-a7cd-4eadcc163855" />

Closing sa-199

Removing the only usage of the text formatting. 