### PR TITLE
lint: svg react imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "plugins": ["./plugins/no-svg-without-react.grit"],
   "linter": {
     "enabled": true,
     "rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
-  "plugins": ["./plugins/no-svg-without-react.grit"],
   "linter": {
     "enabled": true,
     "rules": {
@@ -71,6 +70,10 @@
     }
   },
   "overrides": [
+    {
+      "includes": ["frontend/**"],
+      "plugins": ["./plugins/no-svg-without-react.grit"]
+    },
     {
       "linter": {
         "rules": {

--- a/plugins/no-svg-without-react.grit
+++ b/plugins/no-svg-without-react.grit
@@ -1,0 +1,7 @@
+`import $_ from $source` where {
+    $source <: or {
+        `'$_.svg'`,
+        `"$_.svg"`
+    },
+    register_diagnostic(span=$source, message="SVG must be imported with '?react' to use as a React component (e.g., './icon.svg?react').")
+}

--- a/plugins/no-svg-without-react.grit
+++ b/plugins/no-svg-without-react.grit
@@ -1,7 +1,18 @@
-`import $_ from $source` where {
-    $source <: or {
-        `'$_.svg'`,
-        `"$_.svg"`
+or {
+    `import $name from $source` where {
+        $name <: r"[A-Z]\w*",
+        $source <: or {
+            `'$_.svg'`,
+            `"$_.svg"`
+        },
+        register_diagnostic(span=$source, message="SVG import convention mismatch. PascalCase name = React component: add '?react' so vite-plugin-svgr converts it (e.g. import PascalName from './icon.svg?react'). If you just want a URL string then rename to camelCase and (e.g. import camelName from './icon.svg').")
     },
-    register_diagnostic(span=$source, message="SVG must be imported with '?react' to use as a React component (e.g., './icon.svg?react').")
+    `import $name from $source` where {
+        $name <: r"[a-z]\w*",
+        $source <: or {
+            `'$_.svg?react'`,
+            `"$_.svg?react"`
+        },
+        register_diagnostic(span=$source, message="SVG import convention mismatch. camelCase name = URL string: drop '?react' and keep bare '.svg' (e.g. import camelName from './icon.svg'). If you just want a React component then rename to PascalCase and keep '?react' so vite-plugin-svgr converts it (e.g. import PascalName from './icon.svg?react').")
+    }
 }


### PR DESCRIPTION
Follow up of https://github.com/Unleash/unleash/pull/11766

Inspired by 
https://biomejs.dev/recipes/gritql-plugins/#enforce-strict-equality-except-against-null


* You can import URL if you store it in the camelCase variable
* You can import React component if you store it in PascalCase component name

<img width="976" height="253" alt="Screenshot 2026-05-04 at 12 30 03" src="https://github.com/user-attachments/assets/10bfbf4e-12af-4404-92c5-2204f8e7cf54" />

