### PR TITLE
fix: filter out non-OSS projects for OSS users in personal dashboard

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -195,6 +195,7 @@ export const createStores = (
             db,
             eventBus,
             config.flagResolver,
+            config.isOss,
         ),
         userUnsubscribeStore: new UserUnsubscribeStore(db),
         userSubscriptionsReadModel: new UserSubscriptionsReadModel(db),

--- a/src/lib/features/onboarding/createOnboardingService.ts
+++ b/src/lib/features/onboarding/createOnboardingService.ts
@@ -17,6 +17,7 @@ export const createOnboardingService =
             db,
             eventBus,
             flagResolver,
+            config.isOss,
         );
         const userStore = new UserStore(db, getLogger);
         const onboardingService = new OnboardingService(

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -27,7 +27,12 @@ export const createPersonalDashboardService = (
     return new PersonalDashboardService(
         new PersonalDashboardReadModel(db),
         new ProjectOwnersReadModel(db),
-        new ProjectReadModel(db, config.eventBus, config.flagResolver),
+        new ProjectReadModel(
+            db,
+            config.eventBus,
+            config.flagResolver,
+            config.isOss,
+        ),
         new OnboardingReadModel(db),
         new EventStore(db, config.getLogger),
         new FeatureEventFormatterMd({
@@ -37,7 +42,6 @@ export const createPersonalDashboardService = (
         new PrivateProjectChecker(stores, config),
         new AccountStore(db, config.getLogger),
         new AccessStore(db, config.eventBus, config.getLogger),
-        config.isOss,
     );
 };
 
@@ -55,6 +59,5 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         new FakePrivateProjectChecker(),
         new FakeAccountStore(),
         new FakeAccessStore(),
-        config.isOss,
     );
 };

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -37,6 +37,7 @@ export const createPersonalDashboardService = (
         new PrivateProjectChecker(stores, config),
         new AccountStore(db, config.getLogger),
         new AccessStore(db, config.eventBus, config.getLogger),
+        config.isOss,
     );
 };
 
@@ -54,5 +55,6 @@ export const createFakePersonalDashboardService = (config: IUnleashConfig) => {
         new FakePrivateProjectChecker(),
         new FakeAccountStore(),
         new FakeAccessStore(),
+        config.isOss,
     );
 };

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -87,12 +87,8 @@ export class PersonalDashboardService {
             this.projectReadModel.getProjectsFavoritedByUser(userId),
         ]);
 
-        const projectIds = [
-            ...new Set([...userProjectIds, ...userFavoritedProjectIds]),
-        ];
-
         const projects = await this.projectReadModel.getProjectsForAdminUi({
-            ids: projectIds,
+            ids: [...new Set([...userProjectIds, ...userFavoritedProjectIds])],
             archived: false,
         });
 

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -55,6 +55,8 @@ export class PersonalDashboardService {
 
     private accessStore: IAccessStore;
 
+    private isOss: boolean;
+
     constructor(
         personalDashboardReadModel: IPersonalDashboardReadModel,
         projectOwnersReadModel: IProjectOwnersReadModel,
@@ -65,6 +67,7 @@ export class PersonalDashboardService {
         privateProjectChecker: IPrivateProjectChecker,
         accountStore: IAccountStore,
         accessStore: IAccessStore,
+        isOss: boolean,
     ) {
         this.personalDashboardReadModel = personalDashboardReadModel;
         this.projectOwnersReadModel = projectOwnersReadModel;
@@ -75,6 +78,7 @@ export class PersonalDashboardService {
         this.privateProjectChecker = privateProjectChecker;
         this.accountStore = accountStore;
         this.accessStore = accessStore;
+        this.isOss = isOss;
     }
 
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
@@ -87,8 +91,16 @@ export class PersonalDashboardService {
             this.projectReadModel.getProjectsFavoritedByUser(userId),
         ]);
 
+        let projectIds = [
+            ...new Set([...userProjectIds, ...userFavoritedProjectIds]),
+        ];
+
+        if (this.isOss) {
+            projectIds = projectIds.filter((id) => id === 'default');
+        }
+
         const projects = await this.projectReadModel.getProjectsForAdminUi({
-            ids: [...new Set([...userProjectIds, ...userFavoritedProjectIds])],
+            ids: projectIds,
             archived: false,
         });
 

--- a/src/lib/features/personal-dashboard/personal-dashboard-service.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard-service.ts
@@ -55,8 +55,6 @@ export class PersonalDashboardService {
 
     private accessStore: IAccessStore;
 
-    private isOss: boolean;
-
     constructor(
         personalDashboardReadModel: IPersonalDashboardReadModel,
         projectOwnersReadModel: IProjectOwnersReadModel,
@@ -67,7 +65,6 @@ export class PersonalDashboardService {
         privateProjectChecker: IPrivateProjectChecker,
         accountStore: IAccountStore,
         accessStore: IAccessStore,
-        isOss: boolean,
     ) {
         this.personalDashboardReadModel = personalDashboardReadModel;
         this.projectOwnersReadModel = projectOwnersReadModel;
@@ -78,7 +75,6 @@ export class PersonalDashboardService {
         this.privateProjectChecker = privateProjectChecker;
         this.accountStore = accountStore;
         this.accessStore = accessStore;
-        this.isOss = isOss;
     }
 
     getPersonalFeatures(userId: number): Promise<PersonalFeature[]> {
@@ -91,13 +87,9 @@ export class PersonalDashboardService {
             this.projectReadModel.getProjectsFavoritedByUser(userId),
         ]);
 
-        let projectIds = [
+        const projectIds = [
             ...new Set([...userProjectIds, ...userFavoritedProjectIds]),
         ];
-
-        if (this.isOss) {
-            projectIds = projectIds.filter((id) => id === 'default');
-        }
 
         const projects = await this.projectReadModel.getProjectsForAdminUi({
             ids: projectIds,

--- a/src/lib/features/personal-dashboard/personal-dashboard.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard.e2e.test.ts
@@ -1,0 +1,93 @@
+import dbInit, {
+    type ITestDb,
+} from '../../../test/e2e/helpers/database-init.js';
+import getLogger from '../../../test/fixtures/no-logger.js';
+import {
+    setupAppWithAuth,
+    type IUnleashTest,
+} from '../../../test/e2e/helpers/test-helper.js';
+import { type MinimalUser, RoleName } from '../../server-impl.js';
+
+const userEmail = 'some-user@getunleash.io';
+const enterpriseProjectId = 'enterprise-only-project';
+
+let db: ITestDb;
+let user: MinimalUser;
+
+const startApp = ({ isOss }: { isOss: boolean }): Promise<IUnleashTest> =>
+    setupAppWithAuth(
+        db.stores,
+        { isOss, experimental: { flags: {} } },
+        db.rawDatabase,
+    );
+
+const loginUser = (app: IUnleashTest, email: string) =>
+    app.request.post('/auth/demo/login').send({ email }).expect(200);
+
+beforeAll(async () => {
+    db = await dbInit('personal_dashboard_oss_downgrade', getLogger);
+
+    user = await db.stores.userStore.insert({
+        name: 'downgraded-user',
+        email: userEmail,
+    });
+
+    await db.rawDatabase('projects').insert({
+        id: enterpriseProjectId,
+        name: 'Enterprise Only Project',
+        description: '',
+        health: 100,
+    });
+});
+
+afterAll(async () => {
+    await db.destroy();
+});
+
+test('personal dashboard should not return enterprise-only projects after downgrade to OSS', async () => {
+    // in Enterprise
+    const enterpriseApp = await startApp({ isOss: false });
+    const editorRole = (
+        await enterpriseApp.services.accessService.getRootRoles()
+    ).find((role) => role.name === RoleName.EDITOR)!;
+
+    await enterpriseApp.services.accessService.addUserToRole(
+        user.id,
+        editorRole.id,
+        'default',
+    );
+
+    await enterpriseApp.services.accessService.addUserToRole(
+        user.id,
+        editorRole.id,
+        enterpriseProjectId,
+    );
+
+    await loginUser(enterpriseApp, userEmail);
+
+    const { body: enterpriseDashboardBody } = await enterpriseApp.request
+        .get('/api/admin/personal-dashboard')
+        .expect(200);
+
+    const enterpriseProjectIds = enterpriseDashboardBody.projects.map(
+        (p: { id: string }) => p.id,
+    );
+    expect(enterpriseProjectIds).toContain('default');
+    expect(enterpriseProjectIds).toContain(enterpriseProjectId);
+
+    await enterpriseApp.destroy();
+
+    // in OSS
+    const ossApp = await startApp({ isOss: true });
+
+    await loginUser(ossApp, userEmail);
+    const { body } = await ossApp.request
+        .get('/api/admin/personal-dashboard')
+        .expect(200);
+
+    const projectIds = body.projects.map((p: { id: string }) => p.id);
+    expect(projectIds).toContain('default');
+    expect(projectIds).not.toContain(enterpriseProjectId);
+
+    await ossApp.destroy();
+});

--- a/src/lib/features/personal-dashboard/personal-dashboard.e2e.test.ts
+++ b/src/lib/features/personal-dashboard/personal-dashboard.e2e.test.ts
@@ -10,6 +10,7 @@ import { type MinimalUser, RoleName } from '../../server-impl.js';
 
 const userEmail = 'some-user@getunleash.io';
 const enterpriseProjectId = 'enterprise-only-project';
+const favoritedEnterpriseProjectId = 'favorited-enterprise-project';
 
 let db: ITestDb;
 let user: MinimalUser;
@@ -32,11 +33,24 @@ beforeAll(async () => {
         email: userEmail,
     });
 
-    await db.rawDatabase('projects').insert({
-        id: enterpriseProjectId,
-        name: 'Enterprise Only Project',
-        description: '',
-        health: 100,
+    await db.rawDatabase('projects').insert([
+        {
+            id: enterpriseProjectId,
+            name: 'Enterprise Only Project',
+            description: '',
+            health: 100,
+        },
+        {
+            id: favoritedEnterpriseProjectId,
+            name: 'Favorited Enterprise Only Project',
+            description: '',
+            health: 100,
+        },
+    ]);
+
+    await db.rawDatabase('favorite_projects').insert({
+        project: favoritedEnterpriseProjectId,
+        user_id: user.id,
     });
 });
 
@@ -74,6 +88,7 @@ test('personal dashboard should not return enterprise-only projects after downgr
     );
     expect(enterpriseProjectIds).toContain('default');
     expect(enterpriseProjectIds).toContain(enterpriseProjectId);
+    expect(enterpriseProjectIds).toContain(favoritedEnterpriseProjectId);
 
     await enterpriseApp.destroy();
 
@@ -88,6 +103,7 @@ test('personal dashboard should not return enterprise-only projects after downgr
     const projectIds = body.projects.map((p: { id: string }) => p.id);
     expect(projectIds).toContain('default');
     expect(projectIds).not.toContain(enterpriseProjectId);
+    expect(projectIds).not.toContain(favoritedEnterpriseProjectId);
 
     await ossApp.destroy();
 });

--- a/src/lib/features/project/createProjectReadModel.ts
+++ b/src/lib/features/project/createProjectReadModel.ts
@@ -9,8 +9,9 @@ export const createProjectReadModel = (
     db: Db,
     eventBus: EventEmitter,
     flagResolver: IFlagResolver,
+    isOss: boolean = false,
 ): IProjectReadModel => {
-    return new ProjectReadModel(db, eventBus, flagResolver);
+    return new ProjectReadModel(db, eventBus, flagResolver, isOss);
 };
 
 export const createFakeProjectReadModel = (): IProjectReadModel => {

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -134,6 +134,7 @@ export const createProjectService = (
         db,
         eventBus,
         config.flagResolver,
+        config.isOss,
     );
 
     const onboardingReadModel = createOnboardingReadModel(db);

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -52,8 +52,16 @@ export class ProjectReadModel implements IProjectReadModel {
 
     private timer: Function;
 
-    constructor(db: Db, eventBus: EventEmitter, _flagResolver: IFlagResolver) {
+    private isOss: boolean;
+
+    constructor(
+        db: Db,
+        eventBus: EventEmitter,
+        _flagResolver: IFlagResolver,
+        isOss: boolean = false,
+    ) {
         this.db = db;
+        this.isOss = isOss;
         this.timer = (action) =>
             metricsHelper.wrapTimer(eventBus, DB_TIME, {
                 store: 'project',
@@ -261,7 +269,7 @@ export class ProjectReadModel implements IProjectReadModel {
     }
 
     async getProjectsByUser(userId: number): Promise<string[]> {
-        const projects = await this.db
+        let projects = this.db
             .from((db) => {
                 db.select('role_user.project')
                     .from('role_user')
@@ -289,17 +297,29 @@ export class ProjectReadModel implements IProjectReadModel {
                     .as('query');
             })
             .pluck('project');
+
+        if (this.isOss) {
+            projects = projects.where('project', 'default');
+        }
+
         return projects;
     }
 
     async getProjectsFavoritedByUser(userId: number): Promise<string[]> {
-        const favoritedProjects = await this.db
+        let favoritedProjects = this.db
             .select('favorite_projects.project')
             .from('favorite_projects')
             .leftJoin('projects', 'favorite_projects.project', 'projects.id')
             .where('favorite_projects.user_id', userId)
             .andWhere('projects.archived_at', null)
             .pluck('project');
+
+        if (this.isOss) {
+            favoritedProjects = favoritedProjects.where(
+                'favorite_projects.project',
+                'default',
+            );
+        }
 
         return favoritedProjects;
     }


### PR DESCRIPTION
- Adds the same `isOss` check in the ProjectreadModel that we have in the project store (filters out non 'default' projects when in OSS in `getProjectsByUser` and `getProjectsFavoritedByUser`)

After being downgraded from enterprise, OSS users should not be able to still see their enterprise projects in the personal dashboard.

This duplicates the same check we have in the `ProjectStore`, but maybe it's worth considering unifying the store and the read model in some way at some point (or having some shared layer?).

