### PR TITLE
chore: remove read-only-users-ui flag

### DIFF
--- a/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
+++ b/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
@@ -13,13 +13,9 @@ import { useInstanceStats } from 'hooks/api/getters/useInstanceStats/useInstance
 import { formatApiPath } from '../../../../utils/formatPath.ts';
 import { PageContent } from '../../../common/PageContent/PageContent.tsx';
 import { PageHeader } from '../../../common/PageHeader/PageHeader.tsx';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig.ts';
 
 export const InstanceStats: FC = () => {
     const { stats } = useInstanceStats();
-    const {
-        uiConfig: { resourceLimits },
-    } = useUiConfig();
 
     let versionTitle: string;
     let version: string | undefined;

--- a/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
+++ b/frontend/src/component/admin/instance-admin/InstanceStats/InstanceStats.tsx
@@ -13,7 +13,6 @@ import { useInstanceStats } from 'hooks/api/getters/useInstanceStats/useInstance
 import { formatApiPath } from '../../../../utils/formatPath.ts';
 import { PageContent } from '../../../common/PageContent/PageContent.tsx';
 import { PageHeader } from '../../../common/PageHeader/PageHeader.tsx';
-import { useUiFlag } from 'hooks/useUiFlag.ts';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig.ts';
 
 export const InstanceStats: FC = () => {
@@ -21,7 +20,6 @@ export const InstanceStats: FC = () => {
     const {
         uiConfig: { resourceLimits },
     } = useUiConfig();
-    const readOnlyUsersUIEnabled = useUiFlag('readOnlyUsersUI');
 
     let versionTitle: string;
     let version: string | undefined;
@@ -78,13 +76,6 @@ export const InstanceStats: FC = () => {
             { title: 'SAML enabled', value: stats?.SAMLenabled ? 'Yes' : 'No' },
             { title: 'OIDC enabled', value: stats?.OIDCenabled ? 'Yes' : 'No' },
         );
-
-        if (readOnlyUsersUIEnabled && resourceLimits.readOnlyUsers) {
-            rows.push({
-                title: 'ReadOnly users',
-                value: stats?.readOnlyUsers,
-            });
-        }
     }
 
     return (

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -67,9 +67,6 @@ const UsersList = () => {
     const showAccessRequests = useUiFlag('pendingUserAccessRequests');
     const showSSOUpgrade = isOss() && users.length > 3;
 
-    const showSeatTypes =
-        useUiFlag('readOnlyUsersUI') && resourceLimits.readOnlyUsers;
-
     const {
         settings: { enabled: scimEnabled },
     } = useScimSettings();
@@ -210,14 +207,6 @@ const UsersList = () => {
                 sortType: 'boolean',
             },
             {
-                id: 'seatType',
-                Header: 'Seat type',
-                accessor: 'seatType',
-                maxWidth: 100,
-                sortType: 'boolean',
-                Cell: TextCell,
-            },
-            {
                 Header: '',
                 id: 'Actions',
                 align: 'center',
@@ -256,7 +245,7 @@ const UsersList = () => {
                 searchable: true,
             },
         ],
-        [roles, navigate, isBillingUsers, showSeatTypes],
+        [roles, navigate, isBillingUsers],
     );
 
     const initialState = useMemo(() => {
@@ -266,10 +255,9 @@ const UsersList = () => {
                 'username',
                 'email',
                 ...(isBillingUsers ? [] : ['type']),
-                ...(showSeatTypes ? [] : ['seatType']),
             ],
         };
-    }, [isBillingUsers, showSeatTypes]);
+    }, [isBillingUsers]);
 
     const { data, getSearchText } = useSearch(
         columns,
@@ -300,10 +288,6 @@ const UsersList = () => {
             {
                 condition: !isBillingUsers || isSmallScreen,
                 columns: ['type'],
-            },
-            {
-                condition: !showSeatTypes || isSmallScreen,
-                columns: ['seatType'],
             },
             {
                 condition: isExtraSmallScreen,

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -45,11 +45,7 @@ import { AccessRequestsTable } from './AccessRequestsTable/AccessRequestsTable.t
 
 const UsersList = () => {
     const navigate = useNavigate();
-    const {
-        isEnterprise,
-        isOss,
-        uiConfig: { resourceLimits },
-    } = useUiConfig();
+    const { isEnterprise, isOss } = useUiConfig();
     const { users, roles, refetch, loading } = useUsers();
     const { setToastData, setToastApiError } = useToast();
     const { removeUser, userLoading, userApiErrors } = useAdminUsersApi();

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -85,7 +85,6 @@ export type UiFlags = {
     extendedUsageMetrics?: boolean;
     newInUnleash?: boolean | Variant;
     gtmReleaseManagement?: boolean;
-    readOnlyUsersUI?: boolean;
     regexConstraintOperator?: boolean;
     signupDialog?: boolean;
     enterpriseEdgeTokensList?: boolean;

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -230,12 +230,6 @@ export class UserService {
             }));
         }
 
-        const { readOnlyUsers } =
-            await this.resourceLimitsService.getResourceLimits();
-        if (!readOnlyUsers) {
-            users = users.map(({ seatType: _removed, ...user }) => user);
-        }
-
         return users;
     }
 

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -232,8 +232,8 @@ export class UserService {
 
         const { readOnlyUsers } =
             await this.resourceLimitsService.getResourceLimits();
-        if (!this.flagResolver.isEnabled('readOnlyUsersUI') || !readOnlyUsers) {
-            users = users.map(({ seatType, ...user }) => user);
+        if (!readOnlyUsers) {
+            users = users.map(({ seatType: _removed, ...user }) => user);
         }
 
         return users;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -67,7 +67,6 @@ export type IFlagKey =
     | 'newInUnleash'
     | 'oidcPkceSupport'
     | 'gtmReleaseManagement'
-    | 'readOnlyUsersUI'
     | 'remoteMcpServer'
     | 'regexConstraintOperator'
     | 'signupDialog'
@@ -307,10 +306,6 @@ const flags: IFlags = {
     ),
     gtmReleaseManagement: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_GTM_RELEASE_MANAGEMENT,
-        false,
-    ),
-    readOnlyUsersUI: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_READ_ONLY_USERS_UI,
         false,
     ),
     remoteMcpServer: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -55,7 +55,6 @@ process.nextTick(async () => {
                         milestoneProgression: true,
                         safeguards: true,
                         gtmReleaseManagement: true,
-                        readOnlyUsersUI: true,
                         regexConstraintOperator: true,
                         enterpriseEdgeTokensList: true,
                         filterFavorites: true,


### PR DESCRIPTION
We're removing this data from the UI and the flag, we can bring it back in the future. Currently, it's only enabled internally for our `hosted` instance, just for us to validate, but not rolled out to customers.

Closes #11455 