### PR TITLE
feat: wire implement flag dialog to live metrics

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -38,6 +38,7 @@ export const FeatureImplementFlagBanner = ({
             <ImplementFlagDialog
                 open={dialogOpen}
                 onClose={() => setDialogOpen(false)}
+                projectId={projectId}
                 feature={featureId}
             />
         </>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -285,11 +285,11 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
                         <StatusDot connected={evaluated} />
                         <Typography
                             variant='body2'
-                            color={
-                                evaluated ? 'success.main' : 'warning.main'
-                            }
+                            color={evaluated ? 'success.main' : 'warning.main'}
                         >
-                            {evaluated ? 'Connected' : 'Waiting for evaluations'}
+                            {evaluated
+                                ? 'Connected'
+                                : 'Waiting for evaluations'}
                         </Typography>
                     </StatusIndicator>
                     <Button

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -166,13 +166,13 @@ export const ImplementFlagDialog = ({
     feature,
 }: ImplementFlagDialogProps) => (
     <StyledDialog open={open} onClose={onClose}>
-        {open ? (
+        {open && (
             <DialogBody
                 projectId={projectId}
                 feature={feature}
                 onClose={onClose}
             />
-        ) : null}
+        )}
     </StyledDialog>
 );
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -16,11 +16,8 @@ import {
     CodeRenderer,
     codeRenderSnippets,
 } from 'component/onboarding/dialog/CodeRenderer';
-import {
-    allSdks,
-    clientSdks,
-    type SdkName,
-} from 'component/onboarding/dialog/sharedTypes';
+import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
+import { buildSdkApiUrl } from 'component/onboarding/dialog/buildSdkApiUrl';
 import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
@@ -221,8 +218,7 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
     const evaluated = metrics.seenApplications.length > 0;
 
     const { uiConfig } = useUiConfig();
-    const isFrontendSdk = clientSdks.some((sdk) => sdk.name === sdkName);
-    const apiUrl = `${uiConfig.unleashUrl}/api${isFrontendSdk ? '/frontend' : ''}/`;
+    const apiUrl = buildSdkApiUrl(uiConfig.unleashUrl, sdkName);
 
     const wrappedSnippet = buildFlagUsageSnippet(
         codeRenderSnippets[sdkName] || '',

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -152,6 +152,34 @@ const ListeningText = styled('div')({
     flexDirection: 'column',
 });
 
+const ListeningStatus = ({ evaluated }: { evaluated: boolean }) => (
+    <ListeningCard>
+        <ListeningIcon>
+            {evaluated ? (
+                <CheckIcon />
+            ) : (
+                <>
+                    <span />
+                    <span />
+                    <span />
+                </>
+            )}
+        </ListeningIcon>
+        <ListeningText>
+            <Typography variant='body2' fontWeight='bold' color='primary'>
+                {evaluated
+                    ? 'Got the first evaluation!'
+                    : 'Listening for the first evaluation…'}
+            </Typography>
+            <Typography variant='caption' color='primary'>
+                {evaluated
+                    ? 'Your flag is wired up. Finish setup to close this dialog.'
+                    : 'Render the code path above anywhere to check that we receive metric evaluations.'}
+            </Typography>
+        </ListeningText>
+    </ListeningCard>
+);
+
 interface ImplementFlagDialogProps {
     open: boolean;
     onClose: () => void;
@@ -249,35 +277,7 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
                         >
                             Test flag
                         </Typography>
-                        <ListeningCard>
-                            <ListeningIcon>
-                                {evaluated ? (
-                                    <CheckIcon />
-                                ) : (
-                                    <>
-                                        <span />
-                                        <span />
-                                        <span />
-                                    </>
-                                )}
-                            </ListeningIcon>
-                            <ListeningText>
-                                <Typography
-                                    variant='body2'
-                                    fontWeight='bold'
-                                    color='primary'
-                                >
-                                    {evaluated
-                                        ? 'Got the first evaluation!'
-                                        : 'Listening for the first evaluation…'}
-                                </Typography>
-                                <Typography variant='caption' color='primary'>
-                                    {evaluated
-                                        ? 'Your flag is wired up. Finish setup to close this dialog.'
-                                        : 'Render the code path above anywhere to check that we receive metric evaluations.'}
-                                </Typography>
-                            </ListeningText>
-                        </ListeningCard>
+                        <ListeningStatus evaluated={evaluated} />
                     </Box>
                 </Body>
                 <Footer>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -10,12 +10,19 @@ import {
     useMediaQuery,
     useTheme,
 } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
 import { Markdown } from 'component/common/Markdown/Markdown';
 import {
     CodeRenderer,
     codeRenderSnippets,
 } from 'component/onboarding/dialog/CodeRenderer';
-import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
+import {
+    allSdks,
+    clientSdks,
+    type SdkName,
+} from 'component/onboarding/dialog/sharedTypes';
+import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
 import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
 
@@ -71,17 +78,21 @@ const Footer = styled('div')(({ theme }) => ({
     padding: theme.spacing(2, 3),
 }));
 
-const WaitingIndicator = styled('div')(({ theme }) => ({
+const StatusIndicator = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
 }));
 
-const WaitingDot = styled('span')(({ theme }) => ({
+const StatusDot = styled('span', {
+    shouldForwardProp: (prop) => prop !== 'connected',
+})<{ connected?: boolean }>(({ theme, connected }) => ({
     width: 6,
     height: 6,
     borderRadius: '50%',
-    backgroundColor: theme.palette.warning.main,
+    backgroundColor: connected
+        ? theme.palette.success.main
+        : theme.palette.warning.main,
 }));
 
 const CodeBlockWrapper = styled('div')(({ theme }) => ({
@@ -105,6 +116,7 @@ const ListeningIcon = styled('div')(({ theme }) => ({
     height: 44,
     borderRadius: '50%',
     backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -143,113 +155,158 @@ const ListeningText = styled('div')({
 interface ImplementFlagDialogProps {
     open: boolean;
     onClose: () => void;
+    projectId: string;
     feature: string;
 }
 
 export const ImplementFlagDialog = ({
     open,
     onClose,
+    projectId,
     feature,
-}: ImplementFlagDialogProps) => {
+}: ImplementFlagDialogProps) => (
+    <StyledDialog open={open} onClose={onClose}>
+        {open ? (
+            <DialogBody
+                projectId={projectId}
+                feature={feature}
+                onClose={onClose}
+            />
+        ) : null}
+    </StyledDialog>
+);
+
+interface DialogBodyProps {
+    projectId: string;
+    feature: string;
+    onClose: () => void;
+}
+
+const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
     const theme = useTheme();
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
     const [sdkName, setSdkName] = useState<SdkName>(allSdks[0].name);
 
+    // Poll metrics so we can flip from "waiting" → "connected" the moment
+    // the SDK reports the first evaluation, without the user reloading.
+    const { metrics } = useFeatureMetrics(projectId, feature, {
+        refreshInterval: 1000,
+    });
+    const evaluated = metrics.seenApplications.length > 0;
+
+    // Server SDKs (Node, Python, Java, …) hit the regular client API; client
+    // SDKs (React, Vue, JS, …) hit the frontend API. Mirror the existing
+    // mapping in onboarding's TestSdkConnection / SelectSdk.
+    const { uiConfig } = useUiConfig();
+    const isFrontendSdk = clientSdks.some((sdk) => sdk.name === sdkName);
+    const apiUrl = `${uiConfig.unleashUrl}/api${isFrontendSdk ? '/frontend' : ''}/`;
+
     const wrappedSnippet = buildFlagUsageSnippet(
         codeRenderSnippets[sdkName] || '',
         feature,
+        apiUrl,
     );
 
     return (
-        <StyledDialog open={open} onClose={onClose}>
-            <Container>
-                <Content>
-                    <Header>
-                        <Typography variant='body1' fontWeight='bold'>
-                            Use the flag in your code
-                        </Typography>
-                    </Header>
-                    <Body>
-                        <Select
-                            value={sdkName}
-                            onChange={(event) =>
-                                setSdkName(event.target.value as SdkName)
-                            }
-                            size='small'
-                            sx={{ maxWidth: 240 }}
+        <Container>
+            <Content>
+                <Header>
+                    <Typography variant='body1' fontWeight='bold'>
+                        Use the flag in your code
+                    </Typography>
+                </Header>
+                <Body>
+                    <Select
+                        value={sdkName}
+                        onChange={(event) =>
+                            setSdkName(event.target.value as SdkName)
+                        }
+                        size='small'
+                        sx={{ maxWidth: 240 }}
+                    >
+                        {allSdks.map((sdk) => (
+                            <MenuItem key={sdk.name} value={sdk.name}>
+                                {sdk.name}
+                            </MenuItem>
+                        ))}
+                    </Select>
+
+                    <Box>
+                        <Typography
+                            variant='body2'
+                            fontWeight='bold'
+                            sx={{ mb: 1 }}
                         >
-                            {allSdks.map((sdk) => (
-                                <MenuItem key={sdk.name} value={sdk.name}>
-                                    {sdk.name}
-                                </MenuItem>
-                            ))}
-                        </Select>
+                            Code example
+                        </Typography>
+                        <CodeBlockWrapper>
+                            <Markdown components={{ code: CodeRenderer }}>
+                                {wrappedSnippet}
+                            </Markdown>
+                        </CodeBlockWrapper>
+                    </Box>
 
-                        <Box>
-                            <Typography
-                                variant='body2'
-                                fontWeight='bold'
-                                sx={{ mb: 1 }}
-                            >
-                                Code example
-                            </Typography>
-                            <CodeBlockWrapper>
-                                <Markdown components={{ code: CodeRenderer }}>
-                                    {wrappedSnippet}
-                                </Markdown>
-                            </CodeBlockWrapper>
-                        </Box>
-
-                        <Box>
-                            <Typography
-                                variant='body1'
-                                fontWeight='bold'
-                                sx={{ mb: 1 }}
-                            >
-                                Test flag
-                            </Typography>
-                            <ListeningCard>
-                                <ListeningIcon>
-                                    <span />
-                                    <span />
-                                    <span />
-                                </ListeningIcon>
-                                <ListeningText>
-                                    <Typography
-                                        variant='body2'
-                                        fontWeight='bold'
-                                        color='primary'
-                                    >
-                                        Listening for the first evaluation…
-                                    </Typography>
-                                    <Typography
-                                        variant='caption'
-                                        color='primary'
-                                    >
-                                        Render the code path above anywhere to
-                                        check that we receive metric
-                                        evaluations.
-                                    </Typography>
-                                </ListeningText>
-                            </ListeningCard>
-                        </Box>
-                    </Body>
-                    <Footer>
-                        <WaitingIndicator>
-                            <WaitingDot />
-                            <Typography variant='body2' color='warning.main'>
-                                Waiting for evaluations
-                            </Typography>
-                        </WaitingIndicator>
-                        <Button variant='contained' disabled>
-                            Finish setup
-                        </Button>
-                    </Footer>
-                </Content>
-                {isLargeScreen && (
-                    <ImplementFlagInformation onClose={onClose} />
-                )}
-            </Container>
-        </StyledDialog>
+                    <Box>
+                        <Typography
+                            variant='body1'
+                            fontWeight='bold'
+                            sx={{ mb: 1 }}
+                        >
+                            Test flag
+                        </Typography>
+                        <ListeningCard>
+                            <ListeningIcon>
+                                {evaluated ? (
+                                    <CheckIcon />
+                                ) : (
+                                    <>
+                                        <span />
+                                        <span />
+                                        <span />
+                                    </>
+                                )}
+                            </ListeningIcon>
+                            <ListeningText>
+                                <Typography
+                                    variant='body2'
+                                    fontWeight='bold'
+                                    color='primary'
+                                >
+                                    {evaluated
+                                        ? 'Got the first evaluation!'
+                                        : 'Listening for the first evaluation…'}
+                                </Typography>
+                                <Typography variant='caption' color='primary'>
+                                    {evaluated
+                                        ? 'Your flag is wired up. Finish setup to close this dialog.'
+                                        : 'Render the code path above anywhere to check that we receive metric evaluations.'}
+                                </Typography>
+                            </ListeningText>
+                        </ListeningCard>
+                    </Box>
+                </Body>
+                <Footer>
+                    <StatusIndicator>
+                        <StatusDot connected={evaluated} />
+                        <Typography
+                            variant='body2'
+                            color={
+                                evaluated ? 'success.main' : 'warning.main'
+                            }
+                        >
+                            {evaluated ? 'Connected' : 'Waiting for evaluations'}
+                        </Typography>
+                    </StatusIndicator>
+                    <Button
+                        variant='contained'
+                        disabled={!evaluated}
+                        onClick={onClose}
+                    >
+                        Finish setup
+                    </Button>
+                </Footer>
+            </Content>
+            {isLargeScreen && <ImplementFlagInformation onClose={onClose} />}
+        </Container>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -187,16 +187,11 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
     const [sdkName, setSdkName] = useState<SdkName>(allSdks[0].name);
 
-    // Poll metrics so we can flip from "waiting" → "connected" the moment
-    // the SDK reports the first evaluation, without the user reloading.
     const { metrics } = useFeatureMetrics(projectId, feature, {
         refreshInterval: 1000,
     });
     const evaluated = metrics.seenApplications.length > 0;
 
-    // Server SDKs (Node, Python, Java, …) hit the regular client API; client
-    // SDKs (React, Vue, JS, …) hit the frontend API. Mirror the existing
-    // mapping in onboarding's TestSdkConnection / SelectSdk.
     const { uiConfig } = useUiConfig();
     const isFrontendSdk = clientSdks.some((sdk) => sdk.name === sdkName);
     const apiUrl = `${uiConfig.unleashUrl}/api${isFrontendSdk ? '/frontend' : ''}/`;

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
 
+const API_URL = 'https://example.com/api/';
+
 describe('buildFlagUsageSnippet', () => {
     it('extracts the last code block from a 3-step snippet and substitutes the flag name', () => {
         const raw = [
@@ -20,12 +22,12 @@ describe('buildFlagUsageSnippet', () => {
             '```',
         ].join('\n');
 
-        expect(buildFlagUsageSnippet(raw, 'my-flag')).toBe(
+        expect(buildFlagUsageSnippet(raw, 'my-flag', API_URL)).toBe(
             "```jsx\nconst enabled = useFlag('my-flag');\n```",
         );
     });
 
-    it('picks the init+check block for 2-step snippets where the flag check lives inside the init block', () => {
+    it('picks the init+check block for 2-step snippets and substitutes both the flag and the API URL', () => {
         const raw = [
             '1\\. Install',
             '```sh',
@@ -34,13 +36,13 @@ describe('buildFlagUsageSnippet', () => {
             '',
             '2\\. Run Unleash',
             '```js',
-            'const u = initialize({ url });',
+            "const u = initialize({ url: '<YOUR_API_URL>' });",
             "setInterval(() => console.log(u.isEnabled('<YOUR_FLAG>')), 1000);",
             '```',
         ].join('\n');
 
-        expect(buildFlagUsageSnippet(raw, 'checkout')).toBe(
-            "```js\nconst u = initialize({ url });\nsetInterval(() => console.log(u.isEnabled('checkout')), 1000);\n```",
+        expect(buildFlagUsageSnippet(raw, 'checkout', API_URL)).toBe(
+            "```js\nconst u = initialize({ url: 'https://example.com/api/' });\nsetInterval(() => console.log(u.isEnabled('checkout')), 1000);\n```",
         );
     });
 
@@ -58,26 +60,29 @@ describe('buildFlagUsageSnippet', () => {
             '- [docs](https://example.com)',
         ].join('\n');
 
-        expect(buildFlagUsageSnippet(raw, 'x')).toBe(
+        expect(buildFlagUsageSnippet(raw, 'x', API_URL)).toBe(
             "```jsx\nuseFlag('x')\n```",
         );
     });
 
-    it('replaces every occurrence of the <YOUR_FLAG> placeholder', () => {
+    it('replaces every occurrence of the placeholders', () => {
         const raw = [
             '```js',
             "const a = isEnabled('<YOUR_FLAG>');",
             "const b = isEnabled('<YOUR_FLAG>');",
+            "fetch('<YOUR_API_URL>'); fetch('<YOUR_API_URL>');",
             '```',
         ].join('\n');
 
-        expect(buildFlagUsageSnippet(raw, 'flag-x')).toBe(
-            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\n```",
+        expect(buildFlagUsageSnippet(raw, 'flag-x', API_URL)).toBe(
+            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\nfetch('https://example.com/api/'); fetch('https://example.com/api/');\n```",
         );
     });
 
     it('returns an empty string when there are no code blocks', () => {
-        expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBe('');
-        expect(buildFlagUsageSnippet('', 'x')).toBe('');
+        expect(buildFlagUsageSnippet('just prose, no fences', 'x', API_URL)).toBe(
+            '',
+        );
+        expect(buildFlagUsageSnippet('', 'x', API_URL)).toBe('');
     });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -80,9 +80,9 @@ describe('buildFlagUsageSnippet', () => {
     });
 
     it('returns an empty string when there are no code blocks', () => {
-        expect(buildFlagUsageSnippet('just prose, no fences', 'x', API_URL)).toBe(
-            '',
-        );
+        expect(
+            buildFlagUsageSnippet('just prose, no fences', 'x', API_URL),
+        ).toBe('');
         expect(buildFlagUsageSnippet('', 'x', API_URL)).toBe('');
     });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
@@ -24,11 +24,14 @@
 export const buildFlagUsageSnippet = (
     rawSnippet: string,
     feature: string,
+    apiUrl: string,
 ): string => {
     const [connectSection] = rawSnippet.split('---\n');
     const lastBlock = extractLastCodeBlock(connectSection);
     if (!lastBlock) return '';
-    const code = lastBlock.code.replaceAll('<YOUR_FLAG>', feature);
+    const code = lastBlock.code
+        .replaceAll('<YOUR_FLAG>', feature)
+        .replaceAll('<YOUR_API_URL>', apiUrl);
     return `\`\`\`${lastBlock.language}\n${code}\n\`\`\``;
 };
 

--- a/frontend/src/component/onboarding/dialog/TestSdkConnection.tsx
+++ b/frontend/src/component/onboarding/dialog/TestSdkConnection.tsx
@@ -8,6 +8,7 @@ import { Stepper } from './Stepper.tsx';
 import { Badge } from 'component/common/Badge/Badge';
 import { Markdown } from 'component/common/Markdown/Markdown';
 import { CodeRenderer, codeRenderSnippets } from './CodeRenderer.tsx';
+import { buildSdkApiUrl } from './buildSdkApiUrl.ts';
 
 const SpacedContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(5, 8, 2, 8),
@@ -41,9 +42,7 @@ export const TestSdkConnection: FC<ITestSdkConnectionProps> = ({
     const { uiConfig } = useUiConfig();
 
     const sdkIcon = allSdks.find((item) => item.name === sdk.name)?.icon;
-    const clientApiUrl = `${uiConfig.unleashUrl}/api/`;
-    const frontendApiUrl = `${uiConfig.unleashUrl}/api/frontend/`;
-    const apiUrl = sdk.type === 'client' ? clientApiUrl : frontendApiUrl;
+    const apiUrl = buildSdkApiUrl(uiConfig.unleashUrl, sdk.name);
 
     const snippet = (codeRenderSnippets[sdk.name] || '')
         .replace('<YOUR_API_TOKEN>', apiKey)

--- a/frontend/src/component/onboarding/dialog/buildSdkApiUrl.test.ts
+++ b/frontend/src/component/onboarding/dialog/buildSdkApiUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildSdkApiUrl } from './buildSdkApiUrl.ts';
+
+describe('buildSdkApiUrl', () => {
+    it('returns the client API URL for server SDKs', () => {
+        expect(buildSdkApiUrl('https://unleash.example', 'Node.js')).toBe(
+            'https://unleash.example/api/',
+        );
+        expect(buildSdkApiUrl('https://unleash.example', 'Python')).toBe(
+            'https://unleash.example/api/',
+        );
+    });
+
+    it('returns the frontend API URL for client SDKs', () => {
+        expect(buildSdkApiUrl('https://unleash.example', 'React')).toBe(
+            'https://unleash.example/api/frontend/',
+        );
+        expect(buildSdkApiUrl('https://unleash.example', 'JavaScript')).toBe(
+            'https://unleash.example/api/frontend/',
+        );
+    });
+});

--- a/frontend/src/component/onboarding/dialog/buildSdkApiUrl.ts
+++ b/frontend/src/component/onboarding/dialog/buildSdkApiUrl.ts
@@ -1,0 +1,14 @@
+import { clientSdks, type SdkName } from './sharedTypes.ts';
+
+/**
+ * Server SDKs (Node.js, Go, Python, …) talk to the regular client API at
+ * `/api/`. Client SDKs (React, Vue, JavaScript, …) talk to the frontend API
+ * at `/api/frontend/`.
+ */
+export const buildSdkApiUrl = (
+    unleashUrl: string | undefined,
+    sdkName: SdkName,
+): string => {
+    const isFrontendSdk = clientSdks.some((sdk) => sdk.name === sdkName);
+    return `${unleashUrl}/api${isFrontendSdk ? '/frontend' : ''}/`;
+};


### PR DESCRIPTION
Polls feature metrics while the dialog is open and flips the UI from "Waiting for evaluations" to "Connected" the moment the SDK reports the first.
<img width="1364" height="881" alt="Screenshot from 2026-04-27 15-43-26" src="https://github.com/user-attachments/assets/b8e7c057-d6ea-4b41-939b-32dd0c49f3ce" />

