### PR TITLE
docs: synchronize Node.js and PostgreSQL version requirements across …

### DIFF
--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before you begin:
 - Check out the [existing issues](https://github.com/unleash/Unleash/issues)
 - Browse the [developer-guide](https://docs.getunleash.io/contribute) for tips on environment setup, running the tests, and running Unleash from source.
 - You need
-  - Node 20
+  - Node 22
   - corepack enabled `corepack enable`
 
 ### Don't see your issue? Open one
@@ -36,7 +36,7 @@ Follow the steps in [the "how to run the project" section](#how-to-run-the-proje
 
 ### Make your update:
 
-Make your changes to the files you'd like to update. You'll need **Node.js v18.0+** and PostgreSQL v13.0+ to run Unleash locally. [See more details](https://docs.getunleash.io/contribute)
+Make your changes to the files you'd like to update. You'll need **Node.js v22.0+** and PostgreSQL v14.0+ to run Unleash locally. [See more details](https://docs.getunleash.io/contribute)
 
 ### Open a pull request
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "types": "./dist/lib/server-impl.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "license": "Apache-2.0",
   "exports": "./dist/lib/server-impl.js",


### PR DESCRIPTION
## Description

This PR resolves multiple inconsistencies in the documented and enforced Node.js and PostgreSQL versions across the repository. Previously, a contributor could find mentions of Node 18, 20, and 22 depending on which file they read.

### The Problem
*   **[.node-version](cci:7://file:///home/13769K/Git/forks/unleash/.node-version:0:0-0:0)** was set to **22.22**.
*   **[backend/overview.md](cci:7://file:///home/13769K/Git/forks/unleash/contributing/backend/overview.md:0:0-0:0)** recommended **Node 22** and **PostgreSQL 14**.
*   **[CONTRIBUTING.md](cci:7://file:///home/13769K/Git/forks/unleash/contributing/CONTRIBUTING.md:0:0-0:0)** had conflicting mentions of **Node 20** (L11) and **Node 18** (L39), along with **PostgreSQL 13**.
*   **Root [package.json](cci:7://file:///home/13769K/Git/forks/unleash/package.json:0:0-0:0)** only enforced **Node >=20**.
*   **[frontend/package.json](cci:7://file:///home/13769K/Git/forks/unleash/frontend/package.json:0:0-0:0)** only enforced **Node >=18**.

### The Solution
To eliminate confusion, this PR standardizes all requirements on **Node 22.0+** and **PostgreSQL 14.0+**, aligning them with the current CI/CD environment and the [.node-version](cci:7://file:///home/13769K/Git/forks/unleash/.node-version:0:0-0:0) file.

## Changes
- **[CONTRIBUTING.md](cci:7://file:///home/13769K/Git/forks/unleash/contributing/CONTRIBUTING.md:0:0-0:0)**: Updated general instructions to specify Node 22 and PostgreSQL 14.
- **[package.json](cci:7://file:///home/13769K/Git/forks/unleash/package.json:0:0-0:0) (Root)**: Bumped `engines.node` to `>=22`.
- **[frontend/package.json](cci:7://file:///home/13769K/Git/forks/unleash/frontend/package.json:0:0-0:0)**: Bumped `engines.node` to `>=22`.

## Verification Results
- [x] Verified [.node-version](cci:7://file:///home/13769K/Git/forks/unleash/.node-version:0:0-0:0) content matches the new documentation.
- [x] Verified backend guide already recommended Node 22.
- [x] Verified GitHub Action [build.yaml](cci:7://file:///home/13769K/Git/forks/unleash/.github/workflows/build.yaml:0:0-0:0) already uses Node 22.
