### PR TITLE
chore: don't highlight the radio label on use

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
@@ -29,6 +29,9 @@ const StyledForm = styled('form')(({ theme }) => ({
 
 const StyledLabel = styled(FormLabel)(({ theme }) => ({
     color: theme.palette.text.primary,
+    '&.Mui-focused': {
+        color: 'currentColor',
+    },
     marginBottom: theme.spacing(1),
 }));
 
@@ -36,7 +39,6 @@ const RadioCardContainer = styled(Card)(({ theme }) => ({
     display: 'flex',
     alignItems: 'flex-start',
     gap: '11px',
-    background: theme.palette.background.default,
 }));
 
 const RadioCard = ({ value, description, examples }) => {


### PR DESCRIPTION
Makes the radio label not change color when focus is on the radio buttons. This makes it consistent with the other labels in this form.

Also: removes a redundant CSS rule (background is already defined in card)

Before:
<img width="1183" height="631" alt="image" src="https://github.com/user-attachments/assets/21b55232-e430-4d43-b5b6-5c86eaf6e7ae" />

After:
<img width="1162" height="586" alt="image" src="https://github.com/user-attachments/assets/d5d9d9b1-1793-4000-8eec-33d397faf2fb" />