### PR TITLE
chore: add register impact metric dialog tests

### DIFF
--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.test.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.test.tsx
@@ -1,9 +1,10 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
 import { render } from 'utils/testRenderer';
 import { RegisterMetricDialog } from './RegisterMetricDialog';
+import ToastRenderer from 'component/common/ToastRenderer/ToastRenderer';
 
 const server = testServerSetup();
 
@@ -13,7 +14,12 @@ beforeEach(() => {
 
 const openDialog = async () => {
     const user = userEvent.setup();
-    render(<RegisterMetricDialog open onClose={vi.fn()} />);
+    render(
+        <>
+            <RegisterMetricDialog open onClose={vi.fn()} />
+            <ToastRenderer />
+        </>,
+    );
     await screen.findByRole('heading', { name: 'Create an impact metric' });
     return {
         user,
@@ -29,10 +35,14 @@ test('submitting the form transitions to success stage', async () => {
     await user.click(submitButton);
 
     await screen.findByText('Implement the impact metric');
-    expect(screen.getByText(/checkout_error_count/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    expect(await screen.findByText(/checkout_error_count/)).toBeInTheDocument();
     expect(
-        screen.getByText(/The metric will be available in the UI shortly/i),
+        await screen.findByRole('button', { name: /done/i }),
+    ).toBeInTheDocument();
+    expect(
+        await screen.findByText(
+            /The metric will be available in the UI shortly/i,
+        ),
     ).toBeInTheDocument();
 });
 
@@ -40,9 +50,9 @@ test('should not proceed to success screen on API error', async () => {
     testServerRoute(
         server,
         '/api/admin/impact-metrics/register',
-        { message: 'Internal server error' },
+        { name: 'AuthenticationRequired', message: 'You must be logged in.' },
         'post',
-        500,
+        401,
     );
 
     const { user, nameInput, submitButton } = await openDialog();
@@ -50,9 +60,11 @@ test('should not proceed to success screen on API error', async () => {
     await user.type(nameInput, 'checkout_error_count');
     await user.click(submitButton);
 
-    await waitFor(() => {
-        expect(screen.getByText(/Define your metric/i)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Define your metric/i)).toBeInTheDocument();
+    expect(
+        await screen.findByText(/Authentication required/i),
+    ).toBeInTheDocument();
+
     expect(
         screen.queryByText(/The metric will be available in the UI shortly/i),
     ).not.toBeInTheDocument();

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.test.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/RegisterMetricDialog.test.tsx
@@ -1,0 +1,59 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { render } from 'utils/testRenderer';
+import { RegisterMetricDialog } from './RegisterMetricDialog';
+
+const server = testServerSetup();
+
+beforeEach(() => {
+    testServerRoute(server, '/api/admin/impact-metrics/register', {}, 'post');
+});
+
+const openDialog = async () => {
+    const user = userEvent.setup();
+    render(<RegisterMetricDialog open onClose={vi.fn()} />);
+    await screen.findByRole('heading', { name: 'Create an impact metric' });
+    return {
+        user,
+        nameInput: screen.getByLabelText(/metric name/i),
+        submitButton: screen.getByRole('button', { name: /next step/i }),
+    };
+};
+
+test('submitting the form transitions to success stage', async () => {
+    const { user, nameInput, submitButton } = await openDialog();
+
+    await user.type(nameInput, 'checkout_error_count');
+    await user.click(submitButton);
+
+    await screen.findByText('Implement the impact metric');
+    expect(screen.getByText(/checkout_error_count/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    expect(
+        screen.getByText(/The metric will be available in the UI shortly/i),
+    ).toBeInTheDocument();
+});
+
+test('should not proceed to success screen on API error', async () => {
+    testServerRoute(
+        server,
+        '/api/admin/impact-metrics/register',
+        { message: 'Internal server error' },
+        'post',
+        500,
+    );
+
+    const { user, nameInput, submitButton } = await openDialog();
+
+    await user.type(nameInput, 'checkout_error_count');
+    await user.click(submitButton);
+
+    await waitFor(() => {
+        expect(screen.getByText(/Define your metric/i)).toBeInTheDocument();
+    });
+    expect(
+        screen.queryByText(/The metric will be available in the UI shortly/i),
+    ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
Adds a test file for `RegisterMetricDialog` for the happy path and the case of an API error. 