### PR TITLE
 feat: open "Use the flag in your code" dialog from implement flag banner     

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
 import { FeatureFlagSetupBannerCard } from './FeatureFlagSetupBannerCard.tsx';
+import { ImplementFlagDialog } from './ImplementFlagDialog/ImplementFlagDialog.tsx';
 
 interface FeatureImplementFlagBannerProps {
     projectId: string;
@@ -13,6 +15,7 @@ export const FeatureImplementFlagBanner = ({
 }: FeatureImplementFlagBannerProps) => {
     const { project } = useProjectOverview(projectId);
     const { metrics, loading } = useFeatureMetrics(projectId, featureId);
+    const [dialogOpen, setDialogOpen] = useState(false);
 
     if (project.onboardingStatus.status !== 'onboarded') {
         return null;
@@ -23,11 +26,18 @@ export const FeatureImplementFlagBanner = ({
     }
 
     return (
-        <FeatureFlagSetupBannerCard
-            title='Implement your flag'
-            description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
-            buttonLabel='Wrap your code'
-            onButtonClick={() => {}}
-        />
+        <>
+            <FeatureFlagSetupBannerCard
+                title='Implement your flag'
+                description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
+                buttonLabel='Wrap your code'
+                onButtonClick={() => setDialogOpen(true)}
+            />
+            <ImplementFlagDialog
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+                feature={featureId}
+            />
+        </>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -17,22 +17,24 @@ export const FeatureImplementFlagBanner = ({
     const { metrics, loading } = useFeatureMetrics(projectId, featureId);
     const [dialogOpen, setDialogOpen] = useState(false);
 
-    if (project.onboardingStatus.status !== 'onboarded') {
-        return null;
-    }
+    const isOnboarded = project.onboardingStatus.status === 'onboarded';
+    const hasNoMetrics = !loading && metrics.seenApplications.length === 0;
+    const showBanner = isOnboarded && hasNoMetrics;
 
-    if (loading || metrics.seenApplications.length > 0) {
+    if (!showBanner && !dialogOpen) {
         return null;
     }
 
     return (
         <>
-            <FeatureFlagSetupBannerCard
-                title='Implement your flag'
-                description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
-                buttonLabel='Wrap your code'
-                onButtonClick={() => setDialogOpen(true)}
-            />
+            {showBanner && (
+                <FeatureFlagSetupBannerCard
+                    title='Implement your flag'
+                    description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
+                    buttonLabel='Wrap your code'
+                    onButtonClick={() => setDialogOpen(true)}
+                />
+            )}
             <ImplementFlagDialog
                 open={dialogOpen}
                 onClose={() => setDialogOpen(false)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -28,13 +28,23 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
         width: '100%',
         backgroundColor: 'transparent',
     },
+    padding: 0,
+    '& .MuiPaper-root > section': {
+        overflowX: 'hidden',
+    },
 }));
+
+const Container = styled('section')({
+    width: '100%',
+    display: 'flex',
+});
 
 const Content = styled('main')(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     display: 'flex',
     flexDirection: 'column',
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     minWidth: 0,
 }));
 
@@ -137,7 +147,7 @@ export const ImplementFlagDialog = ({
 
     return (
         <StyledDialog open={open} onClose={onClose}>
-            <Box sx={{ display: 'flex' }}>
+            <Container>
                 <Content>
                     <Header>
                         <Typography variant='body1' fontWeight='bold'>
@@ -218,7 +228,7 @@ export const ImplementFlagDialog = ({
                 {isLargeScreen && (
                     <ImplementFlagInformation onClose={onClose} />
                 )}
-            </Box>
+            </Container>
         </StyledDialog>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -15,10 +15,7 @@ import {
     CodeRenderer,
     codeRenderSnippets,
 } from 'component/onboarding/dialog/CodeRenderer';
-import {
-    allSdks,
-    type SdkName,
-} from 'component/onboarding/dialog/sharedTypes';
+import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -86,6 +86,12 @@ const WaitingDot = styled('span')(({ theme }) => ({
     backgroundColor: theme.palette.warning.main,
 }));
 
+const CodeBlockWrapper = styled('div')(({ theme }) => ({
+    '& pre': {
+        maxHeight: theme.spacing(45),
+    },
+}));
+
 const ListeningCard = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.secondary.light,
     border: `1px solid ${theme.palette.secondary.border}`,
@@ -178,9 +184,11 @@ export const ImplementFlagDialog = ({
                             >
                                 Code example
                             </Typography>
-                            <Markdown components={{ code: CodeRenderer }}>
-                                {wrappedSnippet}
-                            </Markdown>
+                            <CodeBlockWrapper>
+                                <Markdown components={{ code: CodeRenderer }}>
+                                    {wrappedSnippet}
+                                </Markdown>
+                            </CodeBlockWrapper>
                         </Box>
 
                         <Box>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -107,13 +107,34 @@ const ListeningIcon = styled('div')(({ theme }) => ({
     height: 44,
     borderRadius: '50%',
     backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
-    fontWeight: theme.typography.fontWeightBold,
-    letterSpacing: 1,
+    gap: 3,
+    '@keyframes bubble': {
+        '0%, 80%, 100%': {
+            transform: 'scale(0.4)',
+            opacity: 0.5,
+        },
+        '40%': {
+            transform: 'scale(1)',
+            opacity: 1,
+        },
+    },
+    '& span': {
+        width: 6,
+        height: 6,
+        borderRadius: '50%',
+        backgroundColor: theme.palette.primary.contrastText,
+        animation: 'bubble 1.4s infinite ease-in-out both',
+    },
+    '& span:nth-of-type(1)': {
+        animationDelay: '-0.32s',
+    },
+    '& span:nth-of-type(2)': {
+        animationDelay: '-0.16s',
+    },
 }));
 
 const ListeningText = styled('div')({
@@ -200,7 +221,11 @@ export const ImplementFlagDialog = ({
                                 Test flag
                             </Typography>
                             <ListeningCard>
-                                <ListeningIcon>...</ListeningIcon>
+                                <ListeningIcon>
+                                    <span />
+                                    <span />
+                                    <span />
+                                </ListeningIcon>
                                 <ListeningText>
                                     <Typography
                                         variant='body2'

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import {
+    Box,
+    Button,
+    Dialog,
+    MenuItem,
+    Select,
+    styled,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
+import { Markdown } from 'component/common/Markdown/Markdown';
+import {
+    CodeRenderer,
+    codeRenderSnippets,
+} from 'component/onboarding/dialog/CodeRenderer';
+import {
+    allSdks,
+    type SdkName,
+} from 'component/onboarding/dialog/sharedTypes';
+import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialog-paper': {
+        borderRadius: theme.shape.borderRadiusLarge,
+        maxWidth: theme.spacing(135),
+        width: '100%',
+        backgroundColor: 'transparent',
+    },
+}));
+
+const Content = styled('main')(({ theme }) => ({
+    backgroundColor: theme.palette.background.paper,
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minWidth: 0,
+}));
+
+const Header = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(1, 3),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    minHeight: theme.spacing(5),
+}));
+
+const Body = styled('div')(({ theme }) => ({
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+    flex: 1,
+    overflowY: 'auto',
+}));
+
+const Footer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2, 3),
+}));
+
+const WaitingIndicator = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+}));
+
+const WaitingDot = styled('span')(({ theme }) => ({
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.warning.main,
+}));
+
+const ListeningCard = styled('div')(({ theme }) => ({
+    backgroundColor: theme.palette.secondary.light,
+    border: `1px solid ${theme.palette.secondary.border}`,
+    borderRadius: theme.shape.borderRadiusMedium,
+    padding: theme.spacing(2),
+    display: 'flex',
+    gap: theme.spacing(1),
+    alignItems: 'center',
+}));
+
+const ListeningIcon = styled('div')(({ theme }) => ({
+    width: 44,
+    height: 44,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    fontWeight: theme.typography.fontWeightBold,
+    letterSpacing: 1,
+}));
+
+const ListeningText = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+});
+
+const extractLastCodeBlock = (markdown: string) => {
+    const matches = [...markdown.matchAll(/```(\w*)\n([\s\S]*?)```/g)];
+    if (matches.length === 0) return null;
+    const [, language, code] = matches[matches.length - 1];
+    return { language, code: code.trim() };
+};
+
+interface ImplementFlagDialogProps {
+    open: boolean;
+    onClose: () => void;
+    feature: string;
+}
+
+export const ImplementFlagDialog = ({
+    open,
+    onClose,
+    feature,
+}: ImplementFlagDialogProps) => {
+    const theme = useTheme();
+    const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+    const [sdkName, setSdkName] = useState<SdkName>(allSdks[0].name);
+
+    const rawSnippet = codeRenderSnippets[sdkName] || '';
+    const [connectSnippet] = rawSnippet.split('---\n');
+    const lastBlock = extractLastCodeBlock(connectSnippet);
+    const code = (lastBlock?.code ?? '').replaceAll('<YOUR_FLAG>', feature);
+    const wrappedSnippet = lastBlock
+        ? `\`\`\`${lastBlock.language}\n${code}\n\`\`\``
+        : '';
+
+    return (
+        <StyledDialog open={open} onClose={onClose}>
+            <Box sx={{ display: 'flex' }}>
+                <Content>
+                    <Header>
+                        <Typography variant='body1' fontWeight='bold'>
+                            Use the flag in your code
+                        </Typography>
+                    </Header>
+                    <Body>
+                        <Select
+                            value={sdkName}
+                            onChange={(event) =>
+                                setSdkName(event.target.value as SdkName)
+                            }
+                            size='small'
+                            sx={{ maxWidth: 240 }}
+                        >
+                            {allSdks.map((sdk) => (
+                                <MenuItem key={sdk.name} value={sdk.name}>
+                                    {sdk.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+
+                        <Box>
+                            <Typography
+                                variant='body2'
+                                fontWeight='bold'
+                                sx={{ mb: 1 }}
+                            >
+                                Code example
+                            </Typography>
+                            <Markdown components={{ code: CodeRenderer }}>
+                                {wrappedSnippet}
+                            </Markdown>
+                        </Box>
+
+                        <Box>
+                            <Typography
+                                variant='body1'
+                                fontWeight='bold'
+                                sx={{ mb: 1 }}
+                            >
+                                Test flag
+                            </Typography>
+                            <ListeningCard>
+                                <ListeningIcon>...</ListeningIcon>
+                                <ListeningText>
+                                    <Typography
+                                        variant='body2'
+                                        fontWeight='bold'
+                                        color='primary'
+                                    >
+                                        Listening for the first evaluation…
+                                    </Typography>
+                                    <Typography
+                                        variant='caption'
+                                        color='primary'
+                                    >
+                                        Render the code path above anywhere to
+                                        check that we receive metric
+                                        evaluations.
+                                    </Typography>
+                                </ListeningText>
+                            </ListeningCard>
+                        </Box>
+                    </Body>
+                    <Footer>
+                        <WaitingIndicator>
+                            <WaitingDot />
+                            <Typography variant='body2' color='warning.main'>
+                                Waiting for evaluations
+                            </Typography>
+                        </WaitingIndicator>
+                        <Button variant='contained' disabled>
+                            Finish setup
+                        </Button>
+                    </Footer>
+                </Content>
+                {isLargeScreen && (
+                    <ImplementFlagInformation onClose={onClose} />
+                )}
+            </Box>
+        </StyledDialog>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from 'component/onboarding/dialog/CodeRenderer';
 import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
+import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
@@ -139,13 +140,6 @@ const ListeningText = styled('div')({
     flexDirection: 'column',
 });
 
-const extractLastCodeBlock = (markdown: string) => {
-    const matches = [...markdown.matchAll(/```(\w*)\n([\s\S]*?)```/g)];
-    if (matches.length === 0) return null;
-    const [, language, code] = matches[matches.length - 1];
-    return { language, code: code.trim() };
-};
-
 interface ImplementFlagDialogProps {
     open: boolean;
     onClose: () => void;
@@ -161,13 +155,10 @@ export const ImplementFlagDialog = ({
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
     const [sdkName, setSdkName] = useState<SdkName>(allSdks[0].name);
 
-    const rawSnippet = codeRenderSnippets[sdkName] || '';
-    const [connectSnippet] = rawSnippet.split('---\n');
-    const lastBlock = extractLastCodeBlock(connectSnippet);
-    const code = (lastBlock?.code ?? '').replaceAll('<YOUR_FLAG>', feature);
-    const wrappedSnippet = lastBlock
-        ? `\`\`\`${lastBlock.language}\n${code}\n\`\`\``
-        : '';
+    const wrappedSnippet = buildFlagUsageSnippet(
+        codeRenderSnippets[sdkName] || '',
+        feature,
+    );
 
     return (
         <StyledDialog open={open} onClose={onClose}>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
@@ -1,0 +1,102 @@
+import { IconButton, Link, styled, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import GitHubIcon from '@mui/icons-material/GitHub';
+
+const Container = styled('div')(({ theme }) => ({
+    backgroundColor: theme.palette.background.sidebar,
+    color: theme.palette.primary.contrastText,
+    padding: theme.spacing(3, 4),
+    minWidth: 320,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    position: 'relative',
+}));
+
+const CloseButton = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(1),
+    color: theme.palette.primary.contrastText,
+}));
+
+const InlineLink = styled(Link)(({ theme }) => ({
+    color: theme.palette.primary.contrastText,
+    textDecoration: 'underline',
+}));
+
+const ResourceList = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+}));
+
+const ResourceLink = styled(Link)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.palette.primary.contrastText,
+    fontWeight: theme.typography.fontWeightBold,
+    padding: theme.spacing(0.5, 1),
+    borderRadius: theme.shape.borderRadius,
+    textDecoration: 'none',
+    '&:hover': {
+        textDecoration: 'underline',
+    },
+}));
+
+interface ImplementFlagInformationProps {
+    onClose: () => void;
+}
+
+export const ImplementFlagInformation = ({
+    onClose,
+}: ImplementFlagInformationProps) => (
+    <Container>
+        <CloseButton onClick={onClose} size='small'>
+            <CloseIcon />
+        </CloseButton>
+        <Typography variant='body2' fontWeight='bold' sx={{ mt: 4 }}>
+            Define a safe default value
+        </Typography>
+        <Typography variant='body2'>
+            When wrapping code in a feature flag evaluation, always provide an
+            explicit fallback value (typically false) so your application
+            behaves predictably if the flag can't be resolved. Evaluate the flag
+            once at the highest level of your stack and pass the result
+            downstream.
+        </Typography>
+        <Typography variant='body2'>
+            For exceptions and advanced patterns, see{' '}
+            <InlineLink
+                href='https://docs.getunleash.io/guides/manage-feature-flags-in-code'
+                target='_blank'
+                rel='noreferrer'
+            >
+                Managing feature flags in code.
+            </InlineLink>
+        </Typography>
+        <Typography variant='body1' fontWeight='bold' sx={{ mt: 3 }}>
+            Other resources
+        </Typography>
+        <ResourceList>
+            <ResourceLink
+                href='https://docs.getunleash.io/guides/best-practices-using-feature-flags-at-scale'
+                target='_blank'
+                rel='noreferrer'
+            >
+                <MenuBookIcon fontSize='small' />
+                Feature flag best practices
+            </ResourceLink>
+            <ResourceLink
+                href='https://github.com/Unleash/unleash-sdk-examples'
+                target='_blank'
+                rel='noreferrer'
+            >
+                <GitHubIcon fontSize='small' />
+                SDK code examples repo
+            </ResourceLink>
+        </ResourceList>
+    </Container>
+);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
@@ -3,11 +3,13 @@ import CloseIcon from '@mui/icons-material/Close';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import GitHubIcon from '@mui/icons-material/GitHub';
 
-const Container = styled('div')(({ theme }) => ({
+const Container = styled('aside')(({ theme }) => ({
     backgroundColor: theme.palette.background.sidebar,
     color: theme.palette.primary.contrastText,
     padding: theme.spacing(3, 4),
-    minWidth: 320,
+    width: 320,
+    flexGrow: 0,
+    flexShrink: 0,
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(2),

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
+
+describe('buildFlagUsageSnippet', () => {
+    it('extracts the last code block from a 3-step snippet and substitutes the flag name', () => {
+        const raw = [
+            '1\\. Install',
+            '```sh',
+            'npm install foo',
+            '```',
+            '',
+            '2\\. Initialize',
+            '```jsx',
+            'const client = init();',
+            '```',
+            '',
+            '3\\. Check flag',
+            '```jsx',
+            "const enabled = useFlag('<YOUR_FLAG>');",
+            '```',
+        ].join('\n');
+
+        expect(buildFlagUsageSnippet(raw, 'my-flag')).toBe(
+            "```jsx\nconst enabled = useFlag('my-flag');\n```",
+        );
+    });
+
+    it('picks the init+check block for 2-step snippets where the flag check lives inside the init block', () => {
+        const raw = [
+            '1\\. Install',
+            '```sh',
+            'npm install unleash',
+            '```',
+            '',
+            '2\\. Run Unleash',
+            '```js',
+            'const u = initialize({ url });',
+            "setInterval(() => console.log(u.isEnabled('<YOUR_FLAG>')), 1000);",
+            '```',
+        ].join('\n');
+
+        expect(buildFlagUsageSnippet(raw, 'checkout')).toBe(
+            "```js\nconst u = initialize({ url });\nsetInterval(() => console.log(u.isEnabled('checkout')), 1000);\n```",
+        );
+    });
+
+    it('ignores content after the first `---` separator (production variant and resource links)', () => {
+        const raw = [
+            '1\\. Use',
+            '```jsx',
+            "useFlag('<YOUR_FLAG>')",
+            '```',
+            '---',
+            '```jsx',
+            'const config = { token: process.env.TOKEN };',
+            '```',
+            '---',
+            '- [docs](https://example.com)',
+        ].join('\n');
+
+        expect(buildFlagUsageSnippet(raw, 'x')).toBe(
+            "```jsx\nuseFlag('x')\n```",
+        );
+    });
+
+    it('replaces every occurrence of the <YOUR_FLAG> placeholder', () => {
+        const raw = [
+            '```js',
+            "const a = isEnabled('<YOUR_FLAG>');",
+            "const b = isEnabled('<YOUR_FLAG>');",
+            '```',
+        ].join('\n');
+
+        expect(buildFlagUsageSnippet(raw, 'flag-x')).toBe(
+            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\n```",
+        );
+    });
+
+    it('returns an empty string when there are no code blocks', () => {
+        expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBe('');
+        expect(buildFlagUsageSnippet('', 'x')).toBe('');
+    });
+});

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
@@ -1,0 +1,40 @@
+/**
+ * Given a raw onboarding markdown snippet (e.g. `react.md`), returns a
+ * markdown string containing only the flag-usage code block with the
+ * `<YOUR_FLAG>` placeholder replaced by the given feature name.
+ *
+ * Onboarding snippets have the shape:
+ *
+ *     1. Install …
+ *     ```sh …```
+ *     2. Initialize …
+ *     ```js …```
+ *     3. Check flag (optional third step)
+ *     ```jsx …```
+ *     ---
+ *     ```… production variant …```
+ *     ---
+ *     - resource links
+ *
+ * We want just the flag-usage block. We take the content before the first
+ * `---` separator and pick the last fenced code block from it, which is the
+ * check-the-flag example for 3-step SDKs, or the combined init-and-check
+ * block for 2-step SDKs (Node, Python).
+ */
+export const buildFlagUsageSnippet = (
+    rawSnippet: string,
+    feature: string,
+): string => {
+    const [connectSection] = rawSnippet.split('---\n');
+    const lastBlock = extractLastCodeBlock(connectSection);
+    if (!lastBlock) return '';
+    const code = lastBlock.code.replaceAll('<YOUR_FLAG>', feature);
+    return `\`\`\`${lastBlock.language}\n${code}\n\`\`\``;
+};
+
+const extractLastCodeBlock = (markdown: string) => {
+    const matches = [...markdown.matchAll(/```(\w*)\n([\s\S]*?)```/g)];
+    if (matches.length === 0) return null;
+    const [, language, code] = matches[matches.length - 1];
+    return { language, code: code.trim() };
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
@@ -32,8 +32,10 @@ export const buildFlagUsageSnippet = (
     return `\`\`\`${lastBlock.language}\n${code}\n\`\`\``;
 };
 
+const FENCED_CODE_BLOCK = /```(\w*)\n([\s\S]*?)```/g;
+
 const extractLastCodeBlock = (markdown: string) => {
-    const matches = [...markdown.matchAll(/```(\w*)\n([\s\S]*?)```/g)];
+    const matches = [...markdown.matchAll(FENCED_CODE_BLOCK)];
     if (matches.length === 0) return null;
     const [, language, code] = matches[matches.length - 1];
     return { language, code: code.trim() };


### PR DESCRIPTION
 - Wires up the "Wrap your code" banner button to open a modal showing how to evaluate the flag in code
  - SDK picker is a dropdown listing all 15 SDKs from the existing onboarding list, defaults to the first one                                                         
  - Code example extracts the flag-usage code block from the existing onboarding snippets and substitutes the current feature name                                    
  - Right-side purple info pane with "Define a safe default value" guidance plus links to the manage-flags-in-code, best-practices, and SDK examples repo docs        
<img width="2170" height="1456" alt="image" src="https://github.com/user-attachments/assets/9b70aefd-c07b-40a9-9333-2a9ce4b58555" />
