### PR TITLE
chore: trigger Enterprise e2e tests on open PRs

### DIFF
--- a/.github/workflows/trigger-enterprise-e2e.yaml
+++ b/.github/workflows/trigger-enterprise-e2e.yaml
@@ -1,0 +1,47 @@
+name: Trigger Enterprise E2E Tests
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'test-enterprise')
+    outputs:
+      should-test: ${{ steps.check.outputs.should-test }}
+    steps:
+      - id: check
+        run: echo "should-test=true" >> $GITHUB_OUTPUT
+
+  test-enterprise-e2e:
+    needs: check-label
+    if: needs.check-label.outputs.should-test == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OSS
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install and build OSS
+        run: |
+          yarn install --immutable
+          yarn build:backend
+        env:
+          YARN_ENABLE_SCRIPTS: false
+
+      - name: Trigger Enterprise E2E Tests
+        run: |
+          gh workflow run cicd.yml \
+            --repo bricks-software/unleash-enterprise \
+            --ref main \
+            -f commit=${{ github.event.pull_request.head.sha }}
+        env:
+          GH_TOKEN: ${{ secrets.ENTERPRISE_REPO_TOKEN }}


### PR DESCRIPTION
Adds workflow to validate OSS changes against enterprise e2e tests before merging. When a PR is labeled with `test-enterprise`, the workflow builds the OSS changes and triggers enterprise's CI to run its e2e test suite against the exact commit, catching integration issues early.

TLDR: When you add the `test-enterprise` label, it validates that your OSS changes don't break enterprise before you merge.

TODO: 

- [ ] create `ENTERPRISE_REPO_TOKEN` secret

## About the changes
Trigger: Fires whenever a label is added to a PR on this repo.

**Job 1**: `check-label`

- Checks if the PR has the `test-enterprise` label
- Sets an output `should-test=true` if it does
- This gates the entire second job (it won't run without the label)

**Job 2**: `test-enterprise-e2e` (only runs if label is present)

- Checkout OSS: Clones your OSS repository at the PR branch
- Set up Node.js: Installs Node 22.x
- Enable corepack: Activates yarn (Yarn uses corepack for version management)
- Install and build OSS:
  - `yarn install --immutable` - installs deps exactly as lockfile specifies
  - `yarn build:backend` - builds your TypeScript backend
  - `YARN_ENABLE_SCRIPTS: false` - skips postinstall scripts (performance)
 
- Trigger Enterprise E2E Tests:
  - Calls `gh workflow run cicd.yml` on the enterprise repo
  - Passes the current PR's commit SHA as the `commit` input
  - Enterprise's workflow will then check out that exact OSS commit and run its full test suite against it

