### PR TITLE
feat: support UNLEASH_FRONTEND_TOKEN env var for local dev

### DIFF
--- a/frontend/src/component/providers/UnleashFlagProvider/UnleashFlagProvider.tsx
+++ b/frontend/src/component/providers/UnleashFlagProvider/UnleashFlagProvider.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { type FC, useEffect } from 'react';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import FlagProvider, {
+    InMemoryStorageProvider,
     LocalStorageProvider,
     UnleashClient,
 } from '@unleash/proxy-client-react';
@@ -30,7 +31,9 @@ export const UnleashFlagProvider: FC<{ children?: React.ReactNode }> = ({
         token = getUnleashFrontendToken();
 
         client = new UnleashClient({
-            storageProvider: new LocalStorageProvider(`${basePath}:unleash`),
+            storageProvider: token
+                ? new LocalStorageProvider(`${basePath}:unleash`)
+                : new InMemoryStorageProvider(),
             url: UNLEASH_API,
             clientKey: token || 'offline',
             appName: 'Unleash Cloud UI',

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -10,6 +10,7 @@ import envCompatible from 'vite-plugin-env-compatible';
 
 const UNLEASH_API = process.env.UNLEASH_API || 'http://localhost:4242';
 const UNLEASH_BASE_PATH = process.env.UNLEASH_BASE_PATH || '/';
+const UNLEASH_FRONTEND_TOKEN = process.env.UNLEASH_FRONTEND_TOKEN || '';
 
 if (!UNLEASH_BASE_PATH.startsWith('/') || !UNLEASH_BASE_PATH.endsWith('/')) {
     console.error('UNLEASH_BASE_PATH must both start and end with /');
@@ -115,6 +116,15 @@ export default defineConfig(({ mode }) => {
                 },
             },
             plugins: [
+                {
+                    name: 'html-rewrite',
+                    transformIndexHtml(html) {
+                        return html.replace(
+                            /::unleashToken::/gi,
+                            UNLEASH_FRONTEND_TOKEN,
+                        );
+                    },
+                },
                 react(reactPluginArgs),
                 tsconfigPaths(),
                 svgr(),


### PR DESCRIPTION
## Summary
- Use `InMemoryStorageProvider` instead of `LocalStorageProvider` when no frontend token is present, preventing stale cached flags from showing the wrong UI locally
- Add a Vite `transformIndexHtml` plugin that replaces `::unleashToken::` with the `UNLEASH_FRONTEND_TOKEN` env var, mirroring the backend's `rewriteHTML` behavior

### Usage
```bash
UNLEASH_FRONTEND_TOKEN='your-token' yarn dev:frontend
```

Without the env var, all frontend flags default to `false` (old UI), matching the expected behavior when no Unleash frontend API is configured.