### PR TITLE
refactor: impact metrics metadata returns list of options

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureImpactMetrics.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureImpactMetrics.tsx
@@ -178,7 +178,7 @@ export const FeatureImpactMetrics: FC = () => {
                 onClose={handleCloseModal}
                 onSave={handleSaveChart}
                 initialConfig={editingChart}
-                metricSeries={metricOptions}
+                metrics={metricOptions}
                 loading={metadataLoading}
             />
         </PageContent>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
@@ -138,13 +138,14 @@ const setupServerRoutes = () => {
         [],
     );
     testServerRoute(server, '/api/admin/impact-metrics/metadata', {
-        series: {
-            unleash_counter_http_requests_total: {
-                type: 'counter',
+        metrics: [
+            {
+                name: 'unleash_counter_http_requests_total',
                 help: 'Total HTTP requests',
                 displayName: 'http_requests_total',
+                source: 'internal',
             },
-        },
+        ],
     });
     testServerRoute(server, '/api/admin/impact-metrics/data', {
         labels: { appName: [] },
@@ -368,14 +369,14 @@ describe('Safeguard', () => {
         );
 
         testServerRoute(server, '/api/admin/impact-metrics/metadata', {
-            series: {
-                my_custom_metric: {
-                    type: 'unknown',
+            metrics: [
+                {
+                    name: 'my_custom_metric',
                     help: 'A custom metric',
                     displayName: 'my_custom_metric',
                     source: 'external',
                 },
-            },
+            ],
         });
         testServerRoute(server, '/api/admin/impact-metrics/', {
             series: [],
@@ -443,13 +444,14 @@ describe('Safeguard', () => {
         );
 
         testServerRoute(server, '/api/admin/impact-metrics/metadata', {
-            series: {
-                my_custom_metric: {
-                    type: 'unknown',
+            metrics: [
+                {
+                    name: 'my_custom_metric',
                     help: 'A custom metric',
                     displayName: 'my_custom_metric',
+                    source: 'internal',
                 },
-            },
+            ],
         });
         testServerRoute(server, '/api/admin/impact-metrics/', {
             series: [],

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -15,7 +15,7 @@ import { useNumericStringInput } from 'hooks/useNumericStringInput';
 import { MiniMetricsChartWithTooltip } from './MiniMetricsChartWithTooltip.tsx';
 import {
     useImpactMetricsOptions,
-    type ImpactMetricsSeries,
+    type ImpactMetric,
 } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
 import { useImpactMetricsData } from 'hooks/api/getters/useImpactMetricsData/useImpactMetricsData';
 import { RangeSelector } from 'component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/RangeSelector/RangeSelector';
@@ -92,8 +92,6 @@ interface IBaseSafeguardFormProps {
     badge?: ReactNode;
     safeguardType?: SafeguardType;
 }
-
-type MetricOption = { name: string } & ImpactMetricsSeries;
 
 const getInitialValues = (safeguard?: ISafeguard) => ({
     metric: {
@@ -228,7 +226,7 @@ const useSafeguardMetricsData = (
 const useSafeguardFormHandlers = (
     formValues: ReturnType<typeof useSafeguardFormValues>,
     formMode: ReturnType<typeof useSafeguardFormMode>,
-    metricOptions: MetricOption[],
+    metricOptions: ImpactMetric[],
     metricType: MetricType,
 ) => {
     const {

--- a/frontend/src/component/feature/FeatureView/FeatureView.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureView.tsx
@@ -89,7 +89,7 @@ export const FeatureView = () => {
                     open={chartModalOpen}
                     onClose={closeChartModal}
                     onSave={saveChart}
-                    metricSeries={metricOptions}
+                    metrics={metricOptions}
                     loading={metadataLoading}
                 />
             )}

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.test.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.test.tsx
@@ -77,7 +77,7 @@ describe('ImpactMetricModal', () => {
                 open
                 onClose={onClose}
                 onSave={onSave}
-                metricSeries={externalMetricSeries}
+                metrics={externalMetricSeries}
             />,
         );
 
@@ -125,7 +125,7 @@ describe('ImpactMetricModal', () => {
                 open
                 onClose={vi.fn()}
                 onSave={vi.fn()}
-                metricSeries={mixedMetricSeries}
+                metrics={mixedMetricSeries}
             />,
         );
 
@@ -151,7 +151,7 @@ describe('ImpactMetricModal', () => {
                 open
                 onClose={vi.fn()}
                 onSave={vi.fn()}
-                metricSeries={mixedMetricSeries}
+                metrics={mixedMetricSeries}
                 initialConfig={initialConfig}
             />,
         );
@@ -182,7 +182,7 @@ describe('ImpactMetricModal', () => {
                 open
                 onClose={vi.fn()}
                 onSave={vi.fn()}
-                metricSeries={mixedMetricSeries}
+                metrics={mixedMetricSeries}
                 initialConfig={initialConfig}
             />,
         );
@@ -215,7 +215,7 @@ describe('ImpactMetricModal', () => {
                 open
                 onClose={vi.fn()}
                 onSave={vi.fn()}
-                metricSeries={externalMetricSeries}
+                metrics={externalMetricSeries}
                 initialConfig={initialConfig}
             />,
         );

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricModal.tsx
@@ -13,7 +13,7 @@ import FormTemplate from 'component/common/FormTemplate/FormTemplate';
 import { ImpactMetricsControls } from './ImpactMetricsControls/ImpactMetricsControls.tsx';
 import { useChartFormState } from '../hooks/useChartFormState.ts';
 import type { ChartConfig } from '../types.ts';
-import type { ImpactMetricsSeries } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
+import type { ImpactMetric } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
 import { LabelsFilter } from './LabelFilter/LabelsFilter.tsx';
 import { ImpactMetricsChart } from '../ImpactMetricsChart.tsx';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker.ts';
@@ -97,7 +97,7 @@ export interface ImpactMetricModalProps {
     onClose: () => void;
     onSave: (config: Omit<ChartConfig, 'id'>) => void;
     initialConfig?: ChartConfig;
-    metricSeries: (ImpactMetricsSeries & { name: string })[];
+    metrics: ImpactMetric[];
     loading?: boolean;
 }
 
@@ -106,7 +106,7 @@ export const ImpactMetricModal: FC<ImpactMetricModalProps> = ({
     onClose,
     onSave,
     initialConfig,
-    metricSeries,
+    metrics,
     loading = false,
 }) => {
     const { formData, actions, isValid, currentAvailableLabels } =
@@ -203,7 +203,7 @@ export const ImpactMetricModal: FC<ImpactMetricModalProps> = ({
                         <ImpactMetricsControls
                             formData={formData}
                             actions={actions}
-                            metricSeries={metricSeries}
+                            metrics={metrics}
                             loading={loading}
                             labelsFilter={
                                 currentAvailableLabels ? (

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
@@ -1,6 +1,6 @@
 import type { FC, ReactNode } from 'react';
 import { Box, FormControlLabel, Checkbox, MenuItem } from '@mui/material';
-import type { ImpactMetricsSeries } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
+import type { ImpactMetric } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
 import { MetricSelector } from './SeriesSelector/MetricSelector.tsx';
 import { RangeSelector } from './RangeSelector/RangeSelector.tsx';
 import { ModeSelector } from './ModeSelector/ModeSelector.tsx';
@@ -16,7 +16,7 @@ export type ImpactMetricsControlsProps = {
         | 'setLabelSelectors'
         | 'setAggregationMode'
     >;
-    metricSeries: (ImpactMetricsSeries & { name: string })[];
+    metrics: ImpactMetric[];
     loading?: boolean;
     labelsFilter?: ReactNode;
 };
@@ -24,7 +24,7 @@ export type ImpactMetricsControlsProps = {
 export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
     formData,
     actions,
-    metricSeries,
+    metrics,
     loading,
     labelsFilter,
 }) => (
@@ -40,7 +40,7 @@ export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
                 value={formData.metricName}
                 valueSource={formData.source}
                 onChange={actions.handleSeriesChange}
-                options={metricSeries}
+                options={metrics}
                 loading={loading}
             />
 

--- a/frontend/src/component/impact-metrics/ImpactMetrics.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetrics.tsx
@@ -185,7 +185,7 @@ export const ImpactMetrics: FC = () => {
                 onClose={() => setModalOpen(false)}
                 onSave={handleSaveChart}
                 initialConfig={editingChart}
-                metricSeries={metricOptions}
+                metrics={metricOptions}
                 loading={metadataLoading || settingsLoading}
             />
         </>

--- a/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
+++ b/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
@@ -1,16 +1,16 @@
-import { useMemo } from 'react';
 import { fetcher, useApiGetter } from '../useApiGetter/useApiGetter.js';
 import { formatApiPath } from 'utils/formatPath';
 import type { MetricSource } from 'component/impact-metrics/types';
 
-export type ImpactMetricsSeries = {
+export type ImpactMetric = {
+    name: string;
     help: string;
     displayName: string;
-    source?: MetricSource;
+    source: MetricSource;
 };
 
 export type ImpactMetricsMetadata = {
-    series: Record<string, ImpactMetricsSeries>;
+    metrics: ImpactMetric[];
 };
 
 export const useImpactMetricsMetadata = () => {
@@ -31,18 +31,8 @@ export const useImpactMetricsMetadata = () => {
 export const useImpactMetricsOptions = () => {
     const { metadata, loading, error } = useImpactMetricsMetadata();
 
-    const metricOptions = useMemo(() => {
-        if (!metadata?.series) {
-            return [];
-        }
-        return Object.entries(metadata.series).map(([name, rest]) => ({
-            name,
-            ...rest,
-        }));
-    }, [metadata]);
-
     return {
-        metricOptions,
+        metricOptions: metadata?.metrics ?? [],
         loading,
         error,
     };


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

  Description:
  Adopts the new backend response shape { metrics: ImpactMetric[] } for /impact-metrics/metadata. Allows the same metric name to appear once per source (internal/external) instead of being collapsed.        
                                                                                                                                                                                                               
  - useImpactMetricsMetadata types: ImpactMetric (was ImpactMetricsSeries) with required name and source; ImpactMetricsMetadata.metrics: ImpactMetric[].                                                       
  - useImpactMetricsOptions returns metadata?.metrics ?? [] (no more Object.entries mapping).                                                                                                                  
  - Renamed prop metricSeries → metrics across ImpactMetricModal, ImpactMetricsControls, and call sites.                                                                                                       
  - Dropped redundant & { name: string } intersections and the MetricOption alias.                                                                                                                             
  - Updated Safeguard.test.tsx mocks to the new shape.                                                                                                                                                         
                                                                                                                                                                                                               
  Requires: matching backend PR deployed together.   

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
