### PR TITLE
chore: refresh instance status and user on signup

### DIFF
--- a/frontend/src/component/signup/hooks/useSignup.ts
+++ b/frontend/src/component/signup/hooks/useSignup.ts
@@ -23,8 +23,8 @@ export const useSignup = (options?: SWRConfiguration) => {
         isEnterprise,
         uiConfig: { billing },
     } = useUiConfig();
-    const { data: authData } = useAuthEndpoint();
-    const { instanceStatus } = useInstanceStatus();
+    const { data: authData, refetchAuth } = useAuthEndpoint();
+    const { instanceStatus, refetchInstanceStatus } = useInstanceStatus();
     const signupDialogEnabled = useUiFlag('signupDialog');
 
     const isPAYG = isEnterprise() && billing === 'pay-as-you-go';
@@ -56,7 +56,11 @@ export const useSignup = (options?: SWRConfiguration) => {
         signupData,
         signupRequired,
         loading,
-        refetch: mutate,
+        refetch: () => {
+            mutate();
+            refetchAuth();
+            refetchInstanceStatus();
+        },
         error,
     };
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-317/refresh-instance-status-and-user-endpoint-on-signup-complete

During my tests I noticed that instance status and the user endpoints were not being correctly refreshed on signup. E.g., the user name took a while to correctly show up in the dashboard and top right profile button.

By refreshing these endpoints we'll provide a slightly better UX.