### PR TITLE
feat: double metric translation

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -74,7 +74,10 @@ export default class ClientMetricsServiceV2 {
                 maxAge: secondsToMilliseconds(10),
             },
         );
-        this.impactMetricsTranslator = new MetricsTranslator(impactRegister);
+        this.impactMetricsTranslator = new MetricsTranslator(
+            impactRegister,
+            config.flagResolver,
+        );
     }
 
     async clearMetrics(hoursAgo: number) {

--- a/src/lib/features/metrics/impact/metrics-translator.test.ts
+++ b/src/lib/features/metrics/impact/metrics-translator.test.ts
@@ -1,13 +1,15 @@
 import { MetricsTranslator } from './metrics-translator.js';
 import { Registry } from 'prom-client';
 
+const flagResolver = { isEnabled: () => true };
+
 describe('MetricsTranslator', () => {
     describe('Sanitize name', () => {
         let translator: MetricsTranslator;
 
         beforeEach(() => {
             const registry = new Registry();
-            translator = new MetricsTranslator(registry);
+            translator = new MetricsTranslator(registry, flagResolver);
         });
 
         it('should not modify valid names', () => {
@@ -77,20 +79,17 @@ describe('MetricsTranslator', () => {
         ];
 
         const registry = new Registry();
-        const translator = new MetricsTranslator(registry);
+        const translator = new MetricsTranslator(registry, flagResolver);
         const result = await translator.translateAndSerializeMetrics(metrics);
         expect(typeof result).toBe('string');
-        expect(result).toContain(
-            '# HELP unleash_counter_labeled_counter with labels',
-        );
-        expect(result).toContain(
-            '# TYPE unleash_counter_labeled_counter counter',
-        );
         expect(result).toContain(
             'unleash_counter_labeled_counter{unleash_foo="bar",unleash_origin="sdk"} 5',
         );
         expect(result).toContain(
             'unleash_gauge_test_gauge{unleash_env="prod",unleash_origin="sdk"} 10',
+        );
+        expect(result).toContain(
+            'unleash_histogram_response_time_bucket{unleash_origin="sdk",unleash_service="api",le="1"} 3',
         );
         // Plain metrics (no unleash_ prefix, type stored as label)
         expect(result).toContain(
@@ -98,9 +97,6 @@ describe('MetricsTranslator', () => {
         );
         expect(result).toContain(
             'test_gauge{origin="sdk",type="gauge",env="prod"} 10',
-        );
-        expect(result).toContain(
-            'unleash_histogram_response_time_bucket{unleash_origin="sdk",unleash_service="api",le="1"} 3',
         );
         expect(result).toContain(
             'response_time_bucket{origin="sdk",service="api",type="histogram",le="1"} 3',
@@ -130,7 +126,7 @@ describe('MetricsTranslator', () => {
         ];
 
         const registry = new Registry();
-        const translator = new MetricsTranslator(registry);
+        const translator = new MetricsTranslator(registry, flagResolver);
         const result = await translator.translateAndSerializeMetrics(metrics);
         expect(typeof result).toBe('string');
         expect(result).toContain(
@@ -144,7 +140,7 @@ describe('MetricsTranslator', () => {
 
     it('should sanitize metric names and label names', async () => {
         const registry = new Registry();
-        const translator = new MetricsTranslator(registry);
+        const translator = new MetricsTranslator(registry, flagResolver);
 
         const metrics = [
             {
@@ -197,7 +193,7 @@ describe('MetricsTranslator', () => {
 
     it('should handle re-labeling of metrics', async () => {
         const registry = new Registry();
-        const translator = new MetricsTranslator(registry);
+        const translator = new MetricsTranslator(registry, flagResolver);
 
         const metrics1 = [
             {
@@ -311,7 +307,7 @@ describe('MetricsTranslator', () => {
 
     it('should handle histogram bucket changes', async () => {
         const registry = new Registry();
-        const translator = new MetricsTranslator(registry);
+        const translator = new MetricsTranslator(registry, flagResolver);
 
         // Initial histogram with 2 buckets
         const metrics1 = [

--- a/src/lib/features/metrics/impact/metrics-translator.ts
+++ b/src/lib/features/metrics/impact/metrics-translator.ts
@@ -1,5 +1,6 @@
 import { Counter, Gauge, type Registry } from 'prom-client';
 import { BatchHistogram } from './batch-histogram.js';
+import type { IFlagResolver } from '../../../types/experimental.js';
 
 export interface NumericMetricSample {
     labels?: Record<string, string | number>;
@@ -31,9 +32,18 @@ export type Metric = NumericMetric | BucketMetric;
 
 export class MetricsTranslator {
     private registry: Registry;
+    private flagResolver: Pick<IFlagResolver, 'isEnabled'>;
 
-    constructor(registry: Registry) {
+    constructor(
+        registry: Registry,
+        flagResolver: Pick<IFlagResolver, 'isEnabled'>,
+    ) {
         this.registry = registry;
+        this.flagResolver = flagResolver;
+    }
+
+    private isPlainMetricsEnabled(): boolean {
+        return this.flagResolver.isEnabled('externalPrometheusImpactMetrics');
     }
 
     sanitizeName(name: string): string {
@@ -230,7 +240,7 @@ export class MetricsTranslator {
                 counter.inc(this.prefixedLabels(sample), sample.value);
             }
 
-            if (plainValid) {
+            if (this.isPlainMetricsEnabled() && plainValid) {
                 const plainCounter = this.resolveCounter(
                     sanitizedName,
                     metric.help,
@@ -256,7 +266,7 @@ export class MetricsTranslator {
                 gauge.set(this.prefixedLabels(sample), sample.value);
             }
 
-            if (plainValid) {
+            if (this.isPlainMetricsEnabled() && plainValid) {
                 const plainGauge = this.resolveGauge(
                     sanitizedName,
                     metric.help,
@@ -291,7 +301,7 @@ export class MetricsTranslator {
                 });
             }
 
-            if (plainValid) {
+            if (this.isPlainMetricsEnabled() && plainValid) {
                 const plainHistogram = this.resolveHistogram(
                     sanitizedName,
                     metric.help,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

  - When externalPrometheusImpactMetrics flag is enabled, impact metrics are now registered twice: once with the existing unleash_<type>_<name> prefix and unleash_ label prefix, and once without any prefix, 
  using a type label instead
  - Example: `unleash_counter_my_metric{unleash_foo="bar",unleash_origin="sdk"}` vs `my_metric{foo="bar",origin="sdk",type="counter"}`                                                                              
  - Metrics/labels starting with a digit are dropped from plain registration (invalid Prometheus names)  

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
