### PR TITLE
feat: add remote MCP menu in the admin section

### DIFF
--- a/frontend/src/component/admin/Admin.tsx
+++ b/frontend/src/component/admin/Admin.tsx
@@ -19,6 +19,7 @@ import NotFound from 'component/common/NotFound/NotFound';
 import { Banners } from './banners/Banners.tsx';
 import { License } from './license/License.tsx';
 import { AdminHome } from './AdminHome.tsx';
+import { RemoteMcpAdmin } from './remote-mcp/RemoteMcpAdmin.tsx';
 import { lazy } from 'react';
 
 const EnterpriseEdge = lazy(
@@ -51,6 +52,7 @@ export const Admin = () => {
                     element={<FlaggedBillingRedirect />}
                 />
                 <Route path='billing' element={<Billing />} />
+                <Route path='remote-mcp' element={<RemoteMcpAdmin />} />
                 <Route path='instance-privacy' element={<InstancePrivacy />} />
                 <Route path='*' element={<NotFound />} />
             </Routes>

--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -159,6 +159,14 @@ export const adminRoutes: INavigationMenuItem[] = [
         notFlag: 'consumptionModelUI',
     },
 
+    // Remote MCP
+    {
+        path: '/admin/remote-mcp',
+        title: 'Remote MCP server',
+        menu: { adminSettings: true },
+        flag: 'remoteMcpServer',
+    },
+
     // Instance configuration
     {
         path: '/admin/maintenance',

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
@@ -18,7 +18,7 @@ describe('RemoteMcpAdmin', () => {
                 "Ooops. That's a page we haven't toggled on yet.",
             ),
         ).toBeInTheDocument();
-        expect(screen.queryByText('Remote MCP')).not.toBeInTheDocument();
+        expect(screen.queryByText('Remote MCP Server')).not.toBeInTheDocument();
     });
 
     test('shows the page when remoteMcpServer flag is on', async () => {

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
@@ -28,6 +28,8 @@ describe('RemoteMcpAdmin', () => {
 
         render(<RemoteMcpAdmin />, { permissions: [{ permission: 'ADMIN' }] });
 
-        expect(await screen.findByText('Remote MCP')).toBeInTheDocument();
+        expect(
+            await screen.findByText('Remote MCP Server'),
+        ).toBeInTheDocument();
     });
 });

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { RemoteMcpAdmin } from './RemoteMcpAdmin.tsx';
+
+describe('RemoteMcpAdmin', () => {
+    const server = testServerSetup();
+
+    test('shows not found when remoteMcpServer flag is off', async () => {
+        testServerRoute(server, '/api/admin/ui-config', {
+            flags: { remoteMcpServer: false },
+        });
+
+        render(<RemoteMcpAdmin />, { permissions: [{ permission: 'ADMIN' }] });
+
+        expect(
+            await screen.findByText(
+                "Ooops. That's a page we haven't toggled on yet.",
+            ),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Remote MCP')).not.toBeInTheDocument();
+    });
+
+    test('shows the page when remoteMcpServer flag is on', async () => {
+        testServerRoute(server, '/api/admin/ui-config', {
+            flags: { remoteMcpServer: true },
+        });
+
+        render(<RemoteMcpAdmin />, { permissions: [{ permission: 'ADMIN' }] });
+
+        expect(await screen.findByText('Remote MCP')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
@@ -6,6 +6,8 @@ import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
 import { RemoteMcpToggle } from './RemoteMcpToggle.tsx';
+import { useUiFlag } from 'hooks/useUiFlag';
+import NotFound from 'component/common/NotFound/NotFound';
 
 const DOCS_URL = 'https://docs.getunleash.io/reference/remote-mcp';
 
@@ -33,13 +35,21 @@ const StyledDocsLink = styled('a')(({ theme }) => ({
     '&:hover': { textDecoration: 'underline' },
 }));
 
-export const RemoteMcpAdmin = () => (
-    <div>
-        <PermissionGuard permissions={[ADMIN]}>
-            <RemoteMcpPage />
-        </PermissionGuard>
-    </div>
-);
+export const RemoteMcpAdmin = () => {
+    const remoteMcpEnabled = useUiFlag('remoteMcpServer');
+
+    if (!remoteMcpEnabled) {
+        return <NotFound />;
+    }
+
+    return (
+        <div>
+            <PermissionGuard permissions={[ADMIN]}>
+                <RemoteMcpPage />
+            </PermissionGuard>
+        </div>
+    );
+};
 
 const RemoteMcpPage = () => {
     return (

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
@@ -1,0 +1,84 @@
+import { Alert, Box, styled, Typography } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import { PermissionGuard } from 'component/common/PermissionGuard/PermissionGuard';
+import { ADMIN } from 'component/providers/AccessProvider/permissions';
+import { PageContent } from 'component/common/PageContent/PageContent';
+import { PageHeader } from 'component/common/PageHeader/PageHeader';
+import { HelpIcon } from 'component/common/HelpIcon/HelpIcon';
+import { RemoteMcpToggle } from './RemoteMcpToggle.tsx';
+
+const DOCS_URL = 'https://docs.getunleash.io/reference/remote-mcp';
+
+const StyledTitleRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+}));
+
+const StyledLayout = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+}));
+
+const StyledDocsLink = styled('a')(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.palette.primary.main,
+    textDecoration: 'none',
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.body2.fontSize,
+    '&:hover': { textDecoration: 'underline' },
+}));
+
+export const RemoteMcpAdmin = () => (
+    <div>
+        <PermissionGuard permissions={[ADMIN]}>
+            <RemoteMcpPage />
+        </PermissionGuard>
+    </div>
+);
+
+const RemoteMcpPage = () => {
+    return (
+        <PageContent
+            header={
+                <PageHeader
+                    titleElement={
+                        <StyledTitleRow>
+                            Remote MCP
+                            <HelpIcon
+                                htmlTooltip
+                                tooltip={
+                                    <Typography variant='body2'>
+                                        The Model Context Protocol (MCP) server
+                                        allows AI assistants to interact with
+                                        Unleash using natural language.
+                                    </Typography>
+                                }
+                            />
+                        </StyledTitleRow>
+                    }
+                />
+            }
+        >
+            <StyledLayout>
+                <Alert severity='warning'>
+                    Only enable this if your organization allows DCR (Dynamic
+                    Client Registration) application workflows.
+                </Alert>
+                <RemoteMcpToggle />
+                <StyledDocsLink
+                    href={DOCS_URL}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                >
+                    <MenuBookIcon fontSize='small' />
+                    Read the docs
+                </StyledDocsLink>
+            </StyledLayout>
+        </PageContent>
+    );
+};

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpAdmin.tsx
@@ -9,7 +9,8 @@ import { RemoteMcpToggle } from './RemoteMcpToggle.tsx';
 import { useUiFlag } from 'hooks/useUiFlag';
 import NotFound from 'component/common/NotFound/NotFound';
 
-const DOCS_URL = 'https://docs.getunleash.io/reference/remote-mcp';
+const DOCS_URL =
+    'https://github.com/Unleash/unleash-mcp#remote-agent-setup-experimental';
 
 const StyledTitleRow = styled(Box)(({ theme }) => ({
     display: 'flex',
@@ -58,7 +59,7 @@ const RemoteMcpPage = () => {
                 <PageHeader
                     titleElement={
                         <StyledTitleRow>
-                            Remote MCP
+                            Remote MCP Server
                             <HelpIcon
                                 htmlTooltip
                                 tooltip={
@@ -76,8 +77,8 @@ const RemoteMcpPage = () => {
         >
             <StyledLayout>
                 <Alert severity='warning'>
-                    Only enable this if your organization allows DCR (Dynamic
-                    Client Registration) application workflows.
+                    Only enable this if your organization allows OAuth 2.0
+                    Dynamic Client Registration authorization workflow.
                 </Alert>
                 <RemoteMcpToggle />
                 <StyledDocsLink

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -1,4 +1,11 @@
-import { Box, Chip, FormControlLabel, styled, Switch, Typography } from '@mui/material';
+import {
+    Box,
+    Chip,
+    FormControlLabel,
+    styled,
+    Switch,
+    Typography,
+} from '@mui/material';
 import { useState } from 'react';
 import useToast from 'hooks/useToast';
 
@@ -72,6 +79,7 @@ export const RemoteMcpToggle = () => {
                         <Switch
                             onChange={handleToggle}
                             checked={enabled}
+                            disabled={true} // Toggle is disabled until backend support is implemented
                             name='enabled'
                         />
                     }

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import useToast from 'hooks/useToast';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
 const StyledCard = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -43,6 +44,9 @@ const StyledDescription = styled(Typography)(({ theme }) => ({
 
 export const RemoteMcpToggle = () => {
     const [enabled, setEnabled] = useState(false);
+    const {
+        uiConfig: { unleashUrl },
+    } = useUiConfig();
     const { setToastData } = useToast();
 
     const handleToggle = () => {
@@ -58,21 +62,22 @@ export const RemoteMcpToggle = () => {
         <StyledCard>
             <StyledCardLeft>
                 <StyledTitle variant='body1'>
-                    Enable remote MCP for this instance
+                    Enable Remote MCP Server for this instance
                 </StyledTitle>
                 <StyledDescription>
                     When enabled, Unleash exposes a Streamable HTTP MCP server
-                    at /api/mcp. Authentication uses standard Unleash API tokens
-                    — admins choose which tokens may connect.
+                    at{' '}
+                    <pre style={{ display: 'inline' }}>
+                        {unleashUrl}/api/admin/mcp
+                    </pre>
+                </StyledDescription>
+                <StyledDescription>
+                    Authentication uses standard Unleash PAT tokens — once
+                    enabled, users will be able to exchange their current login
+                    session for a PAT token, valid for 24h.
                 </StyledDescription>
             </StyledCardLeft>
             <StyledCardRight>
-                <Chip
-                    label={enabled ? 'Enabled' : 'Disabled'}
-                    color={enabled ? 'success' : 'default'}
-                    variant='outlined'
-                    size='small'
-                />
                 <FormControlLabel
                     sx={{ margin: 0 }}
                     control={
@@ -83,7 +88,7 @@ export const RemoteMcpToggle = () => {
                             name='enabled'
                         />
                     }
-                    label=''
+                    label={enabled ? 'Enabled' : 'Disabled'}
                 />
             </StyledCardRight>
         </StyledCard>

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -1,0 +1,83 @@
+import { Box, Chip, FormControlLabel, styled, Switch, Typography } from '@mui/material';
+import { useState } from 'react';
+import useToast from 'hooks/useToast';
+
+const StyledCard = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    padding: theme.spacing(3),
+    backgroundColor: theme.palette.background.elevation1,
+    borderRadius: `${theme.shape.borderRadiusLarge}px`,
+}));
+
+const StyledCardLeft = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    maxWidth: '75%',
+}));
+
+const StyledCardRight = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+}));
+
+const StyledTitle = styled(Typography)({
+    fontWeight: 'bold',
+});
+
+const StyledDescription = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body2.fontSize,
+}));
+
+export const RemoteMcpToggle = () => {
+    const [enabled, setEnabled] = useState(false);
+    const { setToastData } = useToast();
+
+    const handleToggle = () => {
+        const next = !enabled;
+        setEnabled(next);
+        setToastData({
+            type: 'success',
+            text: `Remote MCP server has been successfully ${next ? 'enabled' : 'disabled'}`,
+        });
+    };
+
+    return (
+        <StyledCard>
+            <StyledCardLeft>
+                <StyledTitle variant='body1'>
+                    Enable remote MCP for this instance
+                </StyledTitle>
+                <StyledDescription>
+                    When enabled, Unleash exposes a Streamable HTTP MCP server
+                    at /api/mcp. Authentication uses standard Unleash API tokens
+                    — admins choose which tokens may connect.
+                </StyledDescription>
+            </StyledCardLeft>
+            <StyledCardRight>
+                <Chip
+                    label={enabled ? 'Enabled' : 'Disabled'}
+                    color={enabled ? 'success' : 'default'}
+                    variant='outlined'
+                    size='small'
+                />
+                <FormControlLabel
+                    sx={{ margin: 0 }}
+                    control={
+                        <Switch
+                            onChange={handleToggle}
+                            checked={enabled}
+                            name='enabled'
+                        />
+                    }
+                    label=''
+                />
+            </StyledCardRight>
+        </StyledCard>
+    );
+};

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -1,6 +1,5 @@
 import {
     Box,
-    Chip,
     FormControlLabel,
     styled,
     Switch,

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminMenuIcons.tsx
@@ -9,6 +9,7 @@ import SingleSignOnIcon from '@mui/icons-material/AssignmentOutlined';
 import LanguageIcon from '@mui/icons-material/Language';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
+import IntegrationInstructionsOutlinedIcon from '@mui/icons-material/IntegrationInstructionsOutlined';
 import EmptyIcon from '@mui/icons-material/CheckBoxOutlineBlankOutlined';
 import type { FC } from 'react';
 
@@ -20,6 +21,7 @@ const icons: Record<string, typeof SvgIcon> = {
     sso: SingleSignOnIcon,
     '/admin/enterprise-edge': LanguageIcon,
     network: HubOutlinedIcon,
+    '/admin/remote-mcp': IntegrationInstructionsOutlinedIcon,
     instance: BuildOutlinedIcon,
     '/admin/billing': BillingIcon,
     '/history': EventNoteIcon,

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -91,6 +91,7 @@ export type UiFlags = {
     impactMetricsFlagPage?: boolean;
     onboardingFlagSetup?: boolean;
     multiMetricChart?: boolean;
+    remoteMcpServer?: boolean;
 };
 
 export interface IVersionInfo {


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
The remote MCP menu has been added to the admin section. This page will contain the toggle to enable/disable the MCP server in an Unleash instance. The page is hidden behind the experimental `remoteMcpServer` flag and does not render if that is off. The UI hasn't been hooked up to any backend logic as that is still being implemented. 


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
- RemoteMcpAdmin.tsx
- RemoteMcpToggle.tsx

But all are really.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Icon was discussed internally already and is OK.

# Tests
Added a basic test to cover the page showing or not.

Also manual testing:

When the `remoteMcpServer` flag is off, the menu doesn't show:
<img width="332" height="574" alt="image" src="https://github.com/user-attachments/assets/3f8af670-4408-44e6-ab99-43ac13263d9c" />


navigating to the page manually shows:
<img width="2280" height="1066" alt="image" src="https://github.com/user-attachments/assets/99fb0a30-daaa-46d5-bcca-f132a03e33d1" />

When the `remoteMcpServer` flag is on, it shows:
<img width="2158" height="578" alt="image" src="https://github.com/user-attachments/assets/b6e9b916-9d41-444b-9fa0-6f48803fdfc8" />
