### PR TITLE
Upgrade react-router-dom from 6.16.0 to 6.30.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,7 +121,7 @@
     "react-hooks-global-state": "2.1.0",
     "react-joyride": "^2.5.3",
     "react-markdown": "^8.0.4",
-    "react-router-dom": "6.16.0",
+    "react-router-dom": "6.30.3",
     "react-table": "7.8.0",
     "react-test-renderer": "18.3.1",
     "regenerator-runtime": "0.14.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2088,10 +2088,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@remix-run/router@npm:1.9.0"
-  checksum: 10c0/560ee341719634d273b8502e00e15b3dc4a0d245cb0a3d9663981a70967cba8675d0ac3ddd94e8f572ae66f6fd2618304130a077faec49bf30347c3241e64b28
+"@remix-run/router@npm:1.23.2":
+  version: 1.23.2
+  resolution: "@remix-run/router@npm:1.23.2"
+  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
   languageName: node
   linkType: hard
 
@@ -8599,27 +8599,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.16.0":
-  version: 6.16.0
-  resolution: "react-router-dom@npm:6.16.0"
+"react-router-dom@npm:6.30.3":
+  version: 6.30.3
+  resolution: "react-router-dom@npm:6.30.3"
   dependencies:
-    "@remix-run/router": "npm:1.9.0"
-    react-router: "npm:6.16.0"
+    "@remix-run/router": "npm:1.23.2"
+    react-router: "npm:6.30.3"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 10c0/f1d898115b395038bc44d295412f0ab480ee3057fb2306048bf64c9c4b3a6e4eba756b058a0557e71e86bddb1090d298849fa22c0d8aa5abcecfa3a61204f7a3
+  checksum: 10c0/e8a1e13c662ed6ee71a785bd3418ba04b700bcd8aff6ea7b32524371e8abb1c85568cd4fe9b9e9d555b8101fd415f6f1796531f593da60be179ce75b37038657
   languageName: node
   linkType: hard
 
-"react-router@npm:6.16.0":
-  version: 6.16.0
-  resolution: "react-router@npm:6.16.0"
+"react-router@npm:6.30.3":
+  version: 6.30.3
+  resolution: "react-router@npm:6.30.3"
   dependencies:
-    "@remix-run/router": "npm:1.9.0"
+    "@remix-run/router": "npm:1.23.2"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/914e3352f26d9d9e3f859483507d459f2bb01ca65fcd1a3f9c5dba91dd005b45e7aae32dbd0f777ea00ecf453dc0e20463d3bcbbdec6ce13f8235be377f66752
+  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
   languageName: node
   linkType: hard
 
@@ -10361,7 +10361,7 @@ __metadata:
     react-hooks-global-state: "npm:2.1.0"
     react-joyride: "npm:^2.5.3"
     react-markdown: "npm:^8.0.4"
-    react-router-dom: "npm:6.16.0"
+    react-router-dom: "npm:6.30.3"
     react-table: "npm:7.8.0"
     react-test-renderer: "npm:18.3.1"
     regenerator-runtime: "npm:0.14.1"


### PR DESCRIPTION
## Summary
This PR upgrades the `react-router-dom` dependency to a newer minor version, bringing in bug fixes and improvements from the React Router library.

## Changes
- Updated `react-router-dom` from version 6.16.0 to 6.30.3 in frontend dependencies

## Notes
- This is a minor version bump within the 6.x release line, which should maintain API compatibility
- The lockfile has been updated to reflect transitive dependency changes

https://claude.ai/code/session_01Eojjz9XpWCQjqhXbiiSii1