### PR TITLE
feat: support impact metrics in frontend API

### DIFF
--- a/src/lib/features/frontend-api/frontend-api-controller.ts
+++ b/src/lib/features/frontend-api/frontend-api-controller.ts
@@ -26,7 +26,6 @@ import { minutesToMilliseconds } from 'date-fns';
 import metricsHelper from '../../util/metrics-helper.js';
 import { FUNCTION_TIME } from '../../metric-events.js';
 import type { IUnleashServices } from '../../services/index.js';
-import type { Metric } from '../metrics/impact/metrics-translator.js';
 
 interface ApiUserRequest<
     PARAM = any,
@@ -229,14 +228,11 @@ export default class FrontendAPIController extends Controller {
             return;
         }
 
-        const { impactMetrics, ...metricsData } = req.body;
-
         await this.services.frontendApiService.registerFrontendApiMetrics(
             req.user,
-            metricsData,
+            req.body,
             extractClientIp(req),
             req.headers['unleash-sdk'],
-            impactMetrics as Metric[],
         );
 
         res.sendStatus(200);

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -119,7 +119,6 @@ export class FrontendApiService {
         metrics: ClientMetricsSchema,
         ip: string,
         sdkVersion?: string | string[],
-        impactMetrics?: Metric[],
     ): Promise<void> {
         FrontendApiService.assertExpectedTokenType(token);
 
@@ -137,12 +136,19 @@ export class FrontendApiService {
             ip,
         );
 
+        // Because we're keeping impact metrics out of the client schema for now,
+        // we need to check for it separately here. We can remove this once impact
+        // metrics are fully integrated into the client schema.
+        const { impactMetrics } = metrics as ClientMetricsSchema & {
+            impactMetrics?: Metric[];
+        };
+
         if (
             this.config.flagResolver.isEnabled('impactMetrics') &&
             impactMetrics
         ) {
             await this.services.clientMetricsServiceV2.registerImpactMetrics(
-                impactMetrics,
+                impactMetrics as Metric[],
             );
         }
 


### PR DESCRIPTION
## Summary
- Extracts `impactMetrics` from the request body in the frontend API controller and forwards them through the service to `clientMetricsServiceV2.registerImpactMetrics()`, matching the existing client API behavior
- Gated behind the existing `impactMetrics` feature flag