### PR TITLE
chore: track edit milestone strategy actions

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -107,7 +107,7 @@ const NewFeatureStrategyEdit = () => {
     const [strategy, setStrategy] = useState<StrategyFormState>({
         name: '', // populated in the effect
     });
-    const [strategyContext, setStrategyContext] =
+    const [strategyScope, setStrategyScope] =
         useState<FeatureEnvironmentStrategyScope>('default');
     const {
         updateStrategyOnFeature,
@@ -209,7 +209,7 @@ const NewFeatureStrategyEdit = () => {
                 .find((strategy) => strategy.id === strategyId);
 
         if (savedStrategy && 'milestoneId' in savedStrategy) {
-            setStrategyContext('milestone');
+            setStrategyScope('milestone');
         }
 
         const constraintsWithId = addIdSymbolToConstraints(savedStrategy);
@@ -250,7 +250,7 @@ const NewFeatureStrategyEdit = () => {
 
     const onStrategyEdit = async (payload: IFeatureStrategyPayload) => {
         const updateFn =
-            strategyContext === 'milestone'
+            strategyScope === 'milestone'
                 ? updateMilestoneStrategyOnFeature
                 : updateStrategyOnFeature;
 
@@ -271,7 +271,7 @@ const NewFeatureStrategyEdit = () => {
     const onStrategyRequestEdit = async (payload: IFeatureStrategyPayload) => {
         await addChange(projectId, environmentId, {
             action:
-                strategyContext === 'milestone'
+                strategyScope === 'milestone'
                     ? 'updateMilestoneStrategy'
                     : 'updateStrategy',
             feature: featureId,
@@ -291,6 +291,14 @@ const NewFeatureStrategyEdit = () => {
     };
 
     const onSubmit = async () => {
+        if (strategyScope === 'milestone') {
+            trackEvent('edit-milestone-strategy', {
+                props: {
+                    eventType: 'form submitted',
+                },
+            });
+        }
+
         try {
             if (isChangeRequestConfigured(environmentId)) {
                 await onStrategyRequestEdit(payload);
@@ -320,7 +328,7 @@ const NewFeatureStrategyEdit = () => {
             documentationLinkLabel={featureStrategyDocsLinkLabel}
             formatApiCode={() =>
                 formatUpdateStrategyApiCode({
-                    strategyScope: strategyContext,
+                    strategyScope,
                     projectId,
                     featureId,
                     environmentId,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -18,6 +18,7 @@ import MenuStrategyRemove from './StrategyItem/MenuStrategyRemove/MenuStrategyRe
 import { Link } from 'react-router-dom';
 import { UPDATE_FEATURE_STRATEGY } from '@server/types/permissions';
 import { StrategyDraggableItem } from './StrategyDraggableItem.tsx';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker.ts';
 
 type EditControlsProps = {
     projectId: string;
@@ -37,38 +38,48 @@ const EditControls = ({
     editStrategyPath,
     otherEnvironments,
     scope,
-}: EditControlsProps) => (
-    <>
-        <PermissionIconButton
-            permission={UPDATE_FEATURE_STRATEGY}
-            environmentId={environmentName}
-            projectId={projectId}
-            component={Link}
-            to={editStrategyPath}
-            tooltipProps={{
-                title: 'Edit strategy',
-            }}
-            data-testid={`STRATEGY_EDIT-${strategy.name}`}
-        >
-            <Edit />
-        </PermissionIconButton>
-        {otherEnvironments && otherEnvironments?.length > 0 ? (
-            <CopyStrategyIconMenu
+}: EditControlsProps) => {
+    const { trackEvent } = usePlausibleTracker();
+    return (
+        <>
+            <PermissionIconButton
+                permission={UPDATE_FEATURE_STRATEGY}
                 environmentId={environmentName}
-                environments={otherEnvironments as string[]}
-                strategy={strategy}
-            />
-        ) : null}
-        {scope === 'milestone' ? null : (
-            <MenuStrategyRemove
                 projectId={projectId}
-                featureId={featureId}
-                environmentId={environmentName}
-                strategy={strategy}
-            />
-        )}
-    </>
-);
+                component={Link}
+                onClick={() => {
+                    if (scope === 'milestone') {
+                        trackEvent('edit-milestone-strategy', {
+                            props: { eventType: 'clicked edit button' },
+                        });
+                    }
+                }}
+                to={editStrategyPath}
+                tooltipProps={{
+                    title: 'Edit strategy',
+                }}
+                data-testid={`STRATEGY_EDIT-${strategy.name}`}
+            >
+                <Edit />
+            </PermissionIconButton>
+            {otherEnvironments && otherEnvironments?.length > 0 ? (
+                <CopyStrategyIconMenu
+                    environmentId={environmentName}
+                    environments={otherEnvironments as string[]}
+                    strategy={strategy}
+                />
+            ) : null}
+            {scope === 'milestone' ? null : (
+                <MenuStrategyRemove
+                    projectId={projectId}
+                    featureId={featureId}
+                    environmentId={environmentName}
+                    strategy={strategy}
+                />
+            )}
+        </>
+    );
+};
 
 type ProjectEnvironmentStrategyDraggableItemProps = {
     strategy: IFeatureStrategy;

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -42,6 +42,7 @@ export type CustomEvents =
     | 'context-usage'
     | 'segment-usage'
     | 'strategy-add'
+    | 'edit-milestone-strategy'
     | 'suggestion-strategy-add'
     | 'playground'
     | 'feature-type-edit'


### PR DESCRIPTION
Adds plausible tracking for milestone strategy editing, both when the edit form is opened and when it is saved.