### PR TITLE
feat: add defaultExpanded and renderStrategy props to ReleasePlanMilestone

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -5,7 +5,10 @@ import {
     AccordionSummary,
     styled,
 } from '@mui/material';
-import type { IReleasePlanMilestone } from 'interfaces/releasePlans';
+import type {
+    IReleasePlanMilestone,
+    IReleasePlanMilestoneStrategy,
+} from 'interfaces/releasePlans';
 import {
     ReleasePlanMilestoneStatus,
     type MilestoneStatus,
@@ -110,6 +113,11 @@ interface IReleasePlanMilestoneProps {
     projectId?: string;
     environmentId: string;
     featureId: string;
+    defaultExpanded?: boolean;
+    renderStrategy?: (
+        strategy: IReleasePlanMilestoneStrategy,
+        index: number,
+    ) => React.ReactNode;
 }
 
 export const ReleasePlanMilestone = ({
@@ -122,8 +130,10 @@ export const ReleasePlanMilestone = ({
     projectId,
     environmentId,
     featureId,
+    defaultExpanded = false,
+    renderStrategy,
 }: IReleasePlanMilestoneProps) => {
-    const [expanded, setExpanded] = useState(false);
+    const [expanded, setExpanded] = useState(defaultExpanded);
     const canEditStrategies = useUiFlag('updateMilestoneStrategy');
     const hasAutomation = Boolean(automationSection);
     const isPreviousMilestonePaused =
@@ -189,6 +199,7 @@ export const ReleasePlanMilestone = ({
             <StyledAccordion
                 status={status}
                 hasAutomation={hasAutomation}
+                defaultExpanded={defaultExpanded}
                 onChange={(_evt, expanded) => setExpanded(expanded)}
             >
                 <StyledAccordionSummary expandIcon={<ExpandMore />}>
@@ -237,33 +248,34 @@ export const ReleasePlanMilestone = ({
                             <StrategyListItem key={strategy.id}>
                                 {index > 0 ? <StrategySeparator /> : null}
 
-                                {canEditStrategies ? (
-                                    <ProjectEnvironmentStrategyDraggableItem
-                                        readonly={readonly}
-                                        scope='milestone'
-                                        featureId={featureId}
-                                        strategy={{
-                                            ...strategy,
-                                            name:
-                                                strategy.name ||
-                                                strategy.strategyName ||
-                                                '',
-                                        }}
-                                        index={index}
-                                        environmentName={environmentId}
-                                    />
-                                ) : (
-                                    <StrategyItem
-                                        strategyHeaderLevel={4}
-                                        strategy={{
-                                            ...strategy,
-                                            name:
-                                                strategy.name ||
-                                                strategy.strategyName ||
-                                                '',
-                                        }}
-                                    />
-                                )}
+                                {renderStrategy?.(strategy, index) ??
+                                    (canEditStrategies ? (
+                                        <ProjectEnvironmentStrategyDraggableItem
+                                            readonly={readonly}
+                                            scope='milestone'
+                                            featureId={featureId}
+                                            strategy={{
+                                                ...strategy,
+                                                name:
+                                                    strategy.name ||
+                                                    strategy.strategyName ||
+                                                    '',
+                                            }}
+                                            index={index}
+                                            environmentName={environmentId}
+                                        />
+                                    ) : (
+                                        <StrategyItem
+                                            strategyHeaderLevel={4}
+                                            strategy={{
+                                                ...strategy,
+                                                name:
+                                                    strategy.name ||
+                                                    strategy.strategyName ||
+                                                    '',
+                                            }}
+                                        />
+                                    ))}
                             </StrategyListItem>
                         ))}
                     </StrategyList>


### PR DESCRIPTION
Add generic extension points to support custom strategy rendering and auto-expanding milestones. 