### PR TITLE
fix: internal imports

### DIFF
--- a/src/lib/openapi/spec/context-query-parameters.ts
+++ b/src/lib/openapi/spec/context-query-parameters.ts
@@ -1,4 +1,4 @@
-import type { FromQueryParams } from 'unleash-server';
+import type { FromQueryParams } from '../util/from-query-params.js';
 
 export const contextQueryParameters = [
     {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,11 +1,9 @@
 import postgresPkg from 'pg';
 const { Client } = postgresPkg;
-import {
-    migrateDb,
-    getDbConfig,
-    testDbPrefix,
-    type IUnleashConfig,
-} from 'unleash-server';
+import { migrateDb } from './migrator.js';
+import { getDbConfig } from './test/e2e/helpers/database-config.js';
+import { testDbPrefix } from './test/e2e/helpers/database-init.js';
+import type { IUnleashConfig } from './lib/types/option.js';
 
 let initializationPromise: Promise<void> | null = null;
 

--- a/src/test/fixtures/fake-impact-metrics.ts
+++ b/src/test/fixtures/fake-impact-metrics.ts
@@ -1,6 +1,13 @@
 import type { IImpactMetricsResolver } from '../../lib/types/index.js';
 
-export const fakeImpactMetricsResolver = () => {
+export const fakeImpactMetricsResolver = (): IImpactMetricsResolver & {
+    counters: Map<string, { value: number; help: string }>;
+    gauges: Map<string, { value: number; help: string }>;
+    histograms: Map<
+        string,
+        { count: number; sum: number; help: string; buckets: number[] }
+    >;
+} => {
     const counters = new Map<string, { value: number; help: string }>();
     const gauges = new Map<string, { value: number; help: string }>();
     const histograms = new Map<


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

 A few files imported types/functions from `'unleash-server'` — the package's own name instead of the internal modules where those symbols are actually defined                                                                                                                           
                                                                                                                                                                                                               
                                                                                                                                                                                                               
  Also added an explicit return type to `fakeImpactMetricsResolver` (`src/test/fixtures/fake-impact-metrics.ts`) to fix TS2742, where the inferred type was pulling a non-portable path to                     
  `unleash-client/lib/impact-metrics/metric-types` into the emitted `.d.ts`.                                                                                                                                   
                                                                                

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
