### PR TITLE
fix: revision id calculation for segments

### DIFF
--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
@@ -59,3 +59,9 @@ export const isDeltaSegmentEvent = (
         event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED
     );
 };
+
+export const isDeltaSegmentUpdatedEvent = (
+    event: DeltaEvent,
+): event is Extract<DeltaEvent, { type: 'segment-updated' }> => {
+    return event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED;
+};

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-types.ts
@@ -51,15 +51,6 @@ export const isDeltaFeatureRemovedEvent = (
     return event.type === DELTA_EVENT_TYPES.FEATURE_REMOVED;
 };
 
-export const isDeltaSegmentEvent = (
-    event: DeltaEvent,
-): event is Extract<DeltaEvent, { type: 'segment-updated' }> => {
-    return (
-        event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED ||
-        event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED
-    );
-};
-
 export const isDeltaSegmentUpdatedEvent = (
     event: DeltaEvent,
 ): event is Extract<DeltaEvent, { type: 'segment-updated' }> => {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -243,7 +243,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -331,7 +332,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -404,7 +406,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 1,
+                    maxSegmentRevision: 1,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -512,7 +515,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         const eventStore = {
             getDeltaRevisionState: async () => ({
                 projectRevisions: new Map([['default', 7]]),
-                visibleSegmentRevision: 7,
+                maxSegmentRevision: 7,
+                segmentRevisions: new Map(),
             }),
             getRevisionRange: async (from: number, to: number) => {
                 if (from === 7 && to === 14) {
@@ -675,7 +679,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 7]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 7,
             } as any,
@@ -725,7 +730,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                 {
                     getDeltaRevisionState: async () => ({
                         projectRevisions: new Map([['default', 85815]]),
-                        visibleSegmentRevision: 0,
+                        maxSegmentRevision: 0,
+                        segmentRevisions: new Map(),
                     }),
                     getMaxRevisionId: async () => globalRevisionId,
                 } as any,
@@ -773,7 +779,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -818,7 +825,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -879,7 +887,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -970,7 +979,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -1078,7 +1088,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['old-project', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {
@@ -1226,7 +1237,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    visibleSegmentRevision: 0,
+                    maxSegmentRevision: 0,
+                    segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
                     {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -243,7 +243,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
@@ -332,7 +331,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
@@ -406,7 +404,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 1,
                     visibleSegmentRevision: 1,
                 }),
                 getRevisionRange: async () => [
@@ -527,7 +524,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 7]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getMaxRevisionId: async () => 7,
@@ -578,7 +574,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                 {
                     getDeltaRevisionState: async () => ({
                         projectRevisions: new Map([['default', 85815]]),
-                        maxCachedSegmentRevisionChange: 0,
                         visibleSegmentRevision: 0,
                     }),
                     getMaxRevisionId: async () => globalRevisionId,
@@ -627,7 +622,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getMaxRevisionId: async () => 0,
@@ -673,7 +667,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getMaxRevisionId: async () => 0,
@@ -735,7 +728,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
@@ -827,7 +819,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
@@ -936,7 +927,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['old-project', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
@@ -1085,7 +1075,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxCachedSegmentRevisionChange: 0,
                     visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -6,7 +6,10 @@ import {
     filterEventsByQuery,
 } from './client-feature-toggle-delta.js';
 import { DeltaCache } from './delta-cache.js';
-import { FEATURE_PROJECT_CHANGE } from '../../../events/index.js';
+import {
+    FEATURE_PROJECT_CHANGE,
+    SEGMENT_DELETED,
+} from '../../../events/index.js';
 
 const createLogger = () =>
     ({
@@ -504,6 +507,99 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                     eventId: 2,
                     type: 'segment-updated',
                     segment: { id: 101, name: 'segment-a', constraints: [] },
+                },
+            ],
+        });
+    });
+
+    test('segment-removed is delivered with the feature update that dereferences it', async () => {
+        let currentRevisionId = 1;
+        let featureReferencesSegment = true;
+
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies: [
+                            featureReferencesSegment
+                                ? { name: 'default', segments: [101] }
+                                : { name: 'default' },
+                        ],
+                    },
+                ],
+            } as any,
+            {
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids === undefined || ids.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    maxReferencedSegmentRevision: 1,
+                    segmentRevisions: new Map([[101, 1]]),
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'feature-updated',
+                        featureName: 'first',
+                        project: 'default',
+                        environment: 'development',
+                        createdAt: new Date(),
+                    },
+                    {
+                        id: 3,
+                        type: SEGMENT_DELETED,
+                        preData: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await delta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        featureReferencesSegment = false;
+        currentRevisionId = 3;
+        await delta.onUpdateRevisionEvent();
+
+        const result = await delta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(result).toEqual({
+            events: [
+                {
+                    eventId: 2,
+                    type: 'feature-updated',
+                    feature: {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies: [{ name: 'default' }],
+                    },
+                },
+                {
+                    eventId: 3,
+                    type: 'segment-removed',
+                    segmentId: 101,
                 },
             ],
         });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -1,11 +1,25 @@
 import type { DeltaEvent } from './client-feature-toggle-delta-types.js';
 import { EventEmitter } from 'events';
+import { register } from 'prom-client';
 import {
     ClientFeatureToggleDelta,
     filterEventsByQuery,
 } from './client-feature-toggle-delta.js';
 import { DeltaCache } from './delta-cache.js';
 import { FEATURE_PROJECT_CHANGE } from '../../../events/index.js';
+
+const createLogger = () =>
+    ({
+        error: () => undefined,
+        info: () => undefined,
+        warn: () => undefined,
+    }) as any;
+
+const createDeltaConfig = () =>
+    ({
+        eventBus: new EventEmitter(),
+        getLogger: () => createLogger(),
+    }) as any;
 
 describe('filterEventsByQuery', () => {
     const mockEvents: DeltaEvent[] = [
@@ -47,6 +61,7 @@ describe('filterEventsByQuery', () => {
             requiredRevisionId,
             ['project3'],
             '',
+            new Set([1, 2]),
         );
         expect(result).toEqual([
             {
@@ -65,7 +80,13 @@ describe('filterEventsByQuery', () => {
     });
 
     test('returns all projects', () => {
-        const result = filterEventsByQuery(mockEvents, 0, ['*'], '');
+        const result = filterEventsByQuery(
+            mockEvents,
+            0,
+            ['*'],
+            '',
+            new Set([1]),
+        );
         expect(result).toEqual(mockEvents);
     });
 
@@ -75,6 +96,7 @@ describe('filterEventsByQuery', () => {
             0,
             ['project1', 'project2'],
             'alpha',
+            new Set([1, 2]),
         );
         expect(result).toEqual([
             {
@@ -96,7 +118,14 @@ describe('filterEventsByQuery', () => {
     });
 
     test('filters by project list', () => {
-        const result = filterEventsByQuery(mockEvents, 0, ['project3'], 'beta');
+        const referencedSegmentIds = new Set([1, 2]);
+        const result = filterEventsByQuery(
+            mockEvents,
+            0,
+            ['project3'],
+            'beta',
+            referencedSegmentIds,
+        );
         expect(result).toEqual([
             {
                 eventId: 3,
@@ -109,6 +138,7 @@ describe('filterEventsByQuery', () => {
                 type: 'segment-updated',
                 segment: { id: 1, name: 'my-segment', constraints: [] },
             },
+            // we propagate segment removed. Once dereferenced removing them should save memory
             { eventId: 5, type: 'segment-removed', segmentId: 2 },
         ]);
     });
@@ -174,6 +204,355 @@ describe('DeltaCache hydration ordering', () => {
 });
 
 describe('ClientFeatureToggleDelta bootstrap behavior', () => {
+    test('segment-created alone does not advance visible revision for an environment where it is unused', async () => {
+        let currentRevisionId = 1;
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
+                    const developmentFeature = {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    };
+
+                    if (environment !== 'development') {
+                        return [];
+                    }
+
+                    if (toggleNames.length === 0) {
+                        return [developmentFeature];
+                    }
+
+                    return toggleNames.includes('first')
+                        ? [developmentFeature]
+                        : [];
+                },
+            } as any,
+            {
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-created',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        const baseline = await delta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await delta.onUpdateRevisionEvent();
+
+        const result = await delta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(baseline?.events[0]?.eventId).toBe(1);
+        expect(result).toBeUndefined();
+    });
+
+    test('segment-created followed by unrelated environment change does not advance visible revision and hydration stays in parity', async () => {
+        const currentRevisionId = 1;
+        const createReadModel = () =>
+            ({
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
+                    const featureByEnvironment = {
+                        development: {
+                            name: 'first',
+                            project: 'default',
+                            enabled: false,
+                        },
+                        production: {
+                            name: 'first',
+                            project: 'default',
+                            enabled: true,
+                        },
+                    };
+                    const feature =
+                        featureByEnvironment[
+                            environment as keyof typeof featureByEnvironment
+                        ];
+
+                    if (!feature) {
+                        return [];
+                    }
+
+                    if (toggleNames.length === 0) {
+                        return [feature];
+                    }
+
+                    return toggleNames.includes('first') ? [feature] : [];
+                },
+            }) as any;
+        const createSegmentModel = () =>
+            ({
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            }) as any;
+        const createEventStore = () =>
+            ({
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-created',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                    {
+                        id: 3,
+                        type: 'feature-updated',
+                        featureName: 'first',
+                        project: 'default',
+                        environment: 'production',
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            }) as any;
+
+        const liveDelta = new ClientFeatureToggleDelta(
+            createReadModel(),
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        const initialHydration = await liveDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(initialHydration?.events[0]?.eventId).toBe(1);
+
+        await liveDelta.onUpdateRevisionEvent();
+
+        const liveResult = await liveDelta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(liveResult).toBeUndefined();
+
+        const freshDelta = new ClientFeatureToggleDelta(
+            createReadModel(),
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {} as any,
+            createDeltaConfig(),
+        );
+
+        const freshHydration = await freshDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(freshHydration?.events[0]?.eventId).toBe(1);
+    });
+
+    test('segment-updated only advances visible revision when the segment is referenced by a visible feature', async () => {
+        let currentRevisionId = 1;
+
+        const createEventStore = () =>
+            ({
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 1]]),
+                    maxCachedSegmentRevisionChange: 1,
+                    visibleSegmentRevision: 1,
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 2,
+                        type: 'segment-updated',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            }) as any;
+
+        const createSegmentModel = () =>
+            ({
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids?.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            }) as any;
+
+        const unreferencedSegment = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    },
+                ],
+            } as any,
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await unreferencedSegment.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await unreferencedSegment.onUpdateRevisionEvent();
+
+        const unusedResult = await unreferencedSegment.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(unusedResult).toBeUndefined();
+
+        const usedDelta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies: [{ name: 'default', segments: [101] }],
+                    },
+                ],
+            } as any,
+            createSegmentModel(),
+            createEventStore(),
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await usedDelta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 2;
+        await usedDelta.onUpdateRevisionEvent();
+
+        const usedResult = await usedDelta.getDelta(1, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(usedResult).toEqual({
+            events: [
+                {
+                    eventId: 2,
+                    type: 'segment-updated',
+                    segment: { id: 101, name: 'segment-a', constraints: [] },
+                },
+            ],
+        });
+    });
+
+    test('materializes delta_environment_revision_id on first hydration request', async () => {
+        const environment = 'metric-materialization-test';
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async () => [
+                    {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                    },
+                ],
+            } as any,
+            {
+                getAllForClientIds: async () => [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 7]]),
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
+                }),
+                getMaxRevisionId: async () => 7,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {} as any,
+            createDeltaConfig(),
+        );
+
+        const result = await delta.getDelta(undefined, {
+            environment,
+            project: ['default'],
+        } as any);
+        const metrics = await register.metrics();
+
+        expect(result?.events[0]?.eventId).toBe(7);
+        expect(metrics).toMatch(
+            new RegExp(
+                `delta_environment_revision_id\\{environment="${environment}"\\} 7`,
+            ),
+        );
+    });
+
     test('returns the same wildcard hydration revision for identical environment state across pods', async () => {
         const createDelta = (globalRevisionId: number) =>
             new ClientFeatureToggleDelta(
@@ -199,7 +578,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                 {
                     getDeltaRevisionState: async () => ({
                         projectRevisions: new Map([['default', 85815]]),
-                        globalSegmentRevision: 0,
+                        maxCachedSegmentRevisionChange: 0,
+                        visibleSegmentRevision: 0,
                     }),
                     getMaxRevisionId: async () => globalRevisionId,
                 } as any,
@@ -247,7 +627,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -292,7 +673,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getMaxRevisionId: async () => 0,
             } as any,
@@ -321,7 +703,13 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         let currentRevisionId = 1;
         const delta = new ClientFeatureToggleDelta(
             {
-                getAll: async ({ environment, toggleNames = [] }) => {
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
                     const developmentFeature = {
                         name: 'first',
                         project: 'default',
@@ -336,7 +724,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                         return [developmentFeature];
                     }
 
-                    // @ts-expect-error - toggle name not defined
                     return toggleNames.includes('first')
                         ? [developmentFeature]
                         : [];
@@ -348,7 +735,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
                     {
@@ -397,7 +785,13 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         let currentRevisionId = 1;
         const delta = new ClientFeatureToggleDelta(
             {
-                getAll: async ({ environment, toggleNames = [] }) => {
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
                     const featuresByEnvironment = {
                         development: {
                             name: 'first',
@@ -424,7 +818,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                         return [feature];
                     }
 
-                    // @ts-expect-error - toggle name not defined
                     return toggleNames.includes('first') ? [feature] : [];
                 },
             } as any,
@@ -434,7 +827,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
                     {
@@ -516,7 +910,13 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         let currentRevisionId = 1;
         const delta = new ClientFeatureToggleDelta(
             {
-                getAll: async ({ environment, toggleNames = [] }) => {
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
                     const feature = {
                         name: 'moved-feature',
                         project: 'new-project',
@@ -525,7 +925,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
 
                     if (environment !== 'development') return [];
                     if (toggleNames.length === 0) return [feature];
-                    // @ts-expect-error - toggle name not defined
                     return toggleNames.includes('moved-feature')
                         ? [feature]
                         : [];
@@ -537,7 +936,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['old-project', 1]]),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
                     {
@@ -643,7 +1043,13 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         let currentRevisionId = 1;
         const delta = new ClientFeatureToggleDelta(
             {
-                getAll: async ({ environment, toggleNames = [] }) => {
+                getAll: async ({
+                    environment,
+                    toggleNames = [],
+                }: {
+                    environment: string;
+                    toggleNames?: string[];
+                }) => {
                     const featuresByEnvironment = {
                         development: {
                             name: 'first',
@@ -670,7 +1076,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                         return [feature];
                     }
 
-                    // @ts-expect-error - toggle name not defined
                     return toggleNames.includes('first') ? [feature] : [];
                 },
             } as any,
@@ -680,7 +1085,8 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    globalSegmentRevision: 0,
+                    maxCachedSegmentRevisionChange: 0,
+                    visibleSegmentRevision: 0,
                 }),
                 getRevisionRange: async () => [
                     {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -740,6 +740,11 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             events: [
                 {
                     eventId: 15,
+                    type: 'segment-updated',
+                    segment: { id: 1, name: 'segment-a', constraints: [] },
+                },
+                {
+                    eventId: 15,
                     type: 'feature-updated',
                     feature: {
                         name: 'test-flag',
@@ -747,11 +752,6 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                         enabled: true,
                         strategies: [{ name: 'default', segments: [1] }],
                     },
-                },
-                {
-                    eventId: 15,
-                    type: 'segment-updated',
-                    segment: { id: 1, name: 'segment-a', constraints: [] },
                 },
             ],
         });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -243,7 +243,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -332,7 +332,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -406,7 +406,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ({
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 1,
+                    maxReferencedSegmentRevision: 1,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -515,7 +515,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         const eventStore = {
             getDeltaRevisionState: async () => ({
                 projectRevisions: new Map([['default', 7]]),
-                maxSegmentRevision: 7,
+                maxReferencedSegmentRevision: 7,
                 segmentRevisions: new Map(),
             }),
             getRevisionRange: async (from: number, to: number) => {
@@ -679,7 +679,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 7]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 7,
@@ -730,7 +730,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
                 {
                     getDeltaRevisionState: async () => ({
                         projectRevisions: new Map([['default', 85815]]),
-                        maxSegmentRevision: 0,
+                        maxReferencedSegmentRevision: 0,
                         segmentRevisions: new Map(),
                     }),
                     getMaxRevisionId: async () => globalRevisionId,
@@ -779,7 +779,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
@@ -825,7 +825,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map(),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getMaxRevisionId: async () => 0,
@@ -887,7 +887,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -979,7 +979,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -1088,7 +1088,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['old-project', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [
@@ -1237,7 +1237,7 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             {
                 getDeltaRevisionState: async () => ({
                     projectRevisions: new Map([['default', 1]]),
-                    maxSegmentRevision: 0,
+                    maxReferencedSegmentRevision: 0,
                     segmentRevisions: new Map(),
                 }),
                 getRevisionRange: async () => [

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -506,6 +506,157 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
         });
     });
 
+    test('returns segment payload when a feature newly references a previously hidden segment update', async () => {
+        let currentRevisionId = 7;
+
+        const eventStore = {
+            getDeltaRevisionState: async () => ({
+                projectRevisions: new Map([['default', 7]]),
+                visibleSegmentRevision: 7,
+            }),
+            getRevisionRange: async (from: number, to: number) => {
+                if (from === 7 && to === 14) {
+                    return [
+                        {
+                            id: 12,
+                            type: 'segment-updated',
+                            data: { id: 1, name: 'segment-a' },
+                            createdAt: new Date(),
+                        },
+                        {
+                            id: 14,
+                            type: 'feature-updated',
+                            featureName: 'test-flag',
+                            project: 'default',
+                            environment: 'development',
+                            data: { name: 'test-flag', enabled: true },
+                            createdAt: new Date(),
+                        },
+                    ];
+                }
+
+                return [
+                    {
+                        id: 15,
+                        type: 'feature-updated',
+                        featureName: 'test-flag',
+                        project: 'default',
+                        environment: 'development',
+                        data: { name: 'test-flag', enabled: true },
+                        createdAt: new Date(),
+                    },
+                ];
+            },
+            getMaxRevisionId: async () => currentRevisionId,
+        } as any;
+
+        const readModel = {
+            getAll: async ({
+                toggleNames = [],
+            }: {
+                toggleNames?: string[];
+            }) => {
+                if (
+                    toggleNames.includes('test-flag') &&
+                    currentRevisionId >= 15
+                ) {
+                    return [
+                        {
+                            name: 'test-flag',
+                            project: 'default',
+                            enabled: true,
+                            strategies: [{ name: 'default', segments: [1] }],
+                        },
+                    ];
+                }
+
+                return [
+                    {
+                        name: 'test-flag',
+                        project: 'default',
+                        enabled: true,
+                        strategies: [{ name: 'default' }],
+                    },
+                ];
+            },
+        } as any;
+
+        const segmentReadModel = {
+            getAllForClientIds: async (ids?: number[]) =>
+                ids?.includes(1)
+                    ? [{ id: 1, name: 'segment-a', constraints: [] }]
+                    : [],
+        } as any;
+
+        const delta = new ClientFeatureToggleDelta(
+            readModel,
+            segmentReadModel,
+            eventStore,
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        const hydration = await delta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(hydration?.events[0]?.eventId).toBe(7);
+
+        currentRevisionId = 14;
+        await delta.onUpdateRevisionEvent();
+
+        const unrelatedUpdate = await delta.getDelta(7, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(unrelatedUpdate).toEqual({
+            events: [
+                {
+                    eventId: 14,
+                    type: 'feature-updated',
+                    feature: {
+                        name: 'test-flag',
+                        project: 'default',
+                        enabled: true,
+                        strategies: [{ name: 'default' }],
+                    },
+                },
+            ],
+        });
+
+        currentRevisionId = 15;
+        await delta.onUpdateRevisionEvent();
+
+        const newlyReferencedSegment = await delta.getDelta(14, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+        expect(newlyReferencedSegment).toEqual({
+            events: [
+                {
+                    eventId: 15,
+                    type: 'feature-updated',
+                    feature: {
+                        name: 'test-flag',
+                        project: 'default',
+                        enabled: true,
+                        strategies: [{ name: 'default', segments: [1] }],
+                    },
+                },
+                {
+                    eventId: 15,
+                    type: 'segment-updated',
+                    segment: { id: 1, name: 'segment-a', constraints: [] },
+                },
+            ],
+        });
+    });
+
     test('materializes delta_environment_revision_id on first hydration request', async () => {
         const environment = 'metric-materialization-test';
         const delta = new ClientFeatureToggleDelta(

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.test.ts
@@ -1411,4 +1411,105 @@ describe('ClientFeatureToggleDelta bootstrap behavior', () => {
             ],
         });
     });
+
+    test('returns delta events in revision order even when cached by event type', async () => {
+        let currentRevisionId = 24;
+
+        const delta = new ClientFeatureToggleDelta(
+            {
+                getAll: async ({
+                    toggleNames = [],
+                }: {
+                    toggleNames?: string[];
+                }) => {
+                    const feature = {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies:
+                            currentRevisionId >= 26
+                                ? [{ name: 'default', segments: [101] }]
+                                : [],
+                    };
+
+                    if (toggleNames.length === 0) {
+                        return [feature];
+                    }
+
+                    return toggleNames.includes('first') ? [feature] : [];
+                },
+            } as any,
+            {
+                getAllForClientIds: async (ids?: number[]) =>
+                    ids === undefined || ids.includes(101)
+                        ? [{ id: 101, name: 'segment-a', constraints: [] }]
+                        : [],
+            } as any,
+            {
+                getDeltaRevisionState: async () => ({
+                    projectRevisions: new Map([['default', 24]]),
+                    maxReferencedSegmentRevision: 0,
+                    segmentRevisions: new Map(),
+                }),
+                getRevisionRange: async () => [
+                    {
+                        id: 25,
+                        type: 'segment-created',
+                        data: { id: 101, name: 'segment-a' },
+                        createdAt: new Date(),
+                    },
+                    {
+                        id: 26,
+                        type: 'feature-updated',
+                        featureName: 'first',
+                        project: 'default',
+                        environment: 'development',
+                        createdAt: new Date(),
+                    },
+                ],
+                getMaxRevisionId: async () => currentRevisionId,
+            } as any,
+            {
+                on: () => undefined,
+            } as any,
+            {
+                isEnabled: (name: string) => name === 'deltaApi',
+            } as any,
+            createDeltaConfig(),
+        );
+
+        await delta.getDelta(undefined, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        currentRevisionId = 26;
+        await delta.onUpdateRevisionEvent();
+
+        const result = await delta.getDelta(24, {
+            environment: 'development',
+            project: ['default'],
+        } as any);
+
+        expect(result?.events.map((event) => event.eventId)).toEqual([25, 26]);
+        expect(result).toEqual({
+            events: [
+                {
+                    eventId: 25,
+                    type: 'segment-updated',
+                    segment: { id: 101, name: 'segment-a', constraints: [] },
+                },
+                {
+                    eventId: 26,
+                    type: 'feature-updated',
+                    feature: {
+                        name: 'first',
+                        project: 'default',
+                        enabled: false,
+                        strategies: [{ name: 'default', segments: [101] }],
+                    },
+                },
+            ],
+        });
+    });
 });

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -588,7 +588,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                     const segmentId = event.segment.id;
                     if (!segmentId) {
                         this.logger.warn(
-                            `Ignoring segment event ${event.type} without a segment id. EventId=${event.id}`,
+                            `Ignoring segment event ${event.type} without a segment id. EventId=${event.eventId}`,
                         );
                         continue;
                     }

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -268,7 +268,11 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             !hasRequestedRevision ||
             delta.isMissingRevision(requestedRevisionId)
         ) {
-            filteredHydrationEvent.eventId = visibleRevision;
+            const returnedHydrationEventId =
+                visibleRevision === 0
+                    ? hydrationEvent.eventId
+                    : visibleRevision;
+            filteredHydrationEvent.eventId = returnedHydrationEventId;
             this.logger.info(
                 `[revision] Fresh delta hydration for environment=${environment} projects=${projects.join(',')} visibleRevision=${visibleRevision} hydrationEventId=${hydrationEvent.eventId} returnedHydrationEventId=${filteredHydrationEvent.eventId}`,
             );

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -45,7 +45,7 @@ export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
     segmentRevisions: Map<number, number>;
-    maxSegmentRevision: number;
+    maxReferencedSegmentRevision: number;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -573,7 +573,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
-            maxSegmentRevision: 0,
+            maxReferencedSegmentRevision: 0,
             segmentRevisions: new Map<number, number>(),
         };
 
@@ -593,8 +593,8 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                     );
                     // only consider visible, updated segments that are referenced
                     if (referencedSegmentIds.has(event.segment.id)) {
-                        revisionState.maxSegmentRevision = Math.max(
-                            revisionState.maxSegmentRevision,
+                        revisionState.maxReferencedSegmentRevision = Math.max(
+                            revisionState.maxReferencedSegmentRevision,
                             event.eventId,
                         );
                     }
@@ -603,7 +603,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         }
 
         // assume segment revision id as max feature event
-        let environmentMax = revisionState.maxSegmentRevision;
+        let environmentMax = revisionState.maxReferencedSegmentRevision;
         for (const event of featureEvents) {
             let project: string | undefined;
             if (event.type === DELTA_EVENT_TYPES.FEATURE_UPDATED) {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -553,8 +553,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         // base segments still has to represent all the known state for segments,
         // otherwise we might miss changes to segments that are not referenced by any feature
         // in the hydration event but are updated/removed in the delta events.
-        // Note: because updated segments comes with all the segment's data,
-        // we could in theory get away with only including referenced segments in the hydration event
         const baseSegments = await this.segmentReadModel.getAllForClientIds();
 
         const maxRevision = getVisibleRevision(revisionState);

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -155,6 +155,23 @@ const materializeReferencedSegments = (
     return materializedEvents;
 };
 
+const getQueryVisibility = (
+    hydrationEvent: DeltaHydrationEvent,
+    projects: string[],
+    namePrefix: string,
+) => {
+    const visibleFeatures = filterHydrationEventByQuery(
+        hydrationEvent,
+        projects,
+        namePrefix,
+    ).features;
+
+    return {
+        visibleFeatures,
+        referencedSegmentIds: getReferencedSegmentIds(visibleFeatures),
+    };
+};
+
 const deltaRevisionIdMetric = createGauge({
     name: 'delta_environment_revision_id',
     help: 'Current delta revision id for environment',
@@ -294,9 +311,8 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         } else {
             const environmentEvents = delta.getEvents();
             const hydrationEvent = delta.getHydrationEvent();
-            // only consider segments that are referenced by the features in hydration event
-            const referencedSegmentIds = getReferencedSegmentIds(
-                hydrationEvent.features,
+            const { referencedSegmentIds } = getQueryVisibility(
+                hydrationEvent,
                 projects,
                 namePrefix,
             );
@@ -601,8 +617,13 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         namePrefix: string = '',
     ): number {
         const revisionState = this.visibleRevisions[environment];
-        const referencedSegmentIds = getReferencedSegmentIds(
-            this.delta[environment]?.getHydrationEvent().features ?? [],
+        const { referencedSegmentIds } = getQueryVisibility(
+            this.delta[environment]?.getHydrationEvent() ?? {
+                eventId: 0,
+                type: DELTA_EVENT_TYPES.HYDRATION,
+                features: [],
+                segments: [],
+            },
             projects,
             namePrefix,
         );

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -25,6 +25,7 @@ import {
     isDeltaFeatureUpdatedEvent,
     isDeltaSegmentUpdatedEvent,
 } from './client-feature-toggle-delta-types.js';
+import type { ClientFeatureSchema } from '../../../openapi/spec/client-feature-schema.js';
 import {
     FEATURE_ARCHIVED,
     FEATURE_DELETED,
@@ -108,6 +109,88 @@ export const filterHydrationEventByQuery = (
             );
         }),
     };
+};
+
+const getFeatureStateAtRevision = (
+    featureName: string,
+    requestedRevisionId: number,
+    environmentEvents: DeltaEvent[],
+): ClientFeatureSchema | undefined => {
+    const latestFeatureEvent = environmentEvents
+        .filter(
+            (event) =>
+                event.eventId <= requestedRevisionId &&
+                ((isDeltaFeatureUpdatedEvent(event) &&
+                    event.feature.name === featureName) ||
+                    (isDeltaFeatureRemovedEvent(event) &&
+                        event.featureName === featureName)),
+        )
+        .sort((a, b) => b.eventId - a.eventId)[0];
+
+    if (!latestFeatureEvent) {
+        return undefined;
+    }
+
+    if (!isDeltaFeatureUpdatedEvent(latestFeatureEvent)) {
+        return undefined;
+    }
+
+    return latestFeatureEvent.feature;
+};
+
+const materializeReferencedSegments = (
+    events: DeltaEvent[],
+    requestedRevisionId: number,
+    hydrationEvent: DeltaHydrationEvent,
+    environmentEvents: DeltaEvent[],
+): DeltaEvent[] => {
+    const emittedSegmentIds = new Set(
+        events
+            .filter(isDeltaSegmentUpdatedEvent)
+            .map((event) => event.segment.id),
+    );
+    const syntheticSegmentEvents: DeltaEvent[] = [];
+
+    for (const event of events) {
+        if (!isDeltaFeatureUpdatedEvent(event)) {
+            continue;
+        }
+
+        const previousFeature = getFeatureStateAtRevision(
+            event.feature.name,
+            requestedRevisionId,
+            environmentEvents,
+        );
+        const previousSegments = getReferencedSegmentIds(
+            previousFeature ? [previousFeature] : [],
+        );
+        const currentSegments = getReferencedSegmentIds([event.feature]);
+
+        for (const segmentId of currentSegments) {
+            if (
+                previousSegments.has(segmentId) ||
+                emittedSegmentIds.has(segmentId)
+            ) {
+                continue;
+            }
+
+            const segment = hydrationEvent.segments.find(
+                (s) => s.id === segmentId,
+            );
+            if (!segment) {
+                continue;
+            }
+
+            syntheticSegmentEvents.push({
+                eventId: event.eventId,
+                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
+                segment,
+            });
+            emittedSegmentIds.add(segmentId);
+        }
+    }
+
+    return syntheticSegmentEvents;
 };
 
 const deltaRevisionIdMetric = createGauge({
@@ -243,9 +326,10 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             return Promise.resolve(response);
         } else {
             const environmentEvents = delta.getEvents();
+            const hydrationEvent = delta.getHydrationEvent();
             // only consider segments that are referenced by the features in hydration event
             const referencedSegmentIds = getReferencedSegmentIds(
-                delta.getHydrationEvent().features,
+                hydrationEvent.features,
                 projects,
                 namePrefix,
             );
@@ -256,13 +340,19 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 namePrefix,
                 referencedSegmentIds,
             );
+            const segmentEvents = materializeReferencedSegments(
+                events,
+                requestedRevisionId,
+                hydrationEvent,
+                environmentEvents,
+            );
 
-            if (events.length === 0) {
+            if (events.length === 0 && segmentEvents.length === 0) {
                 return undefined;
             }
 
             return {
-                events,
+                events: [...events, ...segmentEvents],
             };
         }
     }

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -40,7 +40,6 @@ import {
 } from './visible-revision.js';
 import { createGauge } from '../../../util/metrics/index.js';
 import { BadDataError } from '../../../server-impl.js';
-import { ref } from 'process';
 
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
@@ -143,23 +142,6 @@ const materializeReferencedSegments = (
 
         return [event, ...syntheticNewSegmentEvents];
     });
-};
-
-const getQueryVisibility = (
-    hydrationEvent: DeltaHydrationEvent,
-    projects: string[],
-    namePrefix: string,
-) => {
-    const visibleFeatures = filterHydrationEventByQuery(
-        hydrationEvent,
-        projects,
-        namePrefix,
-    ).features;
-
-    return {
-        visibleFeatures,
-        referencedSegmentIds: getReferencedSegmentIds(visibleFeatures),
-    };
 };
 
 const deltaRevisionIdMetric = createGauge({
@@ -301,11 +283,13 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         } else {
             const environmentEvents = delta.getEvents();
             const hydrationEvent = delta.getHydrationEvent();
-            const { referencedSegmentIds } = getQueryVisibility(
+            const visibleFeatures = filterHydrationEventByQuery(
                 hydrationEvent,
                 projects,
                 namePrefix,
-            );
+            ).features;
+            const referencedSegmentIds =
+                getReferencedSegmentIds(visibleFeatures);
             const filteredEvents = filterEventsByQuery(
                 environmentEvents,
                 requestedRevisionId,
@@ -604,16 +588,18 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         namePrefix: string = '',
     ): number {
         const revisionState = this.visibleRevisions[environment];
-        const { referencedSegmentIds } = getQueryVisibility(
-            this.delta[environment]?.getHydrationEvent() ?? {
-                eventId: 0,
-                type: DELTA_EVENT_TYPES.HYDRATION,
-                features: [],
-                segments: [],
-            },
+        const hydrationEvent = this.delta[environment]?.getHydrationEvent() ?? {
+            eventId: 0,
+            type: DELTA_EVENT_TYPES.HYDRATION,
+            features: [],
+            segments: [],
+        };
+        const visibleFeatures = filterHydrationEventByQuery(
+            hydrationEvent,
             projects,
             namePrefix,
-        );
+        ).features;
+        const referencedSegmentIds = getReferencedSegmentIds(visibleFeatures);
 
         return getVisibleRevision(
             revisionState,

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -111,6 +111,10 @@ export const filterHydrationEventByQuery = (
     };
 };
 
+const sortEventsByRevision = (events: DeltaEvent[]): DeltaEvent[] => {
+    return [...events].sort((first, second) => first.eventId - second.eventId);
+};
+
 const materializeReferencedSegments = (
     events: DeltaEvent[],
     hydrationEvent: DeltaHydrationEvent,
@@ -288,7 +292,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 referencedSegmentIds,
             );
             const events = materializeReferencedSegments(
-                filteredEvents,
+                sortEventsByRevision(filteredEvents),
                 hydrationEvent,
             );
 

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -23,7 +23,7 @@ import {
     type DeltaHydrationEvent,
     isDeltaFeatureRemovedEvent,
     isDeltaFeatureUpdatedEvent,
-    isDeltaSegmentEvent,
+    isDeltaSegmentUpdatedEvent,
 } from './client-feature-toggle-delta-types.js';
 import {
     FEATURE_ARCHIVED,
@@ -34,14 +34,18 @@ import {
     SEGMENT_UPDATED,
     type IEvent,
 } from '../../../events/index.js';
-import { getVisibleRevision } from './visible-revision.js';
+import {
+    getReferencedSegmentIds,
+    getVisibleRevision,
+} from './visible-revision.js';
 import { createGauge } from '../../../util/metrics/index.js';
 import { BadDataError } from '../../../server-impl.js';
 
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
-    globalSegmentRevision: number;
+    visibleSegmentRevision: number;
+    maxCachedSegmentRevisionChange: number;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -51,6 +55,7 @@ export const filterEventsByQuery = (
     requestedRevisionId: number,
     projects: string[],
     namePrefix: string,
+    referencedSegmentIds: Set<number>,
 ) => {
     const targetedEvents = events.filter(
         (revision) => revision.eventId > requestedRevisionId,
@@ -76,7 +81,9 @@ export const filterEventsByQuery = (
 
     return targetedEvents.filter((revision) => {
         return (
-            isDeltaSegmentEvent(revision) ||
+            revision.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED ||
+            (isDeltaSegmentUpdatedEvent(revision) &&
+                referencedSegmentIds.has(revision.segment.id)) ||
             (startsWithPrefix(revision) &&
                 (allProjects || isInProject(revision)))
         );
@@ -220,11 +227,11 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 projects,
                 namePrefix,
             );
-            const effectiveEventId =
-                visibleRevision === 0
-                    ? hydrationEvent.eventId
-                    : visibleRevision;
 
+            const effectiveEventId = this.getVisibleRevision(
+                environment,
+                projects,
+            );
             filteredEvent.eventId = effectiveEventId;
             this.logger.info(
                 `[revision] Fresh delta hydration for environment=${environment} projects=${projects.join(',')} visibleRevision=${visibleRevision} hydrationEventId=${hydrationEvent.eventId} returnedHydrationEventId=${filteredEvent.eventId}`,
@@ -237,11 +244,18 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             return Promise.resolve(response);
         } else {
             const environmentEvents = delta.getEvents();
+            // only consider segments that are referenced by the features in hydration event
+            const referencedSegmentIds = getReferencedSegmentIds(
+                delta.getHydrationEvent().features,
+                projects,
+                namePrefix,
+            );
             const events = filterEventsByQuery(
                 environmentEvents,
                 requestedRevisionId,
                 projects,
                 namePrefix,
+                referencedSegmentIds,
             );
 
             if (events.length === 0) {
@@ -474,6 +488,9 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 environment,
                 [...featuresRemovedEvents, ...featuresUpdatedEvents],
                 [...segmentsUpdatedEvents, ...segmentsRemovedEvents],
+                getReferencedSegmentIds(
+                    this.delta[environment].getHydrationEvent().features,
+                ),
             );
         }
         this.lastDeltaProcessedRevisionId = eventsTo;
@@ -509,6 +526,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         });
         this.lastDeltaProcessedRevisionId = maxRevision;
         this.visibleRevisions[environment] = revisionState;
+        deltaRevisionIdMetric.labels({ environment }).set(maxRevision);
         this.storeFootprint();
     }
 
@@ -524,23 +542,36 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         environment: string,
         featureEvents: DeltaEvent[],
         segmentEvents: DeltaEvent[],
+        referencedSegmentIds: Set<number>,
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
-            globalSegmentRevision: 0,
+            maxCachedSegmentRevisionChange: 0,
+            visibleSegmentRevision: 0,
         };
 
         if (segmentEvents.length > 0) {
             for (const event of segmentEvents) {
-                revisionState.globalSegmentRevision = Math.max(
-                    revisionState.globalSegmentRevision,
+                revisionState.maxCachedSegmentRevisionChange = Math.max(
+                    revisionState.maxCachedSegmentRevisionChange,
                     event.eventId,
                 );
+                // only consider visible, updated segments that are referenced
+                if (
+                    event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&
+                    event.segment.id &&
+                    referencedSegmentIds.has(event.segment.id)
+                ) {
+                    revisionState.visibleSegmentRevision = Math.max(
+                        revisionState.visibleSegmentRevision,
+                        event.eventId,
+                    );
+                }
             }
         }
 
         // assume segment revision id as max feature event
-        let environmentMax = revisionState.globalSegmentRevision;
+        let environmentMax = revisionState.visibleSegmentRevision;
         for (const event of featureEvents) {
             let project: string | undefined;
             if (event.type === DELTA_EVENT_TYPES.FEATURE_UPDATED) {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -25,7 +25,6 @@ import {
     isDeltaFeatureUpdatedEvent,
     isDeltaSegmentUpdatedEvent,
 } from './client-feature-toggle-delta-types.js';
-import type { ClientFeatureSchema } from '../../../openapi/spec/client-feature-schema.js';
 import {
     FEATURE_ARCHIVED,
     FEATURE_DELETED,
@@ -46,6 +45,7 @@ export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
     visibleSegmentRevision: number;
+    segmentRevisions?: Map<number, number>;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -111,66 +111,28 @@ export const filterHydrationEventByQuery = (
     };
 };
 
-const getFeatureStateAtRevision = (
-    featureName: string,
-    requestedRevisionId: number,
-    environmentEvents: DeltaEvent[],
-): ClientFeatureSchema | undefined => {
-    const latestFeatureEvent = environmentEvents
-        .filter(
-            (event) =>
-                event.eventId <= requestedRevisionId &&
-                ((isDeltaFeatureUpdatedEvent(event) &&
-                    event.feature.name === featureName) ||
-                    (isDeltaFeatureRemovedEvent(event) &&
-                        event.featureName === featureName)),
-        )
-        .sort((a, b) => b.eventId - a.eventId)[0];
-
-    if (!latestFeatureEvent) {
-        return undefined;
-    }
-
-    if (!isDeltaFeatureUpdatedEvent(latestFeatureEvent)) {
-        return undefined;
-    }
-
-    return latestFeatureEvent.feature;
-};
-
 const materializeReferencedSegments = (
     events: DeltaEvent[],
-    requestedRevisionId: number,
     hydrationEvent: DeltaHydrationEvent,
-    environmentEvents: DeltaEvent[],
 ): DeltaEvent[] => {
+    const materializedEvents: DeltaEvent[] = [];
     const emittedSegmentIds = new Set(
         events
             .filter(isDeltaSegmentUpdatedEvent)
             .map((event) => event.segment.id),
     );
-    const syntheticSegmentEvents: DeltaEvent[] = [];
 
     for (const event of events) {
+        materializedEvents.push(event);
+
         if (!isDeltaFeatureUpdatedEvent(event)) {
             continue;
         }
 
-        const previousFeature = getFeatureStateAtRevision(
-            event.feature.name,
-            requestedRevisionId,
-            environmentEvents,
-        );
-        const previousSegments = getReferencedSegmentIds(
-            previousFeature ? [previousFeature] : [],
-        );
         const currentSegments = getReferencedSegmentIds([event.feature]);
 
         for (const segmentId of currentSegments) {
-            if (
-                previousSegments.has(segmentId) ||
-                emittedSegmentIds.has(segmentId)
-            ) {
+            if (emittedSegmentIds.has(segmentId)) {
                 continue;
             }
 
@@ -181,7 +143,7 @@ const materializeReferencedSegments = (
                 continue;
             }
 
-            syntheticSegmentEvents.push({
+            materializedEvents.push({
                 eventId: event.eventId,
                 type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
                 segment,
@@ -190,7 +152,7 @@ const materializeReferencedSegments = (
         }
     }
 
-    return syntheticSegmentEvents;
+    return materializedEvents;
 };
 
 const deltaRevisionIdMetric = createGauge({
@@ -290,7 +252,11 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             await this.initEnvironmentDelta(environment);
         }
 
-        const visibleRevision = this.getVisibleRevision(environment, projects);
+        const visibleRevision = this.getVisibleRevision(
+            environment,
+            projects,
+            namePrefix,
+        );
 
         if (hasRequestedRevision && requestedRevisionId >= visibleRevision) {
             this.logger.info(
@@ -313,6 +279,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             const effectiveEventId = this.getVisibleRevision(
                 environment,
                 projects,
+                namePrefix,
             );
             filteredEvent.eventId = effectiveEventId;
             this.logger.info(
@@ -333,26 +300,24 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 projects,
                 namePrefix,
             );
-            const events = filterEventsByQuery(
+            const filteredEvents = filterEventsByQuery(
                 environmentEvents,
                 requestedRevisionId,
                 projects,
                 namePrefix,
                 referencedSegmentIds,
             );
-            const segmentEvents = materializeReferencedSegments(
-                events,
-                requestedRevisionId,
+            const events = materializeReferencedSegments(
+                filteredEvents,
                 hydrationEvent,
-                environmentEvents,
             );
 
-            if (events.length === 0 && segmentEvents.length === 0) {
+            if (events.length === 0) {
                 return undefined;
             }
 
             return {
-                events: [...events, ...segmentEvents],
+                events,
             };
         }
     }
@@ -633,9 +598,20 @@ export class ClientFeatureToggleDelta extends EventEmitter {
     private getVisibleRevision(
         environment: string,
         projects: string[],
+        namePrefix: string = '',
     ): number {
         const revisionState = this.visibleRevisions[environment];
-        return getVisibleRevision(revisionState, projects);
+        const referencedSegmentIds = getReferencedSegmentIds(
+            this.delta[environment]?.getHydrationEvent().features ?? [],
+            projects,
+            namePrefix,
+        );
+
+        return getVisibleRevision(
+            revisionState,
+            projects,
+            referencedSegmentIds,
+        );
     }
 
     private updateVisibleRevisions(
@@ -647,10 +623,24 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
             visibleSegmentRevision: 0,
+            segmentRevisions: new Map<number, number>(),
         };
+        const segmentRevisions =
+            revisionState.segmentRevisions ?? new Map<number, number>();
+        revisionState.segmentRevisions = segmentRevisions;
 
         if (segmentEvents.length > 0) {
             for (const event of segmentEvents) {
+                if (
+                    event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&
+                    event.segment.id
+                ) {
+                    setMaxRevision(
+                        segmentRevisions,
+                        event.segment.id,
+                        event.eventId,
+                    );
+                }
                 // only consider visible, updated segments that are referenced
                 if (
                     event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -40,6 +40,7 @@ import {
 } from './visible-revision.js';
 import { createGauge } from '../../../util/metrics/index.js';
 import { BadDataError } from '../../../server-impl.js';
+import { ref } from 'process';
 
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
@@ -115,44 +116,33 @@ const materializeReferencedSegments = (
     events: DeltaEvent[],
     hydrationEvent: DeltaHydrationEvent,
 ): DeltaEvent[] => {
-    const materializedEvents: DeltaEvent[] = [];
+    const segmentMap = new Map(hydrationEvent.segments.map((s) => [s.id, s]));
     const emittedSegmentIds = new Set(
         events
             .filter(isDeltaSegmentUpdatedEvent)
             .map((event) => event.segment.id),
     );
 
-    for (const event of events) {
-        materializedEvents.push(event);
-
+    return events.flatMap((event) => {
         if (!isDeltaFeatureUpdatedEvent(event)) {
-            continue;
+            return [event];
         }
 
-        const currentSegments = getReferencedSegmentIds([event.feature]);
-
-        for (const segmentId of currentSegments) {
-            if (emittedSegmentIds.has(segmentId)) {
-                continue;
-            }
-
-            const segment = hydrationEvent.segments.find(
-                (s) => s.id === segmentId,
-            );
-            if (!segment) {
-                continue;
-            }
-
-            materializedEvents.push({
-                eventId: event.eventId,
-                type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
-                segment,
+        const syntheticNewSegmentEvents = [
+            ...getReferencedSegmentIds([event.feature]),
+        ]
+            .filter((id) => !emittedSegmentIds.has(id) && segmentMap.has(id))
+            .map((id) => {
+                emittedSegmentIds.add(id);
+                return {
+                    eventId: event.eventId,
+                    type: DELTA_EVENT_TYPES.SEGMENT_UPDATED,
+                    segment: segmentMap.get(id)!,
+                } as DeltaEvent;
             });
-            emittedSegmentIds.add(segmentId);
-        }
-    }
 
-    return materializedEvents;
+        return [event, ...syntheticNewSegmentEvents];
+    });
 };
 
 const getQueryVisibility = (
@@ -558,9 +548,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 environment,
                 [...featuresRemovedEvents, ...featuresUpdatedEvents],
                 [...segmentsUpdatedEvents, ...segmentsRemovedEvents],
-                getReferencedSegmentIds(
-                    this.delta[environment].getHydrationEvent().features,
-                ),
             );
         }
         this.lastDeltaProcessedRevisionId = eventsTo;
@@ -639,7 +626,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         environment: string,
         featureEvents: DeltaEvent[],
         segmentEvents: DeltaEvent[],
-        referencedSegmentIds: Set<number>,
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
@@ -651,6 +637,9 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         revisionState.segmentRevisions = segmentRevisions;
 
         if (segmentEvents.length > 0) {
+            const referencedSegmentIds = getReferencedSegmentIds(
+                this.delta[environment].getHydrationEvent().features,
+            );
             for (const event of segmentEvents) {
                 if (
                     event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&
@@ -661,17 +650,13 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                         event.segment.id,
                         event.eventId,
                     );
-                }
-                // only consider visible, updated segments that are referenced
-                if (
-                    event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&
-                    event.segment.id &&
-                    referencedSegmentIds.has(event.segment.id)
-                ) {
-                    revisionState.visibleSegmentRevision = Math.max(
-                        revisionState.visibleSegmentRevision,
-                        event.eventId,
-                    );
+                    // only consider visible, updated segments that are referenced
+                    if (referencedSegmentIds.has(event.segment.id)) {
+                        revisionState.visibleSegmentRevision = Math.max(
+                            revisionState.visibleSegmentRevision,
+                            event.eventId,
+                        );
+                    }
                 }
             }
         }

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -45,7 +45,6 @@ export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
     visibleSegmentRevision: number;
-    maxCachedSegmentRevisionChange: number;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -510,11 +509,22 @@ export class ClientFeatureToggleDelta extends EventEmitter {
     }
 
     private async initEnvironmentDelta(environment: string) {
-        const revisionState =
-            await this.eventStore.getDeltaRevisionState(environment);
         const baseFeatures = await this.getClientFeatures({
             environment,
         });
+        const referencedSegmentIds = getReferencedSegmentIds(baseFeatures);
+        // get the revision state at the time of hydration, so we can determine the visible revision
+        // for this environment and also determine which segment changes are visible based on the
+        // referenced segments in the hydration features
+        const revisionState = await this.eventStore.getDeltaRevisionState(
+            environment,
+            referencedSegmentIds,
+        );
+        // base segments still has to represent all the known state for segments,
+        // otherwise we might miss changes to segments that are not referenced by any feature
+        // in the hydration event but are updated/removed in the delta events.
+        // Note: because updated segments comes with all the segment's data,
+        // we could in theory get away with only including referenced segments in the hydration event
         const baseSegments = await this.segmentReadModel.getAllForClientIds();
 
         const maxRevision = getVisibleRevision(revisionState);
@@ -546,16 +556,11 @@ export class ClientFeatureToggleDelta extends EventEmitter {
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
-            maxCachedSegmentRevisionChange: 0,
             visibleSegmentRevision: 0,
         };
 
         if (segmentEvents.length > 0) {
             for (const event of segmentEvents) {
-                revisionState.maxCachedSegmentRevisionChange = Math.max(
-                    revisionState.maxCachedSegmentRevisionChange,
-                    event.eventId,
-                );
                 // only consider visible, updated segments that are referenced
                 if (
                     event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -140,7 +140,7 @@ const materializeReferencedSegments = (
                 } as DeltaEvent;
             });
 
-        return [event, ...syntheticNewSegmentEvents];
+        return [...syntheticNewSegmentEvents, event];
     });
 };
 

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -241,7 +241,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             await this.initEnvironmentDelta(environment);
         }
 
-        const visibleRevision = this.getVisibleRevision(
+        const visibleRevision = this.getQueryVisibleRevision(
             environment,
             projects,
             namePrefix,
@@ -265,7 +265,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 namePrefix,
             );
 
-            const effectiveEventId = this.getVisibleRevision(
+            const effectiveEventId = this.getQueryVisibleRevision(
                 environment,
                 projects,
                 namePrefix,
@@ -582,7 +582,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         this.storeFootprint();
     }
 
-    private getVisibleRevision(
+    private getQueryVisibleRevision(
         environment: string,
         projects: string[],
         namePrefix: string = '',

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -586,22 +586,32 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 this.delta[environment].getHydrationEvent().features,
             );
             for (const event of segmentEvents) {
-                if (
-                    event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED &&
-                    event.segment.id
-                ) {
+                if (event.type === DELTA_EVENT_TYPES.SEGMENT_UPDATED) {
+                    const segmentId = event.segment.id;
+                    if (!segmentId) {
+                        this.logger.warn(
+                            `Ignoring segment event ${event.type} without a segment id. EventId=${event.id}`,
+                        );
+                        continue;
+                    }
                     setMaxRevision(
                         revisionState.segmentRevisions,
-                        event.segment.id,
+                        segmentId,
                         event.eventId,
                     );
-                    // only consider visible, updated segments that are referenced
-                    if (referencedSegmentIds.has(event.segment.id)) {
+                    if (referencedSegmentIds.has(segmentId)) {
                         revisionState.maxReferencedSegmentRevision = Math.max(
                             revisionState.maxReferencedSegmentRevision,
                             event.eventId,
                         );
                     }
+                } else if (event.type === DELTA_EVENT_TYPES.SEGMENT_REMOVED) {
+                    // Segment removal does not advance visible revision by itself:
+                    // a valid removal requires the segment to have been dereferenced first,
+                    // and that feature update is what makes the delta visible.
+                    // We only remove the stale per-segment revision entry here because
+                    // the segment no longer exists.
+                    revisionState.segmentRevisions.delete(event.segmentId);
                 }
             }
         }

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -44,8 +44,8 @@ import { BadDataError } from '../../../server-impl.js';
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
-    visibleSegmentRevision: number;
     segmentRevisions?: Map<number, number>;
+    maxSegmentRevision: number;
 };
 
 export const UPDATE_DELTA = 'UPDATE_DELTA';
@@ -615,7 +615,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
     ) {
         const revisionState = this.visibleRevisions[environment] ?? {
             projectRevisions: new Map<string, number>(),
-            visibleSegmentRevision: 0,
+            maxSegmentRevision: 0,
             segmentRevisions: new Map<number, number>(),
         };
         const segmentRevisions =
@@ -638,8 +638,8 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                     );
                     // only consider visible, updated segments that are referenced
                     if (referencedSegmentIds.has(event.segment.id)) {
-                        revisionState.visibleSegmentRevision = Math.max(
-                            revisionState.visibleSegmentRevision,
+                        revisionState.maxSegmentRevision = Math.max(
+                            revisionState.maxSegmentRevision,
                             event.eventId,
                         );
                     }
@@ -648,7 +648,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         }
 
         // assume segment revision id as max feature event
-        let environmentMax = revisionState.visibleSegmentRevision;
+        let environmentMax = revisionState.maxSegmentRevision;
         for (const event of featureEvents) {
             let project: string | undefined;
             if (event.type === DELTA_EVENT_TYPES.FEATURE_UPDATED) {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -44,7 +44,7 @@ import { BadDataError } from '../../../server-impl.js';
 export type EnvironmentRevisions = Record<string, DeltaCache>;
 export type EnvironmentVisibleRevisionState = {
     projectRevisions: Map<string, number>;
-    segmentRevisions?: Map<number, number>;
+    segmentRevisions: Map<number, number>;
     maxSegmentRevision: number;
 };
 
@@ -576,9 +576,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             maxSegmentRevision: 0,
             segmentRevisions: new Map<number, number>(),
         };
-        const segmentRevisions =
-            revisionState.segmentRevisions ?? new Map<number, number>();
-        revisionState.segmentRevisions = segmentRevisions;
 
         if (segmentEvents.length > 0) {
             const referencedSegmentIds = getReferencedSegmentIds(
@@ -590,7 +587,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                     event.segment.id
                 ) {
                     setMaxRevision(
-                        segmentRevisions,
+                        revisionState.segmentRevisions,
                         event.segment.id,
                         event.eventId,
                     );

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -241,10 +241,20 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             await this.initEnvironmentDelta(environment);
         }
 
-        const visibleRevision = this.getQueryVisibleRevision(
-            environment,
+        const delta = this.delta[environment];
+        const hydrationEvent = delta.getHydrationEvent();
+        const filteredHydrationEvent = filterHydrationEventByQuery(
+            hydrationEvent,
             projects,
             namePrefix,
+        );
+        const referencedSegmentIds = getReferencedSegmentIds(
+            filteredHydrationEvent.features,
+        );
+        const visibleRevision = getVisibleRevision(
+            this.visibleRevisions[environment],
+            projects,
+            referencedSegmentIds,
         );
 
         if (hasRequestedRevision && requestedRevisionId >= visibleRevision) {
@@ -253,43 +263,19 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             );
             return undefined;
         }
-        const delta = this.delta[environment];
+
         if (
             !hasRequestedRevision ||
             delta.isMissingRevision(requestedRevisionId)
         ) {
-            const hydrationEvent = delta.getHydrationEvent();
-            const filteredEvent = filterHydrationEventByQuery(
-                hydrationEvent,
-                projects,
-                namePrefix,
-            );
-
-            const effectiveEventId = this.getQueryVisibleRevision(
-                environment,
-                projects,
-                namePrefix,
-            );
-            filteredEvent.eventId = effectiveEventId;
+            filteredHydrationEvent.eventId = visibleRevision;
             this.logger.info(
-                `[revision] Fresh delta hydration for environment=${environment} projects=${projects.join(',')} visibleRevision=${visibleRevision} hydrationEventId=${hydrationEvent.eventId} returnedHydrationEventId=${filteredEvent.eventId}`,
+                `[revision] Fresh delta hydration for environment=${environment} projects=${projects.join(',')} visibleRevision=${visibleRevision} hydrationEventId=${hydrationEvent.eventId} returnedHydrationEventId=${filteredHydrationEvent.eventId}`,
             );
 
-            const response: ClientFeaturesDeltaSchema = {
-                events: [filteredEvent],
-            };
-
-            return Promise.resolve(response);
+            return { events: [filteredHydrationEvent] };
         } else {
             const environmentEvents = delta.getEvents();
-            const hydrationEvent = delta.getHydrationEvent();
-            const visibleFeatures = filterHydrationEventByQuery(
-                hydrationEvent,
-                projects,
-                namePrefix,
-            ).features;
-            const referencedSegmentIds =
-                getReferencedSegmentIds(visibleFeatures);
             const filteredEvents = filterEventsByQuery(
                 environmentEvents,
                 requestedRevisionId,
@@ -306,9 +292,7 @@ export class ClientFeatureToggleDelta extends EventEmitter {
                 return undefined;
             }
 
-            return {
-                events,
-            };
+            return { events };
         }
     }
 
@@ -580,32 +564,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         this.visibleRevisions[environment] = revisionState;
         deltaRevisionIdMetric.labels({ environment }).set(maxRevision);
         this.storeFootprint();
-    }
-
-    private getQueryVisibleRevision(
-        environment: string,
-        projects: string[],
-        namePrefix: string = '',
-    ): number {
-        const revisionState = this.visibleRevisions[environment];
-        const hydrationEvent = this.delta[environment]?.getHydrationEvent() ?? {
-            eventId: 0,
-            type: DELTA_EVENT_TYPES.HYDRATION,
-            features: [],
-            segments: [],
-        };
-        const visibleFeatures = filterHydrationEventByQuery(
-            hydrationEvent,
-            projects,
-            namePrefix,
-        ).features;
-        const referencedSegmentIds = getReferencedSegmentIds(visibleFeatures);
-
-        return getVisibleRevision(
-            revisionState,
-            projects,
-            referencedSegmentIds,
-        );
     }
 
     private updateVisibleRevisions(

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -7,7 +7,7 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['alpha', 11],
         ['beta', 14],
     ]),
-    visibleSegmentRevision: 12,
+    maxSegmentRevision: 12,
     segmentRevisions: new Map([
         [101, 12],
         [202, 9],

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -8,6 +8,10 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['beta', 14],
     ]),
     visibleSegmentRevision: 12,
+    segmentRevisions: new Map([
+        [101, 12],
+        [202, 9],
+    ]),
 };
 
 describe('getVisibleRevision', () => {
@@ -26,5 +30,14 @@ describe('getVisibleRevision', () => {
 
     test('returns 0 when scoped query has no revision state', () => {
         expect(getVisibleRevision(undefined, ['alpha'])).toBe(0);
+    });
+
+    test('uses query-scoped segment revisions when referenced segment ids are provided', () => {
+        expect(
+            getVisibleRevision(revisionState, ['alpha'], new Set([202])),
+        ).toBe(11);
+        expect(
+            getVisibleRevision(revisionState, ['alpha'], new Set([101])),
+        ).toBe(12);
     });
 });

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -7,7 +7,7 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['alpha', 11],
         ['beta', 14],
     ]),
-    maxCachedSegmentRevisionChange: 12,
+    visibleSegmentRevision: 12,
 };
 
 describe('getVisibleRevision', () => {

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -7,7 +7,7 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['alpha', 11],
         ['beta', 14],
     ]),
-    maxSegmentRevision: 12,
+    maxReferencedSegmentRevision: 12,
     segmentRevisions: new Map([
         [101, 12],
         [202, 9],

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.test.ts
@@ -7,7 +7,7 @@ const revisionState: EnvironmentVisibleRevisionState = {
         ['alpha', 11],
         ['beta', 14],
     ]),
-    globalSegmentRevision: 12,
+    maxCachedSegmentRevisionChange: 12,
 };
 
 describe('getVisibleRevision', () => {

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -33,6 +33,7 @@ export const getReferencedSegmentIds = (
 export const getVisibleRevision = (
     revisionState: EnvironmentVisibleRevisionState | undefined,
     projects: string[] = ['*'],
+    referencedSegmentIds?: Set<number>,
 ): number => {
     if (!revisionState) {
         return 0;
@@ -42,8 +43,15 @@ export const getVisibleRevision = (
         projects.length > 0 && !projects.includes(ALL_PROJECTS)
             ? projects
             : Array.from(revisionState.projectRevisions.keys());
-    // assume segment revision as max because segment changes are always visible
     let visibleRevision = revisionState.visibleSegmentRevision ?? 0;
+    if (referencedSegmentIds) {
+        visibleRevision = Math.max(
+            0,
+            ...Array.from(referencedSegmentIds, (segmentId) => {
+                return revisionState.segmentRevisions?.get(segmentId) ?? 0;
+            }),
+        );
+    }
     for (const project of projectList) {
         visibleRevision = Math.max(
             visibleRevision,

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -4,7 +4,7 @@ import type { ClientFeatureSchema } from '../../../openapi/index.js';
 
 export const getReferencedSegmentIds = (
     features: ClientFeatureSchema[],
-    projects: string[] = ['*'],
+    projects: string[] = [ALL_PROJECTS],
     namePrefix: string = '',
 ): Set<number> => {
     const allProjects =
@@ -32,7 +32,7 @@ export const getReferencedSegmentIds = (
 
 export const getVisibleRevision = (
     revisionState: EnvironmentVisibleRevisionState | undefined,
-    projects: string[] = ['*'],
+    projects: string[] = [ALL_PROJECTS],
     referencedSegmentIds?: Set<number>,
 ): number => {
     if (!revisionState) {
@@ -45,12 +45,13 @@ export const getVisibleRevision = (
             : Array.from(revisionState.projectRevisions.keys());
     let visibleRevision = revisionState.maxReferencedSegmentRevision ?? 0;
     if (referencedSegmentIds) {
-        visibleRevision = Math.max(
-            0,
-            ...Array.from(referencedSegmentIds, (segmentId) => {
-                return revisionState.segmentRevisions.get(segmentId) ?? 0;
-            }),
-        );
+        visibleRevision = 0;
+        for (const segmentId of referencedSegmentIds) {
+            visibleRevision = Math.max(
+                visibleRevision,
+                revisionState.segmentRevisions.get(segmentId) ?? 0,
+            );
+        }
     }
     for (const project of projectList) {
         visibleRevision = Math.max(

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -43,7 +43,7 @@ export const getVisibleRevision = (
         projects.length > 0 && !projects.includes(ALL_PROJECTS)
             ? projects
             : Array.from(revisionState.projectRevisions.keys());
-    let visibleRevision = revisionState.maxSegmentRevision ?? 0;
+    let visibleRevision = revisionState.maxReferencedSegmentRevision ?? 0;
     if (referencedSegmentIds) {
         visibleRevision = Math.max(
             0,

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -48,7 +48,7 @@ export const getVisibleRevision = (
         visibleRevision = Math.max(
             0,
             ...Array.from(referencedSegmentIds, (segmentId) => {
-                return revisionState.segmentRevisions?.get(segmentId) ?? 0;
+                return revisionState.segmentRevisions.get(segmentId) ?? 0;
             }),
         );
     }

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -43,7 +43,7 @@ export const getVisibleRevision = (
         projects.length > 0 && !projects.includes(ALL_PROJECTS)
             ? projects
             : Array.from(revisionState.projectRevisions.keys());
-    let visibleRevision = revisionState.visibleSegmentRevision ?? 0;
+    let visibleRevision = revisionState.maxSegmentRevision ?? 0;
     if (referencedSegmentIds) {
         visibleRevision = Math.max(
             0,

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -1,5 +1,34 @@
 import { ALL_PROJECTS } from '../../../util/index.js';
 import type { EnvironmentVisibleRevisionState } from './client-feature-toggle-delta.js';
+import type { ClientFeatureSchema } from '../../../openapi/index.js';
+
+export const getReferencedSegmentIds = (
+    features: ClientFeatureSchema[],
+    projects: string[] = ['*'],
+    namePrefix: string = '',
+): Set<number> => {
+    const allProjects =
+        projects.length === 0 || projects.includes(ALL_PROJECTS);
+    const referencedSegmentIds = new Set<number>();
+
+    for (const feature of features) {
+        if (!feature.name.startsWith(namePrefix)) {
+            continue;
+        }
+
+        if (!allProjects && !projects.includes(feature.project ?? '')) {
+            continue;
+        }
+
+        for (const strategy of feature.strategies ?? []) {
+            for (const segmentId of strategy.segments ?? []) {
+                referencedSegmentIds.add(segmentId);
+            }
+        }
+    }
+
+    return referencedSegmentIds;
+};
 
 export const getVisibleRevision = (
     revisionState: EnvironmentVisibleRevisionState | undefined,
@@ -14,7 +43,7 @@ export const getVisibleRevision = (
             ? projects
             : Array.from(revisionState.projectRevisions.keys());
     // assume segment revision as max because segment changes are always visible
-    let visibleRevision = revisionState.globalSegmentRevision ?? 0;
+    let visibleRevision = revisionState.maxCachedSegmentRevisionChange ?? 0;
     for (const project of projectList) {
         visibleRevision = Math.max(
             visibleRevision,

--- a/src/lib/features/client-feature-toggles/delta/visible-revision.ts
+++ b/src/lib/features/client-feature-toggles/delta/visible-revision.ts
@@ -43,7 +43,7 @@ export const getVisibleRevision = (
             ? projects
             : Array.from(revisionState.projectRevisions.keys());
     // assume segment revision as max because segment changes are always visible
-    let visibleRevision = revisionState.maxCachedSegmentRevisionChange ?? 0;
+    let visibleRevision = revisionState.visibleSegmentRevision ?? 0;
     for (const project of projectList) {
         visibleRevision = Math.max(
             visibleRevision,

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -324,7 +324,10 @@ export class EventStore implements IEventStore {
             this.db(TABLE)
                 .max({ revisionId: 'id' })
                 .where({ type: SEGMENT_UPDATED })
-                .whereIn('id', Array.from(referencedSegmentIds!))
+                .whereIn(
+                    this.db.raw(`CAST(data->>'id' AS INTEGER)`),
+                    Array.from(referencedSegmentIds!),
+                )
                 .first();
         const segmentRow: { revisionId?: number | string } | undefined =
             // referencedSegmentIds === undefined represents the current usage pattern in enterprise

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -324,10 +324,9 @@ export class EventStore implements IEventStore {
             this.db(TABLE)
                 .max({ revisionId: 'id' })
                 .where({ type: SEGMENT_UPDATED })
-                .whereIn(
-                    this.db.raw(`(data->>'id')::int`),
+                .whereRaw(`(data->>'id')::int = ANY(?::int[])`, [
                     Array.from(referencedSegmentIds!),
-                )
+                ])
                 .first();
         const segmentRow: { revisionId?: number | string } | undefined =
             // referencedSegmentIds === undefined represents the current usage pattern in enterprise

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -266,6 +266,7 @@ export class EventStore implements IEventStore {
 
     async getDeltaRevisionState(
         environment: string,
+        referencedSegmentIds: Set<number> | undefined = undefined,
     ): Promise<EnvironmentVisibleRevisionState> {
         const stopTimer = this.metricTimer('getDeltaRevisionState');
         const shouldFilterEnvironment = environment !== ALL_ENVS;
@@ -314,11 +315,26 @@ export class EventStore implements IEventStore {
             .modify(applyEnvironmentFilter)
             .groupByRaw(`data->>'oldProject'`);
 
-        const segmentRow: { revisionId?: number | string } | undefined =
-            await this.db(TABLE)
+        const backwardCompatibilityQuery = async () =>
+            this.db(TABLE)
                 .max({ revisionId: 'id' })
                 .where({ type: SEGMENT_UPDATED })
                 .first();
+        const newQuery = async () =>
+            this.db(TABLE)
+                .max({ revisionId: 'id' })
+                .where({ type: SEGMENT_UPDATED })
+                .whereIn('id', Array.from(referencedSegmentIds!))
+                .first();
+        const segmentRow: { revisionId?: number | string } | undefined =
+            // referencedSegmentIds === undefined represents the current usage pattern in enterprise
+            // next we should adapt the code in enterprise and remove this conditional expecting
+            // always to receive referenced segment ids.
+            referencedSegmentIds === undefined
+                ? await backwardCompatibilityQuery()
+                : referencedSegmentIds.size > 0
+                  ? await newQuery()
+                  : undefined;
 
         stopTimer();
 
@@ -339,7 +355,7 @@ export class EventStore implements IEventStore {
 
         return {
             projectRevisions,
-            maxCachedSegmentRevisionChange: Number(segmentRow?.revisionId ?? 0),
+            visibleSegmentRevision: Number(segmentRow?.revisionId ?? 0),
         };
     }
 

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -352,15 +352,22 @@ export class EventStore implements IEventStore {
             segmentRevisions.set(segmentId, Number(row.revisionId ?? 0));
         }
 
-        const maxReferencedSegmentRevision =
-            referencedSegmentIds === undefined
-                ? Math.max(0, ...segmentRevisions.values())
-                : Math.max(
-                      0,
-                      ...Array.from(referencedSegmentIds, (segmentId) => {
-                          return segmentRevisions.get(segmentId) ?? 0;
-                      }),
-                  );
+        let maxReferencedSegmentRevision = 0;
+        if (referencedSegmentIds === undefined) {
+            for (const revisionId of segmentRevisions.values()) {
+                maxReferencedSegmentRevision = Math.max(
+                    maxReferencedSegmentRevision,
+                    revisionId,
+                );
+            }
+        } else {
+            for (const segmentId of referencedSegmentIds) {
+                maxReferencedSegmentRevision = Math.max(
+                    maxReferencedSegmentRevision,
+                    segmentRevisions.get(segmentId) ?? 0,
+                );
+            }
+        }
 
         return {
             projectRevisions,

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -339,7 +339,7 @@ export class EventStore implements IEventStore {
 
         return {
             projectRevisions,
-            globalSegmentRevision: Number(segmentRow?.revisionId ?? 0),
+            maxCachedSegmentRevisionChange: Number(segmentRow?.revisionId ?? 0),
         };
     }
 

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -325,7 +325,7 @@ export class EventStore implements IEventStore {
                 .max({ revisionId: 'id' })
                 .where({ type: SEGMENT_UPDATED })
                 .whereIn(
-                    await this.db.raw(`CAST(data->>'id' AS INTEGER)`),
+                    this.db.raw(`(data->>'id')::int`),
                     Array.from(referencedSegmentIds!),
                 )
                 .first();

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -325,7 +325,7 @@ export class EventStore implements IEventStore {
                 .max({ revisionId: 'id' })
                 .where({ type: SEGMENT_UPDATED })
                 .whereIn(
-                    this.db.raw(`CAST(data->>'id' AS INTEGER)`),
+                    await this.db.raw(`CAST(data->>'id' AS INTEGER)`),
                     Array.from(referencedSegmentIds!),
                 )
                 .first();

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -352,7 +352,7 @@ export class EventStore implements IEventStore {
             segmentRevisions.set(segmentId, Number(row.revisionId ?? 0));
         }
 
-        const visibleSegmentRevision =
+        const maxSegmentRevision =
             referencedSegmentIds === undefined
                 ? Math.max(0, ...segmentRevisions.values())
                 : Math.max(
@@ -364,7 +364,7 @@ export class EventStore implements IEventStore {
 
         return {
             projectRevisions,
-            visibleSegmentRevision,
+            maxSegmentRevision,
             segmentRevisions,
         };
     }

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -315,32 +315,20 @@ export class EventStore implements IEventStore {
             .modify(applyEnvironmentFilter)
             .groupByRaw(`data->>'oldProject'`);
 
-        const backwardCompatibilityQuery = async () =>
-            this.db(TABLE)
-                .max({ revisionId: 'id' })
-                .where({ type: SEGMENT_UPDATED })
-                .first();
-        const newQuery = async () =>
-            this.db(TABLE)
-                .max({ revisionId: 'id' })
-                .where({ type: SEGMENT_UPDATED })
-                .whereRaw(`(data->>'id')::int = ANY(?::int[])`, [
-                    Array.from(referencedSegmentIds!),
-                ])
-                .first();
-        const segmentRow: { revisionId?: number | string } | undefined =
-            // referencedSegmentIds === undefined represents the current usage pattern in enterprise
-            // next we should adapt the code in enterprise and remove this conditional expecting
-            // always to receive referenced segment ids.
-            referencedSegmentIds === undefined
-                ? await backwardCompatibilityQuery()
-                : referencedSegmentIds.size > 0
-                  ? await newQuery()
-                  : undefined;
+        const segmentRows: Array<{
+            segmentId?: number | string;
+            revisionId?: number | string;
+        }> = await this.db(TABLE)
+            .select(this.db.raw(`(data->>'id')::int as "segmentId"`))
+            .max({ revisionId: 'id' })
+            .where({ type: SEGMENT_UPDATED })
+            .modify(applyEnvironmentFilter)
+            .groupByRaw(`(data->>'id')::int`);
 
         stopTimer();
 
         const projectRevisions = new Map<string, number>();
+        const segmentRevisions = new Map<number, number>();
 
         for (const row of [...projectRows, ...movedRows]) {
             if (!row.project) {
@@ -355,9 +343,29 @@ export class EventStore implements IEventStore {
             }
         }
 
+        for (const row of segmentRows) {
+            const segmentId = Number(row.segmentId);
+            if (!segmentId) {
+                continue;
+            }
+
+            segmentRevisions.set(segmentId, Number(row.revisionId ?? 0));
+        }
+
+        const visibleSegmentRevision =
+            referencedSegmentIds === undefined
+                ? Math.max(0, ...segmentRevisions.values())
+                : Math.max(
+                      0,
+                      ...Array.from(referencedSegmentIds, (segmentId) => {
+                          return segmentRevisions.get(segmentId) ?? 0;
+                      }),
+                  );
+
         return {
             projectRevisions,
-            visibleSegmentRevision: Number(segmentRow?.revisionId ?? 0),
+            visibleSegmentRevision,
+            segmentRevisions,
         };
     }
 

--- a/src/lib/features/events/event-store.ts
+++ b/src/lib/features/events/event-store.ts
@@ -352,7 +352,7 @@ export class EventStore implements IEventStore {
             segmentRevisions.set(segmentId, Number(row.revisionId ?? 0));
         }
 
-        const maxSegmentRevision =
+        const maxReferencedSegmentRevision =
             referencedSegmentIds === undefined
                 ? Math.max(0, ...segmentRevisions.values())
                 : Math.max(
@@ -364,7 +364,7 @@ export class EventStore implements IEventStore {
 
         return {
             projectRevisions,
-            maxSegmentRevision,
+            maxReferencedSegmentRevision,
             segmentRevisions,
         };
     }

--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -88,6 +88,7 @@ import type { Constraint } from 'unleash-client/lib/strategy/strategy.js';
 import {
     type ClientFeatureToggleDelta,
     type DeltaEvent,
+    type EnvironmentVisibleRevisionState,
     UPDATE_DELTA,
 } from './features/client-feature-toggles/delta/client-feature-toggle-delta.js';
 import type { IQueryParam } from './features/feature-toggle/types/feature-toggle-strategies-store-type.js';
@@ -587,6 +588,7 @@ export type {
     Constraint,
     ClientFeatureToggleDelta,
     DeltaEvent,
+    EnvironmentVisibleRevisionState,
     IQueryParam,
     PatService,
     IRoleWithPermissions,

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -42,9 +42,11 @@ export interface IEventStore
         currentMax?: number,
         environment?: string,
     ): Promise<number>;
-    getDeltaRevisionState(environment: string): Promise<{
+    getDeltaRevisionState(
+        environment: string,
+        referencedSegmentIds?: Set<number>,
+    ): Promise<{
         projectRevisions: Map<string, number>;
-        maxCachedSegmentRevisionChange: number;
         visibleSegmentRevision: number;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -48,7 +48,7 @@ export interface IEventStore
     ): Promise<{
         projectRevisions: Map<string, number>;
         maxSegmentRevision: number;
-        segmentRevisions?: Map<number, number>;
+        segmentRevisions: Map<number, number>;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -44,7 +44,8 @@ export interface IEventStore
     ): Promise<number>;
     getDeltaRevisionState(environment: string): Promise<{
         projectRevisions: Map<string, number>;
-        globalSegmentRevision: number;
+        maxCachedSegmentRevisionChange: number;
+        visibleSegmentRevision: number;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -48,6 +48,7 @@ export interface IEventStore
     ): Promise<{
         projectRevisions: Map<string, number>;
         visibleSegmentRevision: number;
+        segmentRevisions?: Map<number, number>;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;
     query(operations: IQueryOperations[]): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -47,7 +47,7 @@ export interface IEventStore
         referencedSegmentIds?: Set<number>,
     ): Promise<{
         projectRevisions: Map<string, number>;
-        maxSegmentRevision: number;
+        maxReferencedSegmentRevision: number;
         segmentRevisions: Map<number, number>;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;

--- a/src/lib/types/stores/event-store.ts
+++ b/src/lib/types/stores/event-store.ts
@@ -47,7 +47,7 @@ export interface IEventStore
         referencedSegmentIds?: Set<number>,
     ): Promise<{
         projectRevisions: Map<string, number>;
-        visibleSegmentRevision: number;
+        maxSegmentRevision: number;
         segmentRevisions?: Map<number, number>;
     }>;
     getRevisionRange(start: number, end: number): Promise<IEvent[]>;

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -518,6 +518,44 @@ describe('getDeltaRevisionState', () => {
         expect(state.projectRevisions.get('default')).toBe(secondStored.id);
         expect(state.visibleSegmentRevision).toBe(segmentStored.id);
     });
+
+    test('filters segment revision by referenced segment ids from event payload', async () => {
+        const firstSegmentEvent = {
+            type: SEGMENT_UPDATED,
+            createdBy: testAudit.username,
+            createdByUserId: testAudit.id,
+            ip: testAudit.ip,
+            data: { id: 123, name: 'segment-a' },
+        };
+
+        const secondSegmentEvent = {
+            type: SEGMENT_UPDATED,
+            createdBy: testAudit.username,
+            createdByUserId: testAudit.id,
+            ip: testAudit.ip,
+            data: { id: 999, name: 'segment-b' },
+        };
+
+        await eventStore.store(firstSegmentEvent);
+        await eventStore.store(secondSegmentEvent);
+
+        const allEvents = await eventStore.getAll();
+        const firstStored = allEvents.find(
+            (e) => e.type === SEGMENT_UPDATED && e.data.id === 123,
+        )!;
+        const secondStored = allEvents.find(
+            (e) => e.type === SEGMENT_UPDATED && e.data.id === 999,
+        )!;
+
+        expect(secondStored.id).toBeGreaterThan(firstStored.id);
+
+        const state = await eventStore.getDeltaRevisionState(
+            ALL_ENVS,
+            new Set([123]),
+        );
+
+        expect(state.visibleSegmentRevision).toBe(firstStored.id);
+    });
 });
 
 test('Should filter events by ID using IS operator', async () => {

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -377,7 +377,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).toBe(defaultStored.id);
         expect(state.projectRevisions.get('other')).toBe(otherStored.id);
-        expect(state.maxSegmentRevision).toBe(segmentStored.id);
+        expect(state.maxReferencedSegmentRevision).toBe(segmentStored.id);
     });
 
     test('respects environment filtering and includes null-environment feature events', async () => {
@@ -452,7 +452,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('old-project')).toBe(storedMove.id);
         expect(state.projectRevisions.get('new-project')).toBe(storedMove.id);
-        expect(state.maxSegmentRevision).toBe(0);
+        expect(state.maxReferencedSegmentRevision).toBe(0);
     });
 
     test('ignores non-interesting feature events', async () => {
@@ -471,7 +471,7 @@ describe('getDeltaRevisionState', () => {
         const state = await eventStore.getDeltaRevisionState(ALL_ENVS);
 
         expect(state.projectRevisions.size).toBe(0);
-        expect(state.maxSegmentRevision).toBe(0);
+        expect(state.maxReferencedSegmentRevision).toBe(0);
     });
 
     test('returns latest project and segment revisions', async () => {
@@ -516,7 +516,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).not.toBe(firstStored.id);
         expect(state.projectRevisions.get('default')).toBe(secondStored.id);
-        expect(state.maxSegmentRevision).toBe(segmentStored.id);
+        expect(state.maxReferencedSegmentRevision).toBe(segmentStored.id);
     });
 
     test('filters segment revision by referenced segment ids from event payload', async () => {
@@ -554,7 +554,7 @@ describe('getDeltaRevisionState', () => {
             new Set([123]),
         );
 
-        expect(state.maxSegmentRevision).toBe(firstStored.id);
+        expect(state.maxReferencedSegmentRevision).toBe(firstStored.id);
     });
 });
 

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -377,7 +377,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).toBe(defaultStored.id);
         expect(state.projectRevisions.get('other')).toBe(otherStored.id);
-        expect(state.globalSegmentRevision).toBe(segmentStored.id);
+        expect(state.visibleSegmentRevision).toBe(segmentStored.id);
     });
 
     test('respects environment filtering and includes null-environment feature events', async () => {
@@ -452,7 +452,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('old-project')).toBe(storedMove.id);
         expect(state.projectRevisions.get('new-project')).toBe(storedMove.id);
-        expect(state.globalSegmentRevision).toBe(0);
+        expect(state.visibleSegmentRevision).toBe(0);
     });
 
     test('ignores non-interesting feature events', async () => {
@@ -471,7 +471,7 @@ describe('getDeltaRevisionState', () => {
         const state = await eventStore.getDeltaRevisionState(ALL_ENVS);
 
         expect(state.projectRevisions.size).toBe(0);
-        expect(state.globalSegmentRevision).toBe(0);
+        expect(state.visibleSegmentRevision).toBe(0);
     });
 
     test('returns latest project and segment revisions', async () => {
@@ -516,7 +516,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).not.toBe(firstStored.id);
         expect(state.projectRevisions.get('default')).toBe(secondStored.id);
-        expect(state.globalSegmentRevision).toBe(segmentStored.id);
+        expect(state.visibleSegmentRevision).toBe(segmentStored.id);
     });
 });
 

--- a/src/test/e2e/stores/event-store.e2e.test.ts
+++ b/src/test/e2e/stores/event-store.e2e.test.ts
@@ -377,7 +377,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).toBe(defaultStored.id);
         expect(state.projectRevisions.get('other')).toBe(otherStored.id);
-        expect(state.visibleSegmentRevision).toBe(segmentStored.id);
+        expect(state.maxSegmentRevision).toBe(segmentStored.id);
     });
 
     test('respects environment filtering and includes null-environment feature events', async () => {
@@ -452,7 +452,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('old-project')).toBe(storedMove.id);
         expect(state.projectRevisions.get('new-project')).toBe(storedMove.id);
-        expect(state.visibleSegmentRevision).toBe(0);
+        expect(state.maxSegmentRevision).toBe(0);
     });
 
     test('ignores non-interesting feature events', async () => {
@@ -471,7 +471,7 @@ describe('getDeltaRevisionState', () => {
         const state = await eventStore.getDeltaRevisionState(ALL_ENVS);
 
         expect(state.projectRevisions.size).toBe(0);
-        expect(state.visibleSegmentRevision).toBe(0);
+        expect(state.maxSegmentRevision).toBe(0);
     });
 
     test('returns latest project and segment revisions', async () => {
@@ -516,7 +516,7 @@ describe('getDeltaRevisionState', () => {
 
         expect(state.projectRevisions.get('default')).not.toBe(firstStored.id);
         expect(state.projectRevisions.get('default')).toBe(secondStored.id);
-        expect(state.visibleSegmentRevision).toBe(segmentStored.id);
+        expect(state.maxSegmentRevision).toBe(segmentStored.id);
     });
 
     test('filters segment revision by referenced segment ids from event payload', async () => {
@@ -554,7 +554,7 @@ describe('getDeltaRevisionState', () => {
             new Set([123]),
         );
 
-        expect(state.visibleSegmentRevision).toBe(firstStored.id);
+        expect(state.maxSegmentRevision).toBe(firstStored.id);
     });
 });
 

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -32,13 +32,18 @@ class FakeEventStore implements IEventStore {
         return Promise.resolve(1);
     }
 
-    getDeltaRevisionState(_environment: string): Promise<{
+    getDeltaRevisionState(
+        _environment: string,
+        _referencedSegmentIds?: Set<number>,
+    ): Promise<{
         projectRevisions: Map<string, number>;
         maxSegmentRevision: number;
+        segmentRevisions: Map<number, number>;
     }> {
         return Promise.resolve({
             projectRevisions: new Map(),
             maxSegmentRevision: 0,
+            segmentRevisions: new Map(),
         });
     }
 

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -34,11 +34,11 @@ class FakeEventStore implements IEventStore {
 
     getDeltaRevisionState(_environment: string): Promise<{
         projectRevisions: Map<string, number>;
-        globalSegmentRevision: number;
+        visibleSegmentRevision: number;
     }> {
         return Promise.resolve({
             projectRevisions: new Map(),
-            globalSegmentRevision: 0,
+            visibleSegmentRevision: 0,
         });
     }
 

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -34,11 +34,11 @@ class FakeEventStore implements IEventStore {
 
     getDeltaRevisionState(_environment: string): Promise<{
         projectRevisions: Map<string, number>;
-        visibleSegmentRevision: number;
+        maxSegmentRevision: number;
     }> {
         return Promise.resolve({
             projectRevisions: new Map(),
-            visibleSegmentRevision: 0,
+            maxSegmentRevision: 0,
         });
     }
 

--- a/src/test/fixtures/fake-event-store.ts
+++ b/src/test/fixtures/fake-event-store.ts
@@ -37,12 +37,12 @@ class FakeEventStore implements IEventStore {
         _referencedSegmentIds?: Set<number>,
     ): Promise<{
         projectRevisions: Map<string, number>;
-        maxSegmentRevision: number;
+        maxReferencedSegmentRevision: number;
         segmentRevisions: Map<number, number>;
     }> {
         return Promise.resolve({
             projectRevisions: new Map(),
-            maxSegmentRevision: 0,
+            maxReferencedSegmentRevision: 0,
             segmentRevisions: new Map(),
         });
     }


### PR DESCRIPTION
## Summary

This PR fixes how delta/streaming revisions are calculated for segments.

The intended rule is:
- segment events should keep the cached delta snapshot up to date
- segment events should only advance the visible `revisionId` when the segment is actually referenced by the visible feature payload for that environment

## The bug

A segment event could advance the in-memory visible `revisionId` for an environment even when the client-visible delta payload for that environment had not changed.

That showed up as inconsistent behavior across pods:
1. a long-lived pod could carry an inflated visible `revisionId`
2. a fresh pod could recompute from persisted state and return a lower one

So the issue was not incorrect flag state, but incorrect visible revision tracking.

## Why the patch also touches segment delivery

While working through this, there was a second correctness issue for segment-by-reference clients.

If a segment was updated while unreferenced, a client could advance past that hidden segment update because of unrelated visible feature changes. Later, a `feature-updated` event could start referencing that segment, but the client would not necessarily receive the segment payload it now needed for evaluation.

To avoid that stale-client case, the delta response now materializes a synthetic `segment-updated` event when a returned `feature-updated` event introduces a segment reference that is not already present in the returned delta event set. The payload comes from the cached hydration snapshot.

## Event ordering and ETags

Delta events are accumulated in the cache by event category, so a response could contain events out of revision order, for example a `feature-updated` event with revision 26 followed by a `segment-updated` event with revision 25.

That matters because the delta controller uses the last returned event id as the response ETag. If the last event is not the highest revision in the response, the client can receive a stale ETag and replay events it has already seen on the next request.

This PR sorts returned cached events by `eventId` before materializing synthetic segment payloads. Synthetic segment payloads are still emitted immediately before the `feature-updated` event that needs them, so segment-by-reference clients receive the segment payload before the feature starts referencing it.

## What this PR changes

- keeps processing segment events so the cached delta snapshot stays current
- only lets referenced segment updates influence the visible `revisionId`
- materializes segment payloads when a later feature update makes a previously hidden segment update relevant to the client
- returns delta events in revision order so the response ETag reflects the latest delivered revision

## Tradeoff

In some cache/bootstrap cases this can conservatively over-send a segment payload that the client may already know about. That is acceptable compared to the stale-client case where a feature references a segment the client never received.

## Scope

This still aims to be smaller in scope than https://github.com/Unleash/unleash/pull/11860. The goal here is to preserve the existing revision model, fix the visible revision drift, and make segment-by-reference delivery correct without a broader refactor.

## Manual verification

This was also verified manually against the delta API in segment-by-reference mode.

Reproduction before the fix:
- hydrate a client
- update a segment while it is unreferenced
- advance the client revision with an unrelated visible feature change
- later update a feature so it starts referencing that segment

Before the fix, the client received the `feature-updated` event with the new segment id reference, but did not receive the current `segment-updated` payload for that segment.

After the fix, the same sequence returns the `feature-updated` event together with the segment payload needed by the client. Hidden segment updates still do not advance the visible `revisionId`, but they are materialized when they become newly relevant to the client.
