### PR TITLE
fix: set the width of the 'Name' column to max on the Flags overview

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -125,6 +125,7 @@ export const FeatureToggleListTable: FC = () => {
                     onFlagTypeClick,
                     onFavorite,
                 ),
+                meta: { width: '100%', align: 'left' },
             }),
             columnHelper.accessor('createdBy', {
                 id: 'createdBy',


### PR DESCRIPTION
#### Issue
UX team noticed that in the Sandbox env (_not yet verified in Prod_), sorting by the '_Created_' or '_Project_' column causes the table columns to shift unexpectedly. This can make it hard for the user to see the information, so here we fix it and set a dynamic fixed width for the '_Name_' column to stop the layout from changing. The table will now be set to the longest possible name length (100 characters). This will make sure the data is always consistent, regardless if they change page.

#### Relates to [EG-4359](https://linear.app/unleash/issue/EG-4359/flag-overview-prevent-layout-shifts)
<br> 

### 📸  Before changes:
the column Name changes width
<br> 
<img width="1388" height="868" alt="Screenshot 2026-04-28 at 14 33 45" src="https://github.com/user-attachments/assets/49eebf9e-71f6-4879-94f3-b23ce106e3e6" />
<img width="1417" height="881" alt="Screenshot 2026-04-28 at 14 33 53" src="https://github.com/user-attachments/assets/f75e315d-2311-496e-b0af-306933296766" />

<br> 

### 🎨 After changes
<br> 
the column Name stays the same
<br> 
<img width="1365" height="964" alt="image" src="https://github.com/user-attachments/assets/e066c767-d5b9-43b8-bcd9-da6de0c7c556" />
<img width="1371" height="977" alt="Screenshot 2026-04-29 at 11 24 03" src="https://github.com/user-attachments/assets/9b8db5a8-2f11-46e1-a390-ea204f91c974" />

