### PR TITLE
chore: hide release templates banner for new user

### DIFF
--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -274,6 +274,9 @@ export const PersonalDashboard = () => {
     const { setWelcomeDialog } = useWelcomeDialogContext();
     const { isOss, isEnterprise } = useUiConfig();
     const gtmReleaseManagementEnabled = useUiFlag('gtmReleaseManagement');
+    const { personalDashboard } = usePersonalDashboard();
+    const isNewUser = personalDashboard?.flags.length === 0;
+
     const name = user?.name || '';
 
     usePageTitle(name ? `Dashboard: ${name}` : 'Dashboard');
@@ -288,10 +291,10 @@ export const PersonalDashboard = () => {
 
     return (
         <MainContent>
-            {isEnterprise() && gtmReleaseManagementEnabled ? (
+            {isEnterprise() && gtmReleaseManagementEnabled && !isNewUser && (
                 <ReleaseTemplatesBanner />
-            ) : null}
-            {isOss() ? <InfoSection /> : null}
+            )}
+            {isOss() && <InfoSection />}
 
             <WelcomeSection>
                 <Typography component='h2' variant='h2'>


### PR DESCRIPTION
Hides release templates banner for users who have never created a flag. 

New user, before:
<img width="900" alt="Screenshot 2026-03-31 at 18 29 40" src="https://github.com/user-attachments/assets/7a36db18-1a31-47e0-a8a1-0c9afaa2c2de" />

after:
<img width="900" alt="Screenshot 2026-03-31 at 18 26 32" src="https://github.com/user-attachments/assets/bc51be70-32dc-4733-a681-dc0371eac2ae" />

