### PR TITLE
fix: exclude chartjs-adapter-date-fns from Vite dep optimization

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -131,6 +131,9 @@ export default defineConfig(({ mode }) => {
                 svgr(),
                 envCompatible(),
             ],
+            optimizeDeps: {
+                exclude: ['chartjs-adapter-date-fns'],
+            },
             esbuild: {
                 logOverride: { 'this-is-undefined-in-esm': 'silent' },
             },


### PR DESCRIPTION
Since the date-fns v2 → v4 upgrade (https://github.com/Unleash/unleash/pull/11592), the Vite dev server intermittently fails with a missing chunk error (e.g. `chunk-WDJOWX42.js not found`) that prevents the frontend from loading. The only workaround has been manually deleting `node_modules/.vite/deps`.

Excluding `chartjs-adapter-date-fns` from `optimizeDeps` tells Vite to serve it as-is via native ESM instead of pre-bundling it into shared chunks. Its `date-fns` imports then resolve to Vite's pre-bundled date-fns entry directly, avoiding the fragile shared chunk. No performance impact, the adapter is a single ~100 line file.


It's the only dependency in the project that does a massive barrel import from date-fns, ~30 named exports in one import { ... } from 'date-fns' statement. That's what makes Vite create shared chunks. Most other code imports one or two date-fns functions at a time, which Vite handles fine.        