### PR TITLE
feat: add connect SDK banner on feature flag overview

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Button, styled, Typography } from '@mui/material';
+import { ConnectSdkDialog } from 'component/onboarding/dialog/ConnectSdkDialog';
+import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import CodeIcon from '@mui/icons-material/Code';
+
+const BannerCard = styled('div')(({ theme }) => ({
+    display: 'flex',
+    gap: theme.spacing(2),
+    alignItems: 'flex-start',
+    padding: theme.spacing(2),
+    paddingRight: theme.spacing(3),
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusLarge,
+}));
+
+const IconBox = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 48,
+    height: 48,
+    flexShrink: 0,
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: theme.shape.borderRadiusMedium,
+    color: theme.palette.common.white,
+}));
+
+const ContentRow = styled('div')({
+    display: 'flex',
+    flex: 1,
+    gap: 16,
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+});
+
+const TextContainer = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+});
+
+const TitleRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+}));
+
+const PendingBadge = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+}));
+
+const PendingDot = styled('span')(({ theme }) => ({
+    width: 5,
+    height: 5,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.warning.main,
+}));
+
+interface FeatureConnectSdkBannerProps {
+    projectId: string;
+    featureId: string;
+}
+
+export const FeatureConnectSdkBanner = ({
+    projectId,
+    featureId,
+}: FeatureConnectSdkBannerProps) => {
+    const { project } = useProjectOverview(projectId);
+    const [connectSdkOpen, setConnectSdkOpen] = useState(false);
+
+    if (project.onboardingStatus.status === 'onboarded') {
+        return null;
+    }
+
+    const environments =
+        project.environments?.map((env) => env.environment) ?? [];
+
+    return (
+        <>
+            <BannerCard>
+                <IconBox>
+                    <CodeIcon />
+                </IconBox>
+                <ContentRow>
+                    <TextContainer>
+                        <TitleRow>
+                            <Typography
+                                variant='body1'
+                                fontWeight='bold'
+                                color='text.primary'
+                            >
+                                Connect SDK
+                            </Typography>
+                            <PendingBadge>
+                                <PendingDot />
+                                <Typography
+                                    variant='caption'
+                                    color='warning.main'
+                                >
+                                    Pending
+                                </Typography>
+                            </PendingBadge>
+                        </TitleRow>
+                        <Typography variant='body2' color='text.secondary'>
+                            You must connect an SDK to the project before you
+                            can implement this flag in your code.
+                        </Typography>
+                    </TextContainer>
+                    <Button
+                        variant='contained'
+                        onClick={() => setConnectSdkOpen(true)}
+                    >
+                        Connect SDK
+                    </Button>
+                </ContentRow>
+            </BannerCard>
+            <ConnectSdkDialog
+                open={connectSdkOpen}
+                onClose={() => setConnectSdkOpen(false)}
+                onFinish={() => setConnectSdkOpen(false)}
+                project={projectId}
+                environments={environments}
+                feature={featureId}
+            />
+        </>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -27,13 +27,13 @@ const IconBox = styled('div')(({ theme }) => ({
     color: theme.palette.common.white,
 }));
 
-const ContentRow = styled('div')({
+const ContentRow = styled('div')(({ theme }) => ({
     display: 'flex',
     flex: 1,
-    gap: 16,
+    gap: theme.spacing(2),
     alignItems: 'flex-end',
     justifyContent: 'space-between',
-});
+}));
 
 const TextContainer = styled('div')({
     display: 'flex',

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -9,7 +9,7 @@ const BannerCard = styled('div')(({ theme }) => ({
     gap: theme.spacing(2),
     alignItems: 'flex-start',
     padding: theme.spacing(2),
-    paddingRight: theme.spacing(3),
+    paddingRight: theme.spacing(8),
     backgroundColor: theme.palette.background.paper,
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -18,6 +18,8 @@ import { useAuthSplash } from 'hooks/api/getters/useAuth/useAuthSplash';
 import { StrategyDragTooltip } from './StrategyDragTooltip.tsx';
 import { CleanupReminder } from '../CleanupReminder/CleanupReminder.tsx';
 import { useFeature } from '../../../../hooks/api/getters/useFeature/useFeature.ts';
+import { FeatureConnectSdkBanner } from './FeatureConnectSdkBanner.tsx';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -43,6 +45,7 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
     const navigate = useNavigate();
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
+    const onboardingFlagSetup = useUiFlag('onboardingFlagSetup');
     const featurePath = formatFeaturePath(projectId, featureId);
     const { hiddenEnvironments, onEnvironmentVisibilityChange } =
         useEnvironmentVisibility();
@@ -89,6 +92,12 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                     ) : null}
                 </div>
                 <StyledMainContent>
+                    {!loading && onboardingFlagSetup && (
+                        <FeatureConnectSdkBanner
+                            projectId={projectId}
+                            featureId={featureId}
+                        />
+                    )}
                     {!loading && header}
                     <FeatureOverviewEnvironments
                         onToggleEnvOpen={toggleShowTooltip}

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -93,6 +93,7 @@ export type UiFlags = {
     filterFavorites?: boolean;
     externalPrometheusImpactMetrics?: boolean;
     pendingUserAccessRequests?: boolean;
+    onboardingFlagSetup?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -78,7 +78,8 @@ export type IFlagKey =
     | 'newSignOut'
     | 'externalPrometheusImpactMetrics'
     | 'onlyFeatureTokensWithFeatureAPIs'
-    | 'pendingUserAccessRequests';
+    | 'pendingUserAccessRequests'
+    | 'onboardingFlagSetup';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -355,6 +356,10 @@ const flags: IFlags = {
     ),
     pendingUserAccessRequests: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_PENDING_USER_ACCESS_REQUESTS,
+        false,
+    ),
+    onboardingFlagSetup: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ONBOARDING_FLAG_SETUP,
         false,
     ),
 };


### PR DESCRIPTION
 - Adds a "Connect SDK" banner on the feature flag overview page when the project hasn't completed SDK onboarding yet                                                
  - Clicking the banner opens the existing ConnectSdkDialog with the current feature pre-filled                                                                       
  - Banner automatically hides once the project reaches onboarded status                                                                                              
  - Gated behind the onboardingFlagSetup feature flag           
  
  
<img width="2128" height="1267" alt="image" src="https://github.com/user-attachments/assets/6fb77818-2f11-4f9c-b600-62e76387a859" />
