### PR TITLE
chore: add ImpactMetricRegistrationContext

### DIFF
--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -13,6 +13,7 @@ import { useTrackFlagpageImpactMetrics } from 'component/impact-metrics/useImpac
 import { useUiFlag } from 'hooks/useUiFlag';
 import { RegisterMetricDialog } from 'component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog';
 import { useTrackRegisterImpactMetrics } from 'component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics';
+import { useRegisterImpactMetric } from 'component/impact-metrics/ImpactMetricRegistrationContext';
 
 type MetricOption = {
     name: string;
@@ -128,8 +129,14 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
 }) => {
     const allOptions = withSelectedValue(options, value, valueSource);
     const registerImpactMetricsEnabled = useUiFlag('registerImpactMetrics');
-    const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
+    const registrationContext = useRegisterImpactMetric();
+    const [registerMetricDialogOpen, setRegisterMetricDialogOpen] =
+        useState(false);
     const { trackFormOpened } = useTrackRegisterImpactMetrics();
+
+    const switchToRegisterDialog = registrationContext?.openRegisterDialog;
+    const handleRegisterClick =
+        switchToRegisterDialog ?? (() => setRegisterMetricDialogOpen(true));
 
     return (
         <>
@@ -188,7 +195,7 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
                         onRegisterClick={
                             registerImpactMetricsEnabled
                                 ? () => {
-                                      setRegisterDialogOpen(true);
+                                      handleRegisterClick();
                                       trackFormOpened();
                                   }
                                 : undefined
@@ -197,10 +204,12 @@ export const MetricSelector: FC<MetricSelectorProps> = ({
                 }
                 sx={{ minWidth: 300 }}
             />
-            <RegisterMetricDialog
-                open={registerDialogOpen}
-                onClose={() => setRegisterDialogOpen(false)}
-            />
+            {!registrationContext && (
+                <RegisterMetricDialog
+                    open={registerMetricDialogOpen}
+                    onClose={() => setRegisterMetricDialogOpen(false)}
+                />
+            )}
         </>
     );
 };

--- a/frontend/src/component/impact-metrics/ImpactMetricRegistrationContext.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricRegistrationContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+type ImpactMetricRegistrationContextType = {
+    openRegisterDialog: () => void;
+};
+
+const ImpactMetricRegistrationContext = createContext<
+    ImpactMetricRegistrationContextType | undefined
+>(undefined);
+
+export const ImpactMetricRegistrationProvider =
+    ImpactMetricRegistrationContext.Provider;
+
+export const useRegisterImpactMetric = () =>
+    useContext(ImpactMetricRegistrationContext);

--- a/frontend/src/component/impact-metrics/ImpactMetrics.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetrics.tsx
@@ -4,6 +4,8 @@ import { Typography, styled, Box } from '@mui/material';
 import { PageHeader } from 'component/common/PageHeader/PageHeader.tsx';
 import { useImpactMetricsOptions } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
 import { ImpactMetricModal } from './ImpactMetricModal/ImpactMetricModal.tsx';
+import { RegisterMetricDialog } from './RegisterMetricDialog/RegisterMetricDialog';
+import { ImpactMetricRegistrationProvider } from './ImpactMetricRegistrationContext';
 import { ChartItem } from './ChartItem.tsx';
 import { PlausibleChartItem } from './PlausibleChartItem.tsx';
 import { GridLayoutWrapper, type GridItem } from './GridLayoutWrapper.tsx';
@@ -31,7 +33,9 @@ const _StyledDragHandle = styled(Box)(({ theme }) => ({
 }));
 
 export const ImpactMetrics: FC = () => {
-    const [modalOpen, setModalOpen] = useState(false);
+    const [createChartDialogOpen, setCreateChartDialogOpen] = useState(false);
+    const [registerMetricDialogOpen, setRegisterMetricDialogOpen] =
+        useState(false);
     const [editingChart, setEditingChart] = useState<ChartConfig | undefined>();
     const { setToastApiError } = useToast();
     const plausibleMetricsEnabled = useUiFlag('plausibleMetrics');
@@ -54,7 +58,7 @@ export const ImpactMetrics: FC = () => {
 
     const handleAddChart = () => {
         setEditingChart(undefined);
-        setModalOpen(true);
+        setCreateChartDialogOpen(true);
         trackEvent('impact-metrics', {
             props: {
                 eventType: 'global chart modal open',
@@ -64,7 +68,7 @@ export const ImpactMetrics: FC = () => {
 
     const handleEditChart = (config: ChartConfig) => {
         setEditingChart(config);
-        setModalOpen(true);
+        setCreateChartDialogOpen(true);
     };
 
     const handleSaveChart = async (config: Omit<ChartConfig, 'id'>) => {
@@ -74,7 +78,7 @@ export const ImpactMetrics: FC = () => {
             } else {
                 await addChart(config);
             }
-            setModalOpen(false);
+            setCreateChartDialogOpen(false);
         } catch (error) {
             setToastApiError(formatUnknownError(error));
         }
@@ -180,14 +184,27 @@ export const ImpactMetrics: FC = () => {
                 </>
             )}
 
-            <ImpactMetricModal
-                open={modalOpen}
-                onClose={() => setModalOpen(false)}
-                onSave={handleSaveChart}
-                initialConfig={editingChart}
-                metrics={metricOptions}
-                loading={metadataLoading || settingsLoading}
-            />
+            <ImpactMetricRegistrationProvider
+                value={{
+                    openRegisterDialog: () => {
+                        setCreateChartDialogOpen(false);
+                        setRegisterMetricDialogOpen(true);
+                    },
+                }}
+            >
+                <ImpactMetricModal
+                    open={createChartDialogOpen}
+                    onClose={() => setCreateChartDialogOpen(false)}
+                    onSave={handleSaveChart}
+                    initialConfig={editingChart}
+                    metrics={metricOptions}
+                    loading={metadataLoading || settingsLoading}
+                />
+                <RegisterMetricDialog
+                    open={registerMetricDialogOpen}
+                    onClose={() => setRegisterMetricDialogOpen(false)}
+                />
+            </ImpactMetricRegistrationProvider>
         </>
     );
 };


### PR DESCRIPTION
Adds a context so that `MetricSelector` (the impact metric empty state) can determine wether to close the "Create impact metric" dialog and open the new register metric dialog, or just open the new register dialog. 
On the `/impact-metrics `page, both dialogs are wrapped in a provider that coordinates the switch. On the flag page (no provider), the register dialog falls back to the original stacked behavior.



 

https://github.com/user-attachments/assets/07599021-6a49-4bb5-b08d-1428e13bb62a

