### PR TITLE
chore: remove signup and welcome dialog backdrop blur

### DIFF
--- a/frontend/src/component/personalDashboard/WelcomeDialog.tsx
+++ b/frontend/src/component/personalDashboard/WelcomeDialog.tsx
@@ -8,9 +8,6 @@ import { formatAssetPath } from 'utils/formatPath';
 import { useWelcomeDialogContext } from './WelcomeDialogContext.tsx';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
-    '.MuiBackdrop-root': {
-        backdropFilter: 'blur(8px)',
-    },
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
         width: '65vw',

--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -22,9 +22,6 @@ import { useWelcomeDialogContext } from 'component/personalDashboard/WelcomeDial
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker.ts';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
-    '.MuiBackdrop-root': {
-        backdropFilter: 'blur(8px)',
-    },
     '& .MuiDialog-paper': {
         display: 'grid',
         gridTemplateColumns: '1fr 1fr',


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-201/consider-ways-to-improve-the-signup-dialog-design

Removes the signup and welcome dialog backdrop blur.

<img width="1775" height="1329" alt="image" src="https://github.com/user-attachments/assets/88f1cb56-79f2-4a51-baf7-7c5c35f5783b" />

<img width="1205" height="1329" alt="image" src="https://github.com/user-attachments/assets/4202458b-6242-43f1-a8b7-8aef5f644114" />