### PR TITLE
chore: small success view fixes

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, styled } from '@mui/material';
+import { Box, Typography, type TypographyProps, styled } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
@@ -41,7 +41,7 @@ const StyledParagraph = styled(Typography)(({ theme }) => ({
 
 const NextStepCard = styled(Box)(({ theme }) => ({
     position: 'relative',
-    border: `1px solid ${theme.palette.divider}`,
+    border: `1.5px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,
     padding: theme.spacing(2),
     transition: 'border-color 120ms ease',
@@ -62,13 +62,9 @@ const CardLink = styled('a')(({ theme }) => ({
     '&:focus-visible': {
         outline: 'none',
     },
-    '&:focus-visible::after': {
-        outline: `1px solid ${theme.palette.primary.main}`,
-        outlineOffset: '2px',
-    },
 }));
 
-const StyledSubHeader = styled(Typography)(({ theme }) => ({
+const StyledSubHeader = styled(Typography)<TypographyProps>(({ theme }) => ({
     marginBottom: theme.spacing(2),
     fontWeight: 'bold',
 }));
@@ -95,7 +91,7 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
             </SuccessBox>
 
             <Box>
-                <StyledSubHeader variant='subtitle1'>
+                <StyledSubHeader component='h5' variant='subtitle1'>
                     What's next?
                 </StyledSubHeader>
                 <NextStepCard>


### PR DESCRIPTION
Fixes a few small nits for the success view:
1. Don't provide an extra outline of the `a::after` pseudo-element. The card has focus styles in and of its own, so we don't need the duplicate (besides, it's had hard edges, while the container has soft edges)
2. Make the card border thicker. This aligns it with the radio cards in the registration form. I think we can consider breaking these out into shared styles somehow (different pr).
3. Make the "what's next" header an h5 instead of h6. Subtitle1 apparently translates to `h6` (who thought that was a good idea?), but there is no h5 on the page and skipping header levels is invalid html.

Card focus before
<img width="865" height="326" alt="image" src="https://github.com/user-attachments/assets/bc66f6d7-bb27-4bea-85a2-6ace06ab43d2" />


Card focus after:
<img width="859" height="364" alt="image" src="https://github.com/user-attachments/assets/986a119d-5dee-42b2-a266-3e72189264fd" />
