### PR TITLE
fix: move clicked docs funnel event from sidebar to MetricSelector

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -42,7 +42,6 @@ export const FeatureView = () => {
         openChartModal,
         closeChartModal,
         saveChart,
-        trackDocsClicked,
         metricOptions,
         metadataLoading,
     } = useFeatureImpactChartActions(projectId, featureId);
@@ -90,7 +89,6 @@ export const FeatureView = () => {
                     open={chartModalOpen}
                     onClose={closeChartModal}
                     onSave={saveChart}
-                    onDocsClicked={trackDocsClicked}
                     metricSeries={metricOptions}
                     loading={metadataLoading}
                 />

--- a/frontend/src/component/feature/FeatureView/useFeatureImpactChartActions.ts
+++ b/frontend/src/component/feature/FeatureView/useFeatureImpactChartActions.ts
@@ -13,8 +13,7 @@ export const useFeatureImpactChartActions = (
     featureName: string,
 ) => {
     const [chartModalOpen, setChartModalOpen] = useState(false);
-    const { trackMetricSaved, trackDocsClicked } =
-        useTrackFlagpageImpactMetrics();
+    const { trackMetricSaved } = useTrackFlagpageImpactMetrics();
 
     const { createImpactMetric } = useImpactMetricsApi({
         projectId,
@@ -51,7 +50,6 @@ export const useFeatureImpactChartActions = (
         openChartModal,
         closeChartModal,
         saveChart,
-        trackDocsClicked,
         metricOptions,
         metadataLoading,
     };

--- a/frontend/src/component/impact-metrics/ChartConfigModal/ChartConfigModal.tsx
+++ b/frontend/src/component/impact-metrics/ChartConfigModal/ChartConfigModal.tsx
@@ -96,7 +96,6 @@ export interface ChartConfigModalProps {
     open: boolean;
     onClose: () => void;
     onSave: (config: Omit<ChartConfig, 'id'>) => void;
-    onDocsClicked?: () => void;
     initialConfig?: ChartConfig;
     metricSeries: (ImpactMetricsSeries & { name: string })[];
     loading?: boolean;
@@ -106,7 +105,6 @@ export const ChartConfigModal: FC<ChartConfigModalProps> = ({
     open,
     onClose,
     onSave,
-    onDocsClicked,
     initialConfig,
     metricSeries,
     loading = false,
@@ -148,7 +146,6 @@ export const ChartConfigModal: FC<ChartConfigModalProps> = ({
                             eventType: 'sidebar docs clicked',
                         },
                     });
-                    onDocsClicked?.();
                 }}
             >
                 <MenuBookIcon fontSize='small' />

--- a/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ChartConfigModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -9,6 +9,7 @@ import {
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import type { MetricSource } from 'component/impact-metrics/types';
+import { useTrackFlagpageImpactMetrics } from 'component/impact-metrics/useImpactMetricsFunnel';
 
 type MetricOption = {
     name: string;
@@ -32,6 +33,7 @@ export type MetricSelectorProps = {
 
 const NoOptionsMessage = () => {
     const { trackEvent } = usePlausibleTracker();
+    const { trackDocsClicked } = useTrackFlagpageImpactMetrics();
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -49,13 +51,14 @@ const NoOptionsMessage = () => {
                 target='_blank'
                 rel='noopener noreferrer'
                 sx={{ alignSelf: 'flex-start', mt: 1 }}
-                onClick={() =>
+                onClick={() => {
                     trackEvent('impact-metrics', {
                         props: {
                             eventType: 'No options docs clicked',
                         },
-                    })
-                }
+                    });
+                    trackDocsClicked();
+                }}
             >
                 Set up your first metric
             </Button>


### PR DESCRIPTION
The `flagpage_funnel_docs_clicked` counter should increased when the 'No options docs clicked' Plausible event is captured (when there is no option in the `MetricSelector` autocomplete). 

- removes unneeded `onDocsClicked` prop,
- removes `trackDocsClicked` from `useFeatureImpactChartActions`
- increases the 'flagpage_funnel_docs_clicked' impact metric counter on `NoOptionsMessage` clicked