### PR TITLE
fix: address long usernames on `Flag details view`

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
@@ -6,6 +6,7 @@ import {
     ListItemIcon,
     ListItemText,
     styled,
+    Tooltip,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { FeatureArchiveDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveDialog';
@@ -78,12 +79,18 @@ export const StyledMetaDataItemLabel = styled('span')(({ theme }) => ({
 
 const StyledMetaDataItemText = styled('span')({
     overflowWrap: 'anywhere',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
 });
 
 export const StyledMetaDataItemValue = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'flex-end',
 }));
 
 export const StyledListItemIcon = styled(ListItemIcon)(({ theme }) => ({
@@ -300,9 +307,11 @@ const FeatureOverviewMetaData: FC<FeatureOverviewMetaDataProps> = ({
                                 Created by:
                             </StyledMetaDataItemLabel>
                             <StyledMetaDataItemValue>
-                                <StyledMetaDataItemText data-loading>
-                                    {feature.createdBy?.name}
-                                </StyledMetaDataItemText>
+                                <Tooltip title={feature.createdBy?.name || ''}>
+                                    <StyledMetaDataItemText data-loading>
+                                        {feature.createdBy?.name}
+                                    </StyledMetaDataItemText>
+                                </Tooltip>
                             </StyledMetaDataItemValue>
                         </StyledMetaDataItem>
                     ) : null}


### PR DESCRIPTION
#### Issue
Here, we address the issue of long usernames on the 'Flag details view' that break the experience.
We hide the whole name using an ellipsis and provide a tooltip that displays the full value when the user hovers over it.

Closes [EG-4360](https://linear.app/unleash/issue/EG-4360/flag-details-box-long-user-name-breaks-the-experience)

### 🐛 **Before changes**
the name and the 'Created by' label occupy two lines
<img width="1920" height="2183" alt="image (3)" src="https://github.com/user-attachments/assets/26f593ec-219e-4acb-bb7d-16c34b7ec600" />


### 🎨  **After changes**
'Created by' label stays consistent, full name in ellipsis 

<img width="385" height="432" alt="Screenshot 2026-04-28 at 17 45 52" src="https://github.com/user-attachments/assets/20f8717d-1b5e-495c-b08c-82d5df2acb2d" />
