### PR TITLE
chore: remove unnecessary title from EnvironmentForm

### DIFF
--- a/frontend/src/component/environments/EnvironmentForm/EnvironmentForm.tsx
+++ b/frontend/src/component/environments/EnvironmentForm/EnvironmentForm.tsx
@@ -29,11 +29,6 @@ const StyledForm = styled('form')({
     height: '100%',
 });
 
-const StyledFormHeader = styled('h3')({
-    fontWeight: 'normal',
-    marginTop: '0',
-});
-
 const StyledContainer = styled('div')({
     maxWidth: '440px',
 });
@@ -83,8 +78,6 @@ const EnvironmentForm: React.FC<IEnvironmentForm> = ({
 }) => {
     return (
         <StyledForm onSubmit={handleSubmit}>
-            <StyledFormHeader>Environment information</StyledFormHeader>
-
             <StyledContainer>
                 <StyledInputDescription>
                     What is your environment name? (Can't be changed later)


### PR DESCRIPTION
Removes redundant header from the create/edit environment form

before: 
<img width="900" alt="image" src="https://github.com/user-attachments/assets/54cc02bc-26cc-4070-ae17-199b64852bd1" />

after:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/04d0830e-a543-44d8-8743-aed8e5a8afd6" />
