### PR TITLE
chore: only show impact metrics accordion when charts exist

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureImpactOverview/FeatureImpactHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureImpactOverview/FeatureImpactHeader.tsx
@@ -1,12 +1,10 @@
 import type { FC } from 'react';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
 import { Button, Collapse, styled, Typography } from '@mui/material';
-import { Badge } from 'component/common/Badge/Badge';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import Add from '@mui/icons-material/Add';
 import { useFeatureImpactMetrics } from 'hooks/api/getters/useFeatureImpactMetrics/useFeatureImpactMetrics';
-import { PlaceholderChart } from './ImpactDashboard/PlaceholderChart';
 import { CompactChartCard } from './CompactChartCard';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
@@ -78,18 +76,6 @@ const StyledChartRow = styled('div')(({ theme }) => ({
     },
 }));
 
-const StyledEmptyDescription = styled(Typography)(({ theme }) => ({
-    fontSize: theme.fontSizes.smallBody,
-    color: theme.palette.text.secondary,
-    maxWidth: '100%',
-}));
-
-const StyledConnectButton = styled(Button)({
-    textTransform: 'none',
-    whiteSpace: 'nowrap',
-    flexShrink: 0,
-});
-
 const StyledFooter = styled('div')(({ theme }) => ({
     padding: theme.spacing(2, 3, 2),
     display: 'flex',
@@ -124,7 +110,6 @@ export const FeatureImpactHeader: FC<FeatureImpactHeaderProps> = ({
 
     const expanded = impactMetricsAccordionState === 'open';
     const chartCount = impactMetrics.configs.length;
-    const hasMetrics = chartCount > 0;
 
     const toggleExpanded = () => {
         if (!expanded) {
@@ -140,74 +125,6 @@ export const FeatureImpactHeader: FC<FeatureImpactHeaderProps> = ({
             toggleExpanded();
         }
     };
-
-    if (!hasMetrics) {
-        return (
-            <StyledContainer>
-                <StyledHeaderBar
-                    role='button'
-                    tabIndex={0}
-                    aria-expanded={expanded}
-                    aria-label='Toggle impact metrics details'
-                    onClick={toggleExpanded}
-                    onKeyDown={onHeaderKeyDown}
-                >
-                    <StyledImpactLabel>
-                        <StyledImpactTitle>
-                            Measure the impact of this feature
-                        </StyledImpactTitle>
-                        <Badge color='success' sx={{ ml: 1 }}>
-                            New
-                        </Badge>
-                    </StyledImpactLabel>
-                    <StyledRightSection sx={{ marginLeft: 'auto' }}>
-                        <StyledConnectButton
-                            variant='outlined'
-                            startIcon={<Add />}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                trackEvent('flagpage-impact-metrics', {
-                                    props: {
-                                        eventType: 'add-impact-metric-clicked',
-                                    },
-                                });
-                                onAddChart();
-                            }}
-                        >
-                            Add impact metric
-                        </StyledConnectButton>
-                        {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                    </StyledRightSection>
-                </StyledHeaderBar>
-                <Collapse in={expanded}>
-                    <StyledExpandedContent>
-                        <StyledEmptyDescription>
-                            Connect your metrics to see how this feature affects
-                            adoption, error counts, latency, and other key
-                            indicators during rollout.
-                        </StyledEmptyDescription>
-                        <StyledChartRow>
-                            <PlaceholderChart
-                                title='Adoption'
-                                change='+1,204'
-                                variant='upward'
-                            />
-                            <PlaceholderChart
-                                title='Errors'
-                                change='3'
-                                variant='downward'
-                            />
-                            <PlaceholderChart
-                                title='Latency (p95)'
-                                change='~230ms'
-                                variant='stable'
-                            />
-                        </StyledChartRow>
-                    </StyledExpandedContent>
-                </Collapse>
-            </StyledContainer>
-        );
-    }
 
     return (
         <StyledContainer>

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -15,6 +15,7 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { FeatureImpactHeader } from './FeatureImpactOverview/FeatureImpactHeader';
 import { ChartConfigModal } from '../../impact-metrics/ChartConfigModal/ChartConfigModal';
 import { useFeatureImpactChartActions } from './useFeatureImpactChartActions';
+import { useFeatureImpactMetrics } from 'hooks/api/getters/useFeatureImpactMetrics/useFeatureImpactMetrics.ts';
 
 export const StyledLink = styled(Link)(() => ({
     maxWidth: '100%',
@@ -30,7 +31,14 @@ export const FeatureView = () => {
 
     const impactMetricsFlagPage = useUiFlag('impactMetricsFlagPage');
     const { isEnterprise } = useUiConfig();
-    const showImpactMetrics = impactMetricsFlagPage && isEnterprise();
+    const { impactMetrics } = useFeatureImpactMetrics({
+        projectId,
+        featureName: featureId,
+    });
+    const chartCount = impactMetrics.configs.length;
+    const hasMetrics = chartCount > 0;
+    const showImpactMetrics =
+        impactMetricsFlagPage && isEnterprise() && hasMetrics;
 
     const { feature, loading, error, status } = useFeature(
         projectId,


### PR DESCRIPTION
The Impact metrics accordion on flag page is adding noise for new users and getting in the way of them actually starting to use Unleash (create a feature flag, etc..), so we're limiting its visibility by only showing it if there are already existing impact metrics charts to display in it.

- Removes the `FeatureImpactHeader` empty state 
- only shows `FeatureImpactHeader` on a flag page if there are already impact metrics charts

Before (no impact metrics charts): 
<img width="900" alt="Screenshot 2026-04-01 at 13 55 28" src="https://github.com/user-attachments/assets/fe6cc2e4-fb90-4ef4-8d67-9b1a25ec65a6" />


After (no impact metrics charts): 
<img width="900" alt="Screenshot 2026-04-01 at 13 53 02" src="https://github.com/user-attachments/assets/7c77dcaa-1bd1-4893-9d14-26bb15911ff8" />
