### PR TITLE
feat: add implement flag banner on feature flag overview

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -1,64 +1,7 @@
 import { useState } from 'react';
-import { Button, styled, Typography } from '@mui/material';
 import { ConnectSdkDialog } from 'component/onboarding/dialog/ConnectSdkDialog';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
-import CodeIcon from '@mui/icons-material/Code';
-
-const BannerCard = styled('div')(({ theme }) => ({
-    display: 'flex',
-    gap: theme.spacing(2),
-    alignItems: 'flex-start',
-    padding: theme.spacing(2),
-    paddingRight: theme.spacing(8),
-    backgroundColor: theme.palette.background.paper,
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadiusLarge,
-}));
-
-const IconBox = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 48,
-    height: 48,
-    flexShrink: 0,
-    backgroundColor: theme.palette.primary.main,
-    borderRadius: theme.shape.borderRadiusMedium,
-    color: theme.palette.common.white,
-}));
-
-const ContentRow = styled('div')(({ theme }) => ({
-    display: 'flex',
-    flex: 1,
-    gap: theme.spacing(2),
-    alignItems: 'flex-end',
-    justifyContent: 'space-between',
-}));
-
-const TextContainer = styled('div')({
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-});
-
-const TitleRow = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1.5),
-}));
-
-const PendingBadge = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.5),
-}));
-
-const PendingDot = styled('span')(({ theme }) => ({
-    width: 5,
-    height: 5,
-    borderRadius: '50%',
-    backgroundColor: theme.palette.warning.main,
-}));
+import { FeatureFlagSetupBannerCard } from './FeatureFlagSetupBannerCard.tsx';
 
 interface FeatureConnectSdkBannerProps {
     projectId: string;
@@ -81,43 +24,12 @@ export const FeatureConnectSdkBanner = ({
 
     return (
         <>
-            <BannerCard>
-                <IconBox>
-                    <CodeIcon />
-                </IconBox>
-                <ContentRow>
-                    <TextContainer>
-                        <TitleRow>
-                            <Typography
-                                variant='body1'
-                                fontWeight='bold'
-                                color='text.primary'
-                            >
-                                Connect SDK
-                            </Typography>
-                            <PendingBadge>
-                                <PendingDot />
-                                <Typography
-                                    variant='caption'
-                                    color='warning.main'
-                                >
-                                    Pending
-                                </Typography>
-                            </PendingBadge>
-                        </TitleRow>
-                        <Typography variant='body2' color='text.secondary'>
-                            You must connect an SDK to the project before you
-                            can implement this flag in your code.
-                        </Typography>
-                    </TextContainer>
-                    <Button
-                        variant='contained'
-                        onClick={() => setConnectSdkOpen(true)}
-                    >
-                        Connect SDK
-                    </Button>
-                </ContentRow>
-            </BannerCard>
+            <FeatureFlagSetupBannerCard
+                title='Connect SDK'
+                description='You must connect an SDK to the project before you can implement this flag in your code.'
+                buttonLabel='Connect SDK'
+                onButtonClick={() => setConnectSdkOpen(true)}
+            />
             <ConnectSdkDialog
                 open={connectSdkOpen}
                 onClose={() => setConnectSdkOpen(false)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from 'react';
+import { Button, styled, Typography } from '@mui/material';
+import CodeIcon from '@mui/icons-material/Code';
+
+const BannerCard = styled('div')(({ theme }) => ({
+    display: 'flex',
+    gap: theme.spacing(2),
+    alignItems: 'flex-start',
+    padding: theme.spacing(2),
+    paddingRight: theme.spacing(8),
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusLarge,
+}));
+
+const IconBox = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 48,
+    height: 48,
+    flexShrink: 0,
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: theme.shape.borderRadiusMedium,
+    color: theme.palette.common.white,
+}));
+
+const ContentRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flex: 1,
+    gap: theme.spacing(2),
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+}));
+
+const TextContainer = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+});
+
+const TitleRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+}));
+
+const PendingBadge = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+}));
+
+const PendingDot = styled('span')(({ theme }) => ({
+    width: 5,
+    height: 5,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.warning.main,
+}));
+
+interface FeatureFlagSetupBannerCardProps {
+    title: string;
+    description: ReactNode;
+    buttonLabel: string;
+    onButtonClick: () => void;
+}
+
+export const FeatureFlagSetupBannerCard = ({
+    title,
+    description,
+    buttonLabel,
+    onButtonClick,
+}: FeatureFlagSetupBannerCardProps) => (
+    <BannerCard>
+        <IconBox>
+            <CodeIcon />
+        </IconBox>
+        <ContentRow>
+            <TextContainer>
+                <TitleRow>
+                    <Typography
+                        variant='body1'
+                        fontWeight='bold'
+                        color='text.primary'
+                    >
+                        {title}
+                    </Typography>
+                    <PendingBadge>
+                        <PendingDot />
+                        <Typography variant='caption' color='warning.main'>
+                            Pending
+                        </Typography>
+                    </PendingBadge>
+                </TitleRow>
+                <Typography variant='body2' color='text.secondary'>
+                    {description}
+                </Typography>
+            </TextContainer>
+            <Button variant='contained' onClick={onButtonClick}>
+                {buttonLabel}
+            </Button>
+        </ContentRow>
+    </BannerCard>
+);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -1,0 +1,33 @@
+import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
+import { FeatureFlagSetupBannerCard } from './FeatureFlagSetupBannerCard.tsx';
+
+interface FeatureImplementFlagBannerProps {
+    projectId: string;
+    featureId: string;
+}
+
+export const FeatureImplementFlagBanner = ({
+    projectId,
+    featureId,
+}: FeatureImplementFlagBannerProps) => {
+    const { project } = useProjectOverview(projectId);
+    const { metrics, loading } = useFeatureMetrics(projectId, featureId);
+
+    if (project.onboardingStatus.status !== 'onboarded') {
+        return null;
+    }
+
+    if (loading || metrics.seenApplications.length > 0) {
+        return null;
+    }
+
+    return (
+        <FeatureFlagSetupBannerCard
+            title='Implement your flag'
+            description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
+            buttonLabel='Wrap your code'
+            onButtonClick={() => {}}
+        />
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -19,6 +19,7 @@ import { StrategyDragTooltip } from './StrategyDragTooltip.tsx';
 import { CleanupReminder } from '../CleanupReminder/CleanupReminder.tsx';
 import { useFeature } from '../../../../hooks/api/getters/useFeature/useFeature.ts';
 import { FeatureConnectSdkBanner } from './FeatureConnectSdkBanner.tsx';
+import { FeatureImplementFlagBanner } from './FeatureImplementFlagBanner.tsx';
 import { useUiFlag } from 'hooks/useUiFlag';
 
 const StyledContainer = styled('div')(({ theme }) => ({
@@ -97,10 +98,16 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                 </div>
                 <StyledMainContent>
                     {!loading && onboardingFlagSetup && (
-                        <FeatureConnectSdkBanner
-                            projectId={projectId}
-                            featureId={featureId}
-                        />
+                        <>
+                            <FeatureConnectSdkBanner
+                                projectId={projectId}
+                                featureId={featureId}
+                            />
+                            <FeatureImplementFlagBanner
+                                projectId={projectId}
+                                featureId={featureId}
+                            />
+                        </>
                     )}
                     {!loading && header}
                     <FeatureOverviewEnvironments


### PR DESCRIPTION
 - Adds an "Implement your flag" banner on the feature flag overview page when the project has SDK connected but this specific flag has no metrics yet
  - Shows when `onboardingStatus === 'onboarded'` AND `seenApplications.length === 0`
  - "Wrap your code" button is a no-op for now
  - Extracts a shared banner card used by both the Connect SDK and Implement Flag banners
  - Gated behind the `onboardingFlagSetup` feature flag
<img width="2090" height="832" alt="image" src="https://github.com/user-attachments/assets/d28f8eb9-05d4-4fdd-a44f-71ca3366eb39" />
