### PR TITLE
feat: smarter orphan metrics

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -525,6 +525,7 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                     <StyledTopRow sx={{ ml: 3, mb: 1.5 }}>
                         <MetricSelector
                             value={metric.metricName}
+                            valueSource={metric.source}
                             onChange={handleMetricChange}
                             options={metricOptions}
                             loading={loading}

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.test.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.test.tsx
@@ -21,18 +21,26 @@ const externalMetricSeries = [
     },
 ];
 
+const baseChartConfig: Omit<ChartConfig, 'metricName' | 'source'> = {
+    id: 'chart-1',
+    timeRange: 'day',
+    yAxisMin: 'auto',
+    aggregationMode: 'count',
+    labelSelectors: {},
+};
+
 const mixedMetricSeries = [
-    {
-        name: 'my_external_metric',
-        displayName: 'my_external_metric',
-        help: 'A custom external metric',
-        source: 'external' as const,
-    },
     {
         name: 'unleash_counter_flag_exposure',
         displayName: 'unleash_counter_flag_exposure',
         help: 'A built-in Unleash metric',
         source: 'internal' as const,
+    },
+    {
+        name: 'my_external_metric',
+        displayName: 'my_external_metric',
+        help: 'A custom external metric',
+        source: 'external' as const,
     },
 ];
 
@@ -128,6 +136,66 @@ describe('ImpactMetricModal', () => {
 
         expect(await screen.findByText('Internal metrics')).toBeInTheDocument();
         expect(await screen.findByText('External metrics')).toBeInTheDocument();
+    });
+
+    test('appends an orphan external metric to the end of the options', async () => {
+        const user = userEvent.setup();
+        const initialConfig: ChartConfig = {
+            ...baseChartConfig,
+            metricName: 'orphan_external_metric',
+            source: 'external',
+        };
+
+        render(
+            <ImpactMetricModal
+                open
+                onClose={vi.fn()}
+                onSave={vi.fn()}
+                metricSeries={mixedMetricSeries}
+                initialConfig={initialConfig}
+            />,
+        );
+
+        await screen.findByRole('heading', { name: 'Edit impact metric' });
+
+        const metricInput = screen.getByLabelText(/metric name/i);
+        await user.click(metricInput);
+
+        const optionNames = (await screen.findAllByRole('option')).map(
+            (o) => o.textContent,
+        );
+        expect(optionNames[optionNames.length - 1]).toContain(
+            'orphan_external_metric',
+        );
+    });
+
+    test('prepends an orphan internal metric to the beginning of the options', async () => {
+        const user = userEvent.setup();
+        const initialConfig: ChartConfig = {
+            ...baseChartConfig,
+            metricName: 'orphan_internal_metric',
+            source: 'internal',
+        };
+
+        render(
+            <ImpactMetricModal
+                open
+                onClose={vi.fn()}
+                onSave={vi.fn()}
+                metricSeries={mixedMetricSeries}
+                initialConfig={initialConfig}
+            />,
+        );
+
+        await screen.findByRole('heading', { name: 'Edit impact metric' });
+
+        const metricInput = screen.getByLabelText(/metric name/i);
+        await user.click(metricInput);
+
+        const optionNames = (await screen.findAllByRole('option')).map(
+            (o) => o.textContent,
+        );
+        expect(optionNames[0]).toContain('orphan_internal_metric');
     });
 
     test('prefills the form when editing an existing external metric chart', async () => {

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
@@ -38,6 +38,7 @@ export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
         >
             <MetricSelector
                 value={formData.metricName}
+                valueSource={formData.source}
                 onChange={actions.handleSeriesChange}
                 options={metricSeries}
                 loading={loading}

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -25,6 +25,7 @@ export type MetricSelection = {
 
 export type MetricSelectorProps = {
     value: string;
+    valueSource?: MetricSource;
     onChange: (selection: MetricSelection) => void;
     options: MetricOption[];
     loading?: boolean;
@@ -69,9 +70,18 @@ const NoOptionsMessage = () => {
 const withSelectedValue = (
     options: MetricOption[],
     value: string,
+    valueSource?: MetricSource,
 ): MetricOption[] => {
     if (value && !options.some((option) => option.name === value)) {
-        return [{ name: value, displayName: value, help: '' }, ...options];
+        const orphan: MetricOption = {
+            name: value,
+            displayName: value,
+            help: '',
+            source: valueSource,
+        };
+        return valueSource === 'external'
+            ? [...options, orphan]
+            : [orphan, ...options];
     }
     return options;
 };
@@ -81,12 +91,13 @@ const groupLabel = (source?: MetricSource) =>
 
 export const MetricSelector: FC<MetricSelectorProps> = ({
     value,
+    valueSource,
     onChange,
     options,
     loading = false,
     label = 'Metric name',
 }) => {
-    const allOptions = withSelectedValue(options, value);
+    const allOptions = withSelectedValue(options, value, valueSource);
 
     return (
         <Autocomplete


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When we have orphan impact metrics created long time ago but prometheus no longer reports it we add it to the beginning of metrics if the metric is internal. If the metric is eternal we add it to the end. The reason for that is internal metrics are always first and external second (backend ordering) and label grouping expects pre-ordered grouping items.
<img width="351" height="506" alt="Screenshot 2026-04-13 at 12 01 35" src="https://github.com/user-attachments/assets/37a85888-7f7d-4270-b624-ead6f209973e" />


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
