### PR TITLE
fix: revision id calculation for deltas

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
@@ -51,11 +51,8 @@ export const isDeltaFeatureRemovedEvent = (
     return event.type === DELTA_EVENT_TYPES.FEATURE_REMOVED;
 };
 
-export const isDeltaSegmentEvent = (
+export const isDeltaVisibleRevisionSegmentEvent = (
     event: DeltaEvent,
 ): event is Extract<DeltaEvent, { type: 'segment-updated' }> => {
-    return (
-        event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED ||
-        event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED
-    );
+    return event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED;
 };

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -1,11 +1,25 @@
 import type { DeltaEvent } from './client-feature-toggle-delta-types.js';
 import { EventEmitter } from 'events';
+import { register } from 'prom-client';
 import {
     ClientFeatureToggleDelta,
     filterEventsByQuery,
 } from './client-feature-toggle-delta.js';
 import { DeltaCache } from './delta-cache.js';
 import { FEATURE_PROJECT_CHANGE } from '../../../events/index.js';
+
+const createLogger = () =>
+    ({
+        error: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+    }) as any;
+
+const createDeltaConfig = () =>
+    ({
+        eventBus: new EventEmitter(),
+        getLogger: () => createLogger(),
+    }) as any;
 
 describe('filterEventsByQuery', () => {
     const mockEvents: DeltaEvent[] = [
@@ -174,6 +188,341 @@ describe('DeltaCache hydration ordering', () => {
 });
 
 describe('ClientFeatureToggleDelta bootstrap behavior', () => {
+    test('segment-created alone does not advance visible revision for an environment where it is unused', async () => {
+        let currentRevisionId = 1;
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async ({ environment, toggleNames = [] }) => {
+                    const developmentFeature = {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    };
+
+                    if (environment !== 'development') {
+                        return [];
+                    }
+
+                    if (toggleNames.length === 0) {
+                        return [developmentFeature];
+                    }
+
+                    // @ts-expect-error - toggle name not defined
+                    return toggleNames.includes('first')
+                        ? [developmentFeature]
+                        : [];
+                },
+            } as any,
+            {
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    segmentRevisions: new Map(),
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-created',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        const baseline = await delta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await delta.onUpdateRevisionEvent();
+
+        const result = await delta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(baseline?.events[0]?.eventId).toBe(1);
+        expect(result).toBeUndefined();
+    });
+
+    test('segment-created followed by unrelated environment change does not advance visible revision and hydration stays in parity', async () => {
+        let currentRevisionId = 1;
+        const createReadModel = () =>
+            ({
+                getAll: async ({ environment, toggleNames = [] }) => {
+                    const featureByEnvironment = {
+                        development: {
+                            name: 'first',
+                            project: 'default',
+                            enabled: false,
+                        },
+                        production: {
+                            name: 'first',
+                            project: 'default',
+                            enabled: true,
+                        },
+                    };
+                    const feature =
+                        featureByEnvironment[
+                            environment as keyof typeof featureByEnvironment
+                        ];
+
+                    if (!feature) {
+                        return [];
+                    }
+
+                    if (toggleNames.length === 0) {
+                        return [feature];
+                    }
+
+                    // @ts-expect-error - toggle name not defined
+                    return toggleNames.includes('first') ? [feature] : [];
+                },
+            }) as any;
+        const createSegmentModel = () =>
+            ({
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            }) as any;
+        const createEventStore = () =>
+            ({
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    segmentRevisions: new Map([[101, 2]]),
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-created',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                    {
+                        id: 3,
+                        type: 'feature-updated',
+                        featureName: 'first',
+                        project: 'default',
+                        environment: 'production',
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            }) as any;
+
+        const liveDelta = new ClientFeatureToggleDelta(
+            createReadModel(),
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await liveDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 3;
+        await liveDelta.onUpdateRevisionEvent();
+
+        const liveResult = await liveDelta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        const freshDelta = new ClientFeatureToggleDelta(
+            createReadModel(),
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {} as any,
+            createDeltaConfig(),
+        );
+
+        const freshHydration = await freshDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(liveResult).toBeUndefined();
+        expect(freshHydration?.events[0]?.eventId).toBe(1);
+    });
+
+    test('segment-updated only advances visible revision when the segment is referenced by a visible feature', async () => {
+        let currentRevisionId = 1;
+
+        const createEventStore = () =>
+            ({
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    segmentRevisions: new Map([[101, 1]]),
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-updated',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            }) as any;
+
+        const createSegmentModel = () =>
+            ({
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            }) as any;
+
+        const unusedDelta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    },
+                ],
+            } as any,
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await unusedDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await unusedDelta.onUpdateRevisionEvent();
+
+        const unusedResult = await unusedDelta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        const usedDelta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies: [{ name: 'default', segments: [101] }],
+                    },
+                ],
+            } as any,
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await usedDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await usedDelta.onUpdateRevisionEvent();
+
+        const usedResult = await usedDelta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(unusedResult).toBeUndefined();
+        expect(usedResult).toEqual({
+            events: [
+                {
+                    eventId: 2,
+                    type: 'segment-updated',
+                    segment: { id: 101, name: 'segment-a', constraints: [] },
+                },
+            ],
+        });
+    });
+
+    test('materializes delta_environment_revision_id on first hydration request', async () => {
+        const environment = 'metric-materialization-test';
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    },
+                ],
+            } as any,
+            {
+                getAllForClientIds: async () => [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 7]]),
+                    segmentRevisions: new Map(),
+                }),
+                getMaxRevisionId: async () => 7,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {} as any,
+            createDeltaConfig(),
+        );
+
+        const result = await delta.getDelta(undefined, {
+            environment,
+            project: ['default'],
+        } as any);
+        const metrics = await register.metrics();
+
+        expect(result?.events[0]?.eventId).toBe(7);
+        expect(metrics).toMatch(
+            new RegExp(
+                `delta_environment_revision_id\\{environment="${environment}"\\} 7`,
+            ),
+        );
+    });
+
     test('returns the same wildcard hydration revision for identical environment state across pods', async () => {
         const createDelta = (globalRevisionId: number) =>
             new ClientFeatureToggleDelta(
@@ -199,7 +548,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                 {
                     getDeltaRevisionState: async () => ({
                         projectRevisions: new Map([['default', 85815]]),
-                        globalSegmentRevision: 0,
+                        segmentRevisions: new Map(),
                     }),
                     getMaxRevisionId: async () => globalRevisionId,
                 } as any,
@@ -247,7 +596,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -292,7 +641,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -348,7 +697,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -434,7 +783,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -537,7 +886,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['old-project', 1]]),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -680,7 +1029,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -16,14 +16,17 @@ import type {
 import { CLIENT_DELTA_MEMORY } from '../../../metric-events.js';
 import EventEmitter from 'events';
 import type { Logger } from '../../../logger.js';
-import type { ClientFeaturesDeltaSchema } from '../../../openapi/index.js';
+import type {
+    ClientFeatureSchema,
+    ClientFeaturesDeltaSchema,
+} from '../../../openapi/index.js';
 import {
     DELTA_EVENT_TYPES,
     type DeltaEvent,
     type DeltaHydrationEvent,
     isDeltaFeatureRemovedEvent,
     isDeltaFeatureUpdatedEvent,
-    isDeltaSegmentEvent,
+    isDeltaVisibleRevisionSegmentEvent,
 } from './client-feature-toggle-delta-types.js';
 import {
     FEATURE_ARCHIVED,
@@ -34,14 +37,21 @@ import {
     SEGMENT_UPDATED,
     type IEvent,
 } from '../../../events/index.js';
-import { getVisibleRevision } from './visible-revision.js';
+import {
+    getReferencedSegmentIds,
+    getVisibleRevision,
+} from './visible-revision.js';
 import { createGauge } from '../../../util/metrics/index.js';
 import { BadDataError } from '../../../server-impl.js';
 
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
-    globalSegmentRevision: number;
+    // Tracks the latest revision per segment so we can keep segment changes in
+    // memory without automatically making every segment event visible for the
+    // whole environment. The environment revision should only consider segment
+    // revisions for segments that are actually referenced by visible features.
+    segmentRevisions: Map<number, number>;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -51,6 +61,7 @@ export const filterEventsByQuery = (
     requestedRevisionId: number,
     projects: string[],
     namePrefix: string,
+    visibleSegmentIds?: Set<number>,
 ) => {
     const targetedEvents = events.filter(
         (revision) => revision.eventId > requestedRevisionId,
@@ -74,9 +85,29 @@ export const filterEventsByQuery = (
         );
     };
 
+    const isVisibleSegment = (revision: DeltaEvent) => {
+        if (
+            !isDeltaVisibleRevisionSegmentEvent(revision) ||
+            !visibleSegmentIds
+        ) {
+            return true;
+        }
+
+        return visibleSegmentIds.has(revision.segment.id);
+    };
+
     return targetedEvents.filter((revision) => {
+        const isAnySegmentDeltaEvent =
+            revision.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED ||
+            revision.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED;
+        const segmentMatches =
+            visibleSegmentIds === undefined
+                ? isAnySegmentDeltaEvent
+                : isDeltaVisibleRevisionSegmentEvent(revision) &&
+                  isVisibleSegment(revision);
+
         return (
-            isDeltaSegmentEvent(revision) ||
+            segmentMatches ||
             (startsWithPrefix(revision) &&
                 (allProjects || isInProject(revision)))
         );
@@ -201,7 +232,16 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             await this.initEnvironmentDelta(environment);
         }
 
-        const visibleRevision = this.getVisibleRevision(environment, projects);
+        const hydrationEvent = this.delta[environment].getHydrationEvent();
+        const visibleSegmentIds = getReferencedSegmentIds(
+            hydrationEvent.features,
+            projects,
+            namePrefix,
+        );
+        const visibleRevision = this.getVisibleRevision(
+            environment,
+            hydrationEvent.features,
+        );
 
         if (hasRequestedRevision && requestedRevisionId >= visibleRevision) {
             this.logger.info(
@@ -214,7 +254,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             !hasRequestedRevision ||
             delta.isMissingRevision(requestedRevisionId)
         ) {
-            const hydrationEvent = delta.getHydrationEvent();
             const filteredEvent = filterHydrationEventByQuery(
                 hydrationEvent,
                 projects,
@@ -242,6 +281,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 requestedRevisionId,
                 projects,
                 namePrefix,
+                visibleSegmentIds,
             );
 
             if (events.length === 0) {
@@ -436,6 +476,15 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             segmentId,
         }));
 
+        // Segment removal needs to update the cached hydration payload for
+        // long-lived pods, but it must not advance the visible revision. Only
+        // segment updates can make an already-visible payload change on their own.
+        const segmentCacheEvents = [
+            ...segmentsUpdatedEvents,
+            ...segmentsRemovedEvents,
+        ];
+        const segmentVisibleRevisionEvents = [...segmentsUpdatedEvents];
+
         for (const environment of environments) {
             // merge globally updated features with environment specific updates, keep the max revision id for each feature
             const featureUpdatesInEnvironment = new Map<string, number>(
@@ -467,13 +516,12 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             this.delta[environment].addEvents([
                 ...featuresRemovedEvents,
                 ...featuresUpdatedEvents,
-                ...segmentsUpdatedEvents,
-                ...segmentsRemovedEvents,
+                ...segmentCacheEvents,
             ]);
             this.updateVisibleRevisions(
                 environment,
                 [...featuresRemovedEvents, ...featuresUpdatedEvents],
-                [...segmentsUpdatedEvents, ...segmentsRemovedEvents],
+                segmentVisibleRevisionEvents,
             );
         }
         this.lastDeltaProcessedRevisionId = eventsTo;
@@ -500,7 +548,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         });
         const baseSegments = await this.segmentReadModel.getAllForClientIds();
 
-        const maxRevision = getVisibleRevision(revisionState);
+        const maxRevision = getVisibleRevision(revisionState, baseFeatures);
         this.delta[environment] = new DeltaCache({
             eventId: maxRevision,
             type: DELTA_EVENT_TYPES.HYDRATION,
@@ -509,38 +557,42 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         });
         this.lastDeltaProcessedRevisionId = maxRevision;
         this.visibleRevisions[environment] = revisionState;
+        deltaRevisionIdMetric.labels({ environment }).set(maxRevision);
         this.storeFootprint();
     }
 
     private getVisibleRevision(
         environment: string,
-        projects: string[],
+        features: ClientFeatureSchema[] = [],
     ): number {
         const revisionState = this.visibleRevisions[environment];
-        return getVisibleRevision(revisionState, projects);
+        return getVisibleRevision(revisionState, features);
     }
 
     private updateVisibleRevisions(
         environment: string,
         featureEvents: DeltaEvent[],
-        segmentEvents: DeltaEvent[],
+        segmentRevisionEvents: DeltaEvent[],
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
-            globalSegmentRevision: 0,
+            segmentRevisions: new Map<number, number>(),
         };
 
-        if (segmentEvents.length > 0) {
-            for (const event of segmentEvents) {
-                revisionState.globalSegmentRevision = Math.max(
-                    revisionState.globalSegmentRevision,
+        if (segmentRevisionEvents.length > 0) {
+            for (const event of segmentRevisionEvents) {
+                if (!isDeltaVisibleRevisionSegmentEvent(event)) {
+                    continue;
+                }
+
+                setMaxRevision(
+                    revisionState.segmentRevisions,
+                    event.segment.id,
                     event.eventId,
                 );
             }
         }
 
-        // assume segment revision id as max feature event
-        let environmentMax = revisionState.globalSegmentRevision;
         for (const event of featureEvents) {
             let project: string | undefined;
             if (event.type === DELTA_EVENT_TYPES.FEATURE_UPDATED) {
@@ -554,9 +606,15 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                     project,
                     event.eventId,
                 );
-                environmentMax = Math.max(environmentMax, event.eventId);
             }
         }
+
+        const hydrationFeatures =
+            this.delta[environment].getHydrationEvent().features;
+        const environmentMax = getVisibleRevision(
+            revisionState,
+            hydrationFeatures,
+        );
 
         deltaRevisionIdMetric.labels({ environment }).set(environmentMax);
         this.visibleRevisions[environment] = revisionState;

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -7,24 +7,91 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['alpha', 11],
         ['beta', 14],
     ]),
-    globalSegmentRevision: 12,
+    segmentRevisions: new Map([
+        [1, 12],
+        [2, 13],
+    ]),
 };
 
 describe('getVisibleRevision', () => {
     test('returns all-project revision for wildcard query', () => {
-        expect(getVisibleRevision(revisionState, ['*'])).toBe(14);
+        expect(
+            getVisibleRevision(revisionState, [
+                {
+                    name: 'alpha-feature',
+                    project: 'alpha',
+                    enabled: true,
+                },
+                {
+                    name: 'beta-feature',
+                    project: 'beta',
+                    enabled: true,
+                    strategies: [{ name: 'default', segments: [2] }],
+                },
+            ] as any),
+        ).toBe(14);
     });
 
     test('uses wildcard semantics for empty project list', () => {
-        expect(getVisibleRevision(revisionState, [])).toBe(14);
+        expect(
+            getVisibleRevision(revisionState, [
+                {
+                    name: 'alpha-feature',
+                    project: 'alpha',
+                    enabled: true,
+                },
+                {
+                    name: 'beta-feature',
+                    project: 'beta',
+                    enabled: true,
+                    strategies: [{ name: 'default', segments: [2] }],
+                },
+            ] as any),
+        ).toBe(14);
     });
 
-    test('returns max project or segment revision for project-scoped query', () => {
-        expect(getVisibleRevision(revisionState, ['alpha'])).toBe(12);
-        expect(getVisibleRevision(revisionState, ['alpha', 'beta'])).toBe(14);
+    test('returns the environment-wide visible revision', () => {
+        expect(
+            getVisibleRevision(revisionState, [
+                {
+                    name: 'alpha-feature',
+                    project: 'alpha',
+                    enabled: true,
+                    strategies: [{ name: 'default', segments: [1] }],
+                },
+            ] as any),
+        ).toBe(14);
+        expect(
+            getVisibleRevision(revisionState, [
+                {
+                    name: 'alpha-feature',
+                    project: 'alpha',
+                    enabled: true,
+                    strategies: [{ name: 'default', segments: [1] }],
+                },
+                {
+                    name: 'beta-feature',
+                    project: 'beta',
+                    enabled: true,
+                    strategies: [{ name: 'default', segments: [2] }],
+                },
+            ] as any),
+        ).toBe(14);
     });
 
-    test('returns 0 when scoped query has no revision state', () => {
-        expect(getVisibleRevision(undefined, ['alpha'])).toBe(0);
+    test('returns 0 when there is no revision state', () => {
+        expect(getVisibleRevision(undefined, [])).toBe(0);
+    });
+
+    test('ignores segment revisions that are not referenced by visible features, but still keeps project revisions environment-wide', () => {
+        expect(
+            getVisibleRevision(revisionState, [
+                {
+                    name: 'alpha-feature',
+                    project: 'alpha',
+                    enabled: true,
+                },
+            ] as any),
+        ).toBe(14);
     });
 });

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -1,24 +1,52 @@
 import { ALL_PROJECTS } from '../../../util/index.js';
 import type { EnvironmentVisibleRevisionState } from './client-feature-toggle-delta.js';
+import type { ClientFeatureSchema } from '../../../openapi/index.js';
+
+export const getReferencedSegmentIds = (
+    features: ClientFeatureSchema[],
+    projects: string[] = ['*'],
+    namePrefix: string = '',
+): Set<number> => {
+    const allProjects =
+        projects.length === 0 || projects.includes(ALL_PROJECTS);
+    const referencedSegmentIds = new Set<number>();
+
+    for (const feature of features) {
+        if (!feature.name.startsWith(namePrefix)) {
+            continue;
+        }
+
+        if (!allProjects && !projects.includes(feature.project ?? '')) {
+            continue;
+        }
+
+        for (const strategy of feature.strategies ?? []) {
+            for (const segmentId of strategy.segments ?? []) {
+                referencedSegmentIds.add(segmentId);
+            }
+        }
+    }
+
+    return referencedSegmentIds;
+};
 
 export const getVisibleRevision = (
     revisionState: EnvironmentVisibleRevisionState | undefined,
-    projects: string[] = ['*'],
+    features: ClientFeatureSchema[] = [],
 ): number => {
     if (!revisionState) {
         return 0;
     }
+    let visibleRevision = 0;
+    for (const revision of revisionState.projectRevisions.values()) {
+        visibleRevision = Math.max(visibleRevision, revision);
+    }
 
-    const projectList =
-        projects.length > 0 && !projects.includes(ALL_PROJECTS)
-            ? projects
-            : Array.from(revisionState.projectRevisions.keys());
-    // assume segment revision as max because segment changes are always visible
-    let visibleRevision = revisionState.globalSegmentRevision ?? 0;
-    for (const project of projectList) {
+    const referencedSegmentIds = getReferencedSegmentIds(features);
+    for (const segmentId of referencedSegmentIds) {
         visibleRevision = Math.max(
             visibleRevision,
-            revisionState.projectRevisions.get(project) ?? 0,
+            revisionState.segmentRevisions.get(segmentId) ?? 0,
         );
     }
 

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -314,11 +314,22 @@ export class EventStore implements IEventStore {
             .modify(applyEnvironmentFilter)
             .groupByRaw(`data->>'oldProject'`);
 
-        const segmentRow: { revisionId?: number | string } | undefined =
-            await this.db(TABLE)
-                .max({ revisionId: 'id' })
-                .where({ type: SEGMENT_UPDATED })
-                .first();
+        const segmentRows: Array<{
+            segmentId?: number | string;
+            revisionId?: number | string;
+        }> = await this.db(TABLE)
+            .select(
+                this.db.raw(
+                    `COALESCE((data->>'id')::int, (pre_data->>'id')::int) as "segmentId"`,
+                ),
+            )
+            .max({ revisionId: 'id' })
+            // Only segment updates can change an already-visible payload on
+            // their own. Segment create/delete are preceded by feature
+            // dereference/reference changes, so visibility should advance via
+            // feature events instead of segment-only revision state.
+            .whereIn('type', [SEGMENT_UPDATED])
+            .groupByRaw(`COALESCE((data->>'id')::int, (pre_data->>'id')::int)`);
 
         stopTimer();
 
@@ -337,9 +348,21 @@ export class EventStore implements IEventStore {
             }
         }
 
+        const segmentRevisions = new Map<number, number>();
+        for (const row of segmentRows) {
+            if (row.segmentId == null) {
+                continue;
+            }
+
+            segmentRevisions.set(
+                Number(row.segmentId),
+                Number(row.revisionId ?? 0),
+            );
+        }
+
         return {
             projectRevisions,
-            globalSegmentRevision: Number(segmentRow?.revisionId ?? 0),
+            segmentRevisions,
         };
     }
 

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -44,7 +44,7 @@ export interface IEventStore
     ): Promise<number>;
     getDeltaRevisionState(environment: string): Promise<{
         projectRevisions: Map<string, number>;
-        globalSegmentRevision: number;
+        segmentRevisions: Map<number, number>;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -6,6 +6,8 @@ import {
     FEATURE_PROJECT_CHANGE,
     FEATURE_TAGGED,
     FEATURE_UPDATED,
+    SEGMENT_CREATED,
+    SEGMENT_DELETED,
     SEGMENT_UPDATED,
     type IEvent,
 } from '../../../lib/events/index.js';
@@ -377,7 +379,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).toBe(defaultStored.id);
         expect(state.projectRevisions.get('other')).toBe(otherStored.id);
-        expect(state.globalSegmentRevision).toBe(segmentStored.id);
+        expect(state.segmentRevisions.get(123)).toBe(segmentStored.id);
     });
 
     test('respects environment filtering and includes null-environment feature events', async () => {
@@ -452,7 +454,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('old-project')).toBe(storedMove.id);
         expect(state.projectRevisions.get('new-project')).toBe(storedMove.id);
-        expect(state.globalSegmentRevision).toBe(0);
+        expect(state.segmentRevisions.size).toBe(0);
     });
 
     test('ignores non-interesting feature events', async () => {
@@ -471,7 +473,42 @@ describe('getDeltaRevisionState', () => {
         const state = await eventStore.getDeltaRevisionState(ALL_ENVS);
 
         expect(state.projectRevisions.size).toBe(0);
-        expect(state.globalSegmentRevision).toBe(0);
+        expect(state.segmentRevisions.size).toBe(0);
+    });
+
+    test('ignores created and deleted segment events when building visible segment revisions', async () => {
+        const segmentCreatedEvent = {
+            type: SEGMENT_CREATED,
+            createdBy: testAudit.username,
+            createdByUserId: testAudit.id,
+            ip: testAudit.ip,
+            data: { id: 321, name: 'segment-a' },
+        };
+
+        const segmentDeletedEvent = {
+            type: SEGMENT_DELETED,
+            createdBy: testAudit.username,
+            createdByUserId: testAudit.id,
+            ip: testAudit.ip,
+            preData: { id: 654, name: 'segment-b' },
+        };
+
+        await eventStore.store(segmentCreatedEvent);
+        await eventStore.store(segmentDeletedEvent);
+
+        const allEvents = await eventStore.getAll();
+        const createdStored = allEvents.find(
+            (e) => e.type === SEGMENT_CREATED,
+        )!;
+        const deletedStored = allEvents.find(
+            (e) => e.type === SEGMENT_DELETED,
+        )!;
+
+        const state = await eventStore.getDeltaRevisionState(ALL_ENVS);
+
+        expect(createdStored).toBeDefined();
+        expect(deletedStored).toBeDefined();
+        expect(state.segmentRevisions.size).toBe(0);
     });
 
     test('returns latest project and segment revisions', async () => {
@@ -516,7 +553,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).not.toBe(firstStored.id);
         expect(state.projectRevisions.get('default')).toBe(secondStored.id);
-        expect(state.globalSegmentRevision).toBe(segmentStored.id);
+        expect(state.segmentRevisions.get(999)).toBe(segmentStored.id);
     });
 });
 

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -34,11 +34,11 @@ class FakeEventStore implements IEventStore {
 
     getDeltaRevisionState(_environment: string): Promise<{
         projectRevisions: Map<string, number>;
-        globalSegmentRevision: number;
+        segmentRevisions: Map<number, number>;
     }> {
         return Promise.resolve({
             projectRevisions: new Map(),
-            globalSegmentRevision: 0,
+            segmentRevisions: new Map(),
         });
     }
 


### PR DESCRIPTION
## Summary
This PR fixes how delta/streaming `revisionId` is calculated for a client environment.

The bug was not in flag evaluation or in the streamed payload itself. The problem was that a long-lived Unleash pod could advance the visible delta `revisionId` for an environment too aggressively, while a fresh pod hydrating from persisted state could show a lower `revisionId` for the same environment.

## Problem
The problematic sequence is:
1. A `SEGMENT_CREATED` or `SEGMENT_DELETED` event happens.
2. Later, a feature change happens in a different environment.
3. A long-lived pod can carry forward an inflated in-memory delta `revisionId` for the original environment even though that environment's visible stream payload did not change.
4. A fresh pod recomputes from persisted state and returns a lower `revisionId`, exposing the inconsistency.

The important point is that this does **not** affect flag evaluation. The visible state can remain unchanged while the delta `revisionId` drifts.

## Final semantics
The visible delta `revisionId` is **per environment**, not per project query.

That means the visible delta `revisionId` for an environment should only advance when the environment-wide visible delta payload changes.

From that, the relevant segment semantics are:
- `SEGMENT_CREATED` should not advance visible delta revision.
- `SEGMENT_DELETED` should not advance visible delta revision.
- `SEGMENT_UPDATED` can advance visible delta revision, but only when the segment is referenced by a visible feature in that environment.
- Feature/strategy changes that add or remove segment references should advance revision through the feature event side, not through segment-only revision state.

## Implementation details
The fix stays in OSS.

### 1. Revision calculation is environment-wide
Revision calculation no longer tries to vary by requested project scope. The code now reflects the actual contract: one visible delta `revisionId` per environment.

### 2. Segment revision state is tracked per segment
Instead of a single `globalSegmentRevision`, we now track per-segment revision state:
- `segmentRevisions: Map<number, number>`

This lets the server keep segment changes in memory without automatically making every segment event visible for the whole environment.

### 3. Only referenced segment updates influence visible revision
Visible revision now considers:
- all environment-visible project revisions
- only segment revisions for segments that are actually referenced by visible features in that environment

### 4. Segment cache maintenance is separate from visible revision advancement
The code now makes this split explicit:
- segment remove events are still used to update the in-memory hydration cache for long-lived pods
- but they do **not** participate in visible revision advancement
- only `segment-updated` is relevant for visible revision tracking

This is intentional and documented in the code, since `segment-removed` serves cache correctness while `segment-updated` is the only segment event type that can change an already-visible payload on its own.

### 5. Hydration/live parity
Hydration and live update behavior now use the same visible-revision semantics, so a fresh pod and a long-lived pod converge on the same visible delta `revisionId` for the same environment state.

### 6. Metric initialization
`delta_environment_revision_id` is now materialized immediately when delta is initialized for an environment, instead of only after a later live update.

## Tests
The added regression coverage verifies:
- unrelated environment changes do not emit no-op deltas for another environment
- `SEGMENT_CREATED` alone does not advance visible revision
- `SEGMENT_CREATED` followed by an unrelated environment change still does not advance visible revision
- `SEGMENT_UPDATED` only matters when the segment is actually referenced by a visible feature
- hydration/live parity between fresh and long-lived pods
- metric materialization on first delta initialization
