### PR TITLE
use `satisfies string[]` instead of `as any`

### DIFF
--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -105,7 +105,7 @@ const searchFeaturesWithLifecycle = async (
 const sortFeatures = async (
     {
         sortBy = '',
-        sortOrder = '',
+        sortOrder = undefined,
         project = 'default',
         favoritesFirst = 'false',
     }: FeatureSearchQueryParameters,

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -141,7 +141,7 @@ export const featureSearchQueryParameters = [
         name: 'sortOrder',
         schema: {
             type: 'string',
-            enum: ['asc', 'desc'] as any,
+            enum: ['asc', 'desc'] satisfies string[],
             example: 'desc',
         },
         description:

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -141,7 +141,7 @@ export const featureSearchQueryParameters = [
         name: 'sortOrder',
         schema: {
             type: 'string',
-            enum: ['asc', 'desc'] satisfies string[],
+            enum: ['asc', 'desc'] satisfies ('asc' | 'desc')[],
             example: 'desc',
         },
         description:


### PR DESCRIPTION
This should also allow us to compile, without erasing the type information.
