### PR TITLE
chore: add unknown token message for SDK api middlewares

### DIFF
--- a/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
@@ -182,17 +182,17 @@ test('should allow requests with a token secret alias', async () => {
         .get('/api/frontend')
         .set('Authorization', 'null')
         .expect('Content-Type', /json/)
-        .expect(401);
+        .expect(403);
     await app.request
         .get('/api/frontend')
         .set('Authorization', randomId())
         .expect('Content-Type', /json/)
-        .expect(401);
+        .expect(403);
     await app.request
         .get('/api/frontend')
         .set('Authorization', tokenA.secret.slice(0, -1))
         .expect('Content-Type', /json/)
-        .expect(401);
+        .expect(403);
     await app.request
         .get('/api/frontend')
         .set('Authorization', tokenA.secret)
@@ -266,7 +266,7 @@ test('should not allow requests with an invalid frontend token', async () => {
         .get('/api/frontend')
         .set('Authorization', frontendToken.secret.slice(0, -1))
         .expect('Content-Type', /json/)
-        .expect(401);
+        .expect(403);
 });
 
 test('should allow requests with a frontend token', async () => {

--- a/src/lib/middleware/api-token-middleware.ts
+++ b/src/lib/middleware/api-token-middleware.ts
@@ -25,6 +25,9 @@ const isProxyApi = ({ path }) => {
 export const TOKEN_TYPE_ERROR_MESSAGE =
     'invalid token: expected a different token type for this endpoint';
 
+export const NO_ACCESS =
+    'no access: unknown or invalid API token';
+
 export const NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED =
     'This endpoint requires an API token. Please add an authorization header to your request with a valid token';
 

--- a/src/lib/middleware/backend-token-middleware.ts
+++ b/src/lib/middleware/backend-token-middleware.ts
@@ -3,6 +3,7 @@ import type { IUnleashConfig } from '../types/option.js';
 import type { IApiRequest, IAuthRequest } from '../routes/unleash-types.js';
 import type { IUnleashServices } from '../services/index.js';
 import {
+    NO_ACCESS,
     NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
     TOKEN_TYPE_ERROR_MESSAGE,
 } from './api-token-middleware.js';
@@ -47,9 +48,7 @@ export const backendApiAccessMiddleware = (
                 return;
             }
 
-            const apiUser = apiToken
-                ? await apiTokenService.getUserForToken(apiToken)
-                : undefined;
+            const apiUser = await apiTokenService.getUserForToken(apiToken);
             const { CLIENT, BACKEND } = ApiTokenType;
 
             if (apiUser) {
@@ -62,8 +61,8 @@ export const backendApiAccessMiddleware = (
                 req.user = apiUser;
                 next();
             } else {
-                res.status(401).send({
-                    message: NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
+                res.status(403).send({
+                    message: NO_ACCESS,
                 });
                 return;
             }

--- a/src/lib/middleware/frontend-token-middleware.ts
+++ b/src/lib/middleware/frontend-token-middleware.ts
@@ -3,6 +3,7 @@ import type { IUnleashConfig } from '../types/option.js';
 import type { IApiRequest, IAuthRequest } from '../routes/unleash-types.js';
 import type { IUnleashServices } from '../services/index.js';
 import {
+    NO_ACCESS,
     NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
     TOKEN_TYPE_ERROR_MESSAGE,
 } from './api-token-middleware.js';
@@ -47,9 +48,7 @@ export const frontendApiAccessMiddleware = (
                 return;
             }
 
-            const apiUser = apiToken
-                ? await apiTokenService.getUserForToken(apiToken)
-                : undefined;
+            const apiUser = await apiTokenService.getUserForToken(apiToken);
             const { FRONTEND } = ApiTokenType;
 
             if (apiUser) {
@@ -62,8 +61,8 @@ export const frontendApiAccessMiddleware = (
                 req.user = apiUser;
                 next();
             } else {
-                res.status(401).send({
-                    message: NO_TOKEN_WHERE_TOKEN_WAS_REQUIRED,
+                res.status(403).send({
+                    message: NO_ACCESS,
                 });
                 return;
             }

--- a/src/test/e2e/api/client/feature.token.access.e2e.test.ts
+++ b/src/test/e2e/api/client/feature.token.access.e2e.test.ts
@@ -227,12 +227,12 @@ test('returns 401 when not provided token', async () => {
         .expect(401);
 });
 
-test('returns 401 when provided token that doesnt exist', async () => {
+test('returns 403 when provided token that doesnt exist', async () => {
     await app.request
         .get('/api/client/features')
         .set('Authorization', '*:production.secret')
         .expect('Content-Type', /json/)
-        .expect(401);
+        .expect(403);
 });
 
 test('returns 403 when provided admin token', async () => {


### PR DESCRIPTION
Changes the unknown token response to a 403 (from 401) and with a better message