### PR TITLE
chore: add `elasticEventSync` feature flag

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -75,7 +75,8 @@ export type IFlagKey =
     | 'userTokenWithClientApiLoggingKillSwitch'
     | 'onlyFeatureTokensWithFeatureAPIs'
     | 'onboardingFlagSetup'
-    | 'multiMetricChart';
+    | 'multiMetricChart'
+    | 'elasticEventSync';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -340,6 +341,10 @@ const flags: IFlags = {
     ),
     multiMetricChart: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_MULTI_METRIC_CHART,
+        false,
+    ),
+    elasticEventSync: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_ELASTIC_EVENT_SYNC,
         false,
     ),
 };


### PR DESCRIPTION
Adds `elasticEventSync` feature flag to gate Elastic event syncing for cloud customers.