### PR TITLE
feat: add signed out screen with snake game

### DIFF
--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -9,6 +9,7 @@ import { NewUser } from 'component/user/NewUser/NewUser';
 import ResetPassword from 'component/user/ResetPassword/ResetPassword';
 import ResetPasswordSuccess from 'component/user/ResetPassword/ResetPasswordSuccess';
 import ForgottenPassword from 'component/user/ForgottenPassword/ForgottenPassword';
+import SignedOut from 'component/user/SignedOut/SignedOut';
 import { ProjectList } from 'component/project/ProjectList/ProjectList';
 import { ArchiveProjectList } from 'component/project/ProjectList/ArchiveProjectList';
 import CreateEnvironment from 'component/environments/CreateEnvironment/CreateEnvironment';
@@ -552,6 +553,15 @@ export const routes: IRoute[] = [
         title: 'Forgotten password',
         hidden: true,
         component: ForgottenPassword,
+        type: 'unprotected',
+        menu: {},
+        isStandalone: true,
+    },
+    {
+        path: '/signed-out',
+        title: 'Signed out',
+        hidden: true,
+        component: SignedOut,
         type: 'unprotected',
         menu: {},
         isStandalone: true,

--- a/frontend/src/component/user/SignedOut/SignedOut.tsx
+++ b/frontend/src/component/user/SignedOut/SignedOut.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { Button, Divider, styled, Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { AuthPageLayout } from '../common/AuthPageLayout';
+import { AuthSuccessIcon } from '../common/AuthSuccessIcon';
+import { SnakeGame } from './SnakeGame';
+
+const StyledContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(3),
+    textAlign: 'center',
+}));
+
+const StyledTitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.h2.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    lineHeight: '28px',
+}));
+
+const StyledSubtitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    lineHeight: '20px',
+    marginTop: theme.spacing(0.5),
+}));
+
+const SignedOut = () => {
+    const [showSnake, setShowSnake] = useState(false);
+
+    return (
+        <AuthPageLayout>
+            <StyledContainer>
+                <div>
+                    <AuthSuccessIcon />
+                    <StyledTitle variant='h2'>
+                        You are signed out of Unleash
+                    </StyledTitle>
+                    <StyledSubtitle variant='body2'>
+                        Bye bye, hope to see you soon!
+                    </StyledSubtitle>
+                </div>
+                <Button
+                    variant='contained'
+                    color='primary'
+                    component={Link}
+                    to='/login'
+                    fullWidth
+                >
+                    Sign back into your instance
+                </Button>
+                {showSnake ? (
+                    <SnakeGame />
+                ) : (
+                    <>
+                        <Divider sx={{ width: '100%' }}>OR</Divider>
+                        <Button
+                            variant='outlined'
+                            fullWidth
+                            onClick={() => setShowSnake(true)}
+                        >
+                            Play snake!
+                        </Button>
+                    </>
+                )}
+            </StyledContainer>
+        </AuthPageLayout>
+    );
+};
+
+export default SignedOut;

--- a/frontend/src/component/user/SignedOut/SnakeGame.tsx
+++ b/frontend/src/component/user/SignedOut/SnakeGame.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { styled } from '@mui/material';
+
+const CELL_SIZE = 16;
+const GRID_W = 22;
+const GRID_H = 16;
+const TICK_MS = 120;
+
+type Pos = { x: number; y: number };
+type Dir = 'UP' | 'DOWN' | 'LEFT' | 'RIGHT';
+
+const opposite: Record<Dir, Dir> = {
+    UP: 'DOWN',
+    DOWN: 'UP',
+    LEFT: 'RIGHT',
+    RIGHT: 'LEFT',
+};
+
+const randomFood = (snake: Pos[]): Pos => {
+    let pos: Pos;
+    do {
+        pos = {
+            x: Math.floor(Math.random() * GRID_W),
+            y: Math.floor(Math.random() * GRID_H),
+        };
+    } while (snake.some((s) => s.x === pos.x && s.y === pos.y));
+    return pos;
+};
+
+const StyledCanvas = styled('canvas')({
+    display: 'block',
+    borderRadius: 4,
+    border: '1px solid #e0e0e0',
+});
+
+const StyledWrapper = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 8,
+});
+
+const StyledScore = styled('span')(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+}));
+
+export const SnakeGame = () => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const dirRef = useRef<Dir>('RIGHT');
+    const nextDirRef = useRef<Dir>('RIGHT');
+    const snakeRef = useRef<Pos[]>([
+        { x: 4, y: 8 },
+        { x: 3, y: 8 },
+        { x: 2, y: 8 },
+    ]);
+    const foodRef = useRef<Pos>(randomFood(snakeRef.current));
+    const [score, setScore] = useState(0);
+    const [gameOver, setGameOver] = useState(false);
+    const gameOverRef = useRef(false);
+
+    const reset = useCallback(() => {
+        snakeRef.current = [
+            { x: 4, y: 8 },
+            { x: 3, y: 8 },
+            { x: 2, y: 8 },
+        ];
+        foodRef.current = randomFood(snakeRef.current);
+        dirRef.current = 'RIGHT';
+        nextDirRef.current = 'RIGHT';
+        gameOverRef.current = false;
+        setGameOver(false);
+        setScore(0);
+    }, []);
+
+    const draw = useCallback(() => {
+        const ctx = canvasRef.current?.getContext('2d');
+        if (!ctx) return;
+
+        ctx.fillStyle = '#f8f9fa';
+        ctx.fillRect(0, 0, GRID_W * CELL_SIZE, GRID_H * CELL_SIZE);
+
+        // food
+        ctx.fillStyle = '#98E3AF';
+        ctx.fillRect(
+            foodRef.current.x * CELL_SIZE + 1,
+            foodRef.current.y * CELL_SIZE + 1,
+            CELL_SIZE - 2,
+            CELL_SIZE - 2,
+        );
+
+        // snake
+        snakeRef.current.forEach((seg, i) => {
+            ctx.fillStyle = i === 0 ? '#6c65e5' : '#8b85ec';
+            ctx.fillRect(
+                seg.x * CELL_SIZE + 1,
+                seg.y * CELL_SIZE + 1,
+                CELL_SIZE - 2,
+                CELL_SIZE - 2,
+            );
+        });
+
+        if (gameOverRef.current) {
+            ctx.fillStyle = 'rgba(0,0,0,0.5)';
+            ctx.fillRect(0, 0, GRID_W * CELL_SIZE, GRID_H * CELL_SIZE);
+            ctx.fillStyle = '#fff';
+            ctx.font = 'bold 20px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText(
+                'Game Over! Click to restart',
+                (GRID_W * CELL_SIZE) / 2,
+                (GRID_H * CELL_SIZE) / 2,
+            );
+        }
+    }, []);
+
+    useEffect(() => {
+        const handleKey = (e: KeyboardEvent) => {
+            const keyMap: Record<string, Dir> = {
+                ArrowUp: 'UP',
+                ArrowDown: 'DOWN',
+                ArrowLeft: 'LEFT',
+                ArrowRight: 'RIGHT',
+                w: 'UP',
+                s: 'DOWN',
+                a: 'LEFT',
+                d: 'RIGHT',
+            };
+            const newDir = keyMap[e.key];
+            if (newDir && newDir !== opposite[dirRef.current]) {
+                e.preventDefault();
+                nextDirRef.current = newDir;
+            }
+        };
+        window.addEventListener('keydown', handleKey);
+        return () => window.removeEventListener('keydown', handleKey);
+    }, []);
+
+    useEffect(() => {
+        const tick = () => {
+            if (gameOverRef.current) return;
+
+            dirRef.current = nextDirRef.current;
+            const head = { ...snakeRef.current[0] };
+            switch (dirRef.current) {
+                case 'UP':
+                    head.y--;
+                    break;
+                case 'DOWN':
+                    head.y++;
+                    break;
+                case 'LEFT':
+                    head.x--;
+                    break;
+                case 'RIGHT':
+                    head.x++;
+                    break;
+            }
+
+            if (
+                head.x < 0 ||
+                head.x >= GRID_W ||
+                head.y < 0 ||
+                head.y >= GRID_H ||
+                snakeRef.current.some((s) => s.x === head.x && s.y === head.y)
+            ) {
+                gameOverRef.current = true;
+                setGameOver(true);
+                draw();
+                return;
+            }
+
+            snakeRef.current.unshift(head);
+
+            if (head.x === foodRef.current.x && head.y === foodRef.current.y) {
+                foodRef.current = randomFood(snakeRef.current);
+                setScore((s) => s + 1);
+            } else {
+                snakeRef.current.pop();
+            }
+
+            draw();
+        };
+
+        const id = setInterval(tick, TICK_MS);
+        draw();
+        return () => clearInterval(id);
+    }, [draw]);
+
+    const handleClick = () => {
+        if (gameOver) {
+            reset();
+        }
+    };
+
+    return (
+        <StyledWrapper>
+            <StyledScore>Score: {score}</StyledScore>
+            <StyledCanvas
+                ref={canvasRef}
+                width={GRID_W * CELL_SIZE}
+                height={GRID_H * CELL_SIZE}
+                onClick={handleClick}
+                tabIndex={0}
+            />
+        </StyledWrapper>
+    );
+};

--- a/src/lib/routes/logout.ts
+++ b/src/lib/routes/logout.ts
@@ -5,6 +5,7 @@ import Controller from './controller.js';
 import type { IAuthRequest } from './unleash-types.js';
 import type { IUnleashServices } from '../services/index.js';
 import type SessionService from '../services/session-service.js';
+import type { IFlagResolver } from '../types/experimental.js';
 
 class LogoutController extends Controller {
     private clearSiteDataOnLogout: boolean;
@@ -15,6 +16,8 @@ class LogoutController extends Controller {
 
     private sessionService: SessionService;
 
+    private flagResolver: IFlagResolver;
+
     constructor(
         config: IUnleashConfig,
         { sessionService }: Pick<IUnleashServices, 'sessionService'>,
@@ -24,6 +27,7 @@ class LogoutController extends Controller {
         this.baseUri = config.server.baseUriPath;
         this.clearSiteDataOnLogout = config.session.clearSiteDataOnLogout;
         this.cookieName = config.session.cookieName;
+        this.flagResolver = config.flagResolver;
 
         this.route({
             method: 'post',
@@ -71,7 +75,10 @@ class LogoutController extends Controller {
         if (req.user?.id) {
             await this.sessionService.deleteSessionsForUser(req.user.id);
         }
-        res.redirect(`${this.baseUri}/`);
+        const redirectPath = this.flagResolver.isEnabled('newSignOut')
+            ? `${this.baseUri}/signed-out`
+            : `${this.baseUri}/`;
+        res.redirect(redirectPath);
     }
 
     private isReqLogoutWithoutCallback(

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -78,7 +78,8 @@ export type IFlagKey =
     | 'featureEnvSafeguards'
     | 'filterFavorites'
     | 'inlineFavoriteInNameColumn'
-    | 'userTokenWithClientApiLoggingKillSwitch';
+    | 'userTokenWithClientApiLoggingKillSwitch'
+    | 'newSignOut';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -355,6 +356,10 @@ const flags: IFlags = {
     userTokenWithClientApiLoggingKillSwitch: parseEnvVarBoolean(
         process.env
             .UNLEASH_EXPERIMENTAL_USERTOKEN_WITH_CLIENTAPI_LOGGING_KILL_SWITCH,
+        false,
+    ),
+    newSignOut: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_SIGN_OUT,
         false,
     ),
 };


### PR DESCRIPTION
## Summary
- Adds a new `/signed-out` page that users see after logging out, with a friendly message and a "Sign back into your instance" button
- Includes a playable snake game as an easter egg behind a "Play snake!" button
- Backend redirect to `/signed-out` is gated behind the `newSignOut` experimental flag (falls back to `/` when disabled)
- Uses the existing `AuthPageLayout` for consistent styling with other auth screens


<img width="1015" height="736" alt="Screenshot from 2026-03-24 15-02-06" src
="https://github.com/user-attachments/assets/46bcc298-4e3e-42c6-b2f9-a8b8781e5c91" />
<img width="1032" height="839" alt="Screenshot from 2026-03-24 15-02-12" src="https://github.com/user-attachments/assets/62dbd745-337c-43b3-85ff-8a930c871a77" />
