### PR TITLE
chore: refactor app.ts authtype mapping

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -145,15 +145,6 @@ export default async function getApp(
             noAuthentication(baseUriPath, app);
             break;
         }
-        case IAuthType.DEMO: {
-            demoAuthentication(
-                app,
-                config.server.baseUriPath,
-                services,
-                config,
-            );
-            break;
-        }
         default: {
             demoAuthentication(
                 app,


### PR DESCRIPTION
Refactors the AuthType middleware mapping to make it easier to refactor api-token middleware