### PR TITLE
feat: use the newer json diff instead of the old, manual diff table for overwrite warnings.

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
@@ -1,6 +1,7 @@
 import { Box, styled } from '@mui/material';
 import type { ChangeRequestState } from 'component/changeRequest/changeRequest.types';
 import type { ChangesThatWouldBeOverwritten } from './strategy-change-diff-calculation.ts';
+import { EventDiff } from 'component/events/EventDiff/EventDiff.tsx';
 
 const ChangesToOverwriteContainer = styled(Box)(({ theme }) => ({
     color: theme.palette.warning.dark,
@@ -11,116 +12,12 @@ const ChangesToOverwriteContainer = styled(Box)(({ theme }) => ({
     marginBottom: theme.spacing(2),
 }));
 
-const OverwriteTable = styled('table')(({ theme }) => ({
-    '&,td,tr,thead': {
-        display: 'block',
-        textAlign: 'margin-inline-start',
-    },
-
-    thead: {
-        clip: 'rect(0 0 0 0)',
-        clipPath: 'inset(50%)',
-        height: '1px',
-        overflow: 'hidden',
-        position: 'absolute',
-        whiteSpace: 'nowrap',
-        width: '1px',
-    },
-
-    'tr + tr': {
-        marginBlockStart: theme.spacing(2),
-    },
-
-    'td:first-of-type': {
-        fontWeight: 'bold',
-        '::after': {
-            content: '":"',
-        },
-        textTransform: 'capitalize',
-        fontSize: theme.fontSizes.bodySize,
-    },
-    'td + td::before': {
-        content: 'attr(data-column)',
-        marginInlineEnd: theme.spacing(1),
-        fontWeight: 'bold',
-    },
-
-    pre: {
-        background: theme.palette.background.default,
-        padding: theme.spacing(2),
-        borderRadius: theme.shape.borderRadius,
-        width: '100%',
-
-        'ins, del': {
-            textDecoration: 'none',
-            'code::before': {
-                marginInlineEnd: theme.spacing(1),
-            },
-        },
-        'del code::before': {
-            content: '"-"',
-        },
-        'ins code::before': {
-            content: '"+"',
-        },
-    },
+const StyledDiff = styled(EventDiff)(({ theme }) => ({
+    padding: theme.spacing(2),
+    backgroundColor: theme.palette.background.default,
+    width: 'fit-content',
+    borderRadius: theme.shape.borderRadius,
 }));
-
-const DetailsTable: React.FC<{
-    changesThatWouldBeOverwritten: ChangesThatWouldBeOverwritten;
-}> = ({ changesThatWouldBeOverwritten }) => {
-    return (
-        <OverwriteTable>
-            <thead>
-                <tr>
-                    <th>Property</th>
-                    <th>Current value</th>
-                    <th>Value after change</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                {changesThatWouldBeOverwritten.map(
-                    ({ property, oldValue, newValue }) => (
-                        <tr key={property}>
-                            <td data-column='Property'>{property}</td>
-                            <td data-column='Current value'>
-                                <pre>
-                                    <del>
-                                        {JSON.stringify(oldValue, null, 2)
-                                            ?.split('\n')
-                                            .map((line, index) => (
-                                                <code
-                                                    key={`${property}${line}${index}`}
-                                                >
-                                                    {`${line}\n`}
-                                                </code>
-                                            ))}
-                                    </del>
-                                </pre>
-                            </td>
-                            <td data-column='Value after change'>
-                                <pre>
-                                    <ins>
-                                        {JSON.stringify(newValue, null, 2)
-                                            ?.split('\n')
-                                            .map((line, index) => (
-                                                <code
-                                                    key={`${property}${line}${index}`}
-                                                >
-                                                    {`${line}\n`}
-                                                </code>
-                                            ))}
-                                    </ins>
-                                </pre>
-                            </td>
-                        </tr>
-                    ),
-                )}
-            </tbody>
-        </OverwriteTable>
-    );
-};
 
 export const OverwriteWarning: React.FC<{
     changeType: 'segment' | 'strategy' | 'environment variant configuration';
@@ -135,6 +32,17 @@ export const OverwriteWarning: React.FC<{
         return null;
     }
 
+    const { data, preData } = Object.values(
+        changesThatWouldBeOverwritten,
+    ).reduce(
+        (acc, { property, oldValue, newValue }) => {
+            acc.data[property] = newValue;
+            acc.preData[property] = oldValue;
+            return acc;
+        },
+        { data: {}, preData: {} },
+    );
+
     return (
         <ChangesToOverwriteContainer>
             <p>
@@ -143,12 +51,10 @@ export const OverwriteWarning: React.FC<{
                 overwrite the configuration that is currently live.
             </p>
             <details>
-                <summary>Changes that would be overwritten</summary>
-                <DetailsTable
-                    changesThatWouldBeOverwritten={
-                        changesThatWouldBeOverwritten
-                    }
-                />
+                <summary>
+                    Configuration that has changed and would be overwritten
+                </summary>
+                <StyledDiff entry={{ data, preData }} />
             </details>
         </ChangesToOverwriteContainer>
     );

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/OverwriteWarning.tsx
@@ -19,6 +19,17 @@ const StyledDiff = styled(EventDiff)(({ theme }) => ({
     borderRadius: theme.shape.borderRadius,
 }));
 
+const mapToJsonDiff = (changes: ChangesThatWouldBeOverwritten) => {
+    return Object.values(changes).reduce(
+        (acc, { property, oldValue, newValue }) => {
+            acc.data[property] = newValue;
+            acc.preData[property] = oldValue;
+            return acc;
+        },
+        { data: {}, preData: {} },
+    );
+};
+
 export const OverwriteWarning: React.FC<{
     changeType: 'segment' | 'strategy' | 'environment variant configuration';
     changesThatWouldBeOverwritten: ChangesThatWouldBeOverwritten | null;
@@ -32,16 +43,7 @@ export const OverwriteWarning: React.FC<{
         return null;
     }
 
-    const { data, preData } = Object.values(
-        changesThatWouldBeOverwritten,
-    ).reduce(
-        (acc, { property, oldValue, newValue }) => {
-            acc.data[property] = newValue;
-            acc.preData[property] = oldValue;
-            return acc;
-        },
-        { data: {}, preData: {} },
-    );
+    const { data, preData } = mapToJsonDiff(changesThatWouldBeOverwritten);
 
     return (
         <ChangesToOverwriteContainer>

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.test.tsx
@@ -1,7 +1,7 @@
 import { render } from 'utils/testRenderer';
 import { StrategyChange } from './StrategyChange.tsx';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 
@@ -165,11 +165,15 @@ test('Editing strategy before change request is applied diffs against current st
     });
     await userEvent.click(viewDiff);
 
-    const rollout = await screen.findByText(`rollout: "${currentRollout}"`);
+    const changeOverview = await screen.findByRole('tabpanel');
+    const changeScope = within(changeOverview);
+    const rollout = await changeScope.findByText(
+        `rollout: "${currentRollout}"`,
+    );
     expect(rollout).toHaveClass('deletion');
-    const oldName = await screen.findByText('name: "current_variant"');
+    const oldName = await changeScope.findByText('name: "current_variant"');
     expect(oldName).toHaveClass('deletion');
-    const newName = await screen.findByText('name: "change_variant"');
+    const newName = await changeScope.findByText('name: "change_variant"');
     expect(newName).toHaveClass('addition');
 });
 

--- a/frontend/src/component/events/EventDiff/EventDiff.tsx
+++ b/frontend/src/component/events/EventDiff/EventDiff.tsx
@@ -5,6 +5,7 @@ import { Button, styled } from '@mui/material';
 interface IEventDiffProps {
     entry: { data?: unknown; preData?: unknown };
     excludeKeys?: string[];
+    className?: string;
 }
 
 const DiffStyles = styled('div')(({ theme }) => ({
@@ -59,7 +60,11 @@ const ButtonIcon = styled('span')(({ theme }) => ({
     marginInlineEnd: theme.spacing(0.5),
 }));
 
-export const EventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
+export const EventDiff: FC<IEventDiffProps> = ({
+    entry,
+    excludeKeys,
+    className,
+}) => {
     const changeType = entry.preData && entry.data ? 'edit' : 'replacement';
     const showExpandButton = changeType === 'edit';
     const [full, setFull] = useState(false);
@@ -79,7 +84,11 @@ export const EventDiff: FC<IEventDiffProps> = ({ entry, excludeKeys }) => {
                         : 'Show all properties'}
                 </Button>
             ) : null}
-            <DiffStyles data-change-type={changeType} id={diffId}>
+            <DiffStyles
+                className={className}
+                data-change-type={changeType}
+                id={diffId}
+            >
                 <JsonDiffComponent
                     jsonA={(entry.preData ?? {}) as JsonValue}
                     jsonB={(entry.data ?? {}) as JsonValue}


### PR DESCRIPTION
Replaces the old manual diff table with the newer json diff component that we also use for other diffs (events, config changes).

I've kept the "show all properties" button for cases where you might have changes in subproperties (e.g. variants), and you want to see all of those changes at once instead of just the changed values. It's niche, but this whole component is pretty niche. It's possible that we could just never elide anything for this (but that might also be overwhelming), so I'm happy with this.

Before:
<img width="1102" height="1146" alt="image" src="https://github.com/user-attachments/assets/1b33652b-69f1-4ca4-8443-14e92abcf3b3" />


After:
<img width="1124" height="520" alt="image" src="https://github.com/user-attachments/assets/cd1d4041-6025-43ad-9ea2-4d77f9e91813" />
<img width="1046" height="503" alt="image" src="https://github.com/user-attachments/assets/23ee2084-ade7-493c-922b-7bfab971996a" />


