### PR TITLE
feat: check newly created metric is available in `SuccessView`

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -1,7 +1,14 @@
-import { Box, Button, Typography, styled } from '@mui/material';
+import {
+    Box,
+    Button,
+    CircularProgress,
+    Typography,
+    styled,
+} from '@mui/material';
 import CodeIcon from '@mui/icons-material/Code';
 import { useTrackRegisterImpactMetrics } from './useTrackRegisterImpactMetrics';
 import { Link } from 'react-router-dom';
+import { useCheckMetricAvailable } from './useCheckMetricAvailable';
 
 type SuccessViewProps = {
     metricName: string;
@@ -51,8 +58,16 @@ const StyledMetricName = styled(Typography)(({ theme }) => ({
     width: 'fit-content',
 }));
 
+const StyledLoading = styled(Box)({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+});
+
 export const SuccessView = ({ metricName }: SuccessViewProps) => {
     const { trackDocsClickedAfterCreation } = useTrackRegisterImpactMetrics();
+    const { isAvailable, timedOut } = useCheckMetricAvailable(metricName);
 
     return (
         <SuccessBox>
@@ -75,6 +90,23 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
                     </Typography>
                     {metricName}
                 </StyledMetricName>
+                {isAvailable ? (
+                    <Typography variant='body2' color='success.main'>
+                        The metric is now available.
+                    </Typography>
+                ) : timedOut ? (
+                    <Typography variant='body2' color='text.secondary'>
+                        Your metric may take a bit longer to become available.
+                        You can close this dialog and check back shortly.
+                    </Typography>
+                ) : (
+                    <StyledLoading>
+                        <CircularProgress size={16} />
+                        <Typography variant='body2' color='text.secondary'>
+                            Waiting for metric to become available…
+                        </Typography>
+                    </StyledLoading>
+                )}
             </TextContent>
 
             <Button

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -91,18 +91,18 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
                     {metricName}
                 </StyledMetricName>
                 {isAvailable ? (
-                    <Typography variant='body2' color='success.main'>
+                    <Typography variant='body2'>
                         The metric is now available.
                     </Typography>
                 ) : timedOut ? (
-                    <Typography variant='body2' color='text.secondary'>
+                    <Typography variant='body2'>
                         Your metric may take a bit longer to become available.
                         You can close this dialog and check back shortly.
                     </Typography>
                 ) : (
                     <StyledLoading>
                         <CircularProgress size={16} />
-                        <Typography variant='body2' color='text.secondary'>
+                        <Typography variant='body2'>
                             Waiting for metric to become available…
                         </Typography>
                     </StyledLoading>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useCheckMetricAvailable.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useCheckMetricAvailable.ts
@@ -1,0 +1,26 @@
+import { useImpactMetricsMetadata } from 'hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata';
+import { useEffect, useState } from 'react';
+
+const POLL_INTERVAL = 5_000; // 5 seconds
+const POLL_TIMEOUT = 60_000; // 1 minute
+
+export const useCheckMetricAvailable = (metricName: string) => {
+    const [timedOut, setTimedOut] = useState(false);
+
+    const { metadata } = useImpactMetricsMetadata({
+        refreshInterval: POLL_INTERVAL,
+        enabled: !timedOut,
+    });
+
+    const isAvailable =
+        metadata?.metrics.some((m) => m.name === metricName) || false;
+
+    useEffect(() => {
+        if (isAvailable) return;
+
+        const timeout = setTimeout(() => setTimedOut(true), POLL_TIMEOUT);
+        return () => clearTimeout(timeout);
+    }, [isAvailable]);
+
+    return { isAvailable, timedOut };
+};

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useCheckMetricAvailable.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useCheckMetricAvailable.ts
@@ -8,8 +8,7 @@ export const useCheckMetricAvailable = (metricName: string) => {
     const [timedOut, setTimedOut] = useState(false);
 
     const { metadata } = useImpactMetricsMetadata({
-        refreshInterval: POLL_INTERVAL,
-        enabled: !timedOut,
+        refreshInterval: timedOut ? 0 : POLL_INTERVAL,
     });
 
     const isAvailable =

--- a/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
+++ b/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
@@ -1,4 +1,7 @@
-import { fetcher, useApiGetter } from '../useApiGetter/useApiGetter.js';
+import type { SWRConfiguration } from 'swr';
+import { useCallback } from 'react';
+import { fetcher } from '../useApiGetter/useApiGetter.js';
+import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR.js';
 import { formatApiPath } from 'utils/formatPath';
 import type {
     AvailableImpactMetricsSchema,
@@ -8,17 +11,29 @@ import type {
 export type ImpactMetric = AvailableImpactMetricsSchemaMetricsItem;
 export type ImpactMetricsMetadata = AvailableImpactMetricsSchema;
 
-export const useImpactMetricsMetadata = () => {
-    const PATH = `api/admin/impact-metrics/metadata`;
-    const { data, refetch, loading, error } =
-        useApiGetter<ImpactMetricsMetadata>(formatApiPath(PATH), () =>
-            fetcher(formatApiPath(PATH), 'Impact metrics metadata'),
-        );
+const fallbackMetadata: ImpactMetricsMetadata = { metrics: [] };
+
+export const useImpactMetricsMetadata = (
+    options?: SWRConfiguration & { enabled?: boolean },
+) => {
+    const enabled = options?.enabled ?? true;
+    const PATH = formatApiPath('api/admin/impact-metrics/metadata');
+    const { data, error, mutate } = useConditionalSWR<ImpactMetricsMetadata>(
+        enabled,
+        fallbackMetadata,
+        PATH,
+        () => fetcher(PATH, 'Impact metrics metadata'),
+        options,
+    );
+
+    const refetch = useCallback(() => {
+        mutate();
+    }, [mutate]);
 
     return {
         metadata: data,
         refetch,
-        loading,
+        loading: !error && !data,
         error,
     };
 };

--- a/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
+++ b/frontend/src/hooks/api/getters/useImpactMetricsMetadata/useImpactMetricsMetadata.ts
@@ -1,7 +1,5 @@
 import type { SWRConfiguration } from 'swr';
-import { useCallback } from 'react';
-import { fetcher } from '../useApiGetter/useApiGetter.js';
-import { useConditionalSWR } from '../useConditionalSWR/useConditionalSWR.js';
+import { fetcher, useApiGetter } from '../useApiGetter/useApiGetter.js';
 import { formatApiPath } from 'utils/formatPath';
 import type {
     AvailableImpactMetricsSchema,
@@ -11,29 +9,19 @@ import type {
 export type ImpactMetric = AvailableImpactMetricsSchemaMetricsItem;
 export type ImpactMetricsMetadata = AvailableImpactMetricsSchema;
 
-const fallbackMetadata: ImpactMetricsMetadata = { metrics: [] };
-
-export const useImpactMetricsMetadata = (
-    options?: SWRConfiguration & { enabled?: boolean },
-) => {
-    const enabled = options?.enabled ?? true;
-    const PATH = formatApiPath('api/admin/impact-metrics/metadata');
-    const { data, error, mutate } = useConditionalSWR<ImpactMetricsMetadata>(
-        enabled,
-        fallbackMetadata,
-        PATH,
-        () => fetcher(PATH, 'Impact metrics metadata'),
-        options,
-    );
-
-    const refetch = useCallback(() => {
-        mutate();
-    }, [mutate]);
+export const useImpactMetricsMetadata = (options?: SWRConfiguration) => {
+    const PATH = `api/admin/impact-metrics/metadata`;
+    const { data, refetch, loading, error } =
+        useApiGetter<ImpactMetricsMetadata>(
+            formatApiPath(PATH),
+            () => fetcher(formatApiPath(PATH), 'Impact metrics metadata'),
+            options,
+        );
 
     return {
         metadata: data,
         refetch,
-        loading: !error && !data,
+        loading,
         error,
     };
 };


### PR DESCRIPTION
Polls the metadata endpoint after registering an impact metric to show the user when it becomes available for chart creation. Times out after 1 minute with a fallback message.

- Refactors `useImpactMetricsMetadata` to take optional `options`, so we can pass `refreshInterval`
- Polls every 5 seconds, and times out after 1 minute
- Adds messaging in the `SuccessView` about the status of the newly created metric.

<img width="1336" height="713" alt="Screenshot 2026-04-17 at 12 28 18" src="https://github.com/user-attachments/assets/510a5b30-f094-4f36-bad4-40cb69e9a1f0" />
====
<img width="1336" height="713" alt="Screenshot 2026-04-17 at 12 13 23" src="https://github.com/user-attachments/assets/99acf83f-9f71-4d44-a60b-60409b56a69e" />

====
<img width="1336" height="713" alt="Screenshot 2026-04-17 at 12 10 22" src="https://github.com/user-attachments/assets/457a1f59-d20f-43b5-84cc-09f4aff715ae" />
