### PR TITLE
chore: set minheight for strategy header

### DIFF
--- a/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
+++ b/frontend/src/component/common/StrategyItemContainer/StrategyItemContainer.tsx
@@ -63,6 +63,7 @@ const StyledHeader = styled('div', {
     display: 'flex',
     alignItems: 'center',
     color: disabled ? theme.palette.text.secondary : theme.palette.text.primary,
+    minHeight: theme.spacing(5), // <- mui button height; avoids collapsing when there are no actions
 }));
 
 const StyledHeaderInner = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Adds a min height to the strategy header component. The min height is equal to the height of MUI's buttons. This is to prevent the header from collapsing when there are no buttons, ensuring that it looks the same regardless of whether there are actions or not.

I noticed it when reviewing closed CR that disabled a milestone strat. Compare the difference in spacing around the "disabled" badge in the before and afters:

Before:
<img width="771" height="607" alt="image" src="https://github.com/user-attachments/assets/48310db5-60b0-4edb-9511-0a54a229b7f1" />

After:
<img width="764" height="609" alt="image" src="https://github.com/user-attachments/assets/108841dd-4efb-4dba-bd23-19cbf35fadd2" />

Compare that to the strategy in the actual release plan, where it has an edit button (both before and after look the same here):
<img width="757" height="442" alt="image" src="https://github.com/user-attachments/assets/69a437df-1b92-4377-b3a5-5edf0a1d17d6" />

This change also affects other strategies of course, but most of them are rendered with actions and I think it makes sense to enforce the same min height on them even if they don't have actions. It's a small change and can easily be reverted if anyone complains. 
