### PR TITLE
fix: use formatAssetPath for auth screen images

### DIFF
--- a/frontend/src/component/user/common/AuthPageLayout.tsx
+++ b/frontend/src/component/user/common/AuthPageLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { styled } from '@mui/material';
 import { ReactComponent as UnleashLogo } from 'assets/img/logoDarkWithText.svg';
 import loginBackground from 'assets/img/loginBackground.png';
+import { formatAssetPath } from 'utils/formatPath';
 
 const StyledPage = styled('div')(({ theme }) => ({
     minHeight: '100vh',
@@ -65,7 +66,7 @@ interface AuthPageLayoutProps {
 export const AuthPageLayout = ({ children }: AuthPageLayoutProps) => {
     return (
         <StyledPage>
-            <StyledBackground src={loginBackground} alt='' />
+            <StyledBackground src={formatAssetPath(loginBackground)} alt='' />
             <StyledHeader>
                 <StyledLogo aria-label='Unleash logo' />
             </StyledHeader>

--- a/frontend/src/component/user/common/AuthSuccessIcon.tsx
+++ b/frontend/src/component/user/common/AuthSuccessIcon.tsx
@@ -1,5 +1,6 @@
 import passwordSuccess from 'assets/img/passwordSuccess.png';
+import { formatAssetPath } from 'utils/formatPath';
 
 export const AuthSuccessIcon = () => (
-    <img src={passwordSuccess} alt='' width={56} height={56} />
+    <img src={formatAssetPath(passwordSuccess)} alt='' width={56} height={56} />
 );


### PR DESCRIPTION
 - Fix 404 errors for auth screen images (loginBackground.png, passwordSuccess.png) on deployments with a non-root baseUriPath by wrapping them with formatAssetPath()