### PR TITLE
chore: update text to point out we're using node 22, not 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v6
         with:
           node-version: 22.x

--- a/.github/workflows/build_frontend_prs.yml
+++ b/.github/workflows/build_frontend_prs.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
           node-version: 22.x

--- a/.github/workflows/publish-new-version.yaml
+++ b/.github/workflows/publish-new-version.yaml
@@ -31,7 +31,7 @@ jobs:
       changelog: ${{ steps.generate_changelog.outputs.changelog }}
     strategy:
       matrix:
-        node-version: [ 20.x ]
+        node-version: [ 22.x ]
 
     services:
       # Label used to access the service container
@@ -123,7 +123,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-      - name: Use Node js 20
+      - name: Use Node js 22
         uses: actions/setup-node@v6
         with:
           node-version: '22.x'

--- a/.github/workflows/update_contributors.yaml
+++ b/.github/workflows/update_contributors.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
           node-version: 22.x

--- a/.github/workflows/validate-migrations.yaml
+++ b/.github/workflows/validate-migrations.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
           node-version: 22.x


### PR DESCRIPTION
As the title says. Mostly updates text to point out we're running node 22, not 20, but also updates one workflow to use 22 rather than being the only one using 20.