### PR TITLE
chore: add entry point to registerImpactMetric form_opened counter

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -529,6 +529,7 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                             options={metricOptions}
                             loading={loading}
                             label=''
+                            entryPoint='flag-safeguards'
                         />
 
                         <StyledTopRow>

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/ImpactMetricsControls.tsx
@@ -5,6 +5,7 @@ import { MetricSelector } from './SeriesSelector/MetricSelector.tsx';
 import { RangeSelector } from './RangeSelector/RangeSelector.tsx';
 import { ModeSelector } from './ModeSelector/ModeSelector.tsx';
 import type { ChartFormState } from '../../hooks/useChartFormState.ts';
+import { useLocation } from 'react-router-dom';
 
 export type ImpactMetricsControlsProps = {
     formData: ChartFormState['formData'];
@@ -27,59 +28,67 @@ export const ImpactMetricsControls: FC<ImpactMetricsControlsProps> = ({
     metrics,
     loading,
     labelsFilter,
-}) => (
-    <Box>
-        <Box
-            sx={(theme) => ({
-                display: 'flex',
-                flexDirection: 'column',
-                gap: theme.spacing(3),
-            })}
-        >
-            <MetricSelector
-                value={formData.metricName}
-                valueSource={formData.source}
-                onChange={actions.handleSeriesChange}
-                options={metrics}
-                loading={loading}
-            />
+}) => {
+    const { pathname } = useLocation();
+    const entryPoint = pathname.includes('/impact-metrics')
+        ? 'impact-metrics-page'
+        : 'flag-impact-metrics-accordion';
 
-            {labelsFilter}
+    return (
+        <Box>
+            <Box
+                sx={(theme) => ({
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: theme.spacing(3),
+                })}
+            >
+                <MetricSelector
+                    value={formData.metricName}
+                    valueSource={formData.source}
+                    onChange={actions.handleSeriesChange}
+                    options={metrics}
+                    loading={loading}
+                    entryPoint={entryPoint}
+                />
 
+                {labelsFilter}
+
+                {formData.metricName ? (
+                    <>
+                        <RangeSelector
+                            value={formData.timeRange}
+                            onChange={actions.setTimeRange}
+                        >
+                            <MenuItem value='hour'>Last hour</MenuItem>
+                            <MenuItem value='day'>Last 24 hours</MenuItem>
+                            <MenuItem value='week'>Last 7 days</MenuItem>
+                            <MenuItem value='month'>Last 30 days</MenuItem>
+                        </RangeSelector>
+                        <ModeSelector
+                            value={formData.aggregationMode}
+                            onChange={actions.setAggregationMode}
+                            metricType={formData.metricType}
+                        />
+                    </>
+                ) : null}
+            </Box>
             {formData.metricName ? (
-                <>
-                    <RangeSelector
-                        value={formData.timeRange}
-                        onChange={actions.setTimeRange}
-                    >
-                        <MenuItem value='hour'>Last hour</MenuItem>
-                        <MenuItem value='day'>Last 24 hours</MenuItem>
-                        <MenuItem value='week'>Last 7 days</MenuItem>
-                        <MenuItem value='month'>Last 30 days</MenuItem>
-                    </RangeSelector>
-                    <ModeSelector
-                        value={formData.aggregationMode}
-                        onChange={actions.setAggregationMode}
-                        metricType={formData.metricType}
-                    />
-                </>
+                <FormControlLabel
+                    sx={(theme) => ({ margin: theme.spacing(1.5, 0) })}
+                    control={
+                        <Checkbox
+                            checked={formData.yAxisMin === 'zero'}
+                            onChange={(e) =>
+                                actions.setYAxisMin(
+                                    e.target.checked ? 'zero' : 'auto',
+                                )
+                            }
+                        />
+                    }
+                    label='Begin at zero'
+                />
             ) : null}
         </Box>
-        {formData.metricName ? (
-            <FormControlLabel
-                sx={(theme) => ({ margin: theme.spacing(1.5, 0) })}
-                control={
-                    <Checkbox
-                        checked={formData.yAxisMin === 'zero'}
-                        onChange={(e) =>
-                            actions.setYAxisMin(
-                                e.target.checked ? 'zero' : 'auto',
-                            )
-                        }
-                    />
-                }
-                label='Begin at zero'
-            />
-        ) : null}
-    </Box>
-);
+    );
+};

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/ImpactMetricsControls/SeriesSelector/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { useState } from 'react';
 import {
     Autocomplete,
     TextField,
@@ -39,10 +39,16 @@ export type MetricSelectorProps = {
     options: MetricOption[];
     loading?: boolean;
     label?: string;
+    entryPoint?:
+        | 'impact-metrics-page'
+        | 'flag-impact-metrics-accordion'
+        | 'flag-safeguards';
 };
 
-const NoOptionsMessage: FC<{ onRegisterClick?: () => void }> = ({
+const NoOptionsMessage = ({
     onRegisterClick,
+}: {
+    onRegisterClick?: () => void;
 }) => {
     const { trackEvent } = usePlausibleTracker();
     const { trackDocsClicked } = useTrackFlagpageImpactMetrics();
@@ -118,18 +124,19 @@ const withSelectedValue = (
 const groupLabel = (source?: MetricSource) =>
     source === 'external' ? 'External metrics' : 'Internal metrics';
 
-export const MetricSelector: FC<MetricSelectorProps> = ({
+export const MetricSelector = ({
     value,
     valueSource,
     onChange,
     options,
     loading = false,
     label = 'Metric name',
-}) => {
+    entryPoint,
+}: MetricSelectorProps) => {
     const allOptions = withSelectedValue(options, value, valueSource);
     const registerImpactMetricsEnabled = useUiFlag('registerImpactMetrics');
     const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
-    const { trackFormOpened } = useTrackRegisterImpactMetrics();
+    const { trackFormOpened } = useTrackRegisterImpactMetrics(entryPoint);
 
     return (
         <>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/useTrackRegisterImpactMetrics.ts
@@ -2,9 +2,27 @@ import { useImpactMetricsCounter } from 'hooks/useImpactMetrics';
 
 const help = 'Tracks user journey of creating an impact metric from the UI.';
 
-export const useTrackRegisterImpactMetrics = () => {
+export const useTrackRegisterImpactMetrics = (
+    entryPoint?:
+        | 'impact-metrics-page'
+        | 'flag-impact-metrics-accordion'
+        | 'flag-safeguards',
+) => {
+    const determineFormCounter = () => {
+        switch (entryPoint) {
+            case 'impact-metrics-page':
+                return 'registerImpactMetric_form_opened_from_impact_metrics_page';
+            case 'flag-impact-metrics-accordion':
+                return 'registerImpactMetric_form_opened_from_flagpage_accordion';
+            case 'flag-safeguards':
+                return 'registerImpactMetric_form_opened_from_safeguards';
+            default:
+                return 'registerImpactMetric_form_opened';
+        }
+    };
+
     const { increment: formOpened } = useImpactMetricsCounter(
-        'registerImpactMetric_form_opened',
+        determineFormCounter(),
         help,
     );
     const { increment: metricCreated } = useImpactMetricsCounter(


### PR DESCRIPTION
We want to be able to tell what is the entry point we're adding impact metrics from (safeguards, impact metric page or flag page accordion). It's a good idea to review with the "hide whitespace" option checked to see the actual changes.

- Adds `entryPoint` prop to `MetricSelector` 
- Determines counter name for `trackFormOpened` depending on the entry point 