### PR TITLE
chore: add new success screen

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,92 +1,91 @@
-import { Box, Typography, styled } from '@mui/material';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { Box, Button, Typography, styled } from '@mui/material';
+import CodeIcon from '@mui/icons-material/Code';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
-import { Card, ExternalLink } from './RegisterMetricDialog.styles';
+import { Link } from 'react-router-dom';
 
 type SuccessViewProps = {
     metricName: string;
 };
 
-const StyledContainer = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(4),
-}));
-
 const StyledIconWrapper = styled(Box)(({ theme }) => ({
+    alignItems: 'center',
+    aspectRatio: '1 / 1',
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: theme.shape.borderRadiusMedium,
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
     width: theme.spacing(6),
-    height: theme.spacing(6),
-    borderRadius: '50%',
-    backgroundColor: theme.palette.success.light,
-    margin: '0 auto',
-    marginBottom: theme.spacing(2),
 }));
 
 const SuccessBox = styled(Box)(({ theme }) => ({
+    alignItems: 'center',
+    display: 'flex',
+    flex: 'auto',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    marginBlock: theme.spacing(2),
     textAlign: 'center',
-    marginTop: theme.spacing(4),
-    marginBottom: theme.spacing(2),
 }));
 
-const StyledCheckIcon = styled(CheckCircleOutlineIcon)(({ theme }) => ({
-    color: theme.palette.success.main,
-    fontSize: theme.spacing(4),
+const StyledIcon = styled(CodeIcon)(({ theme }) => ({
+    color: theme.palette.primary.contrastText,
 }));
 
-const StyledParagraph = styled(Typography)(({ theme }) => ({
-    color: theme.palette.text.secondary,
+const TextContent = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    maxWidth: '423px',
+    marginBlockStart: theme.spacing(2),
+    marginBlockEnd: theme.spacing(2.5),
+    p: {
+        color: theme.palette.text.secondary,
+    },
 }));
 
-const StyledSubHeader = styled(Typography)(({ theme }) => ({
-    marginBottom: theme.spacing(2),
-    fontWeight: 'bold',
-})) as typeof Typography;
+const StyledMetricName = styled(Typography)(({ theme }) => ({
+    border: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(0.5, 1),
+    borderRadius: theme.shape.borderRadiusMedium,
+    width: 'fit-content',
+}));
 
 export const SuccessView = ({ metricName }: SuccessViewProps) => {
     const { trackDocsClickedAfterCreation } = useTrackRegisterImpactMetrics();
 
     return (
-        <StyledContainer>
-            <SuccessBox>
-                <StyledIconWrapper>
-                    <StyledCheckIcon />
-                </StyledIconWrapper>
-                <Typography variant='h2' component='h4'>
-                    Metric registered
-                </Typography>
-                <StyledParagraph variant='body2'>
-                    Your impact metric <strong>{metricName}</strong> has been
-                    created.
-                </StyledParagraph>
-                <StyledParagraph variant='body2'>
-                    It will be available in a few seconds.
-                </StyledParagraph>
-            </SuccessBox>
+        <SuccessBox>
+            <StyledIconWrapper>
+                <StyledIcon />
+            </StyledIconWrapper>
 
-            <Box>
-                <StyledSubHeader component='h5' variant='subtitle1'>
-                    What's next?
-                </StyledSubHeader>
-                <Card>
-                    <StyledSubHeader
-                        data-card-action
-                        to='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
-                        onClick={() => trackDocsClickedAfterCreation()}
-                        variant='subtitle2'
-                        component={ExternalLink}
-                    >
-                        Implement in your code
-                    </StyledSubHeader>
-                    <StyledParagraph variant='body2'>
-                        To start collecting data, you need to implement the
-                        metric in your application code using one of our SDKs.
-                        View the documentation for setup instructions.
-                    </StyledParagraph>
-                </Card>
-            </Box>
-        </StyledContainer>
+            <TextContent>
+                <Typography variant='h2' component='h4'>
+                    Implement the impact metric
+                </Typography>
+                <Typography>
+                    The metric is now accessible from the UI. You'll need to add
+                    it to your code to start receiving metrics.
+                </Typography>
+                <StyledMetricName>
+                    <Typography component='span' fontWeight='bold'>
+                        Metric name:&nbsp;
+                    </Typography>
+                    {metricName}
+                </StyledMetricName>
+            </TextContent>
+
+            <Button
+                component={Link}
+                target='_blank'
+                rel='noopener noreferrer'
+                variant='contained'
+                to='https://docs.getunleash.io/concepts/impact-metrics#define-and-record-metrics-in-the-sdk'
+                onClick={() => trackDocsClickedAfterCreation()}
+            >
+                View instructions
+            </Button>
+        </SuccessBox>
     );
 };

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -65,8 +65,9 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
                     Implement the impact metric
                 </Typography>
                 <Typography>
-                    The metric is now accessible from the UI. You'll need to add
-                    it to your code to start receiving metrics.
+                    The metric will be available in the UI shortly (typically
+                    within a minute). You'll need to add it to your code to
+                    start receiving actual metric data.
                 </Typography>
                 <StyledMetricName>
                     <Typography component='span' fontWeight='bold'>


### PR DESCRIPTION
Updates the text on the success page of the register impact metric form.

<img width="2077" height="1114" alt="image" src="https://github.com/user-attachments/assets/52a46df7-78b8-40b9-b6ca-f3a6ca3988a1" />



Closes 1-4567.