### PR TITLE
chore: Let radio focus-visible indicator bloom

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
@@ -35,8 +35,11 @@ const StyledLabel = styled(FormLabel)(({ theme }) => ({
 const RadioCardContainer = styled(Card)(({ theme }) => ({
     display: 'flex',
     alignItems: 'flex-start',
-    gap: '11px',
     background: theme.palette.background.default,
+    paddingInlineStart: theme.spacing(0.5),
+    '.MuiRadio-root': {
+        marginBlockStart: `calc(-1 * ${theme.spacing(1.5)})`,
+    },
 }));
 
 const RadioCard = ({ value, description, examples }) => {
@@ -47,7 +50,6 @@ const RadioCard = ({ value, description, examples }) => {
     return (
         <RadioCardContainer>
             <Radio
-                sx={{ padding: 0 }}
                 id={radioId}
                 value={value}
                 aria-describedby={`${descriptionId} ${exampleId}`}


### PR DESCRIPTION
Undoes the padding clipping we did of the radio icon, in favor of giving it a negative margin. On the bright side, this also undoes the need for the weird `11px` gap.

In short: before this change, the radio icon keyboard focus indicator was clipped compared to normal mui radio buttons. After this change, it shows up in all its glory.

Before:
<img width="1118" height="521" alt="image" src="https://github.com/user-attachments/assets/cdbff407-9a3d-4192-b96f-d45d553a1f99" />


After:
<img width="1112" height="524" alt="image" src="https://github.com/user-attachments/assets/013e5626-4aae-4a53-8f25-b02c5cd15ae0" />
