### PR TITLE
fix: support dark mode logo on login screen

### DIFF
--- a/frontend/src/component/user/common/AuthPageLayout.tsx
+++ b/frontend/src/component/user/common/AuthPageLayout.tsx
@@ -74,12 +74,8 @@ export const AuthPageLayout = ({ children }: AuthPageLayoutProps) => {
             <StyledBackground src={loginBackground} alt='' />
             <StyledHeader>
                 <ThemeMode
-                    darkmode={
-                        <StyledLogoWhite aria-label='Unleash logo' />
-                    }
-                    lightmode={
-                        <StyledLogoDark aria-label='Unleash logo' />
-                    }
+                    darkmode={<StyledLogoWhite aria-label='Unleash logo' />}
+                    lightmode={<StyledLogoDark aria-label='Unleash logo' />}
                 />
             </StyledHeader>
             <StyledMain>


### PR DESCRIPTION
## Summary
- The login screen (`AuthPageLayout`) was hardcoding `logoDarkWithText.svg` regardless of the active theme, causing poor contrast in dark mode
- Now uses the `ThemeMode` component to switch between dark and white logo variants, matching the main navigation sidebar behavior