### PR TITLE
chore: add auto create domain users toggle to signup dialog

### DIFF
--- a/frontend/src/component/admin/users/AutoCreateDomainUsersToggle.tsx
+++ b/frontend/src/component/admin/users/AutoCreateDomainUsersToggle.tsx
@@ -30,7 +30,13 @@ const StyledBody = styled(Box)(({ theme }) => ({
     gap: theme.spacing(0.5),
 }));
 
-export const UsersHeaderAutoCreateDomainUsers = () => {
+export interface IAutoCreateDomainUsersToggleProps {
+    showFallback?: boolean;
+}
+
+export const AutoCreateDomainUsersToggle = ({
+    showFallback = false,
+}: IAutoCreateDomainUsersToggleProps) => {
     const { setToastData, setToastApiError } = useToast();
     const { instanceStatus, refetchInstanceStatus, loading } =
         useInstanceStatus();
@@ -65,6 +71,7 @@ export const UsersHeaderAutoCreateDomainUsers = () => {
     };
 
     if (!instanceStatus?.ucaSignup) return null;
+    if (!instanceStatus.emailDomain && !showFallback) return null;
 
     return (
         <StyledElement>

--- a/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
+++ b/frontend/src/component/admin/users/UsersHeader/UsersHeader.tsx
@@ -2,7 +2,7 @@ import { Box, styled } from '@mui/material';
 import { InviteLinkBar } from '../InviteLinkBar/InviteLinkBar.tsx';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { LicensedUsersBox } from './LicensedUsersBox.tsx';
-import { UsersHeaderAutoCreateDomainUsers } from './UsersHeaderAutoCreateDomainUsers.tsx';
+import { AutoCreateDomainUsersToggle } from '../AutoCreateDomainUsersToggle.tsx';
 
 const StyledContainer = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -50,7 +50,7 @@ export const UsersHeader = () => {
                     </StyledElement>
                 )}
             </StyledUsersHeaderRow>
-            <UsersHeaderAutoCreateDomainUsers />
+            <AutoCreateDomainUsersToggle showFallback />
         </StyledContainer>
     );
 };

--- a/frontend/src/component/signup/SignupDialog/SignupDialogInviteOthers.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialogInviteOthers.tsx
@@ -6,6 +6,7 @@ import {
     type SignupStepContent,
 } from './SignupDialog';
 import { useCallback, useState } from 'react';
+import { AutoCreateDomainUsersToggle } from 'component/admin/users/AutoCreateDomainUsersToggle';
 
 const StyledButtonRow = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -35,7 +36,10 @@ export const SignupDialogInviteOthers: SignupStepContent = ({
     setData,
     onNext,
     onBack,
+    signupData,
 }) => {
+    const isFirstSignup = !signupData?.companyName;
+
     const [inputValue, setInputValue] = useState('');
 
     const setInviteEmails = useCallback(
@@ -82,6 +86,7 @@ export const SignupDialogInviteOthers: SignupStepContent = ({
 
     return (
         <>
+            {isFirstSignup && <AutoCreateDomainUsersToggle />}
             <StyledSignupDialogField>
                 <StyledSignupDialogLabel>
                     Invite team members


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-260/add-this-new-configuration-to-the-signup-dialog

Adds the new "auto create domain users" toggle to the signup dialog, in the "invite others" step.

This is only shown for the first signup, checked by the fact that the company name has not been submitted yet.

Unlike in the users list, this will not be visible at all here if the emailDomain is not available (e.g. public domain), which is why I added the `showFallback` prop.

Since this is now used in multiple places, I extracted this into a `AutoCreateDomainUsersToggle` component.

<img width="1413" height="700" alt="image" src="https://github.com/user-attachments/assets/d7890651-779b-48e2-a0a7-c44ce56c82a2" />
