### PR TITLE
fix: address React warnings surfaced by frontend test run

### DIFF
--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -65,10 +65,7 @@ export const RemoteMcpToggle = () => {
                 </StyledTitle>
                 <StyledDescription>
                     When enabled, Unleash exposes a Streamable HTTP MCP server
-                    at{' '}
-                    <pre style={{ display: 'inline' }}>
-                        {unleashUrl}/api/admin/mcp
-                    </pre>
+                    at <code>{unleashUrl}/api/admin/mcp</code>
                 </StyledDescription>
                 <StyledDescription>
                     Authentication uses standard Unleash PAT tokens — once

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConsolidatedReleasePlanChanges.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConsolidatedReleasePlanChanges.tsx
@@ -177,9 +177,12 @@ export const ConsolidatedReleasePlanChanges: FC<{
                             const changes = changesByMilestone[id];
                             if (!changes) return null;
 
-                            return changes.map(({ description }) => {
+                            return changes.map(({ change, description }) => {
                                 return (
-                                    <li data-action={description.action}>
+                                    <li
+                                        key={change.id}
+                                        data-action={description.action}
+                                    >
                                         {description.text}
                                     </li>
                                 );

--- a/frontend/src/component/common/AnimateOnMount/AnimateOnMount.tsx
+++ b/frontend/src/component/common/AnimateOnMount/AnimateOnMount.tsx
@@ -36,9 +36,10 @@ const AnimateOnMount: FC<IAnimateOnMountProps> = ({
             if (mounted) {
                 setShow(true);
                 onStart?.();
-                setTimeout(() => {
+                const timeout = setTimeout(() => {
                     setStyles(enter);
                 }, 50);
+                return () => clearTimeout(timeout);
             } else {
                 if (!leave) {
                     setShow(false);

--- a/frontend/src/component/impact-metrics/MultimetricChart/MultimetricTotals.tsx
+++ b/frontend/src/component/impact-metrics/MultimetricChart/MultimetricTotals.tsx
@@ -108,7 +108,7 @@ export const MultimetricTotals: FC<MultimetricTotalsProps> = ({ steps }) => {
             <StyledStackedBar>
                 {steps.map((step, index) => (
                     <StyledSegment
-                        key={step.label}
+                        key={`${index}-${step.label}`}
                         style={{
                             width: `${normalizedWidths[index]}%`,
                             backgroundColor: getStepColor(index),
@@ -118,7 +118,7 @@ export const MultimetricTotals: FC<MultimetricTotalsProps> = ({ steps }) => {
             </StyledStackedBar>
             <StyledLegend>
                 {steps.map((step, index) => (
-                    <StyledLegendItem key={step.label}>
+                    <StyledLegendItem key={`${index}-${step.label}`}>
                         <StyledColorDot
                             sx={{ backgroundColor: getStepColor(index) }}
                         />

--- a/frontend/src/component/impact-metrics/MultimetricChart/MultimetricTotals.tsx
+++ b/frontend/src/component/impact-metrics/MultimetricChart/MultimetricTotals.tsx
@@ -4,6 +4,7 @@ import { formatLargeNumbers } from '../metricsFormatters';
 import { ConversionIndicator } from './ConversionIndicator';
 
 export type MultimetricStep = {
+    id: string;
     label: string;
     value: number;
     previousStepPercentage: number | null;
@@ -108,7 +109,7 @@ export const MultimetricTotals: FC<MultimetricTotalsProps> = ({ steps }) => {
             <StyledStackedBar>
                 {steps.map((step, index) => (
                     <StyledSegment
-                        key={`${index}-${step.label}`}
+                        key={step.id}
                         style={{
                             width: `${normalizedWidths[index]}%`,
                             backgroundColor: getStepColor(index),
@@ -118,7 +119,7 @@ export const MultimetricTotals: FC<MultimetricTotalsProps> = ({ steps }) => {
             </StyledStackedBar>
             <StyledLegend>
                 {steps.map((step, index) => (
-                    <StyledLegendItem key={`${index}-${step.label}`}>
+                    <StyledLegendItem key={step.id}>
                         <StyledColorDot
                             sx={{ backgroundColor: getStepColor(index) }}
                         />

--- a/frontend/src/hooks/api/getters/useImpactMetricsData/useGroupedImpactMetricsData.ts
+++ b/frontend/src/hooks/api/getters/useImpactMetricsData/useGroupedImpactMetricsData.ts
@@ -106,6 +106,7 @@ export const useGroupedImpactMetricsData = (
     }));
 
     const stepTotals: MultimetricStep[] = data.map((response, i) => ({
+        id: configs[i].id,
         label: configs[i].title || configs[i].displayName,
         value: aggregateTotal(response.series, configs[i].aggregationMode),
         previousStepPercentage: null,


### PR DESCRIPTION
Fixes a couple warnings that were appearing during `yarn test`.

1. Missing `key` prop in ConsolidatedReleasePlanChanges Warning: Each child in a list should have a unique "key" prop. Check the render method of `ConsolidatedReleasePlanChanges`. The `<li>` rendered inside `flatMap` -> `map` had no key. Used `change.id` (numeric, unique per change) from `IChangeRequestChangeBase`.

2. Duplicate keys in MultimetricTotals Warning: Encountered two children with the same key, `Signups`. Both `steps.map(...)` blocks used `key={step.label}`, but step labels are not guaranteed unique. Switched to `${index}-${step.label}` since the steps are inherently positional.

3. Invalid DOM nesting in RemoteMcpToggle Warning: validateDOMNesting(...): `<pre>` cannot appear as a descendant of `<p>`. `<pre style={{ display: 'inline' }}>` was nested inside `StyledDescription` (an MUI `Typography` rendering as `<p>`). Replaced with `<code>`, which is semantic for an inline URL and is a valid descendant of `<p>`.

4. setTimeout leak in AnimateOnMount Vitest unhandled error: ReferenceError: window is not defined at AnimateOnMount.tsx:40 (setStyles called from setTimeout) The 50ms `setTimeout` that triggers the enter animation was never cleared, so it could fire after the component unmounted (and after the test's jsdom environment had torn down). Captured the timeout handle and return a `clearTimeout` from the effect.
