### PR TITLE
fix: prevent cannot split of undefined crash in CR view

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
@@ -103,7 +103,7 @@ const DetailsTable: React.FC<{
                                 <pre>
                                     <ins>
                                         {JSON.stringify(newValue, null, 2)
-                                            .split('\n')
+                                            ?.split('\n')
                                             .map((line, index) => (
                                                 <code
                                                     key={`${property}${line}${index}`}


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-359/prevent-cannot-split-of-undefined-crashes-in-cr-view

Prevents "cannot split of undefined" crashes when viewing a CR.

Follow-up to: https://github.com/Unleash/unleash/pull/11786