### PR TITLE
chore: don't diff sort order for strategies

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.test.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.test.ts
@@ -205,7 +205,7 @@ describe('Strategy change conflict detection', () => {
             change,
         );
 
-        const { id, name, ...changedProperties } = withChanges;
+        const { id, name, sortOrder, ...changedProperties } = withChanges;
 
         const expectedOutput = Object.entries(changedProperties).map(
             ([property, oldValue]) => ({
@@ -438,6 +438,20 @@ describe('Strategy change conflict detection', () => {
         const result = getStrategyChangesThatWouldBeOverwritten(
             existingStrategy,
             changedVersion,
+        );
+
+        expect(result).toBeNull();
+    });
+
+    test('it does not list sort order as a strategy change, even if it has been updated since ', () => {
+        const currentWithDifferentSortOrder = {
+            ...existingStrategy,
+            sortOrder: 5,
+        };
+
+        const result = getStrategyChangesThatWouldBeOverwritten(
+            currentWithDifferentSortOrder,
+            change,
         );
 
         expect(result).toBeNull();

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeOverwriteWarning/strategy-change-diff-calculation.ts
@@ -165,7 +165,7 @@ export function getStrategyChangesThatWouldBeOverwritten(
     })();
 
     return getChangesThatWouldBeOverwritten(
-        omit(withSortedSegments.current, 'strategyName'),
+        omit(withSortedSegments.current, 'strategyName', 'sortOrder'),
         withSortedSegments.change,
         fallbacks,
     );


### PR DESCRIPTION
Bug fix: omit `sortOrder` from strategy change overwrite comparison

The overwrite warning logic iterates over all properties on the current strategy config and compares them against the change request payload. `sortOrder` exists on `IFeatureStrategy` but is not part of the change request payload.

When the live strategy's `sortOrder` differs from the snapshot's (e.g., because strategies were reordered after the change request was created), this would previously show a diff for that property. However, strategy order diffs are a separate change type on CRs and should not be included here.

The fix adds `'sortOrder'` to the `omit()` call that already strips `'strategyName'` from the current config before comparison, so `sortOrder` never enters the diff loop.
