### PR TITLE
chore: Add tracking to register impact metric flow

### DIFF
--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -12,6 +12,7 @@ import type { MetricSource } from 'component/impact-metrics/types';
 import { useTrackFlagpageImpactMetrics } from 'component/impact-metrics/useImpactMetricsFunnel';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { RegisterMetricDialog } from 'component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog';
+import { useTrackRegisterImpactMetrics } from 'component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics';
 
 type MetricOption = {
     name: string;
@@ -128,6 +129,7 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
     const allOptions = withSelectedValue(options, value, valueSource);
     const registerImpactMetricsEnabled = useUiFlag('registerImpactMetrics');
     const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
+    const { trackFormOpened } = useTrackRegisterImpactMetrics();
 
     return (
         <>
@@ -185,7 +187,10 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
                     <NoOptionsMessage
                         onRegisterClick={
                             registerImpactMetricsEnabled
-                                ? () => setRegisterDialogOpen(true)
+                                ? () => {
+                                      setRegisterDialogOpen(true);
+                                      trackFormOpened();
+                                  }
                                 : undefined
                         }
                     />

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { DefineMetricForm } from './DefineMetricForm';
 import { SuccessView } from './SuccessView';
 import { MetricDefinitionSidebar } from './InfoSidebar';
+import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
 type RegisterMetricDialogProps = {
     open: boolean;
@@ -96,6 +97,7 @@ const InnerDialog = ({ onClose }: Omit<RegisterMetricDialogProps, 'open'>) => {
         stage: 'define',
     });
     const formId = useId();
+    const { trackMetricCreated } = useTrackRegisterImpactMetrics();
 
     return (
         <StyledDialog open={true} onClose={onClose}>
@@ -141,6 +143,7 @@ const InnerDialog = ({ onClose }: Omit<RegisterMetricDialogProps, 'open'>) => {
                                         stage: 'success',
                                         metricName,
                                     });
+                                    trackMetricCreated();
                                 }}
                             />
                         </>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
@@ -17,8 +17,8 @@ export const useTrackRegisterImpactMetrics = () => {
     );
 
     return {
-        trackFormOpened: formOpened,
-        trackMetricCreated: metricCreated,
-        trackDocsClickedAfterCreation: docsClickedAfterCreation,
+        trackFormOpened: () => formOpened(),
+        trackMetricCreated: () => metricCreated(),
+        trackDocsClickedAfterCreation: () => docsClickedAfterCreation(),
     };
 };


### PR DESCRIPTION
Instruments counters to track user flow of creating an impact metric from the Unleash UI (form opened, metric creation, docs click after creation). 


