### PR TITLE
chore: make helper text and label red if your input is invalid

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
@@ -119,7 +119,18 @@ export const DefineMetricForm = ({
 
     return (
         <StyledForm id={formId} onSubmit={handleSubmit}>
-            <FormControl>
+            <FormControl
+                sx={(theme) => ({
+                    '.MuiFormHelperText-root, label': {
+                        transition: 'color 0.2s ease',
+                    },
+                    ':has(input:invalid:not(:placeholder-shown))': {
+                        '.MuiFormHelperText-root, label': {
+                            color: theme.palette.error.main,
+                        },
+                    },
+                })}
+            >
                 <StyledLabel htmlFor={metricNameInputId}>
                     Metric name
                 </StyledLabel>


### PR DESCRIPTION
This makes the helper text red when your input is invalid and there is no placeholder text (e.g. after the user has started typing).

This approximates how we show validation errors in other forms, but uses pure CSS to make it happen. Because we already have the helper text, we can just highlight that instead of showing new text content.

As-you-type validation can often be a bad user experience, because it can try to validate, say, an email before you have gotten to the @, for instance. However, in this case, if you type a bad character, it’s always a bad character, so there’s no chance that you just haven’t gotten around to making it valid. In other words, there's no "false positives", so I think it's fine.

<img width="1059" height="590" alt="image" src="https://github.com/user-attachments/assets/aaff295c-038f-4b59-9079-a2da14c0be83" />

https://github.com/user-attachments/assets/cd4d2163-25f3-4a4e-8409-08f31c7074ad



For comparison: input error in create flag form
<img width="824" height="311" alt="image" src="https://github.com/user-attachments/assets/b8db53df-fe1b-44a3-88c2-2ae61406d61b" />

