### PR TITLE
chore: update success screen and tracking for impact metric registration

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Typography, styled } from '@mui/material';
+import { Box, Typography, styled } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
@@ -24,7 +24,7 @@ const StyledIconWrapper = styled(Box)(({ theme }) => ({
     marginBottom: theme.spacing(2),
 }));
 
-const StyledSuccessBox = styled(Box)(({ theme }) => ({
+const SuccessBox = styled(Box)(({ theme }) => ({
     textAlign: 'center',
     marginTop: theme.spacing(4),
     marginBottom: theme.spacing(2),
@@ -35,18 +35,37 @@ const StyledCheckIcon = styled(CheckCircleOutlineIcon)(({ theme }) => ({
     fontSize: theme.spacing(4),
 }));
 
-const StyledHeader = styled(Typography)(({ theme }) => ({
-    marginBottom: theme.spacing(1),
-}));
-
 const StyledParagraph = styled(Typography)(({ theme }) => ({
     color: theme.palette.text.secondary,
 }));
 
-const StyledNextStepCard = styled(Box)(({ theme }) => ({
+const NextStepCard = styled(Box)(({ theme }) => ({
+    position: 'relative',
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(2),
+    transition: 'border-color 120ms ease',
+    '&:hover, &:focus-within': {
+        borderColor: theme.palette.primary.main,
+    },
+}));
+
+const CardLink = styled('a')(({ theme }) => ({
+    color: 'inherit',
+    textDecoration: 'none',
+    '&::after': {
+        content: '""',
+        position: 'absolute',
+        inset: 0,
+        borderRadius: 'inherit',
+    },
+    '&:focus-visible': {
+        outline: 'none',
+    },
+    '&:focus-visible::after': {
+        outline: `1px solid ${theme.palette.primary.main}`,
+        outlineOffset: '2px',
+    },
 }));
 
 const StyledSubHeader = styled(Typography)(({ theme }) => ({
@@ -59,39 +78,43 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
 
     return (
         <StyledContainer>
-            <StyledSuccessBox>
+            <SuccessBox>
                 <StyledIconWrapper>
                     <StyledCheckIcon />
                 </StyledIconWrapper>
-                <StyledHeader variant='h2'>Metric registered</StyledHeader>
+                <Typography variant='h2' component='h4'>
+                    Metric registered
+                </Typography>
                 <StyledParagraph variant='body2'>
                     Your impact metric <strong>{metricName}</strong> has been
                     created.
-                    <br />
+                </StyledParagraph>
+                <StyledParagraph variant='body2'>
                     It will be available in a few seconds.
                 </StyledParagraph>
-            </StyledSuccessBox>
+            </SuccessBox>
 
             <Box>
-                <StyledSubHeader variant='body2'>What's next?</StyledSubHeader>
-                <StyledNextStepCard>
-                    <StyledSubHeader variant='body2'>
-                        Implement in your code
+                <StyledSubHeader variant='subtitle1'>
+                    What's next?
+                </StyledSubHeader>
+                <NextStepCard>
+                    <StyledSubHeader variant='subtitle1'>
+                        <CardLink
+                            href='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            onClick={() => trackDocsClickedAfterCreation()}
+                        >
+                            Implement in your code
+                        </CardLink>
                     </StyledSubHeader>
                     <StyledParagraph variant='body2'>
                         To start collecting data, you need to implement the
-                        metric in your application code using one of our SDKs.{' '}
-                        <Link
-                            href='https://docs.getunleash.io/reference/impact-metrics'
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            onClick={trackDocsClickedAfterCreation}
-                        >
-                            View the documentation
-                        </Link>{' '}
-                        for setup instructions.
+                        metric in your application code using one of our SDKs.
+                        View the documentation for setup instructions.
                     </StyledParagraph>
-                </StyledNextStepCard>
+                </NextStepCard>
             </Box>
         </StyledContainer>
     );

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,54 +1,98 @@
-import type { FC } from 'react';
-import { Box, Link, Typography } from '@mui/material';
+import { Box, Link, Typography, styled } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
 type SuccessViewProps = {
     metricName: string;
 };
 
-export const SuccessView: FC<SuccessViewProps> = ({ metricName }) => {
+const StyledContainer = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(4),
+}));
+
+const StyledIconWrapper = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: theme.spacing(6),
+    height: theme.spacing(6),
+    borderRadius: '50%',
+    backgroundColor: theme.palette.success.light,
+    margin: '0 auto',
+    marginBottom: theme.spacing(2),
+}));
+
+const StyledSuccessBox = styled(Box)(({ theme }) => ({
+    textAlign: 'center',
+    marginTop: theme.spacing(4),
+    marginBottom: theme.spacing(2),
+}));
+
+const StyledCheckIcon = styled(CheckCircleOutlineIcon)(({ theme }) => ({
+    color: theme.palette.success.main,
+    fontSize: theme.spacing(4),
+}));
+
+const StyledHeader = styled(Typography)(({ theme }) => ({
+    marginBottom: theme.spacing(1),
+}));
+
+const StyledParagraph = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+}));
+
+const StyledNextStepCard = styled(Box)(({ theme }) => ({
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusLarge,
+    padding: theme.spacing(2),
+}));
+
+const StyledSubHeader = styled(Typography)(({ theme }) => ({
+    marginBottom: theme.spacing(2),
+    fontWeight: 'bold',
+}));
+
+export const SuccessView = ({ metricName }: SuccessViewProps) => {
+    const { trackDocsClickedAfterCreation } = useTrackRegisterImpactMetrics();
+
     return (
-        <Box
-            sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 3,
-            }}
-        >
-            <Box>
-                <Typography variant='h2' sx={{ mb: 1 }}>
-                    Metric registered
-                </Typography>
-                <Typography variant='body2' color='text.secondary'>
-                    Your impact metric{' '}
-                    <Typography
-                        component='span'
-                        variant='body2'
-                        fontWeight='bold'
-                    >
-                        {metricName}
-                    </Typography>{' '}
-                    has been created. Your impact metrics will be available in a
-                    few seconds.
-                </Typography>
-            </Box>
+        <StyledContainer>
+            <StyledSuccessBox>
+                <StyledIconWrapper>
+                    <StyledCheckIcon />
+                </StyledIconWrapper>
+                <StyledHeader variant='h2'>Metric registered</StyledHeader>
+                <StyledParagraph variant='body2'>
+                    Your impact metric <strong>{metricName}</strong> has been
+                    created.
+                    <br />
+                    It will be available in a few seconds.
+                </StyledParagraph>
+            </StyledSuccessBox>
 
             <Box>
-                <Typography variant='body2' fontWeight='bold' sx={{ mb: 1 }}>
-                    Implement in your code
-                </Typography>
-                <Typography variant='body2' color='text.secondary'>
-                    To start collecting data, you need to implement the metric
-                    in your application code using one of our SDKs.{' '}
-                    <Link
-                        href='https://docs.getunleash.io/reference/impact-metrics'
-                        target='_blank'
-                        rel='noopener noreferrer'
-                    >
-                        View the documentation
-                    </Link>{' '}
-                    for setup instructions.
-                </Typography>
+                <StyledSubHeader variant='body2'>What's next?</StyledSubHeader>
+                <StyledNextStepCard>
+                    <StyledSubHeader variant='body2'>
+                        Implement in your code
+                    </StyledSubHeader>
+                    <StyledParagraph variant='body2'>
+                        To start collecting data, you need to implement the
+                        metric in your application code using one of our SDKs.{' '}
+                        <Link
+                            href='https://docs.getunleash.io/reference/impact-metrics'
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            onClick={trackDocsClickedAfterCreation}
+                        >
+                            View the documentation
+                        </Link>{' '}
+                        for setup instructions.
+                    </StyledParagraph>
+                </StyledNextStepCard>
             </Box>
-        </Box>
+        </StyledContainer>
     );
 };

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
@@ -16,13 +16,9 @@ export const useTrackRegisterImpactMetrics = () => {
         help,
     );
 
-    const trackFormOpened = () => formOpened();
-    const trackMetricCreated = () => metricCreated();
-    const trackDocsClickedAfterCreation = () => docsClickedAfterCreation();
-
     return {
-        trackFormOpened,
-        trackMetricCreated,
-        trackDocsClickedAfterCreation,
+        trackFormOpened: formOpened,
+        trackMetricCreated: metricCreated,
+        trackDocsClickedAfterCreation: docsClickedAfterCreation,
     };
 };

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
@@ -1,0 +1,28 @@
+import { useImpactMetricsCounter } from 'hooks/useImpactMetrics';
+
+const help = 'Tracks user journey of creating an impact metric from the UI.';
+
+export const useTrackRegisterImpactMetrics = () => {
+    const { increment: formOpened } = useImpactMetricsCounter(
+        'registerImpactMetric_form_opened',
+        help,
+    );
+    const { increment: metricCreated } = useImpactMetricsCounter(
+        'registerImpactMetric_metric_created',
+        help,
+    );
+    const { increment: docsClickedAfterCreation } = useImpactMetricsCounter(
+        'registerImpactMetric_docs_clicked_after_creation',
+        help,
+    );
+
+    const trackFormOpened = () => formOpened();
+    const trackMetricCreated = () => metricCreated();
+    const trackDocsClickedAfterCreation = () => docsClickedAfterCreation();
+
+    return {
+        trackFormOpened,
+        trackMetricCreated,
+        trackDocsClickedAfterCreation,
+    };
+};


### PR DESCRIPTION
- Updates the styling of `SuccessView` used in `RegisterMetricDialog`
- Adds impact metric counters to track the impact metric creation flow

I took the liberty of updating the success view quite a bit 😇 I thought the old look was confusing. I kind of meshed what we had already with a version that's closer to the original design. 

<img width="996" height="700" alt="Screenshot 2026-04-15 at 14 31 00" src="https://github.com/user-attachments/assets/84300f3d-cb25-4186-8943-8a95a09e567f" />
