### PR TITLE
fix: consolidated release plan changes don't leave empty boxes (plus border fixing)

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
@@ -8,14 +8,6 @@ import type {
     IFeatureChange,
 } from 'component/changeRequest/changeRequest.types';
 
-vi.mock('./ReleasePlanChange.tsx', () => ({
-    isConsolidatedMilestoneAction: (action: string) =>
-        action === 'changeMilestoneProgression' ||
-        action === 'deleteMilestoneProgression' ||
-        action === 'updateMilestoneStrategy',
-    ReleasePlanChange: () => null,
-}));
-
 describe('Schedule conflicts', () => {
     const change = {
         id: 15,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
@@ -154,6 +154,37 @@ describe('Schedule conflicts', () => {
 });
 
 describe('Consolidated milestone changes', () => {
+    const planSnapshot = {
+        id: 'plan-1',
+        name: 'Test plan',
+        description: '',
+        createdAt: '',
+        createdByUserId: 1,
+        featureName: 'milestone-test',
+        environment: 'default',
+        safeguards: [],
+        milestones: [
+            {
+                id: 'milestone-1',
+                name: 'Milestone 1',
+                releasePlanDefinitionId: 'plan-1',
+                strategies: [],
+            },
+            {
+                id: 'milestone-2',
+                name: 'Milestone 2',
+                releasePlanDefinitionId: 'plan-1',
+                strategies: [],
+            },
+            {
+                id: 'milestone-3',
+                name: 'Milestone 3',
+                releasePlanDefinitionId: 'plan-1',
+                strategies: [],
+            },
+        ],
+    };
+
     const makeConsolidatedChange = (id: number): IFeatureChange => ({
         id,
         action: 'changeMilestoneProgression' as const,
@@ -161,6 +192,7 @@ describe('Consolidated milestone changes', () => {
             sourceMilestone: `milestone-${id}`,
             targetMilestone: `milestone-${id + 1}`,
             transitionCondition: { intervalMinutes: 30 },
+            snapshot: planSnapshot,
         },
         createdAt: new Date(),
         createdBy: { id: 1, username: 'admin', imageUrl: '' },
@@ -188,35 +220,42 @@ describe('Consolidated milestone changes', () => {
         approvals: [],
         rejections: [],
         comments: [],
-        state: 'Draft',
+        state: 'Applied',
     };
 
-    it('renders only one change container when multiple consolidated milestone changes are present', () => {
-        const { getByTestId } = render(
-            <div data-testid='feature-changes'>
-                <FeatureChange
-                    actions={null}
-                    changeRequest={changeRequest}
-                    change={change1}
-                    feature={multiChangeFeature}
-                />
-                <FeatureChange
-                    actions={null}
-                    changeRequest={changeRequest}
-                    change={change2}
-                    feature={multiChangeFeature}
-                />
-                <FeatureChange
-                    actions={null}
-                    changeRequest={changeRequest}
-                    change={change3}
-                    feature={multiChangeFeature}
-                />
-            </div>,
+    it('renders the first consolidated change with all changes listed', () => {
+        render(
+            <FeatureChange
+                actions={null}
+                changeRequest={changeRequest}
+                change={change1}
+                feature={multiChangeFeature}
+            />,
         );
 
-        // Only the first consolidated milestone change should render a container;
-        // subsequent ones return null and do not appear in the document.
-        expect(getByTestId('feature-changes').children).toHaveLength(1);
+        const items = screen.getAllByRole('listitem');
+        expect(items).toHaveLength(3);
+        expect(items[0]).toHaveTextContent(
+            'Editing automation for Milestone 1',
+        );
+        expect(items[1]).toHaveTextContent(
+            'Editing automation for Milestone 2',
+        );
+        expect(items[2]).toHaveTextContent(
+            'Editing automation for Milestone 3',
+        );
+    });
+
+    it('renders nothing for consolidated changes after the first', () => {
+        render(
+            <FeatureChange
+                actions={null}
+                changeRequest={changeRequest}
+                change={change2}
+                feature={multiChangeFeature}
+            />,
+        );
+
+        expect(screen.queryAllByRole('listitem')).toHaveLength(0);
     });
 });

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.test.tsx
@@ -8,6 +8,14 @@ import type {
     IFeatureChange,
 } from 'component/changeRequest/changeRequest.types';
 
+vi.mock('./ReleasePlanChange.tsx', () => ({
+    isConsolidatedMilestoneAction: (action: string) =>
+        action === 'changeMilestoneProgression' ||
+        action === 'deleteMilestoneProgression' ||
+        action === 'updateMilestoneStrategy',
+    ReleasePlanChange: () => null,
+}));
+
 describe('Schedule conflicts', () => {
     const change = {
         id: 15,
@@ -150,5 +158,73 @@ describe('Schedule conflicts', () => {
         const alert = screen.queryByRole('alert');
 
         expect(alert).toBe(null);
+    });
+});
+
+describe('Consolidated milestone changes', () => {
+    const makeConsolidatedChange = (id: number): IFeatureChange => ({
+        id,
+        action: 'changeMilestoneProgression' as const,
+        payload: {
+            sourceMilestone: `milestone-${id}`,
+            targetMilestone: `milestone-${id + 1}`,
+            transitionCondition: { intervalMinutes: 30 },
+        },
+        createdAt: new Date(),
+        createdBy: { id: 1, username: 'admin', imageUrl: '' },
+    });
+
+    const change1 = makeConsolidatedChange(1);
+    const change2 = makeConsolidatedChange(2);
+    const change3 = makeConsolidatedChange(3);
+
+    const multiChangeFeature: IChangeRequestFeature = {
+        name: 'milestone-test',
+        changes: [change1, change2, change3],
+    };
+
+    const changeRequest: ChangeRequestType = {
+        id: 1,
+        title: '',
+        project: 'default',
+        environment: 'default',
+        minApprovals: 1,
+        createdBy: { id: 1, username: 'user1', imageUrl: '' },
+        createdAt: new Date(),
+        features: [multiChangeFeature],
+        segments: [],
+        approvals: [],
+        rejections: [],
+        comments: [],
+        state: 'Draft',
+    };
+
+    it('renders only one change container when multiple consolidated milestone changes are present', () => {
+        const { getByTestId } = render(
+            <div data-testid='feature-changes'>
+                <FeatureChange
+                    actions={null}
+                    changeRequest={changeRequest}
+                    change={change1}
+                    feature={multiChangeFeature}
+                />
+                <FeatureChange
+                    actions={null}
+                    changeRequest={changeRequest}
+                    change={change2}
+                    feature={multiChangeFeature}
+                />
+                <FeatureChange
+                    actions={null}
+                    changeRequest={changeRequest}
+                    change={change3}
+                    feature={multiChangeFeature}
+                />
+            </div>,
+        );
+
+        // Only the first consolidated milestone change should render a container;
+        // subsequent ones return null and do not appear in the document.
+        expect(getByTestId('feature-changes').children).toHaveLength(1);
     });
 });

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -13,16 +13,18 @@ import { EnvironmentStrategyExecutionOrder } from './EnvironmentStrategyExecutio
 import { ArchiveFeatureChange } from './ArchiveFeatureChange.tsx';
 import { DependencyChange } from './DependencyChange.tsx';
 import { Link } from 'react-router-dom';
-import { ReleasePlanChange } from './ReleasePlanChange.tsx';
+import {
+    ReleasePlanChange,
+    isConsolidatedMilestoneAction,
+} from './ReleasePlanChange.tsx';
 import { FeatureEnvSafeguardChange } from './FeatureEnvSafeguardChange.tsx';
 import { StrategyChange } from './StrategyChange.tsx';
 
 const StyledSingleChangeBox = styled(Box)(({ theme }) => ({
     overflow: 'hidden',
-    border: '1px solid',
-    borderBottom: 'none',
+    border: `1px solid${theme.palette.divider}`,
+    borderBottomWidth: 0,
     borderRadius: 0,
-    borderColor: theme.palette.divider,
     '&[data-conflict="change"]': {
         borderColor: theme.palette.warning.border,
     },
@@ -33,7 +35,7 @@ const StyledSingleChangeBox = styled(Box)(({ theme }) => ({
         borderTopColor: theme.palette.divider,
     },
     '&:last-child': {
-        borderBottomStyle: 'solid',
+        borderBottomWidth: '1px',
         borderRadius: `0 0 ${theme.shape.borderRadiusLarge}px ${theme.shape.borderRadiusLarge}px`,
     },
 }));
@@ -57,9 +59,6 @@ const InlineList = styled('ul')(({ theme }) => ({
 
 const ChangeInnerBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(3),
-    '&:empty': {
-        display: 'none',
-    },
 }));
 
 export const FeatureChange: FC<{
@@ -79,6 +78,15 @@ export const FeatureChange: FC<{
     isDefaultChange,
     onRefetch,
 }) => {
+    if (isConsolidatedMilestoneAction(change.action)) {
+        const firstConsolidated = feature.changes.find((c) =>
+            isConsolidatedMilestoneAction(c.action),
+        );
+        if (firstConsolidated && firstConsolidated !== change) {
+            return null;
+        }
+    }
+
     const conflict = change.conflict || change.scheduleConflicts;
     return (
         <StyledSingleChangeBox

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -22,7 +22,7 @@ import { StrategyChange } from './StrategyChange.tsx';
 
 const StyledSingleChangeBox = styled(Box)(({ theme }) => ({
     overflow: 'hidden',
-    border: `1px solid${theme.palette.divider}`,
+    border: `1px solid ${theme.palette.divider}`,
     borderBottomWidth: 0,
     borderRadius: 0,
     '&[data-conflict="change"]': {

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -14,6 +14,7 @@ import {
     type IChangeRequestResumeMilestoneProgression,
     type IChangeRequestStartMilestone,
     type IChangeRequestUpdateMilestoneStrategy,
+    type IFeatureChange,
 } from 'component/changeRequest/changeRequest.types';
 import { useReleasePlanPreview } from 'hooks/useReleasePlanPreview';
 import { useFeatureReleasePlans } from 'hooks/api/getters/useFeatureReleasePlans/useFeatureReleasePlans';
@@ -44,6 +45,13 @@ import {
     SafeguardDeleteView,
 } from './SafeguardChangeViews.tsx';
 import { StrategyItem } from 'component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx';
+
+export const isConsolidatedMilestoneAction = (
+    action: IFeatureChange['action'],
+): boolean =>
+    action === 'changeMilestoneProgression' ||
+    action === 'deleteMilestoneProgression' ||
+    action === 'updateMilestoneStrategy';
 
 const StyledTabs = styled(Tabs)(({ theme }) => ({
     display: 'flex',
@@ -489,34 +497,7 @@ export const ReleasePlanChange: FC<{
         }
     };
 
-    // If this is a release plan modification change (progression or milestone strategy)
-    // and we have the full feature object, consolidate with other such changes
-    if (
-        feature &&
-        (change.action === 'changeMilestoneProgression' ||
-            change.action === 'deleteMilestoneProgression' ||
-            change.action === 'updateMilestoneStrategy')
-    ) {
-        const consolidatedChanges = feature.changes.filter(
-            (
-                change,
-            ): change is
-                | IChangeRequestChangeMilestoneProgression
-                | IChangeRequestDeleteMilestoneProgression
-                | IChangeRequestUpdateMilestoneStrategy =>
-                change.action === 'changeMilestoneProgression' ||
-                change.action === 'deleteMilestoneProgression' ||
-                change.action === 'updateMilestoneStrategy',
-        );
-
-        // Only render if this is the first consolidated change
-        const isFirst =
-            consolidatedChanges.length > 0 && consolidatedChanges[0] === change;
-
-        if (!isFirst) {
-            return null; // Skip rendering, will be handled by the first one
-        }
-
+    if (feature && isConsolidatedMilestoneAction(change.action)) {
         return (
             <ConsolidatedReleasePlanChanges
                 feature={feature}


### PR DESCRIPTION
Makes it so that consolidated release plan changes don't leave empty boxes following the first one. This was an issue previously because the empty boxes also had borders, causing thick lines to appear following release plan changes.

It also fixes an unrelated issue with very thick final borders for changes.

Before:
<img width="1145" height="290" alt="image" src="https://github.com/user-attachments/assets/471ee184-d320-4f74-8271-bd6744d189f4" />
<img width="1183" height="473" alt="image" src="https://github.com/user-attachments/assets/873ee9ef-9f6a-4935-b118-df096e0ead04" />


After:
<img width="1079" height="370" alt="image" src="https://github.com/user-attachments/assets/f7ba6e18-0416-43cf-9055-6dd1488e13a0" />
<img width="1138" height="391" alt="image" src="https://github.com/user-attachments/assets/2f95ec9a-21dd-4b70-bdac-df6978e572f0" />
