### PR TITLE
chore: expose emailDomain and autoCreateDomainUsers in status

### DIFF
--- a/frontend/src/interfaces/instance.ts
+++ b/frontend/src/interfaces/instance.ts
@@ -24,6 +24,8 @@ export interface IInstanceStatus {
     isCustomBilling?: boolean;
     billing?: InstanceBilling;
     ucaSignup?: boolean;
+    emailDomain?: string;
+    autoCreateDomainUsers?: boolean;
 }
 
 export enum InstanceState {


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-270/expose-emaildomain-and-autocreatedomainusers-to-the-unleash-instance

Adds `emailDomain` and `autoCreateDomainUsers` to the instance status type, now that they are available.

<img width="871" height="501" alt="image" src="https://github.com/user-attachments/assets/436e8c40-2b75-4f22-89a7-670e463b06dd" />