### PR TITLE
chore: enforce naming conventions for metrics

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartData.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartData.ts
@@ -16,16 +16,16 @@ export const createChartData = (
     locationSettings: ILocationSettings,
 ): ChartData<'bar', IPoint[], string> => {
     const yesSeries = {
-        label: 'Exposed',
-        borderColor: theme.palette.charts.flagMetrics.exposed,
-        backgroundColor: theme.palette.charts.flagMetrics.exposed,
+        label: 'Enabled',
+        borderColor: theme.palette.charts.flagMetrics.enabled,
+        backgroundColor: theme.palette.charts.flagMetrics.enabled,
         data: createChartPoints(metrics, locationSettings, (m) => m.yes),
     };
 
     const noSeries = {
-        label: 'Not exposed',
-        borderColor: theme.palette.charts.flagMetrics.notExposed,
-        backgroundColor: theme.palette.charts.flagMetrics.notExposed,
+        label: 'Not enabled',
+        borderColor: theme.palette.charts.flagMetrics.notEnabled,
+        backgroundColor: theme.palette.charts.flagMetrics.notEnabled,
         data: createChartPoints(metrics, locationSettings, (m) => m.no),
     };
 

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.tsx
@@ -44,7 +44,7 @@ export const createChartOptions = (
                 usePointStyle: true,
                 position: 'nearest',
                 itemSort: (a, b) => {
-                    const order = ['Exposed', 'Not exposed'];
+                    const order = ['Enabled', 'Not enabled'];
                     const aIndex = order.indexOf(a.dataset.label!);
                     const bIndex = order.indexOf(b.dataset.label!);
                     return aIndex - bIndex;
@@ -66,7 +66,7 @@ export const createChartOptions = (
                         ] as unknown as IPoint;
 
                         if (
-                            item.dataset.label !== 'Exposed' ||
+                            item.dataset.label !== 'Enabled' ||
                             data.variants === undefined
                         ) {
                             return '';

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsChart/createChartOptions.tsx
@@ -55,7 +55,7 @@ export const createChartOptions = (
                             (sum, item) => sum + item.parsed.y,
                             0,
                         );
-                        return `${total.toLocaleString(locationSettings.locale)} - Total requests`;
+                        return `${total.toLocaleString(locationSettings.locale)} - Total evaluations`;
                     },
                     label: (item) => {
                         return `${item.formattedValue} - ${item.dataset.label}`;

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsStats/FeatureMetricsStats.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsStats/FeatureMetricsStats.test.tsx
@@ -9,7 +9,7 @@ test('render hourly metrics stats', async () => {
     expect(screen.getByText('50%')).toBeInTheDocument();
     expect(
         screen.getByText(
-            'Total requests for the feature in the environment in the last 48 hours (local time).',
+            'Total evaluations for the feature in the environment in the last 48 hours (local time).',
         ),
     ).toBeInTheDocument();
 });
@@ -21,7 +21,7 @@ test('render daily metrics stats', async () => {
 
     expect(
         screen.getByText(
-            'Total requests for the feature in the environment in the last 7 days (UTC).',
+            'Total evaluations for the feature in the environment in the last 7 days (UTC).',
         ),
     ).toBeInTheDocument();
 });

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsStats/FeatureMetricsStats.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsStats/FeatureMetricsStats.tsx
@@ -95,7 +95,7 @@ export const FeatureMetricsStats = ({
                         <PrettifyLargeNumber value={totalYes + totalNo} />
                     </StyledValue>
                     <StyledText>
-                        Total requests for the feature in the environment{' '}
+                        Total evaluations for the feature in the environment{' '}
                         {hoursSuffix}.
                     </StyledText>
                 </StyledItem>

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/FeatureMetricsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/FeatureMetricsTable.tsx
@@ -121,7 +121,7 @@ const COLUMNS = [
         accessor: (original: any) => original.yes + original.no,
     },
     {
-        Header: 'Exposed',
+        Header: 'Enabled',
         accessor: 'yes',
     },
 ];

--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
@@ -114,7 +114,7 @@ export const MetricsSummaryTooltip: VFC<{ tooltip: TooltipState | null }> = ({
                     />
                     <InfoLine
                         iconChar={'▣ '}
-                        title={`Total requests: ${(point.value.totalRequests ?? 0).toLocaleString()}`}
+                        title={`Total evaluations: ${(point.value.totalRequests ?? 0).toLocaleString()}`}
                         color={'info'}
                     />
                     <InfoLine

--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsChartTooltip/MetricsChartTooltip.tsx
@@ -119,12 +119,12 @@ export const MetricsSummaryTooltip: VFC<{ tooltip: TooltipState | null }> = ({
                     />
                     <InfoLine
                         iconChar={'▲ '}
-                        title={`Exposed: ${(point.value.totalYes ?? 0).toLocaleString()}`}
+                        title={`Enabled: ${(point.value.totalYes ?? 0).toLocaleString()}`}
                         color={'success'}
                     />
                     <InfoLine
                         iconChar={'▼ '}
-                        title={`Not exposed: ${(point.value.totalNo ?? 0).toLocaleString()}`}
+                        title={`Not enabled: ${(point.value.totalNo ?? 0).toLocaleString()}`}
                         color={'error'}
                     />
                     <ConditionallyRender

--- a/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsSummaryChart.tsx
+++ b/frontend/src/component/insights/componentsChart/MetricsSummaryChart/MetricsSummaryChart.tsx
@@ -56,7 +56,7 @@ export const MetricsSummaryChart: VFC<IMetricsSummaryChartProps> = ({
         return {
             datasets: [
                 {
-                    label: 'Total Requests',
+                    label: 'Total Evaluations',
                     data: data,
                     borderColor: theme.palette.primary.light,
                     backgroundColor: fillGradientPrimary,

--- a/frontend/src/component/personalDashboard/createChartData.ts
+++ b/frontend/src/component/personalDashboard/createChartData.ts
@@ -14,16 +14,16 @@ export const createChartData = (
     metrics: IFeatureMetricsRaw[],
 ): ChartData<'bar', IPoint[], string> => {
     const yesSeries = {
-        label: 'Exposed',
-        hoverBackgroundColor: theme.palette.charts.flagMetrics.exposed,
-        backgroundColor: theme.palette.charts.flagMetrics.exposed,
+        label: 'Enabled',
+        hoverBackgroundColor: theme.palette.charts.flagMetrics.enabled,
+        backgroundColor: theme.palette.charts.flagMetrics.enabled,
         data: createChartPoints(metrics, (m) => m.yes),
     };
 
     const noSeries = {
-        label: 'Not exposed',
-        hoverBackgroundColor: theme.palette.charts.flagMetrics.notExposed,
-        backgroundColor: theme.palette.charts.flagMetrics.notExposed,
+        label: 'Not enabled',
+        hoverBackgroundColor: theme.palette.charts.flagMetrics.notEnabled,
+        backgroundColor: theme.palette.charts.flagMetrics.notEnabled,
         data: createChartPoints(metrics, (m) => m.no),
     };
 

--- a/frontend/src/component/personalDashboard/createChartOptions.ts
+++ b/frontend/src/component/personalDashboard/createChartOptions.ts
@@ -126,7 +126,7 @@ export const createBarChartOptions = (
                         ] as unknown as IPoint;
 
                         if (
-                            item.dataset.label !== 'Exposed' ||
+                            item.dataset.label !== 'Enabled' ||
                             data.variants === undefined
                         ) {
                             return '';

--- a/frontend/src/themes/dark-theme.ts
+++ b/frontend/src/themes/dark-theme.ts
@@ -230,8 +230,8 @@ const theme = {
             E1: '#68A611',
             series: colors.chartSeries,
             flagMetrics: {
-                exposed: '#A39EFF',
-                notExposed: '#D8D6FF',
+                enabled: '#A39EFF',
+                notEnabled: '#D8D6FF',
             },
         },
 

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -288,8 +288,8 @@ const theme = {
             E1: '#68A611',
             series: colors.chartSeries,
             flagMetrics: {
-                exposed: '#A39EFF',
-                notExposed: '#D8D6FF',
+                enabled: '#A39EFF',
+                notEnabled: '#D8D6FF',
             },
         },
 

--- a/frontend/src/themes/themeTypes.ts
+++ b/frontend/src/themes/themeTypes.ts
@@ -148,8 +148,8 @@ declare module '@mui/material/styles' {
             E1: string;
             series: string[];
             flagMetrics: {
-                exposed: string;
-                notExposed: string;
+                enabled: string;
+                notEnabled: string;
             };
         };
 


### PR DESCRIPTION
Replaces wording for exposure metrics to make it consistent with naming conventions: 
- Total requests -> Total evaluations

- Exposed -> Enabled

- Not exposed -> Not enabled

<img width="1041" height="584" alt="Screenshot 2026-04-27 at 14 38 11" src="https://github.com/user-attachments/assets/2a730421-7796-4b2e-9623-2e58916c2b21" />
