### PR TITLE
chore: simplify signupRequired condition

### DIFF
--- a/frontend/src/component/signup/hooks/useSignup.ts
+++ b/frontend/src/component/signup/hooks/useSignup.ts
@@ -49,11 +49,7 @@ export const useSignup = (options?: SWRConfiguration) => {
         authData &&
         'user' in authData &&
         authData.user?.email?.toLowerCase().endsWith('@getunleash.io');
-    const dataIncomplete =
-        signupData &&
-        (signupData.shouldSetPassword ||
-            !signupData.companyRole ||
-            !signupData.companyName);
+    const dataIncomplete = signupData && !signupData.companyRole;
     const signupRequired = isUCASignup && !isUnleashUser && dataIncomplete;
 
     return {


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-234/fix-only-consider-company-role-in-order-to-show-the-signup-dialog

We had an issue where a recently signed up email account would see the signup dialog again when navigating to the `/login` page. This was especially obvious when trying to accept new access requests from users, since the link in the email directs you to the login page.

This is because we have a middleware in the `/login` route that resets the current `req.user` to whatever is in UCA's JWT, which would still include `shouldSetPassword: true`.

We reached the conclusion that the easiest fix for now is to simplify the condition to show the dialog. A missing `companyRole` for the current user should be all we need to consider signup data incomplete and show the dialog, regardless of whether the user already set the password or not.

Co-authored-by: Krzysztof (Kris) Kula <kris.kula@getunleash.io>