### PR TITLE
refactor: extract shared Card and ExternalLink styles for register metric dialog

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
@@ -8,6 +8,7 @@ import {
     Typography,
     styled,
 } from '@mui/material';
+import { Card } from './RegisterMetricDialog.styles';
 import { useRegisterImpactMetricApi } from 'hooks/api/actions/useImpactMetricsApi/useRegisterImpactMetricApi';
 import type { RegisterImpactMetricSchemaType } from 'openapi';
 
@@ -31,31 +32,11 @@ const StyledLabel = styled(FormLabel)(({ theme }) => ({
     marginBottom: theme.spacing(1),
 }));
 
-const CardContent = styled('div')(({ theme }) => ({
+const RadioCardContainer = styled(Card)(({ theme }) => ({
     display: 'flex',
     alignItems: 'flex-start',
-    padding: theme.spacing(2),
-    background: theme.palette.background.default,
     gap: '11px',
-    border: `1.5px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadiusLarge,
-    transition: 'border-color 0.3s',
-    position: 'relative',
-
-    ':hover, :focus-within': {
-        borderColor: theme.palette.primary.main,
-    },
-
-    label: {
-        textTransform: 'capitalize',
-        fontWeight: 'bold',
-        '::before': {
-            content: "''",
-            position: 'absolute',
-            inset: 0,
-            zIndex: 1,
-        },
-    },
+    background: theme.palette.background.default,
 }));
 
 const RadioCard = ({ value, description, examples }) => {
@@ -64,7 +45,7 @@ const RadioCard = ({ value, description, examples }) => {
     const exampleId = useId();
 
     return (
-        <CardContent>
+        <RadioCardContainer>
             <Radio
                 sx={{ padding: 0 }}
                 id={radioId}
@@ -72,7 +53,13 @@ const RadioCard = ({ value, description, examples }) => {
                 aria-describedby={`${descriptionId} ${exampleId}`}
             />
             <div>
-                <label htmlFor={radioId}>{value}</label>
+                <label
+                    data-card-action
+                    htmlFor={radioId}
+                    style={{ textTransform: 'capitalize', fontWeight: 'bold' }}
+                >
+                    {value}
+                </label>
                 <Typography id={descriptionId}>{description}</Typography>
                 <Typography
                     variant='body2'
@@ -83,7 +70,7 @@ const RadioCard = ({ value, description, examples }) => {
                     Examples: {examples}
                 </Typography>
             </div>
-        </CardContent>
+        </RadioCardContainer>
     );
 };
 

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/InfoSidebar.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/InfoSidebar.tsx
@@ -53,7 +53,7 @@ const StyledLink = styled(Link)(({ theme }) => ({
     },
 
     svg: {
-        fontSize: '20px',
+        fontSize: '1.4em',
     },
 }));
 

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/InfoSidebar.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/InfoSidebar.tsx
@@ -1,9 +1,8 @@
 import { Typography, styled } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Link } from 'react-router-dom';
 import HelpOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
+import { ExternalLink } from './RegisterMetricDialog.styles';
 
 const SidebarSection = styled('article')(({ theme }) => ({
     '--vertical-spacing': theme.spacing(1.5),
@@ -36,34 +35,6 @@ const Header = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
     marginBlockEnd: theme.spacing(2),
 }));
-
-const StyledLink = styled(Link)(({ theme }) => ({
-    textDecoration: 'underline',
-    color: 'inherit',
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    fontSize: 'body2.fontSize',
-    width: 'fit-content',
-    borderRadius: theme.shape.borderRadius,
-
-    ':focus-visible': {
-        outline: `2px solid currentColor`,
-        outlineOffset: theme.spacing(0.5),
-    },
-
-    svg: {
-        fontSize: '1.4em',
-    },
-}));
-
-const SidebarLink = ({ to, children }) => {
-    return (
-        <StyledLink target='_blank' rel='noopener noreferrer' to={to}>
-            {children} <OpenInNewIcon />
-        </StyledLink>
-    );
-};
 
 export const MetricDefinitionSidebar = () => {
     return (
@@ -107,9 +78,9 @@ export const MetricDefinitionSidebar = () => {
             </SidebarSection>
 
             <div>
-                <SidebarLink to='https://docs.getunleash.io/reference/impact-metrics'>
+                <ExternalLink to='https://docs.getunleash.io/reference/impact-metrics'>
                     View full documentation
-                </SidebarLink>
+                </ExternalLink>
             </div>
         </>
     );
@@ -130,14 +101,14 @@ export const SuccessSidebar = () => {
                 </Typography>
                 <LinkList role='list'>
                     <li>
-                        <SidebarLink to='https://docs.getunleash.io/reference/impact-metrics'>
+                        <ExternalLink to='https://docs.getunleash.io/reference/impact-metrics'>
                             View full documentation
-                        </SidebarLink>
+                        </ExternalLink>
                     </li>
                     <li>
-                        <SidebarLink to='https://docs.getunleash.io/reference/impact-metrics'>
+                        <ExternalLink to='https://docs.getunleash.io/reference/impact-metrics'>
                             Guide to choosing metric types
-                        </SidebarLink>
+                        </ExternalLink>
                     </li>
                 </LinkList>
             </SidebarSection>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.styles.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.styles.tsx
@@ -1,0 +1,67 @@
+import { styled } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Link } from 'react-router-dom';
+
+/**
+ * A card container with a border that highlights on hover/focus.
+ *
+ * Any child with the `data-card-action` attribute becomes the card's
+ * primary action: it gets a pseudo-element overlay that stretches over
+ * the entire card, making the whole card clickable/tappable. You should only have one such child.
+ *
+ *   <Card>
+ *     <a data-card-action href="...">Link text</a>
+ *     <p>Supporting content</p>
+ *   </Card>
+ */
+export const Card = styled('div')(({ theme }) => ({
+    position: 'relative',
+    border: `1.5px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusLarge,
+    background: theme.palette.background.default,
+    padding: theme.spacing(2),
+    transition: 'border-color 150ms ease',
+    '&:hover, &:focus-within': {
+        borderColor: theme.palette.primary.main,
+    },
+    '[data-card-action]': {
+        color: 'inherit',
+        textDecoration: 'none',
+        '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 'inherit',
+        },
+        '&:focus-visible': {
+            outline: 'none',
+        },
+    },
+}));
+
+export const ExternalLink = styled(
+    ({ children, ...props }: React.ComponentProps<typeof Link>) => (
+        <Link target='_blank' rel='noopener noreferrer' {...props}>
+            {children} <OpenInNewIcon />
+        </Link>
+    ),
+)(({ theme }) => ({
+    textDecoration: 'underline',
+    color: 'inherit',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    fontSize: theme.typography.body2.fontSize,
+    width: 'fit-content',
+    borderRadius: theme.shape.borderRadius,
+
+    ':focus-visible': {
+        outline: '2px solid currentColor',
+        outlineOffset: theme.spacing(0.5),
+    },
+
+    svg: {
+        fontSize: '1.4em',
+        verticalAlign: 'bottom',
+    },
+}));

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
@@ -1,4 +1,4 @@
-import { type FC, useId, useState } from 'react';
+import { useId, useState } from 'react';
 import {
     Button,
     Dialog,
@@ -86,9 +86,7 @@ const Sidebar = styled('aside')(({ theme }) => {
     };
 });
 
-const InnerDialog: FC<Omit<RegisterMetricDialogProps, 'open'>> = ({
-    onClose,
-}) => {
+const InnerDialog = ({ onClose }: Omit<RegisterMetricDialogProps, 'open'>) => {
     const theme = useTheme();
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
@@ -186,9 +184,9 @@ const InnerDialog: FC<Omit<RegisterMetricDialogProps, 'open'>> = ({
     );
 };
 
-export const RegisterMetricDialog: FC<RegisterMetricDialogProps> = ({
+export const RegisterMetricDialog = ({
     open,
     ...props
-}) => {
+}: RegisterMetricDialogProps) => {
     return open ? <InnerDialog {...props} /> : null;
 };

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography, type TypographyProps, styled } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
@@ -62,6 +63,9 @@ const CardLink = styled('a')(({ theme }) => ({
     '&:focus-visible': {
         outline: 'none',
     },
+    svg: {
+        fontSize: '1.4em',
+    },
 }));
 
 const StyledSubHeader = styled(Typography)<TypographyProps>(({ theme }) => ({
@@ -95,14 +99,14 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
                     What's next?
                 </StyledSubHeader>
                 <NextStepCard>
-                    <StyledSubHeader variant='subtitle1'>
+                    <StyledSubHeader variant='subtitle1' component='p'>
                         <CardLink
                             href='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
                             target='_blank'
                             rel='noopener noreferrer'
                             onClick={() => trackDocsClickedAfterCreation()}
                         >
-                            Implement in your code
+                            Implement in your code <OpenInNewIcon />
                         </CardLink>
                     </StyledSubHeader>
                     <StyledParagraph variant='body2'>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,7 +1,7 @@
-import { Box, Typography, type TypographyProps, styled } from '@mui/material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Box, Typography, styled } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
+import { Card, ExternalLink } from './RegisterMetricDialog.styles';
 
 type SuccessViewProps = {
     metricName: string;
@@ -40,38 +40,10 @@ const StyledParagraph = styled(Typography)(({ theme }) => ({
     color: theme.palette.text.secondary,
 }));
 
-const NextStepCard = styled(Box)(({ theme }) => ({
-    position: 'relative',
-    border: `1.5px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadiusLarge,
-    padding: theme.spacing(2),
-    transition: 'border-color 120ms ease',
-    '&:hover, &:focus-within': {
-        borderColor: theme.palette.primary.main,
-    },
-}));
-
-const CardLink = styled('a')(({ theme }) => ({
-    color: 'inherit',
-    textDecoration: 'none',
-    '&::after': {
-        content: '""',
-        position: 'absolute',
-        inset: 0,
-        borderRadius: 'inherit',
-    },
-    '&:focus-visible': {
-        outline: 'none',
-    },
-    svg: {
-        fontSize: '1.4em',
-    },
-}));
-
-const StyledSubHeader = styled(Typography)<TypographyProps>(({ theme }) => ({
+const StyledSubHeader = styled(Typography)(({ theme }) => ({
     marginBottom: theme.spacing(2),
     fontWeight: 'bold',
-}));
+})) as typeof Typography;
 
 export const SuccessView = ({ metricName }: SuccessViewProps) => {
     const { trackDocsClickedAfterCreation } = useTrackRegisterImpactMetrics();
@@ -98,23 +70,22 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
                 <StyledSubHeader component='h5' variant='subtitle1'>
                     What's next?
                 </StyledSubHeader>
-                <NextStepCard>
-                    <StyledSubHeader variant='subtitle1' component='p'>
-                        <CardLink
-                            href='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            onClick={() => trackDocsClickedAfterCreation()}
-                        >
-                            Implement in your code <OpenInNewIcon />
-                        </CardLink>
+                <Card>
+                    <StyledSubHeader
+                        data-card-action
+                        to='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
+                        onClick={() => trackDocsClickedAfterCreation()}
+                        variant='subtitle2'
+                        component={ExternalLink}
+                    >
+                        Implement in your code
                     </StyledSubHeader>
                     <StyledParagraph variant='body2'>
                         To start collecting data, you need to implement the
                         metric in your application code using one of our SDKs.
                         View the documentation for setup instructions.
                     </StyledParagraph>
-                </NextStepCard>
+                </Card>
             </Box>
         </StyledContainer>
     );


### PR DESCRIPTION
- Extracts shared `Card` and `ExternalLink` styled components into `RegisterMetricDialog.styles.tsx`, replacing duplicated card/link styles across `DefineMetricForm`, `SuccessView`, and `InfoSidebar`
- `Card` supports a `data-card-action` data attribute on any child element to make the whole card clickable via a pseudo-element overlay, removing the need for a separate wrapper component
- `ExternalLink` bakes in `target="_blank"`, `rel="noopener noreferrer"`, and the `OpenInNewIcon`, so consumers don't need to repeat that boilerplate
- Remove `FC` in favor of normal type annotations