### PR TITLE
chore: add impact metrics for form opened and metric created

### DIFF
--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -12,6 +12,7 @@ import type { MetricSource } from 'component/impact-metrics/types';
 import { useTrackFlagpageImpactMetrics } from 'component/impact-metrics/useImpactMetricsFunnel';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { RegisterMetricDialog } from 'component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog';
+import { useTrackRegisterImpactMetrics } from 'component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics';
 
 type MetricOption = {
     name: string;
@@ -125,6 +126,8 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
     loading = false,
     label = 'Metric name',
 }) => {
+    const { trackFormOpened } = useTrackRegisterImpactMetrics();
+
     const allOptions = withSelectedValue(options, value, valueSource);
     const registerImpactMetricsEnabled = useUiFlag('registerImpactMetrics');
     const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
@@ -185,7 +188,10 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
                     <NoOptionsMessage
                         onRegisterClick={
                             registerImpactMetricsEnabled
-                                ? () => setRegisterDialogOpen(true)
+                                ? () => {
+                                      trackFormOpened();
+                                      setRegisterDialogOpen(true);
+                                  }
                                 : undefined
                         }
                     />

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { DefineMetricForm } from './DefineMetricForm';
 import { SuccessView } from './SuccessView';
 import { MetricDefinitionSidebar } from './InfoSidebar';
+import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 
 type RegisterMetricDialogProps = {
     open: boolean;
@@ -89,6 +90,7 @@ const Sidebar = styled('aside')(({ theme }) => {
 });
 
 const InnerDialog = ({ onClose }: Omit<RegisterMetricDialogProps, 'open'>) => {
+    const { trackMetricCreated } = useTrackRegisterImpactMetrics();
     const theme = useTheme();
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
@@ -141,6 +143,7 @@ const InnerDialog = ({ onClose }: Omit<RegisterMetricDialogProps, 'open'>) => {
                                         stage: 'success',
                                         metricName,
                                     });
+                                    trackMetricCreated();
                                 }}
                             />
                         </>


### PR DESCRIPTION
These already existed but were seemingly not wired up yet.
